### PR TITLE
[RFC] tests: group applications in subdirectories

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -202,6 +202,14 @@ include $(RIOTMAKE)/boards.inc.mk
 # Debug targets for build system migration
 include $(RIOTMAKE)/dependencies_debug.inc.mk
 
+# List all available applications
+include $(RIOTMAKE)/app_dirs.inc.mk
+
+ifeq (,$(filter $(APPDIR),$(APPLICATION_DIRS_ABSOLUTE)))
+  $(error Application parent directory is not listed in the list of examples \
+          or tests subdirectories. Please update 'makefiles/app_dirs.inc.mk')
+endif
+
 # Use TOOLCHAIN environment variable to select the toolchain to use.
 # If native, TOOLCHAIN for OSX is llvm
 ifeq ($(BOARD),native)

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -3,7 +3,7 @@
 # fallback so empty RIOTBASE won't lead to "/examples/"
 RIOTBASE ?= .
 
-# Define the list of examples subdirectories that container application directories
+# Define the list of examples subdirectories that contain application directories
 EXAMPLES_APPLICATIONS_SUBDIRS :=  \
     ble                       \
     coap                      \

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -44,14 +44,14 @@ APPLICATION_DIRS :=                   \
     $(TEST_APPLICATIONS_SUBDIRS)      \
     #
 
-APPLICATION_DIRS := $(addprefix $(RIOTBASE)/,$(APPLICATION_DIRS))
-APPLICATION_DIRS := $(addsuffix /*/Makefile,$(APPLICATION_DIRS))
-
 # 1. use wildcard to find Makefiles
 # 2. use patsubst to drop trailing "/"
 # 3. use patsubst to drop possible leading "./"
 # 4. sort
-APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(dir $(wildcard $(APPLICATION_DIRS))))))
+APPLICATION_DIRS := $(addprefix $(RIOTBASE)/,$(APPLICATION_DIRS))
+APPLICATION_DIRS_RELATIVE := $(dir $(wildcard $(addsuffix /*/Makefile,$(APPLICATION_DIRS))))
+APPLICATION_DIRS_ABSOLUTE := $(abspath $(APPLICATION_DIRS_RELATIVE))
+APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(APPLICATION_DIRS_RELATIVE))))
 
 info-applications:
 	@for dir in $(APPLICATION_DIRS); do echo $$dir; done

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -11,7 +11,7 @@ EXAMPLES_APPLICATIONS_SUBDIRS :=  \
     dtls                      \
     gnrc                      \
     icn                       \
-    lora                      \
+    lorawan                   \
     mqtt                      \
     posix                     \
     #

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -3,16 +3,40 @@
 # fallback so empty RIOTBASE won't lead to "/examples/"
 RIOTBASE ?= .
 
+# Define the list of tests sudirectories that contain application directories
+TEST_APPLICATIONS_SUBDIRS :=  \
+    arch                      \
+    bench                     \
+    boards                    \
+    bootloaders               \
+    build_system              \
+    core                      \
+    cpp                       \
+    drivers                   \
+    periph                    \
+    pkg                       \
+    sys                       \
+    sys/net                   \
+    #
+TEST_APPLICATIONS_SUBDIRS := $(addprefix tests/,$(TEST_APPLICATIONS_SUBDIRS))
+
+# Prepare the list of application directories
+APPLICATION_DIRS :=                   \
+    fuzzing                           \
+    bootloaders                       \
+    examples                          \
+    tests                             \
+    $(TEST_APPLICATIONS_SUBDIRS)      \
+    #
+
+APPLICATION_DIRS := $(addprefix $(RIOTBASE)/,$(APPLICATION_DIRS))
+APPLICATION_DIRS := $(addsuffix /*/Makefile,$(APPLICATION_DIRS))
+
 # 1. use wildcard to find Makefiles
 # 2. use patsubst to drop trailing "/"
 # 3. use patsubst to drop possible leading "./"
 # 4. sort
-APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(dir $(wildcard \
-	$(RIOTBASE)/fuzzing/*/Makefile     \
-	$(RIOTBASE)/bootloaders/*/Makefile \
-	$(RIOTBASE)/examples/*/Makefile    \
-	$(RIOTBASE)/tests/*/Makefile       \
-	)))))
+APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(dir $(wildcard $(APPLICATION_DIRS))))))
 
 info-applications:
 	@for dir in $(APPLICATION_DIRS); do echo $$dir; done

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -3,6 +3,20 @@
 # fallback so empty RIOTBASE won't lead to "/examples/"
 RIOTBASE ?= .
 
+# Define the list of examples subdirectories that container application directories
+EXAMPLES_APPLICATIONS_SUBDIRS :=  \
+    ble                       \
+    coap                      \
+    cord                      \
+    dtls                      \
+    gnrc                      \
+    icn                       \
+    lora                      \
+    mqtt                      \
+    posix                     \
+    #
+EXAMPLES_APPLICATIONS_SUBDIRS := $(addprefix examples/,$(EXAMPLES_APPLICATIONS_SUBDIRS))
+
 # Define the list of tests sudirectories that contain application directories
 TEST_APPLICATIONS_SUBDIRS :=  \
     arch                      \
@@ -26,6 +40,7 @@ APPLICATION_DIRS :=                   \
     bootloaders                       \
     examples                          \
     tests                             \
+    $(EXAMPLES_APPLICATIONS_SUBDIRS)  \
     $(TEST_APPLICATIONS_SUBDIRS)      \
     #
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR slightly adapts the `makefiles/app_dirs.inc.mk` in order to declare lists of subdirectories that can contain applications. This change is applied to the `tests` directory where the `bench`, `cpp`, `drivers`, `gnrc`, `periph`, `pkg`, `thread`, `xtimer` and `ztimer` subdirectories are introduced.
Application name prefix are also removed, since they are not redundant (`gnrc_`, `driver_`, etc).

Some changes were also required in each application Makefile:
```
include ../Makefile.tests_common
```
=>
```
RIOTBASE ?= $(CURDIR)/../../..
include $(RIOTBASE)/tests/Makefile.tests_common
```

The application is relatively one level lower compared to the common tests Makefile, so this had to be adapted.

This PR is marked as RFC because I think some discussion is needed regarding how to group applications.
In the current state, a preliminary set of groups is defined because I found them the most obvious. Maybe we could also define other groups (like sys ?).
This PR could also be a starting work to group example applications into categories (network, basic, etc) and maybe some test applications (in drivers and/or pkg) could be moved to the examples applications.

All this needs discussion and if we can reach some agreement, the remaining work could be done in follow-up PRs (a tracking issue could be worth I think).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock should be enough to detect side effects
- Verify that the number of applications remain unchanged compared to master:

```
$ git checkout master 
Switched to branch 'master'
Your branch is up to date with 'riot/master'.
$ make info-applications | wc -l
459
$ git checkout pr/examples/app_in_subdirs
Switched to branch 'pr/examples/app_in_subdirs'
$ make info-applications | wc -l
459
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

similar to #9933 (and maybe some ideas from there could be reused)
loosely related to #5105

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
