### PR TITLE
examples: add I2C scanner

### DIFF
--- a/sys/shell/commands/Kconfig
+++ b/sys/shell/commands/Kconfig
@@ -5,6 +5,11 @@
 # directory for more details.
 #
 
-config MODULE_SHELL_COMMANDS
+menuconfig MODULE_SHELL_COMMANDS
     bool "Basic shell commands"
     depends on MODULE_SHELL
+
+config MODULE_I2C_SCAN
+    bool "I2c scanner"
+    depends on MODULE_SHELL
+    depends on MODULE_PERIPH_I2C

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -5,6 +5,8 @@ FEATURES_REQUIRED = periph_i2c
 FEATURES_OPTIONAL = periph_i2c_reconfigure
 
 USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += i2c_scan
 USEMODULE += xtimer
 
 # avoid running Kconfig by default

--- a/tests/periph_i2c/Makefile.ci
+++ b/tests/periph_i2c/Makefile.ci
@@ -5,4 +5,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     nucleo-l011k4 \
+    samd10-xmini \
     #

--- a/tests/periph_i2c/app.config.test
+++ b/tests/periph_i2c/app.config.test
@@ -1,5 +1,7 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
+CONFIG_MODULE_I2C_SCAN=y
 CONFIG_MODULE_PERIPH_I2C=y
 CONFIG_MODULE_SHELL=y
+CONFIG_MODULE_SHELL_COMMANDS=y
 CONFIG_MODULE_XTIMER=y


### PR DESCRIPTION
### Contribution description
This PR adds a small little tool to scan a given I2C bus for all connected devices and simply list them to STDIO. This is quite useful when trying to find out I2C the active address of freely configurable slaves or some strange modules with unknown documentation.

Not sure if we have something like this in the code base already, at least I could not find anything...

### Testing procedure
Simply run this example on any board that has 1 or more I2C devices connected to it. You should see the addresses of all connected devices listed to STDIO.

### Issues/PRs references
none