### PR TITLE
core: debug: remove parenthesis around ENABLE_DEBUG define

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -68,7 +68,7 @@ extern "C" {
  *          @ref DEBUG() will generate output only if ENABLE_DEBUG is non-zero.
  */
 #if !defined(ENABLE_DEBUG) || defined(DOXYGEN)
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #endif
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
One `ENABLE_DEBUG` was forgotten in https://github.com/RIOT-OS/RIOT/pull/15285: The very one in `core/include/debug.h`. 

~~In addition, this PR uses `IS_ACTIVE(ENABLE_DEBUG)` within `core/include/debug.h` for both the `DEBUG()` and `DEBUG_PUTS()` definitions. This allows for `ENABLE_DEBUG` to not be defined before including `debug.h` when the same behavior as `#define ENABLE_DEBUG 0` is desired.~~
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Murdock should be happy, binaries should stay the same, `ENABLE_DEBUG=1` in any C-file should yield debug output (of course only if it is triggered). Removing a `#define ENABLE_DEBUG 0`, but not the `debug.h` should now be compilable.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/15285
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
