### PR TITLE
drivers/mtd_flashpage: fix erasure of multiple sectors

### DIFF
--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -106,7 +106,7 @@ int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 #endif
 
     for (size_t i = 0; i < size; i += sector_size) {
-        flashpage_write(flashpage_page((void *)dst_addr), NULL);
+        flashpage_write(flashpage_page((void *)(dst_addr + i)), NULL);
     }
 
     return 0;

--- a/tests/mtd_flashpage/main.c
+++ b/tests/mtd_flashpage/main.c
@@ -99,8 +99,11 @@ static void test_mtd_write_erase(void)
 
     int ret = mtd_write(dev, buf, TEST_ADDRESS1, sizeof(buf));
     TEST_ASSERT_EQUAL_INT(0, ret);
+    ret = mtd_write(dev, buf, TEST_ADDRESS2, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
-    ret = mtd_erase(dev, TEST_ADDRESS1, dev->pages_per_sector * dev->page_size);
+    /* Erase both sectors */
+    ret = mtd_erase(dev, TEST_ADDRESS2, 2 * dev->pages_per_sector * dev->page_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
 
     uint8_t expected[sizeof(buf_read)];
@@ -110,6 +113,9 @@ static void test_mtd_write_erase(void)
     memset(expected, 0xff, sizeof(expected));
 #endif
     ret = mtd_read(dev, buf_read, TEST_ADDRESS1, sizeof(buf_read));
+    TEST_ASSERT_EQUAL_INT(0, ret);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(expected, buf_read, sizeof(buf_read)));
+    ret = mtd_read(dev, buf_read, TEST_ADDRESS2, sizeof(buf_read));
     TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(expected, buf_read, sizeof(buf_read)));
 }


### PR DESCRIPTION
### Contribution description

This PR fixes erasure of mutliple sectors in one go.

### Testing procedure

I've extended the driver's test.

Just cherry-pick 2c85ba2af2931d1ec00446413bf5e0e6229c1d02 on master and see the test failing.

### Issues/PRs references

*None*