### PR TITLE
net/gcoap: Fix reference to COAP_LINK_FLAGS in documentation

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -580,6 +580,7 @@ extern "C" {
 
 /**
  * @name Bitwise positional flags for encoding resource links
+ * @anchor COAP_LINK_FLAG_
  * @{
  */
 #define COAP_LINK_FLAG_INIT_RESLIST  (1)  /**< initialize as for first resource
@@ -592,8 +593,8 @@ extern "C" {
 typedef struct {
     unsigned content_format;            /**< link format */
     size_t link_pos;                    /**< position of link within listener */
-    uint16_t flags;                     /**< encoder switches; see GCOAP_LINK_FLAG_*
-                                             constants */
+    uint16_t flags;                     /**< encoder switches; see @ref
+                                             COAP_LINK_FLAG_ constants */
 } coap_link_encoder_ctx_t;
 
 /**


### PR DESCRIPTION
### Contribution description

This is almost a typo-only fix.

It primarily fixes a broken reference (said `GCOAP_LINK_FLAGS`, meant `COAP_LINK_FLAGS`), and in doing that also makes it a link to follow through doxygen.

### Testing procedure

Build documentation, go to coap_link_encoder_ctx_t, look at whether you can find what the flags should be.