### PR TITLE
drivers/mtd_aes: MTD wrapper for seamless en-/decryption

### DIFF
--- a/drivers/include/mtd_aes.h
+++ b/drivers/include/mtd_aes.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 SSV Software Systems GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mtd_aes  MTD AES encryption
+ * @ingroup     drivers_storage
+ * @brief       Driver for flash memory encryption
+ *
+ * @{
+ *
+ * @brief       Interface definitions for MTD AES encryption
+ *
+ * @author      Juergen Fitschen <jfi@ssv-embedded.de>
+ */
+
+#ifndef MTD_AES_H
+#define MTD_AES_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "mtd.h"
+#include "mutex.h"
+#include "crypto/aes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MTD AES instance
+ */
+typedef struct {
+    mtd_dev_t mtd;                /**< MTD context                         */
+    mtd_dev_t *parent;            /**< MTD context of the parent device    */
+    uint64_t iv[2];  /**< initialization vector for AES-CTR   */
+    cipher_t cipher;              /**< context for AES encryption          */
+} mtd_aes_t;
+
+/**
+ * @brief   Intializes the AES context for mtd_aes
+ *
+ * Please note: The underlying MTD must be initialized separately.
+ *
+ * @param      aes    the MTD AED context
+ * @param[in]  parent the parent MTD device
+ * @param[in]  key    the AES key
+ * @param[in]  iv     the initialization vector for CTR mode
+ *
+ * @return CIPHER_INIT_SUCCESS if initialization was successful
+ * @return <= 0 if an error occurred
+ */
+extern const mtd_desc_t mtd_aes_driver;
+
+
+int mtd_aes_init(mtd_aes_t * aes, mtd_dev_t * parent,
+                 const uint8_t key[AES_KEY_SIZE], const uint8_t iv[AES_BLOCK_SIZE]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_AES_H */
+/** @} */

--- a/drivers/mtd_aes/Makefile
+++ b/drivers/mtd_aes/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mtd_aes/Makefile.dep
+++ b/drivers/mtd_aes/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += crypto_aes
+USEMODULE += cipher_modes

--- a/drivers/mtd_aes/mtd_aes.c
+++ b/drivers/mtd_aes/mtd_aes.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2020 SSV Software Systems GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mtd_aes
+ * @{
+ *
+ * @file
+ * @brief       Driver for flash memory encryption
+ *
+ * @author      Juergen Fitschen <jfi@ssv-embedded.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <errno.h>
+
+#include "kernel_defines.h"
+#include "mtd.h"
+#include "mtd_aes.h"
+#include "mutex.h"
+#include "byteorder.h"
+#include "crypto/modes/ctr.h"
+#include "od.h"
+
+static inline bool _add_overflow(uint64_t a, uint64_t b, uint64_t *res)
+{
+#ifdef BUILTIN_ADD_OVERFLOW_EXIST
+    return __builtin_add_overflow(a, b, res);
+#else
+    *res = a + b;
+    return (a > UINT64_MAX - b);
+#endif
+}
+
+static inline void _store_iv(mtd_aes_t *aes, const uint8_t iv[AES_BLOCK_SIZE])
+{
+    /* network_uint64_t is big endian */
+    const network_uint64_t * iv_be = (const network_uint64_t*) iv;
+    for (size_t i = 0; i < AES_BLOCK_SIZE / sizeof(network_uint64_t); i++) {
+        /* store the iv with the CPU's endianess */
+        aes->iv[i] = byteorder_ntohll(iv_be[i]);
+    }
+}
+
+static inline void _get_ctr(const mtd_aes_t *aes, uint64_t offset, uint8_t ctr[AES_BLOCK_SIZE])
+{
+    network_uint64_t * ctr_be = (network_uint64_t*) ctr;
+    for (ssize_t i = 1; i >= 0; i--) {
+        uint64_t sum;
+
+        if (offset) {
+            bool overflow = _add_overflow(aes->iv[i], offset, &sum);
+            offset = overflow ? 1 : 0;
+        } else {
+            sum = aes->iv[i];
+        }
+
+        ctr_be[i] = byteorder_htonll(sum);
+    }
+}
+
+static inline size_t _min(size_t a, size_t b)
+{
+    return (a < b) ? a : b;
+}
+
+static int _init(mtd_dev_t *mtd)
+{
+    mtd_aes_t *aes = container_of(mtd, mtd_aes_t, mtd);
+    return mtd_init(aes->parent);
+}
+
+static int _write_page(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset, uint32_t count)
+{
+    int rc;
+    mtd_aes_t *aes = container_of(mtd, mtd_aes_t, mtd);
+    uint8_t ctr[AES_BLOCK_SIZE];
+    uint8_t buf[aes->mtd.page_size];
+    uint32_t written = 0;
+
+    assert(offset < aes->mtd.page_size);
+
+    /* Craft nonce from page number */
+    _get_ctr(aes, page * mtd->page_size / AES_BLOCK_SIZE, ctr);
+
+    /* Go thru src page by page */
+    while (count) {
+        const size_t to_copy = _min(aes->mtd.page_size - offset, count);
+
+        /* Copy src into buf with correct alignment */
+        memcpy(buf + offset, src, to_copy);
+
+        /* Crypt page buffer */
+        rc = cipher_encrypt_ctr(&aes->cipher, ctr, 0, buf, sizeof(buf), buf);
+        if (rc < 0) {
+            return -EIO;
+        }
+
+        /* Write crypted buffer into parent device */
+        rc = mtd_write_page(aes->parent, buf + offset, page, offset, to_copy);
+        if (rc < 0) {
+            return rc;
+        }
+
+        offset = 0;
+        count -= to_copy;
+        written += to_copy;
+        page += 1;
+    }
+
+    return written;
+}
+
+static int _read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset, uint32_t count)
+{
+    int rc;
+    mtd_aes_t *aes = container_of(mtd, mtd_aes_t, mtd);
+    uint8_t ctr[AES_BLOCK_SIZE];
+    uint8_t buf[aes->mtd.page_size];
+    uint32_t read = 0;
+
+    assert(offset < aes->mtd.page_size);
+
+    /* Craft nonce from page number */
+    _get_ctr(aes, page * mtd->page_size / AES_BLOCK_SIZE, ctr);
+
+    /* Read from parent page by page */
+    while (count) {
+        const size_t to_copy = _min(aes->mtd.page_size - offset, count);
+
+        /* Copy src into buf with correct alignment */
+        rc = mtd_read_page(aes->parent, buf + offset, page, offset, to_copy);
+        if (rc < 0) {
+            return rc;
+        }
+
+        /* Crypt page buffer */
+        rc = cipher_encrypt_ctr(&aes->cipher, ctr, 0, buf, sizeof(buf), buf);
+        if (rc < 0) {
+            return -EIO;
+        }
+
+        /* Copy crypted buffer to dest */
+        memcpy(dest, buf + offset, to_copy);
+
+        offset = 0;
+        count -= to_copy;
+        read += to_copy;
+        page += 1;
+    }
+
+    return read;
+}
+
+static int _erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t count)
+{
+    mtd_aes_t *aes = container_of(mtd, mtd_aes_t, mtd);
+    return mtd_erase_sector(aes->parent, sector, count);
+}
+
+static int _power(mtd_dev_t *mtd, enum mtd_power_state power)
+{
+    mtd_aes_t *aes = container_of(mtd, mtd_aes_t, mtd);
+    return mtd_power(aes->parent, power);
+}
+
+int mtd_aes_init(mtd_aes_t * aes, mtd_dev_t * parent,
+                 const uint8_t key[AES_KEY_SIZE], const uint8_t iv[AES_BLOCK_SIZE])
+{
+    aes->parent = parent;
+    aes->mtd.driver = &mtd_aes_driver;
+    aes->mtd.page_size = parent->page_size;
+    aes->mtd.pages_per_sector = parent->pages_per_sector;
+    aes->mtd.sector_count = parent->sector_count;
+    _store_iv(aes, iv);
+    return cipher_init(&aes->cipher, CIPHER_AES_128, key, AES_KEY_SIZE);
+}
+
+const mtd_desc_t mtd_aes_driver = {
+    .init = _init,
+    .read_page = _read_page,
+    .write_page = _write_page,
+    .erase_sector = _erase_sector,
+    .power = _power,
+};

--- a/tests/mtd_aes/Makefile
+++ b/tests/mtd_aes/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += mtd_aes
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mtd_aes/Makefile.ci
+++ b/tests/mtd_aes/Makefile.ci
@@ -1,0 +1,13 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    chronos \
+    msb-430 \
+    msb-430h \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    stm32f030f4-demo \
+    #

--- a/tests/mtd_aes/main.c
+++ b/tests/mtd_aes/main.c
@@ -1,0 +1,160 @@
+/*
+* Copyright (C) 2020 SSV Software Systems GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       mtd_aes module test
+ *
+ * @author      Juergen Fitschen <jfi@ssv-embedded.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <errno.h>
+#include <string.h>
+
+#include "embUnit.h"
+
+#include "mtd.h"
+#include "mtd_aes.h"
+
+
+static uint8_t TEST_1_KEY[16] = {
+    0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+    0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c
+};
+
+static uint8_t TEST_1_COUNTER[16] = {
+    0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+    0xf8, 0xf9, 0xfa, 0xfb, 0x00, 0x00, 0x00, 0x00
+};
+
+static uint8_t TEST_1_PLAIN[] = {
+    0xce, 0x69, 0xf0, 0xc2, 0xef, 0xb8, 0x19, 0x02,
+    0x05, 0x14, 0xa3, 0x67, 0x83, 0xb3, 0xb0, 0xa9,
+    0xdb, 0x47, 0x60, 0x4e, 0x42, 0xa9, 0xa7, 0xc1,
+    0xb2, 0x79, 0xa4, 0x0d, 0xd1, 0xea, 0x52, 0xc6,
+    0x5f, 0xec, 0x6c, 0x13, 0x17, 0xc9, 0xf4, 0x89,
+    0x51, 0x71, 0x4d, 0xcb, 0x87, 0x96, 0xae, 0x27,
+    0xfa, 0xb7, 0xfc, 0x11, 0x82, 0x2f, 0xc4, 0x64,
+    0x77, 0x56, 0xb4, 0xe1, 0xac, 0x40, 0xad, 0x45
+};
+
+static uint8_t TEST_1_CIPHER[] = {
+    0x87, 0x4d, 0x61, 0x91, 0xb6, 0x20, 0xe3, 0x26,
+    0x1b, 0xef, 0x68, 0x64, 0x99, 0x0d, 0xb6, 0xce,
+    0x98, 0x06, 0xf6, 0x6b, 0x79, 0x70, 0xfd, 0xff,
+    0x86, 0x17, 0x18, 0x7b, 0xb9, 0xff, 0xfd, 0xff,
+    0x5a, 0xe4, 0xdf, 0x3e, 0xdb, 0xd5, 0xd3, 0x5e,
+    0x5b, 0x4f, 0x09, 0x02, 0x0d, 0xb0, 0x3e, 0xab,
+    0x1e, 0x03, 0x1d, 0xda, 0x2f, 0xbe, 0x03, 0xd1,
+    0x79, 0x21, 0x70, 0xa0, 0xf3, 0x00, 0x9c, 0xee
+};
+#define TEST_1_DATA_LEN (64)
+
+/* Test mock object implementing a simple RAM-based mtd */
+#define SECTOR_COUNT    (TEST_1_DATA_LEN / AES_BLOCK_SIZE / 2)
+#define PAGE_PER_SECTOR (TEST_1_DATA_LEN / AES_BLOCK_SIZE / 2)
+#define PAGE_SIZE       (AES_BLOCK_SIZE)
+
+#define MEMORY_SIZE     (PAGE_SIZE * PAGE_PER_SECTOR * SECTOR_COUNT)
+
+static uint8_t _dummy_memory[MEMORY_SIZE];
+
+static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+
+    if (addr + size > sizeof(_dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    memcpy(buff, _dummy_memory + addr, size);
+
+    return 0;
+}
+
+static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr,
+                  uint32_t size)
+{
+    (void)dev;
+
+    if (addr + size > sizeof(_dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    if (size > PAGE_SIZE) {
+        return -EOVERFLOW;
+    }
+    memcpy(_dummy_memory + addr, buff, size);
+
+    return 0;
+}
+
+static const mtd_desc_t _driver = {
+    .read = _read,
+    .write = _write
+};
+
+static mtd_dev_t _parent = {
+    .driver = &_driver,
+    .sector_count = SECTOR_COUNT,
+    .pages_per_sector = PAGE_PER_SECTOR,
+    .page_size = PAGE_SIZE,
+};
+
+static mtd_aes_t _aes;
+
+static mtd_dev_t *_aesmtd = &_aes.mtd;
+
+static void test_mtd_read(void)
+{
+    static uint8_t _buffer[PAGE_SIZE];
+
+    memcpy(_dummy_memory, TEST_1_CIPHER, TEST_1_DATA_LEN);
+    mtd_aes_init(&_aes, &_parent, TEST_1_KEY, TEST_1_COUNTER);
+    for (uint32_t i = 0; i < MEMORY_SIZE; i += PAGE_SIZE) {
+        mtd_read(_aesmtd, _buffer, i, PAGE_SIZE);
+        int cmp = memcmp(_buffer, &TEST_1_PLAIN[i], PAGE_SIZE);
+        TEST_ASSERT_MESSAGE(0 == cmp, "wrong plaintext");
+    }
+}
+
+static void test_mtd_write(void)
+{
+    memset(_dummy_memory, 0x00, TEST_1_DATA_LEN);
+    mtd_aes_init(&_aes, &_parent, TEST_1_KEY, TEST_1_COUNTER);
+    for (uint32_t i = 0; i < MEMORY_SIZE; i += PAGE_SIZE) {
+        mtd_write(_aesmtd, &TEST_1_PLAIN[i], i, PAGE_SIZE);
+    }
+
+    int cmp = memcmp(_dummy_memory, TEST_1_CIPHER, TEST_1_DATA_LEN);
+    TEST_ASSERT_MESSAGE(0 == cmp, "wrong plaintext");
+}
+
+Test *tests_mtd_aes_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_mtd_read),
+        new_TestFixture(test_mtd_write),
+    };
+
+    EMB_UNIT_TESTCALLER(mtd_flashpage_tests, NULL, NULL, fixtures);
+
+    return (Test *)&mtd_flashpage_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_mtd_aes_tests());
+    TESTS_END();
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR implements a `mtd` wrapper for AES-128-CTR encryption.

It's still work-in-progress, but I'm interested if this is useful for others and is worthy to be merged into RIOT after everything is in the right place.

Basically, this wrapper encrypts/decrypts data on-the-fly in write and read calls. Our use case: Receiving encrypted data over a wireless network and decrypt it while writing it to a MTD.

But please be warned: The symmetric key could be exposed when writing different data with the same IV and key. So using this as an encryption layer for - let's say - littlefs might be a bad idea! (cf. https://crypto.stackexchange.com/questions/59/taking-advantage-of-one-time-pad-key-reuse for a very good visual explanation of this problem.)

### Testing procedure

See `tests/mtd_aes`.

### Issues/PRs references

#15362 could help to play around with `mtd_aes`.
