### PR TITLE
net/gcoap: Insert registrations at the front

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -887,7 +887,7 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
     ctx.flags = COAP_LINK_FLAG_INIT_RESLIST;
 
     /* write payload */
-    while (listener) {
+    for (; listener != NULL; listener = listener->next) {
         if (!listener->link_encoder) {
             continue;
         }
@@ -912,8 +912,6 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
                 break;
             }
         }
-
-        listener = listener->next;
     }
 
     return (int)pos;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -636,17 +636,12 @@ kernel_pid_t gcoap_init(void)
 
 void gcoap_register_listener(gcoap_listener_t *listener)
 {
-    /* Add the listener to the end of the linked list. */
-    gcoap_listener_t *_last = _coap_state.listeners;
-    while (_last->next) {
-        _last = _last->next;
-    }
-
-    listener->next = NULL;
     if (!listener->link_encoder) {
         listener->link_encoder = gcoap_encode_link;
     }
-    _last->next = listener;
+
+    listener->next = _coap_state.listeners;
+    _coap_state.listeners = listener;
 }
 
 int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
@@ -875,8 +870,7 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
 {
     assert(cf == COAP_FORMAT_LINK);
 
-    /* skip the first listener, gcoap itself (we skip /.well-known/core) */
-    gcoap_listener_t *listener = _coap_state.listeners->next;
+    gcoap_listener_t *listener = _coap_state.listeners;
 
     char *out = (char *)buf;
     size_t pos = 0;

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -49,7 +49,7 @@ static gcoap_listener_t listener_second = {
     .next          = NULL
 };
 
-static const char *resource_list_str = "</act/switch>,</sensor/temp>,</test/info/all>,</second/part>";
+static const char *resource_list_str = "</second/part>,</act/switch>,</sensor/temp>,</test/info/all>";
 
 /*
  * Client GET request success case. Test request generation.


### PR DESCRIPTION
### Contribution description

This is a set of two small fixes to Gcoap:

>   net/gcoap: Avoid endless loop on error
>    
>   The NULL case can not regularly be reached (because regularly
    gcoap_register_listener sets thel link_encoder to a default one), but if
    it is (eg. because an application unsets its link_encoder to hide a
    resource set at runtime), the existing `continue` is a good idea (skip
    over this entry) but erroneously created an endless loop by skipping the
    advancement step.

(Still flagged as "enhancement" because I doubt that this has ever been triggered. If it were, it'd be hard to debug though, as the old check creates an endless loop that "may be assumed by the implementation to terminate").

>   net/gcoap: Register additional resources head-first
> 
>   This simplifies (written and compiled) code by doing a head rather than
    a tail insertion of the new listener into gcoap's list.
>    
>    As handling of listeners without a link_encoder is now fixed,
    gcoap_get_resource_list can handles this now without having to manually
    skip over the .well-known/core handler (which is not the first entry any
    more now).
>    
>    Incidentally, this allows the user to install a custom handler for
    .well-known/core, as the default handler is now evaluated last.

Other than code simplification, this has two more effects:

* If multiple listeners are registered, their links now show up in reversed order. Few applications do this, probably, and either way it's not like there's any semantics to the sequence.
* If addresses are specified in two listeners, the latest now takes precedence. We do not specify how those are resolved. The only practical to-be-overridden path I can think of is .well-known/core, being able to override which is convenient for applications that want more of their .well-known/core than the default implementation can do. (By the way, this is what I was aiming for with those fixes, but I though I'd have to introduce a flag to disable the built-in .well-known/core. While fixing stuff like loops that only worked if they had >= 1 iterations, this change happened, and removes the need for anything complicated).
* The newer listeners are evaluated first. In the common case where .well-known/core is accessed once at discovery, and then many interactions with discovered resources happen, the change should be favorable, but it can't be more than a few hundred cycles difference either way.

### Testing procedure

```
$ make -C examples/gcoap all term &

$ aiocoap-client 'coap://[fe80::something%tapbr0]'/.well-known/core
</cli/stats>; ct="0"; rt="count"; obs,
</riot/board>
$ aiocoap-client 'coap://[fe80::something%tapbr0]'/riot/board
native
```