### PR TITLE
boards/common/particle-mesh: fix SPI configuration

### DIFF
--- a/boards/common/particle-mesh/include/periph_conf_common.h
+++ b/boards/common/particle-mesh/include/periph_conf_common.h
@@ -39,9 +39,9 @@ extern "C" {
 static const spi_conf_t spi_config[] = {
     {
         .dev  = NRF_SPIM0,
-        .sclk = 15,
-        .mosi = 13,
-        .miso = 14,
+        .sclk = GPIO_PIN(1,15),
+        .mosi = GPIO_PIN(1,13),
+        .miso = GPIO_PIN(1,14),
     }
 };
 


### PR DESCRIPTION
### Contribution description
I just tried to connect a SPI device to a `particle-xenon` board - it did not work... The reason was that the SPI pin configuration for that (and the other particle mesh boards) was broken: in the [board layout](https://docs.particle.io/assets/images/xenon/xenon-pinout-v1.0.pdf) the default pins for SPI are mapped to P1.13-P1.15. However, the RIOT config was mapped to P0.13-P0.15.

This PR fixes that and now I am able to interface with my SDCard as expected :-)

### Testing procedure
Connect any SPI device to any partcle-mesh board and interact with that device.

### Issues/PRs references
none