### PR TITLE
tests/trace: use raw strings in expect regexp

### DIFF
--- a/tests/trace/tests/01-run.py
+++ b/tests/trace/tests/01-run.py
@@ -5,8 +5,8 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect("n=   0 t=\ +\d+ v=0x00000000\r\n")
-    child.expect("n=   1 t=\+\ +\d+ v=0x00000001\r\n")
+    child.expect(r"n=   0 t=\ +\d+ v=0x00000000\r\n")
+    child.expect(r"n=   1 t=\+\ +\d+ v=0x00000001\r\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the Python automated test script of the `tests/trace` application: regexp string should be marked as raw string to avoid the following flake8 errors:

```
tests/sys/trace/tests/01-run.py:8:28: W605 invalid escape sequence '\ '
tests/sys/trace/tests/01-run.py:8:31: W605 invalid escape sequence '\d'
tests/sys/trace/tests/01-run.py:9:28: W605 invalid escape sequence '\+'
tests/sys/trace/tests/01-run.py:9:30: W605 invalid escape sequence '\ '
tests/sys/trace/tests/01-run.py:9:33: W605 invalid escape sequence '\d'
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- `make -C tests/trace all test` is successful:

<details>

```
$ make -C tests/trace all test --no-print-directory 
Building application "tests_trace" for "native" with MCU "native".

"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/trace
"make" -C /work/riot/RIOT/sys/xtimer
/usr/bin/ld: /work/riot/RIOT/tests/trace/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
   text	   data	    bss	    dec	    hex	filename
  32670	    596	  48380	  81646	  13eee	/work/riot/RIOT/tests/trace/bin/native/tests_trace.elf
r
/work/riot/RIOT/tests/trace/bin/native/tests_trace.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.01-devel-568-gef871-pr/tests/trace_script_cleanup)
n=   0 t=  3056935 v=0x00000000
n=   1 t=+       3 v=0x00000001

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Raised when running the static test locally in #15358

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
