### PR TITLE
usb-serial/list-ttys: Resolve shellcheck issues

### DIFF
--- a/dist/tools/usb-serial/list-ttys.sh
+++ b/dist/tools/usb-serial/list-ttys.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright (C) 2015 Eistec AB
 # Copyright (C) 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
@@ -8,25 +8,26 @@
 # details.
 
 if [ ! -d /sys/bus/usb/devices ]; then
-    echo "$(basename $0): /sys/bus/usb/devices not a directory (/sys is not mounted?)" >&2
+    echo "$(basename "$0"): /sys/bus/usb/devices not a directory (/sys is not mounted?)" >&2
     exit 1
 fi
 
 # iterate over usb-tty devices:
-for basedev in $(find /sys/bus/usb/devices/ -regex "/sys/bus/usb/devices/[0-9]+[^:/]*" -maxdepth 2 -follow 2>/dev/null); do
-    ttydirs=$(find ${basedev} -regex "${basedev}/[^/]*:.*" -mindepth 2 -maxdepth 3 -name tty -follow 2>/dev/null)
+while IFS= read -r -d '' basedev
+do
+    ttydirs=$(find "${basedev}" -regex "${basedev}/[^/]*:.*" -mindepth 2 -maxdepth 3 -name tty -follow 2>/dev/null)
     if [ -z "${ttydirs}" ]; then
         continue
     fi
     # See if the device has any tty devices assigned to it.
-    ttys=$(find ${ttydirs} -maxdepth 1 -mindepth 1 -printf '%f, ' | sed -e 's/, $/\n/' 2>/dev/null)
+    ttys=$(find "${ttydirs}" -maxdepth 1 -mindepth 1 -printf '%f, ' | sed -e 's/, $/\n/' 2>/dev/null)
     if [ -z "${ttys}" ]; then
         continue
     fi
     # Get all info
-    parent=$(echo ${basedev} | sed -e 's%\(/sys/bus/usb/devices/[^/]*\)/.*%\1%')
+    parent=$(echo "${basedev}" | sed -e 's%\(/sys/bus/usb/devices/[^/]*\)/.*%\1%')
     serial=$(cat "${parent}/serial" 2>/dev/null)
     manuf=$(cat "${parent}/manufacturer" 2>/dev/null)
     product=$(cat "${parent}/product" 2>/dev/null)
     echo "${parent}: ${manuf} ${product}, serial: '${serial}', tty(s): ${ttys}"
-done
+done < <(find /sys/bus/usb/devices/ -regex "/sys/bus/usb/devices/[0-9]+[^:/]*" -maxdepth 2 -follow -print0 2>/dev/null);


### PR DESCRIPTION
### Contribution description

And another one.

See [Sc2044](https://github.com/koalaman/shellcheck/wiki/Sc2044) for the construct with `find`

### Testing procedure

`make -C examples/hello-world list-ttys` must be unchanged.

### Issues/PRs references

None