### PR TITLE
sys/frac: make gcd32() public

### DIFF
--- a/sys/frac/frac.c
+++ b/sys/frac/frac.c
@@ -24,15 +24,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/**
- * @brief   compute greatest common divisor of @p u and @p v
- *
- * @param[in]   u    first operand
- * @param[in]   v    second operand
- *
- * @return  Greatest common divisor of @p u and @p v
- */
-static uint32_t gcd32(uint32_t u, uint32_t v)
+uint32_t gcd32(uint32_t u, uint32_t v)
 {
     /* Source: https://en.wikipedia.org/wiki/Binary_GCD_algorithm#Iterative_version_in_C */
     unsigned shift;
@@ -81,7 +73,7 @@ static uint32_t gcd32(uint32_t u, uint32_t v)
     return u << shift;
 }
 
-uint32_t frac_long_divide(uint32_t num, uint32_t den, int *prec, uint32_t *rem)
+static uint32_t frac_long_divide(uint32_t num, uint32_t den, int *prec, uint32_t *rem)
 {
     /* Binary long division with adaptive number of fractional bits */
     /* The result will be a Qx.y number where x is the number of bits in the

--- a/sys/include/frac.h
+++ b/sys/include/frac.h
@@ -56,6 +56,16 @@ typedef struct {
 } frac_t;
 
 /**
+ * @brief   Compute greatest common divisor of @p u and @p v
+ *
+ * @param[in]   u    first operand
+ * @param[in]   v    second operand
+ *
+ * @return  Greatest common divisor of @p u and @p v
+ */
+uint32_t gcd32(uint32_t u, uint32_t v);
+
+/**
  * @brief   Initialize frac_t struct
  *
  * This function computes the mathematical parameters used by the frac algorithm.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A function to calculate the greatest common divisor is generally useful.
In turn declare the internal `frac_long_divide()` as `static`, it's not used anywhere outside this module and has no public header.


### Testing procedure

No functional change.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
