### PR TITLE
ieee802154/submac: fix inconsistent state on NO_ACK

### DIFF
--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -36,6 +36,7 @@ static void _tx_end(ieee802154_submac_t *submac, int status,
 
     ieee802154_radio_request_set_trx_state(dev, submac->state == IEEE802154_STATE_LISTEN ? IEEE802154_TRX_STATE_RX_ON : IEEE802154_TRX_STATE_TRX_OFF);
 
+    submac->wait_for_ack = false;
     submac->tx = false;
     while (ieee802154_radio_confirm_set_trx_state(dev) == -EAGAIN) {}
     submac->cb->tx_done(submac, status, info);
@@ -160,7 +161,6 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
             ieee802154_tx_info_t tx_info;
             tx_info.retrans = submac->retrans;
             bool fp = (ack[0] & IEEE802154_FCF_FRAME_PEND);
-            submac->wait_for_ack = false;
             ieee802154_radio_set_rx_mode(submac->dev,
                                          IEEE802154_RX_AACK_ENABLED);
             _tx_end(submac, fp ? TX_STATUS_FRAME_PENDING : TX_STATUS_SUCCESS,
@@ -228,7 +228,6 @@ static void _handle_tx_no_ack(ieee802154_submac_t *submac)
 
     if (ieee802154_radio_has_frame_retrans(dev)) {
         ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_RX_ON);
-        submac->wait_for_ack = false;
         _tx_end(submac, TX_STATUS_NO_ACK, NULL);
     }
     else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR addresses the issue described in https://github.com/RIOT-OS/RIOT/pull/15275#issuecomment-717319029.
I forgot to reset the `wait_for_ack` variable when the SubMAC got a NO_ACK event. This caused the SubMAC to keep waiting an ACK forever, so data frames were simply ignored.

The `wait_for_ack` variable is always reset on `tx_end`, regardless of the cause of the event.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
2 alternatives:

1) Use the procedure described in https://github.com/RIOT-OS/RIOT/pull/15275#issuecomment-717319029 (by @benpicco)
2) Try 2 nodes using the SubMAC. Node B pings to a non existing address (with ACK_REQ on). Node A tries to ping node B (laso with ACK_REQ on). A should be still be able to receive ping packets from B, while B is trying to ping
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/15275
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
