### PR TITLE
sys/net/ipv{4, 6}: add address parsing from char buffer

### DIFF
--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -22,6 +22,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #include "byteorder.h"
 
@@ -74,14 +75,31 @@ char *ipv4_addr_to_str(char *result, const ipv4_addr_t *addr, uint8_t result_len
  * @brief   Converts an IPv4 address string representation to a byte-represented
  *          IPv4 address
  *
- * @param[in] result    The resulting byte representation
- * @param[in] addr      An IPv4 address string representation
+ * @param[out] result    The resulting byte representation
+ * @param[in] addr       An IPv4 address string representation
  *
  * @return  @p result, on success
  * @return  NULL, if @p addr was malformed
  * @return  NULL, if @p result or @p addr was NULL
  */
 ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr);
+
+/**
+ * @brief   Converts an IPv4 address from a buffer of characters to a
+ *          byte-represented IPv4 address
+ *
+ * @note    @p addr_len should be between 0 and IPV4_ADDR_MAX_STR_LEN
+ *
+ * @param[out] result    The resulting byte representation
+ * @param[in] addr       An IPv4 address string representation
+ * @param[in] addr_len   The amount of characters to parse
+ *
+ * @return  @p result, on success
+ * @return  NULL, if @p addr was malformed
+ * @return  NULL, if @p result or @p addr was NULL
+ */
+ipv4_addr_t *ipv4_addr_from_buf(ipv4_addr_t *result, const char *addr,
+                                size_t addr_len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -720,14 +720,35 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
  *          RFC 5952
  *      </a>
  *
- * @param[in] result    The resulting byte representation
- * @param[in] addr      An IPv6 address string representation
+ * @param[out] result    The resulting byte representation
+ * @param[in] addr       An IPv6 address string representation
  *
  * @return  @p result, on success
  * @return  NULL, if @p addr was malformed
  * @return  NULL, if @p result or @p addr was NULL
  */
 ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr);
+
+/**
+ * @brief   Converts an IPv6 address from a buffer of characters to a
+ *          byte-represented IPv6 address
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc5952">
+ *          RFC 5952
+ *      </a>
+ *
+ * @note    @p addr_len should be between 0 and IPV6_ADDR_MAX_STR_LEN
+ *
+ * @param[out] result    The resulting byte representation
+ * @param[in] addr       An IPv6 address string representation
+ * @param[in] addr_len   The amount of characters to parse
+ *
+ * @return  @p result, on success
+ * @return  NULL, if @p addr was malformed
+ * @return  NULL, if @p result or @p addr was NULL
+ */
+ipv6_addr_t *ipv6_addr_from_buf(ipv6_addr_t *result, const char *addr,
+                                size_t addr_len);
 
 /**
  * @brief split IPv6 address string representation and return remaining string

--- a/sys/net/network_layer/ipv4/addr/ipv4_addr_from_str.c
+++ b/sys/net/network_layer/ipv4/addr/ipv4_addr_from_str.c
@@ -13,6 +13,7 @@
  */
 
 #include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
 
 #include "net/ipv4/addr.h"
@@ -20,12 +21,15 @@
 #define DEC     "0123456789"
 
 /* based on inet_pton4() by Paul Vixie */
-ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr)
+ipv4_addr_t *ipv4_addr_from_buf(ipv4_addr_t *result, const char *addr,
+                                size_t addr_len)
 {
-    uint8_t saw_digit, octets, ch;
+    uint8_t saw_digit, octets;
     uint8_t tmp[sizeof(ipv4_addr_t)], *tp;
+    const char *start = addr;
 
-    if ((result == NULL) || (addr == NULL)) {
+    if ((result == NULL) || (addr == NULL) || (addr_len == 0) ||
+        (addr_len > IPV4_ADDR_MAX_STR_LEN)) {
         return NULL;
     }
 
@@ -33,7 +37,8 @@ ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr)
     octets = 0;
     *(tp = tmp) = 0;
 
-    while ((ch = *addr++) != '\0') {
+    while ((size_t)(addr - start) < addr_len) {
+        uint8_t ch = *addr++;
         const char *pch;
 
         if ((pch = strchr(DEC, ch)) != NULL) {
@@ -72,6 +77,15 @@ ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr)
 
     memcpy(result, tmp, sizeof(ipv4_addr_t));
     return result;
+}
+
+ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr)
+{
+    if ((result == NULL) || (addr == NULL)) {
+        return NULL;
+    }
+
+    return ipv4_addr_from_buf(result, addr, strlen(addr));
 }
 
 

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
@@ -38,18 +38,20 @@
 #define HEX_U   "0123456789ABCDEF"
 
 /* based on inet_pton6() by Paul Vixie */
-ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
+ipv6_addr_t *ipv6_addr_from_buf(ipv6_addr_t *result, const char *addr,
+                                size_t addr_len)
 {
     uint8_t *colonp = 0;
+    const char *start = addr;
 #ifdef MODULE_IPV4_ADDR
     const char *curtok = addr;
 #endif
     uint32_t val = 0;
-    char ch;
     uint8_t saw_xdigit = 0;
     uint8_t i = 0;
 
-    if ((result == NULL) || (addr == NULL)) {
+    if ((result == NULL) || (addr == NULL) || (addr_len == 0) ||
+        (addr_len > IPV6_ADDR_MAX_STR_LEN)) {
         return NULL;
     }
 
@@ -62,7 +64,8 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
         }
     }
 
-    while ((ch = *addr++) != '\0') {
+    while ((size_t)(addr - start) < addr_len) {
+        char ch = *addr++;
         const char *pch;
         const char *xdigits;
 
@@ -109,8 +112,8 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
 
 #ifdef MODULE_IPV4_ADDR
         if (ch == '.' && ((i + sizeof(ipv4_addr_t)) <= sizeof(ipv6_addr_t)) &&
-            ipv4_addr_from_str((ipv4_addr_t *)(&(result->u8[i])),
-                               curtok) != NULL) {
+            ipv4_addr_from_buf((ipv4_addr_t *)(&(result->u8[i])),
+                               curtok, addr_len - (curtok - start)) != NULL) {
             i += sizeof(ipv4_addr_t);
             saw_xdigit = 0;
             break;  /* '\0' was seen by ipv4_addr_from_str(). */
@@ -149,6 +152,15 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
     }
 
     return result;
+}
+
+ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
+{
+    if ((result == NULL) || (addr == NULL)) {
+        return NULL;
+    }
+
+    return ipv6_addr_from_buf(result, addr, strlen(addr));
 }
 
 /**

--- a/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c
+++ b/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c
@@ -132,6 +132,34 @@ static void test_ipv4_addr_from_str__success2(void)
     TEST_ASSERT(ipv4_addr_equal(&a, &result));
 }
 
+static void test_ipv4_addr_from_buf__success(void)
+{
+    ipv4_addr_t a = { { 1, 1, 1, 1 } };
+    ipv4_addr_t result;
+
+    TEST_ASSERT_NOT_NULL(ipv4_addr_from_buf(&result, "1.1.1.1%tap0", 7));
+    TEST_ASSERT(ipv4_addr_equal(&a, &result));
+}
+
+static void test_ipv4_addr_from_buf__result_NULL(void)
+{
+    TEST_ASSERT_NULL(ipv4_addr_from_buf(NULL, "::", 2));
+}
+
+static void test_ipv4_addr_from_buf__illegal_chars(void)
+{
+    ipv4_addr_t result;
+
+    TEST_ASSERT_NULL(ipv4_addr_from_buf(&result, "1.1.1.1%tap0", 13));
+}
+
+static void test_ipv4_addr_from_buf__too_long_len(void)
+{
+    ipv4_addr_t result;
+
+    TEST_ASSERT_NULL(ipv4_addr_from_buf(&result, "1.1.1.1", IPV4_ADDR_MAX_STR_LEN + 1));
+}
+
 Test *tests_ipv4_addr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -150,6 +178,10 @@ Test *tests_ipv4_addr_tests(void)
         new_TestFixture(test_ipv4_addr_from_str__result_NULL),
         new_TestFixture(test_ipv4_addr_from_str__success),
         new_TestFixture(test_ipv4_addr_from_str__success2),
+        new_TestFixture(test_ipv4_addr_from_buf__success),
+        new_TestFixture(test_ipv4_addr_from_buf__result_NULL),
+        new_TestFixture(test_ipv4_addr_from_buf__illegal_chars),
+        new_TestFixture(test_ipv4_addr_from_buf__too_long_len),
     };
 
     EMB_UNIT_TESTCALLER(ipv4_addr_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -1056,6 +1056,30 @@ static void test_ipv6_addr_split_prefix__with_prefix(void)
     TEST_ASSERT_EQUAL_INT(strcmp("fd00:dead:beef::1", a), 0);
 }
 
+static void test_ipv6_addr_from_buf__success(void)
+{
+    ipv6_addr_t a = { {
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 255, 255, 255, 255
+        }
+    };
+    ipv6_addr_t result;
+
+#ifdef MODULE_IPV4_ADDR
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_buf(&result, "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255%tap0", 45));
+#else
+    TEST_ASSERT_NOT_NULL(ipv6_addr_from_buf(&result, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%tap0", 39));
+#endif
+    TEST_ASSERT(ipv6_addr_equal(&a, &result));
+}
+
+static void test_ipv6_addr_from_buf__too_long_len(void)
+{
+    ipv6_addr_t result;
+
+    TEST_ASSERT_NULL(ipv6_addr_from_buf(&result, "::1", IPV6_ADDR_MAX_STR_LEN + 1));
+}
+
 Test *tests_ipv6_addr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -1148,6 +1172,8 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_split_iface__with_iface),
         new_TestFixture(test_ipv6_addr_split_prefix__no_prefix),
         new_TestFixture(test_ipv6_addr_split_prefix__with_prefix),
+        new_TestFixture(test_ipv6_addr_from_buf__success),
+        new_TestFixture(test_ipv6_addr_from_buf__too_long_len),
     };
 
     EMB_UNIT_TESTCALLER(ipv6_addr_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
This PR extends the IPv4 and IPv6 address parsing to accept characters from a buffer that may not end in `\0`, by receiving the length. The implementations of the string parsing are now using these functions to avoid repetition.

### Testing procedure
- Green CI
- Murdock will run IPv4 and IPv6 tests, but additionally the IPv6 test can be executed with `USEMODULE=ipv4_addr` to test the parsing of encapsulated IPv4.

### Issues/PRs references
Useful for ##13790
