### PR TITLE
drivers/at86rf215: fix dependency resolution for single radio

### DIFF
--- a/drivers/at86rf215/Makefile.dep
+++ b/drivers/at86rf215/Makefile.dep
@@ -1,5 +1,13 @@
 DEFAULT_MODULE += auto_init_at86rf215
-DEFAULT_MODULE += at86rf215_subghz
+
+ifeq (,$(filter at86rf215m,$(USEMODULE)))
+  USEMODULE += at86rf215_subghz
+endif
+
+ifeq (,$(filter at86rf215_subghz at86rf215_24ghz,$(USEMODULE)))
+  DEFAULT_MODULE += at86rf215_subghz
+  DEFAULT_MODULE += at86rf215_24ghz
+endif
 
 DEFAULT_MODULE += netdev_ieee802154_multimode
 
@@ -10,10 +18,6 @@ DEFAULT_MODULE += netdev_ieee802154_mr_ofdm
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_spi
-
-ifeq (,$(filter at86rf215m,$(USEMODULE)))
-  DEFAULT_MODULE += at86rf215_24ghz
-endif
 
 USEMODULE += xtimer
 USEMODULE += netif


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Let the user chose `at86rf215_subghz`/`at86rf215_24ghz` if they only want a single radio.


### Testing procedure

If you have an `openmote-b` you can now use both the `cc2538_rf` radio (for 2.4 GHz) and `at86rf215` (for sub-GHz) if you add
`USEMODULE += cc2538_rf at86rf215_subghz` to your `Makefile`.

You will also need this patch

```patch
diff --git a/cpu/cc2538/radio/cc2538_rf.c b/cpu/cc2538/radio/cc2538_rf.c
index e72dd782af..11d77fe4e6 100644
--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -114,9 +114,9 @@ void cc2538_init(void)
     CCTEST_OBSSEL7 = OBSSEL_EN | rfc_obs_sig2; /* PC7 = GREEN_LED      */
 #else
     /* Assume BOARD_CC2538DK (or similar). */
-    CCTEST_OBSSEL0 = OBSSEL_EN | rfc_obs_sig0; /* PC0 = LED_1 (red)    */
-    CCTEST_OBSSEL1 = OBSSEL_EN | rfc_obs_sig1; /* PC1 = LED_2 (yellow) */
-    CCTEST_OBSSEL2 = OBSSEL_EN | rfc_obs_sig2; /* PC2 = LED_3 (green)  */
+//    CCTEST_OBSSEL0 = OBSSEL_EN | rfc_obs_sig0; /* PC0 = LED_1 (red)    */
+//    CCTEST_OBSSEL1 = OBSSEL_EN | rfc_obs_sig1; /* PC1 = LED_2 (yellow) */
+//    CCTEST_OBSSEL2 = OBSSEL_EN | rfc_obs_sig2; /* PC2 = LED_3 (green)  */
     CCTEST_OBSSEL3 = 0;                        /* PC3 = LED_4 (red)    */
     CCTEST_OBSSEL4 = 0;                        /* PC4 = BTN_L          */
     CCTEST_OBSSEL5 = 0;                        /* PC5 = BTN_R          */
```

so the blinken-LED output is not wrongly stealing the SPI pins.

### Issues/PRs references

#15144 fixes the pin issue on `openmote-b`
