### PR TITLE
fe310: Fix potential deadlock in thread_yield_higher

### DIFF
--- a/cpu/fe310/irq_arch.c
+++ b/cpu/fe310/irq_arch.c
@@ -85,7 +85,7 @@ void handle_trap(uint32_t mcause)
             case IRQ_M_SOFT:
                 /* Handle software interrupt - flag for context switch */
                 sched_context_switch_request = 1;
-                CLINT_REG(0) = 0;
+                CLINT_REG(CLINT_MSIP) = 0;
                 break;
 
 #ifdef MODULE_PERIPH_TIMER

--- a/cpu/fe310/thread_arch.c
+++ b/cpu/fe310/thread_arch.c
@@ -180,8 +180,10 @@ void thread_yield_higher(void)
     /* Use SW intr to schedule context switch */
     CLINT_REG(CLINT_MSIP) = 1;
 
-    /* Latency of SW intr can be 4-7 cycles; wait for the SW intr */
-    __asm__ volatile ("wfi");
+    /* Latency of SW intr can be a few cycles; wait for the SW intr.
+     * We cannot use WFI here as the SW intr may be delivered before we
+     * reach the WFI instruction, thereby causing a thread deadlock. */
+    while (CLINT_REG(CLINT_MSIP) == 1) {};
 }
 
 /**


### PR DESCRIPTION
### Contribution description

The software interrupt may be raised before the WFI instruction is reached, if it is and no other interrupt is raised afterwards the thread will deadlock as it will never awake from the WFI.

I noticed this bug with a [custom RISC-V simulator](https://github.com/agra-uni-bremen/riscv-vp) and cannot reproduce it on real hardware though. However, even on real hardware the WFI instruction may be implemented as a NOP, thus the current code is (in my opinion) suboptimal either way. The change proposed here simply busy waits until the interrupt handler for the software interrupt is invoked (which sets `CLINT_MSIP`), since this should only take a few cycles it shouldn't have a big impact on power consumption.

### Testing procedure

I encountered this bug with the following application. However, since this is a concurrency issue, which I personally cannot reproduce on real hardware (the HiFive1), it's probably difficult to test this PR using the application. I would instead suggest reasoning based on my observations and the suggested changes.

```C
#include <stdio.h>
#include <stdlib.h>
#include "xtimer.h"
#include "timex.h"

int main(void)
{
    puts("Sleeping for 5 seconds...");
    xtimer_sleep(5);
    puts("Sleep done!");
}
```

Due to the bug the bug in `thread_yield_higher` the mutex (used internally by `xtimer`) would deadlock here:

https://github.com/RIOT-OS/RIOT/blob/57264c50597687e9365cce6f37bec9281bdaadfb/core/mutex.c#L61-L65

I think this example also illustrates why the current implementation of `thread_yield_higher` might be a bad idea, given that `WFI` might be implemented as a NOP.

### Issues/PRs references

I have only tested this on the HiFive1, not the HiFive1b. Maybe this could explain some of the test failures on the HiFive1b (xtimer failures in #13086) were timing might differ from the HiFive1 in terms of interrupt delivery? Just a wild guess...