### PR TITLE
drivers/kw41zrf: register with netdev

### DIFF
--- a/drivers/include/kw41zrf.h
+++ b/drivers/include/kw41zrf.h
@@ -135,8 +135,10 @@ typedef struct {
  * @brief   Setup an KW41ZRF based device state
  *
  * @param[out] dev          device descriptor
+ * @param[in]  index        index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  */
-void kw41zrf_setup(kw41zrf_t *dev);
+void kw41zrf_setup(kw41zrf_t *dev, uint8_t index);
 
 /**
  * @brief   Initialize the given KW41ZRF device

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -283,6 +283,7 @@ typedef enum {
     NETDEV_CC2538,
     NETDEV_DOSE,
     NETDEV_ENC28J60,
+    NETDEV_KW41ZRF,
     NETDEV_MRF24J40,
     NETDEV_NRF802154,
     /* add more if needed */

--- a/drivers/kw41zrf/Makefile.dep
+++ b/drivers/kw41zrf/Makefile.dep
@@ -1,4 +1,3 @@
-USEMODULE += luid
 USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154

--- a/drivers/kw41zrf/kw41zrf.c
+++ b/drivers/kw41zrf/kw41zrf.c
@@ -21,7 +21,6 @@
 
 #include "log.h"
 #include "msg.h"
-#include "luid.h"
 #include "net/gnrc.h"
 #include "net/ieee802154.h"
 
@@ -39,23 +38,24 @@
 static void kw41zrf_set_address(kw41zrf_t *dev)
 {
     DEBUG("[kw41zrf] Set MAC address\n");
-    eui64_t addr_long;
-    network_uint16_t addr_short;
-
-    /* get unique IDs to use as hardware addresses */
-    luid_get_eui64(&addr_long);
-    luid_get_short(&addr_short);
 
     /* set short and long address */
-    kw41zrf_set_addr_long(dev, &addr_long);
-    kw41zrf_set_addr_short(dev, &addr_short);
+    kw41zrf_set_addr_long(dev, (eui64_t *)&dev->netdev.long_addr);
+    kw41zrf_set_addr_short(dev, (network_uint16_t *)&dev->netdev.short_addr);
 }
 
-void kw41zrf_setup(kw41zrf_t *dev)
+void kw41zrf_setup(kw41zrf_t *dev, uint8_t index)
 {
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &kw41zrf_driver;
+
+    /* register with netdev */
+    netdev_register(netdev, NETDEV_KW41ZRF, index);
+
+    /* get unique IDs to use as hardware addresses */
+    netdev_ieee802154_setup(&dev->netdev);
+
     /* initialize device descriptor */
     dev->idle_seq = XCVSEQ_RECEIVE;
     dev->pm_blocked = 0;

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -68,7 +68,7 @@ void openthread_bootstrap(void)
     netdev_t *netdev = (netdev_t *) &at86rf2xx_dev;
 #endif
 #ifdef MODULE_KW41ZRF
-    kw41zrf_setup(&kw41z_dev);
+    kw41zrf_setup(&kw41z_dev, 0);
     netdev_t *netdev = (netdev_t *) &kw41z_dev;
 #endif
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw41zrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw41zrf.c
@@ -56,7 +56,7 @@ void auto_init_kw41zrf(void)
 {
     for (unsigned i = 0; i < KW41ZRF_NUMOF; i++) {
         LOG_DEBUG("[auto_init_netif] initializing kw41zrf #%u\n", i);
-        kw41zrf_setup(&kw41zrf_devs[i]);
+        kw41zrf_setup(&kw41zrf_devs[i], i);
 
 #if defined(MODULE_GNRC_GOMACH)
         gnrc_netif_gomach_create(&_netif[i], _kw41zrf_stacks[i], KW41ZRF_NETIF_STACKSIZE,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Register `kw41zrf` with netdev so we don't have to generate a EUI inside the driver but can make use of an EUI provider if available.




### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #14363