### PR TITLE
drivers/scd30: Add reset function to Sensirion scd30 sensor

### DIFF
--- a/drivers/include/scd30.h
+++ b/drivers/include/scd30.h
@@ -167,6 +167,15 @@ int scd30_start_periodic_measurement(scd30_t *dev, uint16_t *interval,
  */
 int8_t scd30_stop_measurements(const scd30_t *dev);
 
+/**
+ *  @brief  Soft reset sensor
+ *
+ *  @param dev          scd30 dev device
+ *
+ *  @return             SCD30_OK if soft reset successful
+ */
+int8_t scd30_reset(scd30_t *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/scd30/include/scd30_internal.h
+++ b/drivers/scd30/include/scd30_internal.h
@@ -44,6 +44,7 @@ extern "C" {
                           1013.25 mBar */
 
 #define SCD30_READ_WRITE_SLEEP_US       (4 * US_PER_MS)
+#define SCD30_RESET_SLEEP_US            (25 * US_PER_MS)
 #define SCD30_DATA_RDY_TIMEOUT          (1 * US_PER_SEC)
 
 #define SCD30_MIN_INTERVAL              2


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR adds reset function to driver for Sensirion's SCD30 co2 concentration, temperature and relative humidity sensor.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Modify parameters as per board specification in scd30_params.h and run tests/driver_scd30 using the command:

`make BOARD=... TEST_ITERATIONS=... -C test/driver_scd30 flash term`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
\-