### PR TITLE
boards cpu: move OpenWSN defintions to openwsn_defs.h

### DIFF
--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -62,23 +62,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    OpenWSN timing constants
- *
- * @{
- */
-/* Measured 440us + ~10% */
-#define PORT_maxTxDataPrepare   (500/PORT_US_PER_TICK)
-/* Measured 200us + ~10% */
-#define PORT_maxRxAckPrepare    (300/PORT_US_PER_TICK)
-/* Measured 300us + ~10% */
-#define PORT_maxRxDataPrepare   (350/PORT_US_PER_TICK)
-/* Measured 316us + ~10% */
-#define PORT_maxTxAckPrepare    (350/PORT_US_PER_TICK)
-/* Measured 360us with openwsn_sctimer_rtt */
-#define PORT_delayTx            (360/PORT_US_PER_TICK)
-/** @} */
-
-/**
  * @name    Define the interface to the AT86RF231 radio
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}

--- a/boards/common/iotlab/include/openwsn_defs.h
+++ b/boards/common/iotlab/include/openwsn_defs.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for pkg/openwsn
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef OPENWSN_DEFS_H
+#define OPENWSN_DEFS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    OpenWSN timing constants
+ *
+ * @{
+ */
+/* Measured 440us + ~10% */
+#define PORT_maxTxDataPrepare   (500/PORT_US_PER_TICK)
+/* Measured 200us + ~10% */
+#define PORT_maxRxAckPrepare    (300/PORT_US_PER_TICK)
+/* Measured 300us + ~10% */
+#define PORT_maxRxDataPrepare   (350/PORT_US_PER_TICK)
+/* Measured 316us + ~10% */
+#define PORT_maxTxAckPrepare    (350/PORT_US_PER_TICK)
+/* Measured 360us with openwsn_sctimer_rtt */
+#define PORT_delayTx            (360/PORT_US_PER_TICK)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENWSN_DEFS_H */
+/** @} */

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -88,6 +88,9 @@
 
 /**
  * @name    OpenWSN leds configuration
+ *
+ * @note This configuration mimics the one done in OpenWSN-fw for the
+ *       same platform
  * @{
  */
 #define OPENWSN_LEDPIN_ERROR    LED0_PIN

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -82,22 +82,6 @@ static inline int _edbg_get_eui64(const void *arg, eui64_t *addr)
 #define EUI64_PROVIDER_INDEX  0
 /** @} */
 
-/**
- * @name    OpenWSN timing constants
- *
- * @{
- */
-/* Measured 800us + ~10% */
-#define PORT_maxTxDataPrepare   (900/PORT_US_PER_TICK)
-/* Measured 450us + ~10% */
-#define PORT_maxRxAckPrepare    (500/PORT_US_PER_TICK)
-/* Measured 500us + ~10% */
-#define PORT_maxRxDataPrepare   (550/PORT_US_PER_TICK)
-/* Measured 660us + ~10% */
-#define PORT_maxTxAckPrepare    (750/PORT_US_PER_TICK)
-/* Measured 650us with openwsn_sctimer_rtt */
-#define PORT_delayTx            (650/PORT_US_PER_TICK)
-/** @} */
 
 /**
  * @name    LED pin definitions and handlers

--- a/boards/samr21-xpro/include/openwsn_defs.h
+++ b/boards/samr21-xpro/include/openwsn_defs.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samr21-xpro
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for pkg/openwsn
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef OPENWSN_DEFS_H
+#define OPENWSN_DEFS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    OpenWSN timing constants
+ *
+ * @{
+ */
+/* Measured 800us + ~10% */
+#define PORT_maxTxDataPrepare   (900/PORT_US_PER_TICK)
+/* Measured 450us + ~10% */
+#define PORT_maxRxAckPrepare    (500/PORT_US_PER_TICK)
+/* Measured 500us + ~10% */
+#define PORT_maxRxDataPrepare   (550/PORT_US_PER_TICK)
+/* Measured 660us + ~10% */
+#define PORT_maxTxAckPrepare    (750/PORT_US_PER_TICK)
+/* Measured 650us with openwsn_sctimer_rtt */
+#define PORT_delayTx            (650/PORT_US_PER_TICK)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENWSN_DEFS_H */
+/** @} */

--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -43,7 +43,6 @@ extern "C" {
 #define CPU_HAS_BITBAND                 (1)
 /** @} */
 
-
 /**
  * @brief   Flash page configuration
  * @{
@@ -69,19 +68,6 @@ extern "C" {
 #define FLASHPAGE_RAW_BLOCKSIZE    (4U)
 /* Writing should be always 4 bytes aligned */
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
-/** @} */
-
-/**
- * @name    OpenWSN timing constants
- *
- * @{
- */
-/* Taken from openwsn-fw */
-#define PORT_maxTxDataPrepare   (460/PORT_US_PER_TICK)
-#define PORT_maxRxAckPrepare    (300/PORT_US_PER_TICK)
-#define PORT_maxRxDataPrepare   (300/PORT_US_PER_TICK)
-#define PORT_maxTxAckPrepare    (460/PORT_US_PER_TICK)
-#define PORT_delayTx            (400/PORT_US_PER_TICK)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/cc2538/include/openwsn_defs.h
+++ b/cpu/cc2538/include/openwsn_defs.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu
+ * @{
+ *
+ * @file
+ * @brief       cc2538 specific definitions for pkg/openwsn
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef OPENWSN_DEFS_H
+#define OPENWSN_DEFS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    OpenWSN timing constants
+ *
+ * @{
+ */
+/* Taken from openwsn-fw */
+#define PORT_maxTxDataPrepare   (460/PORT_US_PER_TICK)
+#define PORT_maxRxAckPrepare    (300/PORT_US_PER_TICK)
+#define PORT_maxRxDataPrepare   (300/PORT_US_PER_TICK)
+#define PORT_maxTxAckPrepare    (460/PORT_US_PER_TICK)
+#define PORT_delayTx            (400/PORT_US_PER_TICK)
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENWSN_DEFS_H */
+/** @} */

--- a/cpu/nrf52/include/openwsn_defs.h
+++ b/cpu/nrf52/include/openwsn_defs.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu
+ * @{
+ *
+ * @file
+ * @brief       nrf52 specific definitions for pkg/openwsn
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef OPENWSN_DEFS_H
+#define OPENWSN_DEFS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CPU_MODEL_NRF52840XXAA
+/**
+ * @name    OpenWSN timing constants
+ *
+ * @{
+ */
+/* Taken from OpenWSN @32.768Hz */
+#define PORT_maxTxDataPrepare   (400/PORT_US_PER_TICK)
+#define PORT_maxRxAckPrepare    (400/PORT_US_PER_TICK)
+#define PORT_maxRxDataPrepare   (400/PORT_US_PER_TICK)
+#define PORT_maxTxAckPrepare    (400/PORT_US_PER_TICK)
+/* Measured 220us */
+#define PORT_delayTx            (300/PORT_US_PER_TICK)
+#define PORT_delayRx            (150/PORT_US_PER_TICK)
+/** @} */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENWSN_DEFS_H */
+/** @} */

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -104,3 +104,9 @@ dedup
 
 # circularly (used in "circularly linked list" in clist.h) => circular
 circularly
+
+# Chang (common name) => Change
+Chang
+
+# chang (common name) => change
+chang

--- a/pkg/openwsn/include/board_info.h
+++ b/pkg/openwsn/include/board_info.h
@@ -31,6 +31,12 @@
 #include "periph_conf.h"
 #include "timex.h"
 
+#if defined __has_include
+#  if __has_include ("openwsn_defs.h")
+#    include "openwsn_defs.h"
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
### Contribution description

Offline @bergzand mentioned he did not like having pkg specific definitions in `cpu` configuration files. I moved them to `openwsn_defs.h` which is conditionally included based on `__has_include` (This should be supported by all our compilers, but I can replace it by a macro instead if prefered)

### Testing procedure

Is the reordering better?

- Green Murdock

- Add a couple of `#error` to verify correct header inclusion and macro definition.

### Issues/PRs references

