### PR TITLE
[backport] boards/nucleo-{f207zg,f746zg,f767zi}: periph_conf

### DIFF
--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -241,7 +241,7 @@ static const eth_conf_t eth_config = {
     .speed = ETH_SPEED_100TX_FD,
     .dma = 6,
     .dma_chan = 8,
-    .phy_addr = 0x01,
+    .phy_addr = 0x00,
     .pins = {
         GPIO_PIN(PORT_G, 13),
         GPIO_PIN(PORT_B, 13),

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -212,7 +212,7 @@ static const eth_conf_t eth_config = {
     .speed = ETH_SPEED_100TX_FD,
     .dma = 7,
     .dma_chan = 8,
-    .phy_addr = 0x01,
+    .phy_addr = 0x00,
     .pins = {
         GPIO_PIN(PORT_G, 13),
         GPIO_PIN(PORT_B, 13),

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -160,7 +160,7 @@ static const eth_conf_t eth_config = {
     .speed = ETH_SPEED_100TX_FD,
     .dma = 3,
     .dma_chan = 8,
-    .phy_addr = 0x01,
+    .phy_addr = 0x00,
     .pins = {
         GPIO_PIN(PORT_G, 13),
         GPIO_PIN(PORT_B, 13),


### PR DESCRIPTION
# Partial backport of https://github.com/RIOT-OS/RIOT/pull/15193

### Contribution description

This is a backport of the commit fixing the PHY addresses in the periph confs of the Nucleo-F207ZG, Nucleo-F746ZG, and the Nucleo-F767ZI. The cleanup of the Ethernet driver of https://github.com/RIOT-OS/RIOT/pull/15193 were not backported, as this doesn't fix a bug.

Some dubious references for 0 being the correct PHY address and not 1 (in absence of proper references):

https://www.carminenoviello.com/2016/01/22/getting-started-stm32-nucleo-f746zg/
https://community.st.com/s/question/0D50X00009XkgfISAR/stm32f767-nucleo-ethernet-not-working

### Testing procedure

Basic network operation should still be possible

### Issues/PRs references

Partial backport of https://github.com/RIOT-OS/RIOT/pull/15193