### PR TITLE
drivers/saul: fix typo in auto_init adc function name

### DIFF
--- a/drivers/saul/init_devs/auto_init_saul_adc.c
+++ b/drivers/saul/init_devs/auto_init_saul_adc.c
@@ -48,7 +48,7 @@ static saul_reg_t saul_reg_entries[SAUL_ADC_NUMOF];
  */
 extern saul_driver_t adc_saul_driver;
 
-void audo_init_saul_adc(void)
+void auto_init_saul_adc(void)
 {
     for (unsigned i = 0; i < SAUL_ADC_NUMOF; i++) {
         const saul_adc_params_t *p = &saul_adc_params[i];

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -28,8 +28,8 @@
 void saul_init_devs(void)
 {
     if (IS_USED(MODULE_SAUL_ADC)) {
-        extern void audo_init_saul_adc(void);
-        audo_init_saul_adc();
+        extern void auto_init_saul_adc(void);
+        auto_init_saul_adc();
     }
     if (IS_USED(MODULE_SAUL_GPIO)) {
         extern void auto_init_gpio(void);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a typo in the `auto_init_saul_adc` function name. The typo was introduced in #15233 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

The typo was introduced in #15233 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
