### PR TITLE
boards/native: use cross-compiler for native if needed

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -19,6 +19,14 @@ export VALGRIND ?= valgrind
 export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
+# newer Ubuntu versions require cross compilation for i686
+ifeq (gnu,$(TOOLCHAIN))
+ifeq (0,$(shell i686-linux-gnu-gcc --version > /dev/null; echo $$?))
+  TARGET_ARCH_NATIVE = i686-linux-gnu
+  TARGET_ARCH ?= $(TARGET_ARCH_NATIVE)
+endif
+endif
+
 # basic cflags:
 CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG)
 CFLAGS_DBG ?= -g3


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

On newer Ubuntu version (20.10) it looks like it's no longer possible to produce 32 bit binaries with the native gcc.

The problem is that `libgcc.a` can't be found. `/usr/lib/gcc/i686-linux-gnu/10/libgcc.a` still exists, but it's not within the search patch of `gcc -m32 -print-search-dirs`.

An easy solution is to install the `gcc-i686-linux-gnu` cross toolchain.
That means now we also need to set a cross-compile prefix also on `native`.


### Testing procedure

Install the `gcc-i686-linux-gnu` package.
Compiling `native` should work again on the latest Ubuntu release. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
