### PR TITLE
boards/nucleo-l152re: fix DMA configuration [backport 2020.10]

### DIFF
--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -39,10 +39,10 @@ static const dma_conf_t dma_config[] = {
     { .stream = 4 },    /* DMA1 Channel 4 - USART1_TX */
 };
 
-#define DMA_0_ISR  isr_dma1_ch2
-#define DMA_1_ISR  isr_dma1_ch3
-#define DMA_2_ISR  isr_dma1_ch7
-#define DMA_3_ISR  isr_dma1_ch4
+#define DMA_0_ISR  isr_dma1_channel2
+#define DMA_1_ISR  isr_dma1_channel3
+#define DMA_2_ISR  isr_dma1_channel7
+#define DMA_3_ISR  isr_dma1_channel4
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
 /** @} */


### PR DESCRIPTION
# Backport of #15177

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the DMA configuration of the nucleo-152re board as reported in https://github.com/RIOT-OS/RIOT/pull/14595#issuecomment-704989693

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check the ISR function names generated in `cpu/stm32/vectors/STM32L153xE.c`, they should match with the configuration
- `tests/periph_dma` is working on nucleo-l152re

<details>

```
$ BUILD_IN_DOCKER=1 TRIBE_CI=1 make BOARD=nucleo-l152re -C tests/periph_dma flash test
make: Entering directory '/work/riot/RIOT/tests/periph_dma'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l152re'  -w '/data/riotbuild/riotbase/tests/periph_dma/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l152re'    
Building application "tests_periph_dma" for "nucleo-l152re" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l152re
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  10908	    132	   2452	  13492	   34b4	/data/riotbuild/riotbase/tests/periph_dma/bin/nucleo-l152re/tests_periph_dma.elf
rsync --chmod=ugo=rwX /work/riot/RIOT/tests/periph_dma/bin/nucleo-l152re/tests_periph_dma.elf ci@ci-riot-tribe.saclay.inria.fr:/builds/boards/bin/nucleo-l152re_flashfile.elf
ssh ci@ci-riot-tribe.saclay.inria.fr 'IMAGE_OFFSET= BOARD=nucleo-l152re QUIET=0 make --no-print-directory -C /builds/boards flash-only FLASHFILE=/builds/boards/bin/nucleo-l152re_flashfile.elf'
/builds/boards/RIOT/dist/tools/openocd/openocd.sh flash /builds/boards/bin/nucleo-l152re_flashfile.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-g68611ef-dirty (2020-07-20-09:42)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.259064
Info : stm32l1.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l1.cpu on 0
Info : Listening on port 45929 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l1.cpu        hla_target little stm32l1.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000740 msp: 0x20000200
Info : Device: STM32L1xx (Cat.5/Cat.6)
Info : STM32L flash has dual banks. Bank (0) size is 256kb, base address is 0x8000000
auto erase enabled
wrote 12288 bytes from file /builds/boards/bin/nucleo-l152re_flashfile.elf in 1.576905s (7.610 KiB/s)

verified 11040 bytes in 0.720334s (14.967 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing
r
ssh -t ci@ci-riot-tribe.saclay.inria.fr 'BOARD=nucleo-l152re QUIET=0 make --no-print-directory -C /builds/boards term' 
/builds/boards/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-nucleo-l152re" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-10-07 17:52:20,983 # Connect to serial port /dev/riot/tty-nucleo-l152re
Welcome to pyterm!
Type '/exit' to exit.
2020-10-07 17:52:21,990 # READY
s
2020-10-07 17:52:22,134 # START
2020-10-07 17:52:22,142 # main(): This is RIOT! (Version: 2021.01-devel-52-g28b08-pr/boards/nucleo-l152re_dma_fix)
2020-10-07 17:52:22,146 # DMA is working

make: Leaving directory '/work/riot/RIOT/tests/periph_dma'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Regression introduced in #14595

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
