### PR TITLE
gnrc/lorawan : Bug fix for zero CFList

### DIFF
--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -103,7 +103,7 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data,
 
     /* Subtract 1 from join accept max size, since the MHDR was already read */
     uint8_t out[GNRC_LORAWAN_JOIN_ACCEPT_MAX_SIZE - 1];
-    uint8_t has_cflist = (size - 1) >= CFLIST_SIZE;
+    uint8_t has_cflist = (size - 1) > CFLIST_SIZE;
 
     gnrc_lorawan_decrypt_join_accept(mac->appskey, data + 1,
                                      has_cflist, out);
@@ -138,7 +138,10 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data,
     /* delay 0 maps to 1 second */
     mac->rx_delay = ja_hdr->rx_delay ? ja_hdr->rx_delay : 1;
 
-    gnrc_lorawan_process_cflist(mac, out + sizeof(lorawan_join_accept_t) - 1);
+    if (has_cflist) {
+        gnrc_lorawan_process_cflist(mac, out + sizeof(lorawan_join_accept_t) - 1);
+    }
+
     mac->mlme.activation = MLME_ACTIVATION_OTAA;
     status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
 


### PR DESCRIPTION
### Contribution description - 

The PR adds Bugfix to handle zero CFlist in the Join ACK message.

### Testing procedure

- Tested gnrc_lorawan example in [examples](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_lorawan)

- Successfully tested for EU868

###  Issues/PRs references

The issue was discovered while porting region. Random values were getting assigned to channels above 2 which affected uplinks. 
#15081 
