### PR TITLE
tests/periph_wdt: send newline to get prompt

### DIFF
--- a/tests/periph_wdt/Makefile
+++ b/tests/periph_wdt/Makefile
@@ -1,6 +1,9 @@
 BOARD ?= nucleo-l152re
 include ../Makefile.tests_common
 
+# Use socat so '\n' are not ignored when waiting for '>'
+RIOT_TERMINAL ?= socat
+
 FEATURES_REQUIRED += periph_wdt
 
 USEMODULE += xtimer

--- a/tests/periph_wdt/tests/01-run.py
+++ b/tests/periph_wdt/tests/01-run.py
@@ -51,6 +51,7 @@ def get_reset_time(child):
 
 
 def testfunc(child):
+    child.sendline("\n")
     child.expect_exact(">")
     child.sendline("range")
     child.expect(r"lower_bound: (\d+) upper_bound: (\d+)\s*\r\n",
@@ -59,11 +60,13 @@ def testfunc(child):
     wdt_upper_bound = int(child.match.group(2))
 
     for rst_time in reset_times_ms:
+        child.sendline("\n")
         child.expect_exact(">")
         child.sendline("setup 0 {}".format(rst_time))
         if rst_time < wdt_lower_bound or rst_time > wdt_upper_bound:
             child.expect_exact("invalid time, see \"range\"", timeout=1)
         else:
+            child.sendline("\n")
             child.expect_exact(">")
             child.sendline("startloop")
             child.expect(r"start time: (\d+) us", timeout=1)


### PR DESCRIPTION
### Contribution description

While running release tests I found that on `arduino-mega2560` the test timed out waiting for the prompt, send a "\n" to force a prompt.

### Testing procedure

`tests/periph_wdt` passes on `arduino-mega2560`.

### Issues/PRs references


Found while running tests for RIOT-OS/Release-Specs#192.
