### PR TITLE
GNRC TCP: internal api cleanup

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -25,14 +25,14 @@
 #include "evtimer_mbox.h"
 #include "mbox.h"
 #include "net/af.h"
+#include "net/tcp.h"
 #include "net/gnrc.h"
 #include "net/gnrc/tcp.h"
-#include "internal/common.h"
-#include "internal/fsm.h"
-#include "internal/pkt.h"
-#include "internal/option.h"
-#include "internal/eventloop.h"
-#include "internal/rcvbuf.h"
+#include "include/gnrc_tcp_common.h"
+#include "include/gnrc_tcp_fsm.h"
+#include "include/gnrc_tcp_pkt.h"
+#include "include/gnrc_tcp_eventloop.h"
+#include "include/gnrc_tcp_rcvbuf.h"
 
 #ifdef MODULE_GNRC_IPV6
 #include "net/gnrc/ipv6.h"
@@ -112,7 +112,7 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
     }
 
     /* Setup messaging */
-    _fsm_set_mbox(tcb, &mbox);
+    _gnrc_tcp_fsm_set_mbox(tcb, &mbox);
 
     /* Setup passive connection */
     if (passive) {
@@ -167,7 +167,7 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
     }
 
     /* Call FSM with event: CALL_OPEN */
-    ret = _fsm(tcb, FSM_EVENT_CALL_OPEN, NULL, NULL, 0);
+    ret = _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_OPEN, NULL, NULL, 0);
     if (ret == -ENOMEM) {
         TCP_DEBUG_ERROR("-ENOMEM: All receive buffers are in use.");
     }
@@ -200,11 +200,11 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
                  * 2) Passive connections stop the ongoing retransmissions and repeat the
                  *    open call to wait for the next connection attempt. */
                 if (tcb->status & STATUS_PASSIVE) {
-                    _fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
-                    _fsm(tcb, FSM_EVENT_CALL_OPEN, NULL, NULL, 0);
+                    _gnrc_tcp_fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
+                    _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_OPEN, NULL, NULL, 0);
                 }
                 else {
-                    _fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
+                    _gnrc_tcp_fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
                     TCP_DEBUG_ERROR("-ETIMEDOUT: Connection timed out.");
                     ret = -ETIMEDOUT;
                 }
@@ -216,7 +216,7 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
     }
 
     /* Cleanup */
-    _fsm_set_mbox(tcb, NULL);
+    _gnrc_tcp_fsm_set_mbox(tcb, NULL);
     _unsched_mbox(&tcb->event_misc);
     if (tcb->state == FSM_STATE_CLOSED && ret == 0) {
         TCP_DEBUG_ERROR("-ECONNREFUSED: Connection refused by peer.");
@@ -387,14 +387,14 @@ int gnrc_tcp_ep_from_str(gnrc_tcp_ep_t *ep, const char *str)
 int gnrc_tcp_init(void)
 {
     TCP_DEBUG_ENTER;
-    /* Initialize TCB list */
-    _rcvbuf_init();
+    /* Initialize receive buffers */
+    _gnrc_tcp_rcvbuf_init();
 
     /* Initialize timers */
     evtimer_init_mbox(&_tcp_mbox_timer);
 
     /* Start TCP processing thread */
-    kernel_pid_t pid = _gnrc_tcp_event_loop_init();
+    kernel_pid_t pid = _gnrc_tcp_eventloop_init();
     TCP_DEBUG_LEAVE;
     return pid;
 }
@@ -510,7 +510,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
     }
 
     /* Setup messaging */
-    _fsm_set_mbox(tcb, &mbox);
+    _gnrc_tcp_fsm_set_mbox(tcb, &mbox);
 
     /* Setup connection timeout */
     _sched_connection_timeout(&tcb->event_misc, &mbox);
@@ -544,7 +544,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
 
         /* Try to send data in case there nothing has been sent and we are not probing */
         if (ret == 0 && !probing_mode) {
-            ret = _fsm(tcb, FSM_EVENT_CALL_SEND, NULL, (void *) data, len);
+            ret = _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_SEND, NULL, (void *) data, len);
         }
 
         /* Wait for responses */
@@ -552,14 +552,14 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
         switch (msg.type) {
             case MSG_TYPE_CONNECTION_TIMEOUT:
                 TCP_DEBUG_INFO("Received MSG_TYPE_CONNECTION_TIMEOUT.");
-                _fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
+                _gnrc_tcp_fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
                 TCP_DEBUG_ERROR("-ECONNABORTED: Connection timed out.");
                 ret = -ECONNABORTED;
                 break;
 
             case MSG_TYPE_USER_SPEC_TIMEOUT:
                 TCP_DEBUG_INFO("Received MSG_TYPE_USER_SPEC_TIMEOUT.");
-                _fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
+                _gnrc_tcp_fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
                 TCP_DEBUG_ERROR("-ETIMEDOUT: User specified timeout expired.");
                 ret = -ETIMEDOUT;
                 break;
@@ -567,7 +567,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
             case MSG_TYPE_PROBE_TIMEOUT:
                 TCP_DEBUG_INFO("Received MSG_TYPE_PROBE_TIMEOUT.");
                 /* Send probe */
-                _fsm(tcb, FSM_EVENT_SEND_PROBE, NULL, NULL, 0);
+                _gnrc_tcp_fsm(tcb, FSM_EVENT_SEND_PROBE, NULL, NULL, 0);
                 probe_timeout_duration_ms += probe_timeout_duration_ms;
 
                 /* Boundary check for time interval between probes */
@@ -599,7 +599,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
     }
 
     /* Cleanup */
-    _fsm_set_mbox(tcb, NULL);
+    _gnrc_tcp_fsm_set_mbox(tcb, NULL);
     _unsched_mbox(&tcb->event_misc);
     _unsched_mbox(&event_probe_timeout);
     _unsched_mbox(&event_user_timeout);
@@ -636,7 +636,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
     /* If FIN was received (CLOSE_WAIT), no further data can be received. */
     /* Copy received data into given buffer and return number of bytes. Can be zero. */
     if (tcb->state == FSM_STATE_CLOSE_WAIT) {
-        ret = _fsm(tcb, FSM_EVENT_CALL_RECV, NULL, data, max_len);
+        ret = _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_RECV, NULL, data, max_len);
         mutex_unlock(&(tcb->function_lock));
         TCP_DEBUG_LEAVE;
         return ret;
@@ -644,7 +644,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
 
     /* If this call is non-blocking (timeout_duration_ms == 0): Try to read data and return */
     if (timeout_duration_ms == 0) {
-        ret = _fsm(tcb, FSM_EVENT_CALL_RECV, NULL, data, max_len);
+        ret = _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_RECV, NULL, data, max_len);
         if (ret == 0) {
             TCP_DEBUG_ERROR("-EAGAIN: Not data available, try later again.");
             ret = -EAGAIN;
@@ -655,7 +655,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
     }
 
     /* Setup messaging */
-    _fsm_set_mbox(tcb, &mbox);
+    _gnrc_tcp_fsm_set_mbox(tcb, &mbox);
 
     /* Setup connection timeout */
     _sched_connection_timeout(&tcb->event_misc, &mbox);
@@ -675,7 +675,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
         }
 
         /* Try to read available data */
-        ret = _fsm(tcb, FSM_EVENT_CALL_RECV, NULL, data, max_len);
+        ret = _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_RECV, NULL, data, max_len);
 
         /* If FIN was received (CLOSE_WAIT), no further data can be received. Leave event loop */
         if (tcb->state == FSM_STATE_CLOSE_WAIT) {
@@ -688,14 +688,14 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
             switch (msg.type) {
                 case MSG_TYPE_CONNECTION_TIMEOUT:
                     TCP_DEBUG_INFO("Received MSG_TYPE_CONNECTION_TIMEOUT.");
-                    _fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
+                    _gnrc_tcp_fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
                     TCP_DEBUG_ERROR("-ECONNABORTED: Connection timed out.");
                     ret = -ECONNABORTED;
                     break;
 
                 case MSG_TYPE_USER_SPEC_TIMEOUT:
                     TCP_DEBUG_INFO("Received MSG_TYPE_USER_SPEC_TIMEOUT.");
-                    _fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
+                    _gnrc_tcp_fsm(tcb, FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
                     TCP_DEBUG_ERROR("-ETIMEDOUT: User specified timeout expired.");
                     ret = -ETIMEDOUT;
                     break;
@@ -711,7 +711,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
     }
 
     /* Cleanup */
-    _fsm_set_mbox(tcb, NULL);
+    _gnrc_tcp_fsm_set_mbox(tcb, NULL);
     _unsched_mbox(&tcb->event_misc);
     _unsched_mbox(&event_user_timeout);
     mutex_unlock(&(tcb->function_lock));
@@ -739,13 +739,13 @@ void gnrc_tcp_close(gnrc_tcp_tcb_t *tcb)
     }
 
     /* Setup messaging */
-    _fsm_set_mbox(tcb, &mbox);
+    _gnrc_tcp_fsm_set_mbox(tcb, &mbox);
 
     /* Setup connection timeout */
     _sched_connection_timeout(&tcb->event_misc, &mbox);
 
     /* Start connection teardown sequence */
-    _fsm(tcb, FSM_EVENT_CALL_CLOSE, NULL, NULL, 0);
+    _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_CLOSE, NULL, NULL, 0);
 
     /* Loop until the connection has been closed */
     while (tcb->state != FSM_STATE_CLOSED) {
@@ -753,7 +753,7 @@ void gnrc_tcp_close(gnrc_tcp_tcb_t *tcb)
         switch (msg.type) {
             case MSG_TYPE_CONNECTION_TIMEOUT:
                 TCP_DEBUG_INFO("Received MSG_TYPE_CONNECTION_TIMEOUT.");
-                _fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
+                _gnrc_tcp_fsm(tcb, FSM_EVENT_TIMEOUT_CONNECTION, NULL, NULL, 0);
                 break;
 
             case MSG_TYPE_NOTIFY_USER:
@@ -766,7 +766,7 @@ void gnrc_tcp_close(gnrc_tcp_tcb_t *tcb)
     }
 
     /* Cleanup */
-    _fsm_set_mbox(tcb, NULL);
+    _gnrc_tcp_fsm_set_mbox(tcb, NULL);
     _unsched_mbox(&tcb->event_misc);
     mutex_unlock(&(tcb->function_lock));
     TCP_DEBUG_LEAVE;
@@ -781,7 +781,7 @@ void gnrc_tcp_abort(gnrc_tcp_tcb_t *tcb)
     mutex_lock(&(tcb->function_lock));
     if (tcb->state != FSM_STATE_CLOSED) {
         /* Call FSM ABORT event */
-        _fsm(tcb, FSM_EVENT_CALL_ABORT, NULL, NULL, 0);
+        _gnrc_tcp_fsm(tcb, FSM_EVENT_CALL_ABORT, NULL, NULL, 0);
     }
     mutex_unlock(&(tcb->function_lock));
     TCP_DEBUG_LEAVE;
@@ -803,7 +803,7 @@ int gnrc_tcp_calc_csum(const gnrc_pktsnip_t *hdr, const gnrc_pktsnip_t *pseudo_h
         return -EBADMSG;
     }
 
-    csum = _pkt_calc_csum(hdr, pseudo_hdr, hdr->next);
+    csum = _gnrc_tcp_pkt_calc_csum(hdr, pseudo_hdr, hdr->next);
     if (csum == 0) {
         TCP_DEBUG_ERROR("-ENOENT");
         TCP_DEBUG_LEAVE;

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_common.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_common.c
@@ -17,11 +17,11 @@
  * @}
  */
 
-#include "internal/common.h"
+#include "include/gnrc_tcp_common.h"
 
-static tcb_list_t _list = {NULL, MUTEX_INIT};
+static _gnrc_tcp_common_tcb_list_t _list = {NULL, MUTEX_INIT};
 
-tcb_list_t *_gnrc_tcp_common_get_tcb_list(void)
+_gnrc_tcp_common_tcb_list_t *_gnrc_tcp_common_get_tcb_list(void)
 {
     return &_list;
 }

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -24,12 +24,12 @@
 #include "net/gnrc.h"
 #include "evtimer.h"
 #include "evtimer_msg.h"
-#include "internal/common.h"
-#include "internal/eventloop.h"
-#include "internal/pkt.h"
-#include "internal/option.h"
-#include "internal/rcvbuf.h"
-#include "internal/fsm.h"
+#include "include/gnrc_tcp_common.h"
+#include "include/gnrc_tcp_eventloop.h"
+#include "include/gnrc_tcp_pkt.h"
+#include "include/gnrc_tcp_option.h"
+#include "include/gnrc_tcp_rcvbuf.h"
+#include "include/gnrc_tcp_fsm.h"
 
 #ifdef MODULE_GNRC_IPV6
 #include "net/gnrc/ipv6.h"
@@ -57,7 +57,7 @@ static int _is_local_port_in_use(const uint16_t port_number)
 {
     TCP_DEBUG_ENTER;
     gnrc_tcp_tcb_t *iter = NULL;
-    tcb_list_t *list = _gnrc_tcp_common_get_tcb_list();
+    _gnrc_tcp_common_tcb_list_t *list = _gnrc_tcp_common_get_tcb_list();
     LL_SEARCH_SCALAR(list->head, iter, local_port, port_number);
     TCP_DEBUG_LEAVE;
     return (iter != NULL);
@@ -93,7 +93,7 @@ static int _clear_retransmit(gnrc_tcp_tcb_t *tcb)
 {
     TCP_DEBUG_ENTER;
     if (tcb->pkt_retransmit != NULL) {
-        _gnrc_tcp_event_loop_unsched(&tcb->event_retransmit);
+        _gnrc_tcp_eventloop_unsched(&tcb->event_retransmit);
         gnrc_pktbuf_release(tcb->pkt_retransmit);
         tcb->pkt_retransmit = NULL;
     }
@@ -111,9 +111,9 @@ static int _clear_retransmit(gnrc_tcp_tcb_t *tcb)
 static int _restart_timewait_timer(gnrc_tcp_tcb_t *tcb)
 {
     TCP_DEBUG_ENTER;
-    _gnrc_tcp_event_loop_unsched(&tcb->event_retransmit);
-    _gnrc_tcp_event_loop_sched(&tcb->event_retransmit, 2 * CONFIG_GNRC_TCP_MSL_MS,
-                               MSG_TYPE_TIMEWAIT, tcb);
+    _gnrc_tcp_eventloop_unsched(&tcb->event_retransmit);
+    _gnrc_tcp_eventloop_sched(&tcb->event_retransmit, 2 * CONFIG_GNRC_TCP_MSL_MS,
+                              MSG_TYPE_TIMEWAIT, tcb);
     TCP_DEBUG_LEAVE;
     return 0;
 }
@@ -128,11 +128,11 @@ static int _restart_timewait_timer(gnrc_tcp_tcb_t *tcb)
  * @return   -EADDRINUSE, if @p state == FSM_STATE_SYN_SENT and tcb->local_port
  *           is already in use.
  */
-static int _transition_to(gnrc_tcp_tcb_t *tcb, fsm_state_t state)
+static int _transition_to(gnrc_tcp_tcb_t *tcb, _gnrc_tcp_fsm_state_t state)
 {
     TCP_DEBUG_ENTER;
     gnrc_tcp_tcb_t *iter = NULL;
-    tcb_list_t *list = _gnrc_tcp_common_get_tcb_list();
+    _gnrc_tcp_common_tcb_list_t *list = _gnrc_tcp_common_get_tcb_list();
 
     switch (state) {
         case FSM_STATE_CLOSED:
@@ -145,7 +145,7 @@ static int _transition_to(gnrc_tcp_tcb_t *tcb, fsm_state_t state)
             mutex_unlock(&list->lock);
 
             /* Free potentially allocated receive buffer */
-            _rcvbuf_release_buffer(tcb);
+            _gnrc_tcp_rcvbuf_release_buffer(tcb);
             tcb->status |= STATUS_NOTIFY_USER;
             break;
 
@@ -228,7 +228,7 @@ static int _fsm_call_open(gnrc_tcp_tcb_t *tcb)
     int ret = 0;
 
     /* Allocate receive buffer */
-    if (_rcvbuf_get_buffer(tcb) == -ENOMEM) {
+    if (_gnrc_tcp_rcvbuf_get_buffer(tcb) == -ENOMEM) {
         TCP_DEBUG_ERROR("-ENOMEM: Can't allocate receive buffer.");
         TCP_DEBUG_LEAVE;
         return -ENOMEM;
@@ -257,9 +257,10 @@ static int _fsm_call_open(gnrc_tcp_tcb_t *tcb)
         /* Send SYN */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
-        _pkt_build(tcb, &out_pkt, &seq_con, MSK_SYN, tcb->iss, 0, NULL, 0);
-        _pkt_setup_retransmit(tcb, out_pkt, false);
-        _pkt_send(tcb, out_pkt, seq_con, false);
+        _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_SYN, tcb->iss, 0,
+                            NULL, 0);
+        _gnrc_tcp_pkt_setup_retransmit(tcb, out_pkt, false);
+        _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
     }
     TCP_DEBUG_LEAVE;
     return ret;
@@ -289,9 +290,10 @@ static int _fsm_call_send(gnrc_tcp_tcb_t *tcb, void *buf, size_t len)
         /* Calculate payload size for this segment */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
-        _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK | MSK_PSH, tcb->snd_nxt, tcb->rcv_nxt, buf, payload);
-        _pkt_setup_retransmit(tcb, out_pkt, false);
-        _pkt_send(tcb, out_pkt, seq_con, false);
+        _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK | MSK_PSH,
+                            tcb->snd_nxt, tcb->rcv_nxt, buf, payload);
+        _gnrc_tcp_pkt_setup_retransmit(tcb, out_pkt, false);
+        _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
         TCP_DEBUG_LEAVE;
         return payload;
     }
@@ -327,8 +329,9 @@ static int _fsm_call_recv(gnrc_tcp_tcb_t *tcb, void *buf, size_t len)
         /* Send ACK to announce window update */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
-        _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-        _pkt_send(tcb, out_pkt, seq_con, false);
+        _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt,
+                            tcb->rcv_nxt, NULL, 0);
+        _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
     }
     TCP_DEBUG_LEAVE;
     return rcvd;
@@ -351,9 +354,10 @@ static int _fsm_call_close(gnrc_tcp_tcb_t *tcb)
         /* Send FIN packet */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
-        _pkt_build(tcb, &out_pkt, &seq_con, MSK_FIN_ACK, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-        _pkt_setup_retransmit(tcb, out_pkt, false);
-        _pkt_send(tcb, out_pkt, seq_con, false);
+        _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_FIN_ACK, tcb->snd_nxt,
+                            tcb->rcv_nxt, NULL, 0);
+        _gnrc_tcp_pkt_setup_retransmit(tcb, out_pkt, false);
+        _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
     }
 
     if (tcb->state == FSM_STATE_LISTEN) {
@@ -388,8 +392,9 @@ static int _fsm_call_abort(gnrc_tcp_tcb_t *tcb)
         /* Send RST packet without retransmit */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
-        _pkt_build(tcb, &out_pkt, &seq_con, MSK_RST, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-        _pkt_send(tcb, out_pkt, seq_con, false);
+        _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_RST, tcb->snd_nxt,
+                            tcb->rcv_nxt, NULL, 0);
+        _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
     }
 
     /* From here on any state must transition into CLOSED state */
@@ -425,7 +430,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
     tcp_hdr_t *tcp_hdr = (tcp_hdr_t *) snp->data;
 
     /* Parse packet options, return if they are malformed */
-    if (_option_parse(tcb, tcp_hdr) < 0) {
+    if (_gnrc_tcp_option_parse(tcb, tcp_hdr) < 0) {
         TCP_DEBUG_ERROR("Failed to parse TCP header options.");
         TCP_DEBUG_LEAVE;
         return 0;
@@ -458,8 +463,8 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
         }
         /* 2) Check ACK: if ACK is set: send RST with seq_no = ack_no and return */
         if (ctl & MSK_ACK) {
-            _pkt_build_reset_from_pkt(&out_pkt, in_pkt);
-            _pkt_send(tcb, out_pkt, 0, false);
+            _gnrc_tcp_pkt_build_reset_from_pkt(&out_pkt, in_pkt);
+            _gnrc_tcp_pkt_send(tcb, out_pkt, 0, false);
             TCP_DEBUG_INFO("ACK flag set in packet. Send reset.");
             TCP_DEBUG_LEAVE;
             return 0;
@@ -531,9 +536,10 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
             tcb->snd_wnd = seg_wnd;
 
             /* Send SYN+ACK: seq_no = iss, ack_no = rcv_nxt, T: LISTEN -> SYN_RCVD */
-            _pkt_build(tcb, &out_pkt, &seq_con, MSK_SYN_ACK, tcb->iss, tcb->rcv_nxt, NULL, 0);
-            _pkt_setup_retransmit(tcb, out_pkt, false);
-            _pkt_send(tcb, out_pkt, seq_con, false);
+            _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_SYN_ACK, tcb->iss,
+                                tcb->rcv_nxt, NULL, 0);
+            _gnrc_tcp_pkt_setup_retransmit(tcb, out_pkt, false);
+            _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
             _transition_to(tcb, FSM_STATE_SYN_RCVD);
         }
         TCP_DEBUG_LEAVE;
@@ -547,8 +553,9 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
             if (seg_ack <= tcb->iss || seg_ack > tcb->snd_nxt) {
                 /* ... send reset, if RST is not set else return */
                 if ((ctl & MSK_RST) != MSK_RST) {
-                    _pkt_build(tcb, &out_pkt, &seq_con, MSK_RST, seg_ack, 0, NULL, 0);
-                    _pkt_send(tcb, out_pkt, seq_con, false);
+                    _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_RST,
+                                        seg_ack, 0, NULL, 0);
+                    _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
                 }
                 TCP_DEBUG_LEAVE;
                 return 0;
@@ -569,7 +576,7 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
             tcb->irs = seg_seq;
             if (ctl & MSK_ACK) {
                 tcb->snd_una = seg_ack;
-                _pkt_acknowledge(tcb, seg_ack);
+                _gnrc_tcp_pkt_acknowledge(tcb, seg_ack);
             }
             /* Set local network layer address accordingly */
 #ifdef MODULE_GNRC_IPV6
@@ -584,15 +591,17 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
 
             /* SYN has been ACKed. Send ACK, T: SYN_SENT -> ESTABLISHED */
             if (tcb->snd_una > tcb->iss) {
-                _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-                _pkt_send(tcb, out_pkt, seq_con, false);
+                _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK,
+                                    tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
+                _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
                 _transition_to(tcb, FSM_STATE_ESTABLISHED);
             }
             /* Simultaneous SYN received. Send SYN+ACK, T: SYN_SENT -> SYN_RCVD */
             else {
-                _pkt_build(tcb, &out_pkt, &seq_con, MSK_SYN_ACK, tcb->iss, tcb->rcv_nxt, NULL, 0);
-                _pkt_setup_retransmit(tcb, out_pkt, false);
-                _pkt_send(tcb, out_pkt, seq_con, false);
+                _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_SYN_ACK,
+                                    tcb->iss, tcb->rcv_nxt, NULL, 0);
+                _gnrc_tcp_pkt_setup_retransmit(tcb, out_pkt, false);
+                _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
                 _transition_to(tcb, FSM_STATE_SYN_RCVD);
             }
             tcb->snd_wnd = seg_wnd;
@@ -604,14 +613,15 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
     }
     /* Handle other states */
     else {
-        uint32_t seg_len = _pkt_get_seg_len(in_pkt);
-        uint32_t pay_len = _pkt_get_pay_len(in_pkt);
+        uint32_t seg_len = _gnrc_tcp_pkt_get_seg_len(in_pkt);
+        uint32_t pay_len = _gnrc_tcp_pkt_get_pay_len(in_pkt);
         /* 1) Verify sequence number ... */
-        if (_pkt_chk_seq_num(tcb, seg_seq, pay_len)) {
+        if (_gnrc_tcp_pkt_chk_seq_num(tcb, seg_seq, pay_len)) {
             /* ... if invalid, and RST not set, reply with pure ACK, return */
             if ((ctl & MSK_RST) != MSK_RST) {
-                _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-                _pkt_send(tcb, out_pkt, seq_con, false);
+                _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK,
+                                    tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
+                _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
             }
             TCP_DEBUG_LEAVE;
             return 0;
@@ -631,8 +641,9 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
         /* 3) Check SYN: If SYN is set ... */
         if (ctl & MSK_SYN) {
             /* ... send RST, seq_no = snd_nxt, ack_no = rcv_nxt */
-            _pkt_build(tcb, &out_pkt, &seq_con, MSK_RST, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-            _pkt_send(tcb, out_pkt, seq_con, false);
+            _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_RST, tcb->snd_nxt,
+                                tcb->rcv_nxt, NULL, 0);
+            _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
             _transition_to(tcb, FSM_STATE_CLOSED);
             TCP_DEBUG_LEAVE;
             return 0;
@@ -651,8 +662,9 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
                     _transition_to(tcb, FSM_STATE_ESTABLISHED);
                 }
                 else {
-                    _pkt_build(tcb, &out_pkt, &seq_con, MSK_RST, seg_ack, 0, NULL, 0);
-                    _pkt_send(tcb, out_pkt, seq_con, false);
+                    _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_RST,
+                                        seg_ack, 0, NULL, 0);
+                    _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
                 }
             }
             /* Acknowledgment processing */
@@ -662,13 +674,13 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
                 /* Acknowledge previously sent data */
                 if (LSS_32_BIT(tcb->snd_una, seg_ack) && LEQ_32_BIT(seg_ack, tcb->snd_nxt)) {
                     tcb->snd_una = seg_ack;
-                    _pkt_acknowledge(tcb, seg_ack);
+                    _gnrc_tcp_pkt_acknowledge(tcb, seg_ack);
                 }
                 /* ACK received for something not yet sent: Reply with pure ACK */
                 else if (LSS_32_BIT(tcb->snd_nxt, seg_ack)) {
-                    _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt,
-                               NULL, 0);
-                    _pkt_send(tcb, out_pkt, seq_con, false);
+                    _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK,
+                                        tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
+                    _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
                     TCP_DEBUG_LEAVE;
                     return 0;
                 }
@@ -739,9 +751,9 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
                 /* Send ACK, if FIN processing sends ACK already */
                 /* NOTE: this is the place to add payload piggybagging in the future */
                 if (!(ctl & MSK_FIN)) {
-                    _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt,
-                               NULL, 0);
-                    _pkt_send(tcb, out_pkt, seq_con, false);
+                    _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK,
+                                        tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
+                    _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
                 }
             }
         }
@@ -754,8 +766,9 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
             }
             /* Advance rcv_nxt over FIN bit */
             tcb->rcv_nxt = seg_seq + seg_len;
-            _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);
-            _pkt_send(tcb, out_pkt, seq_con, false);
+            _gnrc_tcp_pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt,
+                                tcb->rcv_nxt, NULL, 0);
+            _gnrc_tcp_pkt_send(tcb, out_pkt, seq_con, false);
 
             if (tcb->state == FSM_STATE_SYN_RCVD || tcb->state == FSM_STATE_ESTABLISHED) {
                 _transition_to(tcb, FSM_STATE_CLOSE_WAIT);
@@ -806,8 +819,8 @@ static int _fsm_timeout_retransmit(gnrc_tcp_tcb_t *tcb)
 {
     TCP_DEBUG_ENTER;
     if (tcb->pkt_retransmit != NULL) {
-        _pkt_setup_retransmit(tcb, tcb->pkt_retransmit, true);
-        _pkt_send(tcb, tcb->pkt_retransmit, 0, true);
+        _gnrc_tcp_pkt_setup_retransmit(tcb, tcb->pkt_retransmit, true);
+        _gnrc_tcp_pkt_send(tcb, tcb->pkt_retransmit, 0, true);
     }
     else {
         TCP_DEBUG_INFO("Retransmission queue is empty.");
@@ -845,9 +858,9 @@ static int _fsm_send_probe(gnrc_tcp_tcb_t *tcb)
     uint8_t probe_pay[] = {1};       /* Probe payload */
 
     /* The probe sends a already acknowledged sequence no. with a garbage byte. */
-    _pkt_build(tcb, &out_pkt, NULL, MSK_ACK, tcb->snd_una - 1, tcb->rcv_nxt, probe_pay,
-               sizeof(probe_pay));
-    _pkt_send(tcb, out_pkt, 0, false);
+    _gnrc_tcp_pkt_build(tcb, &out_pkt, NULL, MSK_ACK, tcb->snd_una - 1,
+                        tcb->rcv_nxt, probe_pay, sizeof(probe_pay));
+    _gnrc_tcp_pkt_send(tcb, out_pkt, 0, false);
     TCP_DEBUG_LEAVE;
     return 0;
 }
@@ -881,8 +894,8 @@ static int _fsm_clear_retransmit(gnrc_tcp_tcb_t *tcb)
  *           -EADDRINUSE if given local port number in @p tcb is already in use.
  *           -EOPNOTSUPP if event is not implemented.
  */
-static int _fsm_unprotected(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip_t *in_pkt,
-                            void *buf, size_t len)
+static int _fsm_unprotected(gnrc_tcp_tcb_t *tcb, _gnrc_tcp_fsm_event_t event,
+                            gnrc_pktsnip_t *in_pkt, void *buf, size_t len)
 {
     TCP_DEBUG_ENTER;
     int ret = 0;
@@ -926,7 +939,8 @@ static int _fsm_unprotected(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip
     return ret;
 }
 
-int _fsm(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip_t *in_pkt, void *buf, size_t len)
+int _gnrc_tcp_fsm(gnrc_tcp_tcb_t *tcb, _gnrc_tcp_fsm_event_t event,
+                  gnrc_pktsnip_t *in_pkt, void *buf, size_t len)
 {
     TCP_DEBUG_ENTER;
     /* Lock FSM */
@@ -949,7 +963,7 @@ int _fsm(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip_t *in_pkt, void *b
     return result;
 }
 
-void _fsm_set_mbox(gnrc_tcp_tcb_t *tcb, mbox_t *mbox)
+void _gnrc_tcp_fsm_set_mbox(gnrc_tcp_tcb_t *tcb, mbox_t *mbox)
 {
     TCP_DEBUG_ENTER;
     mutex_lock(&(tcb->fsm_lock));

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_option.c
@@ -16,13 +16,13 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  * @}
  */
-#include "internal/common.h"
-#include "internal/option.h"
+#include "include/gnrc_tcp_common.h"
+#include "include/gnrc_tcp_option.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
+int _gnrc_tcp_option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr)
 {
     TCP_DEBUG_ENTER;
     /* Extract offset value. Return if no options are set */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -24,10 +24,10 @@
 #include "evtimer_msg.h"
 #include "net/inet_csum.h"
 #include "net/gnrc.h"
-#include "internal/common.h"
-#include "internal/eventloop.h"
-#include "internal/option.h"
-#include "internal/pkt.h"
+#include "include/gnrc_tcp_common.h"
+#include "include/gnrc_tcp_eventloop.h"
+#include "include/gnrc_tcp_option.h"
+#include "include/gnrc_tcp_pkt.h"
 
 #ifdef MODULE_GNRC_IPV6
 #include "net/gnrc/ipv6.h"
@@ -49,7 +49,8 @@ static inline uint32_t _max(const uint32_t x, const uint32_t y)
   return (x > y) ? x : y;
 }
 
-int _pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt, gnrc_pktsnip_t *in_pkt)
+int _gnrc_tcp_pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt,
+                                       gnrc_pktsnip_t *in_pkt)
 {
     TCP_DEBUG_ENTER;
     tcp_hdr_t tcp_hdr_out;
@@ -89,7 +90,8 @@ int _pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt, gnrc_pktsnip_t *in_pkt)
             seq_no += 1;
         }
         uint32_t tmp = byteorder_ntohl(tcp_hdr_in->seq_num);
-        tcp_hdr_out.ack_num = byteorder_htonl(seq_no + tmp  + _pkt_get_pay_len(in_pkt));
+        tcp_hdr_out.ack_num = byteorder_htonl(
+            seq_no + tmp + _gnrc_tcp_pkt_get_pay_len(in_pkt));
     }
 
     /* Allocate new TCB header */
@@ -144,9 +146,10 @@ int _pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt, gnrc_pktsnip_t *in_pkt)
     return 0;
 }
 
-int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
-               const uint16_t ctl, const uint32_t seq_num, const uint32_t ack_num,
-               void *payload, const size_t payload_len)
+int _gnrc_tcp_pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt,
+                        uint16_t *seq_con, const uint16_t ctl,
+                        const uint32_t seq_num, const uint32_t ack_num,
+                        void *payload, const size_t payload_len)
 {
     TCP_DEBUG_ENTER;
     gnrc_pktsnip_t *pay_snp = NULL;
@@ -180,7 +183,8 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
         offset += 1;
     }
     /* Set offset and control bit accordingly */
-    tcp_hdr.off_ctl = byteorder_htons(_option_build_offset_control(offset, ctl));
+    tcp_hdr.off_ctl = byteorder_htons(
+        _gnrc_tcp_option_build_offset_control(offset, ctl));
 
     tcp_snp = gnrc_pktbuf_add(pay_snp, &tcp_hdr, sizeof(tcp_hdr), GNRC_NETTYPE_TCP);
     if (tcp_snp == NULL) {
@@ -210,7 +214,9 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
 
             /* If SYN flag is set: Add MSS option */
             if (ctl & MSK_SYN) {
-                network_uint32_t mss_option = byteorder_htonl(_option_build_mss(CONFIG_GNRC_TCP_MSS));
+                network_uint32_t mss_option = byteorder_htonl(
+                    _gnrc_tcp_option_build_mss(CONFIG_GNRC_TCP_MSS));
+
                 memcpy(opt_ptr, &mss_option, sizeof(mss_option));
             }
             /* Increase opt_ptr and decrease opt_left, if other options are added */
@@ -271,8 +277,8 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
     return 0;
 }
 
-int _pkt_send(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *out_pkt, const uint16_t seq_con,
-              const bool retransmit)
+int _gnrc_tcp_pkt_send(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *out_pkt,
+                       const uint16_t seq_con, const bool retransmit)
 {
     TCP_DEBUG_ENTER;
     if (out_pkt == NULL) {
@@ -301,7 +307,8 @@ int _pkt_send(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *out_pkt, const uint16_t seq_c
     return 0;
 }
 
-int _pkt_chk_seq_num(const gnrc_tcp_tcb_t *tcb, const uint32_t seq_num, const uint32_t seg_len)
+int _gnrc_tcp_pkt_chk_seq_num(const gnrc_tcp_tcb_t *tcb, const uint32_t seq_num,
+                              const uint32_t seg_len)
 {
     TCP_DEBUG_ENTER;
     uint32_t l_edge = tcb->rcv_nxt;
@@ -338,7 +345,7 @@ int _pkt_chk_seq_num(const gnrc_tcp_tcb_t *tcb, const uint32_t seq_num, const ui
     return -1;
 }
 
-uint32_t _pkt_get_seg_len(gnrc_pktsnip_t *pkt)
+uint32_t _gnrc_tcp_pkt_get_seg_len(gnrc_pktsnip_t *pkt)
 {
     TCP_DEBUG_ENTER;
     uint32_t seq = 0;
@@ -346,7 +353,7 @@ uint32_t _pkt_get_seg_len(gnrc_pktsnip_t *pkt)
     gnrc_pktsnip_t *snp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TCP);
     tcp_hdr_t *hdr = (tcp_hdr_t *) snp->data;
     ctl = byteorder_ntohs(hdr->off_ctl);
-    seq = _pkt_get_pay_len(pkt);
+    seq = _gnrc_tcp_pkt_get_pay_len(pkt);
     if (ctl & MSK_SYN) {
         seq += 1;
     }
@@ -357,7 +364,7 @@ uint32_t _pkt_get_seg_len(gnrc_pktsnip_t *pkt)
     return seq;
 }
 
-uint32_t _pkt_get_pay_len(gnrc_pktsnip_t *pkt)
+uint32_t _gnrc_tcp_pkt_get_pay_len(gnrc_pktsnip_t *pkt)
 {
     TCP_DEBUG_ENTER;
     uint32_t seg_len = 0;
@@ -370,7 +377,8 @@ uint32_t _pkt_get_pay_len(gnrc_pktsnip_t *pkt)
     return seg_len;
 }
 
-int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool retransmit)
+int _gnrc_tcp_pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt,
+                                   const bool retransmit)
 {
     TCP_DEBUG_ENTER;
     gnrc_pktsnip_t *snp = NULL;
@@ -394,7 +402,7 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
     /* Extract control bits and segment length */
     snp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TCP);
     ctl = byteorder_ntohs(((tcp_hdr_t *) snp->data)->off_ctl);
-    len = _pkt_get_pay_len(pkt);
+    len = _gnrc_tcp_pkt_get_pay_len(pkt);
 
     /* Check if pkt contains reset or is a pure ACK, return */
     if ((ctl & MSK_RST) || (((ctl & MSK_SYN_FIN_ACK) == MSK_ACK) && len == 0)) {
@@ -438,13 +446,13 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
     }
 
     /* Setup retransmission timer, msg to TCP thread with ptr to TCB */
-    _gnrc_tcp_event_loop_sched(&tcb->event_retransmit, tcb->rto,
-                               MSG_TYPE_RETRANSMISSION, tcb);
+    _gnrc_tcp_eventloop_sched(&tcb->event_retransmit, tcb->rto,
+                              MSG_TYPE_RETRANSMISSION, tcb);
     TCP_DEBUG_LEAVE;
     return 0;
 }
 
-int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
+int _gnrc_tcp_pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
 {
     TCP_DEBUG_ENTER;
     uint32_t seg = 0;
@@ -462,11 +470,12 @@ int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
     hdr = (tcp_hdr_t *) snp->data;
 
     /* There must be a packet, waiting to be acknowledged. */
-    seg = byteorder_ntohl(hdr->seq_num) + _pkt_get_seg_len(tcb->pkt_retransmit) - 1;
+    seg = byteorder_ntohl(hdr->seq_num) + _gnrc_tcp_pkt_get_seg_len(
+        tcb->pkt_retransmit) - 1;
 
-    /* If segment can be acknowledged -> stop timer, release packet from pktbuf and update rto. */
+        /* If segment can be acknowledged -> stop timer, release packet from pktbuf and update rto. */
     if (LSS_32_BIT(seg, ack)) {
-        _gnrc_tcp_event_loop_unsched(&tcb->event_retransmit);
+        _gnrc_tcp_eventloop_unsched(&tcb->event_retransmit);
         gnrc_pktbuf_release(tcb->pkt_retransmit);
         tcb->pkt_retransmit = NULL;
 
@@ -493,8 +502,9 @@ int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
     return 0;
 }
 
-uint16_t _pkt_calc_csum(const gnrc_pktsnip_t *hdr, const gnrc_pktsnip_t *pseudo_hdr,
-                        const gnrc_pktsnip_t *payload)
+uint16_t _gnrc_tcp_pkt_calc_csum(const gnrc_pktsnip_t *hdr,
+                                 const gnrc_pktsnip_t *pseudo_hdr,
+                                 const gnrc_pktsnip_t *payload)
 {
     TCP_DEBUG_ENTER;
     uint16_t csum = 0;

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
@@ -17,8 +17,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef COMMON_H
-#define COMMON_H
+#ifndef GNRC_TCP_COMMON_H
+#define GNRC_TCP_COMMON_H
 
 #include <stdint.h>
 #include "assert.h"
@@ -152,18 +152,18 @@ extern "C" {
 typedef struct {
     gnrc_tcp_tcb_t *head; /**< Head of TCB list */
     mutex_t lock;         /**< Lock of TCB list */
-} tcb_list_t;
+} _gnrc_tcp_common_tcb_list_t;
 
 /**
  * @brief Function to access to TCB list
  *
  * @returns Pointer to global TCB list.
  */
-tcb_list_t *_gnrc_tcp_common_get_tcb_list(void);
+_gnrc_tcp_common_tcb_list_t *_gnrc_tcp_common_get_tcb_list(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* COMMON_H */
+#endif /* GNRC_TCP_COMMON_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_eventloop.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_eventloop.h
@@ -17,8 +17,8 @@
 * @author       Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef EVENTLOOP_H
-#define EVENTLOOP_H
+#ifndef GNRC_TCP_EVENTLOOP_H
+#define GNRC_TCP_EVENTLOOP_H
 
 #include <stdint.h>
 
@@ -35,7 +35,7 @@ extern "C" {
  * @retval  -EEXIST if processing thread was already started
  * @retval  see @ref thread_create() for more error cases.
  */
-int _gnrc_tcp_event_loop_init(void);
+int _gnrc_tcp_eventloop_init(void);
 
 /**
  * @brief   Schedule event to event loop
@@ -46,8 +46,8 @@ int _gnrc_tcp_event_loop_init(void);
  * @param[in] type      Type of the message for the event
  * @param[in] context   Context of the event.
  */
-void _gnrc_tcp_event_loop_sched(evtimer_msg_event_t *event, uint32_t offset,
-                                uint16_t type, void *context);
+void _gnrc_tcp_eventloop_sched(evtimer_msg_event_t *event, uint32_t offset,
+                               uint16_t type, void *context);
 
 /**
  * @brief   Unschedule event to event loop
@@ -56,11 +56,11 @@ void _gnrc_tcp_event_loop_sched(evtimer_msg_event_t *event, uint32_t offset,
  *
  * @param[in] event The event to unschedule
  */
-void _gnrc_tcp_event_loop_unsched(evtimer_msg_event_t *event);
+void _gnrc_tcp_eventloop_unsched(evtimer_msg_event_t *event);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* EVENTLOOP_H */
+#endif /* GNRC_TCP_EVENTLOOP_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_fsm.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_fsm.h
@@ -17,8 +17,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef FSM_H
-#define FSM_H
+#ifndef GNRC_TCP_FSM_H
+#define GNRC_TCP_FSM_H
 
 #include <stdint.h>
 #include "mbox.h"
@@ -44,7 +44,7 @@ typedef enum {
     FSM_STATE_FIN_WAIT_2,
     FSM_STATE_CLOSING,
     FSM_STATE_TIME_WAIT
-} fsm_state_t;
+} _gnrc_tcp_fsm_state_t;
 
 /**
  *  @brief Events that trigger transitions in TCP FSM.
@@ -61,7 +61,7 @@ typedef enum {
     FSM_EVENT_TIMEOUT_CONNECTION, /* Timeout: connection */
     FSM_EVENT_SEND_PROBE,         /* Send zero window probe */
     FSM_EVENT_CLEAR_RETRANSMIT    /* Clear retransmission mechanism */
-} fsm_event_t;
+} _gnrc_tcp_fsm_event_t;
 
 /**
  * @brief TCP finite state maschine
@@ -76,7 +76,8 @@ typedef enum {
  *            Positive Number, number of bytes sent from or copied into @p buf.
  *            -ENOSYS if event is not implemented
  */
-int _fsm(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip_t *in_pkt, void *buf, size_t len);
+int _gnrc_tcp_fsm(gnrc_tcp_tcb_t *tcb, _gnrc_tcp_fsm_event_t event,
+                  gnrc_pktsnip_t *in_pkt, void *buf, size_t len);
 
 /**
  * @brief Associate mbox with tcb. Messages sent from the FSM will be stored in the mbox.
@@ -85,11 +86,11 @@ int _fsm(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip_t *in_pkt, void *b
  * @param[in]      mbox  Message box used to store messages from the FSM.
  *                       If @p mbox is NULL, no messages will be stored.
  */
-void _fsm_set_mbox(gnrc_tcp_tcb_t *tcb, mbox_t *mbox);
+void _gnrc_tcp_fsm_set_mbox(gnrc_tcp_tcb_t *tcb, mbox_t *mbox);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* FSM_H */
+#endif /* GNRC_TCP_FSM_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_option.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_option.h
@@ -17,8 +17,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef OPTION_H
-#define OPTION_H
+#ifndef GNRC_TCP_OPTION_H
+#define GNRC_TCP_OPTION_H
 
 #include <stdint.h>
 #include "assert.h"
@@ -36,7 +36,7 @@ extern "C" {
  *
  * @returns   MSS option value.
  */
-static inline uint32_t _option_build_mss(uint16_t mss)
+static inline uint32_t _gnrc_tcp_option_build_mss(uint16_t mss)
 {
     return (((uint32_t) TCP_OPTION_KIND_MSS << 24) |
             ((uint32_t) TCP_OPTION_LENGTH_MSS << 16) | mss);
@@ -50,7 +50,7 @@ static inline uint32_t _option_build_mss(uint16_t mss)
  *
  * @returns   Bitfield with encoded control bits and number of options.
  */
-static inline uint16_t _option_build_offset_control(uint16_t nopts, uint16_t ctl)
+static inline uint16_t _gnrc_tcp_option_build_offset_control(uint16_t nopts, uint16_t ctl)
 {
     assert(TCP_HDR_OFFSET_MIN <= nopts && nopts <= TCP_HDR_OFFSET_MAX);
     return (nopts << 12) | ctl;
@@ -65,11 +65,11 @@ static inline uint16_t _option_build_offset_control(uint16_t nopts, uint16_t ctl
  * @returns   Zero on success.
  *            Negative value on error.
  */
-int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr);
+int _gnrc_tcp_option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OPTION_H */
+#endif /* GNRC_TCP_OPTION_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_pkt.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_pkt.h
@@ -17,8 +17,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef PKT_H
-#define PKT_H
+#ifndef GNRC_TCP_PKT_H
+#define GNRC_TCP_PKT_H
 
 #include <stdint.h>
 #include "net/gnrc.h"
@@ -40,7 +40,8 @@ extern "C" {
  * @returns   Zero on success
  *            -ENOMEM if pktbuf is full.
  */
-int _pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt, gnrc_pktsnip_t *in_pkt);
+int _gnrc_tcp_pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt,
+                                       gnrc_pktsnip_t *in_pkt);
 
 /**
  * @brief Build and allocate a TCB packet, TCB stores pointer to new packet.
@@ -57,9 +58,10 @@ int _pkt_build_reset_from_pkt(gnrc_pktsnip_t **out_pkt, gnrc_pktsnip_t *in_pkt);
  * @returns   Zero on success.
  *            -ENOMEM if pktbuf is full.
  */
-int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
-               const uint16_t ctl, const uint32_t seq_num, const uint32_t ack_num,
-               void *payload, const size_t payload_len);
+int _gnrc_tcp_pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt,
+                        uint16_t *seq_con, const uint16_t ctl,
+                        const uint32_t seq_num, const uint32_t ack_num,
+                        void *payload, const size_t payload_len);
 
 /**
  * @brief Sends packet to peer.
@@ -72,8 +74,8 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
  * @returns   Zero on success.
  *            -EINVAL if out_pkt was NULL.
  */
-int _pkt_send(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *out_pkt, const uint16_t seq_con,
-              const bool retransmit);
+int _gnrc_tcp_pkt_send(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *out_pkt,
+                       const uint16_t seq_con, const bool retransmit);
 
 /**
  * @brief Verify sequence number.
@@ -85,7 +87,8 @@ int _pkt_send(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *out_pkt, const uint16_t seq_c
  * @returns    Zero if the sequence number is acceptable.
  *             Negative value if the sequence number is not acceptable.
  */
-int _pkt_chk_seq_num(const gnrc_tcp_tcb_t *tcb, const uint32_t seq_num, const uint32_t seg_len);
+int _gnrc_tcp_pkt_chk_seq_num(const gnrc_tcp_tcb_t *tcb, const uint32_t seq_num,
+                              const uint32_t seg_len);
 
 /**
  * @brief Extracts the length of a segment.
@@ -94,7 +97,7 @@ int _pkt_chk_seq_num(const gnrc_tcp_tcb_t *tcb, const uint32_t seq_num, const ui
  *
  * @returns   Segments length in bytes (== sequence number consumption).
  */
-uint32_t _pkt_get_seg_len(gnrc_pktsnip_t *pkt);
+uint32_t _gnrc_tcp_pkt_get_seg_len(gnrc_pktsnip_t *pkt);
 
 /**
  * @brief Calculates a packets payload length.
@@ -103,7 +106,7 @@ uint32_t _pkt_get_seg_len(gnrc_pktsnip_t *pkt);
  *
  * @returns   The packets payload length in bytes.
  */
-uint32_t _pkt_get_pay_len(gnrc_pktsnip_t *pkt);
+uint32_t _gnrc_tcp_pkt_get_pay_len(gnrc_pktsnip_t *pkt);
 
 /**
  * @brief Adds a packet to the retransmission mechanism.
@@ -116,7 +119,8 @@ uint32_t _pkt_get_pay_len(gnrc_pktsnip_t *pkt);
  *            -ENOMEM if the retransmission queue is full.
  *            -EINVAL if pkt is null.
  */
-int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool retransmit);
+int _gnrc_tcp_pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt,
+                                   const bool retransmit);
 
 /**
  * @brief Acknowledges and removes packet from the retransmission mechanism.
@@ -127,7 +131,7 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
  * @returns   Zero on success.
  *            -ENODATA if there is nothing to acknowledge.
  */
-int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack);
+int _gnrc_tcp_pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack);
 
 /**
  * @brief Calculates checksum over payload, TCP header and network layer header.
@@ -139,12 +143,13 @@ int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack);
  * @returns   Non-zero checksum if given network layer is supported.
  *            Zero if given network layer is not supported.
  */
-uint16_t _pkt_calc_csum(const gnrc_pktsnip_t *hdr, const gnrc_pktsnip_t *pseudo_hdr,
-                        const gnrc_pktsnip_t *payload);
+uint16_t _gnrc_tcp_pkt_calc_csum(const gnrc_pktsnip_t *hdr,
+                                 const gnrc_pktsnip_t *pseudo_hdr,
+                                 const gnrc_pktsnip_t *payload);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* PKT_H */
+#endif /* GNRC_TCP_PKT_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_rcvbuf.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_rcvbuf.h
@@ -17,12 +17,9 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef RCVBUF_H
-#define RCVBUF_H
+#ifndef GNRC_TCP_RCVBUF_H
+#define GNRC_TCP_RCVBUF_H
 
-#include <stdint.h>
-#include "mutex.h"
-#include "net/gnrc/tcp/config.h"
 #include "net/gnrc/tcp/tcb.h"
 
 #ifdef __cplusplus
@@ -30,25 +27,9 @@ extern "C" {
 #endif
 
 /**
- * @brief Receive buffer entry.
+ * @brief Initializes global receive buffer.
  */
-typedef struct rcvbuf_entry {
-    uint8_t used;                          /**< Flag: Is buffer in use? */
-    uint8_t buffer[GNRC_TCP_RCV_BUF_SIZE]; /**< Receive buffer storage */
-} rcvbuf_entry_t;
-
-/**
- * @brief   Struct holding receive buffers.
- */
-typedef struct rcvbuf {
-    mutex_t lock;                                 /**< Lock for allocation synchronization */
-    rcvbuf_entry_t entries[CONFIG_GNRC_TCP_RCV_BUFFERS]; /**< Maintained receive buffers */
-} rcvbuf_t;
-
-/**
- * @brief   Initializes global receive buffer.
- */
-void _rcvbuf_init(void);
+void _gnrc_tcp_rcvbuf_init(void);
 
 /**
  * @brief Allocate receive buffer and assign it to TCB.
@@ -58,18 +39,18 @@ void _rcvbuf_init(void);
  * @returns   Zero  on success.
  *            -ENOMEM if all receive buffers are currently used.
  */
-int _rcvbuf_get_buffer(gnrc_tcp_tcb_t *tcb);
+int _gnrc_tcp_rcvbuf_get_buffer(gnrc_tcp_tcb_t *tcb);
 
 /**
  * @brief Release allocated receive buffer.
  *
  * @param[in,out] tcb   TCB holding the receive buffer that should be released.
  */
-void _rcvbuf_release_buffer(gnrc_tcp_tcb_t *tcb);
+void _gnrc_tcp_rcvbuf_release_buffer(gnrc_tcp_tcb_t *tcb);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* RCVBUF_H */
+#endif /* GNRC_TCP_RCVBUF_H */
 /** @} */


### PR DESCRIPTION
### Contribution description
The goal of this PR is to cleanup the gnrc_tcp internal naming according to the following rules:

* Compilation unit local functions and types must be prefixed with "_".
* Module internal functions and types must be prefixed with "\_gnrc_tcp_\<compilation unit name\>"

In addition internal headers were renamed to match the name of the corresponding implementation files. 
Last but not least all internal headers were moved from "internal" to "include". 

### Testing procedure
The tests in "tests/gnrc_tcp" must run successfully.

### Issues/PRs references
None