### PR TITLE
cpu/stm32: Fix & cleanup periph_eth

### DIFF
--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -251,7 +251,7 @@ static const eth_conf_t eth_config = {
     .speed = ETH_SPEED_100TX_FD,
     .dma = 6,
     .dma_chan = 8,
-    .phy_addr = 0x01,
+    .phy_addr = 0x00,
     .pins = {
         GPIO_PIN(PORT_G, 13),
         GPIO_PIN(PORT_B, 13),

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -222,7 +222,7 @@ static const eth_conf_t eth_config = {
     .speed = ETH_SPEED_100TX_FD,
     .dma = 7,
     .dma_chan = 8,
-    .phy_addr = 0x01,
+    .phy_addr = 0x00,
     .pins = {
         GPIO_PIN(PORT_G, 13),
         GPIO_PIN(PORT_B, 13),

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -170,7 +170,7 @@ static const eth_conf_t eth_config = {
     .speed = ETH_SPEED_100TX_FD,
     .dma = 3,
     .dma_chan = 8,
-    .phy_addr = 0x01,
+    .phy_addr = 0x00,
     .pins = {
         GPIO_PIN(PORT_G, 13),
         GPIO_PIN(PORT_B, 13),


### PR DESCRIPTION
### Contribution description

The function to check the link status of the STM32 Ethernet peripheral used the hard coded PHY address 0, rather than the configured address. This made me realize that the API of the MII register access functions sucks, as only one PHY is supported anyway.

- Dropped the PHY address parameter in the MII register read and write functions
    - Instead, the configured PHY address is used
- Updated all calls to it
- Fixed the PHY address of the Nucleos
    - The reason why address 0 worked for reading the link status is that apparently 0 is the correct PHY address
    - The Ethernet on Nucleo-F767ZI works as good as before with PHY address 0 (with occasionally the PHY getting configured to 10 Mbps half-duplex while the MAC is configured at 100 Mbps full-duplex, resulting in https://github.com/RIOT-OS/RIOT/issues/13490 that is already present in master)

### Testing procedure

E.g. flash `examples/gnrc_networking`
- `ifconfig` should still properly see the link status
- `ping6 <addr>` should work, unless the issue in https://github.com/RIOT-OS/RIOT/issues/13490 hits (roughly one out of three boots)

### Issues/PRs references

None