### PR TITLE
cpu/samd21: remove GCLK7 magic

### DIFF
--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -203,7 +203,7 @@ static void poweroff(pwm_t dev)
     *cfg->tim.mclk &= ~cfg->tim.mclk_mask;
 #else
     PM->APBCMASK.reg &= ~cfg->tim.pm_mask;
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_GEN_GCLK7
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_GEN(cfg->gclk_src)
                       | GCLK_CLKCTRL_ID(cfg->tim.gclk_id);
 #endif
 }

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -251,11 +251,8 @@ static void clk_init(void)
                       | GCLK_GENCTRL_SRC_XOSC32K);
 #endif
 
-    /* redirect all peripherals to a disabled clock generator (7) by default */
-    for (int i = 0x3; i <= 0x22; i++) {
-        GCLK->CLKCTRL.reg = ( GCLK_CLKCTRL_ID(i) | GCLK_CLKCTRL_GEN_GCLK7 );
-        while (GCLK->STATUS.bit.SYNCBUSY) {}
-    }
+    /* make sure we synchronize clock generator 0 before we go on */
+    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 }
 
 void cpu_init(void)


### PR DESCRIPTION
### Contribution description

On samd21 there are still some remnants of an odd practice: connecting a peripheral to a disabled GCLK in order to disable it.

This is not needed. Clearing the `GCLK_CLKCTRL_CLKEN` is entirely sufficient to disable the clock connection to a peripheral, but even just disabling the peripheral in `PM` should be enough.

As it turns out not all members of the extended samd21 family have a GCLK7, this hack is causing more trouble than it's worth. 

### Testing procedure

Run `tests/periph_pwm` and observe the current draw.

```
2020-10-02 22:17:44,639 #  init  0 0 8000 256
2020-10-02 22:17:44,642 # The pwm frequency is set to 11718
5.97 mA

2020-10-02 22:18:09,454 #  power 0 0
2020-10-02 22:18:09,456 # Powering down PWM device
5.30 mA
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
