### PR TITLE
boards/nucleo-l552ze-q: add notes in doc about patched openocd

### DIFF
--- a/boards/nucleo-l552ze-q/doc.txt
+++ b/boards/nucleo-l552ze-q/doc.txt
@@ -5,14 +5,30 @@
 
 ## Flashing the device
 
-The ST Nucleo-L552ZE-Q board includes an on-board ST-LINK V2.1 programmer. The
-easiest way to program the board is to use OpenOCD. Once you have installed
-OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
-installation instructions), you can flash the board simply by typing
+The ST Nucleo-L552ZE-Q board includes an on-board ST-LINK programmer and can be
+flashed using OpenOCD.
+@note The upstream version of OpenOCD doesn't contain yet support for this board,
+so the source code version from http://openocd.zylin.com/#/c/5510
+must be built to be able to flash this board (adapt the configure command with
+your preferred installation directory):
+
+```
+$ git clone https://git.code.sf.net/p/openocd/code openocd
+$ cd openocd
+$ git fetch http://openocd.zylin.com/openocd refs/changes/10/5510/5 && git checkout FETCH_HEAD
+$ ./bootstrap
+$ ./configure --prefix=<installation directory>
+$ make -j
+$ sudo make install
+```
+
+Once the patched OpenOCD is built and installed, you can flash the board simply
+by typing
 
 ```
 make BOARD=nucleo-l552ze-q flash
 ```
+
 and debug via GDB by simply typing
 ```
 make BOARD=nucleo-l552ze-q debug


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

#15192 was merged but the support in openocd is not yet available upstream and requires [this patch](http://openocd.zylin.com/#/c/5510).

This PR slightly extends the documentation of the nucleo-l552ze-q with some notes explaining how to get and build the openocd patch version.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Follow the instructions to build the custom OpenOCD version
- `make doc` and read the generated doc

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Was missed in #15192

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
