### PR TITLE
tests/driver_bme680: improve automated test script

### DIFF
--- a/tests/driver_bme680/main.c
+++ b/tests/driver_bme680/main.c
@@ -55,6 +55,7 @@ int main(void)
         printf("Initialize BME680 sensor %u ... ", i);
         if (bme680_init(&dev[i], &bme680_params[i]) != BME680_OK) {
             puts("failed");
+            return -1;
         }
         else {
             puts("OK");

--- a/tests/driver_bme680/tests/01-run.py
+++ b/tests/driver_bme680/tests/01-run.py
@@ -16,13 +16,12 @@ def testfunc(child):
     if i == 1:
         print('FAILED')
         return
-    child.expect('\[bme680\]: dev=0, ')
-    child.expect(r'T = \d+.\d+ degC, ')
-    child.expect(r'P = \d+ Pa, ')
-    child.expect(r'H = \d+.\d+ \%, ')
-    child.expect(r'G = \d+ ohms')
+    child.expect(r'\[bme680\]: dev=0, '
+                 r'T = \d+.\d+ degC, '
+                 r'P = \d+ Pa, '
+                 r'H = \d+.\d+ \%, '
+                 r'G = \d+ ohms\r\n')
     print('SUCCESS')
-    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the automated test script of `tests/driver_bme680` and also provides a minor enhancement of the test application (exit if driver initialization fails).

Otherwise flake8 raises:
```
tests/drivers/bme680/tests/01-run.py:19:19: W605 invalid escape sequence '\['
tests/drivers/bme680/tests/01-run.py:19:27: W605 invalid escape sequence '\]'
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check the test script is still working. This is difficult without the hardware. I don't have it but to test the regexp, I modified the test application to print fake values before the driver initialization. The version of this PR should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Raised when running the static test locally in #15358

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
