### PR TITLE
boards/waspmote-pro: add arduino feature

### DIFF
--- a/boards/waspmote-pro/Kconfig
+++ b/boards/waspmote-pro/Kconfig
@@ -16,3 +16,4 @@ config BOARD_WASPMOTE_PRO
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_ARDUINO

--- a/boards/waspmote-pro/Makefile.features
+++ b/boards/waspmote-pro/Makefile.features
@@ -8,3 +8,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
+FEATURES_PROVIDED += arduino

--- a/boards/waspmote-pro/include/arduino_board.h
+++ b/boards/waspmote-pro/include/arduino_board.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2020 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waspmote-pro
+ * @{
+ *
+ * @file
+ * @brief       Configuration of the Arduino API for Waspmote Pro board
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+#include "periph/pwm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ *
+ * The waspmote-pro board has 2 programmable LEDs: green connected to pin 13
+ * (aka LED1), and red connected to pin 12 (aka LED0).
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_16,
+    ARDUINO_PIN_17,
+    ARDUINO_PIN_18,
+    ARDUINO_PIN_19,
+    ARDUINO_PIN_20,
+    ARDUINO_PIN_21,
+    ARDUINO_PIN_22,
+    ARDUINO_PIN_23,
+    ARDUINO_PIN_24,
+    ARDUINO_PIN_25,
+    ARDUINO_PIN_26,
+    ARDUINO_PIN_27,
+    ARDUINO_PIN_28,
+    ARDUINO_PIN_29,
+    ARDUINO_PIN_30,
+    ARDUINO_PIN_31,
+    ARDUINO_PIN_32,
+    ARDUINO_PIN_33,
+    ARDUINO_PIN_34,
+    ARDUINO_PIN_35,
+    ARDUINO_PIN_36,
+    ARDUINO_PIN_37,
+    ARDUINO_PIN_38,
+    ARDUINO_PIN_39,
+    ARDUINO_PIN_40,
+    ARDUINO_PIN_41,
+    ARDUINO_PIN_42,
+    ARDUINO_PIN_43,
+    ARDUINO_PIN_44,
+    ARDUINO_PIN_45,
+    ARDUINO_PIN_46,
+    ARDUINO_PIN_47,
+    ARDUINO_PIN_48,
+    ARDUINO_PIN_49,
+    ARDUINO_PIN_50,
+    ARDUINO_PIN_51,
+    ARDUINO_PIN_52,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+    ARDUINO_A6,
+    ARDUINO_A7,
+};
+
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU       (490U)
+
+/**
+ * @brief   List of PWM GPIO mappings
+ */
+static const arduino_pwm_t arduino_pwm_list[] = {
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/waspmote-pro/include/arduino_pinmap.h
+++ b/boards/waspmote-pro/include/arduino_pinmap.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waspmote-pro
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins for Waspmote Pro board
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ *
+ * @note    ISCP pins are not mapped.
+ * @{
+ */
+
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_E, 0)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_E, 1)
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_E, 3)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_E, 4)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_C, 4)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_C, 5)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_C, 6)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_C, 7)
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_A, 2)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_A, 3)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_A, 4)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_D, 5)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_D, 6)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_C, 1)
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_F, 1)
+#define ARDUINO_PIN_15          GPIO_PIN(PORT_F, 2)
+#define ARDUINO_PIN_16          GPIO_PIN(PORT_F, 3)
+#define ARDUINO_PIN_17          GPIO_PIN(PORT_F, 4)
+#define ARDUINO_PIN_18          GPIO_PIN(PORT_F, 5)
+#define ARDUINO_PIN_19          GPIO_PIN(PORT_F, 6)
+#define ARDUINO_PIN_20          GPIO_PIN(PORT_F, 7)
+#define ARDUINO_PIN_21          GPIO_PIN(PORT_F, 0)
+#define ARDUINO_PIN_22          GPIO_PIN(PORT_A, 1)
+#define ARDUINO_PIN_23          GPIO_PIN(PORT_D, 7)
+#define ARDUINO_PIN_24          GPIO_PIN(PORT_E, 5)
+#define ARDUINO_PIN_25          GPIO_PIN(PORT_A, 6)
+#define ARDUINO_PIN_26          GPIO_PIN(PORT_E, 2)
+#define ARDUINO_PIN_27          GPIO_PIN(PORT_A, 5)
+#define ARDUINO_PIN_28          GPIO_PIN(PORT_C, 0)
+#define ARDUINO_PIN_29          GPIO_PIN(PORT_B, 0)
+#define ARDUINO_PIN_30          GPIO_PIN(PORT_B, 1)
+#define ARDUINO_PIN_31          GPIO_PIN(PORT_B, 2)
+#define ARDUINO_PIN_32          GPIO_PIN(PORT_B, 3)
+#define ARDUINO_PIN_33          GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_34          GPIO_PIN(PORT_B, 5)
+#define ARDUINO_PIN_35          GPIO_PIN(PORT_A, 0)
+#define ARDUINO_PIN_36          GPIO_PIN(PORT_B, 6)
+#define ARDUINO_PIN_37          GPIO_PIN(PORT_B, 7)
+#define ARDUINO_PIN_38          GPIO_PIN(PORT_E, 6)
+#define ARDUINO_PIN_39          GPIO_PIN(PORT_E, 7)
+#define ARDUINO_PIN_40          GPIO_PIN(PORT_D, 0)
+#define ARDUINO_PIN_41          GPIO_PIN(PORT_D, 1)
+#define ARDUINO_PIN_42          GPIO_PIN(PORT_C, 3)
+#define ARDUINO_PIN_43          GPIO_PIN(PORT_D, 2)
+#define ARDUINO_PIN_44          GPIO_PIN(PORT_D, 3)
+#define ARDUINO_PIN_45          GPIO_PIN(PORT_A, 7)
+#define ARDUINO_PIN_46          GPIO_PIN(PORT_C, 2)
+#define ARDUINO_PIN_47          GPIO_PIN(PORT_D, 4)
+#define ARDUINO_PIN_48          GPIO_PIN(PORT_G, 2)
+#define ARDUINO_PIN_49          GPIO_PIN(PORT_G, 1)
+#define ARDUINO_PIN_50          GPIO_PIN(PORT_G, 0)
+#define ARDUINO_PIN_51          GPIO_PIN(PORT_G, 3)
+#define ARDUINO_PIN_52          GPIO_PIN(PORT_G, 4)
+#define ARDUINO_PIN_A0          ARDUINO_PIN_14
+#define ARDUINO_PIN_A1          ARDUINO_PIN_15
+#define ARDUINO_PIN_A2          ARDUINO_PIN_16
+#define ARDUINO_PIN_A3          ARDUINO_PIN_17
+#define ARDUINO_PIN_A4          ARDUINO_PIN_18
+#define ARDUINO_PIN_A5          ARDUINO_PIN_19
+#define ARDUINO_PIN_A6          ARDUINO_PIN_20
+#define ARDUINO_PIN_A7          ARDUINO_PIN_21
+
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+#define ARDUINO_A6              ADC_LINE(6)
+#define ARDUINO_A7              ADC_LINE(7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adds the arduino feature to the waspmote-pro board.

The Waspmote Pro board uses the ATmega 1281 MCU, which has a subset of the pins found in the ATmega 2560, both are described in the same datasheet, http://ww1.microchip.com/downloads/en/DeviceDoc/ATmega640-1280-1281-2560-2561-Datasheet-DS40002211A.pdf

The Waspmote technical guide may be useful as well, see http://www.libelium.com/downloads/documentation/waspmote_technical_guide.pdf

To define `arduino_pinmap` I've used https://github.com/Libelium/waspmoteapi/blob/master/waspmote-api/pins_waspmote.h
But comparing with the pinmap from the Atmega 2560, the order looks a bit arbitrary to me: is there some documentation or reference in Arduino that explains the pin numbering?


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've tested this with `tests/sys_arduino`, `tests/sys_arduino_lib` and `tests/periph_gpio_arduino` (toggling the 2 leds, pins 12 and 13). The PWM feature is not provided so `tests/sys_arduino_analog` doesn't work.
Should I test something else?

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #15232

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
