### PR TITLE
boards/nucleo-l011k4: add support

### DIFF
--- a/boards/common/nucleo32/include/arduino_pinmap.h
+++ b/boards/common/nucleo32/include/arduino_pinmap.h
@@ -40,7 +40,7 @@ extern "C" {
 #define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 6)
 #define ARDUINO_PIN_6           GPIO_PIN(PORT_B, 1)
 #if defined(CPU_MODEL_STM32L031K6) || defined(CPU_MODEL_STM32L432KC) || \
-    defined(CPU_MODEL_STM32L412KB)
+    defined(CPU_MODEL_STM32L412KB) || defined(CPU_MODEL_STM32L011K4)
 #define ARDUINO_PIN_7           GPIO_PIN(PORT_C, 14)
 #define ARDUINO_PIN_8           GPIO_PIN(PORT_C, 15)
 #else

--- a/boards/nucleo-l011k4/Kconfig
+++ b/boards/nucleo-l011k4/Kconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l011k4" if BOARD_NUCLEO_L011K4
+
+config BOARD_NUCLEO_L011K4
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32L011K4
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l011k4/Makefile
+++ b/boards/nucleo-l011k4/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-l011k4/Makefile.dep
+++ b/boards/nucleo-l011k4/Makefile.dep
@@ -1,0 +1,5 @@
+# Use Picolibc to reduce ROM usage
+USEMODULE += picolibc
+FEATURES_REQUIRED += picolibc
+
+include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l011k4/Makefile.features
+++ b/boards/nucleo-l011k4/Makefile.features
@@ -1,0 +1,14 @@
+CPU = stm32
+CPU_MODEL = stm32l011k4
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# load the common Makefile.features for Nucleo-32 boards
+include $(RIOTBOARD)/common/nucleo32/Makefile.features

--- a/boards/nucleo-l011k4/Makefile.include
+++ b/boards/nucleo-l011k4/Makefile.include
@@ -1,0 +1,5 @@
+# load the common Makefile.include for Nucleo-32 boards
+include $(RIOTBOARD)/common/nucleo32/Makefile.include
+
+# Reduce default thread stack size so that it fits in the only 2kB of RAM
+CFLAGS += -DTHREAD_STACKSIZE_DEFAULT=512

--- a/boards/nucleo-l011k4/doc.txt
+++ b/boards/nucleo-l011k4/doc.txt
@@ -1,0 +1,5 @@
+/**
+@defgroup    boards_nucleo-l011k4 STM32 Nucleo-L011K4
+@ingroup     boards_common_nucleo32
+@brief       Support for the STM32 Nucleo-L011K4
+ */

--- a/boards/nucleo-l011k4/include/periph_conf.h
+++ b/boards/nucleo-l011k4/include/periph_conf.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-l011k4
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the nucleo-l011k4 board
+ *
+ * @author      Alexandre Aabdie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            1
+#endif
+
+#include "periph_cpu.h"
+#include "l0l1/cfg_clock_default.h"
+#include "cfg_i2c1_pb6_pb7.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_tim2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 15),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF4,
+        .tx_af      = GPIO_AF4,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    }
+};
+
+#define UART_0_ISR          (isr_usart2)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_UNDEF,
+        .mosi_af  = GPIO_AF0,
+        .miso_af  = GPIO_AF0,
+        .sclk_af  = GPIO_AF0,
+        .cs_af    = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },  /* Pin A0 */
+    { GPIO_PIN(PORT_A, 1), 1 },  /* Pin A1 */
+    { GPIO_PIN(PORT_A, 3), 3 },  /* Pin A2 */
+    { GPIO_PIN(PORT_A, 4), 4 },  /* Pin A3 */
+    { GPIO_PIN(PORT_A, 5), 5 },  /* Pin A4 */
+    { GPIO_PIN(PORT_A, 6), 6 },  /* Pin A5 */
+    { GPIO_PIN(PORT_A, 7), 7 },  /* Pin A6 */
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -4,7 +4,12 @@ USEMODULE += cortexm_common
 # include common periph code
 USEMODULE += cortexm_common_periph
 
-ifneq (,$(filter picolibc,$(FEATURES_USED)))
+# Ensure newlib is not added if picolibc is already in FEATURES_USED or USEMODULE.
+# nucleo-l011k4 doesn't use features to forces picolibc but directly set it in
+# USEMODULE. This is because during the first pass of the dependency resolution,
+# with the feature mechanism, the picolib feature is not present in FEATURES_USED
+# at this staged and as a result newlib modules are wrongly added.
+ifneq (,$(filter picolibc,$(FEATURES_USED) $(USEMODULE)))
   # Use Picolibc when explicitly selected
   USEMODULE += picolibc
 else

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -24,7 +24,7 @@ ifeq (f1,$(CPU_FAM))
 endif
 
 # Not all F4 and L0 parts implement a RNG.
-CPU_MODELS_WITHOUT_HWRNG = stm32f401% stm32f411% stm32f446% stm32l031%
+CPU_MODELS_WITHOUT_HWRNG = stm32f401% stm32f411% stm32f446% stm32l031% stm32l011%
 ifneq (,$(filter $(CPU_FAM),f2 f4 f7 g4 l0 l4 wb))
   ifeq (,$(filter $(CPU_MODELS_WITHOUT_HWRNG),$(CPU_MODEL)))
     FEATURES_PROVIDED += periph_hwrng

--- a/cpu/stm32/include/periph/l0/periph_cpu.h
+++ b/cpu/stm32/include/periph/l0/periph_cpu.h
@@ -62,7 +62,9 @@ typedef enum {
 #define EEPROM_SIZE                (2048U)  /* 2kB */
 #elif defined(CPU_LINE_STM32L031xx)
 #define EEPROM_SIZE                (1024U)  /* 1kB */
-#elif defined(CPU_LINE_STM32L010xB) || defined(CPU_LINE_STM32L011x3) || defined(CPU_LINE_STM32L011x4) || defined(CPU_LINE_STM32L021x4)
+#elif defined(CPU_LINE_STM32L010xB) || defined(CPU_LINE_STM32L011x3) || \
+      defined(CPU_LINE_STM32L011x4) || defined(CPU_LINE_STM32L021x4) || \
+      defined(CPU_MODEL_STM32L011K4)
 #define EEPROM_SIZE                (512U)   /* 512B */
 #elif defined(CPU_LINE_STM32L010x6) || defined(CPU_LINE_STM32L010x8)
 #define EEPROM_SIZE                (256U)   /* 256B */

--- a/cpu/stm32/stmclk/stmclk_l0l1.c
+++ b/cpu/stm32/stmclk/stmclk_l0l1.c
@@ -180,7 +180,11 @@ void stmclk_init_sysclk(void)
 
     /* Reset the RCC clock configuration to the default reset state(for debug purpose) */
     /* Reset MSION, HSEON, CSSON and PLLON bits */
+#ifdef RCC_CR_CSSON
     RCC->CR &= ~(RCC_CR_MSION | RCC_CR_HSEON | RCC_CR_HSEBYP | RCC_CR_CSSON | RCC_CR_PLLON);
+#else
+    RCC->CR &= ~(RCC_CR_MSION | RCC_CR_HSEON | RCC_CR_HSEBYP | RCC_CR_PLLON);
+#endif
 
     /* use HSI as system clock while we do any further configuration and
     * configure the AHB and APB clock dividers as configured by the board */

--- a/examples/arduino_hello-world/Makefile.ci
+++ b/examples/arduino_hello-world/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/dtls-echo/Makefile.ci
+++ b/examples/dtls-echo/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -26,6 +26,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/filesystem/Makefile.ci
+++ b/examples/filesystem/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -39,6 +39,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/gnrc_lorawan/Makefile.ci
+++ b/examples/gnrc_lorawan/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/gnrc_minimal/Makefile.ci
+++ b/examples/gnrc_minimal/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/examples/ipc_pingpong/Makefile.ci
+++ b/examples/ipc_pingpong/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -33,6 +33,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/lorawan/Makefile.ci
+++ b/examples/lorawan/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/micropython/Makefile.ci
+++ b/examples/micropython/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     opencm904 \

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/paho-mqtt/Makefile.ci
+++ b/examples/paho-mqtt/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/examples/posix_select/Makefile.ci
+++ b/examples/posix_select/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/examples/riot_and_cpp/Makefile.ci
+++ b/examples/riot_and_cpp/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     stm32f0discovery \
     #

--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     opencm904 \

--- a/pkg/lua/Makefile.dep
+++ b/pkg/lua/Makefile.dep
@@ -12,3 +12,8 @@ FEATURES_BLACKLIST += arch_mips32r2
 # (undefined reference to _times, _unlink and _link functions in provided
 # newlib nano).
 FEATURES_BLACKLIST += arch_riscv
+
+# LUA is not compatible with picolibc and raises errors at compile time:
+# - lua/liolib.c:671:38: error: '_IOFBF' undeclared (first use in this function)
+# - lua/liolib.c:671:46: error: '_IOLBF' undeclared (first use in this function)
+FEATURES_BLACKLIST += picolibc

--- a/tests/bench_msg_pingpong/Makefile.ci
+++ b/tests/bench_msg_pingpong/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench_mutex_pingpong/Makefile.ci
+++ b/tests/bench_mutex_pingpong/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_flags_pingpong/Makefile.ci
+++ b/tests/bench_thread_flags_pingpong/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_yield_pingpong/Makefile.ci
+++ b/tests/bench_thread_yield_pingpong/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/bench_timers/Makefile.ci
+++ b/tests/bench_timers/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     im880b \
+    nucleo-l011k4 \
     olimexino-stm32 \
     stk3200 \
     #

--- a/tests/bench_xtimer_load/Makefile.ci
+++ b/tests/bench_xtimer_load/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/bloom_bytes/Makefile.ci
+++ b/tests/bloom_bytes/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     telosb \
     z1 \

--- a/tests/candev/Makefile.ci
+++ b/tests/candev/Makefile.ci
@@ -1,8 +1,8 @@
-FEATURES_BLACKLIST += arch_msp430
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/cb_mux_bench/Makefile.ci
+++ b/tests/cb_mux_bench/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/cond_order/Makefile.ci
+++ b/tests/cond_order/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053 \
     nucleo-l053r8 \

--- a/tests/cpp11_condition_variable/Makefile.ci
+++ b/tests/cpp11_condition_variable/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/cpp11_mutex/Makefile.ci
+++ b/tests/cpp11_mutex/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/cpp11_thread/Makefile.ci
+++ b/tests/cpp11_thread/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/cpp_ctors/Makefile.ci
+++ b/tests/cpp_ctors/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/cpp_exclude/Makefile.ci
+++ b/tests/cpp_exclude/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     stm32f0discovery \
     #

--- a/tests/cpp_ext/Makefile.ci
+++ b/tests/cpp_ext/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     stm32f0discovery \
     #

--- a/tests/cpu_cortexm_address_check/Makefile.ci
+++ b/tests/cpu_cortexm_address_check/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/devfs/Makefile.ci
+++ b/tests/devfs/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/disp_dev/Makefile.ci
+++ b/tests/disp_dev/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     derfmega128 \
     mega-xplained \
     microduino-corerf \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     waspmote-pro \

--- a/tests/driver_apa102/Makefile.ci
+++ b/tests/driver_apa102/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_at/Makefile.ci
+++ b/tests/driver_at/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/driver_at30tse75x/Makefile.ci
+++ b/tests/driver_at30tse75x/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/driver_at86rf215/Makefile.ci
+++ b/tests/driver_at86rf215/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_at86rf2xx/Makefile.ci
+++ b/tests/driver_at86rf2xx/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_at86rf2xx_aes/Makefile.ci
+++ b/tests/driver_at86rf2xx_aes/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_ata8520e/Makefile.ci
+++ b/tests/driver_ata8520e/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_atwinc15x0/Makefile.ci
+++ b/tests/driver_atwinc15x0/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_bmp180/Makefile.ci
+++ b/tests/driver_bmp180/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_bmx055/Makefile.ci
+++ b/tests/driver_bmx055/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stk3200 \
     #

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/driver_dcf77/Makefile.ci
+++ b/tests/driver_dcf77/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_dfplayer/Makefile.ci
+++ b/tests/driver_dfplayer/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_dose/Makefile.ci
+++ b/tests/driver_dose/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_encx24j600/Makefile.ci
+++ b/tests/driver_encx24j600/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_hmc5883l/Makefile.ci
+++ b/tests/driver_hmc5883l/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_ili9341/Makefile.ci
+++ b/tests/driver_ili9341/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/driver_io1_xplained/Makefile.ci
+++ b/tests/driver_io1_xplained/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_kw2xrf/Makefile.ci
+++ b/tests/driver_kw2xrf/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_ltc4150/Makefile.ci
+++ b/tests/driver_ltc4150/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_mpu9x50/Makefile.ci
+++ b/tests/driver_mpu9x50/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/driver_mrf24j40/Makefile.ci
+++ b/tests/driver_mrf24j40/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_netdev_common/Makefile.ci
+++ b/tests/driver_netdev_common/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_nrf24l01p_lowlevel/Makefile.ci
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_pir/Makefile.ci
+++ b/tests/driver_pir/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_rn2xx3/Makefile.ci
+++ b/tests/driver_rn2xx3/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_sdcard_spi/Makefile.ci
+++ b/tests/driver_sdcard_spi/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/driver_sdp3x/Makefile.ci
+++ b/tests/driver_sdp3x/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_sht1x/Makefile.ci
+++ b/tests/driver_sht1x/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_soft_uart/Makefile.ci
+++ b/tests/driver_soft_uart/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_sps30/Makefile.ci
+++ b/tests/driver_sps30/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/driver_sx127x/Makefile.ci
+++ b/tests/driver_sx127x/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/driver_tmp00x/Makefile.ci
+++ b/tests/driver_tmp00x/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_w5100/Makefile.ci
+++ b/tests/driver_w5100/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/driver_xbee/Makefile.ci
+++ b/tests/driver_xbee/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f103rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/event_threads/Makefile.ci
+++ b/tests/event_threads/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/event_wait_timeout/Makefile.ci
+++ b/tests/event_wait_timeout/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/events/Makefile.ci
+++ b/tests/events/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/evtimer_msg/Makefile.ci
+++ b/tests/evtimer_msg/Makefile.ci
@@ -6,5 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/evtimer_underflow/Makefile.ci
+++ b/tests/evtimer_underflow/Makefile.ci
@@ -6,5 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -38,6 +38,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_opt/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
+++ b/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_ipv6_nib/Makefile.ci
+++ b/tests/gnrc_ipv6_nib/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_dns/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_mac_timeout/Makefile.ci
+++ b/tests/gnrc_mac_timeout/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_ndp/Makefile.ci
+++ b/tests/gnrc_ndp/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -39,6 +39,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/gnrc_rpl_p2p/Makefile.ci
+++ b/tests/gnrc_rpl_p2p/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/gnrc_sixlowpan/Makefile.ci
+++ b/tests/gnrc_sixlowpan/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/gnrc_sixlowpan_frag/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_sock_async_event/Makefile.ci
+++ b/tests/gnrc_sock_async_event/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/gnrc_sock_ip/Makefile.ci
+++ b/tests/gnrc_sock_ip/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_sock_neterr/Makefile.ci
+++ b/tests/gnrc_sock_neterr/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/gnrc_sock_udp/Makefile.ci
+++ b/tests/gnrc_sock_udp/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/heap_cmd/Makefile.ci
+++ b/tests/heap_cmd/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/irq/Makefile.ci
+++ b/tests/irq/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/isr_yield_higher/Makefile.ci
+++ b/tests/isr_yield_higher/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/lwip_sock_ip/Makefile.ci
+++ b/tests/lwip_sock_ip/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/lwip_sock_tcp/Makefile.ci
+++ b/tests/lwip_sock_tcp/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/lwip_sock_udp/Makefile.ci
+++ b/tests/lwip_sock_udp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/memarray/Makefile.ci
+++ b/tests/memarray/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/msg_send_receive/Makefile.ci
+++ b/tests/msg_send_receive/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/msg_try_receive/Makefile.ci
+++ b/tests/msg_try_receive/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/mtd_mapper/Makefile.ci
+++ b/tests/mtd_mapper/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/mutex_order/Makefile.ci
+++ b/tests/mutex_order/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/mutex_unlock_and_sleep/Makefile.ci
+++ b/tests/mutex_unlock_and_sleep/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/nanocoap_cli/Makefile.ci
+++ b/tests/nanocoap_cli/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/netdev_test/Makefile.ci
+++ b/tests/netdev_test/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/periph_flashpage/Makefile.ci
+++ b/tests/periph_flashpage/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/periph_gpio_arduino/Makefile.ci
+++ b/tests/periph_gpio_arduino/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/periph_i2c/Makefile.ci
+++ b/tests/periph_i2c/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/periph_spi/Makefile.ci
+++ b/tests/periph_spi/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/periph_uart/Makefile.ci
+++ b/tests/periph_uart/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/periph_uart_nonblocking/tests/01-run.py
+++ b/tests/periph_uart_nonblocking/tests/01-run.py
@@ -10,7 +10,7 @@ import sys
 from testrunner import run
 
 
-PRECISION = 1.002
+PRECISION = 1.005
 
 
 def testfunc(child):

--- a/tests/phydat_dump/Makefile.ci
+++ b/tests/phydat_dump/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/pipe/Makefile.ci
+++ b/tests/pipe/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_c25519/Makefile.ci
+++ b/tests/pkg_c25519/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_cifra/Makefile.ci
+++ b/tests/pkg_cifra/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_cn-cbor/Makefile.ci
+++ b/tests/pkg_cn-cbor/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -19,5 +19,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     derfmega256 \
     mega-xplained \
     microduino-corerf \
+    nucleo-l011k4 \
     saml10-xpro \
     waspmote-pro

--- a/tests/pkg_emlearn/Makefile.ci
+++ b/tests/pkg_emlearn/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/pkg_flatbuffers/Makefile.ci
+++ b/tests/pkg_flatbuffers/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_hacl/Makefile.ci
+++ b/tests/pkg_hacl/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_heatshrink/Makefile.ci
+++ b/tests/pkg_heatshrink/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_libb2/Makefile.ci
+++ b/tests/pkg_libb2/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/pkg_libcoap/Makefile.ci
+++ b/tests/pkg_libcoap/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f070rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_libcose/Makefile.ci
+++ b/tests/pkg_libcose/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_libfixmath_unittests/Makefile.ci
+++ b/tests/pkg_libfixmath_unittests/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/pkg_libhydrogen/Makefile.ci
+++ b/tests/pkg_libhydrogen/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_littlefs/Makefile.ci
+++ b/tests/pkg_littlefs/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_littlefs2/Makefile.ci
+++ b/tests/pkg_littlefs2/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_lvgl/Makefile.ci
+++ b/tests/pkg_lvgl/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/pkg_lvgl_touch/Makefile.ci
+++ b/tests/pkg_lvgl_touch/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/pkg_micro-ecc/Makefile.ci
+++ b/tests/pkg_micro-ecc/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_microcoap/Makefile.ci
+++ b/tests/pkg_microcoap/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_monocypher/Makefile.ci
+++ b/tests/pkg_monocypher/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_qcbor/Makefile.ci
+++ b/tests/pkg_qcbor/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_qdsa/Makefile.ci
+++ b/tests/pkg_qdsa/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_relic/Makefile.ci
+++ b/tests/pkg_relic/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_semtech-loramac/Makefile.ci
+++ b/tests/pkg_semtech-loramac/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/pkg_spiffs/Makefile.ci
+++ b/tests/pkg_spiffs/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pkg_tiny-asn1/Makefile.ci
+++ b/tests/pkg_tiny-asn1/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/pkg_tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg_tinydtls_sock_async/Makefile.ci
@@ -26,6 +26,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/pkg_tweetnacl/Makefile.ci
+++ b/tests/pkg_tweetnacl/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     microduino-corerf \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_u8g2/Makefile.ci
+++ b/tests/pkg_u8g2/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     telosb \

--- a/tests/pkg_ubasic/Makefile.ci
+++ b/tests/pkg_ubasic/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_ucglib/Makefile.ci
+++ b/tests/pkg_ucglib/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     waspmote-pro \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l412kb \

--- a/tests/pkg_wolfcrypt-ed25519-verify/Makefile.ci
+++ b/tests/pkg_wolfcrypt-ed25519-verify/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_wolfssl/Makefile.ci
+++ b/tests/pkg_wolfssl/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     saml10-xpro \

--- a/tests/pkg_yxml/Makefile.ci
+++ b/tests/pkg_yxml/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
-        nucleo-f042k6 \
-        nucleo-f031k6 \
-        stm32f030f4-demo \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l011k4 \
+    stm32f030f4-demo \
     #

--- a/tests/posix_semaphore/Makefile.ci
+++ b/tests/posix_semaphore/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     spark-core \

--- a/tests/prng_sha1prng/Makefile.ci
+++ b/tests/prng_sha1prng/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/prng_sha256prng/Makefile.ci
+++ b/tests/prng_sha256prng/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/progress_bar/Makefile.ci
+++ b/tests/progress_bar/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/ps_schedstatistics/Makefile.ci
+++ b/tests/ps_schedstatistics/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pthread/Makefile.ci
+++ b/tests/pthread/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/pthread_barrier/Makefile.ci
+++ b/tests/pthread_barrier/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32l0538-disco \
     #

--- a/tests/pthread_cleanup/Makefile.ci
+++ b/tests/pthread_cleanup/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/pthread_condition_variable/Makefile.ci
+++ b/tests/pthread_condition_variable/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pthread_cooperation/Makefile.ci
+++ b/tests/pthread_cooperation/Makefile.ci
@@ -10,11 +10,12 @@ BOARD_INSUFFICIENT_MEMORY := \
     derfmega256 \
     hifive1 \
     hifive1b \
-    im880b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32l0538-disco \
     waspmote-pro \
     #

--- a/tests/pthread_flood/Makefile.ci
+++ b/tests/pthread_flood/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/pthread_rwlock/Makefile.ci
+++ b/tests/pthread_rwlock/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/pthread_tls/Makefile.ci
+++ b/tests/pthread_tls/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/rmutex/Makefile.ci
+++ b/tests/rmutex/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/rmutex_cpp/Makefile.ci
+++ b/tests/rmutex_cpp/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/rng/Makefile.ci
+++ b/tests/rng/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stm32f030f4-demo \
     #

--- a/tests/sched_testing/Makefile.ci
+++ b/tests/sched_testing/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/slip/Makefile.ci
+++ b/tests/slip/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/sntp/Makefile.ci
+++ b/tests/sntp/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \

--- a/tests/suit_manifest/Makefile.ci
+++ b/tests/suit_manifest/Makefile.ci
@@ -6,12 +6,13 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     stk3200 \
     stm32f030f4-demo \
-    stm32l0538-disco \
     stm32f0discovery \
+    stm32l0538-disco \
     telosb \
     z1 \
     #

--- a/tests/sys_arduino/Makefile.ci
+++ b/tests/sys_arduino/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/sys_arduino_lib/Makefile.ci
+++ b/tests/sys_arduino_lib/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     #

--- a/tests/sys_crypto/Makefile.ci
+++ b/tests/sys_crypto/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/sys_irq_handler/Makefile.ci
+++ b/tests/sys_irq_handler/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/test_tools/Makefile.ci
+++ b/tests/test_tools/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/thread_basic/Makefile.ci
+++ b/tests/thread_basic/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/thread_cooperation/Makefile.ci
+++ b/tests/thread_cooperation/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430 \
     msb-430h \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     stm32l0538-disco \

--- a/tests/thread_exit/Makefile.ci
+++ b/tests/thread_exit/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/thread_flags/Makefile.ci
+++ b/tests/thread_flags/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/thread_float/Makefile.ci
+++ b/tests/thread_float/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nrf6310 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     opencm9-04 \
     pca10000 \
     pca10005 \

--- a/tests/thread_flood/Makefile.ci
+++ b/tests/thread_flood/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/thread_msg/Makefile.ci
+++ b/tests/thread_msg/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_block_race/Makefile.ci
+++ b/tests/thread_msg_block_race/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     #

--- a/tests/thread_msg_block_w_queue/Makefile.ci
+++ b/tests/thread_msg_block_w_queue/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_block_wo_queue/Makefile.ci
+++ b/tests/thread_msg_block_wo_queue/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_bus/Makefile.ci
+++ b/tests/thread_msg_bus/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_seq/Makefile.ci
+++ b/tests/thread_msg_seq/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/thread_priority_inversion/Makefile.ci
+++ b/tests/thread_priority_inversion/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/thread_race/Makefile.ci
+++ b/tests/thread_race/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/thread_zombie/Makefile.ci
+++ b/tests/thread_zombie/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/trace/Makefile.ci
+++ b/tests/trace/Makefile.ci
@@ -9,5 +9,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -60,6 +60,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \
+    nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/usbus/Makefile.ci
+++ b/tests/usbus/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/vfs_plus_stdio/Makefile.ci
+++ b/tests/vfs_plus_stdio/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/xtimer_drift/Makefile.ci
+++ b/tests/xtimer_drift/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_hang/Makefile.ci
+++ b/tests/xtimer_hang/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_longterm/Makefile.ci
+++ b/tests/xtimer_longterm/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l011k4 \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_msg/Makefile.ci
+++ b/tests/xtimer_msg/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_mutex_lock_timeout/Makefile.ci
+++ b/tests/xtimer_mutex_lock_timeout/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_periodic_wakeup/Makefile.ci
+++ b/tests/xtimer_periodic_wakeup/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/xtimer_rmutex_lock_timeout/Makefile.ci
+++ b/tests/xtimer_rmutex_lock_timeout/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    nucleo-l011k4 \
     #

--- a/tests/ztimer_msg/Makefile.ci
+++ b/tests/ztimer_msg/Makefile.ci
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-f031k6 \
+    nucleo-l011k4 \
     stm32f030f4-demo \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support to the nucleo-l011k4 which is the smallest nucleo boards available: only 2kB of RAM and 16kB of flash memory.

To be able to use it, PICOLIBC must be enabled and the default thread stack size must be reduced to 512B.

Tested with success: UART, ADC, RTC, RTT

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock (it might fail because of picolibc requirement)
- Run `BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . nucleo-l011k4 --jobs=8 --with-test-only`

```
- [tests/driver_apds99xx](tests/driver_apds99xx/test.failed)
- [tests/driver_apds99xx_full](tests/driver_apds99xx_full/test.failed)
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)
- [tests/driver_my9221](tests/driver_my9221/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
