### PR TITLE
gnrc_nettype: remove GNRC_NETTYPE_IOVEC

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -216,6 +216,14 @@ Reason for removal:
 - Ported version even older (last update Feb 2016)
 - Updating to more recent version would be more effort than its worth
 
+### GNRC_NETTYPE_IOVEC [4f243c52eabefe709d78560ce7f1d502d737a999]
+Author(s):
+- Martine S. Lenders <m.lenders@fu-berlin.de>
+- Hauke Petersen <devel@haukepetersen.de>
+
+Reason for removal:
+- Unused since [9fb2f541baca469e34fa01b004d6f19385700ce9]
+
 
 [cdc252ab7bd4161cc046bf93a3e55995704b24d4]: https://github.com/RIOT-OS/RIOT/commit/cdc252ab7bd4161cc046bf93a3e55995704b24d4
 [ed3887ac5c1e95308c2827bce3cdca8b0f146c22]: https://github.com/RIOT-OS/RIOT/commit/ed3887ac5c1e95308c2827bce3cdca8b0f146c22
@@ -238,3 +246,5 @@ Reason for removal:
 [f2760c033c5f332be076b25aa212aca4007c3d65]: https://github.com/RIOT-OS/RIOT/commit/f2760c033c5f332be076b25aa212aca4007c3d65
 [e63cd54f3b1e002a7895bb7c46af889b341c1a15]: https://github.com/RIOT-OS/RIOT/commit/e63cd54f3b1e002a7895bb7c46af889b341c1a15
 [4f243c52eabefe709d78560ce7f1d502d737a999]: https://github.com/RIOT-OS/RIOT/commit/4f243c52eabefe709d78560ce7f1d502d737a999
+[3cac6e0979468ba56659291fd1cd11096611589d]: https://github.com/RIOT-OS/RIOT/commit/3cac6e0979468ba56659291fd1cd11096611589d
+[9fb2f541baca469e34fa01b004d6f19385700ce9]: https://github.com/RIOT-OS/RIOT/commit/9fb2f541baca469e34fa01b004d6f19385700ce9

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -49,15 +49,6 @@ extern "C" {
  */
 typedef enum {
     /**
-     * @brief   Not so much protocol but data type that is passed to network
-     *          devices using the netdev interface
-     *
-     * @deprecated  Unused since https://github.com/RIOT-OS/RIOT/pull/11193.
-     *              Will be removed after 2020.10 release.
-     *
-     */
-    GNRC_NETTYPE_IOVEC = -2,
-    /**
      * @brief   Protocol is as defined in @ref gnrc_netif_hdr_t. Not usable with
      *          @ref net_gnrc_netreg
      */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
NETTYPE is unused in the code base since https://github.com/RIOT-OS/RIOT/pull/11193 and deprecated since https://github.com/RIOT-OS/RIOT/pull/13170 and 2020.10, the release the removal was slated for, already branched of.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read, check if my claims are true, and Murdock should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #13170
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
