### PR TITLE
vfs: Provide generic stat implementation (and use in fatfs)

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -445,6 +445,7 @@ static const vfs_file_system_ops_t fatfs_fs_ops = {
     .unlink = _unlink,
     .mkdir = _mkdir,
     .rmdir = _rmdir,
+    .stat = vfs_sysop_stat_from_fstat,
 };
 
 static const vfs_file_ops_t fatfs_file_ops = {

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -969,6 +969,20 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur);
  */
 const vfs_file_t *vfs_file_get(int fd);
 
+/** @brief  Implementation of `stat` using `fstat`
+ *
+ * This helper can be used by file system drivers that do not have any more
+ * efficient implementation of `fs_op::stat` than opening the file and running
+ * `f_op::fstat` on it.
+ *
+ * It can be set as `fs_op::stat` by a file system driver, provided it
+ * implements `f_op::open` and `f_op::fstat` and `f_op::close`, and its `open`
+ * accepts `NULL` in the `abs_path` position.
+ */
+int vfs_sysop_stat_from_fstat(vfs_mount_t *mountp,
+        const char *restrict path,
+        struct stat *restrict buf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -1000,4 +1000,23 @@ static inline int _fd_is_valid(int fd)
     return 0;
 }
 
+int vfs_sysop_stat_from_fstat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
+{
+    const vfs_file_ops_t * f_op = mountp->fs->f_op;
+    vfs_file_t opened = {
+        .mp = mountp,
+        /* As per definition of the `vfsfile_ops::open` field */
+        .f_op = f_op,
+        .private_data = { .ptr = NULL },
+        .pos = 0,
+    };
+    int err = f_op->open(&opened, path, 0, 0, NULL);
+    if (err < 0) {
+        return err;
+    }
+    err = f_op->fstat(&opened, buf);
+    f_op->close(&opened);
+    return err;
+}
+
 /** @} */

--- a/tests/pkg_fatfs_vfs/main.c
+++ b/tests/pkg_fatfs_vfs/main.c
@@ -318,6 +318,8 @@ static void test_fstat(void)
             vfs_write(fd, test_txt, sizeof(test_txt)) == sizeof(test_txt));
     print_test_result("test_stat__close", vfs_close(fd) == 0);
 
+    print_test_result("test_stat__direct", vfs_stat(FULL_FNAME1, &stat_buf) == 0);
+
     fd = vfs_open(FULL_FNAME1, O_RDONLY, 0);
     print_test_result("test_stat__open", fd >= 0);
     print_test_result("test_stat__stat", vfs_fstat(fd, &stat_buf) == 0);


### PR DESCRIPTION
### Contribution description

When a file system has `fstat` and `open` implemented, `stat` can still
be missing. The new function is a generic implementation, and used in
fatfs to provide a `stat`.

### Testing procedure

The `pkg_fatfs_vfs` test has been extended to cover this version; the test itself can be tested by cherry-picking only the second (testing) commit and observing failure.

### Issues/PRs references

The coap file server code https://github.com/RIOT-OS/RIOT/pull/14397 needed workarounds for this; running it without the "if stat returns err, open and try fstat" workarounds is another way to test this.

### Impact and alternatives

Iff fatfs_vfs is used, this adds another function to implement a missing file operation. If that is too much, we could make FS operations modular on demand (but I think we're far from needing that -- the FS layer is IMO generally used with devices outside the ultra-low end).

The function is a bit heavier at run time than it'd need (three derefs) to be if it were implemented in a fatfs bespoke way. The ability to reuse this should make up for it overall, and if there's ever two FSs in one build that both use it, it'll save some flash.