### PR TITLE
boards/esp32-wrover-kit: add ILI9341 driver params

### DIFF
--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -97,6 +97,32 @@
 #endif
 /** @} */
 
+/**
+ * @name    LCD configuration
+ *
+ * This configuration cannot be changed.
+ * @{
+ */
+#if MODULE_ILI9341 || DOXYGEN
+#define LCD_CS                  GPIO22
+#define LCD_RST                 GPIO18
+#define LCD_DC                  GPIO21
+#define LCD_BACKLIGHT           GPIO5
+
+#define BACKLIGHT_ON            gpio_clear(LCD_BACKLIGHT)
+#define BACKLIGHT_OFF           gpio_set(LCD_BACKLIGHT)
+
+#define ILI9341_PARAM_SPI       SPI_DEV(1)
+#define ILI9341_PARAM_SPI_CLK   SPI_CLK_10MHZ
+#define ILI9341_PARAM_CS        LCD_CS
+#define ILI9341_PARAM_DCX       LCD_DC
+#define ILI9341_PARAM_RST       LCD_RST
+#define ILi9341_PARAM_RGB       1
+#define ILI9341_PARAM_INVERTED  1
+#endif
+/** @} */
+
+
 /* include common board definitions as last step */
 #include "board_common.h"
 
@@ -108,6 +134,10 @@ extern "C" {
  * @brief Initialize the board specific hardware
  */
 static inline void board_init(void) {
+#if MODULE_ILI9341
+    gpio_init(LCD_BACKLIGHT, GPIO_OUT);
+#endif
+
     /* there is nothing special to initialize on this board */
     board_init_common();
 }


### PR DESCRIPTION
### Contribution description

Added SPI parameters configuration for the ILI9341 LCD screen of the ESP32-WROVER-KIT board. This screen is found on the V3.x and V4.x versions of this development kit.

<details>
<summary>Screen working with tests/driver_ili9341</summary>
<img src="https://user-images.githubusercontent.com/5952531/97995201-80788e00-1de6-11eb-870f-903db069e33f.png">
</details>

### Testing procedure

- `make -C tests/driver_ili9341 BOARD=esp32-wrover-kit flash`

### Issues/PRs references

-