### PR TITLE
tools/insufficient_memory: improve error handling and output

### DIFF
--- a/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
@@ -12,18 +12,53 @@ if [ -z $1 ]; then
     exit 1
 fi
 
+if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
+    COK="\e[1;32m"
+    CBIG="\e[1;34m"
+    CNORMAL="\e[1m"
+    CSKIP="\e[1;36m"
+    CERROR="\e[1;31m"
+    CWARN="\e[1;33m"
+    CRESET="\e[0m"
+else
+    COK=
+    CBIG=
+    CNORMAL=
+    CSKIP=
+    CERROR=
+    CWARN=
+    CRESET=
+fi
+
 BOARD=$1
 RIOTBASE=$(dirname $0)/../../..
-PROJECTS+=$RIOTBASE/examples/*/Makefile
-PROJECTS+=" "
-PROJECTS+=$RIOTBASE/tests/*/Makefile
+APPLICATIONS+=examples/*/Makefile
+APPLICATIONS+=" "
+APPLICATIONS+=tests/*/Makefile
 
-for i in $PROJECTS; do
-    test=$(dirname $(realpath $i));
-    if make BOARD=$BOARD -j -C $test 2>&1 >/dev/null | grep -e overflowed -e "not within region" > /dev/null; then
-        echo $(basename $test) is too big for $BOARD
-        make -f Makefile.for_sh -C $(dirname $0) DIR=$test BOARD=$BOARD Makefile.ci > /dev/null
+# Use a standardized build within Docker and with minimal output
+export BUILD_IN_DOCKER=1
+export DOCKER_MAKE_ARGS="-j4"
+export RIOT_CI_BUILD=1
+
+for app in ${APPLICATIONS}; do
+    application=$(dirname ${app})
+    printf "${CNORMAL}%-40s${CRESET}" ${application}
+    output=$(make BOARD=${BOARD} -C ${RIOTBASE}/${application} 2>&1)
+    if [ $? != 0 ]; then
+        if echo ${output} | grep -e overflowed -e "not within region" > /dev/null; then
+            printf "${CBIG}%s${CRESET}\n" "too big"
+            make -f $(dirname $0)/Makefile.for_sh DIR=${RIOTBASE}/${application} BOARD=${BOARD} Makefile.ci > /dev/null
+        elif echo ${output} | grep -e "not whitelisted" -e "unsatisfied feature requirements" > /dev/null; then
+            printf "${CWARN}%s${CRESET}\n" "not supported"
+        else
+            printf "${CERROR}%s${CRESET}\n" "build failed"
+        fi
     else
-        echo $(basename $test) is OK
+        if echo ${output} | grep -e "skipping link step" > /dev/null; then
+            printf "${CSKIP}%s${CRESET}\n" "skipped"
+        else
+            printf "${COK}%s${CRESET}\n" "OK"
+        fi
     fi
 done


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the `insufficient_memory` script to better handle errors during build and to make it use color to better distinguish between errors/not supported/skipped/too big/OK cases.

For example, the script says OK even if the board is not supported (because a feature is missing or because the board is not whitelisted or when the build fails at compile time.
With this PR all cases are correctly handled so the output is more meaningful.

By default, the build is also performed using `BUILD_IN_DOCKER=1` and `RIOT_CI_BUILD=1`: this allows for a more consistent build environment with CI.

Finally, the output is improved with colors, alignment, etc. This is purely cosmetic:

<p align="center">
<img src="https://user-images.githubusercontent.com/1375137/95852106-7fa68c00-0d53-11eb-9150-341bc26e28af.png" width="40%">
</p>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just run `./dist/tools/insufficient_memory/add_insufficient_memory_board.sh <any board>` and check the nice output (see above).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

I had several issues with the script when using it for nucleo-l011k4 (PICOLIBC enabled by default, some builds were failing at compile time, etc)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
