### PR TITLE
tets/ztimer_periodic: blacklist native

### DIFF
--- a/tests/ztimer_periodic/Makefile
+++ b/tests/ztimer_periodic/Makefile
@@ -1,6 +1,12 @@
 DEVELHELP ?= 0
 include ../Makefile.tests_common
 
+# The test depends on how fast and often the host schedules the RIOT native
+# application. If the host is busy enough it won't schedule the process,
+# delaying the application, thus delaying the time measurement. This happens
+# often on ci with resulting offsets of +10ms
+TEST_ON_CI_BLACKLIST += native
+
 USEMODULE += fmt
 USEMODULE += ztimer_usec ztimer_msec
 


### PR DESCRIPTION
### Contribution description

This PR blacklists native for `ztimer_periodic`, its often resulting in outcomes as, it results in many duplicate builds.

```
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: buildtest)
i: 0 time: 2905 offset: 1
i: 1 time: 3004 offset: 1
i: 2 time: 3116 offset: 12
i: 3 time: 3212 offset: 4
i: 4 time: 3308 offset: 4
Test failed!
Timeout in expect script at "child.expect_exact("Test successful.")" (tests/ztimer_periodic/tests/01-run.py:14)
```

Since the offset can be so large I don't think increasing the offset makes sense.

Offline @bergzand explained this as:

> The test depends on how fast and often the host schedules the RIOT native application
> RIOT can request all the processing time it wants, but if the host is busy enough it won't schedule the process, delaying the application, thus delaying the time measurement
> 

### Testing procedure

Murdock

