### PR TITLE
dist/testbed-support: add iotlab mapping for dwm1001

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -65,6 +65,7 @@ IOTLAB_NODE_AUTO_NUM ?= 1
 IOTLAB_ARCHI_arduino-zero   = arduino-zero:xbee
 IOTLAB_ARCHI_b-l072z-lrwan1 = st-lrwan1:sx1276
 IOTLAB_ARCHI_b-l475e-iot01a = st-iotnode:multi
+IOTLAB_ARCHI_dwm1001        = dwm1001:dw1000
 IOTLAB_ARCHI_firefly        = firefly:multi
 IOTLAB_ARCHI_frdm-kw41z     = frdm-kw41z:multi
 IOTLAB_ARCHI_iotlab-a8-m3   = a8:at86rf231


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a mapping for the dwm1001 board with the boards as defined in iot-lab. This allows to use `IOTLAB_NODE` with the dwm1001 boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an IoT-LAB experiment on one dwm1001:

```
$ iotlab-experiment submit -d 120 -l 1,site=saclay+archi=dwm1001:dw1000
$ iotlab-experiment wait
```

- Build and then flash `examples/default` on the board

```
$ make BOARD=dwm1001 -C examples/default
$ make BOARD=dwm1001 -C examples/default flash-only term IOTLAB_NODE=auto-ssh --no-print-directory
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,dwm1001,1 --flash /work/riot/RIOT/examples/default/bin/dwm1001/default.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:dwm1001-1.saclay.iot-lab.info:20000' 
� J�reboot
reboot
main(): This is RIOT! (Version: 2021.01-devel-576-g50649-pr/tools/iotlab_single_dwm1001)
Welcome to RIOT!
> help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
ifconfig             Configure network interfaces
txtsnd               Sends a custom string as is over the link layer
saul                 interact with sensors and actuators using SAUL
ble                  Manage BLE connections for NimBLE
> 
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that this was missing while reviewing #15070 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
