### PR TITLE
pkg/tinycrypt: Fix dependencies [backport 2020.10]

### DIFF
--- a/pkg/tinycrypt/Makefile.dep
+++ b/pkg/tinycrypt/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += arch_32bit

--- a/tests/pkg_tinycrypt/Makefile
+++ b/tests/pkg_tinycrypt/Makefile
@@ -1,9 +1,5 @@
 include ../Makefile.tests_common
 
-# tinycrypt works for 32-bit architectures only. The nrf52dk is chosen as a
-# placeholder for all Cortex-M4 boards.
-BOARD_WHITELIST += native nrf52dk
-
 USEPKG += tinycrypt
 USEMODULE = fmt
 


### PR DESCRIPTION
# Backport of #15242

### Contribution description

`tinycrypt` according to the test application only runs on 32 bit archs. Rather than using a whitelist in the test as ugly hack, simply model the requirements using `FEATURES_REQUIRED += arch_32bit` in the package.

### Testing procedure

`make -C tests/pkg_tinycrypt info-boards-supported` should only yield 32 bit architectures.

### Issues/PRs references

Stumbled upon while reviewing https://github.com/RIOT-OS/RIOT/pull/15241