### PR TITLE
cpu/efm32: fix build with !LETIMER [backport 2020.10]

### DIFF
--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -76,6 +76,7 @@ static inline bool _is_letimer(timer_t dev)
 static void _letimer_init(tim_t dev, unsigned long freq)
 {
     (void) freq;
+#if LETIMER_COUNT
     assert(freq == 32768);
 
     LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
@@ -92,6 +93,9 @@ static void _letimer_init(tim_t dev, unsigned long freq)
     LETIMER_Init_TypeDef letimerInit = LETIMER_INIT_DEFAULT;
     letimerInit.enable = false;
     LETIMER_Init(tim, &letimerInit);
+#else
+    (void) dev;
+#endif
 }
 
 static void _timer_init(tim_t dev, unsigned long freq)
@@ -181,6 +185,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
         tim->CC[channel].CTRL = TIMER_CC_CTRL_MODE_OUTPUTCOMPARE;
     }
     else {
+#if LETIMER_COUNT
         LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
 
         /* LETIMER is countdown only, so we invert the value */
@@ -201,6 +206,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
                 return -2;
                 break;
         }
+#endif
     }
 
     return 0;
@@ -213,6 +219,7 @@ int timer_clear(tim_t dev, int channel)
         tim->CC[channel].CTRL = _TIMER_CC_CTRL_MODE_OFF;
     }
     else {
+#if LETIMER_COUNT
         LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
         switch (channel)
         {
@@ -227,30 +234,33 @@ int timer_clear(tim_t dev, int channel)
             default:
                 return -1;
         }
+#endif
     }
     return 0;
 }
 
 unsigned int timer_read(tim_t dev)
 {
+#if LETIMER_COUNT
     if (_is_letimer(dev)) {
         /* LETIMER is countdown only, so we invert the value */
         return (unsigned int) 0xffff
                     - LETIMER_CounterGet(timer_config[dev].timer.dev);
     }
-    else {
-        return (unsigned int) TIMER_CounterGet(timer_config[dev].timer.dev);
-    }
+#endif
+    return (unsigned int) TIMER_CounterGet(timer_config[dev].timer.dev);
 }
 
 void timer_stop(tim_t dev)
 {
     if (_is_letimer(dev)) {
+#if LETIMER_COUNT
         LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
         if (tim->STATUS & LETIMER_STATUS_RUNNING) {
             pm_unblock(EFM32_LETIMER_PM_BLOCKER);
         }
         LETIMER_Enable(timer_config[dev].timer.dev, false);
+#endif
     }
     else {
         TIMER_TypeDef *tim = timer_config[dev].timer.dev;
@@ -265,11 +275,13 @@ void timer_stop(tim_t dev)
 void timer_start(tim_t dev)
 {
     if (_is_letimer(dev)) {
+#if LETIMER_COUNT
         LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
         if (!(tim->STATUS & LETIMER_STATUS_RUNNING)) {
             pm_block(EFM32_LETIMER_PM_BLOCKER);
         }
         LETIMER_Enable(timer_config[dev].timer.dev, true);
+#endif
     }
     else {
         TIMER_TypeDef *tim = timer_config[dev].timer.dev;
@@ -284,6 +296,7 @@ void timer_start(tim_t dev)
 static void _timer_isr(tim_t dev)
 {
     if (_is_letimer(dev)) {
+#if LETIMER_COUNT
         LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
 
         for (int i = 0; i < timer_config[dev].channel_numof; i++) {
@@ -294,6 +307,7 @@ static void _timer_isr(tim_t dev)
                 isr_ctx[dev].cb(isr_ctx[dev].arg, i);
             }
         }
+#endif
     }
     else {
         TIMER_TypeDef *tim = timer_config[dev].timer.dev;


### PR DESCRIPTION
# Backport of #15158



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Not all SoCs have an LETIMER.
Here the compilation will will fail because LETIMER related symbols are not defined.

Fix the build of `timer.c` for those.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

needed for #12353
