### PR TITLE
mtd/*: drop .write() if .write_page() is implemented

### DIFF
--- a/cpu/esp_common/periph/flash.c
+++ b/cpu/esp_common/periph/flash.c
@@ -83,7 +83,6 @@ extern uint32_t spi_flash_get_id(void);
 /* forward declaration of mtd functions */
 static int _flash_init(mtd_dev_t *dev);
 static int _flash_read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size);
-static int _flash_write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size);
 static int _flash_write_page(mtd_dev_t *dev, const void *buff, uint32_t page,
                               uint32_t offset, uint32_t size);
 static int _flash_erase(mtd_dev_t *dev, uint32_t addr, uint32_t size);
@@ -130,7 +129,6 @@ void spi_flash_drive_init(void)
 
     _flash_driver.init  = &_flash_init;
     _flash_driver.read  = &_flash_read;
-    _flash_driver.write = &_flash_write;
     _flash_driver.write_page = &_flash_write_page;
     _flash_driver.erase = &_flash_erase;
     _flash_driver.power = &_flash_power;
@@ -307,24 +305,6 @@ static int _flash_read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     CHECK_PARAM_RET(_flash_beg + addr + size <= _flash_end, -EOVERFLOW);
 
     return (spi_flash_read(_flash_beg + addr, buff, size) == ESP_OK) ? 0 : -EIO;
-}
-
-static int _flash_write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
-{
-    DEBUG("%s dev=%p addr=%08"PRIx32" size=%"PRIu32" buf=%p\n",
-          __func__, dev, addr, size, buff);
-
-    CHECK_PARAM_RET(dev == &_flash_dev, -ENODEV);
-    CHECK_PARAM_RET(buff != NULL, -ENOTSUP);
-
-    /* size must be within the flash address space */
-    CHECK_PARAM_RET(_flash_beg + addr + size <= _flash_end, -EOVERFLOW);
-
-    /* addr + size must be within a page */
-    CHECK_PARAM_RET(size <= _flashchip->page_size, -EOVERFLOW);
-    CHECK_PARAM_RET((addr % _flashchip->page_size) + size <= _flashchip->page_size, -EOVERFLOW);
-
-    return (spi_flash_write(_flash_beg + addr, buff, size) == ESP_OK) ? 0 : -EIO;
 }
 
 static int _flash_write_page(mtd_dev_t *dev, const void *buff, uint32_t page,  uint32_t offset,

--- a/drivers/at25xxx/mtd/mtd.c
+++ b/drivers/at25xxx/mtd/mtd.c
@@ -51,13 +51,6 @@ static int mtd_at25xxx_read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t 
     return at25xxx_read(mtd_at25xxx_->at25xxx_eeprom, addr, buff, size);
 }
 
-static int mtd_at25xxx_write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
-{
-    DEBUG("[mtd_at25xxx] write: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
-    mtd_at25xxx_t *mtd_at25xxx_ = (mtd_at25xxx_t*)dev;
-    return at25xxx_write(mtd_at25xxx_->at25xxx_eeprom, addr, buff, size);
-}
-
 static int mtd_at25xxx_write_page(mtd_dev_t *dev, const void *src, uint32_t page, uint32_t offset,
                                   uint32_t size)
 {
@@ -87,7 +80,6 @@ static int mtd_at25xxx_power(mtd_dev_t *dev, enum mtd_power_state power)
 const mtd_desc_t mtd_at25xxx_driver = {
     .init = mtd_at25xxx_init,
     .read = mtd_at25xxx_read,
-    .write = mtd_at25xxx_write,
     .write_page = mtd_at25xxx_write_page,
     .erase = mtd_at25xxx_erase,
     .power = mtd_at25xxx_power,

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -251,25 +251,6 @@ struct mtd_desc {
                      uint32_t size);
 
     /**
-     * @brief   Write to the Memory Technology Device (MTD)
-     *
-     * @p addr + @p size must be inside a page boundary. @p addr can be anywhere
-     * but the buffer cannot overlap two pages.
-     *
-     * @param[in] dev       Pointer to the selected driver
-     * @param[in] buff      Pointer to the data to be written
-     * @param[in] addr      Starting address
-     * @param[in] size      Number of bytes
-     *
-     * @retval 0 on success
-     * @retval <0 value on error
-     */
-    int (*write)(mtd_dev_t *dev,
-                 const void *buff,
-                 uint32_t addr,
-                 uint32_t size);
-
-    /**
      * @brief   Write to the Memory Technology Device (MTD) using
      *          pagewise addressing.
      *

--- a/drivers/mtd_emulated/mtd_emulated.c
+++ b/drivers/mtd_emulated/mtd_emulated.c
@@ -60,26 +60,6 @@ static int _read_page(mtd_dev_t *dev, void *dest,
     return size;
 }
 
-static int _write(mtd_dev_t *dev, const void *src, uint32_t addr, uint32_t count)
-{
-    mtd_emulated_t *mtd = (mtd_emulated_t *)dev;
-
-    (void)mtd;
-
-    assert(mtd);
-    assert(src);
-
-    if (/* addr + count must be inside a page boundary. */
-        (((addr % mtd->base.page_size) + count) > mtd->base.page_size) ||
-        /* addr + count must not exceed the size of memory */
-        ((addr + count) > mtd->size)) {
-        return -EOVERFLOW;
-    }
-    memcpy(mtd->memory + addr, src, count);
-
-    return 0;
-}
-
 int _write_page(mtd_dev_t *dev, const void *src,
                 uint32_t page, uint32_t offset, uint32_t size)
 {
@@ -153,7 +133,6 @@ const mtd_desc_t _mtd_emulated_driver = {
     .init = _init,
     .read = _read,
     .read_page = _read_page,
-    .write = _write,
     .write_page = _write_page,
     .erase = _erase,
     .erase_sector = _erase_sector,

--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -102,21 +102,6 @@ static int _init(mtd_dev_t *mtd)
     return res;
 }
 
-static int _write(mtd_dev_t *mtd, const void *src, uint32_t addr,
-                  uint32_t count)
-{
-    mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
-
-    if (addr + count > _region_size(region)) {
-        return -EOVERFLOW;
-    }
-
-    _lock(region);
-    int res = mtd_write(region->parent->mtd, src, addr + _byte_offset(region), count);
-    _unlock(region);
-    return res;
-}
-
 static int _write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
                        uint32_t offset, uint32_t count)
 {
@@ -199,7 +184,6 @@ const mtd_desc_t mtd_mapper_driver = {
     .init = _init,
     .read = _read,
     .read_page = _read_page,
-    .write = _write,
     .write_page = _write_page,
     .erase = _erase,
     .erase_sector = _erase_sector,

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -198,25 +198,10 @@ static int mtd_sdcard_read(mtd_dev_t *dev, void *buff, uint32_t addr,
     return -EOVERFLOW;
 }
 
-static int mtd_sdcard_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
-                            uint32_t size)
-{
-    int res =  mtd_sdcard_write_page(dev, buff, addr / SD_HC_BLOCK_SIZE,
-                                     addr % SD_HC_BLOCK_SIZE, size);
-    if (res < 0) {
-        return res;
-    }
-    if (res == (int)size) {
-        return 0;
-    }
-    return -EOVERFLOW;
-}
-
 const mtd_desc_t mtd_sdcard_driver = {
     .init = mtd_sdcard_init,
     .read = mtd_sdcard_read,
     .read_page = mtd_sdcard_read_page,
-    .write = mtd_sdcard_write,
     .write_page = mtd_sdcard_write_page,
     .erase_sector = mtd_sdcard_erase_sector,
     .power = mtd_sdcard_power,

--- a/drivers/mtd_sdmmc/mtd_sdmmc.c
+++ b/drivers/mtd_sdmmc/mtd_sdmmc.c
@@ -196,25 +196,10 @@ static int mtd_sdmmc_read(mtd_dev_t *dev, void *buff, uint32_t addr,
     return -EOVERFLOW;
 }
 
-static int mtd_sdmmc_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
-                            uint32_t size)
-{
-    int res =  mtd_sdmmc_write_page(dev, buff, addr / SDMMC_SDHC_BLOCK_SIZE,
-                                     addr % SDMMC_SDHC_BLOCK_SIZE, size);
-    if (res < 0) {
-        return res;
-    }
-    if (res == (int)size) {
-        return 0;
-    }
-    return -EOVERFLOW;
-}
-
 const mtd_desc_t mtd_sdmmc_driver = {
     .init = mtd_sdmmc_init,
     .read = mtd_sdmmc_read,
     .read_page = mtd_sdmmc_read_page,
-    .write = mtd_sdmmc_write,
     .write_page = mtd_sdmmc_write_page,
     .erase_sector = mtd_sdmmc_erase_sector,
     .power = mtd_sdmmc_power,

--- a/tests/drivers/mtd_mapper/main.c
+++ b/tests/drivers/mtd_mapper/main.c
@@ -91,22 +91,6 @@ static int _read_page(mtd_dev_t *dev, void *buff, uint32_t page, uint32_t offset
     return size;
 }
 
-static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr,
-                  uint32_t size)
-{
-    (void)dev;
-
-    if (addr + size > sizeof(_dummy_memory)) {
-        return -EOVERFLOW;
-    }
-    if (size > PAGE_SIZE) {
-        return -EOVERFLOW;
-    }
-    memcpy(_dummy_memory + addr, buff, size);
-
-    return 0;
-}
-
 static int _write_page(mtd_dev_t *dev, const void *buff, uint32_t page, uint32_t offset, uint32_t size)
 {
     uint32_t addr = page * dev->page_size + offset;
@@ -168,7 +152,6 @@ static int _power(mtd_dev_t *dev, enum mtd_power_state power)
 static const mtd_desc_t driver = {
     .init = _init,
     .read = _read,
-    .write = _write,
     .erase = _erase,
     .power = _power,
     .read_page    = _read_page,

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -146,7 +146,7 @@ static void test_mtd_write_read(void)
     uint8_t buf_page[page_size + 1];
     memset(buf_page, 1, sizeof(buf_page));
     ret = mtd_write(dev, buf_page, 0, sizeof(buf_page));
-    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     /* Read more than one page */
     ret = mtd_erase(dev, 0, dev->page_size * dev->pages_per_sector);
@@ -163,9 +163,9 @@ static void test_mtd_write_read(void)
 
     /* pages overlap write */
     ret = mtd_write(dev, buf, dev->page_size - (sizeof(buf) / 2), sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     ret = mtd_write(dev, buf_page, 1, sizeof(buf_page) - 1);
-    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
 #ifdef MTD_0


### PR DESCRIPTION
### Contribution description

The old `.write()` function is only used as a fall-back if `.write_page()` is not implemented.
We can drop it.

### Testing procedure

Everything will fall back to `.write_page` now, so no user visible change.
On the driver level, `.write_page` can be much simpler than `.write` as all the common logic is handled by MTD and we can do partial writes (only write to page boundary, MTD will split up the transaction).

 - [x] `native` (tested by CI)
 - [x] ESP8266/ESP32
 - [x] AT25xxx
 - [x] MTD Mapper (tested by CI)
 - [x] MTD SDcard

<details><summary>AT25xxx</summary>

#### tests/mtd_raw
```
2023-03-09 23:26:41,366 # init MTD_0… OK (128 kiB)
2023-03-09 23:26:43,208 # > test 0
2023-03-09 23:26:43,208 # [START]
2023-03-09 23:26:43,286 # [SUCCESS]

2023-03-09 23:28:20,306 # > read 0 0 32
2023-03-09 23:28:20,312 # 00000000  31  32  33  34  35  36  FF  F7  6C  69  74  74  6C  65  66  73
2023-03-09 23:28:20,318 # 00000010  2F  E0  00  10  00  00  02  00  00  01  00  00  00  02  00  00

2023-03-09 23:28:52,800 # > read 0 0 32
2023-03-09 23:28:52,806 # 00000000  31  61  62  63  64  65  66  67  68  69  74  74  6C  65  66  73
2023-03-09 23:28:52,812 # 00000010  2F  E0  00  10  00  00  02  00  00  01  00  00  00  02  00  00
```
</details>

<details><summary>ESP32</summary>

#### tests/mtd_raw
```
2023-03-09 23:31:24,456 # > test 0
2023-03-09 23:31:24,457 # [START]
2023-03-09 23:31:24,603 # [SUCCESS]

2023-03-09 23:32:43,227 # > read 0 0 32
2023-03-09 23:32:43,234 # 00000000  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2023-03-09 23:32:43,240 # 00000010  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF

2023-03-09 23:32:48,918 # > write 0 1 abcdefgh
2023-03-09 23:32:50,963 # 00000000  FF  61  62  63  64  65  66  67  68  FF  FF  FF  FF  FF  FF  FF
2023-03-09 23:32:50,969 # 00000010  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF

2023-03-09 23:32:50,957 # > read 0 0 32
2023-03-09 23:32:50,963 # 00000000  FF  61  62  63  64  65  66  67  68  FF  FF  FF  FF  FF  FF  FF
2023-03-09 23:32:50,969 # 00000010  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
```
</details>

<details><summary>MTD SDcard</summary>

#### tests/mtd_raw
```
2023-12-13 16:55:18,923 - INFO # main(): This is RIOT! (Version: 2024.01-devel-369-ga45d2-mtd_drop_write)
2023-12-13 16:55:18,923 - INFO # Manual MTD test
2023-12-13 16:55:19,034 - INFO # init MTD_0… OK (15223 MiB)
test 0
2023-12-13 16:55:26,746 - INFO # > test 0
2023-12-13 16:55:26,747 - INFO # 
2023-12-13 16:55:26,747 - INFO # [START]
2023-12-13 16:55:27,706 - INFO # [SUCCESS]
```
</details>


<details><summary>MTD spi_nor, at24mac, MTD SDMMC (with #20180)</summary>

#### tests/mtd_raw
```
2023-12-13 17:07:07,125 - INFO # Manual MTD test
2023-12-13 17:07:07,128 - INFO # init MTD_0… OK (8 MiB)
2023-12-13 17:07:07,131 - INFO # init MTD_1… OK (256 byte)
2023-12-13 17:07:07,342 - INFO # init MTD_2… OK (15223 MiB)
test 0
2023-12-13 17:07:10,339 - INFO # > test 0
2023-12-13 17:07:10,339 - INFO # 
2023-12-13 17:07:10,339 - INFO # [START]
2023-12-13 17:07:11,608 - INFO # [SUCCESS]
test 1
2023-12-13 17:07:14,593 - INFO # > test 1
2023-12-13 17:07:14,593 - INFO # 
2023-12-13 17:07:14,594 - INFO # [START]
2023-12-13 17:07:14,648 - INFO # [SUCCESS]
test 2
2023-12-13 17:07:16,275 - INFO # > test 2
2023-12-13 17:07:16,275 - INFO # 
2023-12-13 17:07:16,275 - INFO # [START]
2023-12-13 17:07:16,963 - INFO # [SUCCESS]
```
</details>

### Issues/PRs references

includes #15378
probably also needs #14953 and #19258
