### PR TITLE
examples/gcoap: Allow PUT/POST with empty payload

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -373,7 +373,8 @@ int gcoap_cli_cmd(int argc, char **argv)
 
     if (((argc == apos + 2) && (code_pos == 0)) ||    /* ping */
         ((argc == apos + 3) && (code_pos == 1)) ||    /* get */
-        ((argc == apos + 4) && (code_pos > 1))) {     /* post or put */
+        ((argc == apos + 3 ||
+          argc == apos + 4) && (code_pos > 1))) {     /* post or put */
 
         char *uri = NULL;
         int uri_len = 0;


### PR DESCRIPTION
All access to the respective position in argv is already checked against
the argc count, and the online usage documentation already declares the
argument as optional (where not accepting it at GET seems obvious
enough, but requiring it with POST or PUT does not). Thus, allowing it
in the argument count check is the only thing to remain.

### Contribution description

Sending an empty POST is a thing that comes up eg. in RD registrations (when CLI user wants to do simple registration manually), and an empty PUT is not unreasonable either.

Given that servers may reject requests when their body is not empty if the protocol says that, *having to* put in a payload is a bit odd.

The usage line is already `usage: coap <get|post|put> [-c] <addr>[%iface] <port> <path> [data]`, so data is hinted at being optional. All the other code is in place, so this just enables something that was probably planned for anyway.

### Testing procedure

* Run the gcoap example
* Try registering at the rd.coap.amsuess.com public directory using `coap post 2a01:4f8:190:3064::5 5683 /.well-known/core?ep=dongle`
* Observe failure in the form of a 4.04 (as the query part of the URI is not properly dissected, but that's another bug) rather than a shell error that shows you the usage message.