### PR TITLE
netdev_ieee802154_submac: unify legacy and radio HAL bootstrap

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -25,8 +25,19 @@
 #include <stdbool.h>
 
 #include "net/ieee802154.h"
+#include "kernel_defines.h"
+
+#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
+#include "net/ieee802154/radio.h"
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+#include "net/netdev/ieee802154_submac.h"
+#endif
+#else
 #include "net/netdev.h"
 #include "net/netdev/ieee802154.h"
+#endif
+
+#include "net/netopt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -209,10 +220,15 @@ enum {
 /**
  * @brief   Device descriptor for CC2538 transceiver
  *
- * @extends netdev_ieee802154_t
+ * @extends netdev_ieee802154_t if using legacy radio
+ * @extends netdev_ieee802154_submac_t if using radio HAL
  */
 typedef struct {
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+    netdev_ieee802154_submac_t netdev;   /**< netdev parent struct */
+#elif !IS_USED(MODULE_IEEE802154_RADIO_HAL)
     netdev_ieee802154_t netdev;   /**< netdev parent struct */
+#endif
     uint8_t state;                /**< current state of the radio */
 } cc2538_rf_t;
 

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -197,6 +197,7 @@ void cc2538_setup(cc2538_rf_t *dev)
     (void) dev;
 #if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
     extern ieee802154_dev_t cc2538_rf_dev;
+    netdev_register((netdev_t* )dev, NETDEV_CC2538, 0);
     netdev_ieee802154_submac_init(&dev->netdev, &cc2538_rf_dev);
 #endif
     cc2538_init();

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -193,6 +193,14 @@ bool cc2538_on(void)
 
 void cc2538_setup(cc2538_rf_t *dev)
 {
+#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
+    (void) dev;
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+    extern ieee802154_dev_t cc2538_rf_dev;
+    netdev_ieee802154_submac_init(&dev->netdev, &cc2538_rf_dev);
+#endif
+    cc2538_init();
+#else
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &cc2538_rf_driver;
@@ -210,4 +218,5 @@ void cc2538_setup(cc2538_rf_t *dev)
     cc2538_set_addr_short(dev->netdev.short_addr);
 
     cc2538_on();
+#endif
 }

--- a/cpu/nrf52/include/nrf802154.h
+++ b/cpu/nrf52/include/nrf802154.h
@@ -36,13 +36,32 @@
 #ifndef NRF802154_H
 #define NRF802154_H
 
-#if !IS_USED(MODULE_IEEE802154_RADIO_HAL)
+#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
+#include "net/ieee802154/radio.h"
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+#include "net/netdev/ieee802154_submac.h"
+#endif
+#else
 #include "net/netdev/ieee802154.h"
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief   Device descriptor for NRF802154 transceiver
+ *
+ * @extends netdev_ieee802154_t if using legacy radio
+ * @extends netdev_ieee802154_submac_t if using radio HAL
+ */
+typedef struct {
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+    netdev_ieee802154_submac_t netdev;      /**< netdev SubMAC descriptor */
+#elif !IS_USED(MODULE_IEEE802154_RADIO_HAL)
+    netdev_ieee802154_t netdev;             /**< ieee802154 device descriptor */
+#endif
+} nrf802154_t;
 
 /**
  * @defgroup drivers_nrf52_802154_conf  nrf802154 driver compile configuration
@@ -61,13 +80,6 @@ extern "C" {
 #endif
 /** @} */
 
-#if !IS_USED(MODULE_IEEE802154_RADIO_HAL)
-/**
- * @brief   Export the netdev device descriptor
- */
-extern netdev_ieee802154_t nrf802154_dev;
-#endif
-
 /**
  * @brief   IEEE 802.15.4 radio timer configuration
  *
@@ -85,6 +97,13 @@ extern netdev_ieee802154_t nrf802154_dev;
  * @return negative errno on error
  */
 int nrf802154_init(void);
+
+/**
+ * @brief   Setup a NRF802154 radio device for use with netdev
+ *
+ * @param[out] dev          Device descriptor
+ */
+void nrf802154_setup(nrf802154_t *dev);
 
 #endif /* NRF802154_H */
 /** @} */

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -233,8 +233,6 @@ static int _init(netdev_t *dev)
 {
     (void)dev;
 
-    netdev_register(&nrf802154_dev->netdev, NETDEV_NRF802154, 0);
-
     int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
     assert(result >= 0);
     (void)result;

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -37,28 +37,9 @@
 
 static const netdev_driver_t nrf802154_netdev_driver;
 
-netdev_ieee802154_t nrf802154_dev = {
-    {
-        .driver = &nrf802154_netdev_driver,
-        .event_callback = NULL,
-        .context = NULL,
-    },
-#ifdef MODULE_GNRC
-#ifdef MODULE_GNRC_SIXLOWPAN
-    .proto = GNRC_NETTYPE_SIXLOWPAN,
-#else
-    .proto = GNRC_NETTYPE_UNDEF,
-#endif
-#endif
-    .pan = CONFIG_IEEE802154_DEFAULT_PANID,
-    .short_addr = { 0, 0 },
-    .long_addr = { 0, 0, 0, 0, 0, 0, 0, 0 },
-    .chan = CONFIG_IEEE802154_DEFAULT_CHANNEL,
-    .flags = 0
-};
-
 static uint8_t rxbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
 static uint8_t txbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
+static netdev_ieee802154_t *nrf802154_dev;
 
 #define ED_RSSISCALE        (4U)
 #define ED_RSSIOFFS         (-92)
@@ -197,7 +178,7 @@ static void _set_chan(uint16_t chan)
     /* Channel map between 2400 MHZ ... 2500 MHz
      * -> Frequency = 2400 + FREQUENCY (MHz) */
     NRF_RADIO->FREQUENCY = (chan - 10) * 5;
-    nrf802154_dev.chan = chan;
+    nrf802154_dev->chan = chan;
 }
 
 static int16_t _get_txpower(void)
@@ -252,7 +233,7 @@ static int _init(netdev_t *dev)
 {
     (void)dev;
 
-    netdev_register(&nrf802154_dev.netdev, NETDEV_NRF802154, 0);
+    netdev_register(&nrf802154_dev->netdev, NETDEV_NRF802154, 0);
 
     int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
     assert(result >= 0);
@@ -295,10 +276,11 @@ static int _init(netdev_t *dev)
     NRF_RADIO->MODECNF0 |= RADIO_MODECNF0_RU_Msk;
 
     /* assign default addresses */
-    netdev_ieee802154_setup(&nrf802154_dev);
+    netdev_ieee802154_setup(nrf802154_dev);
 
+    nrf802154_dev->chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
     /* set default channel */
-    _set_chan(nrf802154_dev.chan);
+    _set_chan(nrf802154_dev->chan);
 
     /* set default CCA threshold */
     _set_cca_thresh(CONFIG_NRF802154_CCA_THRESH_DEFAULT);
@@ -411,14 +393,14 @@ static int _recv(netdev_t *dev, void *buf, size_t len, void *info)
 
 static void _isr(netdev_t *dev)
 {
-    if (!nrf802154_dev.netdev.event_callback) {
+    if (!nrf802154_dev->netdev.event_callback) {
         return;
     }
     if (_state & RX_COMPLETE) {
-        nrf802154_dev.netdev.event_callback(dev, NETDEV_EVENT_RX_COMPLETE);
+        nrf802154_dev->netdev.event_callback(dev, NETDEV_EVENT_RX_COMPLETE);
     }
     if (_state & TX_COMPLETE) {
-        nrf802154_dev.netdev.event_callback(dev, NETDEV_EVENT_TX_COMPLETE);
+        nrf802154_dev->netdev.event_callback(dev, NETDEV_EVENT_TX_COMPLETE);
         _state &= ~TX_COMPLETE;
     }
 }
@@ -436,7 +418,7 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
     switch (opt) {
         case NETOPT_CHANNEL:
             assert(max_len >= sizeof(uint16_t));
-            *((uint16_t *)value) = nrf802154_dev.chan;
+            *((uint16_t *)value) = nrf802154_dev->chan;
             return sizeof(uint16_t);
         case NETOPT_TX_POWER:
             assert(max_len >= sizeof(int16_t));
@@ -503,9 +485,9 @@ void isr_radio(void)
         switch(state) {
             case RADIO_STATE_STATE_RxIdle:
                 /* only process packet if event callback is set and CRC is valid */
-                if ((nrf802154_dev.netdev.event_callback) &&
+                if ((nrf802154_dev->netdev.event_callback) &&
                     (NRF_RADIO->CRCSTATUS == 1) &&
-                    (netdev_ieee802154_dst_filter(&nrf802154_dev,
+                    (netdev_ieee802154_dst_filter(nrf802154_dev,
                                                   &rxbuf[1]) == 0)) {
                     _state |= RX_COMPLETE;
                 }
@@ -525,7 +507,7 @@ void isr_radio(void)
                 DEBUG("[nrf802154] Unhandled state: %x\n", (uint8_t)NRF_RADIO->STATE);
         }
         if (_state) {
-            netdev_trigger_event_isr(&nrf802154_dev.netdev);
+            netdev_trigger_event_isr(&nrf802154_dev->netdev);
         }
     }
     else {
@@ -533,6 +515,17 @@ void isr_radio(void)
     }
 
     cortexm_isr_end();
+}
+
+void nrf802154_setup(nrf802154_t *dev)
+{
+    netdev_t *netdev = (netdev_t*) dev;
+    netdev_ieee802154_t *netdev_ieee802154 = (netdev_ieee802154_t*) dev;
+    nrf802154_dev = netdev_ieee802154;
+
+    netdev->driver = &nrf802154_netdev_driver;
+    netdev_register(netdev, NETDEV_NRF802154, 0);
+    netdev_ieee802154_reset(netdev_ieee802154);
 }
 
 /**

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -718,6 +718,8 @@ void nrf802154_setup(nrf802154_t *dev)
 {
     (void) dev;
 #if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+    netdev_t *netdev = (netdev_t*) dev;
+    netdev_register(netdev, NETDEV_NRF802154, 0);
     netdev_ieee802154_submac_init(&dev->netdev, &nrf802154_hal_dev);
 #endif
     nrf802154_init();

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -714,6 +714,15 @@ static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *b
     return 0;
 }
 
+void nrf802154_setup(nrf802154_t *dev)
+{
+    (void) dev;
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
+    netdev_ieee802154_submac_init(&dev->netdev, &nrf802154_hal_dev);
+#endif
+    nrf802154_init();
+}
+
 static const ieee802154_radio_ops_t nrf802154_ops = {
     .write = _write,
     .read = _read,

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -274,33 +274,9 @@ static int _init(netdev_t *netdev)
 {
     netdev_ieee802154_submac_t *netdev_submac =
         (netdev_ieee802154_submac_t *)netdev;
-    /* Call the init function of the device (this will be handled by
-     * `auto_init`) */
-
     ieee802154_submac_t *submac = &netdev_submac->submac;
-
-    ieee802154_submac_init(submac);
-
     netdev_ieee802154_t *netdev_ieee802154 = (netdev_ieee802154_t *)netdev;
-
-    /* This function already sets the PAN ID to the default one */
-    netdev_ieee802154_reset(netdev_ieee802154);
-
-    uint16_t chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
-    int16_t tx_power = CONFIG_IEEE802154_DEFAULT_TXPOWER;
-    netopt_enable_t enable = NETOPT_ENABLE;
-
-    /* Initialise netdev_ieee802154_t struct */
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
-                          &chan, sizeof(chan));
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ADDRESS,
-                          &submac->short_addr, sizeof(submac->short_addr));
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ADDRESS_LONG,
-                          &submac->ext_addr, sizeof(submac->ext_addr));
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
-                          &enable, sizeof(enable));
-
-    netdev_submac->dev.txpower = tx_power;
+    ieee802154_submac_init(submac, (network_uint16_t*) netdev_ieee802154->short_addr, (eui64_t*) netdev_ieee802154->long_addr);
 
     return 0;
 }
@@ -322,6 +298,25 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac,
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;
+
+    netdev_ieee802154_t *netdev_ieee802154 = (netdev_ieee802154_t *)netdev;
+
+    /* This function already sets the PAN ID to the default one */
+    netdev_ieee802154_reset(netdev_ieee802154);
+
+    uint16_t chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
+    int16_t tx_power = CONFIG_IEEE802154_DEFAULT_TXPOWER;
+    netopt_enable_t enable = NETOPT_ENABLE;
+
+    netdev_ieee802154_setup(netdev_ieee802154);
+
+    /* Initialise netdev_ieee802154_t struct */
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
+                          &chan, sizeof(chan));
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
+                          &enable, sizeof(enable));
+
+    netdev_submac->dev.txpower = tx_power;
 
     return 0;
 }

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -158,7 +158,7 @@ extern void stm32_eth_netdev_setup(netdev_t *netdev);
 #endif
 
 #ifdef MODULE_NRF802154
-extern netdev_ieee802154_t nrf802154_dev;
+static nrf802154_t nrf802154_dev;
 #endif
 
 /**
@@ -256,7 +256,8 @@ void lwip_bootstrap(void)
         return;
     }
 #elif defined(MODULE_NRF802154)
-    if (netif_add(&netif[0], &nrf802154_dev, lwip_netdev_init,
+    nrf802154_setup(&nrf802154_dev);
+    if (netif_add(&netif[0], (netdev_ieee802154_t *)&nrf802154_dev, lwip_netdev_init,
                 tcpip_6lowpan_input) == NULL) {
         DEBUG("Could not add nrf802154 device\n");
         return;

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -469,7 +469,6 @@ ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ieee802154_submac,$(USEMODULE)))
-  USEMODULE += luid
   USEMODULE += xtimer
 endif
 

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -332,11 +332,14 @@ static inline int ieee802154_read_frame(ieee802154_submac_t *submac, void *buf,
  * @brief Init the IEEE 802.15.4 SubMAC
  *
  * @param[in] submac pointer to the SubMAC descriptor
+ * @param[in] short_addr pointer to the IEEE 802.15.4 short address
+ * @param[in] ext_addr pointer to the IEEE 802.15.4 extended address
  *
  * @return 0 on success
  * @return negative errno on error
  */
-int ieee802154_submac_init(ieee802154_submac_t *submac);
+int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *short_addr,
+                           const eui64_t *ext_addr);
 
 /**
  * @brief Set the ACK timeout timer

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
@@ -19,8 +19,6 @@
 
 #include "log.h"
 #include "net/gnrc/netif/ieee802154.h"
-#include "net/ieee802154/radio.h"
-#include "net/netdev/ieee802154_submac.h"
 
 #include "cc2538_rf.h"
 
@@ -33,12 +31,7 @@
 #define CC2538_MAC_PRIO            (GNRC_NETIF_PRIO)
 #endif
 
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-extern ieee802154_dev_t cc2538_rf_dev;
-static netdev_ieee802154_submac_t cc2538_rf_submac;
-#else
 static cc2538_rf_t cc2538_rf_dev;
-#endif
 static char _cc2538_rf_stack[CC2538_MAC_STACKSIZE];
 static gnrc_netif_t _netif;
 
@@ -46,18 +39,10 @@ void auto_init_cc2538_rf(void)
 {
     LOG_DEBUG("[auto_init_netif] initializing cc2538 radio\n");
 
-    netdev_t *netdev;
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-    netdev_ieee802154_submac_init(&cc2538_rf_submac, &cc2538_rf_dev);
-    netdev = (netdev_t*) &cc2538_rf_submac;
-    cc2538_init();
-#else
-    netdev = &cc2538_rf_dev.netdev.netdev;
     cc2538_setup(&cc2538_rf_dev);
-#endif
     gnrc_netif_ieee802154_create(&_netif, _cc2538_rf_stack,
                                  CC2538_MAC_STACKSIZE,
                                  CC2538_MAC_PRIO, "cc2538_rf",
-                                 netdev);
+                                 (netdev_t *)&cc2538_rf_dev);
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
@@ -22,9 +22,6 @@
 #include "nrf802154.h"
 #include "net/gnrc/netif/ieee802154.h"
 
-#include "net/ieee802154/radio.h"
-#include "net/netdev/ieee802154_submac.h"
-
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
@@ -40,27 +37,16 @@
 static char _stack[NRF802154_MAC_STACKSIZE];
 static gnrc_netif_t _netif;
 
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-extern ieee802154_dev_t nrf802154_hal_dev;
-static netdev_ieee802154_submac_t nrf802154_submac;
-#endif
+static nrf802154_t nrf802154_dev;
 
 void auto_init_nrf802154(void)
 {
     LOG_DEBUG("[auto_init_netif] initializing nrf802154\n");
 
-    netdev_t *netdev;
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-    netdev_ieee802154_submac_init(&nrf802154_submac, &nrf802154_hal_dev);
-    netdev = (netdev_t*) &nrf802154_submac;
-    nrf802154_init();
-#else
-    netdev = (netdev_t*) &nrf802154_dev;
-#endif
-
+    nrf802154_setup(&nrf802154_dev);
     gnrc_netif_ieee802154_create(&_netif, _stack,
                                  NRF802154_MAC_STACKSIZE,
                                  NRF802154_MAC_PRIO, "nrf802154",
-                                 netdev);
+                                 (netdev_t *)&nrf802154_dev);
 }
 /** @} */

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -290,7 +290,8 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
     return 0;
 }
 
-int ieee802154_submac_init(ieee802154_submac_t *submac)
+int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *short_addr,
+                           const eui64_t *ext_addr)
 {
     ieee802154_dev_t *dev = submac->dev;
 
@@ -300,8 +301,8 @@ int ieee802154_submac_init(ieee802154_submac_t *submac)
     ieee802154_radio_request_on(dev);
 
     /* generate EUI-64 and short address */
-    luid_get_eui64(&submac->ext_addr);
-    luid_get_short(&submac->short_addr);
+    memcpy(&submac->ext_addr, ext_addr, sizeof(eui64_t));
+    memcpy(&submac->short_addr, short_addr, sizeof(network_uint16_t));
     submac->panid = CONFIG_IEEE802154_DEFAULT_PANID;
 
     submac->be.min = CONFIG_IEEE802154_DEFAULT_CSMA_CA_MIN_BE;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR unifies the init procedure for the Radio HAL and legacy `netdev_<device>` interface. This allocates a `netdev_ieee802154_submac_t` descriptor if module `netdev_ieee802154_submac` is present. If it's not present, it allocates the legacy `netdev_ieee802154_t` only if the Radio HAL is not present. This ensures that no `netdev` dependencies are pulled if only the Radio HAL is used (e.g OpenWSN).

This whole step allows to run all radios that implement the Radio HAL with `netdev_ieee802154_submac` without changing the bootstrap code. For instance, #15132 should work with this PR.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

TL;DR: `USEMODULE+=netdev_ieee802154_submac` should work out of the box for all radios that implement the Radio HAL (e.g LWIP, OpenThread can bootstrap a radio in the same way they used to do with `netdev`)

### Testing procedure
- Murdock should do its work compiling `tests/ieee802154_hal` and `tests/ieee802154_submac`.
- Try testing `gnrc_networking` with and without `netdev_ieee802154_submac`.
- Try LWIP with `nrf802154` (the `cc2538_rf` is not yet in the bootstrap list :/)
- Test that addresses don't change if `netdev_ieee802154_submac` is selected.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#15132 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
