### PR TITLE
fe310: Support compilation with clang

### DIFF
--- a/cpu/riscv_common/Makefile.include
+++ b/cpu/riscv_common/Makefile.include
@@ -1,6 +1,8 @@
 CFLAGS += -Wno-pedantic
 INCLUDES += -I$(RIOTCPU)/riscv_common/include
 
+TOOLCHAINS_SUPPORTED = gnu llvm
+
 # All variables must be defined in the CPU configuration when using the common
 # `ldscripts/riscv.ld`
 ifneq (,$(ROM_START_ADDR)$(RAM_START_ADDR)$(ROM_LEN)$(RAM_LEN))

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -116,8 +116,8 @@ void handle_trap(uint32_t mcause)
 #ifdef DEVELHELP
             printf("Unhandled trap:\n");
             printf("  mcause: 0x%" PRIx32 "\n", mcause);
-            printf("  mepc:   0x%" PRIx32 "\n", read_csr(mepc));
-            printf("  mtval:  0x%" PRIx32 "\n", read_csr(mtval));
+            printf("  mepc:   0x%lx\n", read_csr(mepc));
+            printf("  mtval:  0x%lx\n", read_csr(mtval));
 #endif
             /* Unknown trap */
             core_panic(PANIC_GENERAL_ERROR, "Unhandled trap");

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -30,8 +30,15 @@ TARGET_ARCH_RISCV ?= \
 TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
 
 # define build specific options
-CFLAGS_CPU   = -march=rv32imac -mabi=ilp32 -mcmodel=medlow -msmall-data-limit=8
-CFLAGS_LINK  = -nostartfiles -ffunction-sections -fdata-sections
+CFLAGS_CPU   = -march=rv32imac -mabi=ilp32
+ifeq ($(TOOLCHAIN),llvm)
+  # Always use riscv32-none-elf as target triple for clang, as some
+  # autodetected gcc target triples are incompatible with clang
+  TARGET_ARCH_LLVM := riscv32-none-elf
+else
+  CFLAGS_CPU += -mcmodel=medlow -msmall-data-limit=8
+endif
+CFLAGS_LINK  = -ffunction-sections -fdata-sections
 CFLAGS_DBG  ?= -g3
 CFLAGS_OPT  ?= -Os
 
@@ -42,4 +49,4 @@ LINKFLAGS += -T$(LINKER_SCRIPT)
 CFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) $(CFLAGS_LINK)
 ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 # export linker flags
-LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
+LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -nostartfiles -Wl,--gc-sections -static -lgcc


### PR DESCRIPTION
### Contribution description

Not sure if there is any interested in this but I am personally currently working on using the HiFive1 with the clang compiler. The changes below enabled me to do so, currently doing some more manual testing but haven't found any issues so far. 91707a60e858b7501505e3ecc2e510a51ef931b9 might be useful even if you are not interested in supporting the clang/llvm toolchain on the hifive1.

### Testing procedure

Compile some example applications with `BOARD=hifive1` and run them.

### Issues/PRs references

None.
