### PR TITLE
cpu/samd21: improve GCLK7 magic

### DIFF
--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -203,7 +203,7 @@ static void poweroff(pwm_t dev)
     *cfg->tim.mclk &= ~cfg->tim.mclk_mask;
 #else
     PM->APBCMASK.reg &= ~cfg->tim.pm_mask;
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_GEN_GCLK7
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_GEN(SAM0_GCLK_DISABLED)
                       | GCLK_CLKCTRL_ID(cfg->tim.gclk_id);
 #endif
 }

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -252,8 +252,8 @@ static void clk_init(void)
 #endif
 
     /* redirect all peripherals to a disabled clock generator (7) by default */
-    for (int i = 0x3; i <= 0x22; i++) {
-        GCLK->CLKCTRL.reg = ( GCLK_CLKCTRL_ID(i) | GCLK_CLKCTRL_GEN_GCLK7 );
+    for (unsigned i = 0x3; i <= GCLK_CLKCTRL_ID_Msk; i++) {
+        GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID(i) | GCLK_CLKCTRL_GEN(SAM0_GCLK_DISABLED);
         while (GCLK->STATUS.bit.SYNCBUSY) {}
     }
 }

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -60,6 +60,7 @@ enum {
     SAM0_GCLK_1MHZ,                     /**< 1 MHz clock for xTimer */
     SAM0_GCLK_32KHZ,                    /**< 32 kHz clock           */
     SAM0_GCLK_1KHZ,                     /**< 1 kHz clock            */
+    SAM0_GCLK_DISABLED = 0xF,           /**< disabled GCLK          */
 };
 /** @} */
 


### PR DESCRIPTION
### Contribution description

On samd21, unused peripherals are connected to a disabled GCLK7.
This seems very strange an unnecessary, given that it should be enough to clear the `GCLK_CLKCTRL_CLKEN` bit instead.

So I wanted to remove this, only to find out that power savings with this are actually significant. Instead, let's improve it.

As it turns out we don't even need to use a real GCLK here. Using the mask value from `GCLK_CLKCTRL_GEN_Msk` works as well. This way we don't have to 'waste' a real GCLK and this helps with members of the extended samd2x family that don't have a GCLK7.

Make this a named GCLK to make it a bit it less magic. 

Next, let's add back this magic to the `poweroff()` function of the other periph drivers.

### Testing procedure

Run `tests/periph_pwm` and observe the current draw.

#### master

```
# idle
4.22 mA

2020-10-02 22:49:11,658 #  init  0 0 8000 256
2020-10-02 22:49:11,661 # The pwm frequency is set to 11718
4.94 mA

2020-10-02 22:49:29,249 #  power 0 0
2020-10-02 22:49:29,251 # Powering down PWM device.
4.22 mA
```

#### this PR

```
# idle
4.09 mA

2020-10-02 22:17:44,639 #  init  0 0 8000 256
2020-10-02 22:17:44,642 # The pwm frequency is set to 11718
4.81 mA

2020-10-02 22:18:09,454 #  power 0 0
2020-10-02 22:18:09,456 # Powering down PWM device
4.09 mA
```

Without manually disconnecting the GCLK, power consumption is 40 µA higher after the `power 0 0` command (that is, above the level before init).

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
