### PR TITLE
gnrc_netif: add capability to join or leave link layer multicast groups

### DIFF
--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -693,12 +693,36 @@ static inline int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
     assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
     return l2util_ndp_addr_len_from_l2ao(netif->device_type, opt);
 }
+
+/**
+ * @brief   Converts an IPv6 multicast address to a multicast address
+ *          of the respective link layer.
+ *
+ * @pre There is enough allocated space in @p l2_group for an address for a
+ *      device of type @p dev_type (e.g. 6 bytes for an ethernet address).
+ *
+ * @param[in] dev_type      The network interface @p l2_addr should be generated
+ *                          for.
+ * @param[in] ipv6_group    An IPv6 multicast address.
+ * @param[out] l2_group     A link layer multicast address
+ *
+ * @return  Length of @p l2_group in bytes
+ * @return  `-ENOTSUP` if link layer does not support multicast.
+ */
+static inline int gnrc_netif_ipv6_group_to_l2_group(gnrc_netif_t *netif,
+                                                    const ipv6_addr_t *ipv6_group,
+                                                    uint8_t *l2_group)
+{
+    return l2util_ipv6_group_to_l2_group(netif->device_type, ipv6_group,
+                                         l2_group);
+}
 #else   /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 #define gnrc_netif_ipv6_init_mtu(netif)                             (void)netif
 #define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid)   (-ENOTSUP)
 #define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)               (-ENOTSUP)
 #define gnrc_netif_ndp_addr_len_from_l2ao(netif, opt)               (-ENOTSUP)
 #define gnrc_netif_ipv6_get_iid(netif, iid)                         (-ENOTSUP)
+#define gnrc_netif_ipv6_group_to_l2_group(netif, ipv6_group, l2_group)  (-ENOTSUP)
 #endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 /** @} */
 

--- a/sys/include/net/l2util.h
+++ b/sys/include/net/l2util.h
@@ -134,6 +134,25 @@ int l2util_ndp_addr_len_from_l2ao(int dev_type,
                                   const ndp_opt_t *opt);
 
 
+/**
+ * @brief   Converts an IPv6 multicast address to a multicast address
+ *          of the respective link layer.
+ *
+ * @pre There is enough allocated space in @p l2_group for an address for a
+ *      device of type @p dev_type (e.g. 6 bytes for an ethernet address).
+ *
+ * @param[in] dev_type      The network device type of the device @p l2_addr
+ *                          should be generated for.
+ * @param[in] ipv6_group    An IPv6 multicast address.
+ * @param[out] l2_group     A link layer multicast address
+ *
+ * @return  Length of @p l2_group in bytes
+ * @return  `-ENOTSUP` if link layer does not support multicast.
+ */
+int l2util_ipv6_group_to_l2_group(int dev_type,
+                                  const ipv6_addr_t *ipv6_group,
+                                  uint8_t *l2_group);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -748,6 +748,21 @@ typedef enum {
     NETOPT_RSSI,
 
     /**
+     * @brief   (array of byte array) get link layer multicast groups as array
+     *          of byte arrays (length of each byte array corresponds to the
+     *          length of @ref NETOPT_ADDRESS) or join a link layer multicast
+     *          group as byte array on an interface
+     *
+     * When getting the option you can pass an array of byte arrays of any
+     * length greater than 0 to the getter. The array will be filled up to to
+     * its maximum and the remaining addresses on the interface will be ignored
+     */
+    NETOPT_L2_GROUP,
+    /**
+     * @brief   (array of byte arrays) Leave an link layer multicast group
+     */
+    NETOPT_L2_GROUP_LEAVE,
+    /**
      * @brief   maximum number of options defined here.
      *
      * @note    Interfaces are not meant to respond to this option

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -122,6 +122,8 @@ static const char *_netopt_strmap[] = {
     [NETOPT_NUM_GATEWAYS]          = "NETOPT_NUM_GATEWAYS",
     [NETOPT_LINK_CHECK]            = "NETOPT_LINK_CHECK",
     [NETOPT_RSSI]                  = "NETOPT_RSSI",
+    [NETOPT_L2_GROUP]              = "NETOPT_L2_GROUP",
+    [NETOPT_L2_GROUP_LEAVE]        = "NETOPT_L2_GROUP_LEAVE",
     [NETOPT_NUMOF]                 = "NETOPT_NUMOF",
 };
 

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -238,5 +238,27 @@ int l2util_ndp_addr_len_from_l2ao(int dev_type,
     return -ENOTSUP;
 }
 
+int l2util_ipv6_group_to_l2_group(int dev_type,
+                                  const ipv6_addr_t *ipv6_group,
+                                  uint8_t *l2_group)
+{
+    switch (dev_type) {
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
+        case NETDEV_TYPE_ETHERNET:
+            /* see https://tools.ietf.org/html/rfc2464#section-7 */
+            l2_group[0] = 0x33;
+            l2_group[1] = 0x33;
+            l2_group[2] = ipv6_group->u8[12];
+            l2_group[3] = ipv6_group->u8[13];
+            l2_group[4] = ipv6_group->u8[14];
+            l2_group[5] = ipv6_group->u8[15];
+            return sizeof(eui48_t);
+#endif
+        default:
+            (void)ipv6_group;
+            (void)l2_group;
+            return -ENOTSUP;
+    }
+}
 
 /** @} */

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -243,7 +243,7 @@ int l2util_ipv6_group_to_l2_group(int dev_type,
                                   uint8_t *l2_group)
 {
     switch (dev_type) {
-#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
+#if IS_USED(MODULE_NETDEV_ETH)
         case NETDEV_TYPE_ETHERNET:
             /* see https://tools.ietf.org/html/rfc2464#section-7 */
             l2_group[0] = 0x33;

--- a/tests/l2util/Makefile.ci
+++ b/tests/l2util/Makefile.ci
@@ -1,0 +1,6 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    #

--- a/tests/l2util/main.c
+++ b/tests/l2util/main.c
@@ -32,6 +32,10 @@
 #define TEST_EUI48_EUI64    { 0x21, 0x55, 0x31, 0xff, 0xfe, 0x02, 0x41, 0xfd }
 #define TEST_EUI48_IID      { 0x23, 0x55, 0x31, 0xff, 0xfe, 0x02, 0x41, 0xfd }
 #define TEST_EUI64_IID      { 0x23, 0x55, 0x31, 0x02, 0x41, 0xfd, 0xfb, 0xfd }
+#define TEST_IPV6_GROUP     { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+                              0x3f, 0x6c, 0xa1, 0xbb, 0xe5, 0x03, 0x6b, 0xe2 }
+/* see https://tools.ietf.org/html/rfc2464#section-7 */
+#define TEST_ETHERNET_GROUP { 0x33, 0x33, 0xe5, 0x03, 0x6b, 0xe2 }
 
 static void test_eui64_from_addr__success(void)
 {
@@ -381,6 +385,37 @@ static void test_addr_len_from_l2ao__ENOTSUP(void)
                                                         &opt));
 }
 
+static void test_ipv6_group_to_l2group__success(void)
+{
+    static const ipv6_addr_t test_group = {
+        .u8 = TEST_IPV6_GROUP,
+    };
+    static const eui48_t test_ethernet = {
+        .uint8 = TEST_ETHERNET_GROUP,
+    };
+    uint8_t res[L2UTIL_ADDR_MAX_LEN];
+
+    /* test Ethernet */
+    memset(res, 0, sizeof(res));
+    TEST_ASSERT_EQUAL_INT(sizeof(test_ethernet),
+                          l2util_ipv6_group_to_l2_group(NETDEV_TYPE_ETHERNET,
+                                                        &test_group, res));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&test_ethernet, res,
+                                    sizeof(test_ethernet)));
+}
+
+static void test_ipv6_group_to_l2group__ENOTSUP(void)
+{
+    static const ipv6_addr_t test_group = {
+        .u8 = TEST_IPV6_GROUP,
+    };
+    uint8_t res[L2UTIL_ADDR_MAX_LEN];
+
+    TEST_ASSERT_EQUAL_INT(-ENOTSUP,
+                          l2util_ipv6_group_to_l2_group(NETDEV_TYPE_UNKNOWN,
+                                                        &test_group, res));
+}
+
 TestRef test_l2util(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -395,6 +430,8 @@ TestRef test_l2util(void)
         new_TestFixture(test_addr_len_from_l2ao__success),
         new_TestFixture(test_addr_len_from_l2ao__EINVAL),
         new_TestFixture(test_addr_len_from_l2ao__ENOTSUP),
+        new_TestFixture(test_ipv6_group_to_l2group__success),
+        new_TestFixture(test_ipv6_group_to_l2group__ENOTSUP),
     };
 
     EMB_UNIT_TESTCALLER(tests_l2util, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides the capability on the `gnrc_netif` side to join or leave multicast groups on the link layer, such as Ethernet multicast addresses. When an interface joins an IPv6 address, it now also tries to join a multicast address on the device, as long as that device also supports that (not provided in this PR).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/gnrc_networking` should work as before. ~~I will provide tests for the new functionality ASAP but currently there are none, that's why I marked this PR as still being WIP.~~

The following tests should pass on a supported platform of your choice:
- `tests/gnrc_netif`
- `tests/l2utils`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
When there is driver support for `NETOPT_L2_GROUP` and `NETOPT_L2_GROUP_LEAVE`, this should fix #13493.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
