### PR TITLE
cpu/stm32: Fix reception bug in periph_eth [backport]

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -518,6 +518,13 @@ static int stm32_eth_recv(netdev_t *netdev, void *buf, size_t max_len,
         rx_curr = rx_curr->desc_next;
     }
 
+    if ((size + ETHERNET_FCS_LEN - 1) % ETH_RX_BUFFER_SIZE < ETHERNET_FCS_LEN) {
+        /* one additional rx descriptor was needed only for the FCS, hand that
+         * back to the DMA as well */
+        rx_curr->status = RX_DESC_STAT_OWN;
+        rx_curr = rx_curr->desc_next;
+    }
+
     handle_lost_rx_irqs();
     return size;
 }


### PR DESCRIPTION
# Partial backport of "cpu/stm32: Fix reception bug in periph_eth #15318"

### Contribution description

The reception code hands RX DMA descriptors back to the DMA right after its contents were copied into the network stack internal buffer. This increases the odds that the DMA never runs out of DMA descriptors to fill, even under high load. However, the loop fetching the Ethernet frame stops to iterate at the end of the frame. If the DMA used one more descriptor to store the FCS, this descriptor was not returned back to the DMA.

### Testing procedure

Send an Ethernet frame that has a size *n* in bytes with *n % 256 > 252*, e.g. 765 bytes. In master, the driver will stop receiving frames after one such frame. E.g.

```
ping -I eth0 -s 703  fe80::XXX
```

produces an Ethernet frame of the correct size for me. With this PR, the issue is fixed.


### Issues/PRs references

Reported by @kfessel via email.