### PR TITLE
gnrc_pkt: introduce packet list operations

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -178,10 +178,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
     gnrc_pktbuf_remove_snip(pkt, mac_hdr);
     gnrc_pktbuf_remove_snip(pkt, esp_hdr);
-    LL_APPEND(pkt, netif_hdr);
-
-    return pkt;
-
+    return gnrc_pkt_append(pkt, netif_hdr);
 err:
     gnrc_pktbuf_release(pkt);
     return NULL;

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -168,9 +168,7 @@ static gnrc_pktsnip_t *gnrc_nrfmin_recv(gnrc_netif_t *dev)
 
     /* finally: remove the nrfmin header and append the netif header */
     gnrc_pktbuf_remove_snip(pkt_snip, hdr_snip);
-    LL_APPEND(pkt_snip, netif_snip);
-
-    return pkt_snip;
+    return gnrc_pkt_append(pkt_snip, netif_snip);
 }
 
 static const gnrc_netif_ops_t gnrc_nrfmin_ops = {

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -96,7 +96,7 @@ static gnrc_pktsnip_t *cc1xxx_adpt_recv(gnrc_netif_t *netif)
     DEBUG("[cc1xxx-gnrc] recv: successfully parsed packet\n");
 
     /* and append the netif header */
-    LL_APPEND(payload, hdr);
+    payload = gnrc_pkt_append(payload, hdr);
 
 #ifdef MODULE_NETSTATS_L2
     netif->stats.rx_count++;

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -95,9 +95,7 @@ static gnrc_pktsnip_t *xbee_adpt_recv(gnrc_netif_t *netif)
     DEBUG("[xbee-gnrc] recv: successfully parsed packet\n");
 
     /* and append the netif header */
-    LL_APPEND(payload, netif_snip);
-
-    return payload;
+    return gnrc_pkt_append(payload, netif_snip);
 }
 
 static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -94,7 +94,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
             gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
-            LL_PREPEND(ip, netif_hdr);
+            ip = gnrc_pkt_prepend(ip, netif_hdr);
         }
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {

--- a/examples/gnrc_networking_mac/udp.c
+++ b/examples/gnrc_networking_mac/udp.c
@@ -94,7 +94,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
             gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
-            LL_PREPEND(ip, netif_hdr);
+            ip = gnrc_pkt_prepend(ip, netif_hdr);
         }
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -119,7 +119,7 @@ static void _handle_raw_sixlowpan(ble_mac_inbuf_t *inbuf)
     od_hex_dump(inbuf->payload, inbuf->len, OD_WIDTH_DEFAULT);
 #endif
 
-    LL_APPEND(pkt, netif_hdr);
+    pkt = gnrc_pkt_append(pkt, netif_hdr);
 
     /* throw away packet if no one is interested */
     if (!gnrc_netapi_dispatch_receive(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -27,6 +27,7 @@
 
 #include "kernel_types.h"
 #include "net/gnrc/nettype.h"
+#include "utlist.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -123,6 +124,23 @@ typedef struct gnrc_pktsnip {
 } gnrc_pktsnip_t;
 
 /**
+ * @brief   Returns the snip before a given snip in a packet
+ *
+ * @param[in] pkt   A packet.
+ * @param[in] snip  The snip for which the predecessor in @p pkt is searched for.
+ *
+ * @return  The snip before @p snip in @p pkt if @p snip is in @p pkt.
+ * @return  `NULL`, if @p snip is not in @p pkt.
+ */
+static inline gnrc_pktsnip_t *gnrc_pkt_prev_snip(gnrc_pktsnip_t *pkt,
+                                                 gnrc_pktsnip_t *snip)
+{
+    gnrc_pktsnip_t *prev;
+    LL_SEARCH_SCALAR(pkt, prev, next, snip);
+    return prev;
+}
+
+/**
  * @brief Calculates length of a packet in byte.
  *
  * @param[in] pkt  list of packet snips.
@@ -140,6 +158,52 @@ static inline size_t gnrc_pkt_len(const gnrc_pktsnip_t *pkt)
 
     return len;
 }
+
+/**
+ * @brief   Appends a snip to a packet.
+ *
+ * @param[in] pkt   A packet.
+ * @param[in] snip  A snip.
+ *
+ * @return  The new head of @p pkt.
+ */
+static inline gnrc_pktsnip_t *gnrc_pkt_append(gnrc_pktsnip_t *pkt,
+                                              gnrc_pktsnip_t *snip)
+{
+    LL_APPEND(pkt, snip);
+    return pkt;
+}
+
+/**
+ * @brief   Prepends a snip to a packet.
+ *
+ * @param[in] pkt   A packet.
+ * @param[in] snip  A snip.
+ *
+ * @return  The new head of @p pkt.
+ */
+static inline gnrc_pktsnip_t *gnrc_pkt_prepend(gnrc_pktsnip_t *pkt,
+                                               gnrc_pktsnip_t *snip)
+{
+    LL_PREPEND(pkt, snip);
+    return pkt;
+}
+
+/**
+ * @brief   Deletes a snip from a packet.
+ *
+ * @param[in] pkt   A packet.
+ * @param[in] snip  A snip.
+ *
+ * @return  The new head of @p pkt.
+ */
+static inline gnrc_pktsnip_t *gnrc_pkt_delete(gnrc_pktsnip_t *pkt,
+                                              gnrc_pktsnip_t *snip)
+{
+    LL_DELETE(pkt, snip);
+    return pkt;
+}
+
 
 /**
  * @brief Calculates length of a packet in byte up to (including) a snip with the given type.

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -175,7 +175,7 @@ static int _parse_packet(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt,
     gnrc_netif_hdr_set_netif(netif_hdr, netif);
     pkt->type = state->proto;
     gnrc_pktbuf_remove_snip(pkt, pkt->next);
-    LL_APPEND(pkt, netif_snip);
+    pkt = gnrc_pkt_append(pkt, netif_snip);
 
     gnrc_pktsnip_t *gomach_snip = NULL;
     gnrc_gomach_hdr_t *gomach_hdr = NULL;

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -218,7 +218,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 #endif
 #endif
             gnrc_pktbuf_remove_snip(pkt, ieee802154_hdr);
-            LL_APPEND(pkt, netif_hdr);
+            pkt = gnrc_pkt_append(pkt, netif_hdr);
         }
 
         DEBUG("_recv_ieee802154: reallocating.\n");

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -246,7 +246,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
 
         gnrc_pktbuf_remove_snip(pkt, eth_hdr);
-        LL_APPEND(pkt, netif_hdr);
+        pkt = gnrc_pkt_append(pkt, netif_hdr);
     }
 
 out:

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -132,7 +132,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
             gnrc_netif_hdr_set_netif(hdr, netif);
-            LL_APPEND(pkt, netif_snip);
+            pkt = gnrc_pkt_append(pkt, netif_snip);
         }
         else {
             /* Normal mode, try to parse the frame according to IEEE 802.15.4 */
@@ -204,7 +204,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 #endif
 #endif
             gnrc_pktbuf_remove_snip(pkt, ieee802154_hdr);
-            LL_APPEND(pkt, netif_hdr);
+            pkt = gnrc_pkt_append(pkt, netif_hdr);
         }
 
         DEBUG("_recv_ieee802154: reallocating.\n");

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -101,7 +101,7 @@ void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
     /* (netif == NULL) => ipv6_hdr->dst is loopback address */
     gnrc_netif_hdr_set_netif(hdr->data, netif);
 
-    LL_PREPEND(pkt, hdr);
+    pkt = gnrc_pkt_prepend(pkt, hdr);
 
     if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL,
                                    pkt)) {

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -221,7 +221,7 @@ static void _send(gnrc_pktsnip_t *pkt, const gnrc_pktsnip_t *orig_pkt,
                 return;
             }
             gnrc_netif_hdr_set_netif(netif->data, iface);
-            LL_PREPEND(pkt, netif);
+            pkt = gnrc_pkt_prepend(pkt, netif);
         }
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6,
                                        GNRC_NETREG_DEMUX_CTX_ALL,

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -344,7 +344,7 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_build(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *next,
     }
 
     if (ipv6 != NULL) {
-        LL_SEARCH_SCALAR(ipv6, prev, next, next);
+        prev = gnrc_pkt_prev_snip(ipv6, next);
 
         if (prev == NULL) {
             return NULL;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -311,9 +311,7 @@ static gnrc_pktsnip_t *_create_netif_hdr(uint8_t *dst_l2addr,
     hdr->flags = flags;
 
     /* add netif_hdr to front of the pkt list */
-    LL_PREPEND(pkt, netif_hdr);
-
-    return pkt;
+    return gnrc_pkt_prepend(pkt, netif_hdr);
 }
 
 static bool _is_ipv6_hdr(gnrc_pktsnip_t *hdr)

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -851,7 +851,7 @@ static void _send_delayed_nbr_adv(const gnrc_netif_t *netif,
         return;
     }
     gnrc_netif_hdr_set_netif(pkt->data, netif);
-    LL_PREPEND(payload, pkt);
+    pkt = gnrc_pkt_prepend(payload, pkt);
     _evtimer_add(pkt, GNRC_IPV6_NIB_SND_NA, &nce->snd_na,
                  random_uint32_range(0, NDP_MAX_ANYCAST_MS_DELAY));
 }
@@ -1240,7 +1240,8 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                             return false;
                         }
                         gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
-                        LL_PREPEND(queue_entry->pkt, netif_hdr);
+                        queue_entry->pkt = gnrc_pkt_prepend(queue_entry->pkt,
+                                                            netif_hdr);
                     }
                     gnrc_pktqueue_add(&entry->pktqueue, queue_entry);
                 }

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -610,8 +610,7 @@ static gnrc_pktsnip_t *_build_headers(gnrc_netif_t *netif,
         return NULL;
     }
     gnrc_netif_hdr_set_netif(l2hdr->data, netif);
-    LL_PREPEND(iphdr, l2hdr);
-    return l2hdr;
+    return gnrc_pkt_prepend(iphdr, l2hdr);
 }
 
 static inline size_t _get_l2src(const gnrc_netif_t *netif, uint8_t *l2src)

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -116,9 +116,7 @@ static gnrc_pktsnip_t *_build_frag_pkt(gnrc_pktsnip_t *pkt,
     frag_hdr->tag = byteorder_htons(fbuf->tag);
 
 
-    LL_PREPEND(frag, netif);
-
-    return frag;
+    return gnrc_pkt_prepend(frag, netif);
 }
 
 static uint16_t _copy_pkt_to_frag(uint8_t *data, const gnrc_pktsnip_t *pkt,

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -627,7 +627,7 @@ int gnrc_sixlowpan_frag_rb_dispatch_when_complete(gnrc_sixlowpan_frag_rb_t *rbuf
         new_netif_hdr->flags = netif_hdr->flags;
         new_netif_hdr->lqi = netif_hdr->lqi;
         new_netif_hdr->rssi = netif_hdr->rssi;
-        LL_APPEND(rbuf->pkt, netif);
+        rbuf->pkt = gnrc_pkt_append(rbuf->pkt, netif);
 #if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_STATS)
         gnrc_sixlowpan_frag_stats_get()->fragments += _count_frags(rbuf);
         gnrc_sixlowpan_frag_stats_get()->datagrams++;

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -797,8 +797,8 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
                                                        ipv6))) {
             /* add netif header to `ipv6` so its flags can be used when
              * forwarding the fragment */
-            LL_DELETE(sixlo, netif);
-            LL_APPEND(ipv6, netif);
+            sixlo = gnrc_pkt_delete(sixlo, netif);
+            ipv6 = gnrc_pkt_append(ipv6, netif);
             /* provide space to copy remaining payload */
             if (gnrc_pktbuf_realloc_data(ipv6, uncomp_hdr_len + sixlo->size -
                                          payload_offset) != 0) {
@@ -862,8 +862,8 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
 #endif  /* MODULE_GNRC_SIXLOWPAN_FRAG_VRB */
     }
     else {
-        LL_DELETE(sixlo, netif);
-        LL_APPEND(ipv6, netif);
+        sixlo = gnrc_pkt_delete(sixlo, netif);
+        ipv6 = gnrc_pkt_append(ipv6, netif);
         gnrc_sixlowpan_dispatch_recv(ipv6, NULL, page);
     }
     gnrc_pktbuf_release(sixlo);

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -18,7 +18,7 @@
 gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt,
                                         gnrc_pktsnip_t *snip)
 {
-    LL_DELETE(pkt, snip);
+    pkt = gnrc_pkt_delete(pkt, snip);
     snip->next = NULL;
     gnrc_pktbuf_release(snip);
 
@@ -32,8 +32,8 @@ gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
     /* If add is a list we need to preserve its tail */
     if (add->next != NULL) {
         gnrc_pktsnip_t *tail = add->next;
-        gnrc_pktsnip_t *back;
-        LL_SEARCH_SCALAR(tail, back, next, NULL); /* find the last snip in add */
+        /* find the last snip in tail */
+        gnrc_pktsnip_t *back = gnrc_pkt_prev_snip(tail, NULL);
         /* Replace old */
         LL_REPLACE_ELEM(pkt, old, add);
         /* and wire in the tail between */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -224,7 +224,7 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ip
         return;
     }
     gnrc_netif_hdr_set_netif(hdr->data, netif);
-    LL_PREPEND(pkt, hdr);
+    pkt = gnrc_pkt_prepend(pkt, hdr);
 
     if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
         DEBUG("RPL: cannot send packet: no subscribers found.\n");

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -231,7 +231,7 @@ ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
         }
         netif_hdr = netif->data;
         netif_hdr->if_pid = iface;
-        LL_PREPEND(pkt, netif);
+        pkt = gnrc_pkt_prepend(pkt, netif);
     }
 #ifdef MODULE_GNRC_NETERR
     /* cppcheck-suppress uninitvar

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -132,8 +132,7 @@ int _pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt, gnrc_pktsnip_t *in_pkt)
         }
         else {
             ((gnrc_netif_hdr_t *)net_snp->data)->if_pid = net_hdr->if_pid;
-            LL_PREPEND(ip6_snp, net_snp);
-            *(out_pkt) = net_snp;
+            *(out_pkt) = gnrc_pkt_prepend(ip6_snp, net_snp);
         }
     }
 #else
@@ -240,8 +239,7 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
         }
         else {
             ((gnrc_netif_hdr_t *)net_snp->data)->if_pid = (kernel_pid_t)tcb->ll_iface;
-            LL_PREPEND(ip6_snp, net_snp);
-            *(out_pkt) = net_snp;
+            *(out_pkt) = gnrc_pkt_prepend(ip6_snp, net_snp);
         }
     }
 #else

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -321,7 +321,7 @@ static void _pinger(_ping_data_t *data)
             goto error_exit;
         }
         gnrc_netif_hdr_set_netif(tmp->data, data->netif);
-        LL_PREPEND(pkt, tmp);
+        pkt = gnrc_pkt_prepend(pkt, tmp);
     }
     if (data->datalen >= sizeof(uint32_t)) {
         uint32_t now = xtimer_now_usec();

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1593,7 +1593,7 @@ int _gnrc_netif_send(int argc, char **argv)
         gnrc_pktbuf_release(pkt);
         return 1;
     }
-    LL_PREPEND(pkt, hdr);
+    pkt = gnrc_pkt_prepend(pkt, hdr);
     nethdr = (gnrc_netif_hdr_t *)hdr->data;
     nethdr->flags = flags;
     /* and send it */

--- a/tests/gnrc_ipv6_ext_frag/udp.c
+++ b/tests/gnrc_ipv6_ext_frag/udp.c
@@ -96,7 +96,7 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
             gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
             ((gnrc_netif_hdr_t *)netif->data)->if_pid = (kernel_pid_t)iface;
-            LL_PREPEND(ip, netif);
+            ip = gnrc_pkt_prepend(ip, netif);
         }
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1189,7 +1189,7 @@ static void test_netapi_send__raw_unicast_ethernet_packet(void)
     TEST_ASSERT_NOT_NULL(pkt);
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ethernet_netif, pkt);
 }
 
@@ -1204,7 +1204,7 @@ static void test_netapi_send__raw_broadcast_ethernet_packet(void)
     TEST_ASSERT_NOT_NULL(netif);
     hdr = netif->data;
     hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ethernet_netif, pkt);
 }
 
@@ -1217,7 +1217,7 @@ static void test_netapi_send__raw_unicast_ieee802154_long_long_packet(void)
     TEST_ASSERT_NOT_NULL(pkt);
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
 }
 
@@ -1230,7 +1230,7 @@ static void test_netapi_send__raw_unicast_ieee802154_long_short_packet(void)
     TEST_ASSERT_NOT_NULL(pkt);
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
 }
 
@@ -1248,7 +1248,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet1(void)
                 0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
     /* reset src_len */
     src_len = 8U;
@@ -1268,7 +1268,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_long_packet2(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(src, sizeof(src),
             dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
 }
 
@@ -1286,7 +1286,7 @@ static void test_netapi_send__raw_unicast_ieee802154_short_short_packet(void)
                 0, &src_len, sizeof(src_len)));
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst, sizeof(dst));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
     /* reset src_len */
     src_len = 8U;
@@ -1306,7 +1306,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_long_packet(void)
     TEST_ASSERT_NOT_NULL(netif);
     hdr = netif->data;
     hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
 }
 
@@ -1326,7 +1326,7 @@ static void test_netapi_send__raw_broadcast_ieee802154_short_packet(void)
     TEST_ASSERT_NOT_NULL(netif);
     hdr = netif->data;
     hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
     /* reset src_len */
     src_len = 8U;
@@ -1360,7 +1360,7 @@ static void test_netapi_send__ipv6_unicast_ethernet_packet(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst_netif,
             sizeof(dst_netif));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ethernet_netif, pkt);
 }
 
@@ -1387,7 +1387,7 @@ static void test_netapi_send__ipv6_multicast_ethernet_packet(void)
     TEST_ASSERT_NOT_NULL(netif);
     netif_hdr = netif->data;
     netif_hdr->flags |= GNRC_NETIF_HDR_FLAGS_MULTICAST;
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ethernet_netif, pkt);
 }
 
@@ -1416,7 +1416,7 @@ static void test_netapi_send__ipv6_unicast_ieee802154_packet(void)
     gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(NULL, 0, dst_netif,
             sizeof(dst_netif));
     TEST_ASSERT_NOT_NULL(netif);
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
 }
 
@@ -1443,7 +1443,7 @@ static void test_netapi_send__ipv6_multicast_ieee802154_packet(void)
     TEST_ASSERT_NOT_NULL(netif);
     netif_hdr = netif->data;
     netif_hdr->flags |= GNRC_NETIF_HDR_FLAGS_MULTICAST;
-    LL_PREPEND(pkt, netif);
+    pkt = gnrc_pkt_prepend(pkt, netif);
     gnrc_netif_send(&ieee802154_netif, pkt);
 }
 

--- a/tests/gnrc_sock_ip/stack.c
+++ b/tests/gnrc_sock_ip/stack.c
@@ -62,14 +62,13 @@ static gnrc_pktsnip_t *_build_ipv6_packet(const ipv6_addr_t *src,
     ipv6_hdr->len = byteorder_htons((uint16_t)payload->size);
     ipv6_hdr->nh = nh;
     ipv6_hdr->hl = 64;
-    LL_APPEND(payload, ipv6);
+    payload = gnrc_pkt_append(payload, ipv6);
     netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     if (netif_hdr == NULL) {
         return NULL;
     }
     ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = (kernel_pid_t)netif;
-    LL_APPEND(payload, netif_hdr);
-    return payload;
+    return gnrc_pkt_append(payload, netif_hdr);
 }
 
 

--- a/tests/gnrc_sock_udp/stack.c
+++ b/tests/gnrc_sock_udp/stack.c
@@ -85,14 +85,13 @@ static gnrc_pktsnip_t *_build_udp_packet(const ipv6_addr_t *src,
     else {
         udp_hdr->checksum = byteorder_htons(~csum);
     }
-    LL_APPEND(udp, ipv6);
+    udp = gnrc_pkt_append(udp, ipv6);
     netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     if (netif_hdr == NULL) {
         return NULL;
     }
     ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = (kernel_pid_t)netif;
-    LL_APPEND(udp, netif_hdr);
-    return udp;
+    return gnrc_pkt_append(udp, netif_hdr);
 }
 
 

--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -148,7 +148,7 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
                 return;
             }
             gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
-            LL_PREPEND(ip, netif_hdr);
+            ip = gnrc_pkt_prepend(ip, netif_hdr);
         }
         /* send packet */
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -104,7 +104,7 @@ static int test_send(void)
         puts("Could not allocate send header");
         return 0;
     }
-    LL_PREPEND(pkt, hdr);
+    pkt = gnrc_pkt_prepend(pkt, hdr);
     /* prepare expected data */
     memcpy(exp_mac->dst, _test_dst, sizeof(_test_dst));
     memcpy(exp_mac->src, _dev_addr, sizeof(_dev_addr));

--- a/tests/unittests/tests-gnrc_mac_internal/tests-gnrc_mac_internal.c
+++ b/tests/unittests/tests-gnrc_mac_internal/tests-gnrc_mac_internal.c
@@ -63,7 +63,7 @@ static void test_gnrc_mac_queue_tx_packet(void)
     hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
     gnrc_pktsnip_t *pkt_bcast = gnrc_pktbuf_add(NULL, TEST_STRING12, sizeof(TEST_STRING12),
                                                 GNRC_NETTYPE_UNDEF);
-    LL_APPEND(hdr, pkt_bcast);
+    hdr = gnrc_pkt_append(hdr, pkt_bcast);
     pkt_bcast = hdr;
 
     netif_hdr = hdr->data;
@@ -72,13 +72,13 @@ static void test_gnrc_mac_queue_tx_packet(void)
     hdr = gnrc_netif_hdr_build(NULL, 0, dst_addr, 2);
     gnrc_pktsnip_t *pkt1 = gnrc_pktbuf_add(NULL, TEST_STRING4, sizeof(TEST_STRING4),
                                            GNRC_NETTYPE_UNDEF);
-    LL_APPEND(hdr, pkt1);
+    hdr = gnrc_pkt_append(hdr, pkt1);
     pkt1 = hdr;
 
     hdr = gnrc_netif_hdr_build(NULL, 0, dst_addr, 2);
     gnrc_pktsnip_t *pkt2 = gnrc_pktbuf_add(NULL, TEST_STRING8, sizeof(TEST_STRING8),
                                            GNRC_NETTYPE_UNDEF);
-    LL_APPEND(hdr, pkt2);
+    hdr = gnrc_pkt_append(hdr, pkt2);
     pkt2 = hdr;
 
     dst_addr[0] = 0x44;
@@ -87,7 +87,7 @@ static void test_gnrc_mac_queue_tx_packet(void)
     hdr = gnrc_netif_hdr_build(NULL, 0, dst_addr, 2);
     gnrc_pktsnip_t *pkt3 = gnrc_pktbuf_add(NULL, TEST_STRING16, sizeof(TEST_STRING16),
                                            GNRC_NETTYPE_UNDEF);
-    LL_APPEND(hdr, pkt3);
+    hdr = gnrc_pkt_append(hdr, pkt3);
     pkt3 = hdr;
 
 #if CONFIG_GNRC_MAC_NEIGHBOR_COUNT != 0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Up until now `utlist.h` is used to manipulate the packet list within a GNRC pkt snip. Since I always wanted to see if there would be an advantage when using `core`'s `list.h`, I provide this `gnrc_pktsnip_t`-specific API to manipulate the packet list. It has the additional advantage of type safety and that future steps could encapsulate those operations.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read carefully, the changes should be obvious.

~~Binary size should remain unchanged.~~ (see https://github.com/RIOT-OS/RIOT/pull/15212#issuecomment-707800890)

None of the usages of `LL_...` remain in tree for manipulation of `gnrc_pktsnip_t` lists (**attention**: there _are_ other usages!).

All GNRC tests should still pass, `gnrc_networking`, `gnrc_networking_mac`, and `gnrc_border_router` examples should still work~~(but this should also be confirmable with the binaries remaining unchanged)~~.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but together with https://github.com/RIOT-OS/RIOT/pull/15211, there should be no usage of `utlist.h` macros remaining in the tree to manipulate GNRC packets.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
