### PR TITLE
cpu/cc26xx_cc13xx: fix typo on XOSC selection

### DIFF
--- a/cpu/cc26x2_cc13x2/osc.c
+++ b/cpu/cc26x2_cc13x2/osc.c
@@ -54,7 +54,7 @@ void osc_hf_source_switch(uint32_t osc)
     _hf_source_set(osc);
 
     /* Wait for the oscillator to be ready */
-    while (_hf_source_ready()) {}
+    while (!_hf_source_ready()) {}
 
     /* If target clock source is RCOSC, change clock source for DCDC to RCOSC */
     if (osc == OSC_RCOSC_HF) {

--- a/cpu/cc26xx_cc13xx/vectors.c
+++ b/cpu/cc26xx_cc13xx/vectors.c
@@ -227,7 +227,7 @@ ccfg_regs_t cc26xx_cc13xx_ccfg = {
                                         CCFG_MODE_CONF_RTC_COMP_m)
                         & CCFG_SET_BITS(SET_MODE_CONF_XOSC_FREQ,
                                         CCFG_MODE_CONF_XOSC_FREQ_s,
-                                        CCFG_MODE_CONF_RTC_COMP_m)
+                                        CCFG_MODE_CONF_XOSC_FREQ_m)
                         & CCFG_SET_BITS(SET_MODE_CONF_XOSC_CAP_MOD,
                                         CCFG_MODE_CONF_XOSC_CAP_MOD_s,
                                         CCFG_MODE_CONF_XOSC_CAP_MOD_m)
@@ -264,9 +264,9 @@ ccfg_regs_t cc26xx_cc13xx_ccfg = {
                         & CCFG_SET_BITS(SET_BL_CONFIG_BL_ENABLE,
                                         CCFG_BL_CONFIG_BL_ENABLE_s,
                                         CCFG_BL_CONFIG_BL_ENABLE_m),
-    .ERASE_CONF         = 0,
+    .ERASE_CONF         = 0xFFFFFFFF,
     /* debugging */
-    .CCFG_TI_OPTIONS    = 0,
+    .CCFG_TI_OPTIONS    = 0xFFFFFF00,
     .CCFG_TAP_DAP_0     = CCFG_SET_BITS(SET_CCFG_TAP_DAP_0_CPU_DAP_ENABLE,
                                         CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE_s,
                                         CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE_m)
@@ -277,7 +277,7 @@ ccfg_regs_t cc26xx_cc13xx_ccfg = {
                                         CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE_s,
                                         CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE_m),
     /* PBIST2, PBIST1 and AON disabled by default */
-    .CCFG_TAP_DAP_1     = 0,
+    .CCFG_TAP_DAP_1     = 0xFF000000,
     /* flash image vector table */
     .IMAGE_VALID_CONF   = (reg32_t)&cortex_vector_base,
     /* flash sector write protections */


### PR DESCRIPTION
### Contribution description

- Fixes a typo on XOSC selection bitfield that would
make the CPU crash when changing it.
- Sets the other fields to their default values.
- Fixes another bug when changing the oscillator.

### Testing procedure

- `make -C examples/hello-world menuconfig all flash BOARD=cc1312-launchpad` to open menu config, select update CCFG and flash the firmware.

### Issues/PRs references

- Needed for #13295 
