### PR TITLE
cpu/nrf52: provide radio_nrf802154 feature at CPU level

### DIFF
--- a/boards/adafruit-clue/Kconfig
+++ b/boards/adafruit-clue/Kconfig
@@ -16,7 +16,6 @@ config BOARD_ADAFRUIT_CLUE
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
     select HAS_BOOTLOADER_NRFUTIL
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/adafruit-clue/Makefile.features
+++ b/boards/adafruit-clue/Makefile.features
@@ -7,7 +7,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 FEATURES_PROVIDED += bootloader_nrfutil
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/adafruit-itsybitsy-nrf52/Kconfig
+++ b/boards/adafruit-itsybitsy-nrf52/Kconfig
@@ -16,7 +16,6 @@ config BOARD_ADAFRUIT_ITSYBITSY_NRF52
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
     select HAS_BOOTLOADER_NRFUTIL
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/adafruit-itsybitsy-nrf52/Makefile.features
+++ b/boards/adafruit-itsybitsy-nrf52/Makefile.features
@@ -7,7 +7,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 FEATURES_PROVIDED += bootloader_nrfutil
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/arduino-nano-33-ble/Kconfig
+++ b/boards/arduino-nano-33-ble/Kconfig
@@ -16,7 +16,6 @@ config BOARD_ARDUINO_NANO_33_BLE
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
     select HAS_BOOTLOADER_ARDUINO
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/arduino-nano-33-ble/Makefile.features
+++ b/boards/arduino-nano-33-ble/Makefile.features
@@ -7,7 +7,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 FEATURES_PROVIDED += bootloader_arduino
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -13,6 +13,5 @@ config BOARD_COMMON_PARTICLE_MESH
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -8,6 +8,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/feather-nrf52840/Kconfig
+++ b/boards/feather-nrf52840/Kconfig
@@ -16,6 +16,5 @@ config BOARD_FEATHER_NRF52840
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/feather-nrf52840/Makefile.features
+++ b/boards/feather-nrf52840/Makefile.features
@@ -7,6 +7,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840-mdk/Kconfig
+++ b/boards/nrf52840-mdk/Kconfig
@@ -16,6 +16,5 @@ config BOARD_NRF52840_MDK
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840-mdk/Makefile.features
+++ b/boards/nrf52840-mdk/Makefile.features
@@ -7,6 +7,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840dk/Kconfig
+++ b/boards/nrf52840dk/Kconfig
@@ -12,7 +12,6 @@ config BOARD_NRF52840DK
     default y
     select BOARD_COMMON_NRF52XXXDK
     select CPU_MODEL_NRF52840XXAA
-    select HAS_RADIO_NRF802154
     select HAS_PERIPH_PWM
     select HAS_PERIPH_USBDEV
 

--- a/boards/nrf52840dk/Makefile.features
+++ b/boards/nrf52840dk/Makefile.features
@@ -3,6 +3,5 @@ CPU_MODEL = nrf52840xxaa
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/nrf52840dongle/Kconfig
+++ b/boards/nrf52840dongle/Kconfig
@@ -15,7 +15,6 @@ config BOARD_NRF52840DONGLE
     select HAS_PERIPH_PWM
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
     select HAS_BOOTLOADER_NRFUTIL
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840dongle/Makefile.features
+++ b/boards/nrf52840dongle/Makefile.features
@@ -6,7 +6,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 FEATURES_PROVIDED += bootloader_nrfutil
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/reel/Kconfig
+++ b/boards/reel/Kconfig
@@ -16,6 +16,5 @@ config BOARD_REEL
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_RADIO_NRF802154
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/reel/Makefile.features
+++ b/boards/reel/Makefile.features
@@ -7,6 +7,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrf802154
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/cpu/nrf52/Kconfig
+++ b/cpu/nrf52/Kconfig
@@ -30,11 +30,13 @@ config CPU_MODEL_NRF52811XXAA
     bool
     select CPU_CORE_CORTEX_M4
     select CPU_FAM_NRF52
+    select HAS_RADIO_NRF802154
 
 config CPU_MODEL_NRF52820XXAA
     bool
     select CPU_CORE_CORTEX_M4
     select CPU_FAM_NRF52
+    select HAS_RADIO_NRF802154
 
 config CPU_MODEL_NRF52832XXAA
     bool
@@ -46,11 +48,13 @@ config CPU_MODEL_NRF52833XXAA
     bool
     select CPU_CORE_CORTEX_M4F
     select CPU_FAM_NRF52
+    select HAS_RADIO_NRF802154
 
 config CPU_MODEL_NRF52840XXAA
     bool
     select CPU_CORE_CORTEX_M4F
     select CPU_FAM_NRF52
+    select HAS_RADIO_NRF802154
 
 ## CPU common symbols
 config CPU_FAM

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -5,6 +5,11 @@ CPU_CORE = cortex-m4
 endif
 CPU_FAM  = nrf52
 
+# The 802.15.4 radio is not available on all SoCs
+ifneq (,$(filter nrf52811xxaa nrf52820xxaa rf52833xxaa nrf52840xxaa,$(CPU_MODEL)))
+  FEATURES_PROVIDED += radio_nrf802154
+endif
+
 # The ADC does not depend on any board configuration, so always available
 FEATURES_PROVIDED += periph_adc
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The presence of the 802.15.4 radio peripheral is a feature of the CPU, not the board.
Move it to the right place and reduce code duplication.


### Testing procedure

The feature set of the boards should not change.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
