### PR TITLE
tests/lwip_sock_tcp: remove duplicated xtimer_init

### DIFF
--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -965,7 +965,6 @@ int main(void)
     code |= (1 << 6);
 #endif
     printf("code 0x%02x\n", code);
-    xtimer_init();
     _net_init();
     expect(0 < thread_create(_client_stack, sizeof(_client_stack),
                              THREAD_PRIORITY_MAIN - 1, THREAD_CREATE_STACKTEST,

--- a/tests/lwip_sock_tcp/stack.c
+++ b/tests/lwip_sock_tcp/stack.c
@@ -24,6 +24,5 @@
 
 void _net_init(void)
 {
-    xtimer_init();
     lwip_bootstrap();
 }


### PR DESCRIPTION
### Contribution description

xtimer is already initiated in auto_init, no need to perform
initiation twice.

### Testing procedure

Run `tests/lwip_sock_tcp`.

### Issues/PRs references

Found in #15186
