### PR TITLE
boards/efm32: update board definitions and documentation

### DIFF
--- a/boards/common/slwstk6000b/Makefile.include
+++ b/boards/common/slwstk6000b/Makefile.include
@@ -12,6 +12,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # setup JLink for flashing
 include $(RIOTBOARD)/common/slwstk6000b/slwstk6000b.info.mk
 JLINK_DEVICE = $(word 2, $(SLWSTK6000B_MAINBOARD_VARS_$(BOARD_MODULE)))
+JLINK_PRE_FLASH = r
 
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/common/slwstk6000b/doc.txt
+++ b/boards/common/slwstk6000b/doc.txt
@@ -100,7 +100,7 @@ to get familiar with the different clocks.
 | HFXO   | No       | 38.4 MHz   |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
 | LFXO   | No       | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 

--- a/boards/common/slwstk6000b/include/board.h
+++ b/boards/common/slwstk6000b/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/common/slwstk6000b/include/board.h
+++ b/boards/common/slwstk6000b/include/board.h
@@ -33,11 +33,20 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 KHz to increase accuracy.
+ * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
+#define XTIMER_HZ           (32768UL)
+#define XTIMER_WIDTH        (16)
+#else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
+#endif
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -139,21 +139,34 @@ static const spi_dev_t spi_config[] = {
  */
 static const timer_conf_t timer_config[] = {
     {
-        {
+        .prescaler = {
             .dev = TIMER0,
             .cmu = cmuClock_TIMER0
         },
-        {
+        .timer = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 3
+        .channel_numof = 4
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
     }
 };
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
+#define TIMER_1_ISR         isr_letimer0
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/Kconfig
+++ b/boards/ikea-tradfri/Kconfig
@@ -11,6 +11,7 @@ config BOARD_IKEA_TRADFRI
     bool
     default y
     select CPU_MODEL_EFR32MG1P132F256GM32
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -3,6 +3,7 @@ CPU_FAM = efr32mg1p
 CPU_MODEL = efr32mg1p132f256gm32
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -4,6 +4,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # setup JLink for flashing
 JLINK_DEVICE = EFR32MG1PxxxF256
+JLINK_PRE_FLASH = r
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # setup serial terminal

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -18,8 +18,8 @@ More information about the module can be found on this
 | Family          | ARM Cortex-M4F                                                                          |
 | Vendor          | Silicon Labs                                                                            |
 | Vendor Family   | EFR32 Mighty Gecko 1P                                                                   |
-| RAM             | 32.0KiB (1.0KiB reserved)                                                               |
-| Flash           | 256.0KiB                                                                                |
+| RAM             | 32.0 KiB (1.0 KiB reserved)                                                             |
+| Flash           | 256.0 KiB                                                                               |
 | EEPROM          | no                                                                                      |
 | Frequency       | up to 38.4 MHz                                                                          |
 | FPU             | yes                                                                                     |
@@ -30,7 +30,7 @@ More information about the module can be found on this
 | UARTs           | 2x USART, 1x LEUART                                                                     |
 | SPIs            | 2x USART                                                                                |
 | I2Cs            | 1x                                                                                      |
-| Vcc             | 1.85V - 3.8V                                                                            |
+| Vcc             | 1.85 V - 3.8 V                                                                          |
 | Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efr32mg1-datasheet.pdf) |
 | Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/efr32xg1-rm.pdf)     |
 
@@ -66,8 +66,9 @@ Pin 1 is on the top-left side with only 6 contacts.
 | RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)        |
 | SPI        | 0       | USART1          | MOSI: PD15, MISO: PD14, CLK: PD13 |                                                     |
 | Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjecent)      |
+|            | 1       | LETIMER0        |                                   |                                                     |
 | UART       | 0       | USART0          | RX: PB15, TX: PB14                | Default STDIO output                                |
-| LEUART     | 0       | LEUART0         | RX: PB15, TX: PB14                | Alternate to using UART                             |
+|            | 1       | LEUART0         | RX: PB15, TX: PB14                | Baud rate limited (see below)                       |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments |
@@ -94,7 +95,6 @@ Pin 1 is on the top-left side with only 6 contacts.
 ## Board configuration
 
 ### UART selection
-
 By default the UART peripheral is used for the TX/RX pins, however the pinout
 is compatible with LEUART also. You can switch from UART to LEUART by compiling
 with `EFM32_USE_LEUART=1`.
@@ -112,7 +112,7 @@ to get familiar with the different clocks.
 | HFRCO  | Yes      | 19 MHz     | Enabled during startup, changeable |
 | HFXO   | No       | 38.4 MHz   |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -137,6 +137,56 @@ the speeds above, ensure to pass `EFM32_HFXO_FREQ=freq_in_hz` and
 
 You can override the branch's clock source by adding `CLOCK_LFA=source` to
 your compiler defines, e.g. `CLOCK_LFA=cmuSelect_LFRCO`.
+
+### Low-power peripherals
+The low-power UART is capable of providing an UART peripheral using a low-speed
+clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in
+EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is
+desired, set the clock source to CORELEDIV2.
+
+**Note:** peripheral mappings in your board definitions will not be affected by
+this setting. Ensure you do not refer to any low-power peripherals.
+
+### RTC or RTT
+RIOT-OS has support for *Real-Time Tickers* and *Real-Time Clocks*.
+
+However, this board MCU family has support for a 32-bit *Real-Time Clock and
+Calendar*, which can be configured in ticker mode **or** calendar mode.
+Therefore, only one of both peripherals can be enabled at the same time.
+
+Configured at 1 Hz interval, the RTCC will overflow each 136 years.
+
+### Hardware crypto
+This MCU is equipped with a hardware-accelerated crypto peripheral that can
+speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
+computations.
+
+A peripheral driver interface is proposed, but not yet implemented.
+
+### Usage of EMLIB
+This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+While some overhead is to be expected, it ensures proper setup of devices,
+provides chip errata and simplifies development. The exact overhead depends on
+the application and peripheral usage, but the largest overhead is expected
+during peripheral setup. A lot of read/write/get/set methods are implemented as
+inline methods or macros (which have no overhead).
+
+Another advantage of EMLIB are the included assertions. These assertions ensure
+that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
+compiler.
+
+### Pin locations
+The EFM32 platform supports peripherals to be mapped to different pins
+(predefined locations). The definitions in `periph_conf.h` mostly consist of a
+location number and the actual pins. The actual pins are required to configure
+the pins via GPIO driver, while the location is used to map the peripheral to
+these pins.
+
+In other words, these definitions must match. Refer to the data sheet for more
+information.
+
+This MCU has extended pin mapping support. Each pin of a peripheral can be
+connected separately to one of the predefined pins for that peripheral.
 
 ## Flashing the device
 To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is
@@ -167,8 +217,8 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the IKEA TRåDFRI module we strongly recommend the usage of the
-[GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+For using the Silicon Labs STK3600 starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -33,18 +33,20 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 kHz to increase accuracy or 32768 Hz for LETIMER.
+ * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
 #define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
+#define XTIMER_WIDTH        (16)
 #else
 #define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
-#endif
 #define XTIMER_WIDTH        (16)
-#define XTIMER_CHAN (0)
+#endif
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/include/gpio_params.h
+++ b/boards/ikea-tradfri/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -52,7 +52,6 @@ extern "C" {
  * @name    RTT configuration
  * @{
  */
-
 #define RTT_MAX_VALUE       (0xFFFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -49,6 +49,36 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {
+        .dev = ADC0,
+        .cmu = cmuClock_ADC0,
+    }
+};
+
+static const adc_chan_conf_t adc_channel_config[] = {
+    {
+        .dev = 0,
+        .input = adcPosSelTEMP,
+        .reference = adcRef1V25,
+        .acq_time = adcAcqTime8
+    },
+    {
+        .dev = 0,
+        .input = adcPosSelAVDD,
+        .reference = adcRef5V,
+        .acq_time = adcAcqTime8
+    }
+};
+
+#define ADC_DEV_NUMOF       ARRAY_SIZE(adc_config)
+#define ADC_NUMOF           ARRAY_SIZE(adc_channel_config)
+/** @} */
+
+/**
  * @name    RTT configuration
  * @{
  */

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -96,7 +96,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 3
+        .channel_numof = 4
     },
     {
         .prescaler = {
@@ -109,7 +109,7 @@ static const timer_conf_t timer_config[] = {
         },
         .irq = LETIMER0_IRQn,
         .channel_numof = 2
-    },
+    }
 };
 
 #define TIMER_0_ISR         isr_timer1

--- a/boards/slstk3401a/board.c
+++ b/boards/slstk3401a/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3401a/doc.txt
+++ b/boards/slstk3401a/doc.txt
@@ -14,27 +14,28 @@ actively measure the power consumption of your hardware and code, in real-time.
 ## Hardware
 
 ### MCU
-| MCU           | EFM32PG1B200F256GM48                                                                             |
-|---------------|--------------------------------------------------------------------------------------------------|
-| Family        | ARM Cortex-M4F                                                                                   |
-| Vendor        | Silicon Labs                                                                                     |
-| Vendor Family | EFM32 Pearl Gecko 1B                                                                             |
-| RAM           | 32.0KB                                                                                           |
-| Flash         | 256.0KB                                                                                          |
-| EEPROM        | no                                                                                               |
-| Frequency     | up to 40 MHz                                                                                     |
-| FPU           | yes                                                                                              |
-| MPU           | yes                                                                                              |
-| DMA           | 8 channels                                                                                       |
-| Timers        | 2x 16-bit, 1x 16-bit (low power)                                                                 |
-| ADCs          | 12-bit ADC                                                                                       |
-| UARTs         | 2x USART, 1x LEUART                                                                              |
-| SPIs          | 2x USART                                                                                         |
-| I2Cs          | 2x                                                                                               |
-| Vcc           | 1.85V - 3.8V                                                                                     |
-| Datasheet     | [Datasheet](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32PG1-DataSheet.pdf)     |
-| Manual        | [Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32PG1-ReferenceManual.pdf)  |
-| Board Manual  | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug154-stk3401-user-guide.pdf) |
+| MCU             | EFM32PG1B200F256GM48                                                                             |
+|-----------------|--------------------------------------------------------------------------------------------------|
+| Family          | ARM Cortex-M4F                                                                                   |
+| Vendor          | Silicon Labs                                                                                     |
+| Vendor Family   | EFM32 Pearl Gecko 1B                                                                             |
+| RAM             | 32.0 KiB                                                                                         |
+| Flash           | 256.0 KiB                                                                                        |
+| EEPROM          | no                                                                                               |
+| Frequency       | up to 40 MHz                                                                                     |
+| FPU             | yes                                                                                              |
+| MPU             | yes                                                                                              |
+| DMA             | 8 channels                                                                                       |
+| Timers          | 2x 16-bit + 1x 16-bit (low power)                                                                |
+| ADCs            | 12-bit ADC                                                                                       |
+| UARTs           | 2x USART, 1x LEUART                                                                              |
+| SPIs            | 2x USART                                                                                         |
+| I2Cs            | 1x                                                                                               |
+| Vcc             | 1.85 V - 3.8 V                                                                                   |
+| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32pg1-datasheet.pdf)          |
+| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/efm32pg1-rm.pdf)              |
+| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug154-stk3401-user-guide.pdf) |
+| Board Schematic | Can be downloaded using Silicon Labs' Simplicity Studio                                          |
 
 ### Pinout
 This is the pinout of the expansion header on the right side of the board.
@@ -67,9 +68,9 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
 | Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+|            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
-|            | 1       | USART1          | RX: PC6, TX: PC7               |                                                          |
-|            | 2       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
+|            | 1       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
 | Peripheral | Mapped to | Pin | Comments   |
@@ -138,8 +139,7 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.1]
-(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |
@@ -148,7 +148,7 @@ to get familiar with the different clocks.
 | HFXO   | No       | 40 MHz     |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
 | LFXO   | No       | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -193,11 +193,11 @@ Therefore, only one of both peripherals can be enabled at the same time.
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Hardware crypto
-This MCU is equipped with a hardware accelerated crypto peripheral that can
+This MCU is equipped with a hardware-accelerated crypto peripheral that can
 speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
 computations.
 
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
+A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
@@ -253,8 +253,8 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs SLSTK3401A starter kit we strongly recommend the
-usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+For using the Silicon Labs SLSTK3401A starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information

--- a/boards/slstk3401a/include/board.h
+++ b/boards/slstk3401a/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3401a/include/board.h
+++ b/boards/slstk3401a/include/board.h
@@ -32,18 +32,20 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
+ * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
 #define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
+#define XTIMER_WIDTH        (16)
 #else
 #define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
-#endif
 #define XTIMER_WIDTH        (16)
-#define XTIMER_CHAN (0)
+#endif
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/slstk3401a/include/gpio_params.h
+++ b/boards/slstk3401a/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -193,15 +193,6 @@ static const uart_conf_t uart_config[] = {
         .irq = USART0_RX_IRQn
     },
     {
-        .dev = USART1,
-        .rx_pin = GPIO_PIN(PC, 7),
-        .tx_pin = GPIO_PIN(PC, 6),
-        .loc = USART_ROUTELOC0_RXLOC_LOC11 |
-               USART_ROUTELOC0_TXLOC_LOC11,
-        .cmu = cmuClock_USART1,
-        .irq = USART1_RX_IRQn
-    },
-    {
         .dev = LEUART0,
         .rx_pin = GPIO_PIN(PD, 11),
         .tx_pin = GPIO_PIN(PD, 10),
@@ -214,8 +205,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
-#define UART_1_ISR_RX       isr_usart1_rx
-#define UART_2_ISR_RX       isr_leuart0
+#define UART_1_ISR_RX       isr_leuart0
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -141,8 +141,7 @@ static const spi_dev_t spi_config[] = {
 /**
  * @name    Timer configuration
  *
- * The implementation can use one low-energy timer
- * or two regular timers in cascade mode.
+ * The implementation uses two timers in cascade mode.
  * @{
  */
 static const timer_conf_t timer_config[] = {
@@ -156,7 +155,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 3
+        .channel_numof = 4
     },
     {
         .prescaler = {
@@ -169,13 +168,12 @@ static const timer_conf_t timer_config[] = {
         },
         .irq = LETIMER0_IRQn,
         .channel_numof = 2
-    },
+    }
 };
 
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_1_ISR         isr_letimer0
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**

--- a/boards/slstk3402a/board.c
+++ b/boards/slstk3402a/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3402a/doc.txt
+++ b/boards/slstk3402a/doc.txt
@@ -14,27 +14,28 @@ actively measure the power consumption of your hardware and code, in real-time.
 ## Hardware
 
 ### MCU
-| MCU           | EFM32PG12B500F1024GL125                                                                          |
-|---------------|--------------------------------------------------------------------------------------------------|
-| Family        | ARM Cortex-M4F                                                                                   |
-| Vendor        | Silicon Labs                                                                                     |
-| Vendor Family | EFM32 Pearl Gecko 12B                                                                            |
-| RAM           | 256.0KB                                                                                          |
-| Flash         | 1024.0KB                                                                                         |
-| EEPROM        | no                                                                                               |
-| Frequency     | up to 40 MHz                                                                                     |
-| FPU           | yes                                                                                              |
-| MPU           | yes                                                                                              |
-| DMA           | 8 channels                                                                                       |
-| Timers        | 2x 32-bit, 2x 16-bit, 1x 16-bit (low power)                                                      |
-| ADCs          | 12-bit ADC                                                                                       |
-| UARTs         | 4x USART, 1x LEUART                                                                              |
-| SPIs          | 4x USART                                                                                         |
-| I2Cs          | 2x                                                                                               |
-| Vcc           | 1.85V - 3.8V                                                                                     |
-| Datasheet     | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32pg12-datasheet.pdf)         |
-| Manual        | [Manual](https://www.silabs.com/documents/public/reference-manuals/efm32pg12-rm.pdf)             |
-| Board Manual  | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug257-stk3402-usersguide.pdf) |
+| MCU             | EFM32PG12B500F1024GL125                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------|
+| Family          | ARM Cortex-M4F                                                                                   |
+| Vendor          | Silicon Labs                                                                                     |
+| Vendor Family   | EFM32 Pearl Gecko 12B                                                                            |
+| RAM             | 256.0 KiB                                                                                        |
+| Flash           | 1024.0 KiB                                                                                       |
+| EEPROM          | no                                                                                               |
+| Frequency       | up to 40 MHz                                                                                     |
+| FPU             | yes                                                                                              |
+| MPU             | yes                                                                                              |
+| DMA             | 8 channels                                                                                       |
+| Timers          | 2x 16-bit + 1x 16-bit (low power)                                                                |
+| ADCs            | 12-bit ADC                                                                                       |
+| UARTs           | 2x USART, 1x LEUART                                                                              |
+| SPIs            | 2x USART                                                                                         |
+| I2Cs            | 1x                                                                                               |
+| Vcc             | 1.85 V - 3.8 V                                                                                   |
+| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32pg12-datasheet.pdf)         |
+| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/efm32pg12-rm.pdf)             |
+| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug257-stk3402-usersguide.pdf) |
+| Board Schematic | Can be downloaded using Silicon Labs' Simplicity Studio                                          |
 
 ### Pinout
 This is the pinout of the expansion header on the right side of the board.
@@ -68,9 +69,10 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTC        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
 | Timer      | 0       | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjecent)          |
+| Timer      | 1       | TIMER0 + TIMER1   |                                | TIMER0 is used as prescaler (must be adjecent)           |
+|            | 2       | LETIMER0          |                                |                                                          |
 | UART       | 0       | USART0            | RX: PA1, TX: PA0               | Default STDIO output                                     |
-|            | 1       | USART1            | RX: PC6, TX: PC7               |                                                          |
-|            | 2       | LEUART0           | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
+|            | 1       | LEUART0           | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
 | Peripheral | Mapped to | Pin | Comments   |
@@ -140,8 +142,7 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.1]
-(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |
@@ -150,7 +151,7 @@ to get familiar with the different clocks.
 | HFXO   | No       | 40 MHz     |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
 | LFXO   | No       | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -195,11 +196,11 @@ Therefore, only one of both peripherals can be enabled at the same time.
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Hardware crypto
-This MCU is equipped with a hardware accelerated crypto peripheral that can
+This MCU is equipped with a hardware-accelerated crypto peripheral that can
 speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
 computations.
 
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
+A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
@@ -255,8 +256,8 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs SLSTK3402A starter kit we strongly recommend the
-usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+For using the Silicon Labs SLSTK3402A starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -31,6 +31,9 @@ extern "C" {
 
 /**
  * @name    Xtimer configuration
+ *
+ * The timer runs at 1000 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
@@ -42,7 +45,7 @@ extern "C" {
 #define XTIMER_HZ           (1000000UL)
 #define XTIMER_WIDTH        (32)
 #endif
-#define XTIMER_CHAN (0)
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -37,7 +37,7 @@ extern "C" {
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
+#define XTIMER_DEV          (TIMER_DEV(2))
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else

--- a/boards/slstk3402a/include/gpio_params.h
+++ b/boards/slstk3402a/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -132,8 +132,7 @@ static const spi_dev_t spi_config[] = {
 /**
  * @name    Timer configuration
  *
- * The implementation can use one low-energy timer
- * or two regular timers in cascade mode.
+ * The implementation uses two timers in cascade mode.
  * @{
  */
 static const timer_conf_t timer_config[] = {
@@ -147,7 +146,19 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_WTIMER1
         },
         .irq = WTIMER1_IRQn,
-        .channel_numof = 3
+        .channel_numof = 4
+    },
+    {
+        .prescaler = {
+            .dev = TIMER0,
+            .cmu = cmuClock_TIMER0
+        },
+        .timer = {
+            .dev = TIMER1,
+            .cmu = cmuClock_TIMER1
+        },
+        .irq = TIMER1_IRQn,
+        .channel_numof = 4
     },
     {
         .prescaler = {
@@ -160,13 +171,13 @@ static const timer_conf_t timer_config[] = {
         },
         .irq = LETIMER0_IRQn,
         .channel_numof = 2
-    },
+    }
 };
 
-#define TIMER_0_ISR         isr_wtimer1
-#define TIMER_1_ISR         isr_letimer0
-
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+#define TIMER_0_ISR         isr_wtimer1
+#define TIMER_1_ISR         isr_timer1
+#define TIMER_2_ISR         isr_letimer0
 /** @} */
 
 /**

--- a/boards/sltb001a/board.c
+++ b/boards/sltb001a/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/sltb001a/doc.txt
+++ b/boards/sltb001a/doc.txt
@@ -14,28 +14,28 @@ actively measure the power consumption of your hardware and code, in real-time.
 ## Hardware
 
 ### MCU
-| MCU             | EFR32MG1P132F256GM48                                                                    |
-|-----------------|-----------------------------------------------------------------------------------------|
-| Family          | ARM Cortex-M4F                                                                          |
-| Vendor          | Silicon Labs                                                                            |
-| Vendor Family   | EFR32 Mighty Gecko 1P                                                                   |
-| RAM             | 32.0KB (1.0KB reserved)                                                                 |
-| Flash           | 256.0KB                                                                                 |
-| EEPROM          | no                                                                                      |
-| Frequency       | up to 38.4 MHz                                                                          |
-| FPU             | yes                                                                                     |
-| MPU             | yes                                                                                     |
-| DMA             | 12 channels                                                                             |
-| Timers          | 2x 16-bit + 1x 16-bit (low power)                                                       |
-| ADCs            | 12-bit ADC                                                                              |
-| UARTs           | 2x USART, 1x LEUART                                                                     |
-| SPIs            | 2x USART                                                                                |
-| I2Cs            | 1x                                                                                      |
-| Vcc             | 1.85V - 3.8V                                                                            |
-| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efr32mg1-datasheet.pdf) |
-| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/efr32xg1-rm.pdf)     |
-| Board Manual    | [Board Manual](http://www.silabs.com/Support%20Documents/TechnicalDocs/UG250.pdf)       |
-| Board Schematic | [Board Schematic](http://www.silabs.com/Support%20Documents/TechnicalDocs/UG250.pdf)    |
+| MCU             | EFR32MG1P132F256GM48                                                                           |
+|-----------------|------------------------------------------------------------------------------------------------|
+| Family          | ARM Cortex-M4F                                                                                 |
+| Vendor          | Silicon Labs                                                                                   |
+| Vendor Family   | EFR32 Mighty Gecko 1P                                                                          |
+| RAM             | 31.0 KiB                                                                                       |
+| Flash           | 256.0 KiB                                                                                      |
+| EEPROM          | no                                                                                             |
+| Frequency       | up to 38.4 MHz                                                                                 |
+| FPU             | yes                                                                                            |
+| MPU             | yes                                                                                            |
+| DMA             | 12 channels                                                                                    |
+| Timers          | 2x 16-bit + 1x 16-bit (low power)                                                              |
+| ADCs            | 12-bit ADC                                                                                     |
+| UARTs           | 3x UART, 2x USART, 1x LEUART                                                                   |
+| SPIs            | 2x USART                                                                                       |
+| I2Cs            | 1x                                                                                             |
+| Vcc             | 1.85 V - 3.8 V                                                                                 |
+| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efr32mg1-datasheet.pdf)        |
+| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/efr32xg1-rm.pdf)            |
+| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/ug250-tb001-user-guide.pdf) |
+| Board Schematic | Can be downloaded using Silicon Labs' Simplicity Studio                                        |
 
 ### Pinout
 This is the pinout of the expansion pins on the front side of the board. PIN 1
@@ -56,7 +56,6 @@ is the top-left contact, marked on the silkscreen.
 
 **Note**: not all starter kits by Silicon Labs share the same pinout!
 
-
 ### Peripheral mapping
 | Peripheral | Number  | Hardware        | Pins                           | Comments                                                 |
 |------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
@@ -67,9 +66,9 @@ is the top-left contact, marked on the silkscreen.
 | RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
 | Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+|            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
-|            | 1       | USART1          | RX: PC6, TX: PC7               |                                                          |
-|            | 2       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
+|            | 1       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments  |
@@ -109,8 +108,8 @@ adding `DISABLE_MODULE=silabs_pic` to the `make` command.
 ## Board configuration
 
 ### Board controller
-The starter kit is equipped with a Board Controller. This controller provides a
-virtual serial port.
+The starter kit is equipped with a Board Controller. This controller provides
+a virtual serial port.
 
 **Note:** the board controller *always* configures the virtual serial port at
 115200 baud with 8 bits, no parity and one stop bit. This also means that it
@@ -118,8 +117,7 @@ expects data from the MCU with the same settings.
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.1]
-(https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |
@@ -128,7 +126,7 @@ to get familiar with the different clocks.
 | HFXO   | No       | 38.4 MHz   |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
 | LFXO   | No       | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -140,7 +138,7 @@ The sources can be used to clock following branches:
 | LFE    | LFRCO, LFXO             | Real-time Clock and Calendar |
 
 CORELEDIV2 is a source that depends on the clock source that powers the core.
-It is divided by 2 or 4 to not exceed maximum clock frequencies (emlib takes
+It is divided by 2 or 4 to not exceed maximum clock frequencies (EMLIB takes
 care of this).
 
 The frequencies mentioned in the tables above are specific for this starter
@@ -173,21 +171,21 @@ Therefore, only one of both peripherals can be enabled at the same time.
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Hardware crypto
-This MCU is equipped with a hardware accelerated crypto peripheral that can
+This MCU is equipped with a hardware-accelerated crypto peripheral that can
 speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
 computations.
 
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
+A peripheral driver interface is proposed, but not yet implemented.
 
-### Usage of emlib
-This port makes uses of emlib by Silicon Labs to abstract peripheral registers.
+### Usage of EMLIB
+This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
 during peripheral setup. A lot of read/write/get/set methods are implemented as
 inline methods or macros (which have no overhead).
 
-Another advantage of emlib are the included assertions. These assertions ensure
+Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
 compiler.
 
@@ -233,10 +231,10 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs SLTB001A starter kit we strongly recommend the usage
-of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+For using the Silicon Labs SLTB001A starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information
-* Silicon Labs' emlib: zlib-style license (permits distribution of source).
+* Silicon Labs' EMLIB: zlib-style license (permits distribution of source).
  */

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -32,7 +32,8 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
+ * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
@@ -44,7 +45,7 @@ extern "C" {
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
 #endif
-#define XTIMER_CHAN (0)
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -119,7 +119,7 @@ extern "C" {
  * @{
  */
 #ifndef ICM20648_ENABLED
-#define ICM20648_ENABLED    (0)
+#define ICM20648_ENABLED    0
 #endif
 #define ICM20648_SPI        SPI_DEV(0)
 #define ICM20648_PIC_ADDR   (0x00)
@@ -144,16 +144,16 @@ extern "C" {
  * @{
  */
 #ifndef RGB_LED1_ENABLED
-#define RGB_LED1_ENABLED    (1)
+#define RGB_LED1_ENABLED    1
 #endif
 #ifndef RGB_LED2_ENABLED
-#define RGB_LED2_ENABLED    (1)
+#define RGB_LED2_ENABLED    1
 #endif
 #ifndef RGB_LED3_ENABLED
-#define RGB_LED3_ENABLED    (1)
+#define RGB_LED3_ENABLED    1
 #endif
 #ifndef RGB_LED4_ENABLED
-#define RGB_LED4_ENABLED    (1)
+#define RGB_LED4_ENABLED    1
 #endif
 #define RGB_LED_ADDR        (0x04)
 #define RGB_LED_EN_BIT      (0x00)
@@ -170,7 +170,7 @@ extern "C" {
  * @{
  */
 #ifndef SI1133_ENABLED
-#define SI1133_ENABLED      (0)
+#define SI1133_ENABLED      0
 #endif
 #define SI1133_I2C          I2C_DEV(0)
 /** @} */
@@ -194,7 +194,7 @@ extern "C" {
  * @{
  */
 #ifndef SI7210_ENABLED
-#define SI7210_ENABLED      (0)
+#define SI7210_ENABLED      0
 #endif
 #define SI7210_I2C          I2C_DEV(0)
 /** @} */

--- a/boards/sltb001a/include/gpio_params.h
+++ b/boards/sltb001a/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -141,8 +141,7 @@ static const spi_dev_t spi_config[] = {
 /**
  * @name    Timer configuration
  *
- * The implementation can use one low-energy timer
- * or two regular timers in cascade mode.
+ * The implementation uses two timers in cascade mode.
  * @{
  */
 static const timer_conf_t timer_config[] = {
@@ -156,7 +155,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 3
+        .channel_numof = 4
     },
     {
         .prescaler = {
@@ -169,13 +168,12 @@ static const timer_conf_t timer_config[] = {
         },
         .irq = LETIMER0_IRQn,
         .channel_numof = 2
-    },
+    }
 };
 
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_1_ISR         isr_letimer0
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -193,15 +193,6 @@ static const uart_conf_t uart_config[] = {
         .irq = USART0_RX_IRQn
     },
     {
-        .dev = USART1,
-        .rx_pin = GPIO_PIN(PC, 6),
-        .tx_pin = GPIO_PIN(PC, 7),
-        .loc = USART_ROUTELOC0_RXLOC_LOC11 |
-               USART_ROUTELOC0_TXLOC_LOC11,
-        .cmu = cmuClock_USART1,
-        .irq = USART1_RX_IRQn
-    },
-    {
         .dev = LEUART0,
         .rx_pin = GPIO_PIN(PD, 11),
         .tx_pin = GPIO_PIN(PD, 10),
@@ -214,8 +205,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
-#define UART_1_ISR_RX       isr_usart1_rx
-#define UART_2_ISR_RX       isr_leuart0
+#define UART_1_ISR_RX       isr_leuart0
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stk3200/Makefile.include
+++ b/boards/stk3200/Makefile.include
@@ -5,5 +5,8 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# setup JLink for flashing
+JLINK_PRE_FLASH = r
+
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3200/board.c
+++ b/boards/stk3200/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3200/doc.txt
+++ b/boards/stk3200/doc.txt
@@ -1,41 +1,45 @@
 /**
-@defgroup    boards_stk3200 Silicon Labs STK3200 starter kit
-@ingroup     boards
-@brief       Support for Silicon Labs STK3200 starter kit
+ * @defgroup    boards_stk3200 Silicon Labs STK3200 starter kit
+ * @ingroup     boards
+ * @brief       Support for Silicon Labs STK3200 starter kit
 
 ## Overview
-Silicon Labs EFM32 Zero Gecko Starter Kit is equipped with the EFM32 microcontroller. It is specifically designed for low-power applications, having energy-saving peripherals, different energy modes and short wake-up times.
+Silicon Labs EFM32 Zero Gecko Starter Kit is equipped with the EFM32
+microcontroller. It is specifically designed for low-power applications, having
+energy-saving peripherals, different energy modes and short wake-up times.
 
-The starter kit is equipped with an Advanced Energy Monitor. This allows you to actively measure the power consumption of your hardware and code, in real-time.
+The starter kit is equipped with an Advanced Energy Monitor. This allows you to
+actively measure the power consumption of your hardware and code, in real-time.
 
 ## Hardware
 
 ### MCU
-| MCU             | EFM32ZG222F32                                        |
-|-----------------|------------------------------------------------------|
-| Family          | ARM Cortex-M0PLUS                                    |
-| Vendor          | Silicon Labs                                         |
-| Vendor Family   | EFM32 Zero Gecko                                     |
-| RAM             | 4.0KB                                                |
-| Flash           | 32.0KB                                               |
-| EEPROM          | no                                                   |
-| Frequency       | up to 24 MHz                                         |
-| FPU             | no                                                   |
-| MPU             | no                                                   |
-| DMA             | 12 channels                                          |
-| Timers          | 2x 16-bit + 1x 16-bit (low power)                    |
-| ADCs            | 12-bit ADC                                           |
-| UARTs           | 2x USART, 1x LEUART                                  |
-| SPIs            | 2x SPI                                               |
-| I2Cs            | 1x                                                   |
-| Vcc             | 1.98V - 3.8V                                         |
-| Datasheet       | [Datasheet](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32ZG222.pdf)                                     |
-| Manual          | [Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32ZG-RM.pdf)                                        |
-| Board Manual    | [Board Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/efm32zg-stk3200-ug.pdf)                          |
-| Board Schematic | [Board Schematic](https://www.silabs.com/Support%20Documents/TechnicalDocs/BRD2010A_B01.pdf)                             |
+| MCU             | EFM32ZG222F32                                                                              |
+|-----------------|--------------------------------------------------------------------------------------------|
+| Family          | ARM Cortex-M0PLUS                                                                          |
+| Vendor          | Silicon Labs                                                                               |
+| Vendor Family   | EFM32 Zero Gecko                                                                           |
+| RAM             | 4.0 KiB                                                                                    |
+| Flash           | 32.0 KiB                                                                                   |
+| EEPROM          | no                                                                                         |
+| Frequency       | up to 24 MHz                                                                               |
+| FPU             | no                                                                                         |
+| MPU             | no                                                                                         |
+| DMA             | 12 channels                                                                                |
+| Timers          | 2x 16-bit                                                                                  |
+| ADCs            | 12-bit ADC                                                                                 |
+| UARTs           | 2x USART, 1x LEUART                                                                        |
+| SPIs            | 2x USART                                                                                   |
+| I2Cs            | 1x                                                                                         |
+| Vcc             | 1.98 V - 3.8 V                                                                             |
+| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32zg-datasheet.pdf)     |
+| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/EFM32ZG-RM.pdf)         |
+| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/efm32zg-stk3200-ug.pdf) |
+| Board Schematic | Can be downloaded using Silicon Labs' Simplicity Studio                                    |
 
 ### Pinout
-This is the pinout of the expansion header on the right side of the board. PIN 1 is the bottom-left contact when the header faces  you horizontally.
+This is the pinout of the expansion header on the right side of the board.
+PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|
@@ -55,68 +59,75 @@ This is the pinout of the expansion header on the right side of the board. PIN 1
 **Note:** some pins are connected to the board controller, when enabled!
 
 ### Peripheral mapping
-| Peripheral | Number  | Hardware        | Pins                            | Comments                                                  |
-|------------|---------|-----------------|---------------------------------|-----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported       |
-| I2C        | 0       | I2C0            | SDA: PE12, SCL: PE13            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate  |
-| HWCRYPTO   | &mdash; | &mdash;         |                                 | AES128/AES256 only                                        |
-| RTT        | &mdash; | RTC             |                                 | Either RTT or RTC (see below)                             |
-| RTC        | &mdash; | RTC             |                                 | Either RTC or RTT (see below)                             |
-| SPI        | 0       | USART1          | MOSI: PD7, MISO: PD6, CLK: PC15 |                                                           |
-| Timer      | 0       | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjecent)            |
-| UART       | 0       | LEUART0         | RX: PD5, TX: PD4                | STDIO Output, Baud rate limited (see below)               |
-|            | 1       | USART1          | RX: PD6, TX: PD7                |                                                           |
+| Peripheral | Number  | Hardware        | Pins                            | Comments                                                 |
+|------------|---------|-----------------|---------------------------------|----------------------------------------------------------|
+| ADC        | 0       | ADC0            | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0       | I2C0            | SDA: PE12, SCL: PE13            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| HWCRYPTO   | &mdash; | &mdash;         |                                 | AES128/AES256 only                                       |
+| RTT        | &mdash; | RTC             |                                 | Either RTT or RTC (see below)                            |
+| RTC        | &mdash; | RTC             |                                 | Either RTC or RTT (see below)                            |
+| SPI        | 0       | USART1          | MOSI: PD7, MISO: PD6, CLK: PC15 |                                                          |
+| Timer      | 0       | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjecent)           |
+| UART       | 0       | LEUART0         | RX: PD5, TX: PD4                | STDIO Output, Baud rate limited (see below)              |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments   |
 |------------|-----------|------|------------|
-| Button      | PB0      | PC8  |            |
-|             | PB1      | PC9  |            |
-| LED         | LED0     | PC10 | Yellow LED |
-|             | LED1     | PC11 | Yellow LED |
+| Button     | PB0_PIN   | PC8  |            |
+|            | PB1_PIN   | PC9  |            |
+| LED        | LED0_PIN  | PC10 | Yellow LED |
+|            | LED1_PIN  | PC11 | Yellow LED |
 
 ## Implementation Status
-| Device                        | ID                                  | Supported | Comments                                                       |
-|-------------------------------|-------------------------------------|-----------|----------------------------------------------------------------|
-| MCU                           | EFM32ZG                             | yes       | Power modes supported                                          |
-| Low-level driver              | ADC                                 | yes       |                                                                |
-|                               | Flash                               | yes       |                                                                |
-|                               | GPIO                                | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto                           | yes       |                                                                |
-|                               | I2C                                 | yes       |                                                                |
-|                               | PWM                                 | yes       |                                                                |
-|                               | RTC                                 | yes       | As RTT or RTC                                                  |
-|                               | SPI                                 | partially | Only master mode                                               |
-|                               | Timer                               | yes       |                                                                |
-|                               | UART                                | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
-|                               | USB                                 | no        |                                                                |
-| LCD driver                    | LS013B7DH03                         | yes       | Sharp Low Power Memory LCD                                     |
-
-
+| Device           | ID          | Supported | Comments                                                       |
+|------------------|-------------|-----------|----------------------------------------------------------------|
+| MCU              | EFM32ZG     | yes       | Power modes supported                                          |
+| Low-level driver | ADC         | yes       |                                                                |
+|                  | Flash       | yes       |                                                                |
+|                  | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
+|                  | HW Crypto   | yes       |                                                                |
+|                  | I2C         | yes       |                                                                |
+|                  | PWM         | yes       |                                                                |
+|                  | RTC         | yes       | As RTT or RTC                                                  |
+|                  | SPI         | partially | Only master mode                                               |
+|                  | Timer       | yes       |                                                                |
+|                  | UART        | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
+|                  | USB         | no        |                                                                |
+| LCD driver       | LS013B7DH03 | yes       | Sharp Low Power Memory LCD via the U8g2 package                |
 
 ## Board configuration
 
 ### Board controller
-The starter kit is equipped with a Board Controller. This controller provides a virtual serial port. The board controller is enabled via a GPIO pin.
+The starter kit is equipped with a Board Controller. This controller provides a
+virtual serial port. The board controller is enabled via a GPIO pin.
 
-By default, this pin is enabled. You can disable the board controller module by passing `DISABLE_MODULE=silabs_bc` to the `make` command.
+By default, this pin is enabled. You can disable the board controller module by
+passing `DISABLE_MODULE=silabs_bc` to the `make` command.
 
-**Note:** to use the virtual serial port, ensure you have the latest board controller firmware installed.
+**Note:** to use the virtual serial port, ensure you have the latest board
+controller firmware installed.
 
-**Note:** the board controller *always* configures the virtual serial port at 115200 baud with 8 bits, no parity and one stop bit. This also means that it expects data from the MCU with the same settings.
+**Note:** the board controller *always* configures the virtual serial port at
+115200 baud with 8 bits, no parity and one stop bit. This also means that it
+expects data from the MCU with the same settings.
 
-The low power LCD is also used by the board controller when the `DISP_SELECTED` pin is low. This pin is not initialized by the board, so you have to ensure this pin is initialized by your application if you want to control the low power LCD.
+The low power LCD is also used by the board controller when the `DISP_SELECTED`
+pin is low. This pin is not initialized by the board, so you have to ensure
+this pin is initialized by your application if you want to control the low
+power LCD.
 
 ### Clock selection
-There are several clock sources that are available for the different peripherals. You are advised to read [AN0004](https://www.silabs.com/Support%20Documents/TechnicalDocs/AN0004.pdf) to get familiar with the different clocks.
+There are several clock sources that are available for the different
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+to get familiar with the different clocks.
 
-| Source  | Internal | Speed                            | Comments                           |
-|---------|----------|----------------------------------|------------------------------------|
-| HFRCO   | Yes      | 14 MHz                           | Enabled during startup, changeable |
-| HFXO    | No       | 24 MHz                           |                                    |
-| LFRCO   | Yes      | 32.768 kHz                       |                                    |
-| LFXO    | No       | 32.768 kHz                       |                                    |
-| ULFRCO  | No       | 1.000 kHz                        | Not very reliable as a time source |
+| Source | Internal | Speed      | Comments                           |
+|--------|----------|------------|------------------------------------|
+| HFRCO  | Yes      | 14 MHz     | Enabled during startup, changeable |
+| HFXO   | No       | 24 MHz     |                                    |
+| LFRCO  | Yes      | 32.768 kHz |                                    |
+| LFXO   | No       | 32.768 kHz |                                    |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -126,43 +137,71 @@ The sources can be used to clock following branches:
 | LFA    | LFRCO, LFXO             | Low-power timers             |
 | LFB    | LFRCO, LFXO, CORELEDIV2 | Low-power UART               |
 
-CORELEDIV2 is a source that depends on the clock source that powers the core. It is divided by 2 or 4 to not exceed maximum clock frequencies (emlib takes care of this).
+CORELEDIV2 is a source that depends on the clock source that powers the core.
+It is divided by 2 or 4 to not exceed maximum clock frequencies (EMLIB takes
+care of this).
 
-The frequencies mentioned in the tables above are specific for this starter kit.
+The frequencies mentioned in the tables above are specific for this starter
+kit.
 
-It is important that the clock speeds are known to the code, for proper calculations of speeds and baud rates. If the HFXO or LFXO are different from the speeds above, ensure to pass `EFM32_HFXO_FREQ=freq_in_hz` and `EFM32_LFXO_FREQ=freq_in_hz` to your compiler.
+It is important that the clock speeds are known to the code, for proper
+calculations of speeds and baud rates. If the HFXO or LFXO are different from
+the speeds above, ensure to pass `EFM32_HFXO_FREQ=freq_in_hz` and
+`EFM32_LFXO_FREQ=freq_in_hz` to your compiler.
 
-You can override the branch's clock source by adding `CLOCK_LFA=source` to your compiler defines, e.g. `CLOCK_LFA=cmuSelect_LFRCO`.
+You can override the branch's clock source by adding `CLOCK_LFA=source` to your
+compiler defines, e.g. `CLOCK_LFA=cmuSelect_LFRCO`.
 
 ### Low-power peripherals
-The low-power UART is capable of providing an UART peripheral using a low-speed clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is desired, set the clock source to CORELEDIV2.
+The low-power UART is capable of providing an UART peripheral using a low-speed
+clock. When the LFB clock source is the LFRCO or LFXO, it can still be used in
+EM2. However, this limits the baud rate to 9600 baud. If a higher baud rate is
+desired, set the clock source to CORELEDIV2.
 
-**Note:** peripheral mappings in your board definitions will not be affected by this setting. Ensure you do not refer to any low-power peripherals.
+**Note:** peripheral mappings in your board definitions will not be affected by
+this setting. Ensure you do not refer to any low-power peripherals.
 
 ### RTC or RTT
 RIOT-OS has support for *Real-Time Tickers* and *Real-Time Clocks*.
 
-However, this board MCU family has support for a 24-bit *Real-Time Counter* only, which is a ticker only. A compatibility layer for ticker-to-calendar is available, but this includes extra code size to convert from timestamps to time structures and visa versa.
+However, this board MCU family has support for a 24-bit *Real-Time Counter*
+only, which is a ticker only. A compatibility layer for ticker-to-calendar is
+available, but this includes extra code size to convert from timestamps to time
+structures and visa versa.
 
-Configured at 1 Hz interval, the RTC will overflow each 194 days. When using the ticker-to-calendar mode, this interval is extended artificially.
+Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
+the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Hardware crypto
-    This MCUs has support for hardware accelerated AES128.
+This MCUs has support for hardware-accelerated AES128.
 
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
+A peripheral driver interface is proposed, but not yet implemented.
 
-### Usage of emlib
-This port makes uses of emlib by Silicon Labs to abstract peripheral registers. While some overhead is to be expected, it ensures proper setup of devices, provides chip errata and simplifies development. The exact overhead depends on the application and peripheral usage, but the largest overhead is expected during peripheral setup. A lot of read/write/get/set methods are implemented as inline methods or macros (which have no overhead).
+### Usage of EMLIB
+This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+While some overhead is to be expected, it ensures proper setup of devices,
+provides chip errata and simplifies development. The exact overhead depends on
+the application and peripheral usage, but the largest overhead is expected
+during peripheral setup. A lot of read/write/get/set methods are implemented as
+inline methods or macros (which have no overhead).
 
-Another advantage of emlib are the included assertions. These assertions ensure that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your compiler.
+Another advantage of EMLIB are the included assertions. These assertions ensure
+that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
+compiler.
 
 ### Pin locations
-The EFM32 platform supports peripherals to be mapped to different pins (predefined locations). The definitions in `periph_conf.h` mostly consist of a location number and the actual pins. The actual pins are required to configure the pins via GPIO driver, while the location is used to map the peripheral to these pins.
+The EFM32 platform supports peripherals to be mapped to different pins
+(predefined locations). The definitions in `periph_conf.h` mostly consist of a
+location number and the actual pins. The actual pins are required to configure
+the pins via GPIO driver, while the location is used to map the peripheral to
+these pins.
 
-In other words, these definitions must match. Refer to the data sheet for more information.
+In other words, these definitions must match. Refer to the data sheet for more
+information.
 
 ## Flashing the device
-To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is required.
+To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is
+required.
 
 Flashing is supported by RIOT-OS using the command below:
 
@@ -189,8 +228,10 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs STK3200 starter kit we strongly recommend the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm) toolchain.
+For using the Silicon Labs STK3200 starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+toolchain.
 
 ## License information
-* Silicon Labs' emlib: zlib-style license (permits distribution of source).
+* Silicon Labs' EMLIB: zlib-style license (permits distribution of source).
  */

--- a/boards/stk3200/include/board.h
+++ b/boards/stk3200/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3200/include/board.h
+++ b/boards/stk3200/include/board.h
@@ -32,11 +32,13 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 KHz to increase accuracy.
+ * The timer runs at 250 kHz.
  * @{
  */
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/stk3200/include/gpio_params.h
+++ b/boards/stk3200/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3200/include/periph_conf.h
+++ b/boards/stk3200/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3200/include/periph_conf.h
+++ b/boards/stk3200/include/periph_conf.h
@@ -97,16 +97,9 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
- */
-#define RTC_NUMOF           (1U)
-
-/**
  * @name    RTT configuration
  * @{
  */
-#define RTT_NUMOF           (1U)
-
 #define RTT_MAX_VALUE       (0xFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */
@@ -147,7 +140,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 3,
+        .channel_numof = 3
     }
 };
 

--- a/boards/stk3600/Makefile.include
+++ b/boards/stk3600/Makefile.include
@@ -5,5 +5,8 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# setup JLink for flashing
+JLINK_PRE_FLASH = r
+
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3600/board.c
+++ b/boards/stk3600/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3600/doc.txt
+++ b/boards/stk3600/doc.txt
@@ -14,28 +14,28 @@ actively measure the power consumption of your hardware and code, in real-time.
 ## Hardware
 
 ### MCU
-| MCU             | EFM32LG990F256                                                                                  |
-|-----------------|-------------------------------------------------------------------------------------------------|
-| Family          | ARM Cortex-M3                                                                                   |
-| Vendor          | Silicon Labs                                                                                    |
-| Vendor Family   | EFM32 Leoppard Gecko                                                                            |
-| RAM             | 32.0KB                                                                                          |
-| Flash           | 256.0KB                                                                                         |
-| EEPROM          | no                                                                                              |
-| Frequency       | up to 48 MHz                                                                                    |
-| FPU             | no                                                                                              |
-| MPU             | yes                                                                                             |
-| DMA             | 12 channels                                                                                     |
-| Timers          | 3x 16-bit, 1x 16-bit (low power)                                                                |
-| ADCs, DACs      | 12-bit ADC, 12-bit DAC                                                                          |
-| UARTs           | 2x UART, 3x USART, 2x LEUART                                                                    |
-| SPIs            | 3x USART                                                                                        |
-| I2Cs            | 2x                                                                                              |
-| Vcc             | 1.98V - 3.8V                                                                                    |
-| Datasheet       | [Datasheet](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32LG990.pdf)            |
-| Manual          | [Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32LG-RM.pdf)               |
-| Board Manual    | [Board Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/efm32lg-stk3600-ug.pdf) |
-| Board Schematic | [Board Schematic](https://www.silabs.com/Support%20Documents/TechnicalDocs/BRD2201A_A02.pdf)    |
+| MCU             | EFM32LG990F256                                                                             |
+|-----------------|--------------------------------------------------------------------------------------------|
+| Family          | ARM Cortex-M3                                                                              |
+| Vendor          | Silicon Labs                                                                               |
+| Vendor Family   | EFM32 Leoppard Gecko                                                                       |
+| RAM             | 32.0 KiB                                                                                   |
+| Flash           | 256.0 KiB                                                                                  |
+| EEPROM          | no                                                                                         |
+| Frequency       | up to 48 MHz                                                                               |
+| FPU             | no                                                                                         |
+| MPU             | yes                                                                                        |
+| DMA             | 12 channels                                                                                |
+| Timers          | 3x 16-bit + 1x 16-bit (low power)                                                          |
+| ADCs, DACs      | 12-bit ADC, 12-bit DAC                                                                     |
+| UARTs           | 2x UART, 3x USART, 2x LEUART                                                               |
+| SPIs            | 3x USART                                                                                   |
+| I2Cs            | 2x                                                                                         |
+| Vcc             | 1.98 V - 3.8 V                                                                             |
+| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32lg-datasheet.pdf)     |
+| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/EFM32LG-RM.pdf)         |
+| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/efm32lg-stk3600-ug.pdf) |
+| Board Schematic | Can be downloaded using Silicon Labs' Simplicity Studio                                    |
 
 ### Pinout
 This is the pinout of the expansion header on the right side of the board.
@@ -72,9 +72,9 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
 |            | 1       | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
 | Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+|            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
-|            | 1       | USART1          | RX: PD1, TX: PD0               |                                                          |
-|            | 2       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
+|            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments   |
@@ -137,8 +137,7 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0]
-(https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |
@@ -147,7 +146,7 @@ to get familiar with the different clocks.
 | HFXO   | No       | 48 MHz     |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
 | LFXO   | No       | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -193,9 +192,9 @@ Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Hardware crypto
-    This MCUs has support for hardware accelerated AES128 and AES256.
+This MCUs has support for hardware-accelerated AES128 and AES256.
 
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
+A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
@@ -248,8 +247,8 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs STK3600 starter kit we strongly recommend the usage
-of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+For using the Silicon Labs STK3600 starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information

--- a/boards/stk3600/include/board.h
+++ b/boards/stk3600/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3600/include/board.h
+++ b/boards/stk3600/include/board.h
@@ -32,7 +32,8 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
+ * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
@@ -44,7 +45,7 @@ extern "C" {
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
 #endif
-#define XTIMER_CHAN (0)
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/stk3600/include/gpio_params.h
+++ b/boards/stk3600/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -246,14 +246,6 @@ static const uart_conf_t uart_config[] = {
         .irq = UART0_RX_IRQn
     },
     {
-        .dev = USART1,
-        .rx_pin = GPIO_PIN(PD, 1),
-        .tx_pin = GPIO_PIN(PD, 0),
-        .loc = USART_ROUTE_LOCATION_LOC1,
-        .cmu = cmuClock_USART1,
-        .irq = USART1_RX_IRQn
-    },
-    {
         .dev = LEUART0,
         .rx_pin = GPIO_PIN(PD, 5),
         .tx_pin = GPIO_PIN(PD, 4),
@@ -265,8 +257,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_uart0_rx
-#define UART_1_ISR_RX       isr_usart1_rx
-#define UART_2_ISR_RX       isr_leuart0
+#define UART_1_ISR_RX       isr_leuart0
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -195,8 +195,7 @@ static const spi_dev_t spi_config[] = {
 /**
  * @name    Timer configuration
  *
- * The implementation can use one low-energy timer
- * or two regular timers in cascade mode.
+ * The implementation uses two timers in cascade mode.
  * @{
  */
 static const timer_conf_t timer_config[] = {
@@ -223,13 +222,12 @@ static const timer_conf_t timer_config[] = {
         },
         .irq = LETIMER0_IRQn,
         .channel_numof = 2
-    },
+    }
 };
 
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_1_ISR         isr_letimer0
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -159,7 +159,6 @@ static const pwm_conf_t pwm_config[] = {
  * @name    RTT configuration
  * @{
  */
-
 #define RTT_MAX_VALUE       (0xFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -5,5 +5,8 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# setup JLink for flashing
+JLINK_PRE_FLASH = r
+
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3700/board.c
+++ b/boards/stk3700/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3700/doc.txt
+++ b/boards/stk3700/doc.txt
@@ -14,28 +14,28 @@ actively measure the power consumption of your hardware and code, in real-time.
 ## Hardware
 
 ### MCU
-| MCU             | EFM32GG990F1024                                                                                               |
-|-----------------|---------------------------------------------------------------------------------------------------------------|
-| Family          | ARM Cortex-M3                                                                                                 |
-| Vendor          | Silicon Labs                                                                                                  |
-| Vendor Family   | EFM32 Giant Gecko                                                                                             |
-| RAM             | 128.0KB                                                                                                       |
-| Flash           | 1024.0KB                                                                                                      |
-| EEPROM          | no                                                                                                            |
-| Frequency       | up to 48 MHz                                                                                                  |
-| FPU             | no                                                                                                            |
-| MPU             | yes                                                                                                           |
-| DMA             | 12 channels                                                                                                   |
-| Timers          | 3x 16-bit, 1x 16-bit (low power)                                                                              |
-| ADCs, DACs      | 12-bit ADC, 12-bit DAC                                                                                        |
-| UARTs           | 2x UART, 3x USART, 2x LEUART                                                                                  |
-| SPIs            | 3x USART                                                                                                      |
-| I2Cs            | 2x                                                                                                            |
-| Vcc             | 1.98V - 3.8V                                                                                                  |
-| Datasheet       | [Datasheet](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32GG990.pdf)                          |
-| Manual          | [Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/EFM32GG-RM.pdf)                             |
-| Board Manual    | [Board Manual](https://www.silabs.com/Support%20Documents/TechnicalDocs/efm32gg-stk3700-ug.pdf)               |
-| Board Schematic | [Board Schematic](https://www.silabs.com/documents/public/schematic-files/EFM32GG-BRD2200A-A03-schematic.pdf) |
+| MCU             | EFM32GG990F1024                                                                            |
+|-----------------|--------------------------------------------------------------------------------------------|
+| Family          | ARM Cortex-M3                                                                              |
+| Vendor          | Silicon Labs                                                                               |
+| Vendor Family   | EFM32 Giant Gecko                                                                          |
+| RAM             | 128.0 KiB                                                                                  |
+| Flash           | 1024.0 KiB                                                                                 |
+| EEPROM          | no                                                                                         |
+| Frequency       | up to 48 MHz                                                                               |
+| FPU             | no                                                                                         |
+| MPU             | yes                                                                                        |
+| DMA             | 12 channels                                                                                |
+| Timers          | 3x 16-bit + 1x 16-bit (low power)                                                          |
+| ADCs, DACs      | 12-bit ADC, 12-bit DAC                                                                     |
+| UARTs           | 2x UART, 3x USART, 2x LEUART                                                               |
+| SPIs            | 3x USART                                                                                   |
+| I2Cs            | 2x                                                                                         |
+| Vcc             | 1.98 V - 3.8 V                                                                             |
+| Datasheet       | [Datasheet](https://www.silabs.com/documents/public/data-sheets/efm32gg-datasheet.pdf)     |
+| Manual          | [Manual](https://www.silabs.com/documents/public/reference-manuals/EFM32GG-RM.pdf)         |
+| Board Manual    | [Board Manual](https://www.silabs.com/documents/public/user-guides/efm32gg-stk3700-ug.pdf) |
+| Board Schematic | Can be downloaded using Silicon Labs' Simplicity Studio                                    |
 
 ### Pinout
 This is the pinout of the expansion header on the right side of the board.
@@ -72,9 +72,9 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
 |            | 1       | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
 | Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjecent)           |
+|            | 1       | LETIMER0        |                                |                                                          |
 | UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
-|            | 1       | USART1          | RX: PD1, TX: PD0               |                                                          |
-|            | 2       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
+|            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments   |
@@ -137,8 +137,7 @@ symbols (`-gdwarf-2` for GCC).
 
 ### Clock selection
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0]
-(https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |
@@ -147,7 +146,7 @@ to get familiar with the different clocks.
 | HFXO   | No       | 48 MHz     |                                    |
 | LFRCO  | Yes      | 32.768 kHz |                                    |
 | LFXO   | No       | 32.768 kHz |                                    |
-| ULFRCO | No       | 1.000 kHz  | Not very reliable as a time source |
+| ULFRCO | No       | 1 kHz      | Not very reliable as a time source |
 
 The sources can be used to clock following branches:
 
@@ -193,9 +192,9 @@ Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Hardware crypto
-This MCUs has support for hardware accelerated AES128 and AES256.
+This MCUs has support for hardware-accelerated AES128 and AES256.
 
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
+A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
@@ -248,8 +247,8 @@ make emulate
 ```
 
 ## Supported Toolchains
-For using the Silicon Labs STK3700 starter kit we strongly recommend the usage
-of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+For using the Silicon Labs STK3700 starter kit we strongly recommend
+the usage of the [GNU Tools for ARM Embedded Processors](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
 toolchain.
 
 ## License information

--- a/boards/stk3700/include/board.h
+++ b/boards/stk3700/include/board.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3700/include/board.h
+++ b/boards/stk3700/include/board.h
@@ -32,7 +32,8 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
+ * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * LETIMER is used.
  * @{
  */
 #if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
@@ -44,7 +45,7 @@ extern "C" {
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
 #endif
-#define XTIMER_CHAN (0)
+#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/stk3700/include/gpio_params.h
+++ b/boards/stk3700/include/gpio_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
+ * Copyright (C) 2015-2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -246,14 +246,6 @@ static const uart_conf_t uart_config[] = {
         .irq = UART0_RX_IRQn
     },
     {
-        .dev = USART1,
-        .rx_pin = GPIO_PIN(PD, 1),
-        .tx_pin = GPIO_PIN(PD, 0),
-        .loc = USART_ROUTE_LOCATION_LOC1,
-        .cmu = cmuClock_USART1,
-        .irq = USART1_RX_IRQn
-    },
-    {
         .dev = LEUART0,
         .rx_pin = GPIO_PIN(PD, 5),
         .tx_pin = GPIO_PIN(PD, 4),
@@ -265,8 +257,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_uart0_rx
-#define UART_1_ISR_RX       isr_usart1_rx
-#define UART_2_ISR_RX       isr_leuart0
+#define UART_1_ISR_RX       isr_leuart0
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -195,8 +195,7 @@ static const spi_dev_t spi_config[] = {
 /**
  * @name    Timer configuration
  *
- * The implementation can use one low-energy timer
- * or two regular timers in cascade mode.
+ * The implementation uses two timers in cascade mode.
  * @{
  */
 static const timer_conf_t timer_config[] = {
@@ -223,13 +222,12 @@ static const timer_conf_t timer_config[] = {
         },
         .irq = LETIMER0_IRQn,
         .channel_numof = 2
-    },
+    }
 };
 
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_1_ISR         isr_letimer0
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -159,7 +159,6 @@ static const pwm_conf_t pwm_config[] = {
  * @name    RTT configuration
  * @{
  */
-
 #define RTT_MAX_VALUE       (0xFFFFFF)
 #define RTT_FREQUENCY       (1U)
 /** @} */


### PR DESCRIPTION
### Contribution description
This PR updates the board definitions and documentation.

* Exposes LETIMER0 to board that did not have this configured yet
* Removes shared peripherals from SPI and UART (e.g. `UART_DEV(1).dev` == `SPI_DEV(0).dev`).
* Updates documentation (line length, CPU info, tables)
* Flashing improvements

Basically, this aligns many changes already done to separate boards, but are now also applied to the ones that haven't been updated.

### Testing procedure
It would be wise to test with a EFM32 board. However, most changes are configuration only, so Murdock should be happy.

I have tested this with the STK3600, SLST3401a, SLSTK3402a and SLTB001a.

### Issues/PRs references
#14780 
#11548
#15274
#14201