### PR TITLE
netdev/ieee802154_submac: enable ACK_REQ by default

### DIFF
--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -279,6 +279,7 @@ static int _init(netdev_t *netdev)
 
     uint16_t chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
     int16_t tx_power = CONFIG_IEEE802154_DEFAULT_TXPOWER;
+    netopt_enable_t enable = NETOPT_ENABLE;
 
     /* Initialise netdev_ieee802154_t struct */
     netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
@@ -287,6 +288,8 @@ static int _init(netdev_t *netdev)
                           &submac->short_addr, sizeof(submac->short_addr));
     netdev_ieee802154_set(netdev_ieee802154, NETOPT_ADDRESS_LONG,
                           &submac->ext_addr, sizeof(submac->ext_addr));
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
+                          &enable, sizeof(enable));
 
     netdev_submac->dev.txpower = tx_power;
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

One of the features of the sub-MAC is to allow for ACK-handling in software.
So enable the use of ACKs by default, just like the netdev drivers do that support this feature in hardware.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

searched quite a bit why ACKs were not working in https://github.com/RIOT-OS/RIOT/pull/14448#issuecomment-707109638
