### PR TITLE
info.inc.mk: Add info-build-json as JSON-formatted build info

### DIFF
--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -14,8 +14,6 @@ priv_symbols += FLUSH_TO_ZERO
 priv_symbols += FLASH_START APP_START FLASH_APP_START
 priv_symbols += ISR_VEC_SPACE ISR_VECTOR_COUNT
 
-comma := ,
-
 # A bit of makefile magic:
 # foreach symbol in overridable ld-symbols :
 #   If symbol has a value, produce a linker argument for that symbol.

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -114,6 +114,72 @@ info-build:
 	@echo ''
 	@echo -e 'MAKEFILE_LIST:$(patsubst %, \n\t%, $(abspath $(MAKEFILE_LIST)))'
 
+define json_string_or_null
+$(or $(1:%="%"), null)
+endef
+
+# Convert a space separated list to a JSON array
+define _to_json_string_list
+[$(filter-out "","$(subst $(space),"$(comma)$(space)",$(1))")]
+endef
+
+# Strips out any existing quotes so that the generated JSON is valid, not necessary sensible
+define to_json_string_list
+$(call _to_json_string_list,$(strip $(subst ",,$(subst \",,$(1)))))
+endef
+
+# Crude json encoded build info.
+# The output generated here is a best-effort JSON encoding, it is not perfect,
+# converting the space separated lists in Make to a JSON array is flawed, it
+# doesn't consider quoted parts as a single list item.  This mainly shows up in
+# cflags such as:  -DNIMBLE_HOST_PRIO="(NIMBLE_CONTROLLER_PRIO + 1)", this is
+# splitted into 3 array elements. To ensure that the generated JSON is valid,
+# double quotes are currently stripped before generating the array.
+info-build-json:
+	@echo '{ '
+	@echo '"APPLICATION": "$(APPLICATION)",'
+	@echo '"APPDIR": "$(APPDIR)",'
+	@echo '"BOARD": "$(BOARD)",'
+	@echo '"CPU": "$(CPU)",'
+	@echo '"MCU": "$(MCU)",'
+	@echo '"RIOTBASE": "$(RIOTBASE)",'
+	@echo '"BOARDDIR": "$(BOARDDIR)",'
+	@echo '"RIOTCPU": "$(RIOTCPU)",'
+	@echo '"RIOTPKG": "$(RIOTPKG)",'
+	@echo '"EXTERNAL_BOARD_DIRS": $(call json_string_or_null $(EXTERNAL_BOARD_DIRS)),'
+	@echo '"BINDIR": "$(BINDIR)",'
+	@echo '"ELFFILE": "$(ELFFILE)",'
+	@echo '"HEXFILE": "$(HEXFILE)",'
+	@echo '"BINFILE": "$(BINFILE)",'
+	@echo '"FLASHFILE": "$(FLASHFILE)",'
+	@echo '"DEFAULT_MODULE": $(call to_json_string_list,$(sort $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE)))),'
+	@echo '"DISABLE_MODULE": $(call to_json_string_list,$(sort $(DISABLE_MODULE))),'
+	@echo '"USEMODULE": $(call to_json_string_list,$(sort $(filter-out $(DEFAULT_MODULE), $(USEMODULE)))),'
+	@echo '"FEATURES_USED": $(call to_json_string_list,$(FEATURES_USED)),'
+	@echo '"FEATURES_REQUIRED": $(call to_json_string_list,$(sort $(FEATURES_REQUIRED))),'
+	@echo '"FEATURES_REQUIRED_ANY": $(call to_json_string_list,$(sort $(FEATURES_REQUIRED_ANY))),'
+	@echo '"FEATURES_OPTIONAL_ONLY": $(call to_json_string_list,$(FEATURES_OPTIONAL_ONLY)),'
+	@echo '"FEATURES_OPTIONAL_MISSING": $(call to_json_string_list,$(FEATURES_OPTIONAL_MISSING)),'
+	@echo '"FEATURES_PROVIDED": $(call to_json_string_list,$(sort $(FEATURES_PROVIDED))),'
+	@echo '"FEATURES_MISSING": $(call to_json_string_list,$(FEATURES_MISSING)),'
+	@echo '"FEATURES_BLACKLIST": $(call to_json_string_list,$(sort $(FEATURES_BLACKLIST))),'
+	@echo '"FEATURES_USED_BLACKLISTED": $(call to_json_string_list,$(sort $(FEATURES_USED_BLACKLISTED))),'
+	@echo '"FEATURES_CONFLICT": $(call to_json_string_list,$(FEATURES_CONFLICT)),'
+	@echo '"FEATURES_CONFLICTING": $(call to_json_string_list,$(FEATURES_CONFLICTING)),'
+	@echo '"PREFIX": $(call json_string_or_null,$(PREFIX)),'
+	@echo '"CC": "$(CC)",'
+	@echo '"CXX": "$(CXX)",'
+	@echo '"LINK": "$(LINK)",'
+	@echo '"OBJCOPY": "$(OBJCOPY)",'
+	@echo '"INCLUDES": $(call to_json_string_list,$(strip $(INCLUDES))),'
+	@echo '"OFLAGS":  $(call to_json_string_list,$(OFLAGS)),'
+	@echo '"CFLAGS": $(call to_json_string_list,$(CFLAGS)),'
+	@echo '"CXXUWFLAGS": $(call to_json_string_list,$(CXXUWFLAGS)),'
+	@echo '"CXXEXFLAGS": $(call to_json_string_list,$(CXXEXFLAGS)),'
+	@echo '"LINKFLAGS": $(call to_json_string_list,$(LINKFLAGS))'
+	@echo '}'
+
+
 info-files: QUIET := 0
 info-files:
 	@( \

--- a/makefiles/utils/variables.mk
+++ b/makefiles/utils/variables.mk
@@ -1,6 +1,10 @@
 # Utilities to set variables and environment for targets
+# The variables defined here cover edge cases in make string handling.
 # These functions should help replacing immediate evaluation and global 'export'
 
+comma := ,
+blank :=
+space := $(blank) $(blank)
 
 # Evaluate a deferred variable only once on its first usage
 # Uses after that will be as if it was an immediate evaluation

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -42,11 +42,9 @@ info-unittests:
 
 $(UNIT_TESTS): all
 
-charCOMMA := ,
-
 ifeq (, $(UNIT_TESTS))
   CFLAGS += -DNO_TEST_SUITES
   $(warning There was no test suite specified!)
 else
-  CFLAGS += -DTEST_SUITES='$(subst $() $(),$(charCOMMA),$(UNIT_TESTS:tests-%=%))'
+  CFLAGS += -DTEST_SUITES='$(subst $() $(),$(comma),$(UNIT_TESTS:tests-%=%))'
 endif


### PR DESCRIPTION
### Contribution description

This PR adds a JSON-formatted version of the info-build command. This allows RIOT meta applications such as riotctrl to query the build system without having to string parse the output of `info-build`. 

The output is not perfect, converting a space separated list in Make to a JSON array is flawed, it doesn't consider quoted parts as a single item. This mainly shows up in cflags such as: `-DNIMBLE_HOST_PRIO="(NIMBLE_CONTROLLER_PRIO + 1)"`, this is splitted into 3 array elements. To ensure that the JSON remains valid, double quotes are currently stripped before generating the array.

### Testing procedure

The output must be something along the lines of:
<details><summary>make BOARD=acd52832 info-build-json</summary>

with:
```shellsession
koen@morgen ~/dev/RIOT/boards $ make -C examples/default/ BOARD=acd52832 info-build-json| tail -n+2 |head -n-1|jq
```

```json
{
  "APPLICATION": "default",
  "APPDIR": "/home/koen/dev/RIOT-review/examples/default",
  "BOARD": "acd52832",
  "CPU": "nrf52",
  "MCU": "nrf52",
  "RIOTBASE": "/home/koen/dev/RIOT-review",
  "BOARDDIR": "/home/koen/dev/RIOT-review/boards/acd52832",
  "RIOTCPU": "/home/koen/dev/RIOT-review/cpu",
  "RIOTPKG": "/home/koen/dev/RIOT-review/pkg",
  "EXTERNAL_BOARD_DIRS": null,
  "BINDIR": "/home/koen/dev/RIOT-review/examples/default/bin/acd52832",
  "ELFFILE": "/home/koen/dev/RIOT-review/examples/default/bin/acd52832/default.elf",
  "HEXFILE": "/home/koen/dev/RIOT-review/examples/default/bin/acd52832/default.hex",
  "BINFILE": "/home/koen/dev/RIOT-review/examples/default/bin/acd52832/default.bin",
  "FLASHFILE": "/home/koen/dev/RIOT-review/examples/default/bin/acd52832/default.bin",
  "DEFAULT_MODULE": [
    "auto_init",
    "auto_init_gnrc_pktbuf",
    "auto_init_gnrc_pktdump",
    "auto_init_saul",
    "auto_init_xtimer",
    "board",
    "core",
    "core_init",
    "core_msg",
    "core_panic",
    "cortexm_fpu",
    "cpu",
    "periph_init",
    "periph_init_cpuid",
    "periph_init_gpio",
    "periph_init_pm",
    "periph_init_temperature",
    "periph_init_timer",
    "periph_init_uart",
    "sys"
  ],
  "DISABLE_MODULE": [],
  "USEMODULE": [
    "auto_init_gnrc_netif",
    "bluetil_ad",
    "bluetil_addr",
    "core_thread_flags",
    "cortexm_common",
    "cortexm_common_periph",
    "cpu_common",
    "div",
    "eui_provider",
    "event",
    "event_callback",
    "fmt",
    "gnrc",
    "gnrc_netapi",
    "gnrc_netdev_default",
    "gnrc_netif",
    "gnrc_netif_hdr",
    "gnrc_netif_init_devs",
    "gnrc_netreg",
    "gnrc_pkt",
    "gnrc_pktbuf",
    "gnrc_pktbuf_static",
    "gnrc_pktdump",
    "gnrc_txtsnd",
    "isrpipe",
    "l2util",
    "luid",
    "mpu_stack_guard",
    "netdev",
    "netdev_default",
    "netdev_register",
    "netif",
    "newlib",
    "newlib_nano",
    "newlib_syscalls_default",
    "nimble_addr",
    "nimble_controller",
    "nimble_drivers_nrf5x",
    "nimble_host",
    "nimble_host_store_ram",
    "nimble_host_util",
    "nimble_netif",
    "nimble_npl_riot",
    "nimble_porting_nimble",
    "nimble_riot_contrib",
    "nimble_scanlist",
    "nimble_scanner",
    "nimble_tinycrypt",
    "nimble_transport_ram",
    "nrf52_vectors",
    "nrf5x_common_periph",
    "od",
    "periph",
    "periph_common",
    "periph_cpuid",
    "periph_gpio",
    "periph_pm",
    "periph_temperature",
    "periph_timer",
    "periph_uart",
    "phydat",
    "posix_headers",
    "posix_semaphore",
    "ps",
    "saul",
    "saul_default",
    "saul_gpio",
    "saul_init_devs",
    "saul_nrf_temperature",
    "saul_reg",
    "sema",
    "shell",
    "shell_commands",
    "stdin",
    "stdio_uart",
    "stdio_uart_rx",
    "tsrb",
    "xtimer"
  ],
  "FEATURES_USED": [
    "arch_32bit",
    "arch_arm",
    "ble_nimble",
    "ble_nimble_netif",
    "cortexm_fpu",
    "cortexm_mpu",
    "cpu_core_cortexm",
    "no_idle_thread",
    "periph_cpuid",
    "periph_gpio",
    "periph_pm",
    "periph_temperature",
    "periph_timer",
    "periph_uart"
  ],
  "FEATURES_REQUIRED": [
    "arch_32bit",
    "arch_arm",
    "ble_nimble",
    "ble_nimble_netif",
    "cortexm_mpu",
    "cpu_core_cortexm",
    "periph_gpio",
    "periph_temperature",
    "periph_timer",
    "periph_uart"
  ],
  "FEATURES_REQUIRED_ANY": [],
  "FEATURES_OPTIONAL_ONLY": [
    "cortexm_fpu",
    "no_idle_thread",
    "periph_cpuid",
    "periph_pm",
    "periph_rtc"
  ],
  "FEATURES_OPTIONAL_MISSING": [
    "periph_rtc"
  ],
  "FEATURES_PROVIDED": [
    "arch_32bit",
    "arch_arm",
    "ble_nimble",
    "ble_nimble_netif",
    "ble_nordic_softdevice",
    "cortexm_fpu",
    "cortexm_mpu",
    "cortexm_svc",
    "cpp",
    "cpu_check_address",
    "cpu_core_cortexm",
    "cpu_nrf52",
    "libstdcpp",
    "no_idle_thread",
    "periph_adc",
    "periph_cpuid",
    "periph_flashpage",
    "periph_flashpage_raw",
    "periph_gpio",
    "periph_gpio_irq",
    "periph_hwrng",
    "periph_i2c",
    "periph_pm",
    "periph_rtt",
    "periph_spi",
    "periph_temperature",
    "periph_timer",
    "periph_uart",
    "periph_uart_modecfg",
    "periph_wdt",
    "periph_wdt_cb",
    "puf_sram",
    "radio_nrfble",
    "radio_nrfmin",
    "riotboot",
    "ssp"
  ],
  "FEATURES_MISSING": [],
  "FEATURES_BLACKLIST": [
    "bootloader_arduino",
    "bootloader_nrfutil"
  ],
  "FEATURES_USED_BLACKLISTED": [],
  "FEATURES_CONFLICT": [],
  "FEATURES_CONFLICTING": [],
  "PREFIX": "arm-none-eabi-",
  "CC": "arm-none-eabi-gcc",
  "CXX": "arm-none-eabi-g++",
  "LINK": "arm-none-eabi-gcc",
  "OBJCOPY": "/opt/gcc-arm-none-eabi/bin/arm-none-eabi-objcopy",
  "INCLUDES": [
    "-isystem",
    "/opt/gcc-arm-none-eabi-9-2019-q4-major/arm-none-eabi/include/newlib-nano",
    "-I/home/koen/dev/RIOT-review/core/include",
    "-I/home/koen/dev/RIOT-review/drivers/include",
    "-I/home/koen/dev/RIOT-review/sys/include",
    "-I/home/koen/dev/RIOT-review/boards/acd52832/include",
    "-I/home/koen/dev/RIOT-review/boards/common/nrf52/include",
    "-I/home/koen/dev/RIOT-review/cpu/nrf52/include",
    "-I/home/koen/dev/RIOT-review/cpu/nrf5x_common/include",
    "-I/home/koen/dev/RIOT-review/cpu/cortexm_common/include",
    "-I/home/koen/dev/RIOT-review/cpu/cortexm_common/include/vendor",
    "-I/home/koen/dev/RIOT-review/sys/libc/include",
    "-I/home/koen/dev/RIOT-review/pkg/nimble/contrib/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/porting/npl/riot/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/porting/nimble/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/controller/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/drivers/nrf52/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/host/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/host/store/ram/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/host/util/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/ext/tinycrypt/include",
    "-I/home/koen/dev/RIOT-review/build/pkg/nimble/nimble/transport/ram/include",
    "-I/home/koen/dev/RIOT-review/pkg/nimble/addr/include",
    "-I/home/koen/dev/RIOT-review/pkg/nimble/netif/include",
    "-I/home/koen/dev/RIOT-review/pkg/nimble/scanlist/include",
    "-I/home/koen/dev/RIOT-review/pkg/nimble/scanner/include",
    "-I/home/koen/dev/RIOT-review/sys/posix/include",
    "-I/home/koen/dev/RIOT-review/sys/net/link_layer/eui_provider/include"
  ],
  "OFLAGS": [],
  "CFLAGS": [
    "-DCONFIG_GNRC_PKTBUF_SIZE=512",
    "-DDEVELHELP",
    "-Werror",
    "-DCPU_FAM_NRF52",
    "-mno-thumb-interwork",
    "-mcpu=cortex-m4",
    "-mlittle-endian",
    "-mthumb",
    "-mfloat-abi=hard",
    "-mfpu=fpv4-sp-d16",
    "-ffunction-sections",
    "-fdata-sections",
    "-fno-builtin",
    "-fshort-enums",
    "-ggdb",
    "-g3",
    "-Os",
    "-DCPU_MODEL_NRF52832XXAA",
    "-DCPU_CORE_CORTEX_M4F",
    "-DRIOT_APPLICATION=default",
    "-DBOARD_ACD52832=acd52832",
    "-DRIOT_BOARD=BOARD_ACD52832",
    "-DCPU_NRF52=nrf52",
    "-DRIOT_CPU=CPU_NRF52",
    "-DMCU_NRF52=nrf52",
    "-DRIOT_MCU=MCU_NRF52",
    "-std=c99",
    "-fno-common",
    "-ffunction-sections",
    "-fdata-sections",
    "-Wall",
    "-Wextra",
    "-Wmissing-include-dirs",
    "-fno-delete-null-pointer-checks",
    "-fdiagnostics-color",
    "-Wstrict-prototypes",
    "-Wold-style-definition",
    "-gz",
    "-Wformat=2",
    "-Wformat-overflow",
    "-Wformat-truncation",
    "-DNIMBLE_CFG_CONTROLLER=1",
    "-DMYNEWT_VAL_OS_CPUTIME_FREQ=32768",
    "-DNIMBLE_HOST_PRIO=(NIMBLE_CONTROLLER_PRIO",
    "+",
    "1)",
    "-DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=264",
    "-DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=3",
    "-DMYNEWT_VAL_BLE_MAX_CONNECTIONS=3",
    "-DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=35",
    "-DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1",
    "-include",
    "/home/koen/dev/RIOT-review/examples/default/bin/acd52832/riotbuild/riotbuild.h"
  ],
  "CXXUWFLAGS": [
    "-std=%",
    "-Wstrict-prototypes",
    "-Wold-style-definition"
  ],
  "CXXEXFLAGS": [],
  "LINKFLAGS": [
    "-L/home/koen/dev/RIOT-review/cpu/nrf52/ldscripts",
    "-L/home/koen/dev/RIOT-review/cpu/cortexm_common/ldscripts",
    "-Tcortexm.ld",
    "-Wl,--fatal-warnings",
    "-mcpu=cortex-m4",
    "-mlittle-endian",
    "-mthumb",
    "-mfloat-abi=hard",
    "-mfpu=fpv4-sp-d16",
    "-ggdb",
    "-g3",
    "-Os",
    "-static",
    "-lgcc",
    "-nostartfiles",
    "-Wl,--gc-sections",
    "-Wl,--defsym=_rom_start_addr=0x00000000",
    "-Wl,--defsym=_ram_start_addr=0x20000000",
    "-Wl,--defsym=_rom_length=0x80000",
    "-Wl,--defsym=_ram_length=0x10000",
    "-specs=nano.specs",
    "-lc"
  ]
}
```
</details>

I'm testing with the following oneliner:
```console
koen@morgen ~/dev/RIOT $ for board in boards/*/; do echo Testing $(basename ${board}); make -C examples/default BOARD=$(basename ${board}) info-build-json | grep --color=never '{' -A1000 | head -n-1| jq >/dev/null; done
```
using [`jq`](https://stedolan.github.io/jq/) as a JSON verifier.

### Issues/PRs references

None