### PR TITLE
cpu/stm32: Fix periph_eth link status

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -135,6 +135,11 @@ static inline void _phy_write(uint16_t addr, uint8_t reg, uint16_t value)
     _rw_phy(addr, reg, (value & 0xffff) | (ETH_MACMIIAR_MW << 16));
 }
 
+static inline bool _get_link_status(void)
+{
+    return (_phy_read(0, PHY_BSMR) & BSMR_LINK_STATUS);
+}
+
 static void stm32_eth_get_addr(char *out)
 {
     unsigned t;
@@ -216,7 +221,12 @@ static int stm32_eth_get(netdev_t *dev, netopt_t opt,
         res = ETHERNET_ADDR_LEN;
         break;
     case NETOPT_LINK:
-        res = (_phy_read(0, PHY_BSMR) & BSMR_LINK_STATUS);
+        assert(max_len == sizeof(netopt_enable_t));
+        {
+            netopt_enable_t tmp = _get_link_status();
+            memcpy(value, &tmp, sizeof(tmp));
+        }
+        res = sizeof(netopt_enable_t);
         break;
     default:
         res = netdev_eth_get(dev, opt, value, max_len);
@@ -230,7 +240,7 @@ static int stm32_eth_get(netdev_t *dev, netopt_t opt,
 static void _timer_cb(void *arg)
 {
     netdev_t *dev = (netdev_t *)arg;
-    if (stm32_eth_get(dev, NETOPT_LINK, NULL, 0)) {
+    if (_get_link_status()) {
         _link_state = LINK_STATE_UP;
         dev->event_callback(dev, NETDEV_EVENT_ISR);
     }


### PR DESCRIPTION
### Contribution description

The link status was previously not returned via the `value` parameter, as required by the netdev_driver_t API. As a result, e.g. the `ifconfig` shell command showed garbage.

### Testing procedure

1. Run `examples/gnrc_networking` on the Nucleo-F767ZI (or one of the other two STM32 board with peripheral Ethernet support).
2. Check if the shell command `ifconfig` correctly reports that the link is up or down

Note: In about 1 out of 3 tries, the Ethernet chip does not correctly connect... An issue is open for that.

### Issues/PRs references

~~Depends on and includes: https://github.com/RIOT-OS/RIOT/pull/15163~~