### PR TITLE
cpu/stm32: enable overdrive mode on f4 and f7 for high clock speeds

### DIFF
--- a/cpu/stm32/stmclk/stmclk_f2f4f7.c
+++ b/cpu/stm32/stmclk/stmclk_f2f4f7.c
@@ -479,6 +479,25 @@ void stmclk_init_sysclk(void)
     /* Flash config */
     FLASH->ACR = FLASH_ACR_CONFIG;
 
+    /* Enable Over-Drive if HCLK > 168MHz on F4 or HCLK > 180MHz on F7 */
+#if defined(CPU_FAM_STM32F4)
+    if (CLOCK_AHB > MHZ(168)) {
+        PWR->CR |= PWR_CR_ODEN;
+        while (!(PWR->CSR & PWR_CSR_ODRDY)) {}
+        PWR->CR |= PWR_CR_ODSWEN;
+        while (!(PWR->CSR & PWR_CSR_ODSWRDY)) {}
+    }
+#endif
+
+#if defined(CPU_FAM_STM32F7)
+    if (CLOCK_AHB > MHZ(180)) {
+        PWR->CR1 |= PWR_CR1_ODEN;
+        while (!(PWR->CSR1 & PWR_CSR1_ODRDY)) {}
+        PWR->CR1 |= PWR_CR1_ODSWEN;
+        while (!(PWR->CSR1 & PWR_CSR1_ODSWRDY)) {}
+    }
+#endif
+
     /* disable all active clocks except HSI -> resets the clk configuration */
     RCC->CR = (RCC_CR_HSION | RCC_CR_HSITRIM_4);
 


### PR DESCRIPTION
This is only enabled if the HCLK clock is above 168MHz on F4 and 180MHz on f7

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR enables the overdrive mode on F4 and F7 when the HCLK frequency is higher than 168MHz and 180MHz respectively.
The need for this was pointed-out in https://github.com/RIOT-OS/RIOT/pull/15043#issuecomment-707761936

Since this touches the power management, I'm also wondering if enabling overdrive could have implications when switch to deepsleep (I haven't checked yet).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test any application on nucleo-f446re/nucleo-f446ze and any nucleo f7 boards, ideally by using `compile_and_test_for_board.py`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Linked to #14975

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
