### PR TITLE
gnrc_tcp: Fix typo in config.h

### DIFF
--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -127,7 +127,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Clock granularity for TCP in milliseconds. Dedault is 10 milliseconds (see RFC 6298)
+ * @brief Clock granularity for TCP in milliseconds. Default is 10 milliseconds (see RFC 6298)
  */
 #ifndef CONFIG_GNRC_TCP_RTO_GRANULARITY_MS
 #define CONFIG_GNRC_TCP_RTO_GRANULARITY_MS (10U)


### PR DESCRIPTION
### Contribution description
This PR fixes a small typo in the gnrc_tcp api description


### Testing procedure
Since only the comment is changed, there is nothing to test.


### Issues/PRs references
None

