### PR TITLE
docker: pass number of jobs from MAKEFLAGS to the container

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -104,6 +104,16 @@ DOCKER_MAKE_ARGS ?=
 # https://github.com/docker/for-mac/issues/2396
 ETC_LOCALTIME = $(realpath /etc/localtime)
 
+# Fetch the number of jobs from the MAKEFLAGS
+# With $MAKE_VERSION < 4.2, the amount of parallelism is not available in
+# $MAKEFLAGS, only that parallelism is requested. So only -j, even if
+# something like -j3 is specified. This can be unexpected and dangerous
+# in older make so don't enable parallelism if $MAKE_VERSION < 4.2
+MAKE_JOBS_NEEDS = 4.1.999
+MAKE_VERSION_OK = $(call memoized,MAKE_VERSION_OK,$(call \
+    version_is_greater,$(MAKE_VERSION),$(MAKE_JOBS_NEEDS)))
+DOCKER_MAKE_JOBS = $(if $(MAKE_VERSION_OK),$(filter -j%,$(MAKEFLAGS)),)
+DOCKER_MAKE_ARGS += $(DOCKER_MAKE_JOBS)
 
 # # # # # # # # # # # # # # # #
 # Directory mapping functions #


### PR DESCRIPTION
### Contribution description

This PR passes the number of jobs from the `MAKEFLAGS` to the docker container make.

### Testing procedure

This:
```
BUILD_IN_DOCKER=1 make -C examples/default -j5
```
should now use 5 jobs to build the example in parallel.

### Issues/PRs references

None