### PR TITLE
gnrc_tcp: Hide remaining global variables

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -49,16 +49,6 @@
  */
 static evtimer_t _tcp_mbox_timer;
 
-/**
- * @brief Head of liked TCB list.
- */
-gnrc_tcp_tcb_t *_list_tcb_head;
-
-/**
- * @brief Mutex for TCB list synchronization.
- */
-mutex_t _list_tcb_lock;
-
 static void _sched_mbox(evtimer_mbox_event_t *event, uint32_t offset,
                         uint16_t type, mbox_t *mbox)
 {
@@ -352,11 +342,7 @@ int gnrc_tcp_ep_from_str(gnrc_tcp_ep_t *ep, const char *str)
 
 int gnrc_tcp_init(void)
 {
-    /* Initialize mutex for TCB list synchronization */
-    mutex_init(&(_list_tcb_lock));
-
     /* Initialize TCB list */
-    _list_tcb_head = NULL;
     _rcvbuf_init();
 
     /* Initialize timers */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_common.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_common.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Simon Brummer
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc
+ * @{
+ *
+ * @file
+ * @brief       GNRC TCP common function implementation
+ *
+ * @author      Simon Brummer <simon.brummer@posteo.de>
+ * @}
+ */
+
+#include "internal/common.h"
+
+static tcb_list_t _list = {NULL, MUTEX_INIT};
+
+tcb_list_t *_gnrc_tcp_common_get_tcb_list(void)
+{
+    return &_list;
+}

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -216,8 +216,9 @@ static int _receive(gnrc_pktsnip_t *pkt)
     }
 
     /* Find TCB to for this packet */
-    mutex_lock(&_list_tcb_lock);
-    tcb = _list_tcb_head;
+    tcb_list_t *list = _gnrc_tcp_common_get_tcb_list();
+    mutex_lock(&list->lock);
+    tcb = list->head;
     while (tcb) {
 #ifdef MODULE_GNRC_IPV6
         /* Check if current TCB is fitting for the incoming packet */
@@ -250,7 +251,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
 #endif
         tcb = tcb->next;
     }
-    mutex_unlock(&_list_tcb_lock);
+    mutex_unlock(&list->lock);
 
     /* Call FSM with event RCVD_PKT if a fitting TCB was found */
     /* cppcheck-suppress knownConditionTrueFalse

--- a/sys/net/gnrc/transport_layer/tcp/internal/common.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/common.h
@@ -115,14 +115,19 @@ extern "C" {
 #define GET_OFFSET( x ) (((x) & MSK_OFFSET) >> 12)
 
 /**
- * @brief Head of linked TCB list.
+ * @brief TCB list type.
  */
-extern gnrc_tcp_tcb_t *_list_tcb_head;
+typedef struct {
+    gnrc_tcp_tcb_t *head; /**< Head of TCB list */
+    mutex_t lock;         /**< Lock of TCB list */
+} tcb_list_t;
 
 /**
- * @brief Mutex to protect TCB list.
+ * @brief Function to access to TCB list
+ *
+ * @returns Pointer to global TCB list.
  */
-extern mutex_t _list_tcb_lock;
+tcb_list_t *_gnrc_tcp_common_get_tcb_list(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description
This PR hides all remaining global variables in gnrc_tcp within a accessor function.

### Testing procedure
This PR can be tested by running tests/gnrc_tcp. All test cases must succed.

### Issues/PRs references
None