### PR TITLE
cpu/sam3/periph/timer: fix trigger of cleared timer

### DIFF
--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -66,9 +66,14 @@ typedef uint32_t gpio_t;
 #define TIMER_MAX_VAL       (0xffffffff)
 
 /**
- * @brief   We use 3 channels for each defined timer
+ * @brief   We use one channel for each defined timer
+ *
+ * While the peripheral provides three channels, the current interrupt
+ * flag handling leads to a race condition where calling timer_clear() on one
+ * channel can disable a pending flag for other channels.
+ * Until resolved, limit the peripheral to only one channel.
  */
-#define TIMER_CHANNEL_NUMOF (3)
+#define TIMER_CHANNEL_NUMOF (1)
 
 /**
  * @brief   The RTT width is fixed to 32-bit

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -128,6 +128,14 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
         return -1;
     }
     (&dev(tim)->TC_CHANNEL[0].TC_RA)[channel] = value;
+
+    /* read TC status register to clear any possibly pending
+     * ISR flag (that has not been served yet).
+     * timer_clear() disables the interrupt, but does not clear the flags.
+     * if we don't clear them here, re-enabling the interrupt below
+     * can trigger for the previously disabled timer. */
+    (void)dev(tim)->TC_CHANNEL[0].TC_SR;
+
     dev(tim)->TC_CHANNEL[0].TC_IER = (TC_IER_CPAS << channel);
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

From the original issue:

```
I found the issue: the sam3x periph_timer timer_clear() disables the timer's interrupt, but does not clear the corresponding flag. So when a subsequent timer_set_absolute() re-enables the interrupt, the former compare would trigger instantly.
If you run the two "test" commands of the test application very fast (within the 1000000us of the initial timer set), it doesn't crash.

This workaround fixes it for me: https://gist.github.com/kaspar030/16ee3a700780573e2cab6305d9842132

The timer event flag register is clear-on-read, the workaround reads the status register to clear previous flags.

But there's an issue with the work around: the register contains the flags for all channels, thus any timer_set() on one channel might clear the flag of another... I think. We might want to limit this to only one channel (for now), to be safe.
```

This PR implements the workaround and fixes the remaining issue by limiting each peripheral to just one channel.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Please use test application of [original issue](#15330)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #15330.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
