### PR TITLE
info-objsize: Restore info-objsize target

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -14,11 +14,14 @@ info-objsize:
 	  "") SORTROW=4 ;; \
 	  *) echo "Usage: $(MAKE) info-objsize SORTROW=[text|data|bss|dec]" ; return ;; \
 	esac; \
-	printf '   text\t   data\t    bss\t    dec\t    hex\tfilename\n'; \
-	$(SIZE) -d -B $(BASELIBS) | \
-	  tail -n+2 | \
-	  sed -e 's#$(BINDIR)##' | \
-	  sort -rnk$${SORTROW}
+	printf '   text\t   data\t    bss\t    dec\t    hex\tmodule\n'; \
+	for i in $(sort $(BASELIBS:%.module=%)); \
+	do \
+	$(SIZE) -t -d -B $(BINDIR)/$$i/*.o 2> /dev/null | \
+	  tail -n1 | \
+	  sed -e "s#(TOTALS)#$$i#" | \
+	  sed -e 's#$(BINDIR)##'; \
+	done | sort -n -r -k $${SORTROW}
 
 info-buildsize:
 	@$(SIZE) -d -B $(ELFFILE) || echo ''


### PR DESCRIPTION
### Contribution description

This restores ~~most of~~ the functionality of the info-objsize target.
~~Sorting however is not yet available. It sorts now by module name~~

### Testing procedure

`make -C examples/default BOARD=samr21-xpro all info-objsize`

### Issues/PRs references

#15118 