### PR TITLE
cpu/stm32/irqs: fix regexp in vectors generator script

### DIFF
--- a/cpu/stm32/dist/irqs/gen_vectors.py
+++ b/cpu/stm32/dist/irqs/gen_vectors.py
@@ -74,7 +74,7 @@ def parse_cmsis(cpu_line):
             use_line = True
 
         # use a regexp to get the available IRQs
-        match = re.match(r"[ ]+([a-zA-Z0-9_]+_IRQn)[ ]+= \d+,", line)
+        match = re.match(r"[ ]+([a-zA-Z0-9_]+_IRQn)[ ]+= \d+", line)
 
         # Skip lines that don't match
         if match is None:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the regexp in the Python script used to get the list of available IRQs. On STM32L152xE, the last IRQs enum doesn't have a `,` at the end of line, so it's missed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check that in the generated `cpu/stm32/vectors/STM32L152xE.c` file contains `COMP_ACQ_IRQn` at the end of the isr array (remove the file between each check).

<details><summary>this PR</summary>

```
$ rm -f cpu/stm32/vectors/STM32L152xE.c 
$ make BOARD=nucleo-l152re -C examples/hello-world
$ cat cpu/stm32/vectors/STM32L152xE.c 

/*
 * PLEASE DON'T EDIT
 *
 * This file was automatically generated by
 * ./cpu/stm32/dist/irqs/gen_vectors.py
 */

#include "vectors_cortexm.h"

/* define a local dummy handler as it needs to be in the same compilation unit
 * as the alias definition */
void dummy_handler(void) {
    dummy_handler_default();
}

/* STM32L152xE specific interrupt vectors */
WEAK_DEFAULT void isr_wwdg(void);
WEAK_DEFAULT void isr_pvd(void);
WEAK_DEFAULT void isr_tamper_stamp(void);
WEAK_DEFAULT void isr_rtc_wkup(void);
WEAK_DEFAULT void isr_flash(void);
WEAK_DEFAULT void isr_rcc(void);
WEAK_DEFAULT void isr_exti(void);
WEAK_DEFAULT void isr_dma1_channel1(void);
WEAK_DEFAULT void isr_dma1_channel2(void);
WEAK_DEFAULT void isr_dma1_channel3(void);
WEAK_DEFAULT void isr_dma1_channel4(void);
WEAK_DEFAULT void isr_dma1_channel5(void);
WEAK_DEFAULT void isr_dma1_channel6(void);
WEAK_DEFAULT void isr_dma1_channel7(void);
WEAK_DEFAULT void isr_adc1(void);
WEAK_DEFAULT void isr_usb_hp(void);
WEAK_DEFAULT void isr_usb_lp(void);
WEAK_DEFAULT void isr_dac(void);
WEAK_DEFAULT void isr_comp(void);
WEAK_DEFAULT void isr_lcd(void);
WEAK_DEFAULT void isr_tim9(void);
WEAK_DEFAULT void isr_tim10(void);
WEAK_DEFAULT void isr_tim11(void);
WEAK_DEFAULT void isr_tim2(void);
WEAK_DEFAULT void isr_tim3(void);
WEAK_DEFAULT void isr_tim4(void);
WEAK_DEFAULT void isr_i2c1_ev(void);
WEAK_DEFAULT void isr_i2c1_er(void);
WEAK_DEFAULT void isr_i2c2_ev(void);
WEAK_DEFAULT void isr_i2c2_er(void);
WEAK_DEFAULT void isr_spi1(void);
WEAK_DEFAULT void isr_spi2(void);
WEAK_DEFAULT void isr_usart1(void);
WEAK_DEFAULT void isr_usart2(void);
WEAK_DEFAULT void isr_usart3(void);
WEAK_DEFAULT void isr_rtc_alarm(void);
WEAK_DEFAULT void isr_usb_fs_wkup(void);
WEAK_DEFAULT void isr_tim6(void);
WEAK_DEFAULT void isr_tim7(void);
WEAK_DEFAULT void isr_tim5(void);
WEAK_DEFAULT void isr_spi3(void);
WEAK_DEFAULT void isr_uart4(void);
WEAK_DEFAULT void isr_uart5(void);
WEAK_DEFAULT void isr_dma2_channel1(void);
WEAK_DEFAULT void isr_dma2_channel2(void);
WEAK_DEFAULT void isr_dma2_channel3(void);
WEAK_DEFAULT void isr_dma2_channel4(void);
WEAK_DEFAULT void isr_dma2_channel5(void);
WEAK_DEFAULT void isr_comp_acq(void);

/* CPU specific interrupt vector table */
ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
    [WWDG_IRQn                          ] = isr_wwdg,
    [PVD_IRQn                           ] = isr_pvd,
    [TAMPER_STAMP_IRQn                  ] = isr_tamper_stamp,
    [RTC_WKUP_IRQn                      ] = isr_rtc_wkup,
    [FLASH_IRQn                         ] = isr_flash,
    [RCC_IRQn                           ] = isr_rcc,
    [EXTI0_IRQn                         ] = isr_exti,
    [EXTI1_IRQn                         ] = isr_exti,
    [EXTI2_IRQn                         ] = isr_exti,
    [EXTI3_IRQn                         ] = isr_exti,
    [EXTI4_IRQn                         ] = isr_exti,
    [DMA1_Channel1_IRQn                 ] = isr_dma1_channel1,
    [DMA1_Channel2_IRQn                 ] = isr_dma1_channel2,
    [DMA1_Channel3_IRQn                 ] = isr_dma1_channel3,
    [DMA1_Channel4_IRQn                 ] = isr_dma1_channel4,
    [DMA1_Channel5_IRQn                 ] = isr_dma1_channel5,
    [DMA1_Channel6_IRQn                 ] = isr_dma1_channel6,
    [DMA1_Channel7_IRQn                 ] = isr_dma1_channel7,
    [ADC1_IRQn                          ] = isr_adc1,
    [USB_HP_IRQn                        ] = isr_usb_hp,
    [USB_LP_IRQn                        ] = isr_usb_lp,
    [DAC_IRQn                           ] = isr_dac,
    [COMP_IRQn                          ] = isr_comp,
    [EXTI9_5_IRQn                       ] = isr_exti,
    [LCD_IRQn                           ] = isr_lcd,
    [TIM9_IRQn                          ] = isr_tim9,
    [TIM10_IRQn                         ] = isr_tim10,
    [TIM11_IRQn                         ] = isr_tim11,
    [TIM2_IRQn                          ] = isr_tim2,
    [TIM3_IRQn                          ] = isr_tim3,
    [TIM4_IRQn                          ] = isr_tim4,
    [I2C1_EV_IRQn                       ] = isr_i2c1_ev,
    [I2C1_ER_IRQn                       ] = isr_i2c1_er,
    [I2C2_EV_IRQn                       ] = isr_i2c2_ev,
    [I2C2_ER_IRQn                       ] = isr_i2c2_er,
    [SPI1_IRQn                          ] = isr_spi1,
    [SPI2_IRQn                          ] = isr_spi2,
    [USART1_IRQn                        ] = isr_usart1,
    [USART2_IRQn                        ] = isr_usart2,
    [USART3_IRQn                        ] = isr_usart3,
    [EXTI15_10_IRQn                     ] = isr_exti,
    [RTC_Alarm_IRQn                     ] = isr_rtc_alarm,
    [USB_FS_WKUP_IRQn                   ] = isr_usb_fs_wkup,
    [TIM6_IRQn                          ] = isr_tim6,
    [TIM7_IRQn                          ] = isr_tim7,
    [TIM5_IRQn                          ] = isr_tim5,
    [SPI3_IRQn                          ] = isr_spi3,
    [UART4_IRQn                         ] = isr_uart4,
    [UART5_IRQn                         ] = isr_uart5,
    [DMA2_Channel1_IRQn                 ] = isr_dma2_channel1,
    [DMA2_Channel2_IRQn                 ] = isr_dma2_channel2,
    [DMA2_Channel3_IRQn                 ] = isr_dma2_channel3,
    [DMA2_Channel4_IRQn                 ] = isr_dma2_channel4,
    [DMA2_Channel5_IRQn                 ] = isr_dma2_channel5,
    [COMP_ACQ_IRQn                      ] = isr_comp_acq,
};

```

</details>

<details><summary>master</summary>

```
$ rm -f cpu/stm32/vectors/STM32L152xE.c 
$ make BOARD=nucleo-l152re -C examples/hello-world
$ cat cpu/stm32/vectors/STM32L152xE.c 

/*
 * PLEASE DON'T EDIT
 *
 * This file was automatically generated by
 * ./cpu/stm32/dist/irqs/gen_vectors.py
 */

#include "vectors_cortexm.h"

/* define a local dummy handler as it needs to be in the same compilation unit
 * as the alias definition */
void dummy_handler(void) {
    dummy_handler_default();
}

/* STM32L152xE specific interrupt vectors */
WEAK_DEFAULT void isr_wwdg(void);
WEAK_DEFAULT void isr_pvd(void);
WEAK_DEFAULT void isr_tamper_stamp(void);
WEAK_DEFAULT void isr_rtc_wkup(void);
WEAK_DEFAULT void isr_flash(void);
WEAK_DEFAULT void isr_rcc(void);
WEAK_DEFAULT void isr_exti(void);
WEAK_DEFAULT void isr_dma1_channel1(void);
WEAK_DEFAULT void isr_dma1_channel2(void);
WEAK_DEFAULT void isr_dma1_channel3(void);
WEAK_DEFAULT void isr_dma1_channel4(void);
WEAK_DEFAULT void isr_dma1_channel5(void);
WEAK_DEFAULT void isr_dma1_channel6(void);
WEAK_DEFAULT void isr_dma1_channel7(void);
WEAK_DEFAULT void isr_adc1(void);
WEAK_DEFAULT void isr_usb_hp(void);
WEAK_DEFAULT void isr_usb_lp(void);
WEAK_DEFAULT void isr_dac(void);
WEAK_DEFAULT void isr_comp(void);
WEAK_DEFAULT void isr_lcd(void);
WEAK_DEFAULT void isr_tim9(void);
WEAK_DEFAULT void isr_tim10(void);
WEAK_DEFAULT void isr_tim11(void);
WEAK_DEFAULT void isr_tim2(void);
WEAK_DEFAULT void isr_tim3(void);
WEAK_DEFAULT void isr_tim4(void);
WEAK_DEFAULT void isr_i2c1_ev(void);
WEAK_DEFAULT void isr_i2c1_er(void);
WEAK_DEFAULT void isr_i2c2_ev(void);
WEAK_DEFAULT void isr_i2c2_er(void);
WEAK_DEFAULT void isr_spi1(void);
WEAK_DEFAULT void isr_spi2(void);
WEAK_DEFAULT void isr_usart1(void);
WEAK_DEFAULT void isr_usart2(void);
WEAK_DEFAULT void isr_usart3(void);
WEAK_DEFAULT void isr_rtc_alarm(void);
WEAK_DEFAULT void isr_usb_fs_wkup(void);
WEAK_DEFAULT void isr_tim6(void);
WEAK_DEFAULT void isr_tim7(void);
WEAK_DEFAULT void isr_tim5(void);
WEAK_DEFAULT void isr_spi3(void);
WEAK_DEFAULT void isr_uart4(void);
WEAK_DEFAULT void isr_uart5(void);
WEAK_DEFAULT void isr_dma2_channel1(void);
WEAK_DEFAULT void isr_dma2_channel2(void);
WEAK_DEFAULT void isr_dma2_channel3(void);
WEAK_DEFAULT void isr_dma2_channel4(void);
WEAK_DEFAULT void isr_dma2_channel5(void);

/* CPU specific interrupt vector table */
ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
    [WWDG_IRQn                          ] = isr_wwdg,
    [PVD_IRQn                           ] = isr_pvd,
    [TAMPER_STAMP_IRQn                  ] = isr_tamper_stamp,
    [RTC_WKUP_IRQn                      ] = isr_rtc_wkup,
    [FLASH_IRQn                         ] = isr_flash,
    [RCC_IRQn                           ] = isr_rcc,
    [EXTI0_IRQn                         ] = isr_exti,
    [EXTI1_IRQn                         ] = isr_exti,
    [EXTI2_IRQn                         ] = isr_exti,
    [EXTI3_IRQn                         ] = isr_exti,
    [EXTI4_IRQn                         ] = isr_exti,
    [DMA1_Channel1_IRQn                 ] = isr_dma1_channel1,
    [DMA1_Channel2_IRQn                 ] = isr_dma1_channel2,
    [DMA1_Channel3_IRQn                 ] = isr_dma1_channel3,
    [DMA1_Channel4_IRQn                 ] = isr_dma1_channel4,
    [DMA1_Channel5_IRQn                 ] = isr_dma1_channel5,
    [DMA1_Channel6_IRQn                 ] = isr_dma1_channel6,
    [DMA1_Channel7_IRQn                 ] = isr_dma1_channel7,
    [ADC1_IRQn                          ] = isr_adc1,
    [USB_HP_IRQn                        ] = isr_usb_hp,
    [USB_LP_IRQn                        ] = isr_usb_lp,
    [DAC_IRQn                           ] = isr_dac,
    [COMP_IRQn                          ] = isr_comp,
    [EXTI9_5_IRQn                       ] = isr_exti,
    [LCD_IRQn                           ] = isr_lcd,
    [TIM9_IRQn                          ] = isr_tim9,
    [TIM10_IRQn                         ] = isr_tim10,
    [TIM11_IRQn                         ] = isr_tim11,
    [TIM2_IRQn                          ] = isr_tim2,
    [TIM3_IRQn                          ] = isr_tim3,
    [TIM4_IRQn                          ] = isr_tim4,
    [I2C1_EV_IRQn                       ] = isr_i2c1_ev,
    [I2C1_ER_IRQn                       ] = isr_i2c1_er,
    [I2C2_EV_IRQn                       ] = isr_i2c2_ev,
    [I2C2_ER_IRQn                       ] = isr_i2c2_er,
    [SPI1_IRQn                          ] = isr_spi1,
    [SPI2_IRQn                          ] = isr_spi2,
    [USART1_IRQn                        ] = isr_usart1,
    [USART2_IRQn                        ] = isr_usart2,
    [USART3_IRQn                        ] = isr_usart3,
    [EXTI15_10_IRQn                     ] = isr_exti,
    [RTC_Alarm_IRQn                     ] = isr_rtc_alarm,
    [USB_FS_WKUP_IRQn                   ] = isr_usb_fs_wkup,
    [TIM6_IRQn                          ] = isr_tim6,
    [TIM7_IRQn                          ] = isr_tim7,
    [TIM5_IRQn                          ] = isr_tim5,
    [SPI3_IRQn                          ] = isr_spi3,
    [UART4_IRQn                         ] = isr_uart4,
    [UART5_IRQn                         ] = isr_uart5,
    [DMA2_Channel1_IRQn                 ] = isr_dma2_channel1,
    [DMA2_Channel2_IRQn                 ] = isr_dma2_channel2,
    [DMA2_Channel3_IRQn                 ] = isr_dma2_channel3,
    [DMA2_Channel4_IRQn                 ] = isr_dma2_channel4,
    [DMA2_Channel5_IRQn                 ] = isr_dma2_channel5,
};
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that when I found the bug fixed by #15177 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
