### PR TITLE
net/gcoap: add API to register multiple listeners

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -644,6 +644,18 @@ void gcoap_register_listener(gcoap_listener_t *listener)
     _coap_state.listeners = listener;
 }
 
+void gcoap_register_listeners(gcoap_listener_t *listener)
+{
+    gcoap_listener_t *temp = listener->next;
+    while (listener) {
+        gcoap_register_listener(listener);
+        listener = temp;
+        if(temp) {
+            temp = temp->next;
+        }
+    }
+}
+
 int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                    unsigned code, const char *path)
 {


### PR DESCRIPTION
Currently gcoap_register_listener() allows only one
listener to be registered at a time, this fix adds an
API gcoap_register_listeners() that will allow users to
register multiple listeners using single call.


Signed-off-by: iva kik <megatheriumiva@gmail.com>

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #15102
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
