### PR TITLE
cpu/nrf52/radio: change internal state to idle after rx

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -497,6 +497,7 @@ void isr_radio(void)
                  * don't event think of sending an ACK frame :) */
                 if (cfg.promisc) {
                     DEBUG("[nrf802154] Promiscuous mode is enabled.\n");
+                    _state = STATE_IDLE;
                     dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
                 }
                 /* If the L2 filter passes, device if the frame is indicated
@@ -511,6 +512,7 @@ void isr_radio(void)
                     }
                     else {
                         DEBUG("[nrf802154] RX frame doesn't require ACK frame.\n");
+                        _state = STATE_IDLE;
                         dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
                     }
                 }
@@ -518,6 +520,7 @@ void isr_radio(void)
                  * indicate the frame reception */
                 else if (is_ack && !cfg.ack_filter) {
                     DEBUG("[nrf802154] Received ACK.\n");
+                    _state = STATE_IDLE;
                     dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
                 }
                 /* If all failed, simply drop the frame and continue listening


### PR DESCRIPTION
### Contribution description

In #15237 `RX` is enabled after `config_phy` if the current state was `RX`, but the state was never changed to `IDLE` after a valid frame reception, this PR adds that.

### Testing procedure

Use the HAL test `tests/ieee802154_hal`:
- Check that the radio is able to receive and send data
- Use the `config_phy` command to set a different channel. Check that it works as expected.
- Use the `netdev_ieee802154_submac` with this radio with any example (e.g `gnrc_networking`). Everything should work.

### Issues/PRs references

#15237