### PR TITLE
gnrc_netif: add missing gnrc_netif_release() to early return

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -561,6 +561,7 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
               PRIkernel_pid "\n",
               ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
               netif->pid);
+        gnrc_netif_release(netif);
         return res;
     }
 #else  /* CONFIG_GNRC_IPV6_NIB_ARSM */


### PR DESCRIPTION
### Contribution description

The `gnrc_netif_ipv6_addr_add_internal()` function unconditionally acquires the global netif rrmutex but doesn't release this rmutex on this specific path (i.e. if `gnrc_netif_ipv6_group_join_internal()` failed). This can cause a deadlock as no other thread will afterwards be capable of acquiring the netif rmutex.

### Testing procedure

I think this is obvious from reading the code, i.e. all other branches invoke `gnrc_netif_release()` before returning.

For example:

https://github.com/RIOT-OS/RIOT/blob/af03cd8f4f6e6702251f0dd85f3d36bc245ca31a/sys/net/gnrc/netif/gnrc_netif.c#L547-L550

### Issues/PRs references

None.