### PR TITLE
cpu/efm32: extend timer isr

### DIFF
--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -336,3 +336,17 @@ void TIMER_1_ISR(void)
     _timer_isr(1);
 }
 #endif /* TIMER_1_ISR */
+
+#ifdef TIMER_2_ISR
+void TIMER_2_ISR(void)
+{
+    _timer_isr(2);
+}
+#endif /* TIMER_2_ISR */
+
+#ifdef TIMER_3_ISR
+void TIMER_3_ISR(void)
+{
+    _timer_isr(3);
+}
+#endif /* TIMER_3_ISR */


### PR DESCRIPTION
### Contribution description
PR #15368 extends the number of timers for the SLSTK3402a to three. I realized that the EFM32 does not expose that many ISR handlers. This PR fixes that.

### Testing procedure
There is no way to test this, until #15368 is merged.

Murdock should be happy.

### Issues/PRs references
#15368
