### PR TITLE
netdev/ieee802154_submac: add retransmission reporting

### DIFF
--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -49,6 +49,7 @@ typedef struct {
     ieee802154_submac_t submac;         /**< IEEE 802.15.4 SubMAC descriptor */
     xtimer_t ack_timer;                 /**< xtimer descriptor for the ACK timeout timer */
     int isr_flags;                      /**< netdev submac @ref NETDEV_EVENT_ISR flags */
+    int8_t retrans;                     /**< number of frame retransmissions of the last TX */
 } netdev_ieee802154_submac_t;
 
 /**

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -61,6 +61,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
         case NETOPT_STATE:
             *((netopt_state_t*) value) = _get_submac_state(submac);
             return 0;
+        case NETOPT_TX_RETRIES_NEEDED:
+            if (netdev_submac->retrans < 0) {
+                return -ENOTSUP;
+            }
+            *((uint8_t*) value) = netdev_submac->retrans;
+            return 1;
         default:
             break;
     }
@@ -201,11 +207,14 @@ static void submac_tx_done(ieee802154_submac_t *submac, int status,
                            ieee802154_tx_info_t *info)
 {
     (void)status;
-    (void)info;
     netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
                                                              netdev_ieee802154_submac_t,
                                                              submac);
     netdev_t *netdev = (netdev_t *)netdev_submac;
+
+    if (info) {
+        netdev_submac->retrans = info->retrans;
+    }
 
     switch (status) {
     case TX_STATUS_SUCCESS:

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -252,7 +252,7 @@ typedef struct {
  */
 typedef struct {
     ieee802154_tx_status_t status;      /**< status of the last transmission */
-    uint8_t retrans;                    /**< number of frame retransmissions of the last TX */
+    int8_t retrans;                     /**< number of frame retransmissions of the last TX */
 } ieee802154_tx_info_t;
 
 /**

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -182,6 +182,9 @@ static void _handle_tx_success(ieee802154_submac_t *submac,
 
     if (ieee802154_radio_has_frame_retrans(dev) ||
         ieee802154_radio_has_irq_ack_timeout(dev) || !submac->wait_for_ack) {
+        if (!ieee802154_radio_has_frame_retrans_info(dev)) {
+            info->retrans = -1;
+        }
         _tx_end(submac, info->status, info);
     }
     else {


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If we do software retransmissions, we already keep a count.
Allow to query it with `NETOPT_TX_RETRIES_NEEDED`.


### Testing procedure


### Issues/PRs references

#14448
