### PR TITLE
drivers/netdev: Clarify documentation

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -433,6 +433,8 @@ typedef struct netdev_driver {
      * @pre     for array types of @ref netopt_t @p max_len must greater or
      *          equal the required length (see
      *          [netopt documentation](@ref net_netopt) for type)
+     * @pre     @p value must have the natural alignment of its type (see
+     *          [netopt documentation](@ref net_netopt) for type)
      *
      * @param[in]   dev     network device descriptor
      * @param[in]   opt     option type
@@ -454,6 +456,8 @@ typedef struct netdev_driver {
      *          for type)
      * @pre     for array types of @ref netopt_t @p value_len must lesser or
      *          equal the required length (see
+     *          [netopt documentation](@ref net_netopt) for type)
+     * @pre     @p value must have the natural alignment of its type (see
      *          [netopt documentation](@ref net_netopt) for type)
      *
      * @param[in]   dev         network device descriptor


### PR DESCRIPTION
### Contribution description

Clarify that in `netdev_driver_t::get()` and `netdev_driver_t::set()` the argument `value` must point to something not only of matching size, but also of matching alignment as required by the given value for the argument `netopt_t opt`.

The reason is that the implementations often look like this:

```C
int foo_device_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
{
    switch (opt){
    case NETOPT_BAR:
        *((baz_t *)value) = get_baz();
        return sizeof(baz_t);
    ...
    }

    return -ENOTSUP;
}
```

If a user would now pass a `char` array of correct size via `value`, this would result in unaligned memory access. But previously, the documentation didn't forbid doing so.

### Testing procedure

Read the doc

### Issues/PRs references

None