### PR TITLE
ieee802154/radio: add `read` function

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -204,7 +204,7 @@ static inline int8_t _hwval_to_ieee802154_dbm(uint8_t hwval)
     return (ED_RSSISCALE * hwval) + ED_RSSIOFFS;
 }
 
-static int _indication_rx(ieee802154_dev_t *dev, void *buf, size_t max_size,
+static int _read(ieee802154_dev_t *dev, void *buf, size_t max_size,
                           ieee802154_rx_info_t *info)
 {
     (void) dev;
@@ -233,8 +233,6 @@ static int _indication_rx(ieee802154_dev_t *dev, void *buf, size_t max_size,
         }
         memcpy(buf, &rxbuf[1], pktlen);
     }
-
-    NRF_RADIO->TASKS_START = 1;
 
     return pktlen;
 }
@@ -718,10 +716,10 @@ static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *b
 
 static const ieee802154_radio_ops_t nrf802154_ops = {
     .write = _write,
+    .read = _read,
     .request_transmit = _request_transmit,
     .confirm_transmit = _confirm_transmit,
     .len = _len,
-    .indication_rx = _indication_rx,
     .off = _off,
     .request_on = _request_on,
     .confirm_on = _confirm_on,

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -325,7 +325,7 @@ static inline int ieee802154_get_frame_length(ieee802154_submac_t *submac)
 static inline int ieee802154_read_frame(ieee802154_submac_t *submac, void *buf,
                                         size_t len, ieee802154_rx_info_t *info)
 {
-    return ieee802154_radio_indication_rx(submac->dev, buf, len, info);
+    return ieee802154_radio_read(submac->dev, buf, len, info);
 }
 
 /**

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -76,8 +76,8 @@ typedef struct {
      * This function is called from the SubMAC to indicate a IEEE 802.15.4
      * frame is ready to be fetched from the device.
      *
-     * If @ref ieee802154_submac_t::state is @ref IEEE802154_STATE_LISTEN, the
-     * SubMAC is ready to receive frames.
+     * @post If @ref ieee802154_submac_t::state is @ref IEEE802154_STATE_LISTEN, the
+     * SubMAC is ready to receive frames
      *
      * @note ACK frames are automatically handled and discarded by the SubMAC.
      * @param[in] submac pointer to the SubMAC descriptor
@@ -89,7 +89,7 @@ typedef struct {
      * This function is called from the SubMAC to indicate that the TX
      * procedure finished.
      *
-     * If @ref ieee802154_submac_t::state is @ref IEEE802154_STATE_LISTEN, the
+     * @pre If @ref ieee802154_submac_t::state is @ref IEEE802154_STATE_LISTEN, the
      * SubMAC is ready to receive frames.
      *
      * @param[in] submac pointer to the SubMAC descriptor

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -169,6 +169,18 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
     }
     else {
         submac->cb->rx_done(submac);
+
+        /* The Radio HAL will be in "FB Lock" state. We need to do a state
+         * transition here in order to release it */
+        ieee802154_trx_state_t next_state = submac->state == IEEE802154_STATE_LISTEN ? IEEE802154_TRX_STATE_RX_ON : IEEE802154_TRX_STATE_TRX_OFF;
+
+        /* Some radios will run some house keeping tasks on RX_DONE (e.g
+         * sending ACK frames). In such case we need to wait until the radio is
+         * not busy
+         */
+        while (ieee802154_radio_request_set_trx_state(submac->dev, next_state) == -EBUSY);
+
+        while (ieee802154_radio_confirm_set_trx_state(submac->dev) == -EAGAIN) {}
     }
 }
 

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -154,7 +154,7 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
     if (!_does_handle_ack(dev) && submac->wait_for_ack) {
         uint8_t ack[3];
 
-        if (ieee802154_radio_indication_rx(dev, ack, 3, NULL) &&
+        if (ieee802154_radio_read(dev, ack, 3, NULL) &&
             ack[0] & IEEE802154_FCF_TYPE_ACK) {
             ieee802154_submac_ack_timer_cancel(submac);
             ieee802154_tx_info_t tx_info;

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -111,7 +111,7 @@ void _rx_done_handler(event_t *event)
      * NOTE: It's possible to call `ieee802154_radio_len` to retrieve the packet
      * length. Since the buffer is fixed in this test, we don't use it
      */
-    int size = ieee802154_radio_indication_rx(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID), buffer, 127, &info);
+    int size = ieee802154_radio_read(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID), buffer, 127, &info);
     if (size > 0) {
         /* Print packet while we wait for the state transition */
         _print_packet(size, info.lqi, info.rssi);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR separates the framebuffer access logic from the abstract state machine logic of the Radio HAL. In concrete, this replaces the `indication_rx` function with a `read` function that can be called at any time (analogue to `write`).
This idea was introduced in the [Radio HAL RDM](https://github.com/RIOT-OS/RIOT/pull/13943#issuecomment-707202968). The consequences are:
- Now it's possible to read the framebuffer at any time! E.g `RX_DONE event -> set transceiver to TRX_OFF -> read frame` is a valid operation.
- The `read` function doesn't need semantics for dropping frames, since `set_trx_state(RX_ON)` already flushes the framebuffer. this simplifies the driver implementation and reduces potential bugs

The abstract state machine of the HAL becomes to this:
```
+---------+                               +---------+
|         |                               |         |  [2]
|   CCA   |                               |   Off    |<----*
|         |<--------------+               |         |
+---------+               |               +---------+                
    |                     |                    |                      
    | [12]                | [11](*)            | [1]                          
    |                     |                    v                     
    |                +---------+          +---------+                     
    |                |         |    [3]   |         |                     
    +--------------->|   RX    |<-------->| TRX OFF |                     
                     |         |<---+     |         |                     
                     +---------+    |     +---------+                             
    *                   ^     |     | [3]      ^                         
    ^ [10]              |[9]  |[7]  +-------+  |[3]                             
    |                   |     v             v  v                         
+---------+          +---------+          +---------+   [6]    +---------+
|         |    [8]   |         |          |         |<---------|         |    
| FB LOCK |<---------| RX BUSY |          |    TX   |          | TX BUSY |
|         |          |         |          |         |--------->|         |
+---------+          +---------+          +---------+   [4]    +---------+

[1]: on() is successful (request_on() and confirm_on() counterpart)
[2]: off() is successful. Can be called from any state.
[3]: set_trx_state() is successful (request_set_trx_state() and
confirm_set_trx_state() counterpart)
[4]: request_transmit() is successful.
[5] and [6]: confirm_transmit() returns != -EAGAIN. The TX_DONE event indicates
when this function can be called without polling.
This will end up in RX if depending of the configuration of `set_rxen_on_tx`
function is set and the transmission was performed (as shown in [5]). This is required
for radios that cannot comply with TX<->RX turnaround time without using internal
optimizations (e.g CC2530). Otherwise it will end up in TX ([6]), regardless of
the transmission state (CCA busy, No ACK, etc).
[7]: SFD detected. `set_trx_state()` will return -EBUSY during this state. The
     RX_START is generated here (if available)
[8]: RX_DONE event locks the framebuffer.
[9]: CRC failed or Address doesn't match source.
[10]: `set_trx_state` is called. This goes to either RX, TX or TRX_OFF. The framebuffer
     is released.
[11]: request_cca() is successful
[12]: confirm_cca() returns != -EAGAIN.
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Try `gnrc_networking` with `netdev_submac_ieee802154`. Ping command should work OK with big payloads and very short interval time (e.g 1024 bytes every 170 ms).
- Try the following patch to prove that it's possible to turn off the radio before reading:
```
diff --git a/sys/net/link_layer/ieee802154/submac.c b/sys/net/link_layer/ieee802154/submac.c
index 0584ba95a3..cfd3a91282 100644
--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -168,6 +168,9 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
         }
     }
     else {
+        while (ieee802154_radio_request_set_trx_state(submac->dev, IEEE802154_TRX_STATE_TRX_OFF) == -EBUSY);
+
+        while (ieee802154_radio_confirm_set_trx_state(submac->dev) == -EAGAIN) {}
         submac->cb->rx_done(submac);
 
         /* The Radio HAL will be in "FB Lock" state. We need to do a state

```
- Try the following patch to prove that's not required to releae the framebuffer with the `read` function (a call to `set_trx_state(RX_ON)` is enough).
```
diff --git a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
index 5c231403e0..cf37067d00 100644
--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -180,21 +180,14 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     netdev_ieee802154_submac_t *netdev_submac =
         (netdev_ieee802154_submac_t *)netdev;
     ieee802154_submac_t *submac = &netdev_submac->submac;
-    ieee802154_rx_info_t rx_info;
 
     if (buf == NULL && len == 0) {
         return ieee802154_get_frame_length(submac);
     }
 
-    int res = ieee802154_read_frame(submac, buf, len, &rx_info);
-
-    if (info) {
-        netdev_ieee802154_rx_info_t *netdev_rx_info = info;
-        netdev_rx_info->rssi = rx_info.rssi;
-        netdev_rx_info->lqi = rx_info.lqi;
-    }
-
-    return res;
+    (void) info;
+    puts("FRAME!");
+    return 0;
 }
 
 static void submac_tx_done(ieee802154_submac_t *submac, int status,
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/13943#issuecomment-707202968
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
