### PR TITLE
boards/feather-m0: add support for feather-m0-lora version

### DIFF
--- a/boards/feather-m0-lora/Kconfig
+++ b/boards/feather-m0-lora/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "feather-m0-lora" if BOARD_FEATHER_M0_LORA
+
+config BOARD_FEATHER_M0_LORA
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO

--- a/boards/feather-m0-lora/Makefile
+++ b/boards/feather-m0-lora/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/feather-m0
+include $(RIOTBASE)/Makefile.base

--- a/boards/feather-m0-lora/Makefile.dep
+++ b/boards/feather-m0-lora/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1276
+endif
+
+include $(RIOTBOARD)/feather-m0/Makefile.dep

--- a/boards/feather-m0-lora/Makefile.features
+++ b/boards/feather-m0-lora/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/feather-m0/Makefile.features

--- a/boards/feather-m0-lora/Makefile.include
+++ b/boards/feather-m0-lora/Makefile.include
@@ -1,0 +1,2 @@
+INCLUDES  += -I$(RIOTBOARD)/feather-m0/include
+include $(RIOTBOARD)/feather-m0/Makefile.include

--- a/boards/feather-m0-lora/doc.txt
+++ b/boards/feather-m0-lora/doc.txt
@@ -1,0 +1,12 @@
+/**
+@defgroup    boards_feather-m0-lora Adafruit Feather M0 LoRa
+@ingroup     boards
+@brief       Support for the Adafruit Feather M0 LoRa.
+
+### General information
+
+The board is a variant of the @ref boards_feather-m0 board with
+a LoRa module on board. Please see @ref boards_feather-m0 for detailed
+information about the board and how to flash it.
+
+*/

--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -65,6 +65,20 @@ and define the required WiFi parameters, for example:
 For detailed information about the parameters, see section
 @ref drivers_atwinc15x0.
 
+### Using with LoRa module
+
+To enable the LoRa module available on the
+[Feather M0 LoRa](https://learn.adafruit.com/adafruit-feather-m0-radio-with-lora-radio-module)
+variant of the board automatically for LoRa applications,
+use `feather-m0-lora` as board:
+
+```
+make BOARD=feather-m0-lora -C examples/gnrc_lorawan
+```
+
+For detailed information about the parameters, see section
+@ref drivers_sx127x.
+
 ### Accessing STDIO via UART
 
 STDIO of RIOT is directly available over the USB port.

--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -55,6 +55,20 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Configuration for Feather M0 LoRa and the SX1276 module
+ * @{
+ **/
+#define SX127X_PARAM_SPI                SPI_DEV(0)
+#define SX127X_PARAM_SPI_NSS            GPIO_PIN(PA, 6)
+#define SX127X_PARAM_RESET              GPIO_PIN(PA, 8)
+#define SX127X_PARAM_DIO0               GPIO_PIN(PA, 9)
+#define SX127X_PARAM_DIO1               GPIO_UNDEF
+#define SX127X_PARAM_DIO2               GPIO_UNDEF
+#define SX127X_PARAM_DIO3               GPIO_UNDEF
+#define SX127X_PARAM_PASELECT           (SX127X_PA_BOOST)
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     esp8266-olimex-mod \
     esp8266-sparkfun-thing \
     feather-m0 \
+    feather-m0-lora \
     feather-m0-wifi \
     firefly \
     frdm-kl43z \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -25,6 +25,7 @@ LOW_MEMORY_BOARDS += \
   e104-bt5010a-tb \
   derfmega128 \
   feather-m0 \
+  feather-m0-lora \
   feather-m0-wifi \
   hifive1 \
   hifive1b \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The [feather-m0](https://www.adafruit.com/product/3178) board, lacked of support and documentation for its LoRa version that ship with a RFM95 module on it. The driver for the RFM95 LoRa module is exactly the same as the SX1276 already supported by RIOT-OS.
This PR add the pins mapping for the driver to the board definition to make the `feather-m0-lora` board work out of the box. I used those [schematics](https://cdn-learn.adafruit.com/assets/assets/000/032/914/original/feather_schem.png?1465421956) to find the pin mapping.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The contribution was tested on a `feather-m0-lora` with the `test/driver_sx127x` example.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
I didn't found any reference to the `feather-m0-lora` in the existing issues.
