### PR TITLE
cpu/cortexm_common: flush pipeline before disabling interrupts in idle [backport 2020.10]

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -509,5 +509,6 @@ void sched_arch_idle(void)
     /* Briefly re-enable IRQs to allow pending interrupts to be serviced and
      * have them update the runqueue */
     __enable_irq();
+    __ISB();
     __disable_irq();
 }


### PR DESCRIPTION
# Backport of #15236



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When enabling & disabling interrupts back-to-back pending interrupts are not serviced on Cortex-M23/M33.

Flush the pipeline to give interrupts a chance of executing in `sched_arch_idle()`.

This fixes `no_idle_thread` on Cortex-M23.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14557#issuecomment-710014764
