### PR TITLE
A basic stm32's HRTIM peripheral driver API and implementation

### DIFF
--- a/boards/nucleo-f334r8/Kconfig
+++ b/boards/nucleo-f334r8/Kconfig
@@ -17,6 +17,7 @@ config BOARD_NUCLEO_F334R8
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
+    select HAS_PERIPH_HRTIM
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_SPI

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32f334r8
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_hrtim
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -72,6 +72,32 @@ static const dma_conf_t dma_config[] = {
 /** @} */
 
 /**
+ * @name    HRTIM configuration
+ * @{
+ */
+static const hrtim_conf_t hrtim_config[] = {
+    {
+        .dev = HRTIM1,
+        .rcc_sw_mask = RCC_CFGR3_HRTIMSW,
+        .rcc_mask = RCC_APB2ENR_HRTIM1EN,
+        .tu = { { .pin = { GPIO_PIN(PORT_A,  8), GPIO_PIN(PORT_A,  9) },
+                  .af = GPIO_AF13 },
+                { .pin = { GPIO_PIN(PORT_A, 10), GPIO_PIN(PORT_A, 11) },
+                  .af = GPIO_AF13 },
+                { .pin = { GPIO_PIN(PORT_B, 12), GPIO_PIN(PORT_B, 13) },
+                  .af = GPIO_AF13 },
+                { .pin = { GPIO_PIN(PORT_B, 14), GPIO_PIN(PORT_B, 15) },
+                  .af = GPIO_AF13 },
+                { .pin = { GPIO_PIN(PORT_C,  8), GPIO_PIN(PORT_C,  9) },
+                  .af = GPIO_AF3  } },
+        .bus = APB2
+    }
+};
+
+#define HRTIM_NUMOF           ARRAY_SIZE(hrtim_config)
+/** @} */
+
+/**
  * @name   UART configuration
  * @{
  */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -1259,6 +1259,39 @@ typedef struct eth_dma_desc {
 #define ANER_LP_AN_ABLE                    (0x0001)
 /** @} */
 
+#ifdef MODULE_PERIPH_HRTIM
+/**
+ * @brief   HRTIM have 5 or 6 timing units
+ */
+#ifdef HRTIM_MCR_TFCEN
+#define HRTIM_STU_NUMOF (6U)        /**< number of slave timing units */
+#else
+#define HRTIM_STU_NUMOF (5U)
+#endif
+
+/**
+ * @brief   HRTIM timing unit
+ */
+typedef struct {
+    gpio_t pin[2];                  /**< GPIO pins mapped to this output */
+    gpio_af_t af;                   /**< alternate function used */
+} hrtim_tu_conf_t;
+
+/**
+ * @brief   HRTIM configuration
+ */
+typedef struct {
+    HRTIM_TypeDef *dev;             /**< Timer used */
+    uint32_t rcc_sw_mask;           /**< bit in clock configuration register */
+    uint32_t rcc_mask;              /**< bit in clock enable register */
+    hrtim_tu_conf_t tu[HRTIM_STU_NUMOF];    /**< output mapping
+                                              * set to {GPIO_UNDEF, 0}
+                                              * if not used */
+    uint8_t bus;                    /**< APB bus */
+} hrtim_conf_t;
+
+#endif /* MODULE_PERIPH_HRTIM */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/periph/hrtim.c
+++ b/cpu/stm32/periph/hrtim.c
@@ -149,30 +149,30 @@ void hrtim_pwm_set(hrtim_t hrtim, hrtim_tu_t tu, uint16_t value, uint16_t shift)
     if (shift != prev_shift[tu]) {
         prev_shift[tu] = shift;
 
-        /* Set reset comparator for phase positionning */
+        /* Set reset comparator for phase positioning */
         if (shift) {
             dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTPER;
             switch (tu) {
-                /* TimerA is the phase shift reference so it can't be phase
+                /* Timer A is the phase shift reference so it can't be phase
                  * shifted */
-                case TIMB: /* TimerB reset on master cmp1 */
+                case TIMB: /* Timer B reset on master cmp1 */
                     dev(hrtim)->sMasterRegs.MCMP1R = shift;
                     dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP1;
                     break;
-                case TIMC: /* TimerC reset on master cmp2 */
+                case TIMC: /* Timer C reset on master cmp2 */
                     dev(hrtim)->sMasterRegs.MCMP2R = shift;
                     dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP2;
                     break;
-                case TIMD: /* TimerD reset on master cmp3 */
+                case TIMD: /* Timer D reset on master cmp3 */
                     dev(hrtim)->sMasterRegs.MCMP3R = shift;
                     dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP3;
                     break;
-                case TIME: /* TimerE reset on master cmp4 */
+                case TIME: /* Timer E reset on master cmp4 */
                     dev(hrtim)->sMasterRegs.MCMP4R = shift;
                     dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP4;
                     break;
     #if (HRTIM_STU_NUMOF == 6)
-                case TIMF: /* TimerF reset on timerA cmp2 */
+                case TIMF: /* Timer F reset on timerA cmp2 */
                     dev(hrtim)->sTimerxRegs[0].CMP2xR = shift;
                     dev(hrtim)->sTimerxRegs[tu].RSTxR |= RSTF_TACMP2;
                     break;

--- a/cpu/stm32/periph/hrtim.c
+++ b/cpu/stm32/periph/hrtim.c
@@ -343,16 +343,16 @@ void hrtim_cmp_set(hrtim_t hrtim, hrtim_tu_t tu, hrtim_cmp_t cmp,
 {
     if (tu == MSTR) {
         switch (cmp) {
-            case CMP1xR:
+            case MCMP1R:
                 dev(hrtim)->sMasterRegs.MCMP1R = value;
                 break;
-            case CMP2xR:
+            case MCMP2R:
                 dev(hrtim)->sMasterRegs.MCMP2R = value;
                 break;
-            case CMP3xR:
+            case MCMP3R:
                 dev(hrtim)->sMasterRegs.MCMP3R = value;
                 break;
-            case CMP4xR:
+            case MCMP4R:
                 dev(hrtim)->sMasterRegs.MCMP4R = value;
                 break;
             default:

--- a/cpu/stm32/periph/hrtim.c
+++ b/cpu/stm32/periph/hrtim.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2020 LAAS-CNRS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32
+ * @ingroup     drivers_periph_hrtim
+ * @{
+ *
+ * @file
+ * @brief       Low-level HRTIM driver implementation
+ *
+ * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ *
+ * @}
+ */
+
+#include "periph/hrtim.h"
+#include "cpu.h"
+#include "assert.h"
+#include "periph/gpio.h"
+
+#include "xtimer.h"
+
+static inline HRTIM_TypeDef *dev(hrtim_t hrtim)
+{
+    return hrtim_config[hrtim].dev;
+}
+
+static inline void _clk_init(hrtim_t hrtim)
+{
+    /* 1. selection of the high-speed PLL output */
+    RCC->CFGR3 |= hrtim_config[hrtim].rcc_sw_mask;
+    /* 2. clock enable for the registers mapped on the APB2 bus */
+    periph_clk_en(hrtim_config[hrtim].bus, hrtim_config[hrtim].rcc_mask);
+
+    /* HRTIM DLL initialization */
+    /* DLL calibration: periodic calibration enabled, period set to 14μs */
+    dev(hrtim)->sCommonRegs.DLLCR = HRTIM_DLLCR_CALRTE_1
+                                    | HRTIM_DLLCR_CALRTE_0
+                                    | HRTIM_DLLCR_CALEN;
+
+    /* Check DLL end of calibration flag */
+    while(!(dev(hrtim)->sCommonRegs.ISR & HRTIM_IER_DLLRDY)) {}
+}
+
+static inline uint32_t _period_ckpsc(hrtim_t hrtim, uint32_t freq,
+                                        uint16_t *per, uint8_t *ckpsc)
+{
+    uint32_t f_hrtim = periph_apb_clk(hrtim_config[hrtim].bus) * 2;
+
+    /* t_hrck = f_hrck / freq but f_hrck = (f_hrtim * 32) which is too
+     * big for an uint32 so we will firstly divide f_hrtim then also add
+     * the modulo to preserve accuracy. */
+    uint32_t period = (f_hrtim / freq) * 32 + (f_hrtim % freq) * 32 / freq;
+
+    /* period = t_hrck / 2^ckpsc so bits over 15 position directly give
+     * the needed prescaller */
+    *ckpsc = (bitarithm_msb(period) > 15)
+           ? bitarithm_msb(period) - 15 : 0;
+    period /= (1 << *ckpsc);
+
+    /* From the f334 reference manual :
+     * The period and compare values must be within a lower and an upper
+     * limit related to the high-resolution implementation and listed in
+     * Table 82:
+     * • The minimum value must be greater than or equal to 3 periods of
+     * the f HRTIM clock
+     * • The maximum value must be less than or equal to 0xFFFF - 1
+     * periods of the f HRTIM clock */
+    uint16_t min_period = *ckpsc < 5 ? (96 >> *ckpsc) : 0x3;
+    uint16_t max_period = *ckpsc < 4 ? (0xFFFF - (32 >> *ckpsc)) : 0xFFFD;
+
+    /* Adjust prescaler and period if needed */
+    if (period > (uint32_t)max_period) {
+        *ckpsc = *ckpsc + 1;
+        period /= 2;
+    }
+    /* Verify parameters */
+    assert( (*ckpsc <= 7)
+            && (hrtim < HRTIM_NUMOF)
+            && (period >= min_period)
+            && (period <= max_period));
+
+    /* Note: with period = max_period (48MHz frequency for f344) it
+     * theorically not possible to obtain PWM because this limitation
+     * also concern compare value, but it is probably possible to
+     * workaround this limitation and manage a duty cycle using the
+     * dead-time generator which have a 868ps resolution... */
+
+    *per = (uint16_t)period;
+
+    /* Compute and return the effective frequency */
+    uint32_t frequency = (  (f_hrtim / period) * 32
+                            + (f_hrtim % period) * 32 / period
+                         )  / (1 << *ckpsc);
+    return frequency;
+}
+
+uint16_t hrtim_init(hrtim_t hrtim, uint32_t *freq, uint16_t dt)
+{
+    /* Master timer initialization */
+    uint16_t period = hrtim_init_mstr(hrtim, freq);
+
+    /* Slave timers initialization */
+    for (unsigned tu = 0; tu < HRTIM_STU_NUMOF; tu++) {
+        hrtim_init_tu(hrtim, tu, freq);
+
+        /* Set the dead time
+         * Note: this must be done before enable counter */
+        hrtim_pwm_dt(hrtim, tu, dt);
+
+        /* Enable counter */
+        hrtim_cnt_en(hrtim, (1 << (HRTIM_MCR_TACEN_Pos + tu)));
+
+        /* Setup outputs */
+        hrtim_cmpl_pwm_out(hrtim, tu);
+
+        /* Reset on master timer period event */
+        hrtim_rst_evt_en(hrtim, tu, RST_MSTPER);
+    }
+
+    return period;
+}
+
+void hrtim_pwm_set(hrtim_t hrtim, hrtim_tu_t tu, uint16_t value, uint16_t shift)
+{
+    static uint16_t prev_value[HRTIM_STU_NUMOF];
+    static uint16_t prev_shift[HRTIM_STU_NUMOF];
+
+    if (value != prev_value[tu]) {
+        prev_value[tu] = value;
+
+        /* Disable outputs when duty cycle is 0 */
+        if (value == 0) {
+            dev(hrtim)->sCommonRegs.ODISR |= ((OUT1 | OUT2) << (tu * 2));
+            return;
+        }
+        /* Set comparator for duty cycle */
+        dev(hrtim)->sTimerxRegs[tu].CMP1xR = value;
+
+        /* Enable outputs */
+        dev(hrtim)->sCommonRegs.OENR |= ((OUT1 | OUT2) << (tu * 2));
+    }
+    if (shift != prev_shift[tu]) {
+        prev_shift[tu] = shift;
+
+        /* Set reset comparator for phase positionning */
+        if (shift) {
+            dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTPER;
+            switch (tu) {
+                /* TimerA is the phase shift reference so it can't be phase
+                 * shifted */
+                case TIMB: /* TimerB reset on master cmp1 */
+                    dev(hrtim)->sMasterRegs.MCMP1R = shift;
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP1;
+                    break;
+                case TIMC: /* TimerC reset on master cmp2 */
+                    dev(hrtim)->sMasterRegs.MCMP2R = shift;
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP2;
+                    break;
+                case TIMD: /* TimerD reset on master cmp3 */
+                    dev(hrtim)->sMasterRegs.MCMP3R = shift;
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP3;
+                    break;
+                case TIME: /* TimerE reset on master cmp4 */
+                    dev(hrtim)->sMasterRegs.MCMP4R = shift;
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTCMP4;
+                    break;
+    #if (HRTIM_STU_NUMOF == 6)
+                case TIMF: /* TimerF reset on timerA cmp2 */
+                    dev(hrtim)->sTimerxRegs[0].CMP2xR = shift;
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR |= RSTF_TACMP2;
+                    break;
+    #endif
+                default:
+                    break;
+            }
+        }
+        else if(dev(hrtim)->sTimerxRegs[tu].PERxR == dev(hrtim)->sMasterRegs.MPER
+                && (dev(hrtim)->sTimerxRegs[tu].TIMxCR & HRTIM_TIMCR_CK_PSC_Msk)
+                    == (dev(hrtim)->sMasterRegs.MCR & HRTIM_MCR_CK_PSC_Msk)){
+            /* shift == 0 and timing unit run at the same frequency as master */
+            switch (tu) {
+                case TIMB:
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTCMP1;
+                    break;
+                case TIMC:
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTCMP2;
+                    break;
+                case TIMD:
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTCMP3;
+                    break;
+                case TIME:
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTCMP4;
+                    break;
+    #if (HRTIM_STU_NUMOF == 6)
+                case TIMF:
+                    dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RSTF_TACMP2;
+                    break;
+    #endif
+                default:
+                    break;
+            }
+            dev(hrtim)->sTimerxRegs[tu].RSTxR |= RST_MSTPER;
+        }
+        else {
+            /* timing unit do not run at the same frequency as master so
+             * phase positioning is not applicable */
+            dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~RST_MSTPER;
+        }
+    }
+}
+
+uint16_t hrtim_init_mstr(hrtim_t hrtim, uint32_t *freq)
+{
+    uint16_t period;
+    uint8_t ckpsc;
+
+    /* HRTIM clock initialization */
+    _clk_init(hrtim);
+
+    /* At start-up, it is mandatory to initialize first the prescaler
+     * bitfields before writing the compare and period registers. */
+    *freq = _period_ckpsc(hrtim, *freq, &period, &ckpsc);
+    /* master timer prescaler init */
+    dev(hrtim)->sMasterRegs.MCR &= ~HRTIM_MCR_CK_PSC_Msk;
+    dev(hrtim)->sMasterRegs.MCR |= (ckpsc << HRTIM_MCR_CK_PSC_Pos);
+
+    /* Master timer initialization */
+    /* continuous mode, preload enabled on repetition event */
+    dev(hrtim)->sMasterRegs.MCR |= (HRTIM_MCR_CONT | HRTIM_MCR_PREEN
+                                | HRTIM_MCR_MREPU);
+
+    /* Enable counter */
+    dev(hrtim)->sMasterRegs.MCR |= (1 << HRTIM_MCR_MCEN_Pos);
+
+    /* Configure the PWM frequency by setting the period registers */
+    dev(hrtim)->sMasterRegs.MPER = period;
+
+    return period;
+}
+
+uint16_t hrtim_init_tu(hrtim_t hrtim, hrtim_tu_t tu, uint32_t *freq)
+{
+    uint16_t period;
+    uint8_t ckpsc;
+
+    /* Outputs initialization */
+    hrtim_out_dis(hrtim, tu, OUT1 | OUT2);
+    hrtim_tu_conf_t tu_conf = hrtim_config[hrtim].tu[tu];
+    gpio_init(tu_conf.pin[0], GPIO_OUT);
+    gpio_init(tu_conf.pin[1], GPIO_OUT);
+    gpio_init_af(tu_conf.pin[0], tu_conf.af);
+    gpio_init_af(tu_conf.pin[1], tu_conf.af);
+
+    /* At start-up, it is mandatory to initialize first the prescaler
+     * bitfields before writing the compare and period registers. */
+    *freq = _period_ckpsc(hrtim, *freq, &period, &ckpsc);
+    dev(hrtim)->sTimerxRegs[tu].TIMxCR &= ~HRTIM_TIMCR_CK_PSC_Msk;
+    dev(hrtim)->sTimerxRegs[tu].TIMxCR |= (ckpsc << HRTIM_TIMCR_CK_PSC_Pos);
+
+    /* timer initialization */
+    /* continuous mode, preload enabled on repetition event */
+    dev(hrtim)->sTimerxRegs[tu].TIMxCR |= (HRTIM_TIMCR_CONT
+                                      | HRTIM_TIMCR_PREEN
+                                      | HRTIM_TIMCR_TREPU);
+
+    /* Configure the PWM frequency by setting the period registers */
+    dev(hrtim)->sTimerxRegs[tu].PERxR = period;
+
+    return period;
+}
+
+void hrtim_set_cb_set(hrtim_t hrtim, hrtim_tu_t tu, hrtim_out_t out,
+                        hrtim_cb_t cb)
+{
+    if (out == OUT1) {
+        dev(hrtim)->sTimerxRegs[tu].SETx1R |= cb;
+    }
+    else { /* OUT2 */
+        dev(hrtim)->sTimerxRegs[tu].SETx2R |= cb;
+    }
+}
+
+void hrtim_set_cb_unset(hrtim_t hrtim, hrtim_tu_t tu, hrtim_out_t out,
+                        hrtim_cb_t cb)
+{
+    if (out == OUT1) {
+        dev(hrtim)->sTimerxRegs[tu].SETx1R &= ~cb;
+    }
+    else { /* OUT2 */
+        dev(hrtim)->sTimerxRegs[tu].SETx2R &= ~cb;
+    }
+}
+
+void hrtim_rst_cb_set(hrtim_t hrtim, hrtim_tu_t tu, hrtim_out_t out,
+                        hrtim_cb_t cb)
+{
+    if (out == OUT1) {
+        dev(hrtim)->sTimerxRegs[tu].RSTx1R |= cb;
+    }
+    else { /* OUT2 */
+        dev(hrtim)->sTimerxRegs[tu].RSTx2R |= cb;
+    }
+}
+
+void hrtim_rst_cb_unset(hrtim_t hrtim, hrtim_tu_t tu, hrtim_out_t out,
+                            hrtim_cb_t cb)
+{
+    if (out == OUT1) {
+        dev(hrtim)->sTimerxRegs[tu].RSTx1R &= ~cb;
+    }
+    else { /* OUT2 */
+        dev(hrtim)->sTimerxRegs[tu].RSTx2R &= ~cb;
+    }
+}
+
+void hrtim_cmpl_pwm_out(hrtim_t hrtim, hrtim_tu_t tu)
+{
+    dev(hrtim)->sTimerxRegs[tu].SETx1R = PER;
+    dev(hrtim)->sTimerxRegs[tu].RSTx1R = CMP1;
+    dev(hrtim)->sTimerxRegs[tu].SETx2R = CMP1;
+    dev(hrtim)->sTimerxRegs[tu].RSTx2R = PER;
+}
+
+void hrtim_period_set(hrtim_t hrtim, hrtim_tu_t tu, uint16_t value)
+{
+    if (tu == MSTR) {
+        dev(hrtim)->sMasterRegs.MPER = value;
+    }
+    else {
+        dev(hrtim)->sTimerxRegs[tu].PERxR = value;
+    }
+}
+
+void hrtim_cmp_set(hrtim_t hrtim, hrtim_tu_t tu, hrtim_cmp_t cmp,
+                    uint16_t value)
+{
+    if (tu == MSTR) {
+        switch (cmp) {
+            case CMP1xR:
+                dev(hrtim)->sMasterRegs.MCMP1R = value;
+                break;
+            case CMP2xR:
+                dev(hrtim)->sMasterRegs.MCMP2R = value;
+                break;
+            case CMP3xR:
+                dev(hrtim)->sMasterRegs.MCMP3R = value;
+                break;
+            case CMP4xR:
+                dev(hrtim)->sMasterRegs.MCMP4R = value;
+                break;
+            default:
+                break;
+        }
+    }
+    else {
+        switch (cmp) {
+            case CMP1xR:
+                dev(hrtim)->sTimerxRegs[tu].CMP1xR = value;
+                break;
+            case CMP2xR:
+                dev(hrtim)->sTimerxRegs[tu].CMP2xR = value;
+                break;
+            case CMP3xR:
+                dev(hrtim)->sTimerxRegs[tu].CMP3xR = value;
+                break;
+            case CMP4xR:
+                dev(hrtim)->sTimerxRegs[tu].CMP4xR = value;
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+void hrtim_cnt_en(hrtim_t hrtim, hrtim_cen_t cen)
+{
+    dev(hrtim)->sMasterRegs.MCR |= cen;
+}
+
+void hrtim_cnt_dis(hrtim_t hrtim, hrtim_cen_t cen)
+{
+    dev(hrtim)->sMasterRegs.MCR &= ~cen;
+}
+
+void hrtim_rst_evt_en(hrtim_t hrtim, hrtim_tu_t tu, hrtim_rst_evt_t evt)
+{
+    dev(hrtim)->sTimerxRegs[tu].RSTxR |= evt;
+}
+
+void hrtim_rst_evt_dis(hrtim_t hrtim, hrtim_tu_t tu, hrtim_rst_evt_t evt)
+{
+    dev(hrtim)->sTimerxRegs[tu].RSTxR &= ~evt;
+}
+
+void hrtim_out_en(hrtim_t hrtim, hrtim_tu_t tu, hrtim_out_t out)
+{
+    dev(hrtim)->sCommonRegs.OENR |= (out << (tu * 2));
+}
+
+void hrtim_out_dis(hrtim_t hrtim, hrtim_tu_t tu, hrtim_out_t out)
+{
+    dev(hrtim)->sCommonRegs.ODISR |= (out << (tu * 2));
+}
+
+void hrtim_pwm_dt(hrtim_t hrtim, hrtim_tu_t tu, uint16_t ns)
+{
+    uint32_t ps = ns * 1000;
+    /* t_dtg = (2^dtpsc) * (t_hrtim / 8)
+     *       = (2^dtpsc) / (f_hrtim * 8) */
+    uint32_t f_hrtim = periph_apb_clk(hrtim_config[hrtim].bus) * 2;
+    uint8_t dtpsc = 0;
+    uint32_t t_dtg_ps = (1 << dtpsc) * 1000000 / ((f_hrtim * 8) / 1000000);
+    uint16_t dt = ps / t_dtg_ps;
+    while (dt > 511 && dtpsc < 7) {
+        dtpsc++;
+        t_dtg_ps = (1 << dtpsc) * 1000000 / ((f_hrtim * 8) / 1000000);
+        dt = ps / t_dtg_ps;
+    }
+    if (dt > 511) {
+        dt = 511;
+    }
+    dev(hrtim)->sTimerxRegs[tu].DTxR &= ~(HRTIM_DTR_DTPRSC_Msk
+                                        | HRTIM_DTR_DTF_Msk
+                                        | HRTIM_DTR_DTR);
+    dev(hrtim)->sTimerxRegs[tu].DTxR |= (dtpsc << HRTIM_DTR_DTPRSC_Pos);
+    dev(hrtim)->sTimerxRegs[tu].DTxR |= (dt << HRTIM_DTR_DTF_Pos);
+    dev(hrtim)->sTimerxRegs[tu].DTxR |= (dt << HRTIM_DTR_DTR_Pos);
+    dev(hrtim)->sTimerxRegs[tu].OUTxR |= HRTIM_OUTR_DTEN; /* Note: This
+    * parameter cannot be changed once the timer is operating (TxEN bit
+    * set) or if its outputs are enabled and set/reset by another timer. */
+}

--- a/cpu/stm32/periph/hrtim.c
+++ b/cpu/stm32/periph/hrtim.c
@@ -14,7 +14,7 @@
  * @file
  * @brief       Low-level HRTIM driver implementation
  *
- * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ * @author      Hugues Larrive <hugues.larrive@pm.me>
  *
  * @}
  */

--- a/drivers/include/periph/hrtim.h
+++ b/drivers/include/periph/hrtim.h
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2020 LAAS-CNRS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32
+ * @ingroup     drivers_periph_hrtim
+ * @{
+ *
+ * @file
+ * @brief       Low-level HRTIM peripheral driver
+ *
+ * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ *
+ * @}
+ */
+
+#ifndef PERIPH_HRTIM_H
+#define PERIPH_HRTIM_H
+
+#include <stdint.h>
+#include <limits.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+#include "bitarithm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default HRTIM access macro
+ */
+#ifndef HRTIM_DEV
+#define HRTIM_DEV(x)          (x)
+#endif
+
+/**
+ * @brief  Default HRTIM undefined value
+ */
+#ifndef HRTIM_UNDEF
+#define HRTIM_UNDEF           (UINT_MAX)
+#endif
+
+/**
+ * @brief   Default HRTIM type definition
+ */
+#ifndef HAVE_HRTIM_T
+typedef unsigned int hrtim_t;
+#endif
+
+/**
+ * @brief   HRTIM Set/Reset trigger definition
+ */
+typedef enum {
+    SOFT_TRIG = 0x00000001,     /*< Software Set/Reset trigger */
+    RESYNC = 0x00000002,        /*< Timer x resynchronization */
+    PER = 0x00000004,           /*< Timer x Period */
+    CMP1 = 0x00000008,          /*< Timer x Compare 1 */
+    CMP2 = 0x00000010,          /*< Timer x Compare 2 */
+    CMP3 = 0x00000020,          /*< Timer x Compare 3 */
+    CMP4 = 0x00000040,          /*< Timer x Compare 4 */
+    MSTPER = 0x00000080,        /*< Master Period */
+    MSTCMP1 = 0x00000100,       /*< Master Compare 1 */
+    MSTCMP2 = 0x00000200,       /*< Master Compare 2 */
+    MSTCMP3 = 0x00000400,       /*< Master Compare 3 */
+    MSTCMP4 = 0x00000800,       /*< Master Compare 4 */
+    TIMEVNT1 = 0x00001000,      /*< Timer Event 1 */
+    TIMEVNT2 = 0x00002000,      /*< Timer Event 2 */
+    TIMEVNT3 = 0x00004000,      /*< Timer Event 3 */
+    TIMEVNT4 = 0x00008000,      /*< Timer Event 4 */
+    TIMEVNT5 = 0x00010000,      /*< Timer Event 5 */
+    TIMEVNT6 = 0x00020000,      /*< Timer Event 6 */
+    TIMEVNT7 = 0x00040000,      /*< Timer Event 7 */
+    TIMEVNT8 = 0x00080000,      /*< Timer Event 8 */
+    TIMEVNT9 = 0x00100000,      /*< Timer Event 9 */
+    EXTEVNT1 = 0x00200000,      /*< External Event 1 */
+    EXTEVNT2 = 0x00400000,      /*< External Event 2 */
+    EXTEVNT3 = 0x00800000,      /*< External Event 3 */
+    EXTEVNT4 = 0x01000000,      /*< External Event 4 */
+    EXTEVNT5 = 0x02000000,      /*< External Event 5 */
+    EXTEVNT6 = 0x04000000,      /*< External Event 6 */
+    EXTEVNT7 = 0x08000000,      /*< External Event 7 */
+    EXTEVNT8 = 0x10000000,      /*< External Event 8 */
+    EXTEVNT9 = 0x20000000,      /*< External Event 9 */
+    EXTEVNT10 = 0x40000000,     /*< External Event 10 */
+    UPDATE = 0x80000000         /*< Registers update (transfer preload
+                                    to active) */
+} hrtim_cb_t;
+
+/**
+ * @brief   HRTIM timing units definition
+ */
+typedef enum {
+    TIMA,
+    TIMB,
+    TIMC,
+    TIMD,
+    TIME,
+#if (HRTIM_STU_NUMOF == 6)
+    TIMF,
+#endif
+    MSTR
+} hrtim_tu_t;
+
+/**
+ * @brief   HRTIM comparators definition
+ */
+typedef enum {
+    CMP1xR = 1,
+    CMP2xR = 2,
+    CMP3xR = 3,
+    CMP4xR = 4,
+    MCMP1R = 1,
+    MCMP2R = 2,
+    MCMP3R = 3,
+    MCMP4R = 4
+} hrtim_cmp_t;
+
+/**
+ * @brief   HRTIM outputs definition
+ */
+typedef enum {
+    OUT1 = 1,
+    OUT2 = 2
+} hrtim_out_t;
+
+/**
+ * @brief   HRTIM Timerx reset event definition
+ *
+ * Note: Bit definitions in stm32xxxx.h are for RSTAR (Timer A)
+ * where Bits 19:30 are reset signals come from TIMB, TIMC,
+ * TIMD, TIME so they are not usable for another unit.
+ */
+typedef enum {
+    RST_UPDT = 0x00000002,          /*< Timer x Update reset */
+    RST_CMP2 = 0x00000004,          /*< Timer x compare 2 reset */
+    RST_CMP4 = 0x00000008,          /*< Timer x compare 4 reset */
+    RST_MSTPER = 0x00000010,        /*< Master timer Period */
+    RST_MSTCMP1 = 0x00000020,       /*< Master Compare 1 */
+    RST_MSTCMP2 = 0x00000040,       /*< Master Compare 2 */
+    RST_MSTCMP3 = 0x00000080,       /*< Master Compare 3 */
+    RST_MSTCMP4 = 0x00000100,       /*< Master Compare 4 */
+    RST_EXTEVNT1 = 0x00000200,      /*< External Event 1 */
+    RST_EXTEVNT2 = 0x00000400,      /*< External Event 2 */
+    RST_EXTEVNT3 = 0x00000800,      /*< External Event 3 */
+    RST_EXTEVNT4 = 0x00001000,      /*< External Event 4 */
+    RST_EXTEVNT5 = 0x00002000,      /*< External Event 5 */
+    RST_EXTEVNT6 = 0x00004000,      /*< External Event 6 */
+    RST_EXTEVNT7 = 0x00008000,      /*< External Event 7 */
+    RST_EXTEVNT8 = 0x00010000,      /*< External Event 8 */
+    RST_EXTEVNT9 = 0x00020000,      /*< External Event 9 */
+    RST_EXTEVNT10 = 0x00040000,     /*< External Event 10 */
+    RSTA_TBCMP1 = 0x00080000,       /*< Timer B Compare 1 for TIMA */
+    RSTA_TBCMP2 = 0x00100000,       /*< Timer B Compare 2 for TIMA */
+    RSTA_TBCMP4 = 0x00200000,       /*< Timer B Compare 4 for TIMA */
+    RSTA_TCCMP1 = 0x00400000,       /*< Timer C Compare 1 for TIMA */
+    RSTA_TCCMP2 = 0x00800000,       /*< Timer C Compare 2 for TIMA */
+    RSTA_TCCMP4 = 0x01000000,       /*< Timer C Compare 4 for TIMA */
+    RSTA_TDCMP1 = 0x02000000,       /*< Timer D Compare 1 for TIMA */
+    RSTA_TDCMP2 = 0x04000000,       /*< Timer D Compare 2 for TIMA */
+    RSTA_TDCMP4 = 0x08000000,       /*< Timer D Compare 4 for TIMA */
+    RSTA_TECMP1 = 0x10000000,       /*< Timer E Compare 1 for TIMA */
+    RSTA_TECMP2 = 0x20000000,       /*< Timer E Compare 2 for TIMA */
+    RSTA_TECMP4 = 0x40000000,       /*< Timer E Compare 4 for TIMA */
+    RSTB_TACMP1 = 0x00080000,       /*< Timer A Compare 1 for TIMB */
+    RSTB_TACMP2 = 0x00100000,       /*< Timer A Compare 2 for TIMB */
+    RSTB_TACMP4 = 0x00200000,       /*< Timer A Compare 4 for TIMB */
+    RSTB_TCCMP1 = 0x00400000,       /*< Timer C Compare 1 for TIMB */
+    RSTB_TCCMP2 = 0x00800000,       /*< Timer C Compare 2 for TIMB */
+    RSTB_TCCMP4 = 0x01000000,       /*< Timer C Compare 4 for TIMB */
+    RSTB_TDCMP1 = 0x02000000,       /*< Timer D Compare 1 for TIMB */
+    RSTB_TDCMP2 = 0x04000000,       /*< Timer D Compare 2 for TIMB */
+    RSTB_TDCMP4 = 0x08000000,       /*< Timer D Compare 4 for TIMB */
+    RSTB_TECMP1 = 0x10000000,       /*< Timer E Compare 1 for TIMB */
+    RSTB_TECMP2 = 0x20000000,       /*< Timer E Compare 2 for TIMB */
+    RSTB_TECMP4 = 0x40000000,       /*< Timer E Compare 4 for TIMB */
+    RSTC_TACMP1 = 0x00080000,       /*< Timer A Compare 1 for TIMC */
+    RSTC_TACMP2 = 0x00100000,       /*< Timer A Compare 2 for TIMC */
+    RSTC_TACMP4 = 0x00200000,       /*< Timer A Compare 4 for TIMC */
+    RSTC_TBCMP1 = 0x00400000,       /*< Timer B Compare 1 for TIMC */
+    RSTC_TBCMP2 = 0x00800000,       /*< Timer B Compare 2 for TIMC */
+    RSTC_TBCMP4 = 0x01000000,       /*< Timer B Compare 4 for TIMC */
+    RSTC_TDCMP1 = 0x02000000,       /*< Timer D Compare 1 for TIMC */
+    RSTC_TDCMP2 = 0x04000000,       /*< Timer D Compare 2 for TIMC */
+    RSTC_TDCMP4 = 0x08000000,       /*< Timer D Compare 4 for TIMC */
+    RSTC_TECMP1 = 0x10000000,       /*< Timer E Compare 1 for TIMC */
+    RSTC_TECMP2 = 0x20000000,       /*< Timer E Compare 2 for TIMC */
+    RSTC_TECMP4 = 0x40000000,       /*< Timer E Compare 4 for TIMC */
+    RSTD_TACMP1 = 0x00080000,       /*< Timer A Compare 1 for TIMD */
+    RSTD_TACMP2 = 0x00100000,       /*< Timer A Compare 2 for TIMD */
+    RSTD_TACMP4 = 0x00200000,       /*< Timer A Compare 4 for TIMD */
+    RSTD_TBCMP1 = 0x00400000,       /*< Timer B Compare 1 for TIMD */
+    RSTD_TBCMP2 = 0x00800000,       /*< Timer B Compare 2 for TIMD */
+    RSTD_TBCMP4 = 0x01000000,       /*< Timer B Compare 4 for TIMD */
+    RSTD_TCCMP1 = 0x02000000,       /*< Timer C Compare 1 for TIMD */
+    RSTD_TCCMP2 = 0x04000000,       /*< Timer C Compare 2 for TIMD */
+    RSTD_TCCMP4 = 0x08000000,       /*< Timer C Compare 4 for TIMD */
+    RSTD_TECMP1 = 0x10000000,       /*< Timer E Compare 1 for TIMD */
+    RSTD_TECMP2 = 0x20000000,       /*< Timer E Compare 2 for TIMD */
+    RSTD_TECMP4 = 0x40000000,       /*< Timer E Compare 4 for TIMD */
+    RSTE_TACMP1 = 0x00080000,       /*< Timer A Compare 1 for TIME */
+    RSTE_TACMP2 = 0x00100000,       /*< Timer A Compare 2 for TIME */
+    RSTE_TACMP4 = 0x00200000,       /*< Timer A Compare 4 for TIME */
+    RSTE_TBCMP1 = 0x00400000,       /*< Timer B Compare 1 for TIME */
+    RSTE_TBCMP2 = 0x00800000,       /*< Timer B Compare 2 for TIME */
+    RSTE_TBCMP4 = 0x01000000,       /*< Timer B Compare 4 for TIME */
+    RSTE_TCCMP1 = 0x02000000,       /*< Timer C Compare 1 for TIME */
+    RSTE_TCCMP2 = 0x04000000,       /*< Timer C Compare 2 for TIME */
+    RSTE_TCCMP4 = 0x08000000,       /*< Timer C Compare 4 for TIME */
+    RSTE_TDCMP1 = 0x10000000,       /*< Timer D Compare 1 for TIME */
+    RSTE_TDCMP2 = 0x20000000,       /*< Timer D Compare 2 for TIME */
+    RSTE_TDCMP4 = 0x40000000,       /*< Timer D Compare 4 for TIME */
+#if (HRTIM_STU_NUMOF == 6)
+    RSTA_TFCMP2 = 0x80000000,       /*< Timer F Compare 2 for TIMA */
+    RSTB_TFCMP2 = 0x80000000,       /*< Timer F Compare 2 for TIMB */
+    RSTC_TFCMP2 = 0x80000000,       /*< Timer F Compare 2 for TIMC */
+    RSTD_TFCMP2 = 0x80000000,       /*< Timer F Compare 2 for TIMD */
+    RSTE_TFCMP2 = 0x80000000,       /*< Timer F Compare 2 for TIME */
+    RSTF_TACMP1 = 0x00080000,       /*< Timer A Compare 1 for TIMF */
+    RSTF_TACMP2 = 0x00100000,       /*< Timer A Compare 2 for TIMF */
+    RSTF_TACMP4 = 0x00200000,       /*< Timer A Compare 4 for TIMF */
+    RSTF_TBCMP1 = 0x00400000,       /*< Timer B Compare 1 for TIMF */
+    RSTF_TBCMP2 = 0x00800000,       /*< Timer B Compare 2 for TIMF */
+    RSTF_TBCMP4 = 0x01000000,       /*< Timer B Compare 4 for TIMF */
+    RSTF_TCCMP1 = 0x02000000,       /*< Timer C Compare 1 for TIMF */
+    RSTF_TCCMP2 = 0x04000000,       /*< Timer C Compare 2 for TIMF */
+    RSTF_TCCMP4 = 0x08000000,       /*< Timer C Compare 4 for TIMF */
+    RSTF_TDCMP1 = 0x10000000,       /*< Timer D Compare 1 for TIMF */
+    RSTF_TDCMP2 = 0x20000000,       /*< Timer D Compare 2 for TIMF */
+    RSTF_TDCMP4 = 0x40000000,       /*< Timer D Compare 4 for TIMF */
+    RSTF_TECMP2 = 0x80000000,       /*< Timer E Compare 2 for TIMF */
+#endif
+} hrtim_rst_evt_t;
+
+/**
+ * @brief   HRTIM timing units CEN bits
+ */
+typedef enum {
+    MCEN = HRTIM_MCR_MCEN,
+    TACEN = HRTIM_MCR_TACEN,
+    TBCEN = HRTIM_MCR_TBCEN,
+    TCCEN = HRTIM_MCR_TCCEN,
+    TDCEN = HRTIM_MCR_TDCEN,
+    TECEN = HRTIM_MCR_TECEN,
+#if (HRTIM_STU_NUMOF == 6)
+    TFCEN = HRTIM_MCR_TFCEN
+#endif
+} hrtim_cen_t;
+
+/**
+ * @brief   Initialize an HRTIM device and all these timing units for
+ *          complementary pwm outputs with a dead time.
+ *
+ * @param[in] dev           HRTIM device to initialize
+ * @param[inout] freq       HRTIM frequency in Hz
+ * @param[in] dt            Desired dead time in ns
+ *
+ * @return                  actual HRTIM resolution on success
+ * @return                  0 on error
+ */
+uint16_t hrtim_init(hrtim_t dev, uint32_t *freq, uint16_t dt);
+
+/**
+ * @brief   Set the duty-cycle, dead-time and phase shift for a given
+ *          timing unit of a given HRTIM device
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] value         Duty cycle
+ * @param[in] shift         Phase shifting
+ */
+void hrtim_pwm_set(hrtim_t dev, hrtim_tu_t tu, uint16_t value, uint16_t shift);
+
+/**
+ * @brief   Initialize an HRTIM device master timer
+ *
+ * @param[in] dev           HRTIM device to initialize
+ * @param[inout] freq       HRTIM frequency in Hz
+ *
+ * @return                  actual HRTIM resolution on success
+ * @return                  0 on error
+ */
+uint16_t hrtim_init_mstr(hrtim_t dev, uint32_t *freq);
+
+/**
+ * @brief   Initialize a timing unit
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit to initialize
+ * @param[inout] freq       HRTIM frequency in Hz
+ *
+ * @return                  actual timing unit resolution on success
+ * @return                  0 on error
+ */
+uint16_t hrtim_init_tu(hrtim_t dev, hrtim_tu_t tu, uint32_t *freq);
+
+/**
+ * @brief   Set crossbar(s) setting
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] out           Output 1 or 2
+ * @param[in] cb            Set crossbar(s)
+ */
+void hrtim_set_cb_set(hrtim_t dev, hrtim_tu_t tu, hrtim_out_t out,
+                        hrtim_cb_t cb);
+
+/**
+ * @brief   Unset set crossbar(s)
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] out           Output 1 or 2
+ * @param[in] cb            Set crossbar(s)
+ */
+void hrtim_set_cb_unset(hrtim_t dev, hrtim_tu_t tu, hrtim_out_t out,
+                        hrtim_cb_t cb);
+
+/**
+ * @brief   Reset crossbar(s) setting
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] out           Output 1 or 2
+ * @param[in] cb            Reset crossbar(s)
+ */
+void hrtim_rst_cb_set(hrtim_t dev, hrtim_tu_t tu, hrtim_out_t out,
+                        hrtim_cb_t cb);
+
+/**
+ * @brief   Unset reset crossbar(s)
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] out           Output 1 or 2
+ * @param[in] cb            Reset crossbar(s)
+ */
+void hrtim_rst_cb_unset(hrtim_t dev, hrtim_tu_t tu, hrtim_out_t out,
+                            hrtim_cb_t cb);
+
+/**
+ * @brief   Full timing unit outputs set/reset crossbars setting for
+ *          complementary pwm.
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ */
+void hrtim_cmpl_pwm_out(hrtim_t dev, hrtim_tu_t tu);
+
+/**
+ * @brief   Set a period value
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit (TIM{A..F} or MSTR for master)
+ * @param[in] value         Raw value to set
+ */
+void hrtim_period_set(hrtim_t dev, hrtim_tu_t tu, uint16_t value);
+
+/**
+ * @brief   Set a comparator value
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit (TIM{A..F} or MSTR for master)
+ * @param[in] cmp           Comparator from 1 to 4
+ * @param[in] value         Raw value to set
+ */
+void hrtim_cmp_set(hrtim_t dev, hrtim_tu_t tu, hrtim_cmp_t cmp,
+                    uint16_t value);
+
+/**
+ * @brief   Enable a timing unit counter.
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] cen           CEN mask
+ */
+void hrtim_cnt_en(hrtim_t dev, hrtim_cen_t cen);
+
+/**
+ * @brief   Disable a timing unit counter.
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] cen           CEN mask
+ */
+void hrtim_cnt_dis(hrtim_t dev, hrtim_cen_t cen);
+
+/**
+ * @brief   Enable a Timerx reset event
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] evt           Reset event
+ */
+void hrtim_rst_evt_en(hrtim_t dev, hrtim_tu_t tu, hrtim_rst_evt_t evt);
+
+/**
+ * @brief   Disbable a Timerx reset event
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] evt           Reset event
+ */
+void hrtim_rst_evt_dis(hrtim_t dev, hrtim_tu_t tu, hrtim_rst_evt_t evt);
+
+/**
+ * @brief   Enable a given output of a given timing unit.
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] out           Output to enable
+ */
+void hrtim_out_en(hrtim_t dev, hrtim_tu_t tu, hrtim_out_t out);
+
+/**
+ * @brief   Disable a given output of a given timing unit.
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] out           Output to disable
+ */
+void hrtim_out_dis(hrtim_t dev, hrtim_tu_t tu, hrtim_out_t out);
+
+/**
+ * @brief   Setup a dead time in nano second for given complementary
+ *          outputs.
+ *
+ * @param[in] dev           HRTIM device
+ * @param[in] tu            Timing unit
+ * @param[in] ns            The desired dead time in nano second
+ */
+void hrtim_pwm_dt(hrtim_t dev, hrtim_tu_t tu, uint16_t ns);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_HRTIM_H */
+/** @} */

--- a/drivers/include/periph/hrtim.h
+++ b/drivers/include/periph/hrtim.h
@@ -7,16 +7,15 @@
  */
 
 /**
- * @ingroup     cpu_stm32
- * @ingroup     drivers_periph_hrtim
- * @{
- *
- * @file
+ * @defgroup    drivers_periph_hrtim HRTIM
+ * @ingroup     drivers_periph
  * @brief       Low-level HRTIM peripheral driver
  *
- * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ * @{
+ * @file
+ * @brief       Low-level HRTIM peripheral driver interface definitions
  *
- * @}
+ * @author      Hugues Larrive <hugues.larrive@laas.fr>
  */
 
 #ifndef PERIPH_HRTIM_H

--- a/drivers/include/periph/hrtim.h
+++ b/drivers/include/periph/hrtim.h
@@ -15,7 +15,7 @@
  * @file
  * @brief       Low-level HRTIM peripheral driver interface definitions
  *
- * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ * @author      Hugues Larrive <hugues.larrive@pm.me>
  */
 
 #ifndef PERIPH_HRTIM_H

--- a/tests/periph_hrtim/Makefile
+++ b/tests/periph_hrtim/Makefile
@@ -1,0 +1,9 @@
+BOARD ?= nucleo-f334r8
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_hrtim
+
+USEMODULE += xtimer
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_hrtim/README.md
+++ b/tests/periph_hrtim/README.md
@@ -2,7 +2,7 @@ Expected result
 ===============
 You should be able to initialize all the timings units with a given
 frequency and a given deadtime, then manage duty-cycle and phase
-positionning of 5 or 6 complementary PWM outputs.
+positioning of 5 or 6 complementary PWM outputs.
 
 You should also be able to perform some basic HRTIM operations and
 produce the oscillograms of the HRTIM cookbook's section 2.
@@ -11,7 +11,7 @@ Background
 ==========
 Test for the low-level HRTIM driver.
 
-## Complementary pwm outputs with deadtime and phase positionning
+## Complementary pwm outputs with deadtime and phase positioning
 
 5 phase interlaced pwm with 100ns deadtime, 50% duty-cycle example.
 

--- a/tests/periph_hrtim/README.md
+++ b/tests/periph_hrtim/README.md
@@ -1,0 +1,171 @@
+Expected result
+===============
+You should be able to initialize all the timings units with a given
+frequency and a given deadtime, then manage duty-cycle and phase
+positionning of 5 or 6 complementary PWM outputs.
+
+You should also be able to perform some basic HRTIM operations and
+produce the oscillograms of the HRTIM cookbook's section 2.
+
+Background
+==========
+Test for the low-level HRTIM driver.
+
+## Complementary pwm outputs with deadtime and phase positionning
+
+5 phase interlaced pwm with 100ns deadtime, 50% duty-cycle example.
+
+Shell:
+    init 0 100000 100
+   The effective frequency is 100000Hz
+   The period is set to 46080
+    pwm_set 0 0 23040 0
+    pwm_set 0 1 23040 9216
+    pwm_set 0 2 23040 18432
+    pwm_set 0 3 23040 27648
+    pwm_set 0 4 23040 36864
+
+## an4539 - HRTIM cookbook - 2 Basic operating principles
+
+### 2.1 Single PWM generation
+C:
+    uint32_t freq;
+    uint16_t period;
+
+    /* Initialize the master timer and TIMD at 100KHz frequency */
+    freq = KHZ(100);
+    hrtim_init_mstr(0, &freq);
+    period = hrtim_init_tu(0, TIMD, &freq);
+
+    /* Set duty cycle to 50% */
+    hrtim_cmp_set(0, TIMD, CMP1xR, period / 2);
+
+    /* TD1 output set on TIMD period and reset on TIMD CMP1 event */
+    hrtim_set_cb_set(0, TIMD, OUT1, PER);
+    hrtim_rst_cb_set(0, TIMD, OUT1, CMP1);
+
+    /* Start Timer D */
+    hrtim_cnt_en(0, (MCEN | TDCEN));
+
+    /* Enable TD1 output */
+    hrtim_out_en(0, TIMD, OUT1);
+
+Shell:
+    init_mstr 0 100000
+    init_tu 0 3 100000
+    cmp_set 0 3 1 23040
+    set_cb_set 0 3 1 2
+    rst_cb_set 0 3 1 3
+    cnt_en 0 17
+    out_en 0 3 1
+
+### 2.2 Generating multiple PWMs
+C:
+    uint32_t freq;
+    uint16_t period;
+
+    /* Initialize the master timer and TIMD at 100KHz frequency */
+    freq = 33333;
+    hrtim_init_mstr(0, &freq);
+    freq = KHZ(100);
+    period = hrtim_init_tu(0, TIMD, &freq);
+
+    /* Set CMP1 to 25% and CMP2 to 75% of period */
+    hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
+    hrtim_cmp_set(0, TIMD, CMP2xR, period * 3 / 4);
+
+    /* TD1 output set on TIMD period and reset on TIMD CMP1 event*/
+    hrtim_set_cb_set(0, TIMD, OUT1, PER);
+    hrtim_rst_cb_set(0, TIMD, OUT1, CMP1);
+    /* TD2 output set on TIMD CMP2 and reset on TIMD period event*/
+    hrtim_set_cb_set(0, TIMD, OUT2, CMP2);
+    hrtim_rst_cb_set(0, TIMD, OUT2, PER);
+
+    /* Timer A initialization at 33KHz */
+    freq = 33333;
+    period = hrtim_init_tu(0, TIMA, &freq);
+
+    /* Set duty cycles to 25% */
+    hrtim_cmp_set(0, TIMA, CMP1xR, period / 4);
+    hrtim_cmp_set(0, TIMA, CMP2xR, period / 2);
+    hrtim_cmp_set(0, TIMA, CMP3xR, period * 3 / 4);
+
+    /* TA1 output set on TIMA period and reset on TIMA CMP1 event*/
+    hrtim_set_cb_set(0, TIMA, OUT1, PER);
+    hrtim_rst_cb_set(0, TIMA, OUT1, CMP1);
+    /* TA2 output set on TIMA CMP2 and reset on TIMA CMP3 event*/
+    hrtim_set_cb_set(0, TIMA, OUT2, CMP2);
+    hrtim_rst_cb_set(0, TIMA, OUT2, CMP3);
+
+    /* Enable TA1, TA2, TD1 and TD2 outputs */
+    hrtim_out_en(0, TIMA, OUT1 | OUT2);
+    hrtim_out_en(0, TIMD, OUT1 | OUT2);
+
+    /* Start Master, Timer A and Timer D counters*/
+    hrtim_cnt_en(0, (MCEN | TACEN | TDCEN));
+
+    /* Timer A and Timer D counters reset on Master period event */
+    hrtim_rst_evt_en(0, TIMA, RST_MSTPER);
+    hrtim_rst_evt_en(0, TIMD, RST_MSTPER);
+
+
+### 2.3 Generating PWM with other timing units and the master timer
+C:
+    uint32_t freq;
+    uint16_t period;
+
+    /* Initialize the master timer, set period for 100002Hz frequency
+     * and duty cycle to 50% */
+    freq = KHZ(100) + 2;
+    period = hrtim_init_mstr(0, &freq);
+    hrtim_cmp_set(0, MSTR, MCMP1R, period / 2);
+
+    /* Initialize timer D, set period for 100kHz frequency
+     * and duty cycle to 50% */
+    freq = KHZ(100);
+    period = hrtim_init_tu(0, 3, &freq);
+    hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
+
+    /* TD1 output set on TIMD period and reset on TIMD CMP1 event*/
+    hrtim_set_cb_set(0, TIMD, OUT1, PER);
+    hrtim_rst_cb_set(0, TIMD, OUT1, CMP1);
+
+    /* TD2 output set on master timer period and reset on master CMP1 event*/
+    hrtim_set_cb_set(0, TIMD, OUT2, MSTPER);
+    hrtim_rst_cb_set(0, TIMD, OUT2, MSTCMP1);
+
+    /* Enable TD1 and TD2 outputs */
+    hrtim_out_en(0, TIMD, OUT1 | OUT2);
+
+    /* Start Master Timer and Timer D counters*/
+    hrtim_cnt_en(0, MCEN | TDCEN);
+
+### 2.4 Arbitrary waveform generation
+C:
+    uint32_t freq;
+    uint16_t period;
+
+    /* Initialize the master timer and TIMD at 100KHz frequency */
+    freq = KHZ(100);
+    hrtim_init_mstr(0, &freq);
+    period = hrtim_init_tu(0, TIMD, &freq);
+
+    /* Set edge timings */
+    hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
+    hrtim_cmp_set(0, TIMD, CMP2xR, period * 3 / 8);
+    hrtim_cmp_set(0, TIMD, CMP3xR, period / 2);
+
+    /* TD1 toggles on TIMD period, CMP1 and CMP2 event */
+    hrtim_set_cb_set(0, TIMD, OUT1, PER | CMP1 | CMP2);
+    hrtim_rst_cb_set(0, TIMD, OUT1, PER | CMP1 | CMP2);
+
+    /* TD2 output set on TIMD PER and CMP2 and reset on TIMD CMP1
+     * and CMP3 event */
+    hrtim_set_cb_set(0, TIMD, OUT2, PER | CMP2);
+    hrtim_rst_cb_set(0, TIMD, OUT2, CMP1 | CMP3);
+
+    /* Enable TD1 and TD2 outputs */
+    hrtim_out_en(0, TIMD, OUT1 | OUT2);
+
+    /* Start Timer D */
+    hrtim_cnt_en(0, TDCEN);

--- a/tests/periph_hrtim/README.md
+++ b/tests/periph_hrtim/README.md
@@ -16,6 +16,7 @@ Test for the low-level HRTIM driver.
 5 phase interlaced pwm with 100ns deadtime, 50% duty-cycle example.
 
 Shell:
+```shell
     init 0 100000 100
    The effective frequency is 100000Hz
    The period is set to 46080
@@ -24,11 +25,12 @@ Shell:
     pwm_set 0 2 23040 18432
     pwm_set 0 3 23040 27648
     pwm_set 0 4 23040 36864
-
+```
 ## an4539 - HRTIM cookbook - 2 Basic operating principles
 
 ### 2.1 Single PWM generation
 C:
+```c
     uint32_t freq;
     uint16_t period;
 
@@ -49,8 +51,9 @@ C:
 
     /* Enable TD1 output */
     hrtim_out_en(0, TIMD, OUT1);
-
+```
 Shell:
+```shell
     init_mstr 0 100000
     init_tu 0 3 100000
     cmp_set 0 3 1 23040
@@ -58,9 +61,10 @@ Shell:
     rst_cb_set 0 3 1 3
     cnt_en 0 17
     out_en 0 3 1
-
+```
 ### 2.2 Generating multiple PWMs
 C:
+```c
     uint32_t freq;
     uint16_t period;
 
@@ -107,10 +111,11 @@ C:
     /* Timer A and Timer D counters reset on Master period event */
     hrtim_rst_evt_en(0, TIMA, RST_MSTPER);
     hrtim_rst_evt_en(0, TIMD, RST_MSTPER);
-
+```
 
 ### 2.3 Generating PWM with other timing units and the master timer
 C:
+```c
     uint32_t freq;
     uint16_t period;
 
@@ -139,9 +144,10 @@ C:
 
     /* Start Master Timer and Timer D counters*/
     hrtim_cnt_en(0, MCEN | TDCEN);
-
+```
 ### 2.4 Arbitrary waveform generation
 C:
+```c
     uint32_t freq;
     uint16_t period;
 
@@ -169,3 +175,4 @@ C:
 
     /* Start Timer D */
     hrtim_cnt_en(0, TDCEN);
+```

--- a/tests/periph_hrtim/README.md
+++ b/tests/periph_hrtim/README.md
@@ -55,7 +55,11 @@ C:
 Shell:
 ```shell
     init_mstr 0 100000
+   The effective frequency is 100000Hz
+   The period is set to 46080
     init_tu 0 3 100000
+   The effective frequency is 100000Hz
+   The period is set to 46080
     cmp_set 0 3 1 23040
     set_cb_set 0 3 1 2
     rst_cb_set 0 3 1 3
@@ -112,6 +116,36 @@ C:
     hrtim_rst_evt_en(0, TIMA, RST_MSTPER);
     hrtim_rst_evt_en(0, TIMD, RST_MSTPER);
 ```
+Shell:
+```shell
+    init_mstr 0 33333
+   The effective frequency is 33333Hz
+   The period is set to 34560
+    init_tu 0 3 100000
+   The effective frequency is 100000Hz
+   The period is set to 46080
+    cmp_set 0 3 1 11520
+    cmp_set 0 3 2 34560
+    set_cb_set 0 3 1 2
+    rst_cb_set 0 3 1 3
+    set_cb_set 0 3 2 4
+    rst_cb_set 0 3 2 2
+    init_tu 0 0 33333
+   The effective frequency is 33333Hz
+   The period is set to 34560
+    cmp_set 0 0 1 8640
+    cmp_set 0 0 2 17280
+    cmp_set 0 0 3 25920
+    set_cb_set 0 0 1 2
+    rst_cb_set 0 0 1 3
+    set_cb_set 0 0 2 4
+    rst_cb_set 0 0 2 5
+    out_en 0 0 3
+    out_en 0 3 3
+    cnt_en 0 19
+    rst_evt_en 0 0 4
+    rst_evt_en 0 3 4
+```
 
 ### 2.3 Generating PWM with other timing units and the master timer
 C:
@@ -128,7 +162,7 @@ C:
     /* Initialize timer D, set period for 100kHz frequency
      * and duty cycle to 50% */
     freq = KHZ(100);
-    period = hrtim_init_tu(0, 3, &freq);
+    period = hrtim_init_tu(0, TIMD, &freq);
     hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
 
     /* TD1 output set on TIMD period and reset on TIMD CMP1 event*/
@@ -144,6 +178,23 @@ C:
 
     /* Start Master Timer and Timer D counters*/
     hrtim_cnt_en(0, MCEN | TDCEN);
+```
+Shell:
+```shell
+    init_mstr 0 100002
+   The effective frequency is 100002Hz
+   The period is set to 46079
+    cmp_set 0 5 1 23039
+    init_tu 0 3 100000
+   The effective frequency is 100000Hz
+   The period is set to 46080
+    cmp_set 0 3 1 11520
+    set_cb_set 0 3 1 2
+    rst_cb_set 0 3 1 3
+    set_cb_set 0 3 2 7
+    rst_cb_set 0 3 2 8
+    out_en 0 3 3
+    cnt_en 0 17
 ```
 ### 2.4 Arbitrary waveform generation
 C:
@@ -175,4 +226,28 @@ C:
 
     /* Start Timer D */
     hrtim_cnt_en(0, TDCEN);
+```
+Shell:
+```shell
+    init_mstr 0 100000
+   The effective frequency is 100000Hz
+   The period is set to 46080
+    init_tu 0 3 100000
+   The effective frequency is 100000Hz
+   The period is set to 46080
+    cmp_set 0 3 1 11520
+    cmp_set 0 3 2 17280
+    cmp_set 0 3 3 23040
+    set_cb_set 0 3 1 2
+    set_cb_set 0 3 1 3
+    set_cb_set 0 3 1 4
+    rst_cb_set 0 3 1 2
+    rst_cb_set 0 3 1 3
+    rst_cb_set 0 3 1 4
+    set_cb_set 0 3 2 2
+    set_cb_set 0 3 2 4
+    rst_cb_set 0 3 2 3
+    rst_cb_set 0 3 2 5
+    out_en 0 3 3
+    cnt_en 0 16
 ```

--- a/tests/periph_hrtim/main.c
+++ b/tests/periph_hrtim/main.c
@@ -159,7 +159,7 @@ static int cmd_init_mstr(int argc, char** argv)
 
 static int cmd_init_tu(int argc, char** argv)
 {
-    if (argc != 4) {
+    if (argc != 5) {
         uint32_t f_hrtim = periph_apb_clk(hrtim_config[0].bus) * 2;
         uint32_t max_freq = f_hrtim / 3;
         uint16_t min_freq = f_hrtim / 4 / 0xfffd;

--- a/tests/periph_hrtim/main.c
+++ b/tests/periph_hrtim/main.c
@@ -1,0 +1,790 @@
+/*
+ * Copyright (c) 2020 LAAS-CNRS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test for low-level HRTIM drivers
+ *
+ * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "shell.h"
+#include "periph/hrtim.h"
+
+static uint8_t initiated;
+static uint8_t tu_initiated;
+
+static unsigned _get_dev(const char *dev_str)
+{
+    unsigned dev = atoi(dev_str);
+    if (dev >= HRTIM_NUMOF) {
+        printf("Error: device HRTIM_DEV(%u) is unknown\n", dev);
+        return UINT_MAX;
+    }
+    return dev;
+}
+
+static int cmd_init(int argc, char** argv)
+{
+    if (argc != 4) {
+        uint32_t f_hrtim = periph_apb_clk(hrtim_config[0].bus) * 2;
+        uint32_t max_freq = f_hrtim / 3;
+        uint16_t min_freq = f_hrtim / 4 / 0xfffd;
+        min_freq++;
+        printf("usage: %s <dev> <frequency> <dt>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %u\n", HRTIM_NUMOF - 1);
+        printf("\tfrequency: desired frequency between %" PRIu16
+                " and %" PRIu32 " in Hz\n", min_freq, max_freq);
+        puts("\tdt: dead time (ns)");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    uint16_t period;
+    uint32_t freq = (uint32_t)atoi(argv[2]);
+    period = hrtim_init(HRTIM_DEV(dev), &freq, (uint16_t)atoi(argv[3]));
+
+    if (period != 0) {
+        printf("The effective frequency is %" PRIu32 "Hz\n", freq);
+        printf("The period is set to %" PRIu16 "\n", period);
+        for (unsigned i = 0; i < HRTIM_STU_NUMOF; i++) {
+            tu_initiated |= (1 << i);
+        }
+        initiated |= (1 << dev);
+        return 0;
+    }
+
+    puts("Error: device is not initiated");
+    return 1;
+}
+
+static int cmd_pwm_set(int argc, char**argv)
+{
+    if (argc != 5) {
+        printf("usage: %s <dev> <tu> <val> <pha>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+            puts("\t\t0: TIMA");
+            puts("\t\t1: TIMB");
+            puts("\t\t2: TIMC");
+            puts("\t\t3: TIMD");
+            puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+            puts("\t\t5: TIMF");
+#endif
+        puts("\tval: duty cycle");
+        puts("\tpha: phase shift\n");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    if ((initiated & (1 << dev)) == 0) {
+        puts("Error: hrtim is not initiated.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    if ((tu_initiated & (1 << tu)) == 0) {
+        puts("Error: timing unit is not initiated.\n");
+        puts("Execute init_tu function first.\n");
+        return 1;
+    }
+
+    hrtim_pwm_set(HRTIM_DEV(dev), tu, (uint16_t)atoi(argv[3]),
+                    (uint16_t)atoi(argv[4]));
+    return 0;
+}
+
+static int cmd_init_mstr(int argc, char** argv)
+{
+    if (argc != 3) {
+        uint32_t f_hrtim = periph_apb_clk(hrtim_config[0].bus) * 2;
+        uint32_t max_freq = f_hrtim / 3;
+        uint16_t min_freq = f_hrtim / 4 / 0xfffd;
+        min_freq++;
+        printf("usage: %s <dev> <frequency>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %u\n", HRTIM_NUMOF - 1);
+        printf("\tfrequency: desired frequency between %" PRIu16
+                " and %" PRIu32 " in Hz\n", min_freq, max_freq);
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    uint32_t freq = (uint32_t)atoi(argv[2]);
+    uint16_t period;
+    period = hrtim_init_mstr(HRTIM_DEV(dev), &freq);
+
+    if (period != 0) {
+        printf("The effective frequency is %" PRIu32 "Hz\n", freq);
+        printf("The period is set to %" PRIu16 "\n", period);
+        initiated |= (1 << dev);
+        return 0;
+    }
+
+    puts("Error: device is not initiated");
+    return 1;
+}
+
+static int cmd_init_tu(int argc, char** argv)
+{
+    if (argc != 4) {
+        uint32_t f_hrtim = periph_apb_clk(hrtim_config[0].bus) * 2;
+        uint32_t max_freq = f_hrtim / 3;
+        uint16_t min_freq = f_hrtim / 4 / 0xfffd;
+        min_freq++;
+        printf("usage: %s <dev> <tu> <frequency> <dt>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %u\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n",
+                HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+#endif
+        printf("\tfrequency: desired frequency between %" PRIu16
+                " and %" PRIu32 " in Hz\n", min_freq, max_freq);
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    if ((initiated & (1 << dev)) == 0) {
+        puts("Error: hrtim is not initiated.\n");
+        puts("Execute init_mstr function first.\n");
+        return 1;
+    }
+
+    hrtim_tu_t tu = (uint8_t)atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    uint16_t period;
+    uint32_t freq = (uint32_t)atoi(argv[3]);
+    period = hrtim_init_tu(HRTIM_DEV(dev), tu, &freq);
+
+    if (period != 0) {
+        printf("The effective frequency is %" PRIu32 "Hz\n", freq);
+        printf("The period is set to %" PRIu16 "\n", period);
+        tu_initiated |= (1 << tu);
+        return 0;
+    }
+
+    puts("Error: device is not initiated");
+    return 1;
+}
+
+static int cmd_crossbar(int argc, char**argv)
+{
+    if (argc != 5) {
+        printf("usage: %s <dev> <tu> <out> <cb>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+            puts("\t\t 0: TIMA");
+            puts("\t\t 1: TIMB");
+            puts("\t\t 2: TIMC");
+            puts("\t\t 3: TIMD");
+            puts("\t\t 4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+            puts("\t\t 5: TIMF");
+#endif
+        puts("\tout: output 1 or 2");
+        puts("\t\t 1: OUT1");
+        puts("\t\t 2: OUT2");
+        puts("\tcb: crossbar");
+        puts("\t\t 0: SOFT_TRIG\tSoftware Set/Reset trigger");
+        puts("\t\t 1: RESYNC\tTimer x resynchronization");
+        puts("\t\t 2: PER\t\tTimer x Period");
+        puts("\t\t 3: CMP1\tTimer x Compare 1");
+        puts("\t\t 4: CMP2\tTimer x Compare 2");
+        puts("\t\t 5: CMP3\tTimer x Compare 3");
+        puts("\t\t 6: CMP4\tTimer x Compare 4");
+        puts("\t\t 7: MSTPER\tMaster Period");
+        puts("\t\t 8: MSTCMP1\tMaster Compare 1");
+        puts("\t\t 9: MSTCMP2\tMaster Compare 2");
+        puts("\t\t10: MSTCMP3\tMaster Compare 3");
+        puts("\t\t11: MSTCMP4\tMaster Compare 4");
+        puts("\t\t12: TIMEVNT1\tTimer Event 1");
+        puts("\t\t13: TIMEVNT2\tTimer Event 2");
+        puts("\t\t14: TIMEVNT3\tTimer Event 3");
+        puts("\t\t15: TIMEVNT4\tTimer Event 4");
+        puts("\t\t16: TIMEVNT5\tTimer Event 5");
+        puts("\t\t17: TIMEVNT6\tTimer Event 6");
+        puts("\t\t18: TIMEVNT7\tTimer Event 7");
+        puts("\t\t19: TIMEVNT8\tTimer Event 8");
+        puts("\t\t20: TIMEVNT9\tTimer Event 9");
+        puts("\t\t21: EXTEVNT1\tExternal Event 1");
+        puts("\t\t22: EXTEVNT2\tExternal Event 2");
+        puts("\t\t23: EXTEVNT3\tExternal Event 3");
+        puts("\t\t24: EXTEVNT4\tExternal Event 4");
+        puts("\t\t25: EXTEVNT5\tExternal Event 5");
+        puts("\t\t26: EXTEVNT6\tExternal Event 6");
+        puts("\t\t27: EXTEVNT7\tExternal Event 7");
+        puts("\t\t28: EXTEVNT8\tExternal Event 8");
+        puts("\t\t29: EXTEVNT9\tExternal Event 9");
+        puts("\t\t30: EXTEVNT10\tExternal Event 10");
+        puts("\t\t31: UPDATE\tRegisters update (transfer preload to active)\n");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_out_t out = atoi(argv[3]);
+    if (out < 1 || out > 2) {
+        printf("Error: invalid output number: %d.\n", out);
+        return 1;
+    }
+
+    uint8_t cb_pos = atoi(argv[4]);
+    if (cb_pos > 31) {
+        printf("Error: invalid crossbar number: %d.\n", cb_pos);
+        return 1;
+    }
+    hrtim_cb_t cb = (1 << cb_pos);
+
+    if (strcmp(argv[0], "set_cb_set") == 0) {
+        hrtim_set_cb_set(HRTIM_DEV(dev), tu, out, cb);
+    }
+    else if (strcmp(argv[0], "set_cb_unset") == 0) {
+        hrtim_set_cb_unset(HRTIM_DEV(dev), tu, out, cb);
+    }
+    else if (strcmp(argv[0], "rst_cb_set") == 0) {
+        hrtim_rst_cb_set(HRTIM_DEV(dev), tu, out, cb);
+    }
+    else if (strcmp(argv[0], "rst_cb_unset") == 0) {
+        hrtim_rst_cb_unset(HRTIM_DEV(dev), tu, out, cb);
+    }
+    return 0;
+}
+
+static int cmd_cmpl_pwm_out(int argc, char**argv)
+{
+    if (argc != 3) {
+        printf("usage: %s <dev> <tu>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+            puts("\t\t0: TIMA");
+            puts("\t\t1: TIMB");
+            puts("\t\t2: TIMC");
+            puts("\t\t3: TIMD");
+            puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+            puts("\t\t5: TIMF");
+#endif
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+    hrtim_cmpl_pwm_out(HRTIM_DEV(dev), tu);
+    return 0;
+}
+
+static int cmd_period_set(int argc, char**argv)
+{
+    if (argc != 4) {
+        printf("usage: %s <dev> <tu> <val>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+        puts("\t\t6: MSTR (master timer)");
+#else
+        puts("\t\t5: MSTR (master timer)");
+#endif
+        puts("\tval: raw value\n");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu > HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_period_set(HRTIM_DEV(dev), tu, atoi(argv[3]));
+    return 0;
+}
+
+static int cmd_cmp_set(int argc, char**argv)
+{
+    if (argc != 5) {
+        printf("usage: %s <dev> <tu> <cmp> <val>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+        puts("\t\t6: MSTR (master timer)");
+#else
+        puts("\t\t5: MSTR (master timer)");
+#endif
+        puts("\tcmp: comparator from 1 to 4");
+        puts("\tval: raw value\n");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    if ((initiated & (1 << dev)) == 0) {
+        puts("Error: hrtim is not initiated.\n");
+        puts("Execute init function first.\n");
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu > HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+    if ((tu_initiated & (1 << tu)) == 0) {
+        puts("Error: timing unit is not initiated.\n");
+        puts("Execute init_tu function first.\n");
+        return 1;
+    }
+
+    hrtim_cmp_t cmp = atoi(argv[3]);
+    if (cmp < 1 || cmp > 4) {
+        printf("Error: cmp %d is unknown.\n", cmp);
+        return 1;
+    }
+
+    hrtim_cmp_set(HRTIM_DEV(dev), tu, cmp, (uint16_t)atoi(argv[4]));
+
+    return 0;
+}
+
+static int cmd_cnt_en(int argc, char**argv)
+{
+    if (argc != 3) {
+        printf("usage: %s <dev> <cen>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        puts("\tcen: CEN mask");
+        puts("\t\t1: MCEN");
+        puts("\t\t2: TACEN");
+        puts("\t\t4: TBCEN");
+        puts("\t\t8: TCCEN");
+        puts("\t\t16: TDCEN");
+        puts("\t\t32: TECEN");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t64: TFCEN");
+#endif
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_cen_t cen = (atoi(argv[2]) << HRTIM_MCR_MCEN_Pos);
+    hrtim_cnt_en(HRTIM_DEV(dev), cen);
+    return 0;
+}
+
+static int cmd_cnt_dis(int argc, char**argv)
+{
+    if (argc != 3) {
+        printf("usage: %s <dev> <cen>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        puts("\tcen: CEN mask");
+        puts("\t\t1: MCEN");
+        puts("\t\t2: TACEN");
+        puts("\t\t4: TBCEN");
+        puts("\t\t8: TCCEN");
+        puts("\t\t16: TDCEN");
+        puts("\t\t32: TECEN");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t64: TFCEN");
+#endif
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_cen_t cen = (atoi(argv[2]) << HRTIM_MCR_MCEN_Pos);
+    hrtim_cnt_dis(HRTIM_DEV(dev), cen);
+    return 0;
+}
+
+static int cmd_out_en(int argc, char**argv)
+{
+    if (argc != 4) {
+        printf("usage: %s <dev> <tu> <out>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+#endif
+        puts("\tout: output(s) to enable");
+        puts("\t\t1: OUT1");
+        puts("\t\t2: OUT2");
+        puts("\t\t3: OUT1 | OUT2 (both)");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_out_t out = atoi(argv[3]);
+    if (out < 1 || out > 3) {
+        printf("Error: out = %d is invalid.\n", out);
+        return 1;
+    }
+
+    hrtim_out_en(HRTIM_DEV(dev), tu, out);
+    return 0;
+}
+
+static int cmd_out_dis(int argc, char**argv)
+{
+    if (argc != 4) {
+        printf("usage: %s <dev> <tu> <out>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+#endif
+        puts("\tout: output(s) to disable");
+        puts("\t\t1: OUT1");
+        puts("\t\t2: OUT2");
+        puts("\t\t3: OUT1 | OUT2 (both)");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_out_t out = atoi(argv[3]);
+    if (out < 1 || out > 3) {
+        printf("Error: out = %d is invalid.\n", out);
+        return 1;
+    }
+
+    hrtim_out_dis(HRTIM_DEV(dev), tu, out);
+    return 0;
+}
+
+static int cmd_pwm_dt(int argc, char**argv)
+{
+    if (argc != 4) {
+        printf("usage: %s <dev> <tu> <ns>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+#endif
+        puts("\tns: desired dead-time in nano seconds");
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_pwm_dt(HRTIM_DEV(dev), tu, atoi(argv[3]));
+    return 0;
+}
+
+static int cmd_an4539(int argc, char**argv)
+{
+    if (argc != 2) {
+        printf("usage: %s <example>\n", argv[0]);
+        puts("\texample: an4539 basic operating principles example");
+        puts("\t\t1: Single PWM generation");
+        puts("\t\t2: Generating multiple PWMs");
+        puts("\t\t3: Generating PWM with other timing units and the "
+                "master timer");
+        puts("\t\t4: Arbitrary waveform generation");
+        return 1;
+    }
+
+    uint8_t ex = atoi(argv[1]);
+    if (ex < 1 || ex > 4) {
+        printf("Error: invalid example number: %d.\n", ex);
+        return 1;
+    }
+
+    /* reset crossbars */
+    hrtim_set_cb_unset(0, TIMA, OUT1, 0xfffffffe);
+    hrtim_set_cb_unset(0, TIMA, OUT2, 0xfffffffe);
+    hrtim_set_cb_unset(0, TIMD, OUT1, 0xfffffffe);
+    hrtim_set_cb_unset(0, TIMD, OUT2, 0xfffffffe);
+    hrtim_rst_cb_unset(0, TIMA, OUT1, 0xfffffffe);
+    hrtim_rst_cb_unset(0, TIMA, OUT2, 0xfffffffe);
+    hrtim_rst_cb_unset(0, TIMD, OUT1, 0xfffffffe);
+    hrtim_rst_cb_unset(0, TIMD, OUT2, 0xfffffffe);
+
+    uint32_t freq;
+    uint16_t period;
+    switch (ex) {
+        case 1:
+            /* Initialize the master timer and TIMD at 100KHz frequency */
+            freq = KHZ(100);
+            hrtim_init_mstr(0, &freq);
+            period = hrtim_init_tu(0, TIMD, &freq);
+
+            /* Set duty cycle to 50% */
+            hrtim_cmp_set(0, TIMD, CMP1xR, period / 2);
+
+            /* TD1 output set on TIMD period and reset on TIMD CMP1 event */
+            hrtim_set_cb_set(0, TIMD, OUT1, PER);
+            hrtim_rst_cb_set(0, TIMD, OUT1, CMP1);
+
+            /* Start Timer D */
+            hrtim_cnt_en(0, (MCEN | TDCEN));
+
+            /* Enable TD1 output */
+            hrtim_out_en(0, TIMD, OUT1);
+            break;
+        case 2:
+            /* Initialize the master timer and TIMD at 100KHz frequency */
+            freq = 33333;
+            hrtim_init_mstr(0, &freq);
+            freq = KHZ(100);
+            period = hrtim_init_tu(0, TIMD, &freq);
+
+            /* Set CMP1 to 25% and CMP2 to 75% of period */
+            hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
+            hrtim_cmp_set(0, TIMD, CMP2xR, period * 3 / 4);
+
+            /* TD1 output set on TIMD period and reset on TIMD CMP1 event*/
+            hrtim_set_cb_set(0, TIMD, OUT1, PER);
+            hrtim_rst_cb_set(0, TIMD, OUT1, CMP1);
+            /* TD2 output set on TIMD CMP2 and reset on TIMD period event*/
+            hrtim_set_cb_set(0, TIMD, OUT2, CMP2);
+            hrtim_rst_cb_set(0, TIMD, OUT2, PER);
+
+            /* Timer A initialization at 33KHz */
+            freq = 33333;
+            period = hrtim_init_tu(0, TIMA, &freq);
+
+            /* Set duty cycles to 25% */
+            hrtim_cmp_set(0, TIMA, CMP1xR, period / 4);
+            hrtim_cmp_set(0, TIMA, CMP2xR, period / 2);
+            hrtim_cmp_set(0, TIMA, CMP3xR, period * 3 / 4);
+
+            /* TA1 output set on TIMA period and reset on TIMA CMP1 event*/
+            hrtim_set_cb_set(0, TIMA, OUT1, PER);
+            hrtim_rst_cb_set(0, TIMA, OUT1, CMP1);
+            /* TA2 output set on TIMA CMP2 and reset on TIMA CMP3 event*/
+            hrtim_set_cb_set(0, TIMA, OUT2, CMP2);
+            hrtim_rst_cb_set(0, TIMA, OUT2, CMP3);
+
+            /* Enable TA1, TA2, TD1 and TD2 outputs */
+            hrtim_out_en(0, TIMA, OUT1 | OUT2);
+            hrtim_out_en(0, TIMD, OUT1 | OUT2);
+
+            /* Start Master, Timer A and Timer D counters*/
+            hrtim_cnt_en(0, (MCEN | TACEN | TDCEN));
+
+            /* Timer A and Timer D counters reset on Master period event */
+            hrtim_rst_evt_en(0, TIMA, RST_MSTPER);
+            hrtim_rst_evt_en(0, TIMD, RST_MSTPER);
+            break;
+        case 3:
+            /* Initialize the master timer, set period for 100002Hz frequency
+             * and duty cycle to 50% */
+            freq = KHZ(100) + 2;
+            period = hrtim_init_mstr(0, &freq);
+            hrtim_cmp_set(0, MSTR, MCMP1R, period / 2);
+
+            /* Initialize timer D, set period for 100kHz frequency
+             * and duty cycle to 50% */
+            freq = KHZ(100);
+            period = hrtim_init_tu(0, 3, &freq);
+            hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
+
+            /* TD1 output set on TIMD period and reset on TIMD CMP1 event*/
+            hrtim_set_cb_set(0, TIMD, OUT1, PER);
+            hrtim_rst_cb_set(0, TIMD, OUT1, CMP1);
+
+            /* TD2 output set on master timer period and reset on master CMP1 event*/
+            hrtim_set_cb_set(0, TIMD, OUT2, MSTPER);
+            hrtim_rst_cb_set(0, TIMD, OUT2, MSTCMP1);
+
+            /* Enable TD1 and TD2 outputs */
+            hrtim_out_en(0, TIMD, OUT1 | OUT2);
+
+            /* Start Master Timer and Timer D counters*/
+            hrtim_cnt_en(0, MCEN | TDCEN);
+            break;
+        case 4:
+            /* Initialize the master timer and TIMD at 100KHz frequency */
+            freq = KHZ(100);
+            hrtim_init_mstr(0, &freq);
+            period = hrtim_init_tu(0, TIMD, &freq);
+
+            /* Set edge timings */
+            hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
+            hrtim_cmp_set(0, TIMD, CMP2xR, period * 3 / 8);
+            hrtim_cmp_set(0, TIMD, CMP3xR, period / 2);
+
+            /* TD1 toggles on TIMD period, CMP1 and CMP2 event */
+            hrtim_set_cb_set(0, TIMD, OUT1, PER | CMP1 | CMP2);
+            hrtim_rst_cb_set(0, TIMD, OUT1, PER | CMP1 | CMP2);
+
+            /* TD2 output set on TIMD PER and CMP2 and reset on TIMD CMP1
+             * and CMP3 event */
+            hrtim_set_cb_set(0, TIMD, OUT2, PER | CMP2);
+            hrtim_rst_cb_set(0, TIMD, OUT2, CMP1 | CMP3);
+
+            /* Enable TD1 and TD2 outputs */
+            hrtim_out_en(0, TIMD, OUT1 | OUT2);
+
+            /* Start Timer D */
+            hrtim_cnt_en(0, TDCEN);
+            break;
+    }
+
+    return 0;
+}
+
+
+static const shell_command_t shell_commands[] = {
+    { "init", "initial full hrtimer configuration for complementary pwm",
+        cmd_init },
+    { "pwm_set", "set pwm duty cycle, dead time and phase shifting",
+        cmd_pwm_set },
+    { "init_mstr", "initial master timer configuration", cmd_init_mstr },
+    { "init_tu", "initial timing unit configuration", cmd_init_tu },
+    { "set_cb_set", "set a set crossbar for an output", cmd_crossbar },
+    { "set_cb_unset", "unset a set crossbar for an output", cmd_crossbar },
+    { "rst_cb_set", "set a reset crossbar for an output", cmd_crossbar },
+    { "rst_cb_unset", "unset a reset crossbar for an output", cmd_crossbar },
+    { "cmpl_pwm_out", "setup a complementary pwm output", cmd_cmpl_pwm_out },
+    { "period_set", "Set a period value", cmd_period_set },
+    { "cmp_set", "set a comparator value", cmd_cmp_set },
+    { "cnt_en", "enable a timing unit counter", cmd_cnt_en },
+    { "cnt_dis", "disable a timing unit counter", cmd_cnt_dis },
+    { "out_en", "enable the given timing unit output(s)", cmd_out_en },
+    { "out_dis", "disable the given timing unit output(s)", cmd_out_dis },
+    { "pwm_dt", "add a dead-time to a complementary pwm output", cmd_pwm_dt },
+    { "an4539", "AN4539 Single PWM generation example", cmd_an4539 },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("HRTIM peripheral driver test\n");
+    initiated = 0;
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/periph_hrtim/main.c
+++ b/tests/periph_hrtim/main.c
@@ -59,7 +59,7 @@ static int cmd_init(int argc, char** argv)
     }
 
     uint16_t period;
-    uint32_t freq = (uint32_t)atoi(argv[2]);
+    uint32_t freq = atoi(argv[2]);
     period = hrtim_init(HRTIM_DEV(dev), &freq, (uint16_t)atoi(argv[3]));
 
     if (period != 0) {
@@ -142,7 +142,7 @@ static int cmd_init_mstr(int argc, char** argv)
         return 1;
     }
 
-    uint32_t freq = (uint32_t)atoi(argv[2]);
+    uint32_t freq = atoi(argv[2]);
     uint16_t period;
     period = hrtim_init_mstr(HRTIM_DEV(dev), &freq);
 
@@ -192,14 +192,14 @@ static int cmd_init_tu(int argc, char** argv)
         return 1;
     }
 
-    hrtim_tu_t tu = (uint8_t)atoi(argv[2]);
+    hrtim_tu_t tu = atoi(argv[2]);
     if (tu >= HRTIM_STU_NUMOF) {
         printf("Error: tu %d is unknown.\n", tu);
         return 1;
     }
 
     uint16_t period;
-    uint32_t freq = (uint32_t)atoi(argv[3]);
+    uint32_t freq = atoi(argv[3]);
     period = hrtim_init_tu(HRTIM_DEV(dev), tu, &freq);
 
     if (period != 0) {

--- a/tests/periph_hrtim/main.c
+++ b/tests/periph_hrtim/main.c
@@ -150,6 +150,7 @@ static int cmd_init_mstr(int argc, char** argv)
         printf("The effective frequency is %" PRIu32 "Hz\n", freq);
         printf("The period is set to %" PRIu16 "\n", period);
         initiated |= (1 << dev);
+        tu_initiated |= (1 << 5);
         return 0;
     }
 
@@ -159,12 +160,12 @@ static int cmd_init_mstr(int argc, char** argv)
 
 static int cmd_init_tu(int argc, char** argv)
 {
-    if (argc != 5) {
+    if (argc != 4) {
         uint32_t f_hrtim = periph_apb_clk(hrtim_config[0].bus) * 2;
         uint32_t max_freq = f_hrtim / 3;
         uint16_t min_freq = f_hrtim / 4 / 0xfffd;
         min_freq++;
-        printf("usage: %s <dev> <tu> <frequency> <dt>\n", argv[0]);
+        printf("usage: %s <dev> <tu> <frequency>\n", argv[0]);
         printf("\tdev: device by number between 0 and %u\n", HRTIM_NUMOF - 1);
         printf("\ttu: timing unit by number between 0 and %d\n",
                 HRTIM_STU_NUMOF - 1);
@@ -483,6 +484,162 @@ static int cmd_cnt_dis(int argc, char**argv)
     return 0;
 }
 
+static inline void _rst_evt_help(void)
+{
+        puts("\tevt: event to enable");
+        puts("\t\t1: RST_UPDT");
+        puts("\t\t2: RST_CMP2");
+        puts("\t\t3: RST_CMP4");
+        puts("\t\t4: RST_MSTPER");
+        puts("\t\t5: RST_MSTCMP1");
+        puts("\t\t6: RST_MSTCMP2");
+        puts("\t\t7: RST_MSTCMP3");
+        puts("\t\t8: RST_MSTCMP4");
+        puts("\t\t9: RST_EXTEVNT1");
+        puts("\t\t10: RST_EXTEVNT2");
+        puts("\t\t11: RST_EXTEVNT3");
+        puts("\t\t12: RST_EXTEVNT4");
+        puts("\t\t13: RST_EXTEVNT5");
+        puts("\t\t14: RST_EXTEVNT6");
+        puts("\t\t15: RST_EXTEVNT7");
+        puts("\t\t16: RST_EXTEVNT8");
+        puts("\t\t17: RST_EXTEVNT9");
+        puts("\t\t18: RST_EXTEVNT10");
+#if (HRTIM_STU_NUMOF == 6)
+#define OPT_RSTF19  " RSTF_TACMP1"
+#define OPT_RSTF20  " RSTF_TACMP2"
+#define OPT_RSTF21  " RSTF_TACMP4"
+#define OPT_RSTF22  " RSTF_TBCMP1"
+#define OPT_RSTF23  " RSTF_TBCMP2"
+#define OPT_RSTF24  " RSTF_TBCMP4"
+#define OPT_RSTF25  " RSTF_TCCMP1"
+#define OPT_RSTF26  " RSTF_TCCMP2"
+#define OPT_RSTF27  " RSTF_TCCMP4"
+#define OPT_RSTF28  " RSTF_TDCMP1"
+#define OPT_RSTF29  " RSTF_TDCMP2"
+#define OPT_RSTF30  " RSTF_TDCMP4"
+#else
+#define OPT_RSTF19  ""
+#define OPT_RSTF20  ""
+#define OPT_RSTF21  ""
+#define OPT_RSTF22  ""
+#define OPT_RSTF23  ""
+#define OPT_RSTF24  ""
+#define OPT_RSTF25  ""
+#define OPT_RSTF26  ""
+#define OPT_RSTF27  ""
+#define OPT_RSTF28  ""
+#define OPT_RSTF29  ""
+#define OPT_RSTF30  ""
+#endif
+        puts("\t\t19: RSTA_TBCMP1 RSTB_TACMP1 RSTC_TACMP1 RSTD_TACMP1"
+            " RSTE_TACMP1" OPT_RSTF19);
+        puts("\t\t20: RSTA_TBCMP2 RSTB_TACMP2 RSTC_TACMP2 RSTD_TACMP2"
+            " RSTE_TACMP2" OPT_RSTF20);
+        puts("\t\t21: RSTA_TBCMP4 RSTB_TACMP4 RSTC_TACMP4 RSTD_TACMP4"
+            " RSTE_TACMP4" OPT_RSTF21);
+        puts("\t\t22: RSTA_TCCMP1 RSTB_TCCMP1 RSTC_TBCMP1 RSTD_TBCMP1"
+            " RSTE_TBCMP1" OPT_RSTF22);
+        puts("\t\t23: RSTA_TCCMP2 RSTB_TCCMP2 RSTC_TBCMP2 RSTD_TBCMP2"
+            " RSTE_TBCMP2" OPT_RSTF23);
+        puts("\t\t24: RSTA_TCCMP4 RSTB_TCCMP4 RSTC_TBCMP4 RSTD_TBCMP4"
+            " RSTE_TBCMP4" OPT_RSTF24);
+        puts("\t\t25: RSTA_TDCMP1 RSTB_TDCMP1 RSTC_TDCMP1 RSTD_TCCMP1"
+            " RSTE_TCCMP1" OPT_RSTF25);
+        puts("\t\t26: RSTA_TDCMP2 RSTB_TDCMP2 RSTC_TDCMP2 RSTD_TCCMP2"
+            " RSTE_TCCMP2" OPT_RSTF26);
+        puts("\t\t27: RSTA_TDCMP4 RSTB_TDCMP4 RSTC_TDCMP4 RSTD_TCCMP4"
+            " RSTE_TCCMP4" OPT_RSTF27);
+        puts("\t\t28: RSTA_TECMP1 RSTB_TECMP1 RSTC_TECMP1 RSTD_TECMP1"
+            " RSTE_TDCMP1" OPT_RSTF28);
+        puts("\t\t29: RSTA_TECMP2 RSTB_TECMP2 RSTC_TECMP2 RSTD_TECMP2"
+            " RSTE_TDCMP2" OPT_RSTF29);
+        puts("\t\t30: RSTA_TECMP4 RSTB_TECMP4 RSTC_TECMP4 RSTD_TECMP4"
+            " RSTE_TDCMP4" OPT_RSTF30);
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t31: RSTA_TFCMP2 RSTB_TFCMP2 RSTC_TFCMP2 RSTD_TFCMP2"
+            " RSTE_TFCMP2 RSTF_TECMP2");    
+#endif
+}
+
+static int cmd_rst_evt_en(int argc, char**argv)
+{
+    if (argc != 4) {
+        printf("usage: %s <dev> <tu> <evt>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+#endif
+        _rst_evt_help();
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_out_t evt = atoi(argv[3]);
+    if (evt < 1 || evt > 31) {
+        printf("Error: evt = %d is invalid.\n", evt);
+        return 1;
+    }
+
+    hrtim_rst_evt_en(HRTIM_DEV(dev), tu, (1 << evt));
+    return 0;
+}
+
+static int cmd_rst_evt_dis(int argc, char**argv)
+{
+    if (argc != 4) {
+        printf("usage: %s <dev> <tu> <evt>\n", argv[0]);
+        printf("\tdev: device by number between 0 and %d\n", HRTIM_NUMOF - 1);
+        printf("\ttu: timing unit by number between 0 and %d\n", HRTIM_STU_NUMOF - 1);
+        puts("\t\t0: TIMA");
+        puts("\t\t1: TIMB");
+        puts("\t\t2: TIMC");
+        puts("\t\t3: TIMD");
+        puts("\t\t4: TIME");
+#if (HRTIM_STU_NUMOF == 6)
+        puts("\t\t5: TIMF");
+#endif
+        _rst_evt_help();
+        return 1;
+    }
+
+    unsigned dev = _get_dev(argv[1]);
+    if (dev == UINT_MAX) {
+        return 1;
+    }
+
+    hrtim_tu_t tu = atoi(argv[2]);
+    if (tu >= HRTIM_STU_NUMOF) {
+        printf("Error: tu %d is unknown.\n", tu);
+        return 1;
+    }
+
+    hrtim_out_t evt = atoi(argv[3]);
+    if (evt < 1 || evt > 31) {
+        printf("Error: evt = %d is invalid.\n", evt);
+        return 1;
+    }
+
+    hrtim_rst_evt_dis(HRTIM_DEV(dev), tu, (1 << evt));
+    return 0;
+}
+
 static int cmd_out_en(int argc, char**argv)
 {
     if (argc != 4) {
@@ -706,7 +863,7 @@ static int cmd_an4539(int argc, char**argv)
             /* Initialize timer D, set period for 100kHz frequency
              * and duty cycle to 50% */
             freq = KHZ(100);
-            period = hrtim_init_tu(0, 3, &freq);
+            period = hrtim_init_tu(0, TIMD, &freq);
             hrtim_cmp_set(0, TIMD, CMP1xR, period / 4);
 
             /* TD1 output set on TIMD period and reset on TIMD CMP1 event*/
@@ -771,6 +928,8 @@ static const shell_command_t shell_commands[] = {
     { "cmp_set", "set a comparator value", cmd_cmp_set },
     { "cnt_en", "enable a timing unit counter", cmd_cnt_en },
     { "cnt_dis", "disable a timing unit counter", cmd_cnt_dis },
+    { "rst_evt_en", "enable a Timerx reset event", cmd_rst_evt_en },
+    { "rst_evt_dis", "disable a Timerx reset event", cmd_rst_evt_dis },
     { "out_en", "enable the given timing unit output(s)", cmd_out_en },
     { "out_dis", "disable the given timing unit output(s)", cmd_out_dis },
     { "pwm_dt", "add a dead-time to a complementary pwm output", cmd_pwm_dt },

--- a/tests/periph_hrtim/main.c
+++ b/tests/periph_hrtim/main.c
@@ -13,7 +13,7 @@
  * @file
  * @brief       Test for low-level HRTIM drivers
  *
- * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ * @author      Hugues Larrive <hugues.larrive@pm.me>
  *
  * @}
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR provide a basic High Resolution Timer API and implementation with configuration for nucleo-f334r8 and a test.

It is basic in the mean that it only manage outputs for now.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tested using the provided test to produce the oscillograms of the HRTIM cookbook's section 2.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
