### PR TITLE
boards: provide highlevel_stdio feature on STM32 boards with STDIO CDC ACM

### DIFF
--- a/boards/stm32f429i-disco/Kconfig
+++ b/boards/stm32f429i-disco/Kconfig
@@ -22,4 +22,5 @@ config BOARD_STM32F429I_DISCO
     select HAS_PERIPH_USBDEV
 
     # Put other features for this board (in alphabetical order)
+    select HAS_HIGHLEVEL_STDIO
     select HAS_RIOTBOOT

--- a/boards/stm32f429i-disco/Makefile.features
+++ b/boards/stm32f429i-disco/Makefile.features
@@ -1,1 +1,3 @@
+FEATURES_PROVIDED += highlevel_stdio
+
 include $(RIOTBOARD)/stm32f429i-disc1/Makefile.features

--- a/boards/weact-f411ce/Kconfig
+++ b/boards/weact-f411ce/Kconfig
@@ -22,3 +22,6 @@ config BOARD_WEACT_F411CE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_HIGHLEVEL_STDIO

--- a/boards/weact-f411ce/Makefile.features
+++ b/boards/weact-f411ce/Makefile.features
@@ -10,3 +10,5 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+FEATURES_PROVIDED += highlevel_stdio


### PR DESCRIPTION
### Contribution description

I forgot to provide the `highlevel_stdio` on stm32 boards that use `stdio_cdc_acm`.
This results in a 

    There are unsatisfied feature requirements: highlevel_stdio

when trying to build those boards

Alternatively we could just *always* provide the `stdio_cdc_acm` feature as it only gets 'activated' by `FEATURES_REQUIRED`.
However, this might be a bit messy with Kconfig.

### Testing procedure

Compilation should work again

### Issues/PRs references

follow-up on #14952
second commit get be dropped if #15190 gets merged first.
