### PR TITLE
sys/tsrb: Make thread-safe [backport 2020.10]

### DIFF
--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include "irq.h"
 #include "tsrb.h"
 
 static void _push(tsrb_t *rb, uint8_t c)
@@ -31,51 +32,59 @@ static uint8_t _pop(tsrb_t *rb)
 
 int tsrb_get_one(tsrb_t *rb)
 {
+    int retval = -1;
+    unsigned irq_state = irq_disable();
     if (!tsrb_empty(rb)) {
-        return _pop(rb);
+        retval = _pop(rb);
     }
-    else {
-        return -1;
-    }
+    irq_restore(irq_state);
+    return retval;
 }
 
 int tsrb_get(tsrb_t *rb, uint8_t *dst, size_t n)
 {
     size_t tmp = n;
+    unsigned irq_state = irq_disable();
     while (tmp && !tsrb_empty(rb)) {
         *dst++ = _pop(rb);
         tmp--;
     }
+    irq_restore(irq_state);
     return (n - tmp);
 }
 
 int tsrb_drop(tsrb_t *rb, size_t n)
 {
     size_t tmp = n;
+    unsigned irq_state = irq_disable();
     while (tmp && !tsrb_empty(rb)) {
         _pop(rb);
         tmp--;
     }
+    irq_restore(irq_state);
     return (n - tmp);
 }
 
 int tsrb_add_one(tsrb_t *rb, uint8_t c)
 {
+    int retval = -1;
+    unsigned irq_state = irq_disable();
     if (!tsrb_full(rb)) {
         _push(rb, c);
-        return 0;
+        retval = 0;
     }
-    else {
-        return -1;
-    }
+    irq_restore(irq_state);
+    return retval;
 }
 
 int tsrb_add(tsrb_t *rb, const uint8_t *src, size_t n)
 {
     size_t tmp = n;
+    unsigned irq_state = irq_disable();
     while (tmp && !tsrb_full(rb)) {
         _push(rb, *src++);
         tmp--;
     }
+    irq_restore(irq_state);
     return (n - tmp);
 }


### PR DESCRIPTION
# Backport of #15218

### Contribution description

Drop the requirement of having only one writer and one reader, as the name of the ring-buffer does not indicate any limitation on the thread-safety. The two-threads-one-buffer kind of ring buffer can be reintroduced with a different name.

### Testing procedure

On e.g. STM32 or SAM0 boards, have two threads continuously produce stdio output. The thread with higher priority should sleep for random intervals.

Expected output:
- The higher priority threads interrupts the lower priority thread and stdio output gets mixed up. But no characters are lost or printed more than once

Actual output:
- Occasionally, chars get lost or printed more than once

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/9882

Split out of https://github.com/RIOT-OS/RIOT/pull/15103