### PR TITLE
Kconfig: add error symbols and makefile check

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -12,6 +12,9 @@ rsource "kconfigs/Kconfig.consts"
 # Load feature declarations
 rsource "kconfigs/Kconfig.features"
 
+# Load error symbols
+rsource "kconfigs/Kconfig.errors"
+
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
@@ -32,6 +35,9 @@ rsource "pkg/Kconfig"
 
 comment "RIOT is in a migration phase."
 comment "Some configuration options may not be here. Use CFLAGS instead."
+
+comment "!! ERROR: There are conflicting modules active !!"
+    depends on ERROR_MODULES_CONFLICT != ""
 
 config TEST_KCONFIG
     bool

--- a/Makefile.include
+++ b/Makefile.include
@@ -644,7 +644,7 @@ endif
 ..compiler-check:
 	$(call check_cmd,$(CC),Compiler)
 
-..build-message:
+..build-message: $(if $(SHOULD_RUN_KCONFIG), check-kconfig-errors)
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
 	@$(COLOR_ECHO)
 

--- a/boards/stm32f4discovery/Kconfig
+++ b/boards/stm32f4discovery/Kconfig
@@ -27,3 +27,7 @@ config BOARD_STM32F4DISCOVERY
 
     # Various other features (if any)
     select HAS_ARDUINO
+
+config ERROR_MODULES_CONFLICT
+    default "On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0." if MODULE_PERIPH_SPI && MODULE_PERIPH_DAC
+    depends on BOARD_STM32F4DISCOVERY

--- a/cpu/atmega_common/Kconfig
+++ b/cpu/atmega_common/Kconfig
@@ -68,3 +68,7 @@ config HAS_ATMEGA_PCINT3
     bool
     help
         Indicates that the Pin Change Interrupt bank 3 is present.
+
+config ERROR_MODULES_CONFLICT
+    default "On ATmega, the RTC and RTT use to the same hardware timer." if MODULE_PERIPH_RTC && MODULE_PERIPH_RTT
+    depends on CPU_COMMON_ATMEGA

--- a/cpu/efm32/Kconfig
+++ b/cpu/efm32/Kconfig
@@ -37,5 +37,9 @@ config HAS_CPU_EFM32
 config CPU
     default "efm32" if CPU_COMMON_EFM32
 
+config ERROR_MODULES_CONFLICT
+    default "On the EFM32, the RTC and RTT map to the same hardware peripheral." if MODULE_PERIPH_RTC && MODULE_PERIPH_RTT
+    depends on CPU_COMMON_EFM32
+
 orsource "families/*/Kconfig"
 source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/sam0_common/Kconfig
+++ b/cpu/sam0_common/Kconfig
@@ -28,6 +28,9 @@ if CPU_COMMON_SAM0
 
 rsource "periph/Kconfig"
 
+config ERROR_MODULES_CONFLICT
+    default "On SAM0, the RTC and RTT map to the same hardware peripheral." if MODULE_PERIPH_RTC && MODULE_PERIPH_RTT
+
 endif # CPU_COMMON_SAM0
 
 source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -32,7 +32,12 @@ config HAS_BOOTLOADER_STM32
     help
         Indicates that the stm32 bootloader is being used.
 
+config ERROR_MODULES_CONFLICT
+    default "On STM32, the RTC and RTT map to the same hardware peripheral." if MODULE_PERIPH_RTC && MODULE_PERIPH_RTT
+    depends on CPU_STM32
+
 orsource "kconfig/*/Kconfig"
 orsource "kconfig/*/Kconfig.lines"
 orsource "kconfig/*/Kconfig.models"
+
 source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/kconfigs/Kconfig.errors
+++ b/kconfigs/Kconfig.errors
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+# Definition of common error symbols. To indicate an error set the default value
+# to the correspondent symbol guarded with the error condition. e.g.:
+#
+# config ERROR_MODULES_CONFLICT
+#     default "On SAM0 platforms RTT and RTC cannot be set at the same time"
+#     depends on MODULE_PERIPH_RTC && MODULE_PERIPH_RTT && CPU_COMMON_SAM0
+#
+
+config ERROR_MODULES_CONFLICT
+    string
+    help
+        Used to indicate that conflicting modules (i.e. modules that can't be
+        active at the same time) are being used together.

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -168,4 +168,19 @@ $(KCONFIG_GENERATED_AUTOCONF_HEADER_C): $(KCONFIG_OUT_CONFIG) $(GENERATED_DIR_DE
 # Try to load the list of Kconfig files used
 -include $(KCONFIG_OUT_DEP)
 
+# capture all ERROR_ prefixed Kconfig symbols
+_KCONFIG_ERROR_VARS = $(filter CONFIG_ERROR_%,$(.VARIABLES))
+_KCONFIG_ERRORS = $(foreach v,$(_KCONFIG_ERROR_VARS),$($(v)))
+
+# this checks that no Kconfig error symbols are set. These symbols are used
+# to indicate invalid conditions
+check-kconfig-errors: $(KCONFIG_OUT_CONFIG) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+ifneq (,$(_KCONFIG_ERRORS))
+	@$(COLOR_ECHO) "$(COLOR_RED) !! There are ERRORS in the configuration !! $(COLOR_RESET)"
+	@for err in $(_KCONFIG_ERRORS); do \
+	  echo "- $$err"; \
+	done
+	@false
+endif
+
 endif


### PR DESCRIPTION
### Contribution description
This PR splits the error symbol handling from #14777. The idea is to define error string symbols that are used to indicate certain invalid conditions in Kconfig. This PR adds `ERROR_MODULES_CONFLICT`, which is used by platforms to indicate combinations of modules that are invalid when used together. This also adds a check in `kconfig.mk`, to verify that no error symbols are set.

### Testing procedure
- Check that all the invalid configurations are modelled (currently `FEATURES_CONFLICT`).
- This can be seen in action on #14777, when conflicting modules are enabled at the same time for a certain platform. Also, a patch like the following can be applied:
```diff
diff --git a/Kconfig b/Kconfig
index 75fb259853..64ff8d0b29 100644
--- a/Kconfig
+++ b/Kconfig
@@ -46,3 +46,6 @@ config TEST_KCONFIG
         This is used during the Kconfig migration to test the module dependency
         modelling. Don't change the default value unless you know what you are
         doing.
+
+config ERROR_MODULES_CONFLICT
+    default "This simulates an invalid condition"
```

When compiling while using Kconfig (e.g. in `tests/kconfig` application), you should get an error like:
```
> make clean all
make: Nothing to be done for 'clean'.
 !! There are ERRORS in the configuration !! 
- This simulates an invalid condition
make: *** [/RIOT/makefiles/kconfig.mk:181: check-kconfig-errors] Error 1
```
- Configuring via Kconfig (both using .config files and menuconfig) should still work as usual.

### Issues/PRs references
Split from #14777