### PR TITLE
gnrc_tcp: reduce scope of receive buffer

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_rcvbuf.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_rcvbuf.c
@@ -24,7 +24,7 @@
 /**
  * @brief Internal struct holding receive buffers.
  */
-rcvbuf_t _static_buf;
+static rcvbuf_t _static_buf;
 
 /**
  * @brief Initializes all receive buffers.


### PR DESCRIPTION
### Contribution description
This PR declares a compilation unit local variable as static.

### Testing procedure
This PR can be tested by running tests/gnrc_tcp. All tests must be successful.

### Issues/PRs references
None