### PR TITLE
sys/auto_init: auto_init_adc -> auto_init_saul_adc

### DIFF
--- a/drivers/saul/init_devs/auto_init_saul_adc.c
+++ b/drivers/saul/init_devs/auto_init_saul_adc.c
@@ -48,7 +48,7 @@ static saul_reg_t saul_reg_entries[SAUL_ADC_NUMOF];
  */
 extern saul_driver_t adc_saul_driver;
 
-void auto_init_adc(void)
+void audo_init_saul_adc(void)
 {
     for (unsigned i = 0; i < SAUL_ADC_NUMOF; i++) {
         const saul_adc_params_t *p = &saul_adc_params[i];

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -28,8 +28,8 @@
 void saul_init_devs(void)
 {
     if (IS_USED(MODULE_SAUL_ADC)) {
-        extern void auto_init_adc(void);
-        auto_init_adc();
+        extern void audo_init_saul_adc(void);
+        audo_init_saul_adc();
     }
     if (IS_USED(MODULE_SAUL_GPIO)) {
         extern void auto_init_gpio(void);


### PR DESCRIPTION
### Contribution description

Avoid confusion between peripheral device initialization and SAUL registration by renaming `auto_init_adc()` to `auto_init_saul_adc()`.

### Testing procedure

Only a function was renamed, so binaries should not change.

### Issues/PRs references

Suggested in https://github.com/RIOT-OS/RIOT/pull/15106#discussion_r505665391