### PR TITLE
pkg/tinydtls: remove deprecation message about some CFLAGS

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -39,11 +39,6 @@ ifeq (,$(CONFIG_KCONFIG_PKG_TINYDTLS))
   endif
 endif
 
-ifneq (,$(filter -DDTLS_DEBUG,$(CFLAGS)))
-  # For backwards compability. This can be removed after release 2020.10
-  $(warning Warning! DTLS_DEBUG is deprecated use CONFIG_DTLS_DEBUG)
-  CFLAGS += -DCONFIG_DTLS_DEBUG
-endif
 ifneq (,$(or $(CONFIG_DTLS_DEBUG),$(filter -DCONFIG_DTLS_DEBUG,$(CFLAGS))))
   CFLAGS += -DTINYDTLS_LOG_LVL=6
 else
@@ -58,20 +53,10 @@ endif
 # Translate 'CONFIG_' options to package specific flags. This checks if the
 # option is being set via Kconfig or CFLAGS
 
-ifneq (,$(filter -DDTLS_PSK,$(CFLAGS)))
-  # For backwards compability. This can be removed after release 2020.10
-  $(warning Warning! DTLS_PSK is deprecated use CONFIG_DTLS_PSK)
-  CFLAGS += -DCONFIG_DTLS_PSK
-endif
 ifneq (,$(or $(CONFIG_DTLS_PSK),$(filter -DCONFIG_DTLS_PSK,$(CFLAGS))))
     CFLAGS += -DDTLS_PSK
 endif
 
-ifneq (,$(filter -DDTLS_ECC,$(CFLAGS)))
-  # For backwards compability. This can be removed after release 2020.10
-  $(warning Warning! DTLS_ECC is deprecated use CONFIG_DTLS_ECC)
-  CFLAGS += -DCONFIG_DTLS_ECC
-endif
 ifneq (,$(or $(CONFIG_DTLS_ECC),$(filter -DCONFIG_DTLS_ECC,$(CFLAGS))))
     CFLAGS += -DDTLS_ECC
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes 3 deprecation messages in the tinydtls package. These messages are about the `DTLS_DEBUG`, `DTLS_PSK` and `DTLS_ECC` configuration options that were replaced by `CONFIG_DTLS_DEBUG`, `CONFIG_DTLS_PSK` and `CONFIG_DTLS_ECC`, respectively.

The replacement of these defines in the code was already done in #12992.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of  #12992

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
