### PR TITLE
pkg/nimble: bump version and enable all compile warnings

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -19,8 +19,6 @@ ifeq (llvm,$(TOOLCHAIN))
 # Workaround, until https://github.com/apache/mynewt-nimble/pull/566 is merged
 # upstream and the NimBLE version in RIOT is updated.
   CFLAGS += -Wno-sometimes-uninitialized
-else
-  CFLAGS += -Wno-unused-but-set-variable
 endif
 
 IGNORE := nimble_autoconn_%

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = cd7d7aa286ee1083818cbaac1e89bf69fe554f42
+PKG_VERSION = 4f32114fae4ac9343f440eeccadc0d42bf65b91b
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description
Recently NimBLE made a lot or progress in terms of compiler friendliness: it can now be compiled with all the compiler warnings that are set by default by RIOT. So this PR bumps the NimBLE version to the latest fix that enables this and also removes the `-Wno-unused-but-set-variable` flag when compiling NimBLE for RIOT.

### Testing procedure
The `examples/gnrc_networking` and `tests/nimble_l2cap` @ `nrf52dk` applications should still work as expected.

### Issues/PRs references
https://github.com/apache/mynewt-nimble/pull/875
