### PR TITLE
gnrc_tcp: use gnrc_pktsnip_search_type() to search for snips

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -85,13 +85,10 @@ static int _send(gnrc_pktsnip_t *pkt)
     assert(pkt != NULL);
 
     /* NOTE: In sending direction: pkt = nw, nw->next = tcp, tcp->next = payload */
-    gnrc_pktsnip_t *tcp = NULL;
+    /* Search for TCP header */
+    gnrc_pktsnip_t *tcp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TCP);
     gnrc_pktsnip_t *nw = NULL;
 
-    /* Search for TCP header */
-    LL_SEARCH_SCALAR(pkt, tcp, type, GNRC_NETTYPE_TCP);
-    /* cppcheck-suppress knownConditionTrueFalse
-     * (reason: tcp *can* be != NULL after LL_SEARCH_SCALAR) */
     if (tcp == NULL) {
         DEBUG("gnrc_tcp_eventloop : _send() : tcp header missing.\n");
         gnrc_pktbuf_release(pkt);
@@ -101,7 +98,7 @@ static int _send(gnrc_pktsnip_t *pkt)
     /* Search for network layer */
 #ifdef MODULE_GNRC_IPV6
     /* Get IPv6 header, discard packet if doesn't contain an ipv6 header */
-    LL_SEARCH_SCALAR(pkt, nw, type, GNRC_NETTYPE_IPV6);
+    nw = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
     if (nw == NULL) {
         DEBUG("gnrc_tcp_eventloop.c : _send() : pkt contains no ipv6 layer header\n");
         gnrc_pktbuf_release(pkt);
@@ -155,7 +152,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
 
 #ifdef MODULE_GNRC_IPV6
     /* Get IPv6 header, discard packet if doesn't contain an ip header */
-    LL_SEARCH_SCALAR(pkt, ip, type, GNRC_NETTYPE_IPV6);
+    ip = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
     if (ip == NULL) {
         DEBUG("gnrc_tcp_eventloop.c : _receive() : pkt contains no IP Header\n");
         gnrc_pktbuf_release(pkt);
@@ -164,7 +161,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
 #endif
 
     /* Get TCP header */
-    LL_SEARCH_SCALAR(pkt, tcp, type, GNRC_NETTYPE_TCP);
+    tcp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TCP);
     if (tcp == NULL) {
         DEBUG("gnrc_tcp_eventloop.c : _receive() : pkt contains no TCP Header\n");
         gnrc_pktbuf_release(pkt);

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -394,7 +394,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
 {
     gnrc_pktsnip_t *out_pkt = NULL;  /* Outgoing packet */
     uint16_t seq_con = 0;            /* Sequence number consumption of outgoing packet */
-    gnrc_pktsnip_t *snp = NULL;      /* Temporary packet snip */
+    gnrc_pktsnip_t *snp;             /* Temporary packet snip */
     gnrc_tcp_tcb_t *lst = NULL;      /* Temporary pointer to TCB */
     uint16_t ctl = 0;                /* Control bits of the incoming packet */
     uint32_t seg_seq = 0;            /* Sequence number of the incoming packet*/
@@ -403,7 +403,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
 
     DEBUG("gnrc_tcp_fsm.c : _fsm_rcvd_pkt()\n");
     /* Search for TCP header. */
-    LL_SEARCH_SCALAR(in_pkt, snp, type, GNRC_NETTYPE_TCP);
+    snp = gnrc_pktsnip_search_type(in_pkt, GNRC_NETTYPE_TCP);
     tcp_hdr_t *tcp_hdr = (tcp_hdr_t *) snp->data;
 
     /* Parse packet options, return if they are malformed */
@@ -419,7 +419,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
 
     /* Extract network layer header */
 #ifdef MODULE_GNRC_IPV6
-    LL_SEARCH_SCALAR(in_pkt, snp, type, GNRC_NETTYPE_IPV6);
+    snp = gnrc_pktsnip_search_type(in_pkt, GNRC_NETTYPE_IPV6);
     if (snp == NULL) {
         DEBUG("gnrc_tcp_fsm.c : _fsm_rcvd_pkt() : incoming packet had no IPv6 header\n");
         return 0;
@@ -480,10 +480,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
 
                 /* In case peer_addr is link local: Store interface Id in tcb */
                 if (ipv6_addr_is_link_local((ipv6_addr_t *) tcb->peer_addr)) {
-                    gnrc_pktsnip_t *tmp = NULL;
-                    LL_SEARCH_SCALAR(in_pkt, tmp, type, GNRC_NETTYPE_NETIF);
-                    /* cppcheck-suppress knownConditionTrueFalse
-                     * (reason: tmp *can* be != NULL after LL_SEARCH_SCALAR) */
+                    gnrc_pktsnip_t *tmp = gnrc_pktsnip_search_type(in_pkt, GNRC_NETTYPE_NETIF);
                     if (tmp == NULL) {
                         DEBUG("gnrc_tcp_fsm.c : _fsm_rcvd_pkt() :\
                                incoming packet had no netif header\n");
@@ -687,7 +684,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
             if (tcb->state == FSM_STATE_ESTABLISHED || tcb->state == FSM_STATE_FIN_WAIT_1 ||
                 tcb->state == FSM_STATE_FIN_WAIT_2) {
                 /* Search for begin of payload */
-                LL_SEARCH_SCALAR(in_pkt, snp, type, GNRC_NETTYPE_UNDEF);
+                snp = gnrc_pktsnip_search_type(in_pkt, GNRC_NETTYPE_UNDEF);
 
                 /* Accept only data that is expected, to be received */
                 if (tcb->rcv_nxt == seg_seq) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The function `gnrc_pktsnip_search_type()` exists for quite a while now, so why not use it. It

- is easier to read
- is more type-safe than `LL_SEARCH_SCALAR()` and specifically written to search for a packet snip in a packet
- safes memory, as it is encapsulated within the `gnrc_pkt` module and not a C-preprocessor macro, hiding a loop (on `samr21-xpro` I gained 164 bytes of ROM!).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gnrc_tcp` should still run on `native` and `samr21-xpro`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but preparing for a general overhaul of the `gnrc_pkt` manipulation functions.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
