### PR TITLE
drivers/periph: add interface for QSPI (API only)

### DIFF
--- a/drivers/include/periph/qspi.h
+++ b/drivers/include/periph/qspi.h
@@ -170,59 +170,72 @@ void qspi_acquire(qspi_t bus);
  * After release, the given SPI bus should be fully powered down until acquired
  * again.
  *
- * @param[in] bus       QSPI device to release
+ * @param[in]   bus     QSPI device to release
  */
 void qspi_release(qspi_t bus);
 
 /**
  * @brief   Execute a command with response data e.g Read Status, Read JEDEC
  *
- * @param[in]  bus      QSPI device
- * @param[in]  command  The JEDEC command ID
- * @param[out] response Command response data, may be NULL
- * @param[in]  len      Size of the command response buffer
+ * @param[in]   bus      QSPI device
+ * @param[in]   command  The JEDEC command ID
+ * @param[out]  response Buffer for command response
+ * @param[in]   len      Size of the command response buffer
+ *
+ * @return      length of the response
+ *              negative error
  */
-void qspi_cmd_read(qspi_t bus, uint8_t command, void *response, size_t len);
+ssize_t qspi_cmd_read(qspi_t bus, uint8_t command, void *response, size_t len);
 
 /**
  * @brief   Execute a command with data e.g Write Status, Write Enable
  *
- * @param[in] bus       QSPI device
- * @param[in] command   The JEDEC command ID
- * @param[in] data      Command parameter data, may be NULL
- * @param[in] len       Size of the command response buffer
+ * @param[in]   bus      QSPI device
+ * @param[in]   command  The JEDEC command ID
+ * @param[in]   data     Command parameter data, may be NULL
+ * @param[in]   len      Size of the command response buffer
+ *
+ * @return      number of bytes written
+ *              negative error
  */
-void qspi_cmd_write(qspi_t bus, uint8_t command, const void *data, size_t len);
+ssize_t qspi_cmd_write(qspi_t bus, uint8_t command, const void *data, size_t len);
 
 /**
  * @brief   Read data from external memory.
  *          Typically it is implemented by quad read command (`0x6B`).
  *
- * @param[in]  bus      QSPI device
- * @param[in]  address  Address to read from
- * @param[out] data     Buffer to store the data
- * @param[in]  len      Nmber of byte to read
+ * @param[in]   bus      QSPI device
+ * @param[in]   address  Address to read from
+ * @param[out]  data     Buffer to store the data
+ * @param[in]   len      Number of byte to read
+ *
+ * @return      length of bytes read, may be smaller than @p len if the
+ *              driver has a maximal transfer size.
+ *              negative error
  */
-void qspi_read(qspi_t bus, uint32_t addr, void *data, size_t len);
+ssize_t qspi_read(qspi_t bus, uint32_t addr, void *data, size_t len);
 
 /**
  * @brief   Write data to external memory.
  *          Can only write 1 -> 0, so target region should erased first.
  *          Typically it uses quad write command (`0x32`).
  *
- * @param[in] bus       QSPI device
- * @param[in] address   Address to write to
- * @param[in] data      Buffer to write
- * @param[in] len       Nmber of byte to write
+ * @param[in]   bus       QSPI device
+ * @param[in]   address   Address to write to
+ * @param[in]   data      Buffer to write
+ * @param[in]   len       Number of byte to write
+ *
+ * @return      number of bytes written, may be smaller than @p len
+ *              negative error
  */
-void qspi_write(qspi_t bus, uint32_t addr, const void *data, size_t len);
+ssize_t qspi_write(qspi_t bus, uint32_t addr, const void *data, size_t len);
 
 /**
  * @brief   Erase external memory by address
  *
- * @param[in] bus       QSPI device
- * @param[in] address   The address of the block that will be reased
- * @param[in] size      The erase block size to use
+ * @param[in]   bus       QSPI device
+ * @param[in]   address   The address of the block that will be erased
+ * @param[in]   size      The erase block size to use
  */
 void qspi_erase(qspi_t bus, uint32_t address, qspi_erase_size_t size);
 

--- a/drivers/include/periph/qspi.h
+++ b/drivers/include/periph/qspi.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_qspi Quad SPI peripheral
+ * @ingroup     drivers_periph
+ * @brief       Low-level QSPI peripheral driver
+ */
+
+#ifndef PERIPH_QSPI_H
+#define PERIPH_QSPI_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <limits.h>
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Serial Flash JEDEC commands
+ */
+typedef enum {
+    SFLASH_CMD_READ = 0x03,                 /**< Single Read   */
+    SFLASH_CMD_FAST_READ = 0x0B,            /**< Fast Read     */
+    SFLASH_CMD_QUAD_READ = 0x6B,            /**< 1 line address, 4 line data         */
+
+    SFLASH_CMD_READ_JEDEC_ID = 0x9f,        /**< Read Chip ID  */
+
+    SFLASH_CMD_PAGE_PROGRAM = 0x02,         /**< 1 line address, 1 line data         */
+    SFLASH_CMD_QUAD_PAGE_PROGRAM = 0x32,    /**< 1 line address, 4 line data         */
+
+    SFLASH_CMD_READ_STATUS = 0x05,          /**< Read first status register          */
+    SFLASH_CMD_READ_STATUS2 = 0x35,         /**< Read second status register         */
+
+    SFLASH_CMD_WRITE_STATUS = 0x01,         /**< Write first status register         */
+    SFLASH_CMD_WRITE_STATUS2 = 0x31,        /**< Write second status register        */
+
+    SFLASH_CMD_ENABLE_RESET = 0x66,         /**< Must be issued before reset command */
+    SFLASH_CMD_RESET = 0x99,                /**< Reset device state                  */
+
+    SFLASH_CMD_WRITE_ENABLE = 0x06,         /**< Must be issued before write command */
+    SFLASH_CMD_WRITE_DISABLE = 0x04,        /**< Revoke Write Enable                 */
+
+    SFLASH_CMD_ERASE_SECTOR = 0x20,         /**< sector (4k) erase                   */
+    SFLASH_CMD_ERASE_BLOCK = 0xD8,          /**< block (64k) erase                   */
+    SFLASH_CMD_ERASE_CHIP = 0xC7,           /**< whole chip erase                    */
+
+    SFLASH_CMD_4_BYTE_ADDR = 0xB7,          /**< enable 32 bit addressing */
+    SFLASH_CMD_3_BYTE_ADDR = 0xE9,          /**< enable 24 bit addressing */
+} spi_flash_cmd_t;
+
+/**
+ * @brief   Default SPI device access macro
+ */
+#ifndef QSPI_DEV
+#define QSPI_DEV(x)     (x)
+#endif
+
+/**
+ * @brief   Define global value for undefined QSPI device
+ */
+#ifndef QSPI_UNDEF
+#define QSPI_UNDEF      (UINT_MAX)
+#endif
+
+/**
+ * @brief   Default type for QSPI devices
+ */
+#ifndef HAVE_QSPI_T
+typedef unsigned int qspi_t;
+#endif
+
+/**
+ * @brief   Available QSPI modes, defining the configuration of clock polarity
+ *          and clock phase
+ *
+ * RIOT is using the mode numbers as commonly defined by most vendors
+ * (https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Mode_numbers):
+ *
+ * - MODE_0: CPOL=0, CPHA=0 - The first data bit is sampled by the receiver on
+ *           the first SCK rising SCK edge (this mode is used most often).
+ * - MODE_1: CPOL=0, CPHA=1 - The first data bit is sampled by the receiver on
+ *           the second rising SCK edge.
+ * - MODE_2: CPOL=1, CPHA=0 - The first data bit is sampled by the receiver on
+ *           the first falling SCK edge.
+ * - MODE_3: CPOL=1, CPHA=1 - The first data bit is sampled by the receiver on
+ *           the second falling SCK edge.
+ */
+#ifndef HAVE_QSPI_MODE_T
+typedef enum {
+    QSPI_MODE_0 = 0,        /**< CPOL=0, CPHA=0 */
+    QSPI_MODE_1,            /**< CPOL=0, CPHA=1 */
+    QSPI_MODE_2,            /**< CPOL=1, CPHA=0 */
+    QSPI_MODE_3             /**< CPOL=1, CPHA=1 */
+} qspi_mode_t;
+#endif
+
+/**
+ * @brief   Standard QSPI erase block sizes
+ */
+#ifndef HAVE_QSPI_ERASE_SIZE_T
+typedef enum {
+    QSPI_ERASE_4K   = SFLASH_CMD_ERASE_SECTOR,
+    QSPI_ERASE_64K  = SFLASH_CMD_ERASE_BLOCK,
+    QSPI_ERASE_CHIP = SFLASH_CMD_ERASE_CHIP,
+} qspi_erase_size_t;
+#endif
+
+/**
+ * @brief   Configuration Options for QSPI
+ * @{
+ */
+#define QSPI_FLAG_1BIT          (0x0)   /**< single data line           */
+#define QSPI_FLAG_2BIT          (0x1)   /**< two parallel data lines    */
+#define QSPI_FLAG_4BIT          (0x2)   /**< four parallel data lines   */
+#define QSPI_FLAG_8BIT          (0x3)   /**< eight parallel data lines  */
+
+#define QSPI_FLAG_BIT_MASK      (0x3)   /**< mask to get data lines from flags */
+#define QSPI_FLAG_BIT(flags)    ((flags) & QSPI_FLAG_BIT_MASK)
+
+#define QSPI_FLAG_DDR           (0x4)   /**< use Double Data Rate mode  */
+
+#define QSPI_FLAG_ADDR_32BIT    (0x8)   /**< use 32 bit addressing      */
+/** @} */
+
+/**
+ * @brief   Basic initialization of the given QSPI bus
+ *
+ * @note    This function MUST not be called more than once per bus!
+ *
+ * @param[in] bus       QSPI device to initialize
+ */
+void qspi_init(qspi_t bus);
+
+/**
+ * @brief   Configure the QSPI peripheral settings
+ *
+ * @param[in] bus       QSPI device to configure
+ * @param[in] mode      QSPI mode @see qspi_mode_t
+ * @param[in] flags     QSPI Configuration Options
+ * @param[in] clk_hz    QSPI frequency in Hz
+ */
+void qspi_configure(qspi_t bus, qspi_mode_t mode, uint32_t flags, uint32_t clk_hz);
+
+/**
+ * @brief   Start a new QSPI transaction
+ *
+ * Starting a new QSPI transaction will get exclusive access to the QSPI bus
+ * and configure it according to the given values. If another QSPI transaction
+ * is active when this function is called, this function will block until the
+ * other transaction is complete (qspi_relase was called).
+ *
+ * @param[in] bus       QSPI device to access
+ */
+void qspi_acquire(qspi_t bus);
+
+/**
+ * @brief   Finish an ongoing QSPI transaction by releasing the given QSPI bus
+ *
+ * After release, the given SPI bus should be fully powered down until acquired
+ * again.
+ *
+ * @param[in] bus       QSPI device to release
+ */
+void qspi_release(qspi_t bus);
+
+/**
+ * @brief   Execute a command with response data e.g Read Status, Read JEDEC
+ *
+ * @param[in]  bus      QSPI device
+ * @param[in]  command  The JEDEC command ID
+ * @param[out] response Command response data, may be NULL
+ * @param[in]  len      Size of the command response buffer
+ */
+void qspi_cmd_read(qspi_t bus, uint8_t command, void *response, size_t len);
+
+/**
+ * @brief   Execute a command with data e.g Write Status, Write Enable
+ *
+ * @param[in] bus       QSPI device
+ * @param[in] command   The JEDEC command ID
+ * @param[in] data      Command parameter data, may be NULL
+ * @param[in] len       Size of the command response buffer
+ */
+void qspi_cmd_write(qspi_t bus, uint8_t command, const void *data, size_t len);
+
+/**
+ * @brief   Read data from external memory.
+ *          Typically it is implemented by quad read command (`0x6B`).
+ *
+ * @param[in]  bus      QSPI device
+ * @param[in]  address  Address to read from
+ * @param[out] data     Buffer to store the data
+ * @param[in]  len      Nmber of byte to read
+ */
+void qspi_read(qspi_t bus, uint32_t addr, void *data, size_t len);
+
+/**
+ * @brief   Write data to external memory.
+ *          Can only write 1 -> 0, so target region should erased first.
+ *          Typically it uses quad write command (`0x32`).
+ *
+ * @param[in] bus       QSPI device
+ * @param[in] address   Address to write to
+ * @param[in] data      Buffer to write
+ * @param[in] len       Nmber of byte to write
+ */
+void qspi_write(qspi_t bus, uint32_t addr, const void *data, size_t len);
+
+/**
+ * @brief   Erase external memory by address
+ *
+ * @param[in] bus       QSPI device
+ * @param[in] address   The address of the block that will be reased
+ * @param[in] size      The erase block size to use
+ */
+void qspi_erase(qspi_t bus, uint32_t address, qspi_erase_size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_QSPI_H */
+/** @} */

--- a/drivers/include/periph/qspi.h
+++ b/drivers/include/periph/qspi.h
@@ -145,6 +145,8 @@ void qspi_init(qspi_t bus);
 /**
  * @brief   Configure the QSPI peripheral settings
  *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
+ *
  * @param[in] bus       QSPI device to configure
  * @param[in] mode      QSPI mode @see qspi_mode_t
  * @param[in] flags     QSPI Configuration Options
@@ -167,6 +169,8 @@ void qspi_acquire(qspi_t bus);
 /**
  * @brief   Finish an ongoing QSPI transaction by releasing the given QSPI bus
  *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
+ *
  * After release, the given SPI bus should be fully powered down until acquired
  * again.
  *
@@ -176,6 +180,8 @@ void qspi_release(qspi_t bus);
 
 /**
  * @brief   Execute a command with response data e.g Read Status, Read JEDEC
+ *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
  *
  * @param[in]   bus      QSPI device
  * @param[in]   command  The JEDEC command ID
@@ -190,6 +196,8 @@ ssize_t qspi_cmd_read(qspi_t bus, uint8_t command, void *response, size_t len);
 /**
  * @brief   Execute a command with data e.g Write Status, Write Enable
  *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
+ *
  * @param[in]   bus      QSPI device
  * @param[in]   command  The JEDEC command ID
  * @param[in]   data     Command parameter data, may be NULL
@@ -203,6 +211,8 @@ ssize_t qspi_cmd_write(qspi_t bus, uint8_t command, const void *data, size_t len
 /**
  * @brief   Read data from external memory.
  *          Typically it is implemented by quad read command (`0x6B`).
+ *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
  *
  * @param[in]   bus      QSPI device
  * @param[in]   address  Address to read from
@@ -220,6 +230,11 @@ ssize_t qspi_read(qspi_t bus, uint32_t addr, void *data, size_t len);
  *          Can only write 1 -> 0, so target region should erased first.
  *          Typically it uses quad write command (`0x32`).
  *
+ *          The QSPI driver will take care of setting the Write Enable
+ *          on the external flash.
+ *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
+ *
  * @param[in]   bus       QSPI device
  * @param[in]   address   Address to write to
  * @param[in]   data      Buffer to write
@@ -232,6 +247,11 @@ ssize_t qspi_write(qspi_t bus, uint32_t addr, const void *data, size_t len);
 
 /**
  * @brief   Erase external memory by address
+ *
+ *          The QSPI driver will take care of setting the Write Enable
+ *          on the external flash.
+ *
+ * @pre     The @p bus has been acquired with @ref qspi_acquire
  *
  * @param[in]   bus       QSPI device
  * @param[in]   address   The address of the block that will be erased

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -31,6 +31,9 @@
 #ifdef MODULE_PERIPH_INIT_SPI
 #include "periph/spi.h"
 #endif
+#ifdef MODULE_PERIPH_INIT_QSPI
+#include "periph/qspi.h"
+#endif
 #ifdef MODULE_PERIPH_INIT_RTC
 #include "periph/rtc.h"
 #endif
@@ -62,6 +65,13 @@ void periph_init(void)
 #ifdef MODULE_PERIPH_INIT_SPI
     for (unsigned i = 0; i < SPI_NUMOF; i++) {
         spi_init(SPI_DEV(i));
+    }
+#endif
+
+    /* initialize configured QSPI devices */
+#ifdef MODULE_PERIPH_INIT_QSPI
+    for (unsigned i = 0; i < QSPI_NUMOF; i++) {
+        qspi_init(QSPI_DEV(i));
     }
 #endif
 

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -240,6 +240,11 @@ config HAS_PERIPH_SPI_GPIO_MODE
     help
         Indicates that the SPI peripheral supports configuring the GPIOs modes.
 
+config HAS_PERIPH_QSPI
+    bool
+    help
+        Indicates that a Quad-SPI peripheral is present.
+
 config HAS_PERIPH_TEMPERATURE
     bool
     help

--- a/tests/periph_qspi/Makefile
+++ b/tests/periph_qspi/Makefile
@@ -1,0 +1,11 @@
+BOARD ?= same54-xpro
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += periph_qspi
+
+USEMODULE += shell
+USEMODULE += shell_commands
+
+USEMODULE += od
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_qspi/main.c
+++ b/tests/periph_qspi/main.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Application for testing low-level QSPI driver implementations
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "od.h"
+#include "periph/qspi.h"
+#include "shell.h"
+
+static qspi_t _get_dev(int argc, char **argv, bool *oob)
+{
+    qspi_t dev = QSPI_DEV(0);
+    *oob = false;
+
+    if (argc > 1) {
+        unsigned idx = atoi(argv[1]);
+        if (idx >= QSPI_NUMOF) {
+            printf("%s: invalid device: %s\n", argv[0], argv[1]);
+            *oob = true;
+        }
+
+        dev = QSPI_DEV(idx);
+    }
+
+    return dev;
+}
+
+static int cmd_read(int argc, char **argv)
+{
+    bool oob;
+    qspi_t dev = _get_dev(argc, argv, &oob);
+    uint32_t addr, len;
+
+    if (oob) {
+        return -1;
+    }
+
+    if (argc < 4) {
+        printf("usage: %s <dev> <addr> <len>\n", argv[0]);
+        return -1;
+    }
+
+    addr = atoi(argv[2]);
+    len  = atoi(argv[3]);
+
+    void *buffer = malloc(len);
+    if (buffer == NULL) {
+        puts("out of memory");
+        return -1;
+    }
+
+    qspi_acquire(dev);
+    qspi_read(dev, addr, buffer, len);
+    qspi_release(dev);
+
+    od_hex_dump(buffer, len, 0);
+
+    free(buffer);
+
+    return 0;
+}
+
+static int cmd_erase(int argc, char **argv)
+{
+    bool oob;
+    qspi_t dev = _get_dev(argc, argv, &oob);
+    uint32_t addr;
+    uint8_t mode;
+
+    if (oob) {
+        return -1;
+    }
+
+    if (argc < 4) {
+        printf("usage: %s <dev> <addr> <mode>\n", argv[0]);
+        printf("\tmode 0: sector erase\n");
+        printf("\tmode 1: block erase\n");
+        printf("\tmode 2: chip erase\n");
+        return -1;
+    }
+
+    addr = atoi(argv[2]);
+    mode = atoi(argv[3]);
+
+    const qspi_erase_size_t cmds[] = {
+        QSPI_ERASE_4K,
+        QSPI_ERASE_64K,
+        QSPI_ERASE_CHIP,
+    };
+
+    if (mode > ARRAY_SIZE(cmds)) {
+        printf("%s: invalid mode\n", argv[0]);
+        return -1;
+    }
+
+    qspi_acquire(dev);
+    qspi_erase(dev, addr, cmds[mode]);
+    qspi_release(dev);
+
+    return 0;
+}
+static int cmd_write(int argc, char **argv)
+{
+    bool oob;
+    qspi_t dev = _get_dev(argc, argv, &oob);
+    uint32_t addr, len;
+
+    if (oob) {
+        return -1;
+    }
+
+    if (argc < 4) {
+        printf("usage: %s <dev> <addr> <data>\n", argv[0]);
+        return -1;
+    }
+
+    addr = atoi(argv[2]);
+    len  = strlen(argv[3]);
+
+    qspi_acquire(dev);
+    qspi_write(dev, addr, argv[3], len);
+    qspi_release(dev);
+
+    return 0;
+}
+
+static int cmd_jedec(int argc, char **argv)
+{
+    bool oob;
+    qspi_t dev = _get_dev(argc, argv, &oob);
+
+    if (oob) {
+        return -1;
+    }
+
+    struct __attribute__ ((packed)) {
+        uint8_t manuf;
+        uint16_t device;
+        uint8_t unique[17];
+    } jedec_id;
+
+    qspi_acquire(dev);
+    qspi_cmd_read(dev, SFLASH_CMD_READ_JEDEC_ID, &jedec_id, sizeof(jedec_id));
+    qspi_release(dev);
+
+    printf("Manufacturer ID: %x\n", jedec_id.manuf);
+    printf("Device ID: %x\n", jedec_id.device);
+    printf("Unique ID:");
+    for (unsigned i = 0; i < sizeof(jedec_id.unique); ++i) {
+        printf(" %02x", jedec_id.unique[i]);
+    }
+    puts("");
+
+    return 0;
+}
+
+static qspi_mode_t _qspi_mode(unsigned mode)
+{
+    switch (mode) {
+    case 3: return QSPI_MODE_3;
+    case 2: return QSPI_MODE_2;
+    case 1: return QSPI_MODE_1;
+    default:
+    case 0: return QSPI_MODE_0;
+    }
+}
+
+static int cmd_cfg(int argc, char **argv)
+{
+    bool oob;
+    qspi_t dev = _get_dev(argc, argv, &oob);
+
+    if (oob) {
+        return -1;
+    }
+
+    if (argc < 4) {
+        printf("usage: %s <dev> <addr_len> <freq MHz> [mode]\n", argv[0]);
+        return -1;
+    }
+
+    qspi_mode_t mode  = QSPI_MODE_0;
+    unsigned addr_len = atoi(argv[2]);
+    unsigned freq_mhz = atoi(argv[3]);
+
+    uint32_t flags = QSPI_FLAG_4BIT
+                   | (addr_len == 4 ? QSPI_FLAG_ADDR_32BIT : 0);
+
+    if (argc > 3) {
+        mode = _qspi_mode(atoi(argv[4]));
+    }
+
+    printf("QSPI%s: %u-bit, %u MHz\n", argv[1], 8 * addr_len, freq_mhz);
+
+    qspi_configure(dev, mode, flags,  MHZ(freq_mhz));
+
+    return 0;
+}
+static const shell_command_t shell_commands[] = {
+    { "jedec", "Read JEDEC ID of the QSPI flash", cmd_jedec },
+    { "init", "Configure the QSPI peripheral", cmd_cfg },
+    { "read", "Read a region of memory on the QSPI flash", cmd_read },
+    { "erase", "Erase a region of memory on the QSPI flash", cmd_erase },
+    { "write", "Write a region of memory on the QSPI flash", cmd_write },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Manual QSPI peripheral driver test");
+    printf("There are %u QSPI peripherals.\n", QSPI_NUMOF);
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION

### Contribution description

This adds the API for the QSPI peripheral found on many chips.
The border between the external memory chip and the internal QSPI chip is a bit mushy at times when the QSPI peripheral implements part of the JEDEC protocol.

### Testing procedure

Read the API and verify that it makes sense.
There is also a minimal test application that can be used to verify the implementation.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
