### PR TITLE
README: Remove ascii art

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,32 +8,6 @@
 [![IRC][irc-badge]][irc-link]
 [![Matrix][matrix-badge]][matrix-link]
 
-                          ZZZZZZ
-                        ZZZZZZZZZZZZ
-                      ZZZZZZZZZZZZZZZZ
-                     ZZZZZZZ     ZZZZZZ
-                    ZZZZZZ        ZZZZZ
-                    ZZZZZ          ZZZZ
-                    ZZZZ           ZZZZZ
-                    ZZZZ           ZZZZ
-                    ZZZZ          ZZZZZ
-                    ZZZZ        ZZZZZZ
-                    ZZZZ     ZZZZZZZZ       777        7777       7777777777
-              ZZ    ZZZZ   ZZZZZZZZ         777      77777777    77777777777
-          ZZZZZZZ   ZZZZ  ZZZZZZZ           777     7777  7777       777
-        ZZZZZZZZZ   ZZZZ    Z               777     777    777       777
-       ZZZZZZ       ZZZZ                    777     777    777       777
-      ZZZZZ         ZZZZ                    777     777    777       777
-     ZZZZZ          ZZZZZ    ZZZZ           777     777    777       777
-     ZZZZ           ZZZZZ    ZZZZZ          777     777    777       777
-     ZZZZ           ZZZZZ     ZZZZZ         777     777    777       777
-     ZZZZ           ZZZZ       ZZZZZ        777     777    777       777
-     ZZZZZ         ZZZZZ        ZZZZZ       777     777    777       777
-      ZZZZZZ     ZZZZZZ          ZZZZZ      777     7777777777       777
-       ZZZZZZZZZZZZZZZ            ZZZZ      777      77777777        777
-         ZZZZZZZZZZZ               Z
-            ZZZZZ
-
 The friendly Operating System for IoT!
 
 RIOT is a real-time multi-threading operating system that supports a range of


### PR DESCRIPTION
### Contribution description

This PR removes the ASCII art from the readme. It is not relevant for new visitors and it just increases the scrolling distance to the relevant content.

### Testing procedure

Read the new readme

### Issues/PRs references

None

### Discussion

 - Please thumb down if you disagree with this PR.
 - Please thumb up if you agree with this PR.