### PR TITLE
sys/suit: dependencies fixes

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -922,8 +922,11 @@ endif
 ifneq (,$(filter suit,$(USEMODULE)))
   USEPKG += nanocbor
   USEPKG += libcose
-  USEMODULE += libcose_crypt_c25519
   USEMODULE += uuid
+
+  ifeq (,$(filter libcose_crypt_%,$(USEMODULE)))
+    USEMODULE += libcose_crypt_c25519
+  endif
 
   # tests/suit_manifest has some mock implementations,
   # only add the non-mock dependencies if not building that test.

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -817,6 +817,10 @@ ifneq (,$(filter luid,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_cpuid
 endif
 
+ifneq (,$(filter nanocoap_sock,$(USEMODULE)))
+  USEMODULE += sock_udp
+endif
+
 ifneq (,$(filter nanocoap_%,$(USEMODULE)))
   USEMODULE += nanocoap
 endif


### PR DESCRIPTION
### Contribution description

While trying to adapt the `examples/suit_update` example to run on OpenWSN I realized `nanocoap` was missing a `USEMODULE += sock_udp` dependency.

This PR also allows to change the default `libcose_crypto` from the application Makefile.


### Testing procedure

- green murdock
- compile with `USEMODULE = libcose_crypt_hacl`, just checking `info-modules should be enough.`

### Issues/PRs references
