### PR TITLE
dist/tools/bmp: Fix flashing with pygdbmi 0.10.0

### DIFF
--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -219,7 +219,12 @@ def debug_mode(port):
 
 def connect_to_target(port):
     # open GDB in machine interface mode
-    gdbmi = GdbController(gdb_path=args.gdb_path, gdb_args=["--nx", "--quiet", "--interpreter=mi2", args.file])
+    try:
+        # try old API first
+        gdbmi = GdbController(gdb_path=args.gdb_path, gdb_args=["--nx", "--quiet", "--interpreter=mi2", args.file])
+    except TypeError:
+        # and then new API
+        gdbmi = GdbController(command=[args.gdb_path, "--nx", "--quiet", "--interpreter=mi2", args.file])
     assert gdb_write_and_wait_for_result(gdbmi, '-target-select extended-remote %s' % port, 'connecting',
                                          expected_result='connected')
     # set options


### PR DESCRIPTION
### Contribution description

The flashing script for the black magic probe stopped working with pygdbmi in
version 0.10.0 due to an API change. This adapts the code to first try
initialization with the old pygdbmi API (as before), but tries again with the
new API if that fails.

This fixes the following error:

```
/home/maribu/Repos/software/RIOT/dist/tools/bmp/bmp.py  flash /home/maribu/Repos/software/RIOT/tests/bench_atomic_util/bin/bluepill/tests_bench_atomic_util.elf
found following Black Magic GDB servers:
	[/dev/ttyACM0] Serial: C2C8B70D <- default 
connecting to [/dev/ttyACM0]...
Traceback (most recent call last):
  File "/home/maribu/Repos/software/RIOT/dist/tools/bmp/bmp.py", line 265, in <module>
    gdbmi = connect_to_target(port)
  File "/home/maribu/Repos/software/RIOT/dist/tools/bmp/bmp.py", line 222, in connect_to_target
    gdbmi = GdbController(gdb_path=args.gdb_path, gdb_args=["--nx", "--quiet", "--interpreter=mi2", args.file])
TypeError: __init__() got an unexpected keyword argument 'gdb_path'
make: *** [/home/maribu/Repos/software/RIOT/tests/bench_atomic_util/../../Makefile.include:692: flash] Error 1
```

### Testing procedure

```
BOARD=<YOUR_FAVOURITE_BOARD> PROGRAMMER=bmp make -C examples/default flash
```

### Issues/PRs references

None