### PR TITLE
 socket_zep: don't always listen on local port

### DIFF
--- a/cpu/native/include/socket_zep_params.h
+++ b/cpu/native/include/socket_zep_params.h
@@ -35,16 +35,6 @@ extern "C" {
 #endif
 
 /**
- * @name   Default parameters for native argument parsing
- * @{
- */
-#define SOCKET_ZEP_PORT_DEFAULT         "17754" /**< default port */
-#define SOCKET_ZEP_LOCAL_ADDR_DEFAULT   "::"    /**< default local address */
-/**
- * @}
- */
-
-/**
  * @brief   socket_zep configurations
  */
 extern socket_zep_params_t socket_zep_params[SOCKET_ZEP_MAX];

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -309,13 +309,16 @@ void usage_exit(int status)
 "        times (up to UART_NUMOF)\n"
 #ifdef MODULE_PERIPH_GPIO_LINUX
 "    -g <gpio>, --gpio=<gpio>\n"
-"        specify gpiochip device for GPIO access. This argument can be used multiple times.\n"
+"        specify gpiochip device for GPIO access.\n"
+"        This argument can be used multiple times.\n"
 "        Example: --gpio=/dev/gpiochip0 uses gpiochip0 for port 0\n"
 #endif
 #if defined(MODULE_SOCKET_ZEP) && (SOCKET_ZEP_MAX > 0)
 "    -z [<laddr>:<lport>,]<raddr>:<rport> --zep=[<laddr>:<lport>,]<raddr>:<rport>\n"
-"        provide a ZEP interface with (optional) local address and port (<laddr>, <lport>).\n"
-"        The ZEP interface connects to the remote address and may listen on a local address.\n"
+"        provide a ZEP interface with an (optional) local address and port\n"
+"        (<laddr>:<lport>) and a remote address and port (<raddr>:<rport>).\n"
+"        The ZEP interface connects to the remote address and may listen\n"
+"        on a local address.\n"
 "        Required to be provided SOCKET_ZEP_MAX times\n"
 #endif
     );

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -314,8 +314,8 @@ void usage_exit(int status)
 #endif
 #if defined(MODULE_SOCKET_ZEP) && (SOCKET_ZEP_MAX > 0)
 "    -z [<laddr>:<lport>,]<raddr>:<rport> --zep=[<laddr>:<lport>,]<raddr>:<rport>\n"
-"        provide a ZEP interface with local address and port (<laddr>, <lport>)\n"
-"        and remote address and port (default local: [::]:17754).\n"
+"        provide a ZEP interface with (optional) local address and port (<laddr>, <lport>).\n"
+"        The ZEP interface connects to the remote address and may listen on a local address.\n"
 "        Required to be provided SOCKET_ZEP_MAX times\n"
 #endif
     );
@@ -396,8 +396,8 @@ static void _zep_params_setup(char *zep_str, int zep)
     }
     second_ep = strtok_r(NULL, ",", &save_ptr);
     if (second_ep == NULL) {
-        socket_zep_params[zep].local_addr = SOCKET_ZEP_LOCAL_ADDR_DEFAULT;
-        socket_zep_params[zep].local_port = SOCKET_ZEP_PORT_DEFAULT;
+        socket_zep_params[zep].local_addr = NULL;
+        socket_zep_params[zep].local_port = NULL;
         _parse_ep_str(first_ep, &socket_zep_params[zep].remote_addr,
                       &socket_zep_params[zep].remote_port);
     }


### PR DESCRIPTION
### Contribution description

- if no local address is specified, don't listen on a port, just connect to the remote address
- ~~sent a dummy packet at startup (that is dropped by `socket_zep`) to announce one's presence if a UDP dispatcher is used~~


### Testing procedure

`socket_zep` will not bind to a local port unless explicitly requested to do.


### Issues/PRs references

split off #14755
