### PR TITLE
makefiles/kconfig: always allow to use KCONFIG_ADD_CONFIG

### DIFF
--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -37,4 +37,8 @@ endif
 
 FEATURES_PROVIDED += no_idle_thread
 
-KCONFIG_ADD_CONFIG += $(RIOTCPU)/cortexm_common/cortexm_common.config
+# This configuration enables modules that are only available when using Kconfig
+# module modelling
+ifeq (1, $(TEST_KCONFIG))
+  KCONFIG_ADD_CONFIG += $(RIOTCPU)/cortexm_common/cortexm_common.config
+endif

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -17,9 +17,11 @@ FEATURES_PROVIDED += periph_wdt periph_wdt_cb periph_wdt_warning_period
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "The RTC and RTT map to the same hardware peripheral."
 
-KCONFIG_ADD_CONFIG += $(RIOTCPU)/cortexm_common/cortexm_common.config
+include $(RIOTCPU)/cortexm_common/Makefile.features
 
--include $(RIOTCPU)/cortexm_common/Makefile.features
-
-# add sam0 configurations after including cortexm_common so sam0 takes precendence
-KCONFIG_ADD_CONFIG += $(RIOTCPU)/sam0_common/sam0_common.config
+# Add sam0 configurations after including cortexm_common so sam0 takes precendence
+# This configuration enables modules that are only available when using Kconfig
+# module modelling
+ifeq (1, $(TEST_KCONFIG))
+  KCONFIG_ADD_CONFIG += $(RIOTCPU)/sam0_common/sam0_common.config
+endif

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -50,13 +50,11 @@ KCONFIG_OUT_DEP = $(KCONFIG_OUT_CONFIG).d
 
 # Add configurations to merge, in ascendent priority (i.e. a file overrides the
 # previous ones).
-ifeq (1, $(TEST_KCONFIG))
-  # KCONFIG_ADD_CONFIG holds a list of .config files that are merged for the
-  # initial configuration. This allows to split configurations in common files
-  # and share them among boards or cpus.
-  MERGE_SOURCES += $(KCONFIG_ADD_CONFIG)
-endif
-
+#
+# KCONFIG_ADD_CONFIG holds a list of .config files that are merged for the
+# initial configuration. This allows to split configurations in common files
+# and share them among boards or cpus.
+MERGE_SOURCES += $(KCONFIG_ADD_CONFIG)
 MERGE_SOURCES += $(wildcard $(KCONFIG_APP_CONFIG))
 MERGE_SOURCES += $(wildcard $(KCONFIG_USER_CONFIG))
 


### PR DESCRIPTION
### Contribution description
This removes the check for `TEST_KCONFIG` in `kconfig.mk`, allowing to use this variable even when not testing the Kconfig dependency modelling. This allows us to merge configurations from different sources (like boards, or common folders), which makes possible to set defaults for parameters per board, cpu, arch, etc.

This can come up handy, for example, for the work @aabadie is doing for nucleo boards' clock configurations, as a configuration file can be placed in the board folder to set the default clock parameters.

### Testing procedure
- Murdock will check that `hello-world` still works using Kconfig module dependency
- Adding a configuration file to the variable should result in that file being merged in the configuration (note that the order of the configuration files in the list matter, and the last configuration file to be added can override values from the previous ones).

### Issues/PRs references
Split from #14777