### PR TITLE
sock_dns: Fix incorrect buffer bounds check

### DIFF
--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -125,7 +125,8 @@ static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family
             return tmp;
         }
         bufpos += tmp;
-        if ((bufpos + RR_TYPE_LENGTH + RR_CLASS_LENGTH + RR_TTL_LENGTH) >= buflim) {
+        if ((bufpos + RR_TYPE_LENGTH + RR_CLASS_LENGTH +
+             RR_TTL_LENGTH + sizeof(uint16_t)) >= buflim) {
             return -EBADMSG;
         }
         uint16_t _type = ntohs(_get_short(bufpos));


### PR DESCRIPTION
#### Contribution description

The following bounds check performed in `sock_dns` is IMHO incorrect:

https://github.com/RIOT-OS/RIOT/blob/1de14931b8a326d12e35685bad1fd4779848401f/sys/net/application_layer/dns/dns.c#L128-L130

It does not take into account that after the `bufpos` is advanced by `RR_TYPE_LENGTH`, `RR_CLASS_LENGTH`, and `RR_TTL_LENGTH` two bytes are read unconditionally using the `_get_short` function in the following line:

https://github.com/RIOT-OS/RIOT/blob/1de14931b8a326d12e35685bad1fd4779848401f/sys/net/application_layer/dns/dns.c#L137

This is currently not taken into account by the bounds check, thus resulting in a potential out-of-bounds buffer access by a maximum of two bytes.

#### Testing procedure

The easiest way to confirm this issue is using the following application:

```C
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>
#include <panic.h>

#include <net/af.h>

extern int _parse_dns_reply(uint8_t *buf, size_t len, void *addr_out, int family);

static uint8_t buf[] = {
	0, 0, 0, 0, 0, 0, 255, 0, 0, 0, 0, 0, 192, 0, 0, 0, 0, 0, 0, 0, 0, 0,
	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
	0, 0, 0, 0, 0,
};

int main(void)
{
    void *addr;
    uint8_t addr_buf[16];

    addr = &addr_buf[0];
    _parse_dns_reply(buf, sizeof(buf), addr, AF_UNSPEC);

    exit(EXIT_SUCCESS);
    return 0;
}
```

**Attention:** This application passes data directly to `_parse_dns_reply`, for this reason the static keyword must be removed from the `_parse_dns_reply` function in `sys/net/application_layer/dns/dns.c`.

Afterwards, compile the application with:

```
$ make BOARD=native -C examples/sock_dns/ all-asan
```

And execute it with:

```
$ make BOARD=native -C examples/sock_dns/ term
```

This will result in the following error message:

```
==15536==ERROR: AddressSanitizer: global-buffer-overflow on address 0x56655151 at pc 0x56640049 bp 0x5665b798 sp 0x5665b78c
READ of size 2 at 0x56655151 thread T0
    #0 0x56640048 in _get_short /root/RIOT/sys/net/application_layer/dns/dns.c:77
    #1 0x566403b9 in _parse_dns_reply /root/RIOT/sys/net/application_layer/dns/dns.c:141
    #2 0x56616bf0 in main /root/RIOT/examples/sock_dns/main.c:22
    #3 0x56616f5d in main_trampoline /root/RIOT/core/init.c:57
    #4 0xf767453a in makecontext (/lib/i386-linux-gnu/libc.so.6+0x4153a)

0x56655152 is located 0 bytes to the right of global variable 'buf' defined in '/root/RIOT/examples/sock_dns/main.c:10:16' (0x56655120) of size 50
SUMMARY: AddressSanitizer: global-buffer-overflow /root/RIOT/sys/net/application_layer/dns/dns.c:77 in _get_short
Shadow bytes around the buggy address:
  0x2acca9d0: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x2acca9e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x2acca9f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x2accaa00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x2accaa10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x2accaa20: 00 00 00 00 00 00 00 00 00 00[02]f9 f9 f9 f9 f9
  0x2accaa30: 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x2accaa40: 00 00 00 00 f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9
  0x2accaa50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x2accaa60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x2accaa70: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==15536==ABORTING
```

With the proposed patch applied no error is detected by ASAN. I think the `_get_short` function should also be renamed to `_get_u16` and the issue could be avoided all together by passing buffer bounds to `_get_u16` and checking these bounds before performing the access in this function.

#### Issues/PRs references

The incorrect check was introduced in #10740 for fixing #10739.