### PR TITLE
cpu/stm32: simplify stmclk_disable_hsi function

### DIFF
--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -64,13 +64,7 @@ void stmclk_enable_hsi(void)
 
 void stmclk_disable_hsi(void)
 {
-    /* we only disable the HSI clock if not used as input for the PLL and if
-     * not used directly as system clock */
-    if (CLOCK_HSE) {
-        if ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_HSI) {
-            RCC->CR &= ~(RCC_CR_HSION);
-        }
-    }
+    RCC->CR &= ~RCC_CR_HSION;
 }
 
 void stmclk_enable_lfclk(void)

--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -49,9 +49,6 @@
 #define RCC_CSR_LSIRDY          RCC_CSR_LSI1RDY
 #endif
 
-#ifndef CLOCK_HSE
-#define CLOCK_HSE   (0U)
-#endif
 #ifndef CLOCK_LSE
 #define CLOCK_LSE   (0U)
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There is no need to check for CLOCK_HSE or to check if HSI is used as SYSCLK, this is already checked at compile time in the clock initialization code of each STM32 families:

https://github.com/RIOT-OS/RIOT/blob/94fec19f8d762d87a6661dfc115b626e5e66754b/cpu/stm32/stmclk/stmclk_f0f1f3.c#L120-L130

https://github.com/RIOT-OS/RIOT/blob/94fec19f8d762d87a6661dfc115b626e5e66754b/cpu/stm32/stmclk/stmclk_f0f1f3.c#L197-L200

This PR is saving 16 bytes on nucleo-l412kb.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check that boards of each affected family groups (f0f1f3, f2f4f7, l0l1, l4wb, g0g4) are still working and preferably boards for which the PLL is clocked by HSI. I would suggest: nucleo-f042k6, nucleo-l073rz, nucleo-l433rc, nucleo-g070rb. I couldn't find any f2f4f7 board not providing HSE.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick an item in #14975 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
