### PR TITLE
net/netif/gnrc_netif: allow larger IPv6 MTU than minimum for BLE

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -182,8 +182,8 @@ extern "C" {
  *
  * @experimental
  *
- * This feature is non compliant with RFC 4944 and might not be supported by
- * other implementations.
+ * This feature is non compliant with RFC 4944 and RFC 7668 and might not be
+ * supported by other implementations.
  */
 #ifndef CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU
 #define CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU 0

--- a/sys/net/gnrc/netif/Kconfig
+++ b/sys/net/gnrc/netif/Kconfig
@@ -45,8 +45,8 @@ config GNRC_NETIF_NONSTANDARD_6LO_MTU
     depends on USEMODULE_GNRC_NETIF_6LO
     help
         Enables the usage of non standard MTU for 6LoWPAN network interfaces.
-        This is non compliant with RFC 4944 and might not be supported by other
-        implementations.
+        This is non compliant with RFC 4944 and RFC 7668 and might not be
+        supported by other implementations.
 
 config GNRC_NETIF_PKTQ_POOL_SIZE
     int "Packet queue pool size for all network interfaces"

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1199,7 +1199,11 @@ static void _test_options(gnrc_netif_t *netif)
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
             switch (netif->device_type) {
                 case NETDEV_TYPE_BLE:
+#if IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU)
+                    assert(netif->ipv6.mtu >= IPV6_MIN_MTU);
+#else
                     assert(netif->ipv6.mtu == IPV6_MIN_MTU);
+#endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
                     break;
                 case NETDEV_TYPE_ETHERNET:
                     assert(netif->ipv6.mtu == ETHERNET_DATA_LEN);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Currently it is not allowed to have a larger IPv6 MTU for BLE devices than the minimum IPv6 MTU. Since even Bluetooth 5.0 Extended Advertisings allow a maximum data size of 1650 bytes[1] (by chaining packets, but that's done internally) we should allow larger MTUs. 

[1] Bluetooth 5.2 Core Specification: https://www.bluetooth.com/specifications/bluetooth-core-specification/ p. 2891
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
