### PR TITLE
sys/arduino: fix print float

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -13,6 +13,7 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_OPTIONAL += arduino_pwm
   FEATURES_OPTIONAL += periph_adc
   FEATURES_REQUIRED += periph_gpio
+  USEMODULE += fmt
   USEMODULE += xtimer
 endif
 

--- a/sys/arduino/serialport.cpp
+++ b/sys/arduino/serialport.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include <string.h>
 #include <stdio.h>
 
+#include "fmt.h"
 #include "irq.h"
 }
 
@@ -148,7 +149,7 @@ size_t SerialPort::print(float val)
 size_t SerialPort::print(float val, int format)
 {
     char buf[64];
-    size_t len = sprintf(buf, "%.*f", format, (double)val);
+    size_t len = fmt_float(buf, val, format);
     write(buf, len);
     return len;
 }

--- a/tests/sys_arduino/arduino-test.sketch
+++ b/tests/sys_arduino/arduino-test.sketch
@@ -105,6 +105,15 @@ static void print_test(void)
         Serial.print("): ");
         Serial.println(ul, f);
     }
+
+    Serial.print("print(float): ");
+    Serial.print((float)3.1415);
+    Serial.println();
+    for (int i = 0; i < 4; i++) {
+        Serial.print("print(float): ");
+        Serial.print((float)3.1415, i);
+        Serial.println();
+    }
 }
 
 void loop(void)

--- a/tests/sys_arduino/tests/01-run.py
+++ b/tests/sys_arduino/tests/01-run.py
@@ -64,6 +64,11 @@ def testfunc(child):
     child.expect_exact("println(unsigned long, DEC): 1234567890")
     child.expect_exact("print(unsigned long, HEX): 499602d2")
     child.expect_exact("println(unsigned long, HEX): 499602d2")
+    child.expect_exact("print(float): 3.14")
+    child.expect_exact("print(float): 3")
+    child.expect_exact("print(float): 3.1")
+    child.expect_exact("print(float): 3.14")
+    child.expect_exact("print(float): 3.141")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix #15311 

As reported on #15311 I confirmed that `Serial::print(float)` doesn't work on Arduino but also on ARM (tested on nucleo-l073rz). The proposed fix in this PR is to use `fmt_float` instead of `sprintf`.
The size on ROM is increased significantly:

I'm using the following patch on master:

```diff
diff --git a/tests/sys_arduino/arduino-test.sketch b/tests/sys_arduino/arduino-test.sketch
index 1aa30a9cb4..a782af680a 100644
--- a/tests/sys_arduino/arduino-test.sketch
+++ b/tests/sys_arduino/arduino-test.sketch
@@ -104,6 +104,10 @@ static void print_test(void)
         Serial.print(s_formats[f]);
         Serial.print("): ");
         Serial.println(ul, f);
+
+        Serial.print("print(float): ");
+        Serial.print((float)3.14);
+        Serial.println();
     }
 }
 
diff --git a/tests/sys_arduino/tests/01-run.py b/tests/sys_arduino/tests/01-run.py
index abc320348b..f300c0e657 100755
--- a/tests/sys_arduino/tests/01-run.py
+++ b/tests/sys_arduino/tests/01-run.py
@@ -58,10 +58,13 @@ def testfunc(child):
     child.expect_exact("println(long, HEX): b669fd2e")
     child.expect_exact("print(unsigned long, BIN): 1001001100101100000001011010010")
     child.expect_exact("println(unsigned long, BIN): 1001001100101100000001011010010")
+    child.expect_exact("print(float): 3.14")
     child.expect_exact("print(unsigned long, OCT): 11145401322")
     child.expect_exact("println(unsigned long, OCT): 11145401322")
+    child.expect_exact("print(float): 3.14")
     child.expect_exact("print(unsigned long, DEC): 1234567890")
     child.expect_exact("println(unsigned long, DEC): 1234567890")
+    child.expect_exact("print(float): 3.14")
     child.expect_exact("print(unsigned long, HEX): 499602d2")
     child.expect_exact("println(unsigned long, HEX): 499602d2")
 
```

And I'm building with this command:

```
BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=<board> -C tests/sys_arduino --no-print-directory
```

| board  | master + test patch | this PR | diff | 
| -------- | --------- | ---------- | ------- |
| arduino-uno | 12334B  | 13928B | +1594B |
| nucleo-l073rz | 21076B | 23532B | +2456B  |

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nucleo-l073rz -C tests/sys_arduino --no-print-directory flash test` and it should succeed:

- arduino-uno

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=arduino-uno -C tests/sys_arduino --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=arduino-uno' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/sys_arduino/' 'riot/riotbuild:latest' make 'BOARD=arduino-uno'    
Building application "tests_sys_arduino" for "arduino-uno" with MCU "atmega328p".

"make" -C /data/riotbuild/riotbase/boards/arduino-uno
"make" -C /data/riotbuild/riotbase/boards/common/arduino-atmega
"make" -C /data/riotbuild/riotbase/boards/common/atmega
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/atmega328p
"make" -C /data/riotbuild/riotbase/cpu/atmega_common
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/avr_libc_extra
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/arduino
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/cxx_ctor_guards
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
"make" -C /data/riotbuild/riotbase/tests/sys_arduino/bin/arduino-uno/arduino_sketches
   text	   data	    bss	    dec	    hex	filename
  13928	    518	   1341	  15787	   3dab	/data/riotbuild/riotbase/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.elf
avrdude -c arduino -p m328p -P /dev/ttyACM0  -U flash:w:/work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e950f (probably m328p)
avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip
avrdude: reading input file "/work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex"
avrdude: input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex auto detected as Intel Hex
avrdude: writing flash (14446 bytes):

Writing | ################################################## | 100% 2.31s

avrdude: 14446 bytes of flash written
avrdude: verifying flash memory against /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex:
avrdude: load data flash data from input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex:
avrdude: input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex auto detected as Intel Hex
avrdude: input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex contains 14446 bytes
avrdude: reading on-chip flash data:

Reading | ################################################## | 100% 1.85s

avrdude: verifying ...
avrdude: 14446 bytes of flash verified

avrdude: safemode: Fuses OK (E:00, H:00, L:00)

avrdude done.  Thank you.

r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
 Press s to start test, r to print it is ready


Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: test)
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
3538620 3580148 3622556 OK END
print
print(int, BIN): 1111101011000111
println(int, BIN): 1111101011000111
print(int, OCT): 175307
println(int, OCT): 175307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fac7
println(int, HEX): fac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(float): 3.14
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(float): 3.14
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(float): 3.14
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2

```

</details>

<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=arduino-uno -C tests/sys_arduino --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=arduino-uno' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/sys_arduino/' 'riot/riotbuild:latest' make 'BOARD=arduino-uno'    
Building application "tests_sys_arduino" for "arduino-uno" with MCU "atmega328p".

"make" -C /data/riotbuild/riotbase/boards/arduino-uno
"make" -C /data/riotbuild/riotbase/boards/common/arduino-atmega
"make" -C /data/riotbuild/riotbase/boards/common/atmega
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/atmega328p
"make" -C /data/riotbuild/riotbase/cpu/atmega_common
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/avr_libc_extra
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/arduino
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/cxx_ctor_guards
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
"make" -C /data/riotbuild/riotbase/tests/sys_arduino/bin/arduino-uno/arduino_sketches
   text	   data	    bss	    dec	    hex	filename
  12334	    492	   1341	  14167	   3757	/data/riotbuild/riotbase/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.elf
avrdude -c arduino -p m328p -P /dev/ttyACM0  -U flash:w:/work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e950f (probably m328p)
avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip
avrdude: reading input file "/work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex"
avrdude: input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex auto detected as Intel Hex
avrdude: writing flash (12826 bytes):

Writing | ################################################## | 100% 2.07s

avrdude: 12826 bytes of flash written
avrdude: verifying flash memory against /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex:
avrdude: load data flash data from input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex:
avrdude: input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex auto detected as Intel Hex
avrdude: input file /work/riot/RIOT/tests/sys_arduino/bin/arduino-uno/tests_sys_arduino.hex contains 12826 bytes
avrdude: reading on-chip flash data:

Reading | ################################################## | 100% 1.65s

avrdude: verifying ...
avrdude: 12826 bytes of flash verified

avrdude: safemode: Fuses OK (E:00, H:00, L:00)

avrdude done.  Thank you.

r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
: Press s to start test, r to print it is ready


Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: test)
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
3602668 3644200 3686616 OK END
print
print(int, BIN): 1111101011000111
println(int, BIN): 1111101011000111
print(int, OCT): 175307
println(int, OCT): 175307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fac7
println(int, HEX): fac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(float): 
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(float): 
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(float): 
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2
print(float): 

Timeout in expect script at "child.expect_exact("print(float): 3.14")" (tests/sys_arduino/tests/01-run.py:61)
```

</details>

- nucleo-l073rz

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nucleo-l073rz -C tests/sys_arduino --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l073rz' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/sys_arduino/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l073rz'    
Building application "tests_sys_arduino" for "nucleo-l073rz" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l073rz
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/arduino
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
"make" -C /data/riotbuild/riotbase/tests/sys_arduino/bin/nucleo-l073rz/arduino_sketches
   text	   data	    bss	    dec	    hex	filename
  23532	    132	   2756	  26420	   6734	/data/riotbuild/riotbase/tests/sys_arduino/bin/nucleo-l073rz/tests_sys_arduino.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/sys_arduino/bin/nucleo-l073rz/tests_sys_arduino.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J28M17 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.262921
Info : stm32l0.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32l0.cpu on 0
Info : Listening on port 44931 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l0.cpu        hla_target little stm32l0.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x08000f38 msp: 0x20000200
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (0) size is 96kb, base address is 0x8000000
auto erase enabled
wrote 24576 bytes from file /work/riot/RIOT/tests/sys_arduino/bin/nucleo-l073rz/tests_sys_arduino.elf in 5.564739s (4.313 KiB/s)

verified 23664 bytes in 1.023603s (22.577 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: test)
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
5252780 5289577 5326372 OK END
print
print(int, BIN): 11111111111111111111101011000111
println(int, BIN): 11111111111111111111101011000111
print(int, OCT): 37777775307
println(int, OCT): 37777775307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fffffac7
println(int, HEX): fffffac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(float): 3.14
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(float): 3.14
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(float): 3.14
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2

```

</details>

<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nucleo-l073rz -C tests/sys_arduino --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l073rz' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/sys_arduino/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l073rz'    
Building application "tests_sys_arduino" for "nucleo-l073rz" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l073rz
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/arduino
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
"make" -C /data/riotbuild/riotbase/tests/sys_arduino/bin/nucleo-l073rz/arduino_sketches
   text	   data	    bss	    dec	    hex	filename
  21076	    132	   2756	  23964	   5d9c	/data/riotbuild/riotbase/tests/sys_arduino/bin/nucleo-l073rz/tests_sys_arduino.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/sys_arduino/bin/nucleo-l073rz/tests_sys_arduino.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J28M17 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.270853
Info : stm32l0.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32l0.cpu on 0
Info : Listening on port 37517 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l0.cpu        hla_target little stm32l0.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x08000f20 msp: 0x20000200
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (0) size is 96kb, base address is 0x8000000
auto erase enabled
wrote 24576 bytes from file /work/riot/RIOT/tests/sys_arduino/bin/nucleo-l073rz/tests_sys_arduino.elf in 5.606380s (4.281 KiB/s)

verified 21208 bytes in 0.927534s (22.329 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: test)
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
5245934 5282731 5319526 OK END
print
print(int, BIN): 11111111111111111111101011000111
println(int, BIN): 11111111111111111111101011000111
print(int, OCT): 37777775307
println(int, OCT): 37777775307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fffffac7
println(int, HEX): fffffac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(float): 010010000000101101001�D@��
                                       +J
                                       @ @ @ PTX\@ 
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(float): 22010000000101�`@D@�
                                 +J
                                 @ @ @ PTX\@ 
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(float): 23456789000101�`@D@�
                                 +J
                                 @ @ @ PTX\@ 
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2
print(float): 23456789000101�`@D@�
                                 +J
                                 @ @ @ PTX\@ 

Timeout in expect script at "child.expect_exact("print(float): 3.14")" (tests/sys_arduino/tests/01-run.py:61)

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #15311 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
