### PR TITLE
sc_vfs: Add stat command

### DIFF
--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -512,7 +512,10 @@ static int _stat_handler(int argc, char **argv)
     printf("File: %s\n", argv[1]);
     printf("Size: %ld\n", buf.st_size);
     printf("Type: %s\n", S_ISREG(buf.st_mode) ? "file" : S_ISDIR(buf.st_mode) ? "directory" : "other");
-    printf("Access: %o\n", buf.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
+    /* There is no formatter for mode_t like there is PRIu32. Casting to
+     * unsiged contains the regular (lowest 9) bits, and works both on
+     * platforms with unsiged and long unsigned modes. */
+    printf("Access: %o\n", (unsigned)(buf.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)));
     return 0;
 }
 

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -508,13 +508,13 @@ static int _stat_handler(int argc, char **argv)
         printf("stat ERR: %s\n", errbuf);
         return 2;
     }
-    /* Losely modeled after Linux stat output */
+    /* Loosely modeled after Linux stat output */
     printf("File: %s\n", argv[1]);
     printf("Size: %ld\n", buf.st_size);
     printf("Type: %s\n", S_ISREG(buf.st_mode) ? "file" : S_ISDIR(buf.st_mode) ? "directory" : "other");
     /* There is no formatter for mode_t like there is PRIu32. Casting to
-     * unsiged contains the regular (lowest 9) bits, and works both on
-     * platforms with unsiged and long unsigned modes. */
+     * unsigned contains the regular (lowest 9) bits, and works both on
+     * platforms with unsigned and long unsigned modes. */
     printf("Access: %o\n", (unsigned)(buf.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)));
     return 0;
 }


### PR DESCRIPTION
### Contribution description

This adds a `vfs stat` command:
```
> vfs stat /sda/file.txt
File: /sda/file.txt
Size: 16
Type: file
Access: 444
```

### Testing procedure

* Run the filesystem example
* Stat any found file

### Issues/PRs references

This only works on fatfs if https://github.com/RIOT-OS/RIOT/pull/15293 is merged (as this is where I would have needed a quick stat testing tool).

### Caveats

* I haven't found a file system where stat actually works on directories (but only tested constfs, and fatfs where it's implemented using open/fstat)
* Access is exposed in the POSIX style that the stat struct uses internally. It probably only has meaning in distinguishing writable and read-only files.
* Numeric values are formatted using `%ld` or `%d`. I'd rather have PRIu32-style (or any other more fitting) formatters in there, but there don't seem to be any for `off_t` (and the common recommendations of `%td` doesn't work). Unless we find actually good replacements, I'd leave them as they are and adapt whenever they break.
* Which stats to expose really depends on what's implemented; I'd leave it at size, type and rights until FSs start actually implementing anything more.