### PR TITLE
net/sock/dtls: fix return value of sock_dtls_session_create()

### DIFF
--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -794,7 +794,8 @@ static inline int sock_dtls_session_create(sock_dtls_t *sock,
         return res;
     }
 
-    return sock_dtls_recv(sock, remote, buf, sizeof(buf), timeout);
+    res = sock_dtls_recv(sock, remote, buf, sizeof(buf), timeout);
+    return res > 0 : 0 : res;
 }
 
 #include "sock_dtls_types.h"


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`sock_dtls_session_create()` claims to return 0 on success.
In reality it returns the return value of `sock_dtls_recv()` which on success is the number of received bytes.

Comply with the documentation by returning 0 on success.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
