### PR TITLE
treewide: add includes to timex.h

### DIFF
--- a/boards/weact-f411ce/board.c
+++ b/boards/weact-f411ce/board.c
@@ -21,6 +21,7 @@
 #include "board.h"
 #include "cpu.h"
 #include "mtd.h"
+#include "timex.h"
 #include "mtd_spi_nor.h"
 #include "periph/gpio.h"
 

--- a/boards/weact-f411ce/include/board.h
+++ b/boards/weact-f411ce/include/board.h
@@ -27,7 +27,6 @@ extern "C" {
 
 #include "mtd.h"
 #include "periph_cpu.h"
-#include "timex.h"
 
 /**
  * @name    Xtimer configuration

--- a/cpu/esp_common/freertos/portable.c
+++ b/cpu/esp_common/freertos/portable.c
@@ -17,6 +17,7 @@
 
 #include "esp_common.h"
 #include "log.h"
+#include "timex.h"
 
 #include "freertos/FreeRTOS.h"
 

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 
+#include "timex.h"
 #include "net/sock/udp.h"
 #include "tinydtls_keys.h"
 

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -27,6 +27,7 @@
 
 #include "net/sock/udp.h"
 #include "msg.h"
+#include "timex.h"
 #include "tinydtls_keys.h"
 
 /* TinyDTLS */

--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -23,6 +23,7 @@
 #include "net/credman.h"
 #include "msg.h"
 #include "thread.h"
+#include "timex.h"
 
 #include "tinydtls_keys.h"
 

--- a/examples/nimble_heart_rate_sensor/main.c
+++ b/examples/nimble_heart_rate_sensor/main.c
@@ -25,6 +25,7 @@
 #include "event/timeout.h"
 #include "nimble_riot.h"
 #include "net/bluetil/ad.h"
+#include "timex.h"
 
 #include "host/ble_hs.h"
 #include "host/ble_gatt.h"

--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -21,6 +21,8 @@
 
 #include <string.h>
 
+#include "timex.h"
+
 #include "liblwm2m.h"
 
 #include "lwm2m_platform.h"

--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -23,6 +23,7 @@
 #include "log.h"
 #include "random.h"
 #include "byteorder.h"
+#include "timex.h"
 
 #include "net/asymcute.h"
 

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -26,6 +26,7 @@
 
 #include "net/nanocoap_sock.h"
 #include "net/sock/udp.h"
+#include "timex.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -41,6 +41,7 @@
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "net/ndp.h"
 #include "random.h"
+#include "timex.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -25,6 +25,8 @@
 
 #include "net/gnrc/ndp.h"
 
+#include "timex.h"
+
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 

--- a/sys/shell/commands/sc_can.c
+++ b/sys/shell/commands/sc_can.c
@@ -27,6 +27,8 @@
 #include "can/conn/raw.h"
 #include "can/raw.h"
 
+#include "timex.h"
+
 #define SC_CAN_MAX_FILTERS  10
 #define xstr(a) str(a)
 #define str(a) #a

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -20,6 +20,8 @@
 #include "net/gnrc/netif.h"
 #include "net/ipv6/addr.h"
 
+#include "timex.h"
+
 static void _usage(char **argv);
 static int _nib_neigh(int argc, char **argv);
 static int _nib_prefix(int argc, char **argv);

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -24,6 +24,7 @@
 #include "net/gnrc/rpl/dodag.h"
 #include "utlist.h"
 #include "trickle.h"
+#include "xtimer.h"
 #ifdef MODULE_GNRC_RPL_P2P
 #include "net/gnrc/rpl/p2p.h"
 #include "net/gnrc/rpl/p2p_dodag.h"

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -31,6 +31,7 @@
 #include "net/nanocoap_sock.h"
 #include "thread.h"
 #include "periph/pm.h"
+#include "xtimer.h"
 
 #include "suit/transport/coap.h"
 #include "net/sock/util.h"

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -27,6 +27,7 @@
 #include "event.h"
 #include "event/timeout.h"
 #include "event/callback.h"
+#include "xtimer.h"
 
 #define STACKSIZE               THREAD_STACKSIZE_DEFAULT
 #define PRIO                    (THREAD_PRIORITY_MAIN - 1)

--- a/tests/gnrc_ipv6_nib/main.c
+++ b/tests/gnrc_ipv6_nib/main.c
@@ -32,6 +32,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/ndp.h"
 #include "sched.h"
+#include "timex.h"
 
 #define _BUFFER_SIZE    (128)
 #define _CUR_HL         (155)

--- a/tests/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/gnrc_ipv6_nib_6ln/main.c
@@ -35,6 +35,7 @@
 #include "net/ndp.h"
 #include "net/sixlowpan/nd.h"
 #include "sched.h"
+#include "timex.h"
 
 #define _BUFFER_SIZE    (196)
 #define _ARO_LTIME      (4224)

--- a/tests/pkg_tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-client.c
@@ -26,6 +26,7 @@
 #include "net/sock/dtls.h"
 #include "net/ipv6/addr.h"
 #include "net/credman.h"
+#include "timex.h"
 
 #include "tinydtls_common.h"
 #include "tinydtls_keys.h"


### PR DESCRIPTION
### Contribution description
This PR adds includes to `timex.h` (or `xtimer.h` if references to xtimer are used). These fixes make it more obvious, and reduce the dependency on these non-related includes.

In many cases, references to defines such as `US_PER_MS` or xtimer references were available via other non-related includes (e.g. foo.c -> foo.h -> bar.h -> xtimer.h, where foo and bar are non-related). If there were uses of `US_PER_MS` in xtimer related function calls, I added `xtimer.h`. If not, I added `timex.h`.

### Testing procedure
Murdock is happy.

### Issues/PRs references
None