### PR TITLE
pkg/openwsn: add ieee802154_hal based radio

### DIFF
--- a/boards/cc2538dk/Kconfig
+++ b/boards/cc2538dk/Kconfig
@@ -13,6 +13,7 @@ config BOARD_CC2538DK
     select CPU_MODEL_CC2538NF53
     select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART

--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL ?= cc2538nf53
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/openmote-b/Makefile.dep
+++ b/boards/openmote-b/Makefile.dep
@@ -1,3 +1,8 @@
+# ATM openwsn does not support the at86rf215 radio
+ifneq (,$(filter openwsn,$(USEPKG)))
+  USEMODULE += cc2538_rf
+endif
+
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   ifeq (,$(filter cc2538_rf,$(USEMODULE)))
     USEMODULE += at86rf215

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -87,6 +87,30 @@
 /** @} */
 
 /**
+ * @name    OpenWSN leds configuration
+ * @{
+ */
+#define OPENWSN_LEDPIN_ERROR    LED0_PIN
+#define OPENWSN_LEDPIN_SYNC     LED1_PIN
+#define OPENWSN_LEDPIN_RADIO    LED3_PIN
+#define OPENWSN_LEDPIN_DEBUG    LED2_PIN
+/** @} */
+
+/**
+ * @name    OpenWSN debugpins configuration
+ *
+ * @note This configuration mimics the one done in OpenWSN-fw for the
+ *       same platform
+ * @{
+ */
+#define OPENWSN_DEBUGPIN_FRAME  GPIO_PIN(0, 7) /* A7 */
+#define OPENWSN_DEBUGPIN_ISR    GPIO_PIN(2, 3) /* C3 */
+#define OPENWSN_DEBUGPIN_SLOT   GPIO_PIN(1, 3) /* B3 */
+#define OPENWSN_DEBUGPIN_FSM    GPIO_PIN(1, 2) /* B2 */
+#define OPENWSN_DEBUGPIN_TASK   GPIO_PIN(1, 1) /* B1 */
+#define OPENWSN_DEBUGPIN_RADIO  GPIO_PIN(1, 0) /* B0 */
+
+/**
  * @name    AT86RF215 configuration
  * @{
  */

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -266,7 +266,7 @@ enum {
 #define CONFIG_CC2538_RF_OBS_2      rssi_valid
 #endif
 
-/* Default configration for cc2538dk or similar */
+/* Default configuration for cc2538dk or similar */
 #ifndef CONFIG_CC2538_RF_OBS_SIG_0_PCX
 #define CONFIG_CC2538_RF_OBS_SIG_0_PCX  0   /* PC0 = LED_1 (red) */
 #endif

--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -43,6 +43,19 @@ extern "C" {
 #define CPU_HAS_BITBAND                 (1)
 /** @} */
 
+/**
+ * @name    OpenWSN timing constants
+ *
+ * @{
+ */
+/* Taken from openwsn-fw */
+#define PORT_maxTxDataPrepare   (460/PORT_US_PER_TICK)
+#define PORT_maxRxAckPrepare    (300/PORT_US_PER_TICK)
+#define PORT_maxRxDataPrepare   (300/PORT_US_PER_TICK)
+#define PORT_maxTxAckPrepare    (460/PORT_US_PER_TICK)
+#define PORT_delayTx            (400/PORT_US_PER_TICK)
+/** @} */
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -125,7 +125,6 @@ extern "C" {
 #endif /* SOFTDEVICE_PRESENT */
 /** @} */
 
-
 #ifdef CPU_MODEL_NRF52840XXAA
 /**
  * @name    OpenWSN timing constants
@@ -137,8 +136,9 @@ extern "C" {
 #define PORT_maxRxAckPrepare    (400/PORT_US_PER_TICK)
 #define PORT_maxRxDataPrepare   (400/PORT_US_PER_TICK)
 #define PORT_maxTxAckPrepare    (400/PORT_US_PER_TICK)
-/* Measured 40us @32.768Hz */
-#define PORT_delayTx            (40/PORT_US_PER_TICK)
+/* Measured 220us */
+#define PORT_delayTx            (300/PORT_US_PER_TICK)
+#define PORT_delayRx            (150/PORT_US_PER_TICK)
 /** @} */
 #endif
 

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -125,6 +125,23 @@ extern "C" {
 #endif /* SOFTDEVICE_PRESENT */
 /** @} */
 
+
+#ifdef CPU_MODEL_NRF52840XXAA
+/**
+ * @name    OpenWSN timing constants
+ *
+ * @{
+ */
+/* Taken from OpenWSN @32.768Hz */
+#define PORT_maxTxDataPrepare   (400/PORT_US_PER_TICK)
+#define PORT_maxRxAckPrepare    (400/PORT_US_PER_TICK)
+#define PORT_maxRxDataPrepare   (400/PORT_US_PER_TICK)
+#define PORT_maxTxAckPrepare    (400/PORT_US_PER_TICK)
+/* Measured 40us @32.768Hz */
+#define PORT_delayTx            (40/PORT_US_PER_TICK)
+/** @} */
+#endif
+
 /**
  * @brief   Put the CPU in the low-power 'wait for event' state
  */

--- a/pkg/openwsn/Makefile.dep
+++ b/pkg/openwsn/Makefile.dep
@@ -16,8 +16,6 @@ ifneq (,$(filter openwsn_openstack,$(USEMODULE)))
 
   DEFAULT_MODULE += auto_init_openwsn
 
-  USEMODULE += luid
-  USEMODULE += netdev_default
 endif
 
 ifneq (,$(filter openwsn_scheduler,$(USEMODULE)))
@@ -48,6 +46,23 @@ endif
 ifneq (,$(filter openwsn_crypto,$(USEMODULE)))
   USEMODULE += crypto_3des
   USEMODULE += cipher_modes
+endif
+
+ifneq (,$(filter openwsn_radio,$(USEMODULE)))
+  USEMODULE += netdev_default
+  USEMODULE += luid
+  ifneq (,$(filter cc2538_rf nrf802154,$(USEMODULE)))
+    USEMODULE += openwsn_radio_hal
+  endif
+  ifneq (,$(filter at86rf2xx,$(USEMODULE)))
+    USEMODULE += openwsn_radio_netdev
+  endif
+endif
+
+ifneq (,$(filter openwsn_radio_hal,$(USEMODULE)))
+  USEMODULE += ieee802154_radio_hal
+  # Used here only for dependency resolution
+  DISABLE_MODULE += auto_init_gnrc_netif
 endif
 
 ifneq (,$(filter openwsn_sctimer,$(USEMODULE)))

--- a/pkg/openwsn/Makefile.include
+++ b/pkg/openwsn/Makefile.include
@@ -84,5 +84,13 @@ ifneq (,$(filter at86rf2xx,$(USEMODULE)))
   CFLAGS += -DAT86RF2XX_BASIC_MODE
 endif
 
+# We want the highest possible frequency set for periph_rtt, but not all
+# platforms can configure this value. use highest possible RTT_FREQUENCY
+# for platforms that allow it
+ifneq (,$(filter stm32 nrf52 sam%,$(CPU)))
+  RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
+  CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+endif
+
 # LLVM ARM shows issues with missing definitions for stdatomic
 TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/openwsn/contrib/Makefile
+++ b/pkg/openwsn/contrib/Makefile
@@ -1,6 +1,6 @@
 MODULE = openwsn
 
-SRC := $(filter-out sctimer_% ,$(wildcard *.c))
+SRC := $(filter-out sctimer_% radio_%,$(wildcard *.c))
 
 ifneq (,$(filter openwsn_sctimer_rtt,$(USEMODULE)))
   SRC += sctimer_rtt.c
@@ -8,6 +8,14 @@ endif
 
 ifneq (,$(filter openwsn_sctimer_ztimer,$(USEMODULE)))
   SRC += sctimer_ztimer.c
+endif
+
+ifneq (,$(filter openwsn_radio_hal,$(USEMODULE)))
+  SRC += radio_hal.c
+endif
+
+ifneq (,$(filter openwsn_radio_netdev,$(USEMODULE)))
+  SRC += radio_netdev.c
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/openwsn/contrib/eui64.c
+++ b/pkg/openwsn/contrib/eui64.c
@@ -29,8 +29,21 @@
 
 extern openwsn_radio_t openwsn_radio;
 
+#ifdef MODULE_OPENWSN_RADIO_HAL
+/* HACK: temporary hack while eui_provider still depends on netdev */
+static eui64_t _eui64;
+static bool _eui64_is_set = false;
+#endif
+
 void eui64_get(uint8_t *addressToWrite)
 {
+#ifdef MODULE_OPENWSN_RADIO_HAL
+    if (!_eui64_is_set) {
+        luid_get_eui64(&_eui64);
+        _eui64_is_set = true;
+    }
+    memcpy(addressToWrite, _eui64.uint8, sizeof(_eui64.uint8));
+#else
     eui64_t eui64;
 
     if (openwsn_radio.dev->driver->get(openwsn_radio.dev, NETOPT_ADDRESS_LONG,
@@ -41,4 +54,5 @@ void eui64_get(uint8_t *addressToWrite)
     else {
         luid_get_eui64((eui64_t *) addressToWrite);
     }
+#endif
 }

--- a/pkg/openwsn/contrib/radio_hal.c
+++ b/pkg/openwsn/contrib/radio_hal.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ * @brief       RIOT adaption of the "radio" bsp module
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+#include <sys/uio.h>
+
+#include "leds.h"
+#include "debugpins.h"
+#include "sctimer.h"
+#include "idmanager.h"
+#include "eui64.h"
+
+#include "byteorder.h"
+
+#include "luid.h"
+#include "net/ieee802154.h"
+#include "net/ieee802154/radio.h"
+
+#include "openwsn.h"
+#include "openwsn_radio.h"
+
+#define LOG_LEVEL LOG_NONE
+#include "log.h"
+
+openwsn_radio_t openwsn_radio;
+
+/* stores the event capture time */
+static PORT_TIMER_WIDTH _txrx_event_capture_time = 0;
+
+void _idmanager_addr_override(void)
+{
+    /* Initiate Id manager here and not in `openstack_init` function to
+       allow overriding the short id address before additional stack
+       components are initiated */
+    idmanager_init();
+
+    /* override 16b address to avoid short address collision */
+    network_uint16_t short_addr;
+    luid_get_short(&short_addr);
+    open_addr_t id;
+    id.type = ADDR_16B;
+    memcpy(&id.addr_16b, short_addr.u8, IEEE802154_SHORT_ADDRESS_LEN);
+    idmanager_setMyID(&id);
+
+    /* override PANID */
+    id.type = ADDR_PANID;
+    network_uint16_t panid_be = byteorder_htons(OPENWSN_PANID);
+    memcpy(&id.panid, &panid_be, IEEE802154_SHORT_ADDRESS_LEN);
+    idmanager_setMyID(&id);
+
+    /* recover ADDR_64B */
+    eui64_t eui64;
+    eui64_get(eui64.uint8);
+
+    /* Set all IEEE addresses */
+    uint16_t panid = OPENWSN_PANID;
+    ieee802154_radio_set_hw_addr_filter(openwsn_radio.dev, &short_addr,
+                                        &eui64, &panid);
+
+}
+
+static void _hal_radio_cb(ieee802154_dev_t *dev, ieee802154_trx_ev_t status)
+{
+    (void)dev;
+
+    debugpins_isr_set();
+    _txrx_event_capture_time = sctimer_readCounter();
+    debugpins_isr_clr();
+
+    switch (status) {
+    case IEEE802154_RADIO_CONFIRM_TX_DONE:
+        ieee802154_radio_confirm_transmit(openwsn_radio.dev, NULL);
+        ieee802154_radio_request_set_trx_state(openwsn_radio.dev,
+                                               IEEE802154_TRX_STATE_TRX_OFF);
+        while (ieee802154_radio_confirm_set_trx_state(openwsn_radio.dev) == -EAGAIN) {}
+        openwsn_radio.endFrame_cb(_txrx_event_capture_time);
+        break;
+    case IEEE802154_RADIO_INDICATION_RX_DONE:
+        openwsn_radio.endFrame_cb(_txrx_event_capture_time);
+        break;
+    case IEEE802154_RADIO_INDICATION_TX_START:
+        openwsn_radio.startFrame_cb(_txrx_event_capture_time);
+        break;
+    case IEEE802154_RADIO_INDICATION_RX_START:
+        openwsn_radio.startFrame_cb(_txrx_event_capture_time);
+        break;
+    default:
+        break;
+    }
+}
+
+int openwsn_radio_init(void *radio_dev)
+{
+    assert(radio_dev);
+    ieee802154_dev_t *dev = (ieee802154_dev_t *)radio_dev;
+
+    LOG_DEBUG("[openwsn/radio]: initialize riot-adaptation\n");
+    openwsn_radio.dev = dev;
+
+    /* override short_address and panid*/
+    _idmanager_addr_override();
+
+    if (ieee802154_radio_request_on(dev)) {
+        LOG_ERROR("[openwsn/radio]: unable to initialize device\n");
+        return -1;
+    }
+
+    /* Set the Event Notification */
+    dev->cb = _hal_radio_cb;
+
+    /* If the radio is still not in TRX_OFF state, spin */
+    while (ieee802154_radio_confirm_on(dev) == -EAGAIN) {}
+
+    /* Enable basic mode, no AUTOACK. no CSMA */
+    ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_AACK_DISABLED);
+    /* MAC layer retransmissions are disabled by _set_csma_params() */
+    ieee802154_radio_set_csma_params(dev, NULL, -1);
+
+    if (IS_USED(MODULE_CC2538_RF)) {
+        /* If frame filtering is enabled cc2538 will not accept beacons
+        where the destination-address mode is 0 (no destination address).
+        per rfc8180 4.5.1 the destination address must be set, which means
+        the destination-address mode can't be 0 */
+        ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_PROMISC);
+    }
+
+    /* Configure PHY settings (channel, TX power) */
+    ieee802154_phy_conf_t conf =
+    { .channel = CONFIG_IEEE802154_DEFAULT_CHANNEL,
+      .page = CONFIG_IEEE802154_DEFAULT_CHANNEL,
+      .pow = CONFIG_IEEE802154_DEFAULT_TXPOWER };
+
+    ieee802154_radio_config_phy(dev, &conf);
+
+    return 0;
+}
+
+void radio_setStartFrameCb(radio_capture_cbt cb)
+{
+    openwsn_radio.startFrame_cb = cb;
+}
+
+void radio_setEndFrameCb(radio_capture_cbt cb)
+{
+    openwsn_radio.endFrame_cb = cb;
+}
+
+void radio_reset(void)
+{
+    /* TODO: this is not handled correctly since not all radios implement
+       this */
+    ieee802154_radio_off(openwsn_radio.dev);
+    ieee802154_radio_request_on(openwsn_radio.dev);
+    /* If the radio is still not in TRX_OFF state, spin */
+    while (ieee802154_radio_confirm_on(openwsn_radio.dev) == -EAGAIN) {}
+}
+
+void radio_setFrequency(uint8_t frequency, radio_freq_t tx_or_rx)
+{
+    (void)tx_or_rx;
+
+    ieee802154_phy_conf_t conf =
+    { .channel = frequency,
+      .page = CONFIG_IEEE802154_DEFAULT_CHANNEL,
+      .pow = CONFIG_IEEE802154_DEFAULT_TXPOWER };
+
+    ieee802154_radio_config_phy(openwsn_radio.dev, &conf);
+}
+
+void radio_rfOn(void)
+{
+    ieee802154_radio_request_on(openwsn_radio.dev);
+    /* If the radio is still not in TRX_OFF state, spin */
+    while (ieee802154_radio_confirm_on(openwsn_radio.dev) == -EAGAIN) {}
+    /* HACK: cc2538 does not implement on() correctly, remove when it does*/
+    ieee802154_radio_request_set_trx_state(openwsn_radio.dev,
+                                           IEEE802154_TRX_STATE_TRX_OFF);
+    while (ieee802154_radio_confirm_set_trx_state(openwsn_radio.dev) == -EAGAIN) {}
+}
+
+void radio_rfOff(void)
+{
+    /* radio_rfOff is called in the middle of a slot and is not always
+       followed by an `radio_rfOn`, so don't call `ieee802154_radio_off`
+       and only send the radio to `TrxOFF` instead */
+    int ret = ieee802154_radio_request_set_trx_state(openwsn_radio.dev,
+                                                     IEEE802154_TRX_STATE_TRX_OFF);
+
+    if (ret) {
+        LOG_ERROR("[openwsn/radio]: request_set_trx_state failed %s\n",
+                  __FUNCTION__);
+    }
+    else {
+        debugpins_radio_clr();
+        leds_radio_off();
+        while (ieee802154_radio_confirm_set_trx_state(openwsn_radio.dev) ==
+               -EAGAIN) {}
+    }
+
+}
+
+void radio_loadPacket(uint8_t *packet, uint16_t len)
+{
+    /* OpenWSN `len` accounts for the FCS field which is set by default by
+       netdev, so remove from the actual packet `len` */
+    iolist_t pkt = {
+        .iol_base = (void *)packet,
+        .iol_len = (size_t)(len - IEEE802154_FCS_LEN),
+    };
+
+    if (ieee802154_radio_write(openwsn_radio.dev, &pkt) < 0) {
+        LOG_ERROR("[openwsn/radio]: couldn't load pkt\n");
+    }
+}
+
+void radio_txEnable(void)
+{
+    int ret = ieee802154_radio_request_set_trx_state(openwsn_radio.dev,
+                                                     IEEE802154_TRX_STATE_TX_ON);
+
+    if (ret) {
+        LOG_ERROR("[openwsn/radio]: request_set_trx_state failed %s\n",
+                  __FUNCTION__);
+    }
+    else {
+        while (ieee802154_radio_confirm_set_trx_state(openwsn_radio.dev) ==
+               -EAGAIN) {}
+        debugpins_radio_set();
+        leds_radio_on();
+    }
+}
+
+void radio_txNow(void)
+{
+    int ret = ieee802154_radio_request_transmit(openwsn_radio.dev);
+
+    if (ret) {
+        LOG_ERROR("[openwsn/radio]: request_set_trx_state failed %s\n",
+                  __FUNCTION__);
+    }
+    else {
+        /* Trigger startFrame manually if no IEEE802154_CAP_IRQ_TX_START */
+        if (!ieee802154_radio_has_irq_tx_start(openwsn_radio.dev)) {
+            debugpins_isr_set();
+            _txrx_event_capture_time = sctimer_readCounter();
+            debugpins_isr_clr();
+            openwsn_radio.startFrame_cb(_txrx_event_capture_time);
+        }
+    }
+}
+
+void radio_rxEnable(void)
+{
+    int ret = ieee802154_radio_request_set_trx_state(openwsn_radio.dev,
+                                                     IEEE802154_TRX_STATE_TRX_OFF);
+
+    if (ret) {
+        LOG_ERROR("[openwsn/radio]: request_set_trx_state failed %s\n",
+                  __FUNCTION__);
+    }
+    else {
+        while (ieee802154_radio_confirm_set_trx_state(openwsn_radio.dev) ==
+               -EAGAIN) {}
+        debugpins_radio_set();
+        leds_radio_on();
+    }
+}
+
+void radio_rxNow(void)
+{
+    int ret = ieee802154_radio_request_set_trx_state(openwsn_radio.dev,
+                                                     IEEE802154_TRX_STATE_RX_ON);
+
+    if (ret) {
+        LOG_ERROR("[openwsn/radio]: request_set_trx_state failed %s\n",
+                  __FUNCTION__);
+    }
+    else {
+        while (ieee802154_radio_confirm_set_trx_state(openwsn_radio.dev) ==
+               -EAGAIN) {}
+    }
+}
+
+void radio_getReceivedFrame(uint8_t *bufRead,
+                            uint8_t *lenRead,
+                            uint8_t maxBufLen,
+                            int8_t *rssi,
+                            uint8_t *lqi,
+                            bool *crc)
+{
+    ieee802154_rx_info_t rx_info;
+    size_t size = ieee802154_radio_read(openwsn_radio.dev, bufRead,
+                                        maxBufLen, &rx_info);
+
+    /* FCS is skipped by the radio-hal in the returned length, but
+       OpenWSN includes IEEE802154_FCS_LEN in its length value */
+    *lenRead = size + IEEE802154_FCS_LEN;
+    /* get rssi, lqi & crc */
+    *rssi = rx_info.rssi;
+    *lqi = rx_info.lqi;
+    /* only valid crc frames are currently accepted */
+    *crc = 1;
+}

--- a/pkg/openwsn/include/openwsn_debugpins_params.h
+++ b/pkg/openwsn/include/openwsn_debugpins_params.h
@@ -22,6 +22,7 @@
 #ifndef OPENWSN_DEBUGPINS_PARAMS_H
 #define OPENWSN_DEBUGPINS_PARAMS_H
 
+#include "board.h"
 #include "openwsn_debugpins.h"
 
 #ifdef __cplusplus

--- a/pkg/openwsn/include/openwsn_leds_params.h
+++ b/pkg/openwsn/include/openwsn_leds_params.h
@@ -34,28 +34,36 @@ extern "C" {
  * @note On Nucleo boards the LED pin is shared with SPI -> don't use it!
  * @{
  */
+#ifndef OPENWSN_LEDPIN_ERROR
 #if defined (LED0_PIN) && !defined(MODULE_BOARDS_COMMON_NUCLEO)
 #define OPENWSN_LEDPIN_ERROR            LED0_PIN
 #else
 #define OPENWSN_LEDPIN_ERROR            GPIO_UNDEF
 #endif
+#endif
 
+#ifndef OPENWSN_LEDPIN_SYNC
 #ifdef LED1_PIN
 #define OPENWSN_LEDPIN_SYNC             LED1_PIN
 #else
 #define OPENWSN_LEDPIN_SYNC             GPIO_UNDEF
 #endif
+#endif
 
+#ifndef OPENWSN_LEDPIN_RADIO
 #ifdef LED2_PIN
 #define OPENWSN_LEDPIN_RADIO            LED2_PIN
 #else
 #define OPENWSN_LEDPIN_RADIO            GPIO_UNDEF
 #endif
+#endif
 
+#ifndef OPENWSN_LEDPIN_DEBUG
 #ifdef LED3_PIN
 #define OPENWSN_LEDPIN_DEBUG            LED3_PIN
 #else
 #define OPENWSN_LEDPIN_DEBUG            GPIO_UNDEF
+#endif
 #endif
 
 #ifndef OPENWSN_LED_ON_STATE

--- a/pkg/openwsn/include/openwsn_radio.h
+++ b/pkg/openwsn/include/openwsn_radio.h
@@ -55,25 +55,30 @@ extern "C" {
 #endif
 
 #include "net/netdev.h"
+#include "net/ieee802154/radio.h"
 #include "radio.h"
 
 /**
  * @brief   Initialize OpenWSN radio
  *
- * @param[in]   netdev     pointer to a netdev interface
+ * @param[in]   radio_dev     pointer to a dev interface
  *
  * @return  PID of OpenWSN thread
  * @return  -1 on initialization error
  */
-int openwsn_radio_init(netdev_t *netdev);
+int openwsn_radio_init(void *radio_dev);
 
 /**
  * @brief OpenWSN radio variables structure
  */
 typedef struct {
+#if IS_ACTIVE(MODULE_OPENWSN_RADIO_NETDEV)
+    netdev_t *dev;                    /**< netdev device */
+#else
+    ieee802154_dev_t  *dev;           /**< radio hal */
+#endif
     radio_capture_cbt startFrame_cb;  /**< start of frame capture callback */
     radio_capture_cbt endFrame_cb;    /**< end of frame capture callback */
-    netdev_t *dev;                    /**< netdev device */
 } openwsn_radio_t;
 
 #ifdef __cplusplus

--- a/pkg/openwsn/scheduler/scheduler.c
+++ b/pkg/openwsn/scheduler/scheduler.c
@@ -61,14 +61,14 @@ void scheduler_start(unsigned state)
     /* wait for events */
     event_t *event;
     while ((event = event_wait_multi(_queues, TASKPRIO_MAX))) {
-        debugpins_task_clr();
+        debugpins_task_set();
         event->handler(event);
         /* remove from task list */
         memarray_free(&_scheduler_vars.memarray, event);
 #if SCHEDULER_DEBUG_ENABLE
         scheduler_dbg.numTasksCur--;
 #endif
-        debugpins_task_set();
+        debugpins_task_clr();
     }
 }
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -550,6 +550,9 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
     USEMODULE += nimble_scanlist
     USEMODULE += fmt
   endif
+  ifneq (,$(filter openwsn_%,$(USEMODULE)))
+    USEMODULE += netif
+  endif
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))

--- a/tests/pkg_openwsn/Makefile
+++ b/tests/pkg_openwsn/Makefile
@@ -66,11 +66,3 @@ USEMODULE += shell_commands
 USEMODULE += ztimer_usec
 
 include $(RIOTBASE)/Makefile.include
-
-# We want the highest possible frequency set for periph_rtt, but not all
-# platforms can configure this value. use highest possible RTT_FREQUENCY
-# for platforms that allow it
-ifneq (,$(filter stm32,$(CPU)))
-  RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
-  CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
-endif

--- a/tests/pkg_openwsn/Makefile
+++ b/tests/pkg_openwsn/Makefile
@@ -2,14 +2,33 @@ BOARD ?= iotlab-m3
 
 include ../Makefile.tests_common
 
-# list of arm boards that provide at86rf2xx radios, can't require it so
-# add whitelist
+# list of arm boards that provide at86rf2xx radios, cc2538_rf or nrf52840
+# radios
 BOARD_WHITELIST = \
+  adafruit-clue \
+  adafruit-itsybitsy-nrf52 \
+  arduino-nano-33-ble \
+  cc2538dk \
+  feather-nrf52840 \
+  firefly \
   fox \
   iotlab-m3 \
   iotlab-a8-m3 \
+  nrf52840-mdk \
+  nrf52840dk \
+  nrf52840dongle \
+  omote \
+  openmote-b \
+  openmote-cc2538 \
+  particle-argon \
+  particle-boron \
+  particle-xenon \
   samr21-xpro \
   samr30-xpro \
+  reel \
+  remote-pa \
+  remote-reva \
+  remote-revb \
   #
 
 # OpenWSN Modules
@@ -36,7 +55,7 @@ USEMODULE += openwsn_debugpins
 ifneq (,$(filter openwsn_serial,$(USEMODULE)))
 # Uncomment to use STDIO_UART_DEV as the uart for OpenWSN openserial
 # USEMODULE += stdio_null
-  ifneq (,$(filter iotlab-m3 iotlab-a8-m3,$(BOARD)))
+  ifneq (,$(filter iotlab-% openmote-b,$(BOARD)))
     USEMODULE += stdio_null
   endif
   # OpenWSN serial module can't handle data at more than 115200 bauds/s,


### PR DESCRIPTION
### Contribution description

This PR adds the option to use OpenWSN on top of the `ieee802154_hal` which enables using cc2538 and nrf52840 radios.

### Testing procedure

Run `tests/pkg_openwsn` on a cc2538 and a nr52840 based boards.

- cc2538_rf

```
17:53:22 SUCCESS 35d5 [OPENWSN] booted
17:53:27 SUCCESS Setting mote 3248 as root
17:53:27 ERROR 3248 [IEEE802154E] wrong state 1 in startSlot, at slotOffset 1
17:53:28 INFO registering DAGroot 96-68-31-23-96-16-23-37
17:55:02 SUCCESS 35d5 [OPENWSN] booted
17:55:04 WARNING MoteProbe@/dev/riot/tty-openmote-b_1: invalid serial frame: (10B) 7e-53-35-d5-01-00-fe-ca-35-7e wrong CRC
17:55:04 SUCCESS 891 [OPENWSN] booted
17:55:41 SUCCESS 891 [IEEE802154E] synchronized at slotOffset 0
17:55:49 INFO 891 [SIXTOP] sending a 6top request
17:55:51 WARNING 891 [IEEE802154E] large timeCorr.: -6 ticks (code loc. 1)
17:55:52 WARNING 891 [IEEE802154E] large timeCorr.: 6 ticks (code loc. 0)
17:55:52 SUCCESS 891 [SIXTOP] sixtop return code RC_SUCCESS at sixtop state WAIT_ADDRESPONSE
17:55:58 INFO received RPL DAO from bbbb:0:0:0:3696:31f6:2396:6823
        - parents:
           bbbb:0:0:0:9668:3123:9616:2337
        - children:
17:55:58 WARNING 891 [IEEE802154E] large timeCorr.: -6 ticks (code loc. 1)
17:55:59 WARNING 891 [IEEE802154E] large timeCorr.: 6 ticks (code loc. 0)
```

- nrf52840-mdk
 
```

22:24:39 SUCCESS 161c [OPENWSN] booted
22:24:39 WARNING unregistering DAGroot d6-bf-6c-f1-fc-da-3c-e4
22:24:50 SUCCESS Setting mote 161c as root
22:24:50 ERROR 161c [IEEE802154E] wrong state 1 in startSlot, at slotOffset 1
22:24:50 INFO registering DAGroot d6-bf-6c-f1-fc-da-3c-e4
22:29:07 INFO received RPL DAO from bbbb:0:0:0:daf2:7e75:9bf8:6a9b
        - parents:
           bbbb:0:0:0:d6bf:6cf1:fcda:3ce4
        - children:
22:29:25 INFO received RPL DAO from bbbb:0:0:0:daf2:7e75:9bf8:6a9b
        - parents: 
           bbbb:0:0:0:d6bf:6cf1:fcda:3ce4
        - children:
22:29:31 INFO received RPL DAO from bbbb:0:0:0:daf2:7e75:9bf8:6a9b
        - parents:
           bbbb:0:0:0:d6bf:6cf1:fcda:3ce4
        - children:
22:30:52 INFO received RPL DAO from bbbb:0:0:0:daf2:7e75:9bf8:6a9b
        - parents:
           bbbb:0:0:0:d6bf:6cf1:fcda:3ce4
        - children:
22:32:07 INFO received RPL DAO from bbbb:0:0:0:daf2:7e75:9bf8:6a9b
        - parents:
           bbbb:0:0:0:d6bf:6cf1:fcda:3ce4

```

### Issues/PRs references

Depends on #15144 and #15140
