### PR TITLE
native: remove `make all-debug` target

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -137,9 +137,6 @@ endif
 
 all: # do not override first target
 
-all-debug: all
-	@$(COLOR_ECHO) '$(COLOR_RED)`all-debug` is deprecated, just use `all`$(COLOR_RESET)'
-
 all-gprof: all
 
 all-asan: all

--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -31,11 +31,4 @@ On Debian/Ubuntu you can install the required libraries with
 sudo apt install gcc-multilib
 ```
 
-# Building native with debug flags
-@deprecated `make all-debug` is deprecated; `make all` now builds with debugs
-            flags by default. The target will be removed after the 2020.10
-            release.
-
-To build with debug flags for `native` use `make all-debug` instead of
-`make all`
  */

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -50,7 +50,7 @@ then
 
     if [ "$BUILDTEST_MCU_GROUP" == "x86" ]
     then
-        make -C ./tests/unittests all-debug test BOARD=native TERMPROG='gdb -batch -ex r -ex bt $(ELF)' || exit
+        make -C ./tests/unittests all test BOARD=native TERMPROG='gdb -batch -ex r -ex bt $(ELF)' || exit
         set_result $?
     fi
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Was deprecated in https://github.com/RIOT-OS/RIOT/pull/13432 as `make all` now fulfills the same function. I can add this to the LOSTANDFOUND.md once this is merged.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure `all-debug` does not show up in the code base anymore (except for the release notes).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/13432
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
