### PR TITLE
dist/jlink: disable gui and textual improvements

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -155,12 +155,30 @@ test_term() {
     fi
 }
 
+test_version() {
+    JLINK_MINIMUM_VERSION="6.74"
+    JLINK_VERSION=$(echo q | "$JLINK" 2> /dev/null | grep "^DLL version*" | grep -oP "\d+\.\d+")
+
+    if [ $? -ne 0 ]; then
+        echo "Error: J-Link appears not to be installed on your PATH"
+        exit 1
+    fi
+
+    "$RIOTTOOLS"/has_minimal_version/has_minimal_version.sh "$JLINK_VERSION" "$JLINK_MINIMUM_VERSION" 2> /dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "Error: J-Link V$JLINK_MINIMUM_VERSION is required, but V${JLINK_VERSION} is installed"
+        exit 1
+    fi
+}
+
 #
 # now comes the actual actions
 #
 do_flash() {
     BINFILE=$1
     test_config
+    test_version
     test_serial
     test_binfile
     # clear any existing contents in burn file
@@ -190,6 +208,7 @@ do_flash() {
 do_debug() {
     ELFFILE=$1
     test_config
+    test_version
     test_serial
     test_elffile
     test_ports
@@ -212,6 +231,7 @@ do_debug() {
 }
 
 do_debugserver() {
+    test_version
     test_ports
     test_config
     test_serial
@@ -227,6 +247,7 @@ do_debugserver() {
 
 do_reset() {
     test_config
+    test_version
     test_serial
     # reset the board
     sh -c "${JLINK} ${JLINK_SERIAL} \
@@ -241,6 +262,7 @@ do_reset() {
 
 do_term() {
     test_config
+    test_version
     test_serial
     test_term
 

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -5,6 +5,8 @@
 # This script is supposed to be called from RIOTs build system,
 # as it depends on certain environment variables.
 #
+# The minimum supported version of J-Link is V6.74.
+#
 # Global environment variables used:
 # JLINK:            J-Link Commander command name, default: "JLinkExe"
 # JLINK_SERVER:     J-Link GDB Server command name, default: "JLinkGDBServer"
@@ -176,6 +178,7 @@ do_flash() {
     cat ${JLINK_RESET_FILE} >> ${BINDIR}/burn.seg
     # flash device
     sh -c "${JLINK} ${JLINK_SERIAL} \
+                    -nogui 1 \
                     -exitonerror 1 \
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
@@ -194,6 +197,7 @@ do_debug() {
     test_dbg
     # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
+                           -nogui \
                            -device '${JLINK_DEVICE}' \
                            -speed '${JLINK_SPEED}' \
                            -if '${JLINK_IF}' \
@@ -213,6 +217,7 @@ do_debugserver() {
     test_serial
     # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
+                           -nogui \
                            -device '${JLINK_DEVICE}' \
                            -speed '${JLINK_SPEED}' \
                            -if '${JLINK_IF}' \
@@ -225,6 +230,7 @@ do_reset() {
     test_serial
     # reset the board
     sh -c "${JLINK} ${JLINK_SERIAL} \
+                    -nogui 1 \
                     -exitonerror 1 \
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
@@ -254,6 +260,7 @@ do_term() {
 
     # start J-link as RTT server
     sh -c "${JLINK} ${JLINK_SERIAL} \
+            -nogui 1 \
             -exitonerror 1 \
             -device '${JLINK_DEVICE}' \
             -speed '${JLINK_SPEED}' \

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -1,21 +1,22 @@
 #!/bin/sh
 #
-# Unified Segger JLink script for RIOT
+# Unified Segger J-Link script for RIOT
 #
-# This script is supposed to be called from RIOTs make system,
-# as it depends on certain environment variables. An
+# This script is supposed to be called from RIOTs build system,
+# as it depends on certain environment variables.
 #
 # Global environment variables used:
-# JLINK:            JLink command name, default: "JLinkExe"
-# JLINK_SERVER:     JLink GCB server command name, default: "JLinkGDBDerver"
-# JLINK_DEVICE:     Device identifier used by JLink
-# JLINK_SERIAL:     Device serial used by JLink
-# JLINK_IF:         Interface used by JLink, default: "SWD"
+# JLINK:            J-Link Commander command name, default: "JLinkExe"
+# JLINK_SERVER:     J-Link GDB Server command name, default: "JLinkGDBServer"
+# JLINK_DEVICE:     Device identifier used by J-Link
+# JLINK_SERIAL:     Device serial used by J-Link
+# JLINK_IF:         Interface used by J-Link, default: "SWD"
 # JLINK_SPEED:      Interface clock speed to use (in kHz), default "2000"
 # FLASH_ADDR:       Starting address of the target's flash memory, default: "0"
-# IMAGE_OFFSET:     Offset from the targets flash memory, for flashing the image
-# JLINK_PRE_FLASH:  Additional JLink commands to execute before flashing
-# JLINK_POST_FLASH: Additional JLink commands to execute after flashing
+# IMAGE_OFFSET:     Offset from the targets flash memory, for flashing the
+#                   image
+# JLINK_PRE_FLASH:  Additional J-Link commands to execute before flashing
+# JLINK_POST_FLASH: Additional J-Link commands to execute after flashing
 #
 # The script supports the following actions:
 #
@@ -28,7 +29,7 @@
 #
 # debug:        debug <elffile>
 #
-#               starts JLink as GDB server in the background and
+#               starts J-Link as GDB server in the background and
 #               connects to the server with the GDB client specified by
 #               the board (DBG environment variable)
 #
@@ -39,7 +40,7 @@
 #               DBG:            debugger client command, default: 'gdb -q'
 #               TUI:            if TUI!=null, the -tui option will be used
 #
-# debug-server: starts JLink as GDB server, but does not connect to
+# debug-server: starts J-Link as GDB server, but does not connect to
 #               to it with any frontend. This might be useful when using
 #               IDEs.
 #
@@ -50,7 +51,7 @@
 # reset:        triggers a hardware reset of the target board
 #
 #
-# term-rtt:     opens a serial terminal using jlink RTT(reak time transfer)
+# term-rtt:     opens a serial terminal using J-Link RTT (Real-Time Transfer)
 #
 #
 # @author       Hauke Peteresen <hauke.petersen@fu-berlin.de>
@@ -64,7 +65,7 @@
 _GDB_PORT=3333
 # default telnet port
 _TELNET_PORT=4444
-# default JLink command, interface and speed
+# default J-Link command names, interface and speed
 _JLINK=JLinkExe
 _JLINK_SERVER=JLinkGDBServer
 _JLINK_IF=SWD
@@ -191,7 +192,7 @@ do_debug() {
     test_ports
     test_tui
     test_dbg
-    # start the JLink GDB server
+    # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
                            -device '${JLINK_DEVICE}' \
                            -speed '${JLINK_SPEED}' \
@@ -210,7 +211,7 @@ do_debugserver() {
     test_ports
     test_config
     test_serial
-    # start the JLink GDB server
+    # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
                            -device '${JLINK_DEVICE}' \
                            -speed '${JLINK_SPEED}' \
@@ -237,7 +238,7 @@ do_term() {
     test_serial
     test_term
 
-    # temporary file that save the JLink pid
+    # temporary file that save the J-Link Commander pid
     JLINK_PIDFILE=$(mktemp -t "jilnk_pid.XXXXXXXXXX")
     # will be called by trap
     cleanup() {
@@ -251,7 +252,7 @@ do_term() {
     # cleanup after script terminates
     trap "cleanup ${JLINK_PIDFILE}" EXIT INT
 
-    # start Jlink as RTT server
+    # start J-link as RTT server
     sh -c "${JLINK} ${JLINK_SERIAL} \
             -exitonerror 1 \
             -device '${JLINK_DEVICE}' \

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -133,7 +133,7 @@ test_tui() {
 test_serial() {
     if [ -n "${JLINK_SERIAL}" ]; then
         JLINK_SERIAL_SERVER="-select usb='${JLINK_SERIAL}'"
-        JLINK_SERIAL="-SelectEmuBySN '${JLINK_SERIAL}'"
+        JLINK_SERIAL="-selectemubysn '${JLINK_SERIAL}'"
     fi
 }
 
@@ -175,7 +175,7 @@ do_flash() {
     cat ${JLINK_RESET_FILE} >> ${BINDIR}/burn.seg
     # flash device
     sh -c "${JLINK} ${JLINK_SERIAL} \
-                    -ExitOnError 1 \
+                    -exitonerror 1 \
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
@@ -224,7 +224,7 @@ do_reset() {
     test_serial
     # reset the board
     sh -c "${JLINK} ${JLINK_SERIAL} \
-                    -ExitOnError 1 \
+                    -exitonerror 1 \
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
@@ -253,7 +253,7 @@ do_term() {
 
     # start Jlink as RTT server
     sh -c "${JLINK} ${JLINK_SERIAL} \
-            -ExitOnError 1 \
+            -exitonerror 1 \
             -device '${JLINK_DEVICE}' \
             -speed '${JLINK_SPEED}' \
             -if '${JLINK_IF}' \


### PR DESCRIPTION
### Contribution description
In later version of J-Link (since V6.74), a GUI is shown when flashing devices:

On macOS:

<img width="704" alt="segger" src="https://user-images.githubusercontent.com/815976/96719026-2a98f480-13a9-11eb-913f-4188cbcc0057.png">

On Ubuntu (headless):

```
SEGGER J-Link Commander V6.86e (Compiled Oct 16 2020 18:21:57)
DLL version V6.86e, compiled Oct 16 2020 18:21:45

Connecting to J-Link via USB.../opt/SEGGER/JLink_V686e/JLinkGUIServerExe: error while loading shared libraries: libSM.so.6: cannot open shared object file: No such file or directory
```

Since the GUI was introduced in [V7.74](https://wiki.segger.com/J-Link_Commander#-NoGui) (around June 2020), this PR also raises sets a minimal version of J-Link (there was none). I don't believe that this should be a blocker, since Segger J-Link is not part of OS-provided package managers, and is [easy to install](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) on many operating systems.

Note that the JLinkGDBServer has a different `-nogui` [option](https://wiki.segger.com/J-Link_GDB_Server#-nogui).

While fixing this issue, I noticed several other things I could improve as well. I therefore have this single PR to fix several textual issues as well.

### Testing procedure
Any device that uses J-Link for flashing should still work as-is. I've tested `flash`, `debug`, `debug-server` and `reset`. If the option is not supported (because of an older version), it will show in the terminal, for example:

```
SEGGER J-Link Commander V6.86e (Compiled Oct 16 2020 17:22:41)
DLL version V6.86e, compiled Oct 16 2020 17:22:25

Unknown command line option -unsupportedoption.
```

### Issues/PRs references
None