### PR TITLE
gnrc_pktbuf: drop gnrc_pktbuf_replace_snip() 

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -235,6 +235,16 @@ Author(s):
 Reason for removal:
 - Outdated, unmaintained and no longer working
 
+### gnrc_pktbuf_replace_snip() [72821a502f073006643cb4ef7815fc8c42563ce6]
+
+Author(s):
+- Joakim Nohlgård <joakim.nohlgard@eistec.se>
+- Martine S. Lenders <m.lenders@fu-berlin.de>
+
+Reason for removal:
+- Unused, untested and no longer needed
+
+
 [cdc252ab7bd4161cc046bf93a3e55995704b24d4]: https://github.com/RIOT-OS/RIOT/commit/cdc252ab7bd4161cc046bf93a3e55995704b24d4
 [ed3887ac5c1e95308c2827bce3cdca8b0f146c22]: https://github.com/RIOT-OS/RIOT/commit/ed3887ac5c1e95308c2827bce3cdca8b0f146c22
 [0e2a62078850e1ecc74db2db4d639cf2d8fb96d3]: https://github.com/RIOT-OS/RIOT/commit/0e2a62078850e1ecc74db2db4d639cf2d8fb96d3
@@ -259,3 +269,4 @@ Reason for removal:
 [3cac6e0979468ba56659291fd1cd11096611589d]: https://github.com/RIOT-OS/RIOT/commit/3cac6e0979468ba56659291fd1cd11096611589d
 [9fb2f541baca469e34fa01b004d6f19385700ce9]: https://github.com/RIOT-OS/RIOT/commit/9fb2f541baca469e34fa01b004d6f19385700ce9
 [35b6ccedf31f10a5f8e4f97609ad5b10c28bdc34]: https://github.com/RIOT-OS/RIOT/commit/35b6ccedf31f10a5f8e4f97609ad5b10c28bdc34
+[72821a502f073006643cb4ef7815fc8c42563ce6]: https://github.com/RIOT-OS/RIOT/commit/72821a502f073006643cb4ef7815fc8c42563ce6

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -207,23 +207,6 @@ gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt);
 gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *snip);
 
 /**
- * @brief   Replace a snip from a packet and the packet buffer by another snip.
- *
- * @deprecated  Function is not used by anyone (not even tested, see
- *              https://github.com/RIOT-OS/RIOT/issues/5089). Will be removed
- *              after 2020.10 release.
- *
- * @param[in] pkt   A packet
- * @param[in] old   snip currently in the packet
- * @param[in] add   snip which will replace old
- *
- * @return  The new reference to @p pkt
- */
-gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
-                                         gnrc_pktsnip_t *old,
-                                         gnrc_pktsnip_t *add);
-
-/**
  * @brief   Reverses snip order of a packet in a write-protected manner.
  *
  * This can be used to change the send/receive order of a packet (see

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -25,31 +25,6 @@ gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt,
     return pkt;
 }
 
-gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
-                                         gnrc_pktsnip_t *old,
-                                         gnrc_pktsnip_t *add)
-{
-    /* If add is a list we need to preserve its tail */
-    if (add->next != NULL) {
-        gnrc_pktsnip_t *tail = add->next;
-        /* find the last snip in tail */
-        gnrc_pktsnip_t *back = gnrc_pkt_prev_snip(tail, NULL);
-        /* Replace old */
-        LL_REPLACE_ELEM(pkt, old, add);
-        /* and wire in the tail between */
-        back->next = add->next;
-        add->next = tail;
-    }
-    else {
-        /* add is a single element, has no tail, simply replace */
-        LL_REPLACE_ELEM(pkt, old, add);
-    }
-    old->next = NULL;
-    gnrc_pktbuf_release(old);
-
-    return pkt;
-}
-
 gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *reversed = NULL, *ptr = pkt;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The function was deprecated in #13333 and is unused and untested in the current code base.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read, check if there is no occurrence of `gnrc_pktbuf_replace_snip()` in the code base anymore.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #13333
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
