### PR TITLE
pkg/gecko_sdk: update to v2.7.7

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=31a7f247e19fca16dc961427c53f27f777f7b557
+PKG_VERSION=b47581a678a53c01dacea9a0a3956c67854b12f4
 PKG_LICENSE=Zlib
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description
This updates Gecko SDK from 2.7.6 to 2.7.7. 

Unfortunately, Silicon Labs does not provide release notes anymore, so the [diff](https://github.com/basilfx/RIOT-gecko-sdk/commit/b47581a678a53c01dacea9a0a3956c67854b12f4) shows the changes. Most changes are related to the CMU driver.

### Testing procedure
I've tested locally using the STK3600 and SLSTK3401a. The binaries are identical in size. Therefore, Murdock should just be happy.

### Issues/PRs references
None