### PR TITLE
cpu/stm32: Clean up periph_eth

### DIFF
--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -237,7 +237,7 @@ static const adc_conf_t adc_config[] = {
  */
 static const eth_conf_t eth_config = {
     .mode = RMII,
-    .mac = { 0 },
+    .addr = { 0 },
     .speed = ETH_SPEED_100TX_FD,
     .dma = 6,
     .dma_chan = 8,

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -208,7 +208,7 @@ static const spi_conf_t spi_config[] = {
  */
 static const eth_conf_t eth_config = {
     .mode = RMII,
-    .mac = { 0 },
+    .addr = { 0 },
     .speed = ETH_SPEED_100TX_FD,
     .dma = 7,
     .dma_chan = 8,

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -156,7 +156,7 @@ static const spi_conf_t spi_config[] = {
  */
 static const eth_conf_t eth_config = {
     .mode = RMII,
-    .mac = { 0 },
+    .addr = { 0 },
     .speed = ETH_SPEED_100TX_FD,
     .dma = 3,
     .dma_chan = 8,

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -1037,15 +1037,15 @@ typedef enum {
  * @brief   Ethernet Peripheral configuration
  */
 typedef struct {
-    eth_mode_t mode;      /**< Select configuration mode */
-    char mac[6];                /**< Ethernet MAC address */
-    eth_speed_t speed;    /**< Speed selection */
+    eth_mode_t mode;            /**< Select configuration mode */
+    uint8_t addr[6];            /**< Ethernet MAC address */
+    eth_speed_t speed;          /**< Speed selection */
     uint8_t dma;                /**< Locical CMA Descriptor used for TX */
     uint8_t dma_chan;           /**< DMA channel used for TX */
     char phy_addr;              /**< PHY address */
     gpio_t pins[];              /**< Pins to use. MII requires 18 pins,
-                                        RMII 9 and SMI 9. Not all speeds are
-                                        supported by all modes. */
+                                    RMII 9 and SMI 9. Not all speeds are
+                                    supported by all modes. */
 } eth_conf_t;
 
 /**


### PR DESCRIPTION
### Contribution description

 - Use `addr` when refering to L2 address, rather than `mac`
 - Fix code indent

### Testing procedure

No change in generated machine code

### Issues/PRs references

None