### PR TITLE
cpu/cc2538/radio: add `NETDEV_%` events.

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -100,13 +100,6 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
-/**
- * @name Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -78,6 +78,15 @@
 /** @} */
 
 /**
+ * @name    RF CORE observable signals settings
+ * @{
+ */
+#define CONFIG_CC2538_RF_OBS_SIG_0_PCX  0   /* PC4 */
+#define CONFIG_CC2538_RF_OBS_SIG_1_PCX  1   /* PC6 */
+#define CONFIG_CC2538_RF_OBS_SIG_2_PCX  2   /* PC7 */
+/** @} */
+
+/**
  * @name    AT86RF215 configuration
  * @{
  */

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -108,13 +108,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-/**
- * @name    Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -82,6 +82,16 @@
 /** @} */
 
 /**
+ * @name    RF CORE observable signals settings
+ * @{
+ */
+#define CONFIG_CC2538_RF_OBS_SIG_0_PCX  0   /* PC4 */
+#define CONFIG_CC2538_RF_OBS_SIG_1_PCX  1   /* PC6 */
+#define CONFIG_CC2538_RF_OBS_SIG_2_PCX  2   /* PC7 */
+#endif
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -104,13 +104,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-/**
- * @name    Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -214,6 +214,7 @@ enum {
 typedef struct {
     netdev_ieee802154_t netdev;   /**< netdev parent struct */
     uint8_t state;                /**< current state of the radio */
+    uint8_t flags;                /**< Device specific flags */
 } cc2538_rf_t;
 
 /**

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -23,6 +23,10 @@
 #define CC2538_RF_H
 
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdatomic.h>
+
+#include "cc2538_rfcore.h"
 
 #include "net/ieee802154.h"
 #include "net/netdev.h"
@@ -207,6 +211,24 @@ enum {
 };
 
 /**
+ * @name    CC2538 RF interrupts flags
+ *
+ * @{
+ */
+#define CC2538_RF_SFD_RX       (1 << 0)
+#define CC2538_RF_TXDONE       (1 << 1)
+#define CC2538_RF_RXPKTDONE    (1 << 2)
+/** @} */
+
+/**
+ * @name    Internal device option flags
+ * @{
+ */
+#define CC2538_OPT_PRELOADING     (0x01)       /**< preloading enabled */
+
+/** @} */
+
+/**
  * @brief   Device descriptor for CC2538 transceiver
  *
  * @extends netdev_ieee802154_t
@@ -214,7 +236,8 @@ enum {
 typedef struct {
     netdev_ieee802154_t netdev;   /**< netdev parent struct */
     uint8_t state;                /**< current state of the radio */
-    uint8_t flags;                /**< Device specific flags */
+    atomic_uint isr_flags;        /**< interrupt flags */
+    uint8_t flags;                /**< device specific flags */
 } cc2538_rf_t;
 
 /**
@@ -356,6 +379,13 @@ void cc2538_set_pan(uint16_t pan);
  * @param[in]  state        State to set device to
  */
 void cc2538_set_state(cc2538_rf_t *dev, netopt_state_t state);
+
+/**
+ * @brief   Start transmiting
+ *
+ * @param[in]  dev          Device descriptor
+ */
+void cc2538_tx_now(cc2538_rf_t * dev);
 
 /**
  * @brief   Set the transmission power for the device

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -147,6 +147,15 @@ enum {
   * @brief RFCORE_XREG_FRMCTRL0 bits
   */
 enum {
+    SET_RXENMASK_ON_TX  = BIT(0),
+    IGNORE_TX_UNDERF    = BIT(1),
+    PENDING_OR          = BIT(2),
+};
+
+ /*
+  * @brief RFCORE_XREG_FRMCTRL1 bits
+  */
+enum {
     ENERGY_SCAN      = BIT(4),
     AUTOACK          = BIT(5),
     AUTOCRC          = BIT(6),
@@ -180,7 +189,6 @@ enum {
 };
 
 /* Values for use with CCTEST_OBSSELx registers: */
-#define OBSSEL_EN BIT(7)
 enum {
     rfc_obs_sig0 = 0,
     rfc_obs_sig1 = 1,
@@ -208,7 +216,40 @@ enum {
     lock_status      = 0x19,
     pa_pd            = 0x20,
     lna_pd           = 0x2a,
+    disabled         = 0x2b,
 };
+
+/** @} */
+
+/**
+ * @name    RF CORE observable signals settings
+ */
+#ifndef CONFIG_CC2538_RF_OBS_0
+#define CONFIG_CC2538_RF_OBS_0      tx_active
+#endif
+#ifndef CONFIG_CC2538_RF_OBS_1
+#define CONFIG_CC2538_RF_OBS_1      rx_active
+#endif
+#ifndef CONFIG_CC2538_RF_OBS_2
+#define CONFIG_CC2538_RF_OBS_2      ffctrl_fifo
+#endif
+
+/* Default configration for cc2538dk or similar */
+#ifndef CONFIG_CC2538_RF_OBS_SIG_0_PCX
+#define CONFIG_CC2538_RF_OBS_SIG_0_PCX  0   /* PC0 = LED_1 (red) */
+#endif
+#ifndef CONFIG_CC2538_RF_OBS_SIG_1_PCX
+#define CONFIG_CC2538_RF_OBS_SIG_1_PCX  1   /* PC0 = LED_2 (red) */
+#endif
+#ifndef CONFIG_CC2538_RF_OBS_SIG_2_PCX
+#define CONFIG_CC2538_RF_OBS_SIG_2_PCX  2   /* PC0 = LED_3 (red) */
+#endif
+#if ((CONFIG_CC2538_RF_OBS_SIG_2_PCX > 7) || \
+     (CONFIG_CC2538_RF_OBS_SIG_1_PCX > 7) || \
+     (CONFIG_CC2538_RF_OBS_SIG_0_PCX > 7))
+#error "CONFIG_CC2538_RF_OBS_SIG_X_PCX must be between 0-7 (PC0-PC7)"
+#endif
+/** @} */
 
 /**
  * @name    CC2538 RF interrupts flags

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -356,13 +356,6 @@ typedef gpio_t adc_conf_t;
 #define NWDT_TIME_UPPER_LIMIT          (1000U)
 /** @} */
 
-/**
- * @name Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -128,20 +128,20 @@ void cc2538_init(void)
         NVIC_SetPriority(RF_RXTX_ALT_IRQn, RADIO_IRQ_PRIO);
         NVIC_EnableIRQ(RF_RXTX_ALT_IRQn);
 
-        NVIC_SetPriority(RF_ERR_ALT_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(RF_ERR_ALT_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_ERR_ALT_IRQn);
 
-        NVIC_SetPriority(MAC_TIMER_ALT_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(MAC_TIMER_ALT_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(MAC_TIMER_ALT_IRQn);
     }
     else {
-        NVIC_SetPriority(RF_RXTX_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(RF_RXTX_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_RXTX_IRQn);
 
-        NVIC_SetPriority(RF_ERR_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(RF_ERR_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_ERR_IRQn);
 
-        NVIC_SetPriority(MACTIMER_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(MACTIMER_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(MACTIMER_IRQn);
     }
 

--- a/cpu/cc2538/radio/cc2538_rf_getset.c
+++ b/cpu/cc2538/radio/cc2538_rf_getset.c
@@ -188,11 +188,12 @@ void cc2538_set_state(cc2538_rf_t *dev, netopt_state_t state)
             }
             dev->state = state;
             break;
-
         case NETOPT_STATE_TX:
-            dev->state = NETOPT_STATE_IDLE;
+            dev->state = state;
+            if (dev->flags & CC2538_OPT_PRELOADING) {
+                RFCORE_SFR_RFST = ISTXON;
+            }
             break;
-
         case NETOPT_STATE_RESET:
             cc2538_off();
             cc2538_on();

--- a/cpu/cc2538/radio/cc2538_rf_getset.c
+++ b/cpu/cc2538/radio/cc2538_rf_getset.c
@@ -174,6 +174,7 @@ void cc2538_set_monitor(bool mode)
 void cc2538_set_state(cc2538_rf_t *dev, netopt_state_t state)
 {
     switch (state) {
+        case NETOPT_STATE_STANDBY:
         case NETOPT_STATE_OFF:
         case NETOPT_STATE_SLEEP:
             cc2538_off();
@@ -191,7 +192,7 @@ void cc2538_set_state(cc2538_rf_t *dev, netopt_state_t state)
         case NETOPT_STATE_TX:
             dev->state = state;
             if (dev->flags & CC2538_OPT_PRELOADING) {
-                RFCORE_SFR_RFST = ISTXON;
+                cc2538_tx_now(dev);
             }
             break;
         case NETOPT_STATE_RESET:

--- a/cpu/cc2538/radio/cc2538_rf_internal.c
+++ b/cpu/cc2538/radio/cc2538_rf_internal.c
@@ -64,7 +64,7 @@ void isr_rfcoreerr(void)
 
 void isr_rfcorerxtx(void)
 {
-   cc2538_irq_handler();
+    cc2538_irq_handler();
 
     cortexm_isr_end();
 }

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -9,6 +9,7 @@ PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw
 PSEUDOMODULES += ccn-lite-utils
+PSEUDOMODULES += cc2538_rf_obs_sig
 PSEUDOMODULES += conn_can_isotp_multi
 PSEUDOMODULES += cord_ep_standalone
 PSEUDOMODULES += core_%


### PR DESCRIPTION
### Contribution description

I want to add `cc2538` support in OpenWSN, to be able to compare the `radio_hal` with `netdev` I want to have both working on OpenWSN. This PR makes some changes to enable the missing features.

The radio init was also cleaned-up.

- cc2538_rf observable signals are now an optional module `cc2538_rf_obs_sig` the configuration has been moved to each `BOARD`
- `NETOPT_PRELOADING` was added
- `NETDEV_EVENT_RX_COMPLETE`, `NETDEV_EVENT_TX_COMPLETE`, `NETDEV_EVENT_RX_START` & `NETDEV_EVENT_CRC_ERROR` where added based on the `SFD`, `RXPKTDONE` and `TXDONE` interrupts.

To enable the third point I had to reword the radio logic, here I already found some limitations compared to the radio-hal.
Since event handling needs to be offloaded this means that multiple ISR can occur before the event are handled, therefore the timing of the event might not be accurate.

Before the `crc` check was moved from the event ISR to the actual `_recv` function, this was because it was seen that the CRC values that seemed initially valid became invalid, this was because a new frame was being received before the old frame was handled. To avoid this reception is now disabled until the frame is parse. To do this the radio does not automatically switch to receiving after transmitting or the result would be the same.

### Testing procedure

- Communicating between to `cc2538` radios should still work:

```
2020-10-02 11:19:34,012 #  ping -c 1000 -i 170 -s 1024  fe80::212:4b00:14b5:b5d5
2020-10-02 11:19:34,124 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=0 ttl=64 rssi=-40 dBm time=102.694 ms
2020-10-02 11:19:34,295 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=1 ttl=64 rssi=-39 dBm time=102.698 ms
2020-10-02 11:19:34,467 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=2 ttl=64 rssi=-40 dBm time=102.697 ms
...
2020-10-02 11:19:16,126 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=993 ttl=64 rssi=-39 dBm time=102.697 ms
2020-10-02 11:19:16,296 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=994 ttl=64 rssi=-40 dBm time=102.720 ms
2020-10-02 11:19:16,466 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=995 ttl=64 rssi=-39 dBm time=102.695 ms
2020-10-02 11:19:16,637 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=996 ttl=64 rssi=-39 dBm time=102.695 ms
2020-10-02 11:19:16,805 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=997 ttl=64 rssi=-39 dBm time=102.695 ms
2020-10-02 11:19:16,974 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=998 ttl=64 rssi=-39 dBm time=102.698 ms
2020-10-02 11:19:17,147 # 1032 bytes from fe80::212:4b00:14b5:b5d5%6: icmp_seq=999 ttl=64 rssi=-39 dBm time=102.698 ms
2020-10-02 11:19:18,024 #
2020-10-02 11:19:18,025 # --- fe80::212:4b00:14b5:b5d5 PING statistics ---
2020-10-02 11:19:18,047 # 1000 packets transmitted, 997 packets received, 0% packet loss
2020-10-02 11:19:18,048 # round-trip min/avg/max = 102.685/102.700/102.763 ms
```

- A long running test would be nice as well.

- `tests/iee802154_hal` should still work on `cc2538` (they use the same `init` function as `netdev`)

### Issues/PRs references

Depends on #15144
