### PR TITLE
gnrc_pkt: port to list.h

### DIFF
--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -35,6 +35,38 @@
 #define _INIT_ELEM_STATIC_TYPE(_type, _next) \
     { .users = 1, .next = (_next), .data = NULL, .size = 0, .type = (_type) }
 
+static void test_pkt_prev_snip__NULL_NULL(void)
+{
+    TEST_ASSERT_NULL(gnrc_pkt_prev_snip(NULL, NULL));
+}
+
+static void test_pkt_prev_snip__pkt_NULL(void)
+{
+    gnrc_pktsnip_t pkt = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t *res;
+
+    res = gnrc_pkt_prev_snip(&pkt, NULL);
+    TEST_ASSERT((&pkt) == res);
+}
+
+static void test_pkt_prev_snip__NULL_snip(void)
+{
+    gnrc_pktsnip_t snip = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+
+    TEST_ASSERT_NULL(gnrc_pkt_prev_snip(NULL, &snip));
+}
+
+static void test_pkt_prev_snip__pkt_snip(void)
+{
+    gnrc_pktsnip_t snip1 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t snip2 = _INIT_ELEM(SIZE_MAX, NULL, &snip1);
+    gnrc_pktsnip_t pkt = _INIT_ELEM(SIZE_MAX, NULL, &snip2);
+    gnrc_pktsnip_t *res;
+
+    res = gnrc_pkt_prev_snip(&pkt, &snip1);
+    TEST_ASSERT((&snip2) == res);
+}
+
 static void test_pkt_len__NULL(void)
 {
     TEST_ASSERT_EQUAL_INT(0, gnrc_pkt_len(NULL));
@@ -91,6 +123,80 @@ static void test_pkt_len__3_elem(void)
                           gnrc_pkt_len(&snip3));
     TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8) + sizeof(TEST_STRING12), gnrc_pkt_len(&snip2));
     TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), gnrc_pkt_len(&snip1));
+}
+
+static void test_pkt_append(void)
+{
+    gnrc_pktsnip_t snip1 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t snip2 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t pkt = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t *res = &pkt;
+
+    res = gnrc_pkt_append(res, &snip1);
+    TEST_ASSERT((&pkt) == res);
+    TEST_ASSERT((&snip1) == res->next);
+    TEST_ASSERT_NULL(res->next->next);
+    res = gnrc_pkt_append(res, &snip2);
+    TEST_ASSERT((&pkt) == res);
+    TEST_ASSERT((&snip1) == res->next);
+    TEST_ASSERT((&snip2) == res->next->next);
+}
+
+static void test_pkt_prepend(void)
+{
+    gnrc_pktsnip_t snip1 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t snip2 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t pkt = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t *res = &pkt;
+
+    res = gnrc_pkt_prepend(res, &snip1);
+    TEST_ASSERT((&snip1) == res);
+    TEST_ASSERT((&pkt) == res->next);
+    TEST_ASSERT_NULL(res->next->next);
+    res = gnrc_pkt_prepend(res, &snip2);
+    TEST_ASSERT((&snip2) == res);
+    TEST_ASSERT((&snip1) == res->next);
+    TEST_ASSERT((&pkt) == res->next->next);
+}
+
+static void test_pkt_delete__NULL(void)
+{
+    gnrc_pktsnip_t snip1 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t snip2 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t pkt = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t *res = &pkt;
+
+    res = gnrc_pkt_prepend(res, &snip1);
+    res = gnrc_pkt_prepend(res, &snip2);
+    TEST_ASSERT((&snip2) == res);
+    TEST_ASSERT((&snip1) == res->next);
+    TEST_ASSERT((&pkt) == res->next->next);
+    res = gnrc_pkt_delete(res, NULL);
+    /* pkt did not change */
+    TEST_ASSERT((&snip2) == res);
+    TEST_ASSERT((&snip1) == res->next);
+    TEST_ASSERT((&pkt) == res->next->next);
+}
+
+static void test_pkt_delete(void)
+{
+    gnrc_pktsnip_t snip1 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t snip2 = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t pkt = _INIT_ELEM(SIZE_MAX, NULL, NULL);
+    gnrc_pktsnip_t *res = &pkt;
+
+    res = gnrc_pkt_prepend(res, &snip1);
+    res = gnrc_pkt_prepend(res, &snip2);
+    TEST_ASSERT((&snip2) == res);
+    TEST_ASSERT((&snip1) == res->next);
+    TEST_ASSERT((&pkt) == res->next->next);
+    res = gnrc_pkt_delete(res, &snip1);
+    TEST_ASSERT((&snip2) == res);
+    TEST_ASSERT((&pkt) == res->next);
+    res = gnrc_pkt_delete(res, &snip2);
+    TEST_ASSERT((&pkt) == res);
+    res = gnrc_pkt_delete(res, &pkt);
+    TEST_ASSERT_NULL(res);
 }
 
 static void test_pkt_len_upto__NULL(void)
@@ -198,6 +304,10 @@ static void test_pkt_equals_iolist(void)
 Test *tests_pkt_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_pkt_prev_snip__NULL_NULL),
+        new_TestFixture(test_pkt_prev_snip__pkt_NULL),
+        new_TestFixture(test_pkt_prev_snip__NULL_snip),
+        new_TestFixture(test_pkt_prev_snip__pkt_snip),
         new_TestFixture(test_pkt_len__NULL),
         new_TestFixture(test_pkt_len__1_elem__size_MAX),
         new_TestFixture(test_pkt_len__1_elem__size_0),
@@ -205,6 +315,10 @@ Test *tests_pkt_tests(void)
         new_TestFixture(test_pkt_len__2_elem),
         new_TestFixture(test_pkt_len__2_elem__overflow),
         new_TestFixture(test_pkt_len__3_elem),
+        new_TestFixture(test_pkt_append),
+        new_TestFixture(test_pkt_prepend),
+        new_TestFixture(test_pkt_delete__NULL),
+        new_TestFixture(test_pkt_delete),
         new_TestFixture(test_pkt_len_upto__NULL),
         new_TestFixture(test_pkt_len_upto__not_in_list),
         new_TestFixture(test_pkt_len_upto__in_list),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This ports `gnrc_pkt` from `utlist.h` to `list.h`. The bytes won are not earth-shattering, but they are bytes won. Tests for the operations introduced in #15212 are also provided to test for regressions.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run the provided unittests on both `HEAD` and `HEAD~1` on a platform of your choice (you might want to delete `tests/unittests/Makefile.ci` first, otherwise the binary won't be linked):

```console
$ rm tests/unittests/Makefile.ci
$ BOARD=samr21-xpro RIOT_CI_BUILD=1 make -C tests/unittests/ tests-pkt flash-only test
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests'
Building application "tests_unittests" for "samr21-xpro" with MCU "samd21".

   text	   data	    bss	    dec	    hex	filename
  15280	    132	   2948	  18360	   47b8	/home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.bin --verify || /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800008319 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev D)
Verification................................................................ done.
r
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
.......................
OK (23 tests)

make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests'
$ git checkout HEAD~1
D	tests/unittests/Makefile.ci
Note: switching to 'HEAD~1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 3be898757f tests/unittests: add tests for new pkt operations
$ BOARD=samr21-xpro RIOT_CI_BUILD=1 make -C tests/unittests/ tests-pkt flash-only test
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests'
Building application "tests_unittests" for "samr21-xpro" with MCU "samd21".

   text	   data	    bss	    dec	    hex	filename
  15280	    132	   2948	  18360	   47b8	/home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.bin --verify || /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800008319 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev D)
Verification........
at address 0x500 expected 0x30, read 0x03
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800008319 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev D)
Programming................................................................ done.
Verification................................................................ done.
r
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
.......................
OK (23 tests)

make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/unittests'
```

Note that due to the heavy use of those functions changed in the unittests, they are already well optimized in `master` (see https://github.com/RIOT-OS/RIOT/pull/15212#issuecomment-708979978). For `gnrc_networking` I gain a few bytes for the few boards I tested:

```console
$ RIOT_CI_BUILD=1 BOARD=samr21-xpro make -C examples/gnrc_networking -j
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
Building application "gnrc_networking" for "samr21-xpro" with MCU "samd21".

   text	   data	    bss	    dec	    hex	filename
  95424	    184	  18996	 114604	  1bfac	/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
$ git checkout HEAD~1 &> /dev/null
$ RIOT_CI_BUILD=1 BOARD=samr21-xpro make -C examples/gnrc_networking -j
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
Building application "gnrc_networking" for "samr21-xpro" with MCU "samd21".

   text	   data	    bss	    dec	    hex	filename
  95444	    184	  18996	 114624	  1bfc0	/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #15212
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
