### PR TITLE
treewide: cleanup assert.h includes

### DIFF
--- a/cpu/atmega_common/periph/adc.c
+++ b/cpu/atmega_common/periph/adc.c
@@ -22,7 +22,6 @@
 
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/adc.h"
 #include "periph_conf.h"
 

--- a/cpu/atmega_common/periph/rtt.c
+++ b/cpu/atmega_common/periph/rtt.c
@@ -42,6 +42,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <avr/interrupt.h>
 
 #include "byteorder.h"

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <avr/interrupt.h>
 
 #include "board.h"

--- a/cpu/atmega_common/periph/wdt.c
+++ b/cpu/atmega_common/periph/wdt.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph/pm.h"
 #include "periph/wdt.h"

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -17,7 +17,6 @@
  * @}
  */
 
-#include <assert.h>
 #include "stdio_base.h"
 
 #include "cpu.h"

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -21,6 +21,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "cpu.h"

--- a/cpu/cc2538/periph/rtt.c
+++ b/cpu/cc2538/periph/rtt.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "cpu.h"

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stddef.h>
 
 #include "board.h"

--- a/cpu/cc2538/periph/wdt.c
+++ b/cpu/cc2538/periph/wdt.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cc2538.h"
 #include "periph/wdt.h"
 

--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 

--- a/cpu/cc26x2_cc13x2/osc.c
+++ b/cpu/cc26x2_cc13x2/osc.c
@@ -17,7 +17,6 @@
  * @}
  */
 
-#include <assert.h>
 #include "cpu.h"
 
 static inline bool _hf_source_ready(void)

--- a/cpu/cc26xx_cc13xx/periph/uart.c
+++ b/cpu/cc26xx_cc13xx/periph/uart.c
@@ -22,6 +22,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph/uart.h"
 #include "periph_conf.h"

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
 

--- a/cpu/efm32/periph/pwm.c
+++ b/cpu/efm32/periph/pwm.c
@@ -17,6 +17,8 @@
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 
 #include "periph_conf.h"

--- a/cpu/efm32/periph/spi.c
+++ b/cpu/efm32/periph/spi.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "sched.h"
 #include "thread.h"

--- a/cpu/esp32/periph/can.c
+++ b/cpu/esp32/periph/can.c
@@ -15,6 +15,7 @@
  * @{
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -21,6 +21,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <stdbool.h>
 
 #include "log.h"

--- a/cpu/esp8266/periph/pwm.c
+++ b/cpu/esp8266/periph/pwm.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -21,7 +21,6 @@
 #include "tools.h"
 
 #include <string.h>
-#include <assert.h>
 #include <errno.h>
 
 #include "net/gnrc.h"

--- a/cpu/esp_common/freertos/queue.c
+++ b/cpu/esp_common/freertos/queue.c
@@ -13,6 +13,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <string.h>
 
 #include "esp_common.h"

--- a/cpu/esp_common/freertos/semphr.c
+++ b/cpu/esp_common/freertos/semphr.c
@@ -13,6 +13,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <string.h>
 
 #include "esp_common.h"

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -13,6 +13,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <string.h>
 
 #include "esp_common.h"

--- a/cpu/esp_common/freertos/timers.c
+++ b/cpu/esp_common/freertos/timers.c
@@ -13,6 +13,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#include <assert.h>
 #include <string.h>
 
 #include "esp_common.h"

--- a/cpu/esp_common/periph/flash.c
+++ b/cpu/esp_common/periph/flash.c
@@ -20,6 +20,7 @@
 
 #if MODULE_MTD
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>

--- a/cpu/esp_common/periph/spi.c
+++ b/cpu/esp_common/periph/spi.c
@@ -19,12 +19,13 @@
  * @}
  */
 
+#include <assert.h>
+#include <string.h>
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 #include "esp_common.h"
 #include "log.h"
-
-#include <string.h>
 
 #include "cpu.h"
 #include "mutex.h"

--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 

--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdio_ext.h>
 #include <sys/unistd.h>

--- a/cpu/fe310/context_frame.c
+++ b/cpu/fe310/context_frame.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "context_frame.h"
 #include "thread.h"
 

--- a/cpu/fe310/include/context_frame.h
+++ b/cpu/fe310/include/context_frame.h
@@ -21,7 +21,6 @@
 
 #if !defined(__ASSEMBLER__)
 #include <stdint.h>
-#include <assert.h>
 #endif /* __ASSEMBLER__ */
 
 

--- a/cpu/fe310/irq_arch.c
+++ b/cpu/fe310/irq_arch.c
@@ -18,7 +18,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 #include <inttypes.h>
 
 #include "macros/xtstr.h"

--- a/cpu/fe310/periph/plic.c
+++ b/cpu/fe310/periph/plic.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "vendor/encoding.h"
 #include "vendor/platform.h"
 #include "cpu.h"

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -24,6 +24,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "bit.h"
 #include "periph_conf.h"

--- a/cpu/lm4f120/periph/spi.c
+++ b/cpu/lm4f120/periph/spi.c
@@ -17,6 +17,9 @@
  *
  * @}
  */
+
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/gpio.h"

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph/gpio.h"
 

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "cpu.h"

--- a/cpu/lpc23xx/mci/lpc23xx-mci.c
+++ b/cpu/lpc23xx/mci/lpc23xx-mci.c
@@ -12,6 +12,7 @@
 /
 /---------------------------------------------------------------------------*/
 
+#include <assert.h>
 #include <string.h>
 #include "cpu.h"
 #include "VIC.h"

--- a/cpu/lpc23xx/periph/gpio.c
+++ b/cpu/lpc23xx/periph/gpio.c
@@ -19,7 +19,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/cpu/mips32r2_common/thread_arch.c
+++ b/cpu/mips32r2_common/thread_arch.c
@@ -6,6 +6,8 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+#include <assert.h>
 #include <mips/cpu.h>
 #include <mips/hal.h>
 #include <unistd.h>

--- a/cpu/mips_pic32_common/periph/timer.c
+++ b/cpu/mips_pic32_common/periph/timer.c
@@ -17,6 +17,7 @@
   * @}
   */
 
+#include <assert.h>
 #include <mips/cpu.h>
 #include <mips/m32c0.h>
 #include <mips/regdef.h>

--- a/cpu/msp430_common/periph/flashpage.c
+++ b/cpu/msp430_common/periph/flashpage.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "irq.h"
 #include "periph/flashpage.h"

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -16,7 +16,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 #include <inttypes.h>
 #include <errno.h>
 

--- a/cpu/native/periph/pwm.c
+++ b/cpu/native/periph/pwm.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "periph/pwm.h"

--- a/cpu/nrf51/periph/pwm.c
+++ b/cpu/nrf51/periph/pwm.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 #include <inttypes.h>

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/adc.h"

--- a/cpu/nrf52/periph/usbdev.c
+++ b/cpu/nrf52/periph/usbdev.c
@@ -22,6 +22,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -21,6 +21,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include <errno.h>
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -16,6 +16,8 @@
  * @author      José I. Alamos <jose.alamos@haw-hamburg.de>
  * @}
  */
+
+#include <assert.h>
 #include <string.h>
 #include <errno.h>
 

--- a/cpu/nrf52/spi_twi_irq.c
+++ b/cpu/nrf52/spi_twi_irq.c
@@ -20,6 +20,9 @@
  *
  * @}
  */
+
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph_cpu.h"
 

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -28,6 +28,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph/gpio.h"
 #include "periph_cpu.h"

--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -28,6 +28,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/cpu/nrf5x_common/periph/wdt.c
+++ b/cpu/nrf5x_common/periph/wdt.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "timex.h"
 #include "periph/wdt.h"

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "net/gnrc.h"
 #include "thread.h"
 #include "net/gnrc/netif.h"

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph/dac.h"
 #include "periph/gpio.h"

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -21,7 +21,6 @@
 #include "periph_cpu.h"
 #include "periph_conf.h"
 #include "mutex.h"
-#include "assert.h"
 #include "bitarithm.h"
 #include "pm_layered.h"
 #include "thread_flags.h"

--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -22,6 +22,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "board.h"
 #include "periph/gpio.h"

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -18,6 +18,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/cpu/sam3/periph/adc.c
+++ b/cpu/sam3/periph/adc.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 
 

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "macros/units.h"
 #include "periph_conf.h"

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "periph/init.h"
 #include "periph_conf.h"

--- a/cpu/stm32/periph/can.c
+++ b/cpu/stm32/periph/can.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include <errno.h>
 #include <limits.h>

--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -19,6 +19,8 @@
  *
  * @}
  */
+
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/cpu/stm32/periph/rtt_all.c
+++ b/cpu/stm32/periph/rtt_all.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "irq.h"
 #include "periph/rtt.h"

--- a/cpu/stm32/periph/usbdev.c
+++ b/cpu/stm32/periph/usbdev.c
@@ -18,6 +18,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/drivers/ad7746/ad7746.c
+++ b/drivers/ad7746/ad7746.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "ad7746.h"
 #include "ad7746_params.h"
 #include "ad7746_internal.h"

--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "adcxx1c.h"
 #include "adcxx1c_params.h"
 #include "adcxx1c_regs.h"

--- a/drivers/aip31068/aip31068.c
+++ b/drivers/aip31068/aip31068.c
@@ -14,6 +14,7 @@
  * @{
  */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "xtimer.h"

--- a/drivers/apds99xx/apds99xx.c
+++ b/drivers/apds99xx/apds99xx.c
@@ -15,6 +15,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>

--- a/drivers/at86rf2xx/aes_spi.c
+++ b/drivers/at86rf2xx/aes_spi.c
@@ -16,6 +16,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "xtimer.h"
 #include "periph/spi.h"
 #include "at86rf2xx_aes.h"

--- a/drivers/atwinc15x0/atwinc15x0_bsp.c
+++ b/drivers/atwinc15x0/atwinc15x0_bsp.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "atwinc15x0_internal.h"
 #include "mutex.h"
 #include "periph/spi.h"

--- a/drivers/atwinc15x0/atwinc15x0_bus.c
+++ b/drivers/atwinc15x0/atwinc15x0_bus.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "atwinc15x0_internal.h"
 #include "bus_wrapper/include/nm_bus_wrapper.h"
 

--- a/drivers/bme680/bme680.c
+++ b/drivers/bme680/bme680.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "bme680.h"
 #include "bme680_hal.h"
 #include "bme680_params.h"

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -13,6 +13,7 @@
  * @file
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>

--- a/drivers/dfplayer/dfplayer.c
+++ b/drivers/dfplayer/dfplayer.c
@@ -16,7 +16,7 @@
  *
  * @}
  */
-#include <assert.h>
+
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "dose.h"

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -19,7 +19,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <errno.h>
 
 #include "mutex.h"

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -20,7 +20,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <string.h>
 
 #include "log.h"

--- a/drivers/hmc5883l/hmc5883l.c
+++ b/drivers/hmc5883l/hmc5883l.c
@@ -14,6 +14,7 @@
  * @{
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -22,7 +22,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include "assert.h"
 #include "hts221.h"
 #include "periph/i2c.h"
 #include "xtimer.h"

--- a/drivers/include/periph/pm.h
+++ b/drivers/include/periph/pm.h
@@ -24,7 +24,6 @@
 #ifndef PERIPH_PM_H
 #define PERIPH_PM_H
 
-#include "assert.h"
 #include "periph_cpu.h"
 
 #ifdef MODULE_PM_LAYERED

--- a/drivers/itg320x/itg320x.c
+++ b/drivers/itg320x/itg320x.c
@@ -14,6 +14,7 @@
  * @{
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/drivers/kw41zrf/kw41zrf_getset.c
+++ b/drivers/kw41zrf/kw41zrf_getset.c
@@ -16,6 +16,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include "log.h"

--- a/drivers/kw41zrf/kw41zrf_intern.c
+++ b/drivers/kw41zrf/kw41zrf_intern.c
@@ -16,6 +16,7 @@
  * @}
  */
 
+#include <assert.h>
 #include "log.h"
 #include "irq.h"
 #include "panic.h"

--- a/drivers/lsm6dsl/lsm6dsl.c
+++ b/drivers/lsm6dsl/lsm6dsl.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "xtimer.h"
 
 #include "lsm6dsl.h"

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>

--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
 

--- a/drivers/opt3001/opt3001.c
+++ b/drivers/opt3001/opt3001.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "opt3001.h"
 #include "opt3001_regs.h"
 #include "periph/i2c.h"

--- a/drivers/pca9633/pca9633.c
+++ b/drivers/pca9633/pca9633.c
@@ -14,6 +14,7 @@
  * @{
  */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "pca9633.h"

--- a/drivers/pca9685/pca9685.c
+++ b/drivers/pca9685/pca9685.c
@@ -14,6 +14,7 @@
  * @{
  */
 
+#include <assert.h>
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/drivers/rn2xx3/rn2xx3_getset.c
+++ b/drivers/rn2xx3/rn2xx3_getset.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <errno.h>
 
-#include "assert.h"
 #include "fmt.h"
 
 #include "net/loramac.h"

--- a/drivers/saul/init_devs/auto_init_tsl4531x.c
+++ b/drivers/saul/init_devs/auto_init_tsl4531x.c
@@ -22,6 +22,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "log.h"
 #include "saul_reg.h"
 #include "tsl4531x.h"

--- a/drivers/seesaw_soil/seesaw_soil.c
+++ b/drivers/seesaw_soil/seesaw_soil.c
@@ -21,7 +21,6 @@
 
 #include <string.h>
 
-#include "assert.h"
 #include "byteorder.h"
 #include "xtimer.h"
 #include "periph/i2c.h"

--- a/drivers/sht3x/sht3x.c
+++ b/drivers/sht3x/sht3x.c
@@ -17,6 +17,7 @@
 #include "debug.h"
 #include "log.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>

--- a/drivers/soft_uart/include/soft_uart_params.h
+++ b/drivers/soft_uart/include/soft_uart_params.h
@@ -21,6 +21,7 @@
 
 #include "soft_uart.h"
 #include "macros/units.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/soft_uart/soft_uart.c
+++ b/drivers/soft_uart/soft_uart.c
@@ -17,7 +17,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 
 #include "mutex.h"
 #include "soft_uart.h"

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -15,6 +15,7 @@
 #define LOG_LEVEL LOG_DEBUG
 #include "log.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -19,6 +19,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @}
  */
+
+#include <assert.h>
 #include <stdbool.h>
 #include <math.h>
 #include <string.h>

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>

--- a/drivers/tmp00x/tmp00x.c
+++ b/drivers/tmp00x/tmp00x.c
@@ -23,6 +23,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>

--- a/drivers/tsl4531x/tsl4531x.c
+++ b/drivers/tsl4531x/tsl4531x.c
@@ -23,6 +23,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "log.h"

--- a/drivers/ws281x/ws281x.c
+++ b/drivers/ws281x/ws281x.c
@@ -18,7 +18,7 @@
  *
  * @}
  */
-#include <assert.h>
+
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -21,6 +21,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <inttypes.h>
 

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <inttypes.h>
 

--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -31,6 +31,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/pkg/driver_bme680/contrib/bme680_hal.c
+++ b/pkg/driver_bme680/contrib/bme680_hal.c
@@ -19,6 +19,7 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
@@ -18,6 +18,7 @@
  *
  * @}
  */
+
 #include "fatfs/diskio.h"       /**< FatFs lower layer API */
 #include "fatfs_diskio_mtd.h"
 #include "fatfs/ffconf.h"

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "net/ipv4/addr.h"

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -340,6 +340,7 @@ static int _create(int type, int proto, uint16_t flags, struct netconn **out)
     return 0;
 }
 
+#include <assert.h>
 #include <stdio.h>
 
 int lwip_sock_create(struct netconn **conn, const struct _sock_tl_ep *local,

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
+
 #include "mutex.h"
 
 #include "net/sock/tcp.h"

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "net/ipv4/addr.h"

--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -20,7 +20,6 @@
 #ifndef ARCH_CC_H
 #define ARCH_CC_H
 
-#include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "thread.h"
 #include "nimble_riot.h"
 

--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "nimble_netif_conn.h"
 
 #define ENABLE_DEBUG            (0)

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -17,6 +17,8 @@
  *
  * @}
  */
+
+#include <assert.h>
 #include <limits.h>
 
 #include "xtimer.h"

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "net/bluetil/ad.h"
 #include "nimble_scanlist.h"
 #include "nimble/hci_common.h"

--- a/pkg/nimble/scanner/nimble_scanner.c
+++ b/pkg/nimble/scanner/nimble_scanner.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "nimble_riot.h"

--- a/pkg/nordic_softdevice_ble/src/ble-mac.c
+++ b/pkg/nordic_softdevice_ble/src/ble-mac.c
@@ -28,6 +28,7 @@
  *
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -17,7 +17,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include "msg.h"

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -16,8 +16,6 @@
  * @}
  */
 
-#include <assert.h>
-
 #include "openthread/platform/alarm-milli.h"
 #include "openthread/platform/uart.h"
 #include "ot.h"

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -16,7 +16,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/pkg/openthread/contrib/platform_settings.c
+++ b/pkg/openthread/contrib/platform_settings.c
@@ -16,7 +16,6 @@
  * @}
  */
 
-#include "assert.h"
 #include "openthread/error.h"
 #include "openthread/instance.h"
 

--- a/pkg/openwsn/contrib/radio.c
+++ b/pkg/openwsn/contrib/radio.c
@@ -19,6 +19,8 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
+
+#include <assert.h>
 #include <sys/uio.h>
 
 #include "leds.h"

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -11,6 +11,8 @@
  *
  * @author      Javier FILEIV <javier.fileiv@gmail.com>
  */
+
+#include <assert.h>
 #include <string.h>
 #include <errno.h>
 

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -19,6 +19,7 @@
  */
 
 
+#include <assert.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <inttypes.h>

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -16,6 +16,8 @@
  * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
+#include <assert.h>
+
 #include "dtls.h"
 #include "log.h"
 #include "net/sock/dtls.h"

--- a/pkg/ucglib/contrib/ucg_riotos.c
+++ b/pkg/ucglib/contrib/ucg_riotos.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "ucg_riotos.h"

--- a/sys/auto_init/multimedia/auto_init_dfplayer.c
+++ b/sys/auto_init/multimedia/auto_init_dfplayer.c
@@ -22,7 +22,6 @@
 #ifdef MODULE_DFPLAYER
 
 #include "log.h"
-#include "assert.h"
 #include "dfplayer.h"
 #include "dfplayer_params.h"
 

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -24,6 +24,8 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
+
 #include "usb/usbus.h"
 
 #ifdef MODULE_USBUS_CDC_ECM

--- a/sys/can/conn/isotp.c
+++ b/sys/can/conn/isotp.c
@@ -17,6 +17,7 @@
  */
 
 #ifdef MODULE_CAN_ISOTP
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -16,6 +16,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "thread.h"

--- a/sys/can/dll.c
+++ b/sys/can/dll.c
@@ -23,6 +23,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -16,6 +16,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/sys/can/pkt.c
+++ b/sys/can/pkt.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include <limits.h>
 #include <errno.h>

--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 #include "debug.h"
 #include "crypto/helper.h"

--- a/sys/fmt/table.c
+++ b/sys/fmt/table.c
@@ -19,7 +19,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <unistd.h>

--- a/sys/fuzzing/netdev.c
+++ b/sys/fuzzing/netdev.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include <assert.h>
 #include <stddef.h>
 
 #include "mutex.h"

--- a/sys/hashes/sha224.c
+++ b/sys/hashes/sha224.c
@@ -19,7 +19,6 @@
  */
 
 #include <string.h>
-#include <assert.h>
 
 #include "hashes/sha224.h"
 #include "hashes/sha2xx_common.h"

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -18,7 +18,6 @@
 #ifndef NET_GNRC_NETIF_IPV6_H
 #define NET_GNRC_NETIF_IPV6_H
 
-#include <assert.h>
 #include <kernel_defines.h>
 
 #include "evtimer_msg.h"

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -268,7 +268,6 @@
 #ifndef NET_SOCK_IP_H
 #define NET_SOCK_IP_H
 
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -268,7 +268,6 @@
 #ifndef NET_SOCK_UDP_H
 #define NET_SOCK_UDP_H
 
-#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -34,7 +34,6 @@
 #ifndef PM_LAYERED_H
 #define PM_LAYERED_H
 
-#include "assert.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus

--- a/sys/irq_handler/irq_handler.c
+++ b/sys/irq_handler/irq_handler.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <errno.h>
 

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -21,7 +21,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "assert.h"
 #include "periph/cpuid.h"
 
 #include "luid.h"

--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 
+#include <assert.h>
 #include <string.h>
 #include "memarray.h"
 

--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <limits.h>
 
 #include "log.h"

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <stdbool.h>
 
 #include "event.h"

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "log.h"

--- a/sys/net/credman/credman.c
+++ b/sys/net/credman/credman.c
@@ -19,6 +19,7 @@
 #include "net/credman.h"
 #include "mutex.h"
 
+#include <assert.h>
 #include <string.h>
 
 #define ENABLE_DEBUG (0)

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
+
 #include "log.h"
 #include "net/arp.h"
 #include "net/dhcpv6.h"

--- a/sys/net/gnrc/application_layer/dhcpv6/client_6lbr.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_6lbr.c
@@ -13,8 +13,6 @@
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
 
-#include <assert.h>
-
 #include "event.h"
 #include "log.h"
 #include "net/dhcpv6/client.h"

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdbool.h>
 
 #include "periph/rtt.h"

--- a/sys/net/gnrc/link_layer/gomach/timeout.c
+++ b/sys/net/gnrc/link_layer/gomach/timeout.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "xtimer.h"
 #include "net/gnrc/gomach/gomach.h"
 #include "net/gnrc/gomach/timeout.h"

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -13,6 +13,8 @@
  * @author  José Ignacio Alamos <jose.alamos@haw-hamburg.de>
  * @}
  */
+
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "net/lora.h"

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -12,6 +12,8 @@
  * @file
  * @author  José Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
+
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "net/lora.h"

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -14,6 +14,8 @@
  *
  * @}
  */
+
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include "net/lora.h"

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdbool.h>
 
 #include "periph/rtt.h"

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "net/gnrc.h"
 #include "net/gnrc/lwmac/lwmac.h"
 #include "net/gnrc/mac/internal.h"

--- a/sys/net/gnrc/link_layer/lwmac/timeout.c
+++ b/sys/net/gnrc/link_layer/lwmac/timeout.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "net/gnrc/lwmac/timeout.h"

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "periph/rtt.h"
 #include "net/gnrc.h"
 #include "net/gnrc/lwmac/lwmac.h"

--- a/sys/net/gnrc/link_layer/mac/internal.c
+++ b/sys/net/gnrc/link_layer/mac/internal.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdbool.h>
 
 #include "net/gnrc.h"

--- a/sys/net/gnrc/link_layer/mac/timeout.c
+++ b/sys/net/gnrc/link_layer/mac/timeout.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "net/gnrc.h"
 #include "net/gnrc/mac/timeout.h"
 

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "mbox.h"

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -15,6 +15,7 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "net/ethernet/hdr.h"

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -15,6 +15,7 @@
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  */
 
+#include <assert.h>
 #include <string.h>
 #include <kernel_defines.h>
 

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -14,6 +14,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <kernel_defines.h>
 

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
+
 #include "net/gnrc/netif/hdr.h"
 
 gnrc_pktsnip_t *gnrc_netif_hdr_build(const uint8_t *src, uint8_t src_len,

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
@@ -17,6 +17,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
+#include <assert.h>
+
 #include "log.h"
 #include "board.h"
 #include "net/gnrc/netif/lorawan_base.h"

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -13,6 +13,8 @@
  * @author  Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
 
+#include <assert.h>
+
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/lorawan.h"

--- a/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
+++ b/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
+
 #include "net/gnrc/pktqueue.h"
 #include "net/gnrc/netif/conf.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -12,6 +12,8 @@
  * @file
  */
 
+#include <assert.h>
+
 #include "net/ipv6.h"
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/netif.h"

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -15,6 +15,7 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdlib.h>

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -15,6 +15,7 @@
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 
 #include "utlist.h"

--- a/sys/net/gnrc/network_layer/ipv6/ext/opt/gnrc_ipv6_ext_opt.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/opt/gnrc_ipv6_ext_opt.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
+
 #include "net/ipv6.h"
 #include "net/ipv6/ext.h"
 #include "net/ipv6/ext/opt.h"

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
@@ -15,6 +15,8 @@
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
+
 #include "net/ipv6/ext/rh.h"
 #include "net/gnrc.h"
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -12,6 +12,8 @@
  * @file
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
+
+#include <assert.h>
 #include <kernel_defines.h>
 
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
@@ -12,6 +12,8 @@
  * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
+
+#include <assert.h>
 #include <kernel_defines.h>
 
 #include "net/gnrc/ipv6/nib.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -12,6 +12,8 @@
  * @file
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
+
+#include <assert.h>
 #include <kernel_defines.h>
 
 #include "evtimer.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -12,6 +12,8 @@
  * @file
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
+
+#include <assert.h>
 #include <kernel_defines.h>
 
 #include "net/gnrc/ipv6/nib.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <kernel_defines.h>

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <kernel_defines.h>
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "net/gnrc/icmpv6.h"

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -32,6 +32,8 @@
 
 #if ENABLE_DEBUG
 /* For PRIu16 etc. */
+
+#include <assert.h>
 #include <inttypes.h>
 #endif
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -12,6 +12,8 @@
  * @file
  */
 
+#include <assert.h>
+
 #include "kernel_types.h"
 #include "net/gnrc.h"
 #include "thread.h"

--- a/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
+++ b/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/priority_pktqueue.h"
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -15,6 +15,7 @@
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <assert.h>
 #include <string.h>
 #include "kernel_defines.h"
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -16,6 +16,7 @@
  * @author Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <assert.h>
 #include <string.h>
 #include "kernel_defines.h"
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -16,6 +16,7 @@
  * @author      Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
+++ b/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
@@ -14,6 +14,7 @@
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "net/icmpv6.h"

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -15,6 +15,7 @@
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <assert.h>
 #include <string.h>
 #include "net/gnrc/netif/internal.h"
 #include "net/gnrc/ipv6/ext/rh.h"

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
 

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -15,6 +15,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -15,6 +15,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <utlist.h>

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <utlist.h>
 #include <errno.h>
 #include "net/af.h"

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
@@ -21,7 +21,6 @@
 #define GNRC_TCP_COMMON_H
 
 #include <stdint.h>
-#include "assert.h"
 #include "kernel_types.h"
 #include "thread.h"
 #include "mutex.h"

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
 

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -13,6 +13,7 @@
  * @author  Jose I. Alamos <jose.alamos@haw-hamburg.de>
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "errno.h"

--- a/sys/phydat/phydat.c
+++ b/sys/phydat/phydat.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include "phydat.h"
 

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "irq.h"
 #include "periph/pm.h"
 #include "pm_layered.h"

--- a/sys/progress_bar/progress_bar.c
+++ b/sys/progress_bar/progress_bar.c
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <inttypes.h>
-#include <assert.h>
 
 #include "progress_bar.h"
 

--- a/sys/riotboot/slot.c
+++ b/sys/riotboot/slot.c
@@ -20,6 +20,8 @@
  *
  * @}
  */
+
+#include <assert.h>
 #include <string.h>
 
 #include "cpu.h"

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -18,6 +18,7 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
+#include <assert.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <string.h>
 

--- a/sys/trickle/trickle.c
+++ b/sys/trickle/trickle.c
@@ -14,6 +14,8 @@
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <assert.h>
+
 #include "inttypes.h"
 #include "random.h"
 #include "trickle.h"

--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "uri_parser.h"
 
 #define ENABLE_DEBUG (0)

--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -18,6 +18,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
 #include <string.h>
 
 #include "tsrb.h"

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -17,6 +17,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
 #include <string.h>
 
 #include "kernel_defines.h"

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -32,6 +32,7 @@
 #include "usb.h"
 #include "cpu.h"
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 #include <errno.h>

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -18,6 +18,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include <assert.h>
 #include <string.h>
 #include <stdio.h>
 #include "usb/descriptor.h"

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -19,7 +19,7 @@
  *
  * @}
  */
-#include <assert.h>
+
 #include <errno.h>
 #include <stdio.h>
 

--- a/tests/bitarithm_timings/main.c
+++ b/tests/bitarithm_timings/main.c
@@ -29,6 +29,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdatomic.h>
 #include <stdio.h>

--- a/tests/c11_atomics_cpp_compat/main.c
+++ b/tests/c11_atomics_cpp_compat/main.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/tests/candev/main.c
+++ b/tests/candev/main.c
@@ -21,6 +21,7 @@
 
 #define ENABLE_DEBUG (0)
 
+#include <assert.h>
 #include <debug.h>
 #include <errno.h>
 #include <isrpipe.h>

--- a/tests/disp_dev/main.c
+++ b/tests/disp_dev/main.c
@@ -19,7 +19,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 
 #include "disp_dev.h"
 

--- a/tests/driver_lis2dh12/main.c
+++ b/tests/driver_lis2dh12/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "fmt.h"

--- a/tests/gnrc_ipv6_ext_frag/main.c
+++ b/tests/gnrc_ipv6_ext_frag/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/gnrc_sock_ip/main.c
+++ b/tests/gnrc_sock_ip/main.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/gnrc_sock_udp/main.c
+++ b/tests/gnrc_sock_udp/main.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "common.h"

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/pkg_relic/main.c
+++ b/tests/pkg_relic/main.c
@@ -12,7 +12,6 @@
 #if (TEST_RELIC_SHOW_OUTPUT == 1)
 #include <stdio.h>
 #endif
-#include <assert.h>
 #include <stdlib.h>
 
 #include "relic.h"

--- a/tests/thread_msg_bus/main.c
+++ b/tests/thread_msg_bus/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <inttypes.h>
 

--- a/tests/touch_dev/main.c
+++ b/tests/touch_dev/main.c
@@ -19,7 +19,6 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
 #include <stdbool.h>
 
 #include "xtimer.h"


### PR DESCRIPTION
### Contribution description
This PR adds `#include <assert.h>` to files that use the `assert(..)` function, and remove it from files that do not use `assert(..)` function.

Many files were depending on a proxy-include of `assert(..)`, but I believe that each file that uses `assert(..)` should include `assert.h` directly (more robust). It also fixes some warnings about implicit declaration of functions (at least in my IDE).

The list of files was collected using `grep -L assert\.h $(grep -rl assert\( .)` (find all files that use `assert(..)` but lack `assert.h`). I used a script to add the missing includes and reviewed the changes before committing. I then repeated the process in reverse, using `grep -L assert\( $(grep -rl assert\.h .)` (find all files that include `assert.h` but lack `assert(..)`) to identify the files where I should remove `assert.h`. I have updated these files manually. For header files, I also checked if they were used by sources files that include that specific header file.

From both lists I have removed vendor files, C++ files and non-source files. I also skipped `core/panic.c` and `core/assert.c`.

### Testing procedure
Murdock should be happy.

### Issues/PRs references
None