### PR TITLE
cpu/sam0_common: UART: Revert "implement inverted RX & TX"

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -178,8 +178,6 @@ typedef enum {
     UART_FLAG_NONE            = 0x0,    /**< No flags set */
     UART_FLAG_RUN_STANDBY     = 0x1,    /**< run SERCOM in standby mode */
     UART_FLAG_WAKEUP          = 0x2,    /**< wake from sleep on receive */
-    UART_FLAG_RXINV           = 0x4,    /**< invert RX signal */
-    UART_FLAG_TXINV           = 0x8,    /**< invert TX signal */
 } uart_flag_t;
 
 #ifndef DOXYGEN

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -190,18 +190,6 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     if (uart_config[uart].flags & UART_FLAG_RUN_STANDBY) {
         dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_RUNSTDBY;
     }
-#ifdef SERCOM_USART_CTRLA_RXINV
-    /* COM100-61: The TXINV and RXINV bits in the CTRLA register have inverted functionality. */
-    if (uart_config[uart].flags & UART_FLAG_TXINV) {
-        dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_RXINV;
-    }
-#endif
-#ifdef SERCOM_USART_CTRLA_TXINV
-    /* COM100-61: The TXINV and RXINV bits in the CTRLA register have inverted functionality. */
-    if (uart_config[uart].flags & UART_FLAG_RXINV) {
-        dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_TXINV;
-    }
-#endif
 
     /* calculate and set baudrate */
     _set_baud(uart, baudrate);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I did misunderstand this feature: This only inverts the data bits (instead of `c` uart will transmit `~c`), not the whole line level.

This is not very useful on it's own, so revert it.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This reverts #14300

