### PR TITLE
sys/arduino: replace xtimer by ztimer as high-level background timer

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -9,7 +9,8 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   SKETCH_MODULE ?= arduino_sketches
   USEMODULE += $(SKETCH_MODULE)
   USEMODULE += fmt
-  USEMODULE += xtimer
+  USEMODULE += ztimer_usec
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -19,7 +19,8 @@
  */
 
 extern "C" {
-#include "xtimer.h"
+#include "assert.h"
+#include "ztimer.h"
 #include "periph/gpio.h"
 #include "periph/adc.h"
 #include "periph/pwm.h"
@@ -60,22 +61,22 @@ int digitalRead(int pin)
 
 void delay(unsigned long msec)
 {
-    xtimer_usleep(msec * US_PER_MS);
+    ztimer_sleep(ZTIMER_MSEC, msec);
 }
 
 void delayMicroseconds(unsigned long usec)
 {
-    xtimer_usleep(usec);
+    ztimer_sleep(ZTIMER_USEC, usec);
 }
 
 unsigned long micros()
 {
-    return xtimer_now_usec();
+    return ztimer_now(ZTIMER_USEC);
 }
 
 unsigned long millis()
 {
-    return xtimer_now_usec64() / US_PER_MS;
+    return ztimer_now(ZTIMER_MSEC);
 }
 
 #if MODULE_PERIPH_ADC

--- a/tests/sys_arduino/Makefile.ci
+++ b/tests/sys_arduino/Makefile.ci
@@ -1,3 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-uno \
+    arduino-duemilanove \
+    arduino-nano \
     nucleo-l011k4 \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR replaces xtimer by ztimer as high-level background timer for delay/delayMicroseconds/millis/micros functions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- `tests/sys_arduino` should still work:

<details><summary>nucleo-l412kb</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nucleo-l412kb -C tests/sys_arduino --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l412kb' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/sys_arduino/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l412kb'    
Building application "tests_sys_arduino" for "nucleo-l412kb" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l412kb
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/arduino
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/ztimer
"make" -C /data/riotbuild/riotbase/tests/sys_arduino/bin/nucleo-l412kb/arduino_sketches
   text	   data	    bss	    dec	    hex	filename
  21692	    176	   2820	  24688	   6070	/data/riotbuild/riotbase/tests/sys_arduino/bin/nucleo-l412kb/tests_sys_arduino.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/sys_arduino/bin/nucleo-l412kb/tests_sys_arduino.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J31M21 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.243158
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 38363 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000fc8 msp: 0x20000200
Info : device idcode = 0x10006464 (STM32L41/L42xx - Rev: A)
Info : flash size = 128kbytes
Info : flash mode : single-bank
Info : Padding image section 1 at 0x0800556c with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08005570 .. 0x080057ff
auto erase enabled
wrote 21872 bytes from file /work/riot/RIOT/tests/sys_arduino/bin/nucleo-l412kb/tests_sys_arduino.elf in 1.149167s (18.587 KiB/s)

verified 21868 bytes in 0.802228s (26.620 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: test)
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
5233391 5270134 5306862 OK END
print
print(int, BIN): 11111111111111111111101011000111
println(int, BIN): 11111111111111111111101011000111
print(int, OCT): 37777775307
println(int, OCT): 37777775307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fffffac7
println(int, HEX): fffffac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
