### PR TITLE
cpu/cc2538: cleanup init, add cc2538_rf_obs_sig module

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -100,13 +100,6 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
-/**
- * @name Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -78,6 +78,15 @@
 /** @} */
 
 /**
+ * @name    RF CORE observable signals settings
+ * @{
+ */
+#define CONFIG_CC2538_RF_OBS_SIG_0_PCX  5   /* PC5 */
+#define CONFIG_CC2538_RF_OBS_SIG_1_PCX  6   /* PC6 */
+#define CONFIG_CC2538_RF_OBS_SIG_2_PCX  7   /* PC7 */
+/** @} */
+
+/**
  * @name    AT86RF215 configuration
  * @{
  */

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -108,13 +108,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-/**
- * @name    Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -82,6 +82,15 @@
 /** @} */
 
 /**
+ * @name    RF CORE observable signals settings
+ * @{
+ */
+#define CONFIG_CC2538_RF_OBS_SIG_0_PCX  5   /* PC5 */
+#define CONFIG_CC2538_RF_OBS_SIG_1_PCX  6   /* PC6 */
+#define CONFIG_CC2538_RF_OBS_SIG_2_PCX  7   /* PC7 */
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -104,13 +104,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-/**
- * @name    Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -360,13 +360,6 @@ typedef gpio_t adc_conf_t;
 #define NWDT_TIME_UPPER_LIMIT          (1000U)
 /** @} */
 
-/**
- * @name Radio peripheral configuration
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -28,7 +28,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/*
+/**
  * @brief MAC timer period
  *
  * The period is set to the CSMA-CA Backoff Period Unit (20 symbols, 320 us).
@@ -38,42 +38,53 @@
 #define TIMER_PERIOD_LSB           (0xF2)
 #define TIMER_PERIOD_MSB           (0x29)
 
-typedef struct {
-    cc2538_reg_t *reg_addr;
-    uint32_t value;
-} init_pair_t;
+/**
+ * @brief MAC timer period
+ *
+ * The period is set to the CSMA-CA Backoff Period Unit (20 symbols, 320 us).
+ * The system clock runs at 32 MHz. Thus, the timeout period is
+ * 320us * 32MHz = ~10738 (0x29F2)
+ */
+#define CCTEST_OBSSELX_EN           (BIT(7))
 
-static const init_pair_t init_table[] = {
-    {&SYS_CTRL_RCGCRFC,      0x01                     },
-    {&SYS_CTRL_SCGCRFC,      0x01                     },
-    {&SYS_CTRL_DCGCRFC,      0x01                     },
-    {&RFCORE_XREG_CCACTRL0,  0xf8                     },
-    {&RFCORE_XREG_TXFILTCFG, 0x09                     },
-    {&RFCORE_XREG_AGCCTRL1,  0x15                     },
-    {&ANA_REGS_IVCTRL,       0x0b                     },
-    {&RFCORE_XREG_MDMTEST1,  0x08                     },
-    {&RFCORE_XREG_FSCAL1,    0x01                     },
-    {&RFCORE_XREG_RXCTRL,    0x3f                     },
-    {&RFCORE_XREG_MDMCTRL1,  0x14                     },
-    {&RFCORE_XREG_ADCTEST0,  0x10                     },
-    {&RFCORE_XREG_ADCTEST1,  0x0e                     },
-    {&RFCORE_XREG_ADCTEST2,  0x03                     },
-    {&RFCORE_XREG_CSPT,      0xff                     },
-    {&RFCORE_XREG_MDMCTRL0,  0x85                     },
-    {&RFCORE_XREG_FSCTRL,    0x55                     },
-    {&RFCORE_XREG_FRMCTRL0,  AUTOCRC | AUTOACK        },
-    {&RFCORE_XREG_FRMCTRL1,  0x00                     },
-    {&RFCORE_XREG_SRCMATCH,  0x00                     },
-    {&RFCORE_XREG_FIFOPCTRL, CC2538_RF_MAX_DATA_LEN   },
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-    {&RFCORE_XREG_RFIRQM0,   FIFOP | RXPKTDONE | SFD  },
-    {&RFCORE_XREG_RFIRQM1,   TXDONE | CSP_STOP | TXACKDONE  },
-#else
-    {&RFCORE_XREG_RFIRQM0,   FIFOP | RXPKTDONE        },
-#endif
-    {&RFCORE_XREG_RFERRM,    STROBE_ERR | TXUNDERF | TXOVERF | RXUNDERF | RXOVERF | NLOCK},
-    {NULL, 0},
-};
+static void _cc2538_setup_mac_timer(void)
+{
+    RFCORE_SFR_MTMSEL &= ~CC2538_SFR_MTMSEL_MASK;
+    /* Select timer period */
+    RFCORE_SFR_MTMSEL |= CC2538_SFR_MTMSEL_TIMER_P;
+
+    /* Fix timer to Backoff period */
+    RFCORE_SFR_MTM0 |= TIMER_PERIOD_LSB;
+    RFCORE_SFR_MTM1 |= TIMER_PERIOD_MSB;
+
+    RFCORE_SFR_MTMSEL &= ~CC2538_SFR_MTMSEL_MASK;
+    RFCORE_SFR_MTCTRL |= CC2538_MCTRL_SYNC_MASK | CC2538_MCTRL_RUN_MASK;
+}
+
+static void _cc2538_observable_signals(void)
+{
+    /* Select on which pin PC0:7 should the selected observable signals
+       be wired through, the signal is selected in CONFIG_CC2538_RF_OBS_%
+       and the pin in CONFIG_CC2538_RF_OBS_SIG_%_PCX */
+    if (IS_USED(MODULE_CC2538_RF_OBS_SIG)) {
+        if (CONFIG_CC2538_RF_OBS_0 != disabled) {
+            RFCORE_XREG_RFC_OBS_CTRL0 = CONFIG_CC2538_RF_OBS_0;
+            *(&CCTEST_OBSSEL0 + CONFIG_CC2538_RF_OBS_SIG_0_PCX) = \
+                CCTEST_OBSSELX_EN | rfc_obs_sig0;
+        }
+        if (CONFIG_CC2538_RF_OBS_1 != disabled) {
+            RFCORE_XREG_RFC_OBS_CTRL1 = CONFIG_CC2538_RF_OBS_1;
+            *(&CCTEST_OBSSEL0 + CONFIG_CC2538_RF_OBS_SIG_1_PCX) = \
+                CCTEST_OBSSELX_EN | rfc_obs_sig1;
+        }
+        if (CONFIG_CC2538_RF_OBS_2 != disabled) {
+            RFCORE_XREG_RFC_OBS_CTRL2 = CONFIG_CC2538_RF_OBS_2;
+            *(&CCTEST_OBSSEL0 + CONFIG_CC2538_RF_OBS_SIG_2_PCX) = \
+                CCTEST_OBSSELX_EN | rfc_obs_sig2;
+        }
+    }
+}
+
 
 bool cc2538_channel_clear(void)
 {
@@ -93,41 +104,54 @@ bool cc2538_channel_clear(void)
 
 void cc2538_init(void)
 {
-    const init_pair_t *pair;
+    /* Enable RF CORE clock in active mode */
+    SYS_CTRL_RCGCRFC = 1UL;
+    /* Enable  RF CORE  clock in sleep mode */
+    SYS_CTRL_SCGCRFC = 1UL;
+    /* Enable  RF CORE  clock in PM0 (system clock always powered down
+        in PM1-3) */
+    SYS_CTRL_DCGCRFC = 1UL;
+    /* Wait for the clock enabling to take effect */
+    while (!(SYS_CTRL_RCGCRFC & 1UL) || \
+           !(SYS_CTRL_SCGCRFC & 1UL) || \
+           !(SYS_CTRL_DCGCRFC & 1UL)
+           ) {}
 
-    for (pair = init_table; pair->reg_addr != NULL; pair++) {
-        *pair->reg_addr = pair->value;
+    /* Register Setting updates for optimal performance, RM section 23.15 */
+    RFCORE_XREG_TXFILTCFG   = 0x09;
+    RFCORE_XREG_AGCCTRL1    = 0x15;
+    RFCORE_XREG_FSCAL1      = 0x01;
+    ANA_REGS_IVCTRL         = 0x0B;
+
+    /* Enable AUTOCRC and AUTOACK by default*/
+    RFCORE_XREG_FRMCTRL0   = AUTOCRC | AUTOACK;
+
+    /* Disable RX after TX, let upper layer change the state */
+    RFCORE_XREG_FRMCTRL1 = 0x00;
+
+    /* Disable source address matching and pending bits */
+    RFCORE_XREG_SRCMATCH = 0x00;
+
+    /* Set FIFOP_THR to its max value*/
+    RFCORE_XREG_FIFOPCTRL = CC2538_RF_MAX_DATA_LEN;
+
+    /* Set default IRQ */
+    if (IS_USED(MODULE_IEEE802154_RADIO_HAL)) {
+        RFCORE_XREG_RFIRQM1 = TXDONE | CSP_STOP | TXACKDONE;
+        RFCORE_XREG_RFIRQM0 = RXPKTDONE | FIFOP | SFD;
+    } else {
+        RFCORE_XREG_RFIRQM0 = RXPKTDONE | FIFOP;
     }
 
-    /* Select the observable signals (maximum of three) */
-    RFCORE_XREG_RFC_OBS_CTRL0 = tx_active;
-    RFCORE_XREG_RFC_OBS_CTRL1 = rx_active;
-    RFCORE_XREG_RFC_OBS_CTRL2 = ffctrl_fifo;
+    /* Enable all RF CORE error interrupts */
+    RFCORE_XREG_RFERRM = STROBE_ERR | TXUNDERF | TXOVERF | \
+                         RXUNDERF | RXOVERF | NLOCK;
 
-    /* Select output pins for the three observable signals */
-#ifdef BOARD_OPENMOTE_CC2538
-    CCTEST_OBSSEL0 = 0;                        /* PC0 = USB_SEL        */
-    CCTEST_OBSSEL1 = 0;                        /* PC1 = N/C            */
-    CCTEST_OBSSEL2 = 0;                        /* PC2 = N/C            */
-    CCTEST_OBSSEL3 = 0;                        /* PC3 = USER_BUTTON    */
-    CCTEST_OBSSEL4 = OBSSEL_EN | rfc_obs_sig0; /* PC4 = RED_LED        */
-    CCTEST_OBSSEL5 = 0;                        /* PC5 = ORANGE_LED     */
-    CCTEST_OBSSEL6 = OBSSEL_EN | rfc_obs_sig1; /* PC6 = YELLOW_LED     */
-    CCTEST_OBSSEL7 = OBSSEL_EN | rfc_obs_sig2; /* PC7 = GREEN_LED      */
-#else
-    /* Assume BOARD_CC2538DK (or similar). */
-    CCTEST_OBSSEL0 = OBSSEL_EN | rfc_obs_sig0; /* PC0 = LED_1 (red)    */
-    CCTEST_OBSSEL1 = OBSSEL_EN | rfc_obs_sig1; /* PC1 = LED_2 (yellow) */
-    CCTEST_OBSSEL2 = OBSSEL_EN | rfc_obs_sig2; /* PC2 = LED_3 (green)  */
-    CCTEST_OBSSEL3 = 0;                        /* PC3 = LED_4 (red)    */
-    CCTEST_OBSSEL4 = 0;                        /* PC4 = BTN_L          */
-    CCTEST_OBSSEL5 = 0;                        /* PC5 = BTN_R          */
-    CCTEST_OBSSEL6 = 0;                        /* PC6 = BTN_UP         */
-    CCTEST_OBSSEL7 = 0;                        /* PC7 = BTN_DN         */
-#endif /* BOARD_OPENMOTE_CC2538 */
+    _cc2538_observable_signals();
 
-    if (SYS_CTRL->I_MAP) {
-        NVIC_SetPriority(RF_RXTX_ALT_IRQn, RADIO_IRQ_PRIO);
+    /* Enable IRQs */
+    if (SYS_CTRL_I_MAP) {
+        NVIC_SetPriority(RF_RXTX_ALT_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_RXTX_ALT_IRQn);
 
         NVIC_SetPriority(RF_ERR_ALT_IRQn, CPU_DEFAULT_IRQ_PRIO);
@@ -147,16 +171,8 @@ void cc2538_init(void)
         NVIC_EnableIRQ(MACTIMER_IRQn);
     }
 
-    RFCORE_SFR_MTMSEL &= ~CC2538_SFR_MTMSEL_MASK;
-    /* Select timer period */
-    RFCORE_SFR_MTMSEL |= CC2538_SFR_MTMSEL_TIMER_P;
-
-    /* Fix timer to Backoff period */
-    RFCORE_SFR_MTM0 |= TIMER_PERIOD_LSB;
-    RFCORE_SFR_MTM1 |= TIMER_PERIOD_MSB;
-
-    RFCORE_SFR_MTMSEL &= ~CC2538_SFR_MTMSEL_MASK;
-    RFCORE_SFR_MTCTRL |= CC2538_MCTRL_SYNC_MASK | CC2538_MCTRL_RUN_MASK;
+    /* setup mac timer */
+    _cc2538_setup_mac_timer();
 
     /* Flush the receive and transmit FIFOs */
     RFCORE_SFR_RFST = ISFLUSHTX;
@@ -165,7 +181,8 @@ void cc2538_init(void)
 
 bool cc2538_is_on(void)
 {
-    return RFCORE->XREG_FSMSTAT1bits.RX_ACTIVE || RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE;
+    return RFCORE->XREG_FSMSTAT1bits.RX_ACTIVE || \
+           RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE;
 }
 
 void cc2538_off(void)

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -130,20 +130,20 @@ void cc2538_init(void)
         NVIC_SetPriority(RF_RXTX_ALT_IRQn, RADIO_IRQ_PRIO);
         NVIC_EnableIRQ(RF_RXTX_ALT_IRQn);
 
-        NVIC_SetPriority(RF_ERR_ALT_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(RF_ERR_ALT_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_ERR_ALT_IRQn);
 
-        NVIC_SetPriority(MAC_TIMER_ALT_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(MAC_TIMER_ALT_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(MAC_TIMER_ALT_IRQn);
     }
     else {
-        NVIC_SetPriority(RF_RXTX_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(RF_RXTX_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_RXTX_IRQn);
 
-        NVIC_SetPriority(RF_ERR_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(RF_ERR_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(RF_ERR_IRQn);
 
-        NVIC_SetPriority(MACTIMER_IRQn, RADIO_IRQ_PRIO);
+        NVIC_SetPriority(MACTIMER_IRQn, CPU_DEFAULT_IRQ_PRIO);
         NVIC_EnableIRQ(MACTIMER_IRQn);
     }
 

--- a/cpu/cc2538/radio/cc2538_rf_internal.c
+++ b/cpu/cc2538/radio/cc2538_rf_internal.c
@@ -64,7 +64,7 @@ void isr_rfcoreerr(void)
 
 void isr_rfcorerxtx(void)
 {
-   cc2538_irq_handler();
+    cc2538_irq_handler();
 
     cortexm_isr_end();
 }

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -9,6 +9,7 @@ PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw
 PSEUDOMODULES += ccn-lite-utils
+PSEUDOMODULES += cc2538_rf_obs_sig
 PSEUDOMODULES += conn_can_isotp_multi
 PSEUDOMODULES += cord_ep_standalone
 PSEUDOMODULES += core_%


### PR DESCRIPTION
### Contribution description

This PR cleans up the init function of the `cc2538_rf` radio module, only non default parameters are set during the init procedure
and observable signals are made an optional modules. There is one important change where the radio does not automatically switch from `TX` to `RX`.

### Testing procedure

- `examples/gnrc_networking` should still work
- `tests/iee802154_hal` should still work
