### PR TITLE
ieee802154/radio: indicate that FCS is ignored when reading buffer

### DIFF
--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -428,7 +428,9 @@ struct ieee802154_radio_ops {
      * @brief Read a frame from the internal framebuffer
      *
      * This function reads the received frame from the internal framebuffer.
-     * It should try to copy the received frame into @p buf
+     * It should try to copy the received PSDU frame into @p buf. The FCS
+     * field will **not** be copied and its size **not** be taken into account
+     * for the return value.
      *
      * @post It's not safe to call this function again before setting the
      *       transceiver state to @ref IEEE802154_TRX_STATE_RX_ON (thus flushing


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The `read` function ignores the FCS field when reading a frame. This was somehow implicit, but should be explicitly specified in the Radio HAL API
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read :)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
