### PR TITLE
drivers/periph_timer: Use uint32_t over unsigned long for frequency

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -95,7 +95,7 @@ static inline bool is_oneshot(tim_t tim, int chan)
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
 /*
  * A debug pin can be used to probe timer interrupts with an oscilloscope or

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -183,7 +183,7 @@ static inline cc2538_gptimer_t *dev(tim_t tim)
  * @brief Setup the given timer
  *
  */
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     DEBUG("%s(%u, %lu, %p, %p)\n", __FUNCTION__, tim, freq, cb, arg);
 

--- a/cpu/cc26xx_cc13xx/periph/timer.c
+++ b/cpu/cc26xx_cc13xx/periph/timer.c
@@ -98,7 +98,7 @@ static inline gpt_reg_t *dev(tim_t tim)
     return ((gpt_reg_t *)(GPT0_BASE | (((uint32_t)tim) << 12)));
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     DEBUG("timer_init(%u, %lu)\n", tim, freq);
     /* make sure given timer is valid */

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -73,7 +73,7 @@ static inline bool _is_letimer(timer_t dev)
 #endif
 }
 
-static void _letimer_init(tim_t dev, unsigned long freq)
+static void _letimer_init(tim_t dev, uint32_t freq)
 {
     (void) freq;
 #if LETIMER_COUNT
@@ -98,7 +98,7 @@ static void _letimer_init(tim_t dev, unsigned long freq)
 #endif
 }
 
-static void _timer_init(tim_t dev, unsigned long freq)
+static void _timer_init(tim_t dev, uint32_t freq)
 {
     TIMER_TypeDef *pre, *tim;
 
@@ -143,7 +143,7 @@ static void _timer_init(tim_t dev, unsigned long freq)
     TIMER_IntEnable(tim, TIMER_IEN_CC0 | TIMER_IEN_CC1 | TIMER_IEN_CC2);
 }
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t callback, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t callback, void *arg)
 {
     /* test if given timer device is valid */
     if (dev >= TIMER_NUMOF) {

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <inttypes.h>
+
 /*
  * WARNING! enable debugging will have timing side effects and can lead
  * to timer underflows, system crashes or system dead locks in worst case.
@@ -191,9 +193,10 @@ void IRAM hw_timer_handler(void* arg)
     irq_isr_exit();
 }
 
-int timer_init (tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    DEBUG("%s dev=%u freq=%lu cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
+    DEBUG("%s dev=%u freq=%" PRIu32 " cb=%p arg=%p\n",
+          __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  HW_TIMER_NUMOF, -1);
     CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);
@@ -434,7 +437,7 @@ void IRAM hw_timer_handler(void* arg)
     irq_isr_exit();
 }
 
-int timer_init (tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     DEBUG("%s dev=%u freq=%lu cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
 

--- a/cpu/esp8266/periph/timer.c
+++ b/cpu/esp8266/periph/timer.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <inttypes.h>
+
 /* WARNING! enable debugging will have timing side effects and can lead
  * to timer underflows, system crashes or system dead locks in worst case. */
 #define ENABLE_DEBUG 0
@@ -113,9 +115,10 @@ void IRAM hw_timer_handler(void* arg)
     irq_isr_exit();
 }
 
-int timer_init (tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    DEBUG("%s dev=%u freq=%lu cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
+    DEBUG("%s dev=%u freq=%" PRIu32 " cb=%p arg=%p\n",
+          __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  HW_TIMER_NUMOF, -1);
     CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);
@@ -378,7 +381,7 @@ void IRAM os_timer_handler (void* arg)
     irq_isr_exit ();
 }
 
-int timer_init (tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     DEBUG("%s dev=%u freq=%lu cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
 

--- a/cpu/fe310/periph/timer.c
+++ b/cpu/fe310/periph/timer.c
@@ -37,7 +37,7 @@ static timer_cb_t isr_cb;
  */
 static void *isr_arg;
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* Using RISC-V built in timer (64bit value) */
     if (dev != 0) {

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -607,7 +607,7 @@ static inline void lptmr_irq_handler(tim_t tim)
 #endif
 /* ****** Common timer API functions ****** */
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     if ((unsigned int)dev >= TIMER_NUMOF) {
         /* invalid timer */

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -63,7 +63,7 @@ static inline uint32_t _llvalue_to_scaled_value(uint64_t corrected,
     return scaledv;
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     if (tim >= TIMER_NUMOF){
         return -1;

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -39,7 +39,7 @@
  */
 static timer_isr_ctx_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     if (dev == 0) {
         /* save callback */

--- a/cpu/lpc23xx/periph/timer.c
+++ b/cpu/lpc23xx/periph/timer.c
@@ -127,7 +127,7 @@ static inline void pwr_clk_and_isr(tim_t tim, uint32_t scale)
     }
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* get the timers base register */
     lpc23xx_timer_t *dev = get_dev(tim);

--- a/cpu/mips_pic32_common/periph/timer.c
+++ b/cpu/mips_pic32_common/periph/timer.c
@@ -120,7 +120,7 @@ int gettimeofday(struct timeval *__restrict __p, void *__restrict __tz)
     return 0;
 }
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     assert(dev == 0);
 

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -41,7 +41,7 @@ static timer_cb_t isr_cb;
 static void *isr_arg;
 
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* using fixed TIMER_BASE for now */
     if (dev != 0) {

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -81,7 +81,7 @@ void native_isr_timer(void)
     _callback(_cb_arg, 0);
 }
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     (void)freq;
     DEBUG("%s\n", __func__);

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -43,7 +43,7 @@ static inline NRF_TIMER_Type *dev(tim_t tim)
     return timer_config[tim].dev;
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* make sure the given timer is valid */
     if (tim >= TIMER_NUMOF) {

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -89,7 +89,7 @@ static inline void _irq_enable(tim_t tim)
     NVIC_EnableIRQ(timer_config[tim].irq);
 }
 
-static uint8_t _get_prescaler(unsigned long freq_out, unsigned long freq_in)
+static uint8_t _get_prescaler(uint32_t freq_out, uint32_t freq_in)
 {
     uint8_t scale = 0;
     while (freq_in > freq_out) {
@@ -136,7 +136,7 @@ static inline void _set_nfrq(tim_t tim)
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     const tc32_conf_t *cfg = &timer_config[tim];
     uint8_t scale = _get_prescaler(freq, sam0_gclk_freq(cfg->gclk_src));

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -75,7 +75,7 @@ static inline Tc *dev(tim_t tim)
  * For each timer, channel 1 is used to implement a prescaler. Channel 1 is
  * driven by the MCK / 2 (42MHz) (TIMER_CLOCK1).
  */
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* check if device is valid */
     if (tim >= TIMER_NUMOF) {

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -87,7 +87,7 @@ static inline bool is_oneshot(tim_t tim, int chan)
 
 #endif /* MODULE_PERIPH_TIMER_PERIODIC */
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* check if device is valid */
     if (tim >= TIMER_NUMOF) {

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -127,7 +127,7 @@ typedef struct {
  * @return                  0 on success
  * @return                  -1 if speed not applicable or unknown device given
  */
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg);
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg);
 
 /**
  * @brief Set a given timer channel for the given timer device

--- a/sys/include/ztimer/periph_timer.h
+++ b/sys/include/ztimer/periph_timer.h
@@ -54,7 +54,7 @@ typedef struct {
  * @param[in]   max_val maximum value this timer supports
  */
 void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
-                              unsigned long freq, uint32_t max_val);
+                              uint32_t freq, uint32_t max_val);
 
 #ifdef __cplusplus
 }

--- a/sys/ztimer/periph_timer.c
+++ b/sys/ztimer/periph_timer.c
@@ -74,8 +74,7 @@ static const ztimer_ops_t _ztimer_periph_timer_ops = {
 };
 
 void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
-                              unsigned long freq,
-                              uint32_t max_val)
+                              uint32_t freq, uint32_t max_val)
 {
     clock->dev = dev;
     clock->super.ops = &_ztimer_periph_timer_ops;


### PR DESCRIPTION
### Contribution description

For all currently supported architectures `unsigned long` is 32 bit in size. But let's better use `uint32_t` to make sure frequencies are given in 32 bit on future platforms. Also, yadda yadda MISRA C.

### Testing procedure

- Green Murdock
- No change in binaries

### Issues/PRs references

None