### PR TITLE
Add const to ciphers

### DIFF
--- a/sys/crypto/modes/cbc.c
+++ b/sys/crypto/modes/cbc.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include "crypto/modes/cbc.h"
 
-int cipher_encrypt_cbc(cipher_t *cipher, uint8_t iv[16],
+int cipher_encrypt_cbc(const cipher_t *cipher, uint8_t iv[16],
                        const uint8_t *input, size_t length, uint8_t *output)
 {
     size_t offset = 0;
@@ -54,7 +54,7 @@ int cipher_encrypt_cbc(cipher_t *cipher, uint8_t iv[16],
 }
 
 
-int cipher_decrypt_cbc(cipher_t *cipher, uint8_t iv[16],
+int cipher_decrypt_cbc(const cipher_t *cipher, uint8_t iv[16],
                        const uint8_t *input, size_t length, uint8_t *output)
 {
     size_t offset = 0;

--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -34,8 +34,8 @@ static inline int min(int a, int b)
     }
 }
 
-static int ccm_compute_cbc_mac(cipher_t *cipher, const uint8_t iv[16],
-                        const uint8_t *input, size_t length, uint8_t *mac)
+static int ccm_compute_cbc_mac(const cipher_t *cipher, const uint8_t iv[16],
+                               const uint8_t *input, size_t length, uint8_t *mac)
 {
     uint8_t block_size, mac_enc[16] = { 0 };
     uint32_t offset;
@@ -70,9 +70,9 @@ static int ccm_compute_cbc_mac(cipher_t *cipher, const uint8_t iv[16],
 }
 
 
-static int ccm_create_mac_iv(cipher_t *cipher, uint8_t auth_data_len, uint8_t M,
-                      uint8_t L, const uint8_t *nonce, uint8_t nonce_len,
-                      size_t plaintext_len, uint8_t X1[16])
+static int ccm_create_mac_iv(const cipher_t *cipher, uint8_t auth_data_len, uint8_t M,
+                             uint8_t L, const uint8_t *nonce, uint8_t nonce_len,
+                             size_t plaintext_len, uint8_t X1[16])
 {
     uint8_t M_, L_;
 
@@ -106,8 +106,8 @@ static int ccm_create_mac_iv(cipher_t *cipher, uint8_t auth_data_len, uint8_t M,
     return 0;
 }
 
-static int ccm_compute_adata_mac(cipher_t *cipher, const uint8_t *auth_data,
-                          uint32_t auth_data_len, uint8_t X1[16])
+static int ccm_compute_adata_mac(const cipher_t *cipher, const uint8_t *auth_data,
+                                 uint32_t auth_data_len, uint8_t X1[16])
 {
     if (auth_data_len > 0) {
         int len;
@@ -174,7 +174,7 @@ static inline int _fits_in_nbytes(size_t value, uint8_t num_bytes)
 }
 
 
-int cipher_encrypt_ccm(cipher_t *cipher,
+int cipher_encrypt_ccm(const cipher_t *cipher,
                        const uint8_t *auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
                        const uint8_t *nonce, size_t nonce_len,
@@ -240,7 +240,7 @@ int cipher_encrypt_ccm(cipher_t *cipher,
 }
 
 
-int cipher_decrypt_ccm(cipher_t *cipher,
+int cipher_decrypt_ccm(const cipher_t *cipher,
                        const uint8_t *auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
                        const uint8_t *nonce, size_t nonce_len,

--- a/sys/crypto/modes/ctr.c
+++ b/sys/crypto/modes/ctr.c
@@ -21,7 +21,7 @@
 #include "crypto/helper.h"
 #include "crypto/modes/ctr.h"
 
-int cipher_encrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+int cipher_encrypt_ctr(const cipher_t *cipher, uint8_t nonce_counter[16],
                        uint8_t nonce_len, const uint8_t *input, size_t length,
                        uint8_t *output)
 {
@@ -49,7 +49,7 @@ int cipher_encrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
     return offset;
 }
 
-int cipher_decrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+int cipher_decrypt_ctr(const cipher_t *cipher, uint8_t nonce_counter[16],
                        uint8_t nonce_len, const uint8_t *input, size_t length,
                        uint8_t *output)
 {

--- a/sys/crypto/modes/ecb.c
+++ b/sys/crypto/modes/ecb.c
@@ -23,7 +23,7 @@
 
 #include "crypto/modes/ecb.h"
 
-int cipher_encrypt_ecb(cipher_t *cipher, uint8_t *input,
+int cipher_encrypt_ecb(const cipher_t *cipher, const uint8_t *input,
                        size_t length, uint8_t *output)
 {
     size_t offset;
@@ -46,7 +46,7 @@ int cipher_encrypt_ecb(cipher_t *cipher, uint8_t *input,
     return offset;
 }
 
-int cipher_decrypt_ecb(cipher_t *cipher, uint8_t *input,
+int cipher_decrypt_ecb(const cipher_t *cipher, const uint8_t *input,
                        size_t length, uint8_t *output)
 {
     size_t offset = 0;

--- a/sys/crypto/modes/ocb.c
+++ b/sys/crypto/modes/ocb.c
@@ -25,7 +25,7 @@
 #define OCB_MODE_DECRYPT 2
 
 struct ocb_state {
-    cipher_t *cipher;
+    const cipher_t *cipher;
     uint8_t l_star[16];
     uint8_t l_zero[16];
     uint8_t l_dollar[16];
@@ -35,7 +35,7 @@ struct ocb_state {
 
 typedef struct ocb_state ocb_state_t;
 
-static void double_block(uint8_t source[16], uint8_t dest[16])
+static void double_block(const uint8_t source[16], uint8_t dest[16])
 {
     uint8_t msb = source[0] >> 7;
 
@@ -61,7 +61,7 @@ static size_t ntz(size_t n)
     return ret;
 }
 
-static void calculate_l_i(uint8_t l_zero[16], size_t i, uint8_t output[16])
+static void calculate_l_i(const uint8_t l_zero[16], size_t i, uint8_t output[16])
 {
     memcpy(output, l_zero, 16);
     while ((i--) > 0) {
@@ -69,7 +69,7 @@ static void calculate_l_i(uint8_t l_zero[16], size_t i, uint8_t output[16])
     }
 }
 
-static void xor_block(uint8_t block1[16], uint8_t block2[16],
+static void xor_block(const uint8_t block1[16], const uint8_t block2[16],
                       uint8_t output[16])
 {
     for (uint8_t i = 0; i < 16; ++i) {
@@ -78,7 +78,8 @@ static void xor_block(uint8_t block1[16], uint8_t block2[16],
 }
 
 static void processBlock(ocb_state_t *state, size_t blockNumber,
-                         uint8_t input[16], uint8_t output[16], uint8_t mode)
+                         const uint8_t input[16], uint8_t output[16],
+                         uint8_t mode)
 {
     /* Offset_i = Offset_{i-1} xor L_{ntz(i)} */
     uint8_t l_i[16];
@@ -106,7 +107,7 @@ static void processBlock(ocb_state_t *state, size_t blockNumber,
     }
 }
 
-static void hash(ocb_state_t *state, uint8_t *data, size_t data_len,
+static void hash(ocb_state_t *state, const uint8_t *data, size_t data_len,
                  uint8_t output[16])
 {
     /* Calculate the number of full blocks in data */
@@ -149,8 +150,9 @@ static void hash(ocb_state_t *state, uint8_t *data, size_t data_len,
     }
 }
 
-static void init_ocb(cipher_t *cipher, uint8_t tag_len, uint8_t *nonce,
-                     size_t nonce_len, ocb_state_t *state)
+static void init_ocb(const cipher_t *cipher, uint8_t tag_len,
+                     const uint8_t *nonce, size_t nonce_len,
+                     ocb_state_t *state)
 {
 
     state->cipher = cipher;
@@ -203,12 +205,12 @@ static void init_ocb(cipher_t *cipher, uint8_t tag_len, uint8_t *nonce,
     memset(state->checksum, 0, 16);
 }
 
-static int32_t run_ocb(cipher_t *cipher, uint8_t *auth_data,
-                       uint32_t auth_data_len,
-                       uint8_t tag[16], uint8_t tag_len, uint8_t *nonce,
-                       size_t nonce_len,
-                       uint8_t *input, size_t input_len, uint8_t *output,
-                       uint8_t mode)
+static int32_t run_ocb(const cipher_t *cipher,
+                       const uint8_t *auth_data, uint32_t auth_data_len,
+                       uint8_t tag[16], uint8_t tag_len,
+                       const uint8_t *nonce, size_t nonce_len,
+                       const uint8_t *input, size_t input_len,
+                       uint8_t *output, uint8_t mode)
 {
 
     /* OCB mode only works for ciphers of block length 16 */
@@ -288,10 +290,12 @@ static int32_t run_ocb(cipher_t *cipher, uint8_t *auth_data,
     return output_pos;
 }
 
-int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
-                           size_t auth_data_len,
-                           uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
-                           uint8_t *input, size_t input_len, uint8_t *output)
+int32_t cipher_encrypt_ocb(const cipher_t *cipher,
+                           const uint8_t *auth_data, size_t auth_data_len,
+                           uint8_t tag_len,
+                           const uint8_t *nonce, size_t nonce_len,
+                           const uint8_t *input, size_t input_len,
+                           uint8_t *output)
 {
     uint8_t tag[16];
 
@@ -314,10 +318,12 @@ int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
     return (cipher_text_length + tag_len);
 }
 
-int32_t cipher_decrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
-                           size_t auth_data_len,
-                           uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
-                           uint8_t *input, size_t input_len, uint8_t *output)
+int32_t cipher_decrypt_ocb(const cipher_t *cipher,
+                           const uint8_t *auth_data, size_t auth_data_len,
+                           uint8_t tag_len,
+                           const uint8_t *nonce, size_t nonce_len,
+                           const uint8_t *input, size_t input_len,
+                           uint8_t *output)
 {
     if (input_len > (uint32_t)(INT32_MAX + tag_len)) {
         // We would not be able to return the proper output length for data this long

--- a/sys/include/crypto/modes/cbc.h
+++ b/sys/include/crypto/modes/cbc.h
@@ -43,7 +43,7 @@ extern "C" {
  * @return            CIPHER_ERR_ENC_FAILED on internal encryption error
  * @return            otherwise number of input bytes that aren't consumed
  */
-int cipher_encrypt_cbc(cipher_t *cipher, uint8_t iv[16], const uint8_t *input,
+int cipher_encrypt_cbc(const cipher_t *cipher, uint8_t iv[16], const uint8_t *input,
                        size_t input_len, uint8_t *output);
 
 
@@ -62,7 +62,7 @@ int cipher_encrypt_cbc(cipher_t *cipher, uint8_t iv[16], const uint8_t *input,
  * @return            CIPHER_ERR_DEC_FAILED on internal decryption error
  * @return            otherwise number of bytes decrypted
  */
-int cipher_decrypt_cbc(cipher_t *cipher, uint8_t iv[16], const uint8_t *input,
+int cipher_decrypt_cbc(const cipher_t *cipher, uint8_t iv[16], const uint8_t *input,
                        size_t input_len, uint8_t *output);
 
 #ifdef __cplusplus

--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -69,7 +69,7 @@ extern "C" {
  *                         can be 0 if input_len=0 (no plaintext)
  * @return                 A negative error code if something went wrong
  */
-int cipher_encrypt_ccm(cipher_t *cipher,
+int cipher_encrypt_ccm(const cipher_t *cipher,
                        const uint8_t *auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
                        const uint8_t *nonce, size_t nonce_len,
@@ -99,7 +99,7 @@ int cipher_encrypt_ccm(cipher_t *cipher,
  *                         can be 0 if only auth_data and MAC is present.
  * @return                 A negative error code if something went wrong
  */
-int cipher_decrypt_ccm(cipher_t *cipher,
+int cipher_decrypt_ccm(const cipher_t *cipher,
                        const uint8_t *auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
                        const uint8_t *nonce, size_t nonce_len,

--- a/sys/include/crypto/modes/ctr.h
+++ b/sys/include/crypto/modes/ctr.h
@@ -44,7 +44,7 @@ extern "C" {
  * @return              Length of encrypted data on a successful encryption
  * @return              A negative error code if something went wrong
  */
-int cipher_encrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+int cipher_encrypt_ctr(const cipher_t *cipher, uint8_t nonce_counter[16],
                        uint8_t nonce_len, const uint8_t *input, size_t length,
                        uint8_t *output);
 
@@ -68,7 +68,7 @@ int cipher_encrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
  * @return              Length of decrypted data on a successful decryption
  * @return              A negative error code if something went wrong
  */
-int cipher_decrypt_ctr(cipher_t *cipher, uint8_t nonce_counter[16],
+int cipher_decrypt_ctr(const cipher_t *cipher, uint8_t nonce_counter[16],
                        uint8_t nonce_len, const uint8_t *input, size_t length,
                        uint8_t *output);
 

--- a/sys/include/crypto/modes/ecb.h
+++ b/sys/include/crypto/modes/ecb.h
@@ -42,8 +42,8 @@ extern "C" {
  * @return           A negative error code if something went wrong
  *
  */
-int cipher_encrypt_ecb(cipher_t *cipher, uint8_t *input, size_t length,
-                       uint8_t *output);
+int cipher_encrypt_ecb(const cipher_t *cipher, const uint8_t *input,
+                       size_t length, uint8_t *output);
 
 
 /**
@@ -59,8 +59,8 @@ int cipher_encrypt_ecb(cipher_t *cipher, uint8_t *input, size_t length,
  * @return           Length of decrypted data on a successful decryption
  * @return           A negative error code if something went wrong
  */
-int cipher_decrypt_ecb(cipher_t *cipher, uint8_t *input, size_t length,
-                       uint8_t *output);
+int cipher_decrypt_ecb(const cipher_t *cipher, const uint8_t *input,
+                       size_t length, uint8_t *output);
 
 #ifdef __cplusplus
 }

--- a/sys/include/crypto/modes/ocb.h
+++ b/sys/include/crypto/modes/ocb.h
@@ -77,10 +77,12 @@ extern "C" {
  *                         It has to be of size data_len + tag_len.
  * @return                 Length of the encrypted data (including the tag) or a (negative) error code
  */
-int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
-                           size_t auth_data_len,
-                           uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
-                           uint8_t *input, size_t input_len, uint8_t *output);
+int32_t cipher_encrypt_ocb(const cipher_t *cipher,
+                           const uint8_t *auth_data, size_t auth_data_len,
+                           uint8_t tag_len,
+                           const uint8_t *nonce, size_t nonce_len,
+                           const uint8_t *input, size_t input_len,
+                           uint8_t *output);
 
 /**
  * @brief Decrypt and verify the authentication of OCB encrypted data.
@@ -100,10 +102,12 @@ int32_t cipher_encrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
  *                         Will contain only zeroes, if the authentication fails.
  * @return                 Length of the plaintext data or a (negative) error code
  */
-int32_t cipher_decrypt_ocb(cipher_t *cipher, uint8_t *auth_data,
-                           size_t auth_data_len,
-                           uint8_t tag_len, uint8_t *nonce, size_t nonce_len,
-                           uint8_t *input, size_t input_len, uint8_t *output);
+int32_t cipher_decrypt_ocb(const cipher_t *cipher,
+                           const uint8_t *auth_data, size_t auth_data_len,
+                           uint8_t tag_len,
+                           const uint8_t *nonce, size_t nonce_len,
+                           const uint8_t *input, size_t input_len,
+                           uint8_t *output);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/sys_crypto/tests-crypto-modes-ccm.c
+++ b/tests/sys_crypto/tests-crypto-modes-ccm.c
@@ -1255,7 +1255,7 @@ static void test_crypto_modes_ccm_decrypt(void)
 }
 
 
-typedef int (*func_ccm_t)(cipher_t *, const uint8_t *, uint32_t,
+typedef int (*func_ccm_t)(const cipher_t *, const uint8_t *, uint32_t,
                           uint8_t, uint8_t, const uint8_t *, size_t,
                           const uint8_t *, size_t, uint8_t *);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I just added a `const` to the cipher functions because the pointer to the cipher can be const. 

### Testing procedure
```
cd tests/sys_crypto
make BOARD=nucleo-f767zi flash term

```
```
2020-10-05 11:04:15,374 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2020-10-05 11:04:18,882 # START
2020-10-05 11:04:18,889 # main(): This is RIOT! (Version: 2020.10-devel-1802-g75101-add_const_to_ciphers)
2020-10-05 11:04:18,918 # ..................................
2020-10-05 11:04:18,919 # OK (34 tests)
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#15150 
