### PR TITLE
MQTT-SN Clients ( Emcute/ Asymcute) : Kconfig Updates

### DIFF
--- a/examples/asymcute_mqttsn/main.c
+++ b/examples/asymcute_mqttsn/main.c
@@ -257,7 +257,7 @@ static int _cmd_connect(int argc, char **argv)
         return 1;
     }
     if (ep.port == 0) {
-        ep.port = MQTTSN_DEFAULT_PORT;
+        ep.port = CONFIG_ASYMCUTE_DEFAULT_PORT;
     }
 
     /* get request context */

--- a/examples/emcute_mqttsn/main.c
+++ b/examples/emcute_mqttsn/main.c
@@ -31,7 +31,6 @@
 #ifndef EMCUTE_ID
 #define EMCUTE_ID           ("gertrud")
 #endif
-#define EMCUTE_PORT         (1883U)
 #define EMCUTE_PRIO         (THREAD_PRIORITY_MAIN - 1)
 
 #define NUMOFSUBS           (16U)
@@ -46,7 +45,7 @@ static char topics[NUMOFSUBS][TOPIC_MAXLEN];
 static void *emcute_thread(void *arg)
 {
     (void)arg;
-    emcute_run(EMCUTE_PORT, EMCUTE_ID);
+    emcute_run(CONFIG_EMCUTE_DEFAULT_PORT, EMCUTE_ID);
     return NULL;    /* should never be reached */
 }
 
@@ -74,7 +73,7 @@ static unsigned get_qos(const char *str)
 
 static int cmd_con(int argc, char **argv)
 {
-    sock_udp_ep_t gw = { .family = AF_INET6, .port = EMCUTE_PORT };
+    sock_udp_ep_t gw = { .family = AF_INET6, .port = CONFIG_EMCUTE_DEFAULT_PORT };
     char *topic = NULL;
     char *message = NULL;
     size_t len = 0;

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -81,9 +81,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default buffer size used for receive and request buffers
+ */
+#ifndef CONFIG_ASYMCUTE_BUFSIZE
+#define CONFIG_ASYMCUTE_BUFSIZE         (128U)
+#endif
+
+/**
  * @brief   Maximum topic length
  *
- * @note    Must be less than (256 - 8) AND less than ( @ref ASYMCUTE_BUFSIZE - 8).
+ * @note    Must be less than (256 - 8) AND less than ( @ref CONFIG_ASYMCUTE_BUFSIZE - 8).
  */
 #ifndef CONFIG_ASYMCUTE_TOPIC_MAXLEN
 #define CONFIG_ASYMCUTE_TOPIC_MAXLEN       (32U)
@@ -139,13 +146,6 @@ extern "C" {
 #define CONFIG_ASYMCUTE_N_RETRY            (3U)
 #endif
 /** @} */
-
-#ifndef ASYMCUTE_BUFSIZE
-/**
- * @brief   Default buffer size used for receive and request buffers
- */
-#define ASYMCUTE_BUFSIZE            (1 << CONFIG_ASYMCUTE_BUFSIZE_EXP)
-#endif
 
 #ifndef ASYMCUTE_HANDLER_PRIO
 /**
@@ -275,7 +275,7 @@ struct asymcute_req {
     void *arg;                      /**< internally used additional state */
     event_callback_t to_evt;        /**< timeout event */
     event_timeout_t to_timer;       /**< timeout timer */
-    uint8_t data[ASYMCUTE_BUFSIZE]; /**< buffer holding the request's data */
+    uint8_t data[CONFIG_ASYMCUTE_BUFSIZE]; /**< buffer holding the request's data */
     size_t data_len;                /**< length of the request packet in byte */
     uint16_t msg_id;                /**< used message id for this request */
     uint8_t retry_cnt;              /**< retransmission counter */
@@ -297,7 +297,7 @@ struct asymcute_con {
                                          *   connection */
     uint8_t keepalive_retry_cnt;        /**< keep alive transmission counter */
     uint8_t state;                      /**< connection state */
-    uint8_t rxbuf[ASYMCUTE_BUFSIZE];    /**< connection specific receive buf */
+    uint8_t rxbuf[CONFIG_ASYMCUTE_BUFSIZE];    /**< connection specific receive buf */
     char cli_id[MQTTSN_CLI_ID_MAXLEN + 1];  /**< buffer to store client ID */
 };
 

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -64,6 +64,13 @@ extern "C" {
  * @{
  */
 /**
+ * @brief   Default UDP port to listen on
+ */
+#ifndef CONFIG_ASYMCUTE_DEFAULT_PORT
+#define CONFIG_ASYMCUTE_DEFAULT_PORT    (1883U)
+#endif
+
+/**
  * @brief   Default buffer size for Asymcute client (as exponent of 2^n)
  *
  * As the buffer size ALWAYS needs to be power of two, this option represents

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -60,11 +60,18 @@ extern "C" {
 
 /**
  * @defgroup net_asymcute_conf Asymcute (MQTT-SN Client) compile configurations
- * @ingroup config
+ * @ingroup net_mqtt_conf
+ * @brief   Compile-time configuration options for Asymcute, an asynchronous
+ *          MQTT-SN implementation based on the OASIS MQTT-SN protocol. It
+ *          provides a flexible interface that allows users to issue any number
+ *          of concurrent requests to one or more different gateways
+ *          simultaneously.
  * @{
  */
 /**
- * @brief   Default UDP port to listen on
+ * @brief   Default UDP port to listen on. Usage can be found in
+ *          examples/asymcute_mqttsn. Application code is expected to use this
+ *          macro to assign the default port.
  */
 #ifndef CONFIG_ASYMCUTE_DEFAULT_PORT
 #define CONFIG_ASYMCUTE_DEFAULT_PORT    (1883U)
@@ -73,8 +80,8 @@ extern "C" {
 /**
  * @brief   Default buffer size for Asymcute client (as exponent of 2^n)
  *
- * As the buffer size ALWAYS needs to be power of two, this option represents
- * the exponent of 2^n, which will be used as the size of the buffer.
+ * @deprecated Use @ref CONFIG_ASYMCUTE_BUFSIZE instead. Will be removed after
+ * 2021.04 release.
  */
 #ifndef CONFIG_ASYMCUTE_BUFSIZE_EXP
 #define CONFIG_ASYMCUTE_BUFSIZE_EXP     (7U)
@@ -93,18 +100,18 @@ extern "C" {
  * @note    Must be less than (256 - 8) AND less than ( @ref CONFIG_ASYMCUTE_BUFSIZE - 8).
  */
 #ifndef CONFIG_ASYMCUTE_TOPIC_MAXLEN
-#define CONFIG_ASYMCUTE_TOPIC_MAXLEN       (32U)
+#define CONFIG_ASYMCUTE_TOPIC_MAXLEN    (32U)
 #endif
 
 /**
  * @brief   Keep alive interval [in s] communicated to the gateway
  *
- * keep alive interval in seconds which is communicated to the gateway in the
+ * Keep alive interval in seconds which is communicated to the gateway in the
  * CONNECT message. For more information, see MQTT-SN Spec v1.2, section 5.4.4.
  * For default values,see section 7.2 -> TWAIT: > 5 min.
  */
 #ifndef CONFIG_ASYMCUTE_KEEPALIVE
-#define CONFIG_ASYMCUTE_KEEPALIVE          (360)
+#define CONFIG_ASYMCUTE_KEEPALIVE       (360)
 #endif
 
 /**
@@ -116,7 +123,7 @@ extern "C" {
  * @note    Must be less than @ref CONFIG_ASYMCUTE_KEEPALIVE
  */
 #ifndef CONFIG_ASYMCUTE_KEEPALIVE_PING
-#define CONFIG_ASYMCUTE_KEEPALIVE_PING     ((CONFIG_ASYMCUTE_KEEPALIVE / 4) * 3)
+#define CONFIG_ASYMCUTE_KEEPALIVE_PING  ((CONFIG_ASYMCUTE_KEEPALIVE / 4) * 3)
 #endif
 
 /**
@@ -130,7 +137,7 @@ extern "C" {
  * section 6.13. For default values, see section 7.2 -> Tretry: 10 to 15 sec.
  */
 #ifndef CONFIG_ASYMCUTE_T_RETRY
-#define CONFIG_ASYMCUTE_T_RETRY            (10U)
+#define CONFIG_ASYMCUTE_T_RETRY         (10U)
 #endif
 
 /**
@@ -143,7 +150,7 @@ extern "C" {
  * For default values, see section 7.2 -> Nretry: 3-5.
  */
 #ifndef CONFIG_ASYMCUTE_N_RETRY
-#define CONFIG_ASYMCUTE_N_RETRY            (3U)
+#define CONFIG_ASYMCUTE_N_RETRY         (3U)
 #endif
 /** @} */
 
@@ -151,14 +158,14 @@ extern "C" {
 /**
  * @brief   Default priority for Asymcute's handler thread
  */
-#define ASYMCUTE_HANDLER_PRIO       (THREAD_PRIORITY_MAIN - 2)
+#define ASYMCUTE_HANDLER_PRIO           (THREAD_PRIORITY_MAIN - 2)
 #endif
 
 #ifndef ASYMCUTE_HANDLER_STACKSIZE
 /**
  * @brief   Default stack size for Asymcute's handler thread
  */
-#define ASYMCUTE_HANDLER_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
+#define ASYMCUTE_HANDLER_STACKSIZE      (THREAD_STACKSIZE_DEFAULT)
 #endif
 
 #ifndef ASYMCUTE_LISTENER_PRIO
@@ -167,14 +174,14 @@ extern "C" {
  *
  * @note    Must be of higher priority than @ref ASYMCUTE_HANDLER_PRIO
  */
-#define ASYMCUTE_LISTENER_PRIO      (THREAD_PRIORITY_MAIN - 3)
+#define ASYMCUTE_LISTENER_PRIO          (THREAD_PRIORITY_MAIN - 3)
 #endif
 
 #ifndef ASYMCUTE_LISTENER_STACKSIZE
 /**
  * @brief   Default stack size for an Asymcute listener thread
  */
-#define ASYMCUTE_LISTENER_STACKSIZE (THREAD_STACKSIZE_DEFAULT)
+#define ASYMCUTE_LISTENER_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
 #endif
 
 /**

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -136,13 +136,13 @@ extern "C" {
 #define CONFIG_EMCUTE_KEEPALIVE             (360)       /* -> 6 min*/
 #endif
 
-#ifndef EMCUTE_T_RETRY
+#ifndef CONFIG_EMCUTE_T_RETRY
 /**
  * @brief   Re-send interval [in seconds]
  *
  * For the default value, see spec v1.2, section 7.2 -> T_RETRY: 10 to 15 sec
  */
-#define EMCUTE_T_RETRY          (15U)       /* -> 15 sec */
+#define CONFIG_EMCUTE_T_RETRY               (15U)       /* -> 15 sec */
 #endif
 
 #ifndef EMCUTE_N_RETRY

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -145,13 +145,13 @@ extern "C" {
 #define CONFIG_EMCUTE_T_RETRY               (15U)       /* -> 15 sec */
 #endif
 
-#ifndef EMCUTE_N_RETRY
+#ifndef CONFIG_EMCUTE_N_RETRY
 /**
  * @brief   Number of retries when sending packets
  *
  * For the default value, see spec v1.2, section 7.2 -> N_RETRY: 3-5
  */
-#define EMCUTE_N_RETRY          (3U)
+#define CONFIG_EMCUTE_N_RETRY               (3U)
 #endif
 
 /**

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -95,11 +95,11 @@
 extern "C" {
 #endif
 
-#ifndef EMCUTE_DEFAULT_PORT
+#ifndef CONFIG_EMCUTE_DEFAULT_PORT
 /**
  * @brief   Default UDP port to listen on (also used as SRC port)
  */
-#define EMCUTE_DEFAULT_PORT     (1883U)
+#define CONFIG_EMCUTE_DEFAULT_PORT          (1883U)
 #endif
 
 #ifndef CONFIG_EMCUTE_BUFSIZE

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -95,14 +95,23 @@
 extern "C" {
 #endif
 
-#ifndef CONFIG_EMCUTE_DEFAULT_PORT
 /**
- * @brief   Default UDP port to listen on (also used as SRC port)
+ * @defgroup net_emcute_conf EmCute (MQTT-SN Client) compile configurations
+ * @ingroup net_mqtt_conf
+ * @brief   Compile-time configuration options for emCute, an implementation
+ *          of the OASIS MQTT-SN protocol for RIOT. It is designed with a focus
+ *          on small memory footprint and usability
+ * @{
  */
+/**
+ * @brief   Default UDP port to listen on (also used as SRC port). Usage can be
+ *          found in examples/emcute_mqttsn. Application code is expected to use
+ *          this macro to assign the default port.
+ */
+#ifndef CONFIG_EMCUTE_DEFAULT_PORT
 #define CONFIG_EMCUTE_DEFAULT_PORT          (1883U)
 #endif
 
-#ifndef CONFIG_EMCUTE_BUFSIZE
 /**
  * @brief   Buffer size used for emCute's transmit and receive buffers
  *
@@ -111,48 +120,57 @@ extern "C" {
  *
  * The overall buffer size used by emCute is this value time two (Rx + Tx).
  */
+#ifndef CONFIG_EMCUTE_BUFSIZE
 #define CONFIG_EMCUTE_BUFSIZE               (512U)
 #endif
 
-#ifndef CONFIG_EMCUTE_TOPIC_MAXLEN
 /**
  * @brief   Maximum topic length
  *
- * @note    **Must** be less than (256 - 6) AND less than
- *          (@ref CONFIG_EMCUTE_BUFSIZE - 6).
+ * @note    **Must** be less than (256 - 6) AND less than ( @ref CONFIG_EMCUTE_BUFSIZE - 6 )
  */
+#ifndef CONFIG_EMCUTE_TOPIC_MAXLEN
 #define CONFIG_EMCUTE_TOPIC_MAXLEN          (196U)
 #endif
 
-#ifndef CONFIG_EMCUTE_KEEPALIVE
 /**
- * @brief   Keep-alive interval [in s]
+ * @brief   Keep-alive interval [in seconds] communicated to the gateway
  *
- * The node will communicate this interval to the gateway send a ping message
- * every time when this amount of time has passed.
- *
- * For the default value, see spec v1.2, section 7.2 -> T_WAIT: > 5 min
+ * Keep alive interval in seconds which is communicated to the gateway in the
+ * CONNECT message. For more information, see MQTT-SN Spec v1.2, section 5.4.4.
+ * For default values, see section 7.2 -> TWAIT: > 5 min.
  */
+#ifndef CONFIG_EMCUTE_KEEPALIVE
 #define CONFIG_EMCUTE_KEEPALIVE             (360)       /* -> 6 min*/
 #endif
 
-#ifndef CONFIG_EMCUTE_T_RETRY
 /**
  * @brief   Re-send interval [in seconds]
  *
- * For the default value, see spec v1.2, section 7.2 -> T_RETRY: 10 to 15 sec
+ * Interval used for timing the retry messages which are sent when the expected
+ * reply from GW is not received. The retry timer is started by the client when
+ * the message is sent and stopped when the expected reply from GW is received.
+ * If the timer times out and the expected GW’s reply is not received, the
+ * client retransmits the message. For more information, see MQTT-SN Spec v1.2,
+ * section 6.13. For default values, see section 7.2 -> Tretry: 10 to 15 sec.
  */
+#ifndef CONFIG_EMCUTE_T_RETRY
 #define CONFIG_EMCUTE_T_RETRY               (15U)       /* -> 15 sec */
 #endif
 
-#ifndef CONFIG_EMCUTE_N_RETRY
 /**
- * @brief   Number of retries when sending packets
+ * @brief   Number of retransmissions until requests time out
  *
- * For the default value, see spec v1.2, section 7.2 -> N_RETRY: 3-5
+ * Maximum number of retransmissions in the event that the retry timer times
+ * out. After 'CONFIG_EMCUTE_N_RETRY' number of retransmissions, the client
+ * aborts the procedure and assumes that its MQTT-SN connection to the gateway
+ * is disconnected. For more information, see MQTT-SN Spec v1.2, section 6.13.
+ * For default values, see section 7.2 -> Nretry: 3-5.
  */
+#ifndef CONFIG_EMCUTE_N_RETRY
 #define CONFIG_EMCUTE_N_RETRY               (3U)
 #endif
+/** @} */
 
 /**
  * @brief   MQTT-SN flags

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -102,7 +102,7 @@ extern "C" {
 #define EMCUTE_DEFAULT_PORT     (1883U)
 #endif
 
-#ifndef EMCUTE_BUFSIZE
+#ifndef CONFIG_EMCUTE_BUFSIZE
 /**
  * @brief   Buffer size used for emCute's transmit and receive buffers
  *
@@ -111,7 +111,7 @@ extern "C" {
  *
  * The overall buffer size used by emCute is this value time two (Rx + Tx).
  */
-#define EMCUTE_BUFSIZE          (512U)
+#define CONFIG_EMCUTE_BUFSIZE               (512U)
 #endif
 
 #ifndef EMCUTE_TOPIC_MAXLEN
@@ -119,7 +119,7 @@ extern "C" {
  * @brief   Maximum topic length
  *
  * @note    **Must** be less than (256 - 6) AND less than
- *          (@ref EMCUTE_BUFSIZE - 6).
+ *          (@ref CONFIG_EMCUTE_BUFSIZE - 6).
  */
 #define EMCUTE_TOPIC_MAXLEN     (196U)
 #endif
@@ -276,7 +276,7 @@ int emcute_reg(emcute_topic_t *topic);
  * @return  EMCUTE_OK on success
  * @return  EMCUTE_NOGW if not connected to a gateway
  * @return  EMCUTE_REJECT if publish message was rejected (QoS > 0 only)
- * @return  EMCUTE_OVERFLOW if length of data exceeds @ref EMCUTE_BUFSIZE
+ * @return  EMCUTE_OVERFLOW if length of data exceeds @ref CONFIG_EMCUTE_BUFSIZE
  * @return  EMCUTE_TIMEOUT on connection timeout (QoS > 0 only)
  * @return  EMCUTE_NOTSUP on unsupported flag values
  */
@@ -337,7 +337,7 @@ int emcute_willupd_topic(const char *topic, unsigned flags);
  * @return  EMCUTE_OK on success
  * @return  EMCUTE_NOGW if not connected to a gateway
  * @return  EMCUTE_OVERFLOW if length of the given message exceeds
- *          @ref EMCUTE_BUFSIZE
+ *          @ref CONFIG_EMCUTE_BUFSIZE
  * @return  EMCUTE_REJECT on rejection by the gateway
  * @return  EMCUTE_TIMEOUT on response timeout
  */

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -114,14 +114,14 @@ extern "C" {
 #define CONFIG_EMCUTE_BUFSIZE               (512U)
 #endif
 
-#ifndef EMCUTE_TOPIC_MAXLEN
+#ifndef CONFIG_EMCUTE_TOPIC_MAXLEN
 /**
  * @brief   Maximum topic length
  *
  * @note    **Must** be less than (256 - 6) AND less than
  *          (@ref CONFIG_EMCUTE_BUFSIZE - 6).
  */
-#define EMCUTE_TOPIC_MAXLEN     (196U)
+#define CONFIG_EMCUTE_TOPIC_MAXLEN          (196U)
 #endif
 
 #ifndef EMCUTE_KEEPALIVE
@@ -259,7 +259,7 @@ int emcute_discon(void);
  * @return  EMCUTE_OK on success
  * @return  EMCUTE_NOGW if not connected to a gateway
  * @return  EMCUTE_OVERFLOW if length of topic name exceeds
- *          @ref EMCUTE_TOPIC_MAXLEN
+ *          @ref CONFIG_EMCUTE_TOPIC_MAXLEN
  * @return  EMCUTE_TIMEOUT on connection timeout
  */
 int emcute_reg(emcute_topic_t *topic);
@@ -297,7 +297,7 @@ int emcute_pub(emcute_topic_t *topic, const void *buf, size_t len,
  * @return  EMCUTE_OK on success
  * @return  EMCUTE_NOGW if not connected to a gateway
  * @return  EMCUTE_OVERFLOW if length of topic name exceeds
- *          @ref EMCUTE_TOPIC_MAXLEN
+ *          @ref CONFIG_EMCUTE_TOPIC_MAXLEN
  * @return  EMCUTE_TIMEOUT on connection timeout
  */
 int emcute_sub(emcute_sub_t *sub, unsigned flags);
@@ -322,7 +322,7 @@ int emcute_unsub(emcute_sub_t *sub);
  * @return  EMCUTE_OK on success
  * @return  EMCUTE_NOGW if not connected to a gateway
  * @return  EMCUTE_OVERFLOW if length of topic name exceeds
- *          @ref EMCUTE_TOPIC_MAXLEN
+ *          @ref CONFIG_EMCUTE_TOPIC_MAXLEN
  * @return  EMCUTE_REJECT on rejection by the gateway
  * @return  EMCUTE_TIMEOUT on response timeout
  */

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -124,7 +124,7 @@ extern "C" {
 #define CONFIG_EMCUTE_TOPIC_MAXLEN          (196U)
 #endif
 
-#ifndef EMCUTE_KEEPALIVE
+#ifndef CONFIG_EMCUTE_KEEPALIVE
 /**
  * @brief   Keep-alive interval [in s]
  *
@@ -133,7 +133,7 @@ extern "C" {
  *
  * For the default value, see spec v1.2, section 7.2 -> T_WAIT: > 5 min
  */
-#define EMCUTE_KEEPALIVE        (360)       /* -> 6 min*/
+#define CONFIG_EMCUTE_KEEPALIVE             (360)       /* -> 6 min*/
 #endif
 
 #ifndef EMCUTE_T_RETRY

--- a/sys/include/net/mqttsn.h
+++ b/sys/include/net/mqttsn.h
@@ -27,14 +27,6 @@
 extern "C" {
 #endif
 
-
-#ifndef MQTTSN_DEFAULT_PORT
-/**
- * @brief   Default UDP port for MQTT-SN servers
- */
-#define MQTTSN_DEFAULT_PORT     (1883U)
-#endif
-
 /**
  * @name    The client ID must contain 1-23 characters
  *

--- a/sys/net/application_layer/Kconfig
+++ b/sys/net/application_layer/Kconfig
@@ -4,8 +4,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
-rsource "asymcute/Kconfig"
-
 menu "CoAP"
 
 rsource "Kconfig.coap"
@@ -16,3 +14,10 @@ endmenu # CoAP
 
 rsource "cord/Kconfig"
 rsource "dhcpv6/Kconfig"
+
+menu "MQTT-SN"
+
+rsource "asymcute/Kconfig"
+rsource "emcute/Kconfig"
+
+endmenu # MQTT-SN

--- a/sys/net/application_layer/asymcute/Kconfig
+++ b/sys/net/application_layer/asymcute/Kconfig
@@ -24,21 +24,16 @@ config ASYMCUTE_DEFAULT_PORT
         to macro 'CONFIG_ASYMCUTE_DEFAULT_PORT'. Usage can be found in
         examples/asymcute_mqttsn
 
-config ASYMCUTE_BUFSIZE_EXP
-    int "Exponent for the buffer size (resulting in the buffer size 2^n)"
-    default 7
-    help
-        As the buffer size ALWAYS needs to be power of two, this option
-        represents the exponent of 2^n, which will be used as the size of the
-        buffer ('ASYMCUTE_BUFSIZE'). Default value is 7 which corresponds to a
-        buffer size of 128.
+config ASYMCUTE_BUFSIZE
+    int "Size of buffer used for receive and request buffers"
+    default 128
 
 config ASYMCUTE_TOPIC_MAXLEN
     int "Maximum topic length"
     default 32
     help
         Configure maximum length for client's topic. The value must be less than
-        (256 - 8) and less than ('ASYMCUTE_BUFSIZE' - 8).
+        (256 - 8) and less than ('CONFIG_ASYMCUTE_BUFSIZE' - 8).
 
 config ASYMCUTE_KEEPALIVE
     int "Keep alive interval in seconds"

--- a/sys/net/application_layer/asymcute/Kconfig
+++ b/sys/net/application_layer/asymcute/Kconfig
@@ -16,6 +16,14 @@ menuconfig KCONFIG_USEMODULE_ASYMCUTE
 
 if KCONFIG_USEMODULE_ASYMCUTE
 
+config ASYMCUTE_DEFAULT_PORT
+    int "Default UDP port to listen on"
+    default 1883
+    help
+        Default UDP port to listen on (also used as SRC port). This will write
+        to macro 'CONFIG_ASYMCUTE_DEFAULT_PORT'. Usage can be found in
+        examples/asymcute_mqttsn
+
 config ASYMCUTE_BUFSIZE_EXP
     int "Exponent for the buffer size (resulting in the buffer size 2^n)"
     default 7

--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -597,7 +597,7 @@ void *_listener(void *arg)
 
     while (1) {
         sock_udp_ep_t remote;
-        int n = sock_udp_recv(&con->sock, con->rxbuf, ASYMCUTE_BUFSIZE,
+        int n = sock_udp_recv(&con->sock, con->rxbuf, CONFIG_ASYMCUTE_BUFSIZE,
                               SOCK_NO_TIMEOUT, &remote);
         if (n > 0) {
             _on_data(con, (size_t)n, &remote);
@@ -860,7 +860,7 @@ int asymcute_publish(asymcute_con_t *con, asymcute_req_t *req,
         return ASYMCUTE_NOTSUP;
     }
     /* check for message size */
-    if ((data_len + 9) > ASYMCUTE_BUFSIZE) {
+    if ((data_len + 9) > CONFIG_ASYMCUTE_BUFSIZE) {
         return ASYMCUTE_OVERFLOW;
     }
     /* make sure topic is registered */

--- a/sys/net/application_layer/doc.txt
+++ b/sys/net/application_layer/doc.txt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 Freie Universitaet Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_mqtt_conf MQTT client compile configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for different implementations of MQTT clients.
+ */

--- a/sys/net/application_layer/emcute/Kconfig
+++ b/sys/net/application_layer/emcute/Kconfig
@@ -1,0 +1,78 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_USEMODULE_EMCUTE
+    bool "Configure EMCUTE"
+    depends on USEMODULE_EMCUTE
+    help
+        Configure EMCUTE using Kconfig.`EMCUTE` is the implementation of the
+        OASIS MQTT-SN protocol for RIOT. It is designed with a focus on small
+        memory footprint and usability. It is designed to run on top of UDP
+        only, making use of net_sock_udp.
+
+if KCONFIG_USEMODULE_EMCUTE
+
+config EMCUTE_DEFAULT_PORT
+    int "Default UDP port to listen on"
+    default 1883
+    help
+        Default UDP port to listen on (also used as SRC port). This will write
+        to macro 'CONFIG_EMCUTE_DEFAULT_PORT'. Usage can be found in
+        examples/emcute_mqttsn.
+
+config EMCUTE_BUFSIZE
+    int "Buffer size used for TX and RX buffers"
+    range 1 32768 if HAS_ARCH_16BIT || HAS_ARCH_8BIT
+    default 512
+    help
+        Configure the size of buffer used for TX and RX. The buffer size MUST be
+        less than 32768 on 16-bit and 8-bit platforms to prevent buffer
+        overflows.
+
+config EMCUTE_TOPIC_MAXLEN
+    int "Maximum topic length"
+    default 196
+    help
+        Configure maximum length for client's topic. The value must be less than
+        (256 - 6) and less than ('CONFIG_EMCUTE_BUFSIZE' - 6).
+
+config EMCUTE_KEEPALIVE
+    int "Keep alive interval in seconds"
+    range 300 $(UINT32_MAX)
+    default 360
+    help
+        Configure keep alive interval in seconds. The node will communicate this
+        interval to the gateway send a ping message every time when this amount
+        of time has passed. For more information, see MQTT-SN Spec v1.2, section
+        5.4.4. For default values, see section 7.2 -> TWAIT: > 5 min. Default
+        value is 360 seconds which corresponds to 6 minutes.
+
+config EMCUTE_T_RETRY
+    int "Retry timer in seconds"
+    range 10 15
+    default 15
+    help
+        Configure re-send interval used for timing the retry messages which are
+        sent when the expected reply from GW is not received. The retry timer is
+        started by the client when the message is sent and stopped when the
+        expected reply from GW is received. If the timer times out and the
+        expected GW’s reply is not received, the client retransmits the message.
+        For more information, see MQTT-SN Spec v1.2, section 6.13. For default
+        values, see section 7.2 -> Tretry: 10 to 15 sec.
+
+config EMCUTE_N_RETRY
+    int "Maximum number of retransmissions"
+    range 3 5
+    default 3
+    help
+        Configure 'CONFIG_EMCUTE_N_RETRY',the maximum number of retransmissions
+        in the event that the retry timer times out. After
+        'CONFIG_EMCUTE_N_RETRY' number of retransmissions, the client aborts the
+        procedure and assumes that its MQTT-SN connection to the gateway is
+        disconnected. For more information, see MQTT-SN Spec v1.2, section 6.13.
+        For default values, see section 7.2 -> Nretry: 3-5.
+
+endif # KCONFIG_USEMODULE_EMCUTE

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -44,7 +44,6 @@
 #define TFLAGS_TIMEOUT      (0x0002)
 #define TFLAGS_ANY          (TFLAGS_RESP | TFLAGS_TIMEOUT)
 
-
 static const char *cli_id;
 static sock_udp_t sock;
 static sock_udp_ep_t gateway;

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -247,7 +247,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
     /* configure 'state machine' and send the connection request */
     if (will_topic) {
         size_t topic_len = strlen(will_topic);
-        if ((topic_len > EMCUTE_TOPIC_MAXLEN) ||
+        if ((topic_len > CONFIG_EMCUTE_TOPIC_MAXLEN) ||
             ((will_msg_len + 4) > CONFIG_EMCUTE_BUFSIZE)) {
             gateway.port = 0;
             return EMCUTE_OVERFLOW;
@@ -307,7 +307,7 @@ int emcute_reg(emcute_topic_t *topic)
     if (gateway.port == 0) {
         return EMCUTE_NOGW;
     }
-    if (strlen(topic->name) > EMCUTE_TOPIC_MAXLEN) {
+    if (strlen(topic->name) > CONFIG_EMCUTE_TOPIC_MAXLEN) {
         return EMCUTE_OVERFLOW;
     }
 
@@ -375,7 +375,7 @@ int emcute_sub(emcute_sub_t *sub, unsigned flags)
     if (gateway.port == 0) {
         return EMCUTE_NOGW;
     }
-    if (strlen(sub->topic.name) > EMCUTE_TOPIC_MAXLEN) {
+    if (strlen(sub->topic.name) > CONFIG_EMCUTE_TOPIC_MAXLEN) {
         return EMCUTE_OVERFLOW;
     }
 
@@ -451,7 +451,7 @@ int emcute_willupd_topic(const char *topic, unsigned flags)
     if (gateway.port == 0) {
         return EMCUTE_NOGW;
     }
-    if (topic && (strlen(topic) > EMCUTE_TOPIC_MAXLEN)) {
+    if (topic && (strlen(topic) > CONFIG_EMCUTE_TOPIC_MAXLEN)) {
         return EMCUTE_OVERFLOW;
     }
 

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -103,7 +103,7 @@ static int syncsend(uint8_t resp, size_t len, bool unlock)
      * remove was called */
     thread_flags_clear(TFLAGS_ANY);
 
-    for (unsigned retries = 0; retries <= EMCUTE_N_RETRY; retries++) {
+    for (unsigned retries = 0; retries <= CONFIG_EMCUTE_N_RETRY; retries++) {
         DEBUG("[emcute] syncsend: sending round %i\n", retries);
         sock_udp_send(&sock, tbuf, len, &gateway);
 

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -49,8 +49,8 @@ static const char *cli_id;
 static sock_udp_t sock;
 static sock_udp_ep_t gateway;
 
-static uint8_t rbuf[EMCUTE_BUFSIZE];
-static uint8_t tbuf[EMCUTE_BUFSIZE];
+static uint8_t rbuf[CONFIG_EMCUTE_BUFSIZE];
+static uint8_t tbuf[CONFIG_EMCUTE_BUFSIZE];
 
 static emcute_sub_t *subs = NULL;
 
@@ -248,7 +248,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
     if (will_topic) {
         size_t topic_len = strlen(will_topic);
         if ((topic_len > EMCUTE_TOPIC_MAXLEN) ||
-            ((will_msg_len + 4) > EMCUTE_BUFSIZE)) {
+            ((will_msg_len + 4) > CONFIG_EMCUTE_BUFSIZE)) {
             gateway.port = 0;
             return EMCUTE_OVERFLOW;
         }
@@ -338,7 +338,7 @@ int emcute_pub(emcute_topic_t *topic, const void *data, size_t len,
     if (gateway.port == 0) {
         return EMCUTE_NOGW;
     }
-    if (len >= (EMCUTE_BUFSIZE - 9)) {
+    if (len >= (CONFIG_EMCUTE_BUFSIZE - 9)) {
         return EMCUTE_OVERFLOW;
     }
     if (flags & EMCUTE_QOS_2) {
@@ -477,7 +477,7 @@ int emcute_willupd_msg(const void *data, size_t len)
     if (gateway.port == 0) {
         return EMCUTE_NOGW;
     }
-    if (len > (EMCUTE_BUFSIZE - 4)) {
+    if (len > (CONFIG_EMCUTE_BUFSIZE - 4)) {
         return EMCUTE_OVERFLOW;
     }
 

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -107,7 +107,7 @@ static int syncsend(uint8_t resp, size_t len, bool unlock)
         DEBUG("[emcute] syncsend: sending round %i\n", retries);
         sock_udp_send(&sock, tbuf, len, &gateway);
 
-        xtimer_set(&timer, (EMCUTE_T_RETRY * US_PER_SEC));
+        xtimer_set(&timer, (CONFIG_EMCUTE_T_RETRY * US_PER_SEC));
         thread_flags_t flags = thread_flags_wait_any(TFLAGS_ANY);
         if (flags & TFLAGS_RESP) {
             DEBUG("[emcute] syncsend: got response [%i]\n", result);

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -241,7 +241,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
     tbuf[1] = CONNECT;
     tbuf[2] = flags;
     tbuf[3] = PROTOCOL_VERSION;
-    byteorder_htobebufs(&tbuf[4], EMCUTE_KEEPALIVE);
+    byteorder_htobebufs(&tbuf[4], CONFIG_EMCUTE_KEEPALIVE);
     memcpy(&tbuf[6], cli_id, strlen(cli_id));
 
     /* configure 'state machine' and send the connection request */
@@ -509,7 +509,7 @@ void emcute_run(uint16_t port, const char *id)
     }
 
     uint32_t start = xtimer_now_usec();
-    uint32_t t_out = (EMCUTE_KEEPALIVE * US_PER_SEC);
+    uint32_t t_out = (CONFIG_EMCUTE_KEEPALIVE * US_PER_SEC);
 
     while (1) {
         ssize_t len = sock_udp_recv(&sock, rbuf, sizeof(rbuf), t_out, &remote);
@@ -556,13 +556,13 @@ void emcute_run(uint16_t port, const char *id)
         }
 
         uint32_t now = xtimer_now_usec();
-        if ((now - start) >= (EMCUTE_KEEPALIVE * US_PER_SEC)) {
+        if ((now - start) >= (CONFIG_EMCUTE_KEEPALIVE * US_PER_SEC)) {
             send_ping();
             start = now;
-            t_out = (EMCUTE_KEEPALIVE * US_PER_SEC);
+            t_out = (CONFIG_EMCUTE_KEEPALIVE * US_PER_SEC);
         }
         else {
-            t_out = (EMCUTE_KEEPALIVE * US_PER_SEC) - (now - start);
+            t_out = (CONFIG_EMCUTE_KEEPALIVE * US_PER_SEC) - (now - start);
         }
     }
 }

--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -25,7 +25,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += sock_util
 
-CFLAGS += -DEMCUTE_TOPIC_MAXLEN="249"   # 256 - 7
+CFLAGS += -DCONFIG_EMCUTE_TOPIC_MAXLEN="249"   # 256 - 7
 CFLAGS += -DSTDIO_UART_RX_BUFSIZE="512" # Adapt to SHELL_BUFSIZE in app
 
 # The test requires some setup and to be run as root

--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -25,7 +25,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += sock_util
 
-CFLAGS += -DCONFIG_EMCUTE_TOPIC_MAXLEN="249"   # 256 - 7
 CFLAGS += -DSTDIO_UART_RX_BUFSIZE="512" # Adapt to SHELL_BUFSIZE in app
 
 # The test requires some setup and to be run as root
@@ -38,3 +37,8 @@ ethos:
 	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include
+
+# Set CONFIG_EMCUTE_TOPIC_MAXLEN via CFLAGS if not being set via Kconfig.
+ifndef CONFIG_EMCUTE_TOPIC_MAXLEN
+  CFLAGS += -DCONFIG_EMCUTE_TOPIC_MAXLEN=249   # 256 - 7
+endif

--- a/tests/emcute/main.c
+++ b/tests/emcute/main.c
@@ -39,7 +39,7 @@
 
 static char _emcute_stack[THREAD_STACKSIZE_DEFAULT];
 static char _shell_buffer[SHELL_BUFSIZE];
-static uint8_t _pub_buf[EMCUTE_BUFSIZE];
+static uint8_t _pub_buf[CONFIG_EMCUTE_BUFSIZE];
 
 static emcute_topic_t _topics[NUMOFTOPS];
 static emcute_sub_t _subscriptions[NUMOFTOPS];

--- a/tests/emcute/main.c
+++ b/tests/emcute/main.c
@@ -43,7 +43,7 @@ static uint8_t _pub_buf[CONFIG_EMCUTE_BUFSIZE];
 
 static emcute_topic_t _topics[NUMOFTOPS];
 static emcute_sub_t _subscriptions[NUMOFTOPS];
-static char _topic_names[NUMOFTOPS][EMCUTE_TOPIC_MAXLEN + 1];
+static char _topic_names[NUMOFTOPS][CONFIG_EMCUTE_TOPIC_MAXLEN + 1];
 static char _addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 static sock_udp_ep_t _gw = { .family = AF_INET6 };
@@ -155,7 +155,7 @@ static int _topic_name_find(const char *name)
         if ((_topic_names[i][0] == '\0') && (res < 0)) {
             res = i;
         }
-        else if (strncmp(name, _topic_names[i], EMCUTE_TOPIC_MAXLEN) == 0) {
+        else if (strncmp(name, _topic_names[i], CONFIG_EMCUTE_TOPIC_MAXLEN) == 0) {
             return i;
         }
     }
@@ -183,7 +183,7 @@ static int _reg(int argc, char **argv)
         was_set = true;
     }
     else {
-        strncpy(_topic_names[idx], argv[1], EMCUTE_TOPIC_MAXLEN);
+        strncpy(_topic_names[idx], argv[1], CONFIG_EMCUTE_TOPIC_MAXLEN);
     }
     t = &_topics[idx];
     t->name = _topic_names[idx];
@@ -251,7 +251,7 @@ static int _sub(int argc, char **argv)
         return 1;
     }
 
-    if (strlen(argv[1]) > EMCUTE_TOPIC_MAXLEN) {
+    if (strlen(argv[1]) > CONFIG_EMCUTE_TOPIC_MAXLEN) {
         puts("error: topic name exceeds maximum possible size");
         return 1;
     }
@@ -269,7 +269,7 @@ static int _sub(int argc, char **argv)
         was_set = true;
     }
     else {
-        strncpy(_topic_names[idx], argv[1], EMCUTE_TOPIC_MAXLEN);
+        strncpy(_topic_names[idx], argv[1], CONFIG_EMCUTE_TOPIC_MAXLEN);
     }
     _subscriptions[idx].topic.name = _topic_names[idx];
     if (emcute_sub(&_subscriptions[idx], flags) != EMCUTE_OK) {

--- a/tests/emcute/main.c
+++ b/tests/emcute/main.c
@@ -72,7 +72,7 @@ static const shell_command_t _shell_commands[] = {
 static void *_emcute_thread(void *arg)
 {
     (void)arg;
-    emcute_run(MQTTSN_DEFAULT_PORT, EMCUTE_ID);
+    emcute_run(CONFIG_EMCUTE_DEFAULT_PORT, EMCUTE_ID);
     return NULL;    /* should never be reached */
 }
 
@@ -111,7 +111,7 @@ static int _con(int argc, char **argv)
         return 1;
     }
     if (_gw.port == 0) {
-        _gw.port = MQTTSN_DEFAULT_PORT;
+        _gw.port = CONFIG_EMCUTE_DEFAULT_PORT;
     }
     if (argc >= 4) {
         topic = argv[2];


### PR DESCRIPTION
### Contribution description - 

This PR exposes compile configurations in **net/emcute**  and adds additional configuration to **net/asymcute** .

PR removes macro  `MQTTSN_DEFAULT_PORT` since it's no longer required.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/net_emcute

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/76236bcb36952630dd3e3f4a8aaee5576d2058d5)

      Compiled binaries for native and tested on native

3. examples/emcute_mqttsn -> Build Successful
4. examples/asymcute_mqttsn - > Build successful

#### Default State:

##### Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-199-gff86f-Kconfig_EMCute_1)
CONFIG_EMCUTE_DEFAULT_PORT=(1883U)
CONFIG_EMCUTE_BUFSIZE_EXP=(9U)
EMCUTE_BUFSIZE=(1 << (9U))
CONFIG_EMCUTE_TOPIC_MAXLEN=(196U)
CONFIG_EMCUTE_KEEPALIVE=(360)
CONFIG_EMCUTE_T_RETRY=(15U)
CONFIG_EMCUTE_N_RETRY=(3U)
```

#### Usage with CFLAGS :

```
CFLAGS += -DCONFIG_EMCUTE_DEFAULT_PORT=1990
CFLAGS += -DCONFIG_EMCUTE_BUFSIZE_EXP=8
CFLAGS += -DCONFIG_EMCUTE_TOPIC_MAXLEN=200
CFLAGS += -DCONFIG_EMCUTE_KEEPALIVE=300
CFLAGS += -DCONFIG_EMCUTE_T_RETRY=10
CFLAGS += -DCONFIG_EMCUTE_N_RETRY=4
```

##### Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-199-gff86f-Kconfig_EMCute_1)
CONFIG_EMCUTE_DEFAULT_PORT=1990
CONFIG_EMCUTE_BUFSIZE_EXP=8
EMCUTE_BUFSIZE=(1 << 8)
CONFIG_EMCUTE_TOPIC_MAXLEN=200
CONFIG_EMCUTE_KEEPALIVE=300
CONFIG_EMCUTE_T_RETRY=10
CONFIG_EMCUTE_N_RETRY=4
```

#### Usage with menuconfig :

`make menuconfig`

##### Default Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-199-gff86f-Kconfig_EMCute_1)
CONFIG_EMCUTE_DEFAULT_PORT=1883
CONFIG_EMCUTE_BUFSIZE_EXP=9
EMCUTE_BUFSIZE=(1 << 9)
CONFIG_EMCUTE_TOPIC_MAXLEN=196
CONFIG_EMCUTE_KEEPALIVE=360
CONFIG_EMCUTE_T_RETRY=15
CONFIG_EMCUTE_N_RETRY=3
```
##### Configured Firmware Output
```

main(): This is RIOT! (Version: 2021.01-devel-199-gff86f-Kconfig_EMCute_1)
CONFIG_EMCUTE_DEFAULT_PORT=1881
CONFIG_EMCUTE_BUFSIZE_EXP=8
EMCUTE_BUFSIZE=(1 << 8)
CONFIG_EMCUTE_TOPIC_MAXLEN=155
CONFIG_EMCUTE_KEEPALIVE=320
CONFIG_EMCUTE_T_RETRY=11
CONFIG_EMCUTE_N_RETRY=5
```
**MACROS were successfully configured.**

### Issues/PRs references

#14472  Discussion on the usage on Emcute and Asymcute. Concluded that both may be required to be used simultaneously.
#14444
