### PR TITLE
cpu/esp*: fix linker scripts [backport 2020.10]

### DIFF
--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -116,25 +116,25 @@ SECTIONS
     *libc.a:*(.literal .text .literal.* .text.*)
 
     /* Xtensa basic functionality written in assembler should be placed in iram */
-    *xtensa.a:*(.literal .text .literal.* .text.*)
+    *xtensa/*(.literal .text .literal.* .text.*)
     /* ESP-IDF parts that have to run in IRAM */
-    *esp_idf_heap.a:*(.literal .text .literal.* .text.*)
-    *esp_idf_spi_flash.a:*(.literal .text .literal.* .text.*)
+    *esp_idf_heap/*(.literal .text .literal.* .text.*)
+    *esp_idf_spi_flash/*(.literal .text .literal.* .text.*)
     /* parts of RIOT that should to run in IRAM */
-    *core.a:*(.literal .text .literal.* .text.*)
-    *littlefs.a:*(.literal .text .literal.* .text.*)
-    *littlefs2.a:*(.literal .text .literal.* .text.*)
-    *newlib_syscalls_default.a:*(.literal .text .literal.* .text.*)
-    *spiffs_fs.a:*(.literal .text .literal.* .text.*)
-    *spiffs.a:*(.literal .text .literal.* .text.*)
+    *core/*(.literal .text .literal.* .text.*)
+    *littlefs/*(.literal .text .literal.* .text.*)
+    *littlefs2/*(.literal .text .literal.* .text.*)
+    *newlib_syscalls_default/*(.literal .text .literal.* .text.*)
+    *spiffs_fs/*(.literal .text .literal.* .text.*)
+    *spiffs/*(.literal .text .literal.* .text.*)
     *syscalls.o(.literal .text .literal.* .text.*)
-    *vfs.a:*(.literal .text .literal.* .text.*)
+    *vfs/*(.literal .text .literal.* .text.*)
 
     /* part of the RIOT port that should run in IRAM */
-    *cpu.a:*(.literal .text .literal.* .text.*)
-    *esp_common.a:*(.literal .text .literal.* .text.*)
-    *periph.a:*(.literal .text .literal.* .text.*)
-    *mtd.a:**(.literal .text .literal.* .text.*)
+    *cpu/*(.literal .text .literal.* .text.*)
+    *esp_common/*(.literal .text .literal.* .text.*)
+    *periph/*(.literal .text .literal.* .text.*)
+    *mtd/**(.literal .text .literal.* .text.*)
 
     INCLUDE esp32.spiram.rom-functions-iram.ld
     _iram_text_end = ABSOLUTE(.);

--- a/cpu/esp8266/ld/esp8266.riot-os.ld
+++ b/cpu/esp8266/ld/esp8266.riot-os.ld
@@ -114,8 +114,8 @@ SECTIONS
     /* TODO put only necessary .rodata to dram */
     /* *(.rodata .rodata.*) */
     *libc.a:*.o(.rodata.* .rodata)
-    *core.a:*(.rodata.* .rodata)
-    *cpu.a:*(.rodata .rodata.*)
+    *core/*(.rodata.* .rodata)
+    *cpu/*(.rodata .rodata.*)
     *libpp.a:(.rodata.* .rodata)
     *liblog.a:(.rodata.* .rodata)
 
@@ -222,7 +222,7 @@ SECTIONS
     *(.literal .text)
     *core.a:*(.literal .text .literal.* .text.*)
     */
-    *gdbstub.a:*(.literal .text .literal.* .text.*)
+    *gdbstub/*(.literal .text .literal.* .text.*)
     *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     /* RIOT-OS compiled source files that use the .iram1.* section names for IRAM
        functions, etc. */
@@ -230,16 +230,16 @@ SECTIONS
 
     /* SDK libraries that expect their .text or .data sections to link to iram */
     /* TODO *libcore.a:(.bss .data .bss.* .data.* COMMON) */
-    *esp_idf_spi_flash.a:spi_flash_raw.o(.literal .text .literal.* .text.*)
-    *esp_idf_esp8266.a:ets_printf.o(.literal .text .literal.* .text.*)
+    *esp_idf_spi_flash/spi_flash_raw.o(.literal .text .literal.* .text.*)
+    *esp_idf_esp8266/ets_printf.o(.literal .text .literal.* .text.*)
     /*
     *cpu.a:*.o(.literal .text .literal.* .text.*)
     */
-    *core.a:sched.o(.literal .text .literal.* .text.*)
-    *esp_wifi.a:*(.literal .text .literal.* .text.*)
-    *freertos.a:*(.literal .text .literal.* .text.*)
-    *periph.a:*(.literal .text .literal.* .text.*)
-    *xtimer.a:*(.literal .text .literal.* .text.*)
+    *core/sched.o(.literal .text .literal.* .text.*)
+    *esp_wifi/*(.literal .text .literal.* .text.*)
+    *freertos/*(.literal .text .literal.* .text.*)
+    *periph/*(.literal .text .literal.* .text.*)
+    *xtimer/*(.literal .text .literal.* .text.*)
 
     *libhal.a:clock.o(.literal .text .literal.* .text.*)
     *libhal.a:int_asm--set_intclear.o(.literal .text .literal.* .text.*)
@@ -254,7 +254,7 @@ SECTIONS
     *libphy.a:phy_sleep.o(.literal .text .literal.* .text.*)
 
     /* Xtensa basic functionality written in assembler should be placed in iram */
-    *xtensa.a:*(.literal .text .literal.* .text.*)
+    *xtensa/*(.literal .text .literal.* .text.*)
 
     /* libgcc functions required for debugging have to be in IRAM */
     *libgcc.a:unwind-dw2.o(.literal .text .literal.* .text.*)
@@ -286,7 +286,7 @@ SECTIONS
     *libc.a:*fputwc.o(.literal .text .literal.* .text.*)
     */
 
-    enc28j60.a:*(.literal .text .literal.* .text.*)
+    *enc28j60/*(.literal .text .literal.* .text.*)
 
     *(.fini.literal)
     *(.fini)

--- a/tests/mtd_mapper/Makefile
+++ b/tests/mtd_mapper/Makefile
@@ -3,7 +3,4 @@ include ../Makefile.tests_common
 USEMODULE += mtd_mapper
 USEMODULE += embunit
 
-# disabling due to unknown failure. See #15123.
-TEST_ON_CI_BLACKLIST += esp32-wroom-32
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_littlefs/Makefile
+++ b/tests/pkg_littlefs/Makefile
@@ -3,7 +3,4 @@ include ../Makefile.tests_common
 USEMODULE += littlefs
 USEMODULE += embunit
 
-# disabling due to unknown failure. See #15123.
-TEST_ON_CI_BLACKLIST += esp32-wroom-32
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_littlefs2/Makefile
+++ b/tests/pkg_littlefs2/Makefile
@@ -3,7 +3,4 @@ include ../Makefile.tests_common
 USEPKG += littlefs2
 USEMODULE += embunit
 
-# disabling due to unknown failure. See #15123.
-TEST_ON_CI_BLACKLIST += esp32-wroom-32
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_spiffs/Makefile
+++ b/tests/pkg_spiffs/Makefile
@@ -3,7 +3,4 @@ include ../Makefile.tests_common
 USEMODULE += spiffs
 USEMODULE += embunit
 
-# disabling due to unknown failure. See #15123.
-TEST_ON_CI_BLACKLIST += esp32-wroom-32
-
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
# Backport of #15186

### Contribution description
esp32 and esp8266 specify some modules' object files on their linker scripts. #14754 changed the compilation of RIOT modules, so archives are not generated anymore. This was causing the wildcards on the linker scripts to not match the object files. This PR fixes this issue by using the folder instead of the archive name.

With these changes esp8266 is working again, and for esp32 I ran the mtd test successfully (#15123).

### Testing procedure
- both platforms should be functional again, it would be good to run the tests on the CI.
- check in the linker scripts that no more non-existent archives are being referenced.

### Issues/PRs references
- Fixes #15137
- Fixes #15123
- Issue introduced in #14754