### PR TITLE
drivers/at86rf215: give driver threads different names

### DIFF
--- a/sys/include/net/gnrc/netif/ieee802154.h
+++ b/sys/include/net/gnrc/netif/ieee802154.h
@@ -40,7 +40,7 @@ extern "C" {
  * @return  negative number on error
  */
 int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                                 char priority, char *name, netdev_t *dev);
+                                 char priority, const char *name, netdev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -40,7 +40,7 @@ static const gnrc_netif_ops_t ieee802154_ops = {
 };
 
 int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                                 char priority, char *name, netdev_t *dev)
+                                 char priority, const char *name, netdev_t *dev)
 {
     return gnrc_netif_create(netif, stack, stacksize, priority, name, dev,
                              &ieee802154_ops);

--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf215.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf215.c
@@ -52,7 +52,7 @@ static gnrc_netif_t _netif[AT86RF215_NUM * USED_BANDS];
 static char _at86rf215_stacks[AT86RF215_NUM * USED_BANDS][AT86RF215_MAC_STACKSIZE];
 
 static inline void _setup_netif(gnrc_netif_t *netif, void* netdev, void* stack,
-                                int prio)
+                                int prio, const char *name)
 {
     if (netif == NULL || netdev == NULL) {
         return;
@@ -61,18 +61,15 @@ static inline void _setup_netif(gnrc_netif_t *netif, void* netdev, void* stack,
 #if defined(MODULE_GNRC_GOMACH)
         gnrc_netif_gomach_create(netif, stack,
                                  AT86RF215_MAC_STACKSIZE,
-                                 prio, "at86rf215-gomach",
-                                 netdev);
+                                 prio, name, netdev);
 #elif defined(MODULE_GNRC_LWMAC)
         gnrc_netif_lwmac_create(netif, stack,
                                 AT86RF215_MAC_STACKSIZE,
-                                prio, "at86rf215-lwmac",
-                                netdev);
+                                prio, name, netdev);
 #else
         gnrc_netif_ieee802154_create(netif, stack,
                                      AT86RF215_MAC_STACKSIZE,
-                                     prio, "at86rf215",
-                                     netdev);
+                                     prio, name, netdev);
 #endif
 }
 
@@ -105,10 +102,10 @@ void auto_init_at86rf215(void)
         at86rf215_setup(dev_09, dev_24, &at86rf215_params[j], j);
 
         /* setup sub-GHz interface */
-        _setup_netif(netif_09, dev_09, stack_09, AT86RF215_MAC_PRIO_SUBGHZ);
+        _setup_netif(netif_09, dev_09, stack_09, AT86RF215_MAC_PRIO_SUBGHZ, "at86rf215 [sub GHz]");
 
         /* setup 2.4-GHz interface */
-        _setup_netif(netif_24, dev_24, stack_24, AT86RF215_MAC_PRIO);
+        _setup_netif(netif_24, dev_24, stack_24, AT86RF215_MAC_PRIO, "at86rf215 [2.4 GHz]");
     }
 }
 /** @} */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use different names for the sub-GHz and 2.4 GHz driver thread to make it easier to tell which is which is which.



### Testing procedure

```
2020-10-21 19:53:50,608 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current
2020-10-21 19:53:50,622 # 	  - | isr_stack            | -        - |   - |    512 (  232) (  280) | 0x20000000 | 0x200001c8
2020-10-21 19:53:50,623 # 	  1 | main                 | running  Q |   7 |   1536 (  660) (  876) | 0x200002f8 | 0x2000075c
2020-10-21 19:53:50,639 # 	  2 | pktdump              | bl rx    _ |   6 |   1536 (  236) ( 1300) | 0x200035a8 | 0x20003abc
2020-10-21 19:53:50,653 # 	  3 | 6lo                  | bl rx    _ |   3 |   1024 (  332) (  692) | 0x2000420c | 0x2000450c
2020-10-21 19:53:50,655 # 	  4 | ipv6                 | bl rx    _ |   4 |   1024 (  376) (  648) | 0x200009d4 | 0x20000cd4
2020-10-21 19:53:50,670 # 	  5 | udp                  | bl rx    _ |   5 |   1024 (  252) (  772) | 0x200049f0 | 0x20004cf4
2020-10-21 19:53:50,672 # 	  6 | at86rf215 [sub GHz]  | bl rx    _ |   2 |   1024 (  536) (  488) | 0x20001200 | 0x200014c4
2020-10-21 19:53:50,687 # 	  7 | at86rf215 [2.4 GHz]  | bl rx    _ |   2 |   1024 (  536) (  488) | 0x20001600 | 0x200018c4
2020-10-21 19:53:50,689 # 	    | SUM                  |            |     |   8704 ( 3160) ( 5544)
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
