### PR TITLE
tools/codespell: fix new typos and make it fail when typos are found

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -56,8 +56,8 @@ if [ -n "${ERRORS}" ]
 then
     printf "%sThere are typos in the following files:%s\n\n" "${CERROR}" "${CRESET}"
     printf "%s\n" "${ERRORS}"
-    # TODO: return 1 when all typos are fixed
-    exit 0
+    printf "If those are false positives, add them to %s\n" "${RIOTTOOLS}/codespell/ignored_words.txt"
+    exit 1
 else
     exit 0
 fi

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -101,3 +101,6 @@ files'
 
 # dedup (used in a GNRC header file name) => dedupe
 dedup
+
+# circularly (used in "circularly linked list" in clist.h) => circular
+circularly

--- a/drivers/include/mii.h
+++ b/drivers/include/mii.h
@@ -64,7 +64,7 @@ extern "C" {
 #define MII_BMCR_POWER_DOWN BIT11   /**< Set to power down PHY */
 #define MII_BMCR_ISOLATE    BIT10   /**< Set to electrically isolate PHY from
                                          MII (PHY becomes inoperational) */
-#define MII_BMCR_AN_RESTART BIT9    /**< Set to restart auto-negotation */
+#define MII_BMCR_AN_RESTART BIT9    /**< Set to restart auto-negotiation */
 #define MII_BMCR_FULL_DPLX  BIT8    /**< Set for full duplex */
 #define MII_BMCR_HALF_DPLX  (0)     /**< Set for half duplex */
 #define MII_BMCR_COLL_TEST  BIT7    /**< Set to enable collision signal test */

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -311,7 +311,7 @@ void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len,
  * @param[in] dev_addr the Device Address
  * @param[in] fcnt frame counter
  * @param[in] dir direction of the packet (0 is uplink, 1 is downlink)
- * @param[in] frame pointer to the PSDU frame (witout MIC)
+ * @param[in] frame pointer to the PSDU frame (without MIC)
  * @param[in] nwkskey pointer to the Network Session Key
  * @param[out] out calculated MIC
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

New typos were again introduced by #14065 (witout => without) and #15200 (auto-negotation => auto-negotiation), so not so long after #15138 was merged.

This PR is fixing the newly introduced typos and is also adding _circular_ to the list of ignored words (it's detected as a typo locally but according to wikipedia, it seems valid in this context).

The last commit is enforcing the CI to fail if typos are found. I can removed if needed but I think that would enforce most of the typos to be detected immediately.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `./dist/tools/codespell/check.sh`

- this PR:

```
$ ./dist/tools/codespell/check.sh
```

- on master:

```
$ ./dist/tools/codespell/check.sh
There are typos in the following files:

core/include/clist.h:18: circularly ==> circular
drivers/include/mii.h:67: auto-negotation ==> auto-negotiation
sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h:314: witout ==> without
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes typos introduced in #14065 and #15200

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
