### PR TITLE
tests/shell: fix flake8 errors in Python script

### DIFF
--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -24,7 +24,7 @@ EXPECTED_HELP = (
 
 EXPECTED_PS = (
     '\tpid | state    Q | pri',
-    '\t  \d | running  Q |   7'
+    r'\t  \d | running  Q |   7'
 )
 
 RIOT_TERMINAL = os.environ.get('RIOT_TERMINAL')
@@ -74,7 +74,7 @@ CMDS = (
     ('echo escaped\\ space', '"echo""escaped space"'),
     ('echo escape within \'\\s\\i\\n\\g\\l\\e\\q\\u\\o\\t\\e\'', '"echo""escape""within""singlequote"'),
     ('echo escape within "\\d\\o\\u\\b\\l\\e\\q\\u\\o\\t\\e"', '"echo""escape""within""doublequote"'),
-    ("""echo "t\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),
+    ("""echo "t\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),  # noqa: W605
 
     # test correct quoting
     ('echo "hello"world', '"echo""helloworld"'),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the Python automated test script of the `tests/shell` application: there are a couple of errors because of escape characters used in test strings. One can be fixed by using a raw string, the second one is ignored because I don't know how to fix it :)

```
tests/sys/shell/tests/01-run.py:27:10: W605 invalid escape sequence '\d'
tests/sys/shell/tests/01-run.py:77:16: W605 invalid escape sequence '\e'
tests/sys/shell/tests/01-run.py:77:36: W605 invalid escape sequence '\ '
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- `tests/shell` test is still working:

<details>

```
$ make -C tests/shell all test --no-print-directory 
Building application "tests_shell" for "native" with MCU "native".

"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/app_metadata
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
/usr/bin/ld: /work/riot/RIOT/tests/shell/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
   text	   data	    bss	    dec	    hex	filename
  30253	    812	  47812	  78877	  1341d	/work/riot/RIOT/tests/shell/bin/native/tests_shell.elf


/work/riot/RIOT/tests/shell/bin/native/tests_shell.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.01-devel-573-gcf154a-pr/tests/shell_script_enh)
test_shell.
> 
> 
> bufsize
bufsize
128
> ________________________________________________________________________________________________________________________________verylong
________________________________________________________________________________________________________________________________verylong
shell: maximum line length exceeded
> garbage1234
garbage1234
> 
> echo____________________________________________________________________________________________________________________________verylong
_________echo                                                                                                                           
"echo"
> 
shell exited
> 
> start_test
start_test
[TEST_START]
> 


> 
> echo a string
echo a string
"echo""a""string"
> echo   multiple   spaces   between   argv
echo   multiple   spaces   between   argv
"echo""multiple""spaces""between""argv"
> echo 	 tabs		 processed 		like	 		spaces
echo 	 tabs		 processed 		like	 		spaces
"echo""tabs""processed""like""spaces"
> unknown_command
unknown_command
shell: command not found: unknown_command
>      echo leading spaces
     echo leading spaces
"echo""leading""spaces"
> 					echo leading tabs
					echo leading tabs
"echo""leading""tabs"
> echo trailing spaces     
echo trailing spaces     
"echo""trailing""spaces"
> echo trailing tabs					
echo trailing tabs					
"echo""trailing""tabs"
> hello-world
hello-world
shell: command not found: hello-world
echo
echo
"echo"
> echo \'
echo \'
"echo""'"
> echo \"
echo \"
"echo""""
> echo escaped\ space
echo escaped\ space
"echo""escaped space"
> echo escape within '\s\i\n\g\l\e\q\u\o\t\e'
echo escape within '\s\i\n\g\l\e\q\u\o\t\e'
"echo""escape""within""singlequote"
> echo escape within "\d\o\u\b\l\e\q\u\o\t\e"
echo escape within "\d\o\u\b\l\e\q\u\o\t\e"
"echo""escape""within""doublequote"
> echo "t\e st" "\"" '\'' a\ b
echo "t\e st" "\"" '\'' a\ b
"echo""te st"""""'""a b"
> echo "hello"world
echo "hello"world
"echo""helloworld"
> echo hel"lowo"rld
echo hel"lowo"rld
"echo""helloworld"
> echo hello"world"
echo hello"world"
"echo""helloworld"
> echo quoted space " "
echo quoted space " "
"echo""quoted""space"" "
> echo abc"def'ghijk"lmn
echo abc"def'ghijk"lmn
"echo""abcdef'ghijklmn"
> echo abc'def"ghijk'lmn
echo abc'def"ghijk'lmn
"echo""abcdef"ghijklmn"
> echo "'" '"'
echo "'" '"'
"echo""'""""
> echo a\
echo a\
shell: incorrect quoting
> echo "
echo "
shell: incorrect quoting
> echo '
echo '
shell: incorrect quoting
> echo abcdef"ghijklmn
echo abcdef"ghijklmn
shell: incorrect quoting
> echo abcdef'ghijklmn
echo abcdef'ghijklmn
shell: incorrect quoting
> ps
ps
	pid | state    Q | pri 
	  1 | pending  Q |  15
	  2 | running  Q |   7
> help
help
Command              Description
---------------------------------------
bufsize              Get the shell's buffer size
start_test           starts a test
end_test             ends a test
echo                 prints the input command
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
app_metadata         Returns application metadata
> reboot
reboot


		!! REBOOT !!

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.01-devel-573-gcf154a-pr/tests/shell_script_enh)
test_shell.
> end_test
end_test
[TEST_END]
> 

> 
> 
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Raised when running the static test locally in #15358

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
