### PR TITLE
Fixed a critical bug, allowing to crash the whole system with a specially crafted LoRa frame

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -539,13 +539,15 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
 
         case NETDEV_EVENT_RX_COMPLETE:
         {
-            size_t len;
+            int len;
             uint8_t radio_payload[SX127X_RX_BUFFER_SIZE];
             len = dev->driver->recv(dev, NULL, 0, 0);
-            dev->driver->recv(dev, radio_payload, len, &packet_info);
-            semtech_loramac_radio_events.RxDone(radio_payload,
-                                                len, packet_info.rssi,
-                                                packet_info.snr);
+            if (len > 0) {
+                dev->driver->recv(dev, radio_payload, len, &packet_info);
+                semtech_loramac_radio_events.RxDone(radio_payload,
+                                                    len, packet_info.rssi,
+                                                    packet_info.snr);
+            } /* len could be -EBADMSG, in which case a CRC error message will be received shortly */
             break;
         }
         case NETDEV_EVENT_RX_TIMEOUT:

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -540,9 +540,9 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
         case NETDEV_EVENT_RX_COMPLETE:
         {
             int len;
-            uint8_t radio_payload[SX127X_RX_BUFFER_SIZE];
             len = dev->driver->recv(dev, NULL, 0, 0);
             if (len > 0) {
+                uint8_t radio_payload[SX127X_RX_BUFFER_SIZE];
                 dev->driver->recv(dev, radio_payload, len, &packet_info);
                 semtech_loramac_radio_events.RxDone(radio_payload,
                                                     len, packet_info.rssi,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As sometimes SX127x driver can return a -EBADMSG from recv(), it is necessary to check the returned value. Currently len is size_t, which expands to unsigned int at least on ARM Cortex-based platforms, causing the -EBADMSG to be interpreted as an (insanely) large value. The subsequent call to recv() overwrites all the memory available, causing a HardFault.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Whenever LoRaMAC is ready to receive, send a frame with corrupt CRC. The version without a fix will crash.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
