### PR TITLE
ieee802154/radio: add TRX_OFF pre condition to config_phy

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -603,10 +603,7 @@ static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
         return -EINVAL;
     }
 
-    _disable();
-
-    /* This will take in worst case 21 us */
-    while (NRF_RADIO->STATE != RADIO_STATE_STATE_Disabled) {};
+    assert(NRF_RADIO->STATE == RADIO_STATE_STATE_Disabled);
 
     /* The value of this register represents the frequency offset (in MHz) from
      * 2400 MHz.  Channel 11 (first 2.4 GHz band channel) starts at 2405 MHz
@@ -618,13 +615,6 @@ static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
     DEBUG("[nrf802154] setting channel to %i\n", conf->channel);
     DEBUG("[nrf802154] setting TX power to %i\n", conf->pow);
     _set_txpower(pow);
-
-    if (_state == STATE_RX) {
-        NRF_RADIO->TASKS_RXEN = 1;
-
-        /* This takes in worst case 40 us */
-        while (NRF_RADIO->STATE == RADIO_STATE_STATE_RxRu) {}
-    }
 
     return 0;
 }

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -621,13 +621,14 @@ struct ieee802154_radio_ops {
      * function should return -EINVAL
      *
      * @pre the device is on
+     * @pre the transceiver state is @ref IEEE802154_TRX_STATE_TRX_OFF
      *
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] conf the PHY configuration
      *
-     * @return 0 on success
-     * @return -EINVAL if the configuration is not valid for the device.
-     * @return negative errno on error
+     * @return 0        on success
+     * @return -EINVAL  if the configuration is not valid for the device.
+     * @return <0       error, return value is negative errno indicating the cause.
      */
     int (*config_phy)(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf);
 
@@ -800,6 +801,8 @@ static inline int ieee802154_radio_set_cca_mode(ieee802154_dev_t *dev,
 
 /**
  * @brief Shortcut to @ref ieee802154_radio_ops::config_phy
+ *
+ * @pre the transceiver state is @ref IEEE802154_TRX_STATE_TRX_OFF
  *
  * @param[in] dev IEEE802.15.4 device descriptor
  * @param[in] conf the PHY configuration

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -478,6 +478,7 @@ int config_phy(int argc, char **argv)
         puts("Wrong channel configuration (11 <= channel <= 26).");
         return 1;
     }
+    _set_trx_state(IEEE802154_TRX_STATE_TRX_OFF, false);
     ieee802154_dev_t *dev = ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID);
     ieee802154_phy_conf_t conf = {.channel=channel, .page=0, .pow=tx_pow};
     if (ieee802154_radio_config_phy(dev, &conf) < 0) {
@@ -486,6 +487,8 @@ int config_phy(int argc, char **argv)
     else {
         puts("Success!");
     }
+
+    _set_trx_state(IEEE802154_TRX_STATE_RX_ON, false);
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR implements the adds a TRX_OFF state precondition to `config_phy` (as proposed in https://github.com/RIOT-OS/RIOT/pull/13943#issuecomment-714335946). It simplifies driver implementation.

I also adapted the SubMAC and associated tests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Use the HAL test `tests/ieee802154_hal`:
- Check that the radio is able to receive and send data
- Use the `config_phy` command to set a different channel. Check that it works as expected.
- Use the `netdev_ieee802154_submac` with this radio with any example (e.g `gnrc_networking`). Everything should work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#13943 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
