### PR TITLE
dist/tools: Use bash instead of sh where needed

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MAKE=${MAKE:-make}
 

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 MAKE=${MAKE:-make}
 

--- a/dist/tools/coccinelle/check.sh
+++ b/dist/tools/coccinelle/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
 #

--- a/dist/tools/coccinelle/check.sh
+++ b/dist/tools/coccinelle/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
 #

--- a/dist/tools/dlcache/dlcache.sh
+++ b/dist/tools/dlcache/dlcache.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 

--- a/dist/tools/dlcache/dlcache.sh
+++ b/dist/tools/dlcache/dlcache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 

--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 [ "$GIT_CACHE_VERBOSE" != "1" ] && Q=-q
 

--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 [ "$GIT_CACHE_VERBOSE" != "1" ] && Q=-q
 

--- a/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
+++ b/dist/tools/insufficient_memory/add_insufficient_memory_board.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (C) 2019 Benjamin Valentin <benjamin.valentin@ml-pa.com>
 #

--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
 # Copyright 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>

--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
 # Copyright 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>

--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 RIOTBASE=$(git rev-parse --show-toplevel)
 CURDIR=$(cd "$(dirname "$0")" && pwd)
 UNCRUSTIFY_CFG="$RIOTBASE"/uncrustify-riot.cfg

--- a/dist/tools/vera++/check.sh
+++ b/dist/tools/vera++/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
 #


### PR DESCRIPTION
### Contribution description

A number of scripts use features from bash such as `local` which are not
in the POSIX spec. This breaks on systems where sh is not symlinked to
bash.

This patch changes the interpreter indicated by the hashbang to bash for
those scripts

### Testing procedure

Check that the scripts indeed use bash features :)

### Issues/PRs references

None
