### PR TITLE
cpu/native: fix memory leak

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -277,8 +277,10 @@ char *make_message(const char *format, va_list argp)
 
     while (1) {
         int n = vsnprintf(message, size, format, argp);
-        if (n < 0)
+        if (n < 0) {
+            free(message);
             return NULL;
+        }
         if (n < size)
             return message;
         size = n + 1;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In make_message API in syscall.c, memory should be freed before returning

Signed-off-by: avinash <avitahakiknash@gmail.com>


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #15016
