### PR TITLE
cpu/stm32: periph_eth: Use auto-negotation

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -12,6 +12,14 @@ ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
   USEMODULE += tsrb
 endif
 
+ifneq (,$(filter stm32_eth_%,$(USEMODULE)))
+  USEMODULE += stm32_eth
+endif
+
+ifneq (,$(filter stm32_eth_auto,$(USEMODULE)))
+  USEMODULE += stm32_eth_link_up
+endif
+
 ifneq (,$(filter stm32_eth,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eth
   USEMODULE += netdev_eth

--- a/cpu/stm32/periph/doc.txt
+++ b/cpu/stm32/periph/doc.txt
@@ -1,0 +1,32 @@
+/**
+ * @defgroup        stm32_eth STM32 Peripheral Ethernet Driver
+ * @ingroup         drivers_netdev
+ * @brief           Driver for the Peripheral STM32 Ethernet block used across
+ *                  all families of STM32 MCUs
+ *
+ * Link Auto Negotiation
+ * =====================
+ *
+ * To enable Link Auto Negotiation, use the (pseudo) module `stm32_eth_auto`
+ * by amending your applications `Makefile` as follows:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * # Add the following line to your Makefile
+ * USEMODULE += stm32_eth_auto
+ *
+ * # Note: Any addition of modules to USEMODULE must be done prior to the
+ * # following line:
+ * include $(RIOTBASE)/Makefile.include
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * In general, it is highly recommended to use auto-negotiation, as this can
+ * avoid various communication issues on the PHY layer due to configuration
+ * mismatch of the link partners. Note that this feature depends on the link
+ * state events feature.
+ *
+ * Link State Events
+ * =================
+ *
+ * To enable Link Events, use the (pseudo) module `stm32_eth_link_up` (as
+ * described above).
+ */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -121,6 +121,7 @@ PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += stm32_eth
+PSEUDOMODULES += stm32_eth_auto
 PSEUDOMODULES += stm32_eth_link_up
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%


### PR DESCRIPTION
### Contribution description

Most Ethernet PHYs support auto-negotiation of signaling specification. This is more reliable and easier to use than manual configuration, as this will select the fastest configuration supported by both communication partners automatically.

This PR exposes the auto-negotiation capability via the (pseudo-) module `stm32_eth_auto`. Note: It requires that the Ethernet PHY is actually capable of this - but I don't think any Fast Ethernet PHYs without auto-negotiation are on the market anymore.

This PR also fixes the link state notification, why previously only covered link up events and stopped worked after the first event was generated. With this fix, the link state will be continuously monitored (sadly by polling every second the state) and both link up and link down event should be generated.

### Testing procedure

- The Ethernet of the STM32s should still work
- With `USEMODULE += stm32_eth_link_up`, both link up and link down event should be generated. This should now work after the first plugging in.
- With `USEMODULE += stm32_eth_auto`, the Ethernet device should use the highest speed supported by both partners, regardless of manual configuration
    - Check this by e.g. setting manual speed to 10 Mbps and half duplex. When connected to another Ethernet device capable of 100 Mbps and full-duplex, the driver should pick this over the 10 Mbps and half duplex settings
- This should fix https://github.com/RIOT-OS/RIOT/issues/13490 even without `stm32_eth_auto` being used by simply waiting for the PHY to power up before trying to configure it.

### Issues/PRs references

Depends on and includes:

- [x] https://github.com/RIOT-OS/RIOT/pull/15193
- [x] https://github.com/RIOT-OS/RIOT/pull/15200

Fixes: https://github.com/RIOT-OS/RIOT/issues/13490