### PR TITLE
tests/usbus_cdc_ecm: remove unneeded Kconfig file

### DIFF
--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -22,7 +22,4 @@ USB_PID ?= $(USB_PID_TESTING)
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-# Do not run Kconfig by default
-SHOULD_RUN_KCONFIG ?=
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/usbus_cdc_ecm/Kconfig
+++ b/tests/usbus_cdc_ecm/Kconfig
@@ -1,5 +1,0 @@
-config USB_VID
-    default 0x$(DEFAULT_VID) if KCONFIG_USB
-
-config USB_PID
-    default 0x$(DEFAULT_PID) if KCONFIG_USB


### PR DESCRIPTION
### Contribution description
250f6fdfa341ffcf0534b8adbec436d0bf4e3a57 the handling of the USB testing PID and VID changed, moving the defaults to the System USB Kconfig file. The Kconfig file in the `usbus_cdc_edm` was trying to access the removed `DEFAULT_VID` and `DEFAULT_PID` variables, resulting in a warning when Kconfig is executed. This removes the Kconfig file, as it is no longer needed to set the default values.

This also removed the unneeded setting of `SHOULD_RUN_KCONFIG` variable in the `usbus` example application, given that the configuration file has also been removed in 250f6fdfa341ffcf0534b8adbec436d0bf4e3a57.

### Testing procedure
- Green murdock
- The `usbus_cdc_ecm` test application should still work

### Issues/PRs references
Issue introduced in #13382
Found by the checks in #15219