### PR TITLE
boards/microduino-corerf: don't set bootloader size

### DIFF
--- a/boards/microduino-corerf/Makefile.include
+++ b/boards/microduino-corerf/Makefile.include
@@ -8,8 +8,4 @@ BAUD        ?= 115200
 PROGRAMMER_MICRODUINO_CORERF ?= UM232H
 PROGRAMMER ?= $(PROGRAMMER_MICRODUINO_CORERF)
 
-# We don't use a bootloader
-BOOTLOADER_SIZE ?= 0
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
-
 include $(RIOTBOARD)/common/atmega/Makefile.include


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This already gets set by `common/atmega/Makefile.include`.
Setting it in the board prevents auto-selection if a bootloader is used.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
