### PR TITLE
tests/mpu_stack_guard: add automatic test script

### DIFF
--- a/tests/mpu_stack_guard/tests/01-run.py
+++ b/tests/mpu_stack_guard/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("MPU Stack Guard Test\r\n")
+    for _ in range(100):
+        child.expect(r"counter =[ ]+\d+, SP = 0x[0-9a-f]+, canary = 0xdeadbeef")
+    child.expect(r".*RIOT kernel panic:")
+    child.expect_exact("MEM MANAGE HANDLER\r\n")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=10))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a simple Python test script to the `tests/mpu_stack_guard` test application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `make BOARD=<board supporting MPU> tests/mpu_stack_guard flash test`

<details><summary>nucleo-l412kb</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-l412kb -C tests/mpu_stack_guard flash test
make: Entering directory '/work/riot/RIOT/tests/mpu_stack_guard'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l412kb'  -w '/data/riotbuild/riotbase/tests/mpu_stack_guard/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l412kb'    
Building application "tests_mpu_stack_guard" for "nucleo-l412kb" with MCU "stm32".

[INFO] updating stm32cmsis /data/riotbuild/riotbase/cpu/stm32/include/vendor/cmsis/l4/.pkg-state.git-downloaded
echo e442c72651e8d4757f6562acc14da949644944ce   > /data/riotbuild/riotbase/cpu/stm32/include/vendor/cmsis/l4/.pkg-state.git-downloaded
[INFO] patch stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nucleo-l412kb
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  10572	    132	   3916	  14620	   391c	/data/riotbuild/riotbase/tests/mpu_stack_guard/bin/nucleo-l412kb/tests_mpu_stack_guard.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/mpu_stack_guard/bin/nucleo-l412kb/tests_mpu_stack_guard.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-09-29-10:54)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J31M21 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.248453
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 38389 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0800089c msp: 0x20000200
Info : device idcode = 0x10006464 (STM32L41/L42xx - Rev: A)
Info : flash size = 128kbytes
Info : flash mode : single-bank
Warn : Adding extra erase range, 0x080029d0 .. 0x08002fff
auto erase enabled
wrote 10704 bytes from file /work/riot/RIOT/tests/mpu_stack_guard/bin/nucleo-l412kb/tests_mpu_stack_guard.elf in 0.712441s (14.672 KiB/s)

verified 10704 bytes in 0.487184s (21.456 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2021.01-devel-1-g67e53-pr/tests/mpu_stack_guard_autotest)

MPU Stack Guard Test

If the test fails, the canary value will change unexpectedly
after ~150 iterations. If the test succeeds, the MEM MANAGE HANDLER
will trigger a RIOT kernel panic before the canary value changes.

The mpu_stack_guard module is present. Expect the test to succeed.

counter =   0, SP = 0x20000840, canary = 0xdeadbeef
counter =   1, SP = 0x20000838, canary = 0xdeadbeef
counter =   2, SP = 0x20000830, canary = 0xdeadbeef
counter =   3, SP = 0x20000828, canary = 0xdeadbeef
counter =   4, SP = 0x20000820, canary = 0xdeadbeef
counter =   5, SP = 0x20000818, canary = 0xdeadbeef
counter =   6, SP = 0x20000810, canary = 0xdeadbeef
counter =   7, SP = 0x20000808, canary = 0xdeadbeef
counter =   8, SP = 0x20000800, canary = 0xdeadbeef
counter =   9, SP = 0x200007f8, canary = 0xdeadbeef
counter =  10, SP = 0x200007f0, canary = 0xdeadbeef
counter =  11, SP = 0x200007e8, canary = 0xdeadbeef
counter =  12, SP = 0x200007e0, canary = 0xdeadbeef
counter =  13, SP = 0x200007d8, canary = 0xdeadbeef
counter =  14, SP = 0x200007d0, canary = 0xdeadbeef
counter =  15, SP = 0x200007c8, canary = 0xdeadbeef
counter =  16, SP = 0x200007c0, canary = 0xdeadbeef
counter =  17, SP = 0x200007b8, canary = 0xdeadbeef
counter =  18, SP = 0x200007b0, canary = 0xdeadbeef
counter =  19, SP = 0x200007a8, canary = 0xdeadbeef
counter =  20, SP = 0x200007a0, canary = 0xdeadbeef
counter =  21, SP = 0x20000798, canary = 0xdeadbeef
counter =  22, SP = 0x20000790, canary = 0xdeadbeef
counter =  23, SP = 0x20000788, canary = 0xdeadbeef
counter =  24, SP = 0x20000780, canary = 0xdeadbeef
counter =  25, SP = 0x20000778, canary = 0xdeadbeef
counter =  26, SP = 0x20000770, canary = 0xdeadbeef
counter =  27, SP = 0x20000768, canary = 0xdeadbeef
counter =  28, SP = 0x20000760, canary = 0xdeadbeef
counter =  29, SP = 0x20000758, canary = 0xdeadbeef
counter =  30, SP = 0x20000750, canary = 0xdeadbeef
counter =  31, SP = 0x20000748, canary = 0xdeadbeef
counter =  32, SP = 0x20000740, canary = 0xdeadbeef
counter =  33, SP = 0x20000738, canary = 0xdeadbeef
counter =  34, SP = 0x20000730, canary = 0xdeadbeef
counter =  35, SP = 0x20000728, canary = 0xdeadbeef
counter =  36, SP = 0x20000720, canary = 0xdeadbeef
counter =  37, SP = 0x20000718, canary = 0xdeadbeef
counter =  38, SP = 0x20000710, canary = 0xdeadbeef
counter =  39, SP = 0x20000708, canary = 0xdeadbeef
counter =  40, SP = 0x20000700, canary = 0xdeadbeef
counter =  41, SP = 0x200006f8, canary = 0xdeadbeef
counter =  42, SP = 0x200006f0, canary = 0xdeadbeef
counter =  43, SP = 0x200006e8, canary = 0xdeadbeef
counter =  44, SP = 0x200006e0, canary = 0xdeadbeef
counter =  45, SP = 0x200006d8, canary = 0xdeadbeef
counter =  46, SP = 0x200006d0, canary = 0xdeadbeef
counter =  47, SP = 0x200006c8, canary = 0xdeadbeef
counter =  48, SP = 0x200006c0, canary = 0xdeadbeef
counter =  49, SP = 0x200006b8, canary = 0xdeadbeef
counter =  50, SP = 0x200006b0, canary = 0xdeadbeef
counter =  51, SP = 0x200006a8, canary = 0xdeadbeef
counter =  52, SP = 0x200006a0, canary = 0xdeadbeef
counter =  53, SP = 0x20000698, canary = 0xdeadbeef
counter =  54, SP = 0x20000690, canary = 0xdeadbeef
counter =  55, SP = 0x20000688, canary = 0xdeadbeef
counter =  56, SP = 0x20000680, canary = 0xdeadbeef
counter =  57, SP = 0x20000678, canary = 0xdeadbeef
counter =  58, SP = 0x20000670, canary = 0xdeadbeef
counter =  59, SP = 0x20000668, canary = 0xdeadbeef
counter =  60, SP = 0x20000660, canary = 0xdeadbeef
counter =  61, SP = 0x20000658, canary = 0xdeadbeef
counter =  62, SP = 0x20000650, canary = 0xdeadbeef
counter =  63, SP = 0x20000648, canary = 0xdeadbeef
counter =  64, SP = 0x20000640, canary = 0xdeadbeef
counter =  65, SP = 0x20000638, canary = 0xdeadbeef
counter =  66, SP = 0x20000630, canary = 0xdeadbeef
counter =  67, SP = 0x20000628, canary = 0xdeadbeef
counter =  68, SP = 0x20000620, canary = 0xdeadbeef
counter =  69, SP = 0x20000618, canary = 0xdeadbeef
counter =  70, SP = 0x20000610, canary = 0xdeadbeef
counter =  71, SP = 0x20000608, canary = 0xdeadbeef
counter =  72, SP = 0x20000600, canary = 0xdeadbeef
counter =  73, SP = 0x200005f8, canary = 0xdeadbeef
counter =  74, SP = 0x200005f0, canary = 0xdeadbeef
counter =  75, SP = 0x200005e8, canary = 0xdeadbeef
counter =  76, SP = 0x200005e0, canary = 0xdeadbeef
counter =  77, SP = 0x200005d8, canary = 0xdeadbeef
counter =  78, SP = 0x200005d0, canary = 0xdeadbeef
counter =  79, SP = 0x200005c8, canary = 0xdeadbeef
counter =  80, SP = 0x200005c0, canary = 0xdeadbeef
counter =  81, SP = 0x200005b8, canary = 0xdeadbeef
counter =  82, SP = 0x200005b0, canary = 0xdeadbeef
counter =  83, SP = 0x200005a8, canary = 0xdeadbeef
counter =  84, SP = 0x200005a0, canary = 0xdeadbeef
counter =  85, SP = 0x20000598, canary = 0xdeadbeef
counter =  86, SP = 0x20000590, canary = 0xdeadbeef
counter =  87, SP = 0x20000588, canary = 0xdeadbeef
counter =  88, SP = 0x20000580, canary = 0xdeadbeef
counter =  89, SP = 0x20000578, canary = 0xdeadbeef
counter =  90, SP = 0x20000570, canary = 0xdeadbeef
counter =  91, SP = 0x20000568, canary = 0xdeadbeef
counter =  92, SP = 0x20000560, canary = 0xdeadbeef
counter =  93, SP = 0x20000558, canary = 0xdeadbeef
counter =  94, SP = 0x20000550, canary = 0xdeadbeef
counter =  95, SP = 0x20000548, canary = 0xdeadbeef
counter =  96, SP = 0x20000540, canary = 0xdeadbeef
counter =  97, SP = 0x20000538, canary = 0xdeadbeef
counter =  98, SP = 0x20000530, canary = 0xdeadbeef
counter =  99, SP = 0x20000528, canary = 0xdeadbeef
counter = 100, SP = 0x20000520, canary = 0xdeadbeef
counter = 101, SP = 0x20000518, canary = 0xdeadbeef
counter = 102, SP = 0x20000510, canary = 0xdeadbeef
counter = 103, SP = 0x20000508, canary = 0xdeadbeef
counter = 104, SP = 0x20000500, canary = 0xdeadbeef
counter = 105, SP = 0x200004f8, canary = 0xdeadbeef
counter = 106, SP = 0x200004f0, canary = 0xdeadbeef
counter = 107, SP = 0x200004e8, canary = 0xdeadbeef
counter = 108, SP = 0x200004e0, canary = 0xdeadbeef
counter = 109, SP = 0x200004d8, canary = 0xdeadbeef
counter = 110, SP = 0x200004d0, canary = 0xdeadbeef
counter = 111, SP = 0x200004c8, canary = 0xdeadbeef
counter = 112, SP = 0x200004c0, canary = 0xdeadbeef
counter = 113, SP = 0x200004b8, canary = 0xdeadbeef
counter = 114, SP = 0x200004b0, canary = 0xdeadbeef
counter = 115, SP = 0x200004a8, canary = 0xdeadbeef
counter = 116, SP = 0x200004a0, canary = 0xdeadbeef
counter = 117, SP = 0x20000498, canary = 0xdeadbeef
counter = 118, SP = 0x20000490, canary = 0xdeadbeef
counter = 119, SP = 0x20000488, canary = 0xdeadbeef
counter = 120, SP = 0x20000480, canary = 0xdeadbeef
counter = 121, SP = 0x20000478, canary = 0xdeadbeef
counter = 122, SP = 0x20000470, canary = 0xdeadbeef
counter = 123, SP = 0x20000468, canary = 0xdeadbeef
counter = 124, SP = 0x20000460, canary = 0xdeadbeef
counter = 125, SP = 0x20000458, canary = 0xdeadbeef
counter = 126, SP = 0x20000450, canary = 0xdeadbeef
counter = 127, SP = 0x20000448, canary = 0xdeadbeef
counter = 128, SP = 0x20000440, canary = 0xdeadbeef
counter = 129, SP = 0x20000438, canary = 0xdeadbeef
counter = 130, SP = 0x20000430, canary = 0xdeadbeef
counter = 131, SP = 0x20000428, canary = 0xdeadbeef
counter = 132, SP = 0x20000420, canary = 0xdeadbeef
counter = 133, SP = 0x20000418, canary = 0xdeadbeef
counter = 134, SP = 0x20000410, canary = 0xdeadbeef
counter = 135, SP = 0x20000408, canary = 0xdeadbeef
counter = 136, SP = 0x20000400, canary = 0xdeadbeef
counter = 137, SP = 0x200003f8, canary = 0xdeadbeef
counter = 138, SP = 0x200003f0, canary = 0xdeadbeef
counter = 139, SP = 0x200003e8, canary = 0xdeadbeef
counter =*** RIOT kernel panic:
MEM MANAGE HANDLER


make: Leaving directory '/work/riot/RIOT/tests/mpu_stack_guard'

```

</details>

<details><summary>nucleo-g431rb</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-g431rb -C tests/mpu_stack_guard flash test
make: Entering directory '/work/riot/RIOT/tests/mpu_stack_guard'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-g431rb'  -w '/data/riotbuild/riotbase/tests/mpu_stack_guard/' 'riot/riotbuild:latest' make 'BOARD=nucleo-g431rb'    
Building application "tests_mpu_stack_guard" for "nucleo-g431rb" with MCU "stm32".

[INFO] updating stm32cmsis /data/riotbuild/riotbase/cpu/stm32/include/vendor/cmsis/g4/.pkg-state.git-downloaded
echo 7194c403cd5e4bd8bd4621a21d366d525e61b998   > /data/riotbuild/riotbase/cpu/stm32/include/vendor/cmsis/g4/.pkg-state.git-downloaded
[INFO] patch stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nucleo-g431rb
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  11460	    132	   3916	  15508	   3c94	/data/riotbuild/riotbase/tests/mpu_stack_guard/bin/nucleo-g431rb/tests_mpu_stack_guard.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/mpu_stack_guard/bin/nucleo-g431rb/tests_mpu_stack_guard.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-09-29-10:54)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 2000 kHz
Info : STLINK V3J2M1 (API v3) VID:PID 0483:374E
Info : Target voltage: 3.325301
Info : stm32g4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32g4x.cpu on 0
Info : Listening on port 46793 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32g4x.cpu       hla_target little stm32g4x.cpu       reset

Info : Unable to match requested speed 2000 kHz, using 1000 kHz
Info : Unable to match requested speed 2000 kHz, using 1000 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0800089c msp: 0x20000200
Info : device idcode = 0x20016468 (STM32G43/G44xx - Rev: Z)
Info : flash size = 128kbytes
Info : flash mode : single-bank
Warn : Adding extra erase range, 0x08002d48 .. 0x08002fff
auto erase enabled
wrote 11592 bytes from file /work/riot/RIOT/tests/mpu_stack_guard/bin/nucleo-g431rb/tests_mpu_stack_guard.elf in 0.454053s (24.932 KiB/s)

verified 11592 bytes in 0.163313s (69.317 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1000 kHz
Info : Unable to match requested speed 2000 kHz, using 1000 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2021.01-devel-1-g67e53-pr/tests/mpu_stack_guard_autotest)

MPU Stack Guard Test

If the test fails, the canary value will change unexpectedly
after ~150 iterations. If the test succeeds, the MEM MANAGE HANDLER
will trigger a RIOT kernel panic before the canary value changes.

The mpu_stack_guard module is present. Expect the test to succeed.

counter =   0, SP = 0x20000840, canary = 0xdeadbeef
counter =   1, SP = 0x20000838, canary = 0xdeadbeef
counter =   2, SP = 0x20000830, canary = 0xdeadbeef
counter =   3, SP = 0x20000828, canary = 0xdeadbeef
counter =   4, SP = 0x20000820, canary = 0xdeadbeef
counter =   5, SP = 0x20000818, canary = 0xdeadbeef
counter =   6, SP = 0x20000810, canary = 0xdeadbeef
counter =   7, SP = 0x20000808, canary = 0xdeadbeef
counter =   8, SP = 0x20000800, canary = 0xdeadbeef
counter =   9, SP = 0x200007f8, canary = 0xdeadbeef
counter =  10, SP = 0x200007f0, canary = 0xdeadbeef
counter =  11, SP = 0x200007e8, canary = 0xdeadbeef
counter =  12, SP = 0x200007e0, canary = 0xdeadbeef
counter =  13, SP = 0x200007d8, canary = 0xdeadbeef
counter =  14, SP = 0x200007d0, canary = 0xdeadbeef
counter =  15, SP = 0x200007c8, canary = 0xdeadbeef
counter =  16, SP = 0x200007c0, canary = 0xdeadbeef
counter =  17, SP = 0x200007b8, canary = 0xdeadbeef
counter =  18, SP = 0x200007b0, canary = 0xdeadbeef
counter =  19, SP = 0x200007a8, canary = 0xdeadbeef
counter =  20, SP = 0x200007a0, canary = 0xdeadbeef
counter =  21, SP = 0x20000798, canary = 0xdeadbeef
counter =  22, SP = 0x20000790, canary = 0xdeadbeef
counter =  23, SP = 0x20000788, canary = 0xdeadbeef
counter =  24, SP = 0x20000780, canary = 0xdeadbeef
counter =  25, SP = 0x20000778, canary = 0xdeadbeef
counter =  26, SP = 0x20000770, canary = 0xdeadbeef
counter =  27, SP = 0x20000768, canary = 0xdeadbeef
counter =  28, SP = 0x20000760, canary = 0xdeadbeef
counter =  29, SP = 0x20000758, canary = 0xdeadbeef
counter =  30, SP = 0x20000750, canary = 0xdeadbeef
counter =  31, SP = 0x20000748, canary = 0xdeadbeef
counter =  32, SP = 0x20000740, canary = 0xdeadbeef
counter =  33, SP = 0x20000738, canary = 0xdeadbeef
counter =  34, SP = 0x20000730, canary = 0xdeadbeef
counter =  35, SP = 0x20000728, canary = 0xdeadbeef
counter =  36, SP = 0x20000720, canary = 0xdeadbeef
counter =  37, SP = 0x20000718, canary = 0xdeadbeef
counter =  38, SP = 0x20000710, canary = 0xdeadbeef
counter =  39, SP = 0x20000708, canary = 0xdeadbeef
counter =  40, SP = 0x20000700, canary = 0xdeadbeef
counter =  41, SP = 0x200006f8, canary = 0xdeadbeef
counter =  42, SP = 0x200006f0, canary = 0xdeadbeef
counter =  43, SP = 0x200006e8, canary = 0xdeadbeef
counter =  44, SP = 0x200006e0, canary = 0xdeadbeef
counter =  45, SP = 0x200006d8, canary = 0xdeadbeef
counter =  46, SP = 0x200006d0, canary = 0xdeadbeef
counter =  47, SP = 0x200006c8, canary = 0xdeadbeef
counter =  48, SP = 0x200006c0, canary = 0xdeadbeef
counter =  49, SP = 0x200006b8, canary = 0xdeadbeef
counter =  50, SP = 0x200006b0, canary = 0xdeadbeef
counter =  51, SP = 0x200006a8, canary = 0xdeadbeef
counter =  52, SP = 0x200006a0, canary = 0xdeadbeef
counter =  53, SP = 0x20000698, canary = 0xdeadbeef
counter =  54, SP = 0x20000690, canary = 0xdeadbeef
counter =  55, SP = 0x20000688, canary = 0xdeadbeef
counter =  56, SP = 0x20000680, canary = 0xdeadbeef
counter =  57, SP = 0x20000678, canary = 0xdeadbeef
counter =  58, SP = 0x20000670, canary = 0xdeadbeef
counter =  59, SP = 0x20000668, canary = 0xdeadbeef
counter =  60, SP = 0x20000660, canary = 0xdeadbeef
counter =  61, SP = 0x20000658, canary = 0xdeadbeef
counter =  62, SP = 0x20000650, canary = 0xdeadbeef
counter =  63, SP = 0x20000648, canary = 0xdeadbeef
counter =  64, SP = 0x20000640, canary = 0xdeadbeef
counter =  65, SP = 0x20000638, canary = 0xdeadbeef
counter =  66, SP = 0x20000630, canary = 0xdeadbeef
counter =  67, SP = 0x20000628, canary = 0xdeadbeef
counter =  68, SP = 0x20000620, canary = 0xdeadbeef
counter =  69, SP = 0x20000618, canary = 0xdeadbeef
counter =  70, SP = 0x20000610, canary = 0xdeadbeef
counter =  71, SP = 0x20000608, canary = 0xdeadbeef
counter =  72, SP = 0x20000600, canary = 0xdeadbeef
counter =  73, SP = 0x200005f8, canary = 0xdeadbeef
counter =  74, SP = 0x200005f0, canary = 0xdeadbeef
counter =  75, SP = 0x200005e8, canary = 0xdeadbeef
counter =  76, SP = 0x200005e0, canary = 0xdeadbeef
counter =  77, SP = 0x200005d8, canary = 0xdeadbeef
counter =  78, SP = 0x200005d0, canary = 0xdeadbeef
counter =  79, SP = 0x200005c8, canary = 0xdeadbeef
counter =  80, SP = 0x200005c0, canary = 0xdeadbeef
counter =  81, SP = 0x200005b8, canary = 0xdeadbeef
counter =  82, SP = 0x200005b0, canary = 0xdeadbeef
counter =  83, SP = 0x200005a8, canary = 0xdeadbeef
counter =  84, SP = 0x200005a0, canary = 0xdeadbeef
counter =  85, SP = 0x20000598, canary = 0xdeadbeef
counter =  86, SP = 0x20000590, canary = 0xdeadbeef
counter =  87, SP = 0x20000588, canary = 0xdeadbeef
counter =  88, SP = 0x20000580, canary = 0xdeadbeef
counter =  89, SP = 0x20000578, canary = 0xdeadbeef
counter =  90, SP = 0x20000570, canary = 0xdeadbeef
counter =  91, SP = 0x20000568, canary = 0xdeadbeef
counter =  92, SP = 0x20000560, canary = 0xdeadbeef
counter =  93, SP = 0x20000558, canary = 0xdeadbeef
counter =  94, SP = 0x20000550, canary = 0xdeadbeef
counter =  95, SP = 0x20000548, canary = 0xdeadbeef
counter =  96, SP = 0x20000540, canary = 0xdeadbeef
counter =  97, SP = 0x20000538, canary = 0xdeadbeef
counter =  98, SP = 0x20000530, canary = 0xdeadbeef
counter =  99, SP = 0x20000528, canary = 0xdeadbeef
counter = 100, SP = 0x20000520, canary = 0xdeadbeef
counter = 101, SP = 0x20000518, canary = 0xdeadbeef
counter = 102, SP = 0x20000510, canary = 0xdeadbeef
counter = 103, SP = 0x20000508, canary = 0xdeadbeef
counter = 104, SP = 0x20000500, canary = 0xdeadbeef
counter = 105, SP = 0x200004f8, canary = 0xdeadbeef
counter = 106, SP = 0x200004f0, canary = 0xdeadbeef
counter = 107, SP = 0x200004e8, canary = 0xdeadbeef
counter = 108, SP = 0x200004e0, canary = 0xdeadbeef
counter = 109, SP = 0x200004d8, canary = 0xdeadbeef
counter = 110, SP = 0x200004d0, canary = 0xdeadbeef
counter = 111, SP = 0x200004c8, canary = 0xdeadbeef
counter = 112, SP = 0x200004c0, canary = 0xdeadbeef
counter = 113, SP = 0x200004b8, canary = 0xdeadbeef
counter = 114, SP = 0x200004b0, canary = 0xdeadbeef
counter = 115, SP = 0x200004a8, canary = 0xdeadbeef
counter = 116, SP = 0x200004a0, canary = 0xdeadbeef
counter = 117, SP = 0x20000498, canary = 0xdeadbeef
counter = 118, SP = 0x20000490, canary = 0xdeadbeef
counter = 119, SP = 0x20000488, canary = 0xdeadbeef
counter = 120, SP = 0x20000480, canary = 0xdeadbeef
counter = 121, SP = 0x20000478, canary = 0xdeadbeef
counter = 122, SP = 0x20000470, canary = 0xdeadbeef
counter = 123, SP = 0x20000468, canary = 0xdeadbeef
counter = 124, SP = 0x20000460, canary = 0xdeadbeef
counter = 125, SP = 0x20000458, canary = 0xdeadbeef
counter = 126, SP = 0x20000450, canary = 0xdeadbeef
counter = 127, SP = 0x20000448, canary = 0xdeadbeef
counter = 128, SP = 0x20000440, canary = 0xdeadbeef
counter = 129, SP = 0x20000438, canary = 0xdeadbeef
counter = 130, SP = 0x20000430, canary = 0xdeadbeef
counter = 131, SP = 0x20000428, canary = 0xdeadbeef
counter = 132, SP = 0x20000420, canary = 0xdeadbeef
counter = 133, SP = 0x20000418, canary = 0xdeadbeef
counter = 134, SP = 0x20000410, canary = 0xdeadbeef
counter = 135, SP = 0x20000408, canary = 0xdeadbeef
counter = 136, SP = 0x20000400, canary = 0xdeadbeef
counter = 137, SP = 0x200003f8, canary = 0xdeadbeef
counter = 138, SP = 0x200003f0, canary = 0xdeadbeef
counter = 139, SP = 0x200003e8, canary = 0xdeadbeef
counter =*** RIOT kernel panic:
MEM MANAGE HANDLER

*** halted.

Inside isr -12

make: Leaving directory '/work/riot/RIOT/tests/mpu_stack_guard'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
