### PR TITLE
suit/storage/flashwrite: use riotboot_slot_offset [backport 2020.10]

### DIFF
--- a/examples/suit_update/tests/01-run.py
+++ b/examples/suit_update/tests/01-run.py
@@ -68,8 +68,7 @@ def publish(server_dir, server_url, app_ver, keys='default', latest_name=None):
 
 def wait_for_update(child):
     return child.expect([r"Fetching firmware \|[█ ]+\|\s+\d+\%",
-                         "riotboot_flashwrite: riotboot flashing "
-                         "completed successfully"],
+                         "Finalizing payload store"],
                         timeout=UPDATING_TIMEOUT)
 
 

--- a/sys/suit/storage/flashwrite.c
+++ b/sys/suit/storage/flashwrite.c
@@ -149,7 +149,7 @@ static bool _flashwrite_match_offset(const suit_storage_t *storage,
     (void)storage;
 
     int target_slot = riotboot_slot_other();
-    uintptr_t slot_start = (intptr_t)riotboot_slot_get_hdr(target_slot);
+    uintptr_t slot_start = (uintptr_t)riotboot_slot_offset(target_slot);
 
     return (slot_start == (uintptr_t)offset);
 }


### PR DESCRIPTION
# Backport of #15306

### Contribution description

Fixes an issue with riotboot on the stm32f1 and other MCUs where the
flash is remapped to a different region

### Testing procedure

`examples/suit` should work again on the iotlab-m3.

### Issues/PRs references

see https://github.com/RIOT-OS/RIOT/pull/15110#issuecomment-716679264