### PR TITLE
drivers, tests: use xtimer_msleep()

### DIFF
--- a/drivers/ad7746/ad7746.c
+++ b/drivers/ad7746/ad7746.c
@@ -382,7 +382,7 @@ static int _read_voltage_temp(ad7746_t *dev, int *value, ad7746_vt_mode_t mode)
         /* if a mode change is needed wait for a conversion cycle and flush
          * the first sample in order to get a stable output. Took from the Linux
          * driver implementation */
-        xtimer_usleep(_vt_sr_times[dev->params.vt_sample_rate] * US_PER_MS);
+        xtimer_msleep(_vt_sr_times[dev->params.vt_sample_rate]);
         _read_raw_ch(dev, AD7746_READ_VT_CH, &raw);
     }
 

--- a/drivers/aip31068/aip31068.c
+++ b/drivers/aip31068/aip31068.c
@@ -135,7 +135,7 @@ int aip31068_init(aip31068_t *dev, const aip31068_params_t *params)
      * HD44780 hidden behind it so to be sure that it works for all kinds of
      * HD44780 we follow the initialization sequence of the HD44780, even though
      * it might be unnecessary for others. */
-    xtimer_usleep(50 * US_PER_MS);
+    xtimer_msleep(50);
 
     int rc = 0;
 
@@ -146,7 +146,7 @@ int aip31068_init(aip31068_t *dev, const aip31068_params_t *params)
     }
 
     /* wait after the first try */
-    xtimer_usleep(5 * US_PER_MS);
+    xtimer_msleep(5);
 
     /* second try */
     rc = _command(dev, AIP31068_CMD_FUNCTION_SET | _function_set);

--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -45,8 +45,7 @@
 #define INTPIN               (dev->params.int_pin)
 #define RESETPIN             (dev->params.reset_pin)
 #define POWERPIN             (dev->params.power_pin)
-#define SPI_CS_DELAY         (US_PER_MS)
-#define DELAY_10_MS          (10 * US_PER_MS) /* 10 ms */
+#define SPI_CS_DELAY_MS      (1)
 #define TX_TIMEOUT           (8U)             /* 8 s */
 #define TX_RX_TIMEOUT        (50U)            /* 50 s */
 
@@ -167,9 +166,9 @@ static void _spi_transfer_byte(const ata8520e_t *dev, bool cont, uint8_t out)
     /* Manually triggering CS because of a required delay, see datasheet,
        section 2.1.1, page 10 */
     gpio_clear((gpio_t)CSPIN);
-    xtimer_usleep(SPI_CS_DELAY);
+    xtimer_msleep(SPI_CS_DELAY_MS);
     spi_transfer_byte(SPIDEV, SPI_CS_UNDEF, cont, out);
-    xtimer_usleep(SPI_CS_DELAY);
+    xtimer_msleep(SPI_CS_DELAY_MS);
     gpio_set((gpio_t)CSPIN);
 }
 
@@ -179,9 +178,9 @@ static void _spi_transfer_bytes(const ata8520e_t *dev, bool cont,
     /* Manually triggering CS because of a required delay, see datasheet,
        section 2.1.1, page 10 */
     gpio_clear((gpio_t)CSPIN);
-    xtimer_usleep(SPI_CS_DELAY);
+    xtimer_msleep(SPI_CS_DELAY_MS);
     spi_transfer_bytes(SPIDEV, SPI_CS_UNDEF, cont, out, in, len);
-    xtimer_usleep(SPI_CS_DELAY);
+    xtimer_msleep(SPI_CS_DELAY_MS);
     gpio_set((gpio_t)CSPIN);
 }
 
@@ -220,9 +219,9 @@ static void _status(const ata8520e_t *dev)
 static void _reset(const ata8520e_t *dev)
 {
     gpio_set(RESETPIN);
-    xtimer_usleep(DELAY_10_MS);
+    xtimer_msleep(10);
     gpio_clear(RESETPIN);
-    xtimer_usleep(DELAY_10_MS);
+    xtimer_msleep(10);
     gpio_set(RESETPIN);
 }
 
@@ -270,7 +269,7 @@ int ata8520e_init(ata8520e_t *dev, const ata8520e_params_t *params)
         return -ATA8520E_ERR_SPI;
     }
 
-    xtimer_usleep(100 * US_PER_MS); /* 100 ms */
+    xtimer_msleep(100);
 
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         char sigfox_id[SIGFOX_ID_LENGTH + 1];
@@ -392,7 +391,7 @@ static bool _wait_event(ata8520e_t *dev, uint8_t timeout)
 static void _prepare_send_frame(ata8520e_t *dev, uint8_t *msg, uint8_t msg_len)
 {
     _poweron(dev);
-    xtimer_usleep(5 * US_PER_MS);
+    xtimer_msleep(5);
     _status(dev);
 
     /* Verify message length */
@@ -487,7 +486,7 @@ int ata8520e_send_bit(ata8520e_t *dev, bool bit)
 {
     DEBUG("[ata8520e] Sending bit '%d'\n", bit);
     _poweron(dev);
-    xtimer_usleep(5 * US_PER_MS);
+    xtimer_msleep(5);
     _status(dev);
 
     dev->internal_state = ATA8520E_STATE_TX;

--- a/drivers/atwinc15x0/atwinc15x0_bsp.c
+++ b/drivers/atwinc15x0/atwinc15x0_bsp.c
@@ -78,7 +78,7 @@ void nm_bsp_reset(void)
 
 void nm_bsp_sleep(uint32 u32TimeMsec)
 {
-    xtimer_usleep(u32TimeMsec * US_PER_MS);
+    xtimer_msleep(u32TimeMsec);
 }
 
 void nm_bsp_register_isr(tpfNmBspIsr pfIsr)

--- a/drivers/bme680/bme680_saul.c
+++ b/drivers/bme680/bme680_saul.c
@@ -65,7 +65,7 @@ static int _read(int dev)
     if ((drt = bme680_get_duration(&bme680_devs_saul[dev])) < 0) {
         return BME680_INVALID;
     }
-    xtimer_usleep(drt * US_PER_MS);
+    xtimer_msleep(drt);
 
     bme680_field_data_t data;
     if ((res = bme680_get_data(&bme680_devs_saul[dev], &data)) != BME680_OK) {

--- a/drivers/dfplayer/dfplayer_internal.c
+++ b/drivers/dfplayer/dfplayer_internal.c
@@ -321,7 +321,7 @@ static int _send(dfplayer_t *dev, uint8_t cmd, uint8_t p1, uint8_t p2,
         }
 
         /* wait to work around HW bug */
-        xtimer_usleep(DFPLAYER_SEND_DELAY_MS * US_PER_MS);
+        xtimer_msleep(DFPLAYER_SEND_DELAY_MS);
 
         if (!retval) {
             break;

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -118,7 +118,7 @@ int dht_init(dht_t *dev, const dht_params_t *params)
 
     _reset(dev);
 
-    xtimer_usleep(2000 * US_PER_MS);
+    xtimer_msleep(2000);
 
     DEBUG("dht_init: success\n");
     return DHT_OK;

--- a/drivers/ds75lx/ds75lx.c
+++ b/drivers/ds75lx/ds75lx.c
@@ -126,7 +126,7 @@ int ds75lx_wakeup(const ds75lx_t *dev)
 
     if (ret == DS75LX_OK) {
         /* Wait max conversion time (depends on resolution) */
-        xtimer_usleep((DS75LX_MAX_CONVERSION_TIME << dev->params.resolution) * US_PER_MS);
+        xtimer_msleep((DS75LX_MAX_CONVERSION_TIME << dev->params.resolution));
     }
 
     return ret;

--- a/drivers/dsp0401/dsp0401.c
+++ b/drivers/dsp0401/dsp0401.c
@@ -238,12 +238,12 @@ void dsp0401_scroll_text(const dsp0401_t *dev, char *text, uint16_t delay)
     for (unsigned i = 0; i < strlen(text); ++i) {
         _shift_char(dev, text[i]);
         _latch(dev);
-        xtimer_usleep((uint32_t)(delay * US_PER_MS));
+        xtimer_msleep(delay);
     }
 
     for (unsigned i = 0; i < MOD_COUNT * 4; ++i) {
         _shift_char(dev, ' ');
         _latch(dev);
-        xtimer_usleep((uint32_t)(delay * US_PER_MS));
+        xtimer_msleep(delay);
     }
 }

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -99,16 +99,16 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
     if (gpio_is_valid(dev->params->rst_pin)) {
         gpio_init(dev->params->rst_pin, GPIO_OUT);
         gpio_clear(dev->params->rst_pin);
-        xtimer_usleep(120 * US_PER_MS);
+        xtimer_msleep(120);
         gpio_set(dev->params->rst_pin);
     }
-    xtimer_usleep(120 * US_PER_MS);
+    xtimer_msleep(120);
 
     /* Acquire once at release at the end */
     _ili9341_spi_acquire(dev);
     /* Soft Reset */
     _write_cmd(dev, ILI9341_CMD_SWRESET, NULL, 0);
-    xtimer_usleep(120 * US_PER_MS);
+    xtimer_msleep(120);
 
     /* Display off */
     _write_cmd(dev, ILI9341_CMD_DISPOFF, NULL, 0);

--- a/drivers/itg320x/itg320x.c
+++ b/drivers/itg320x/itg320x.c
@@ -221,7 +221,7 @@ int itg320x_power_up(itg320x_t *dev)
     EXEC_RET(_update_reg(dev, ITG320X_REG_PWR_MGM, ITG320X_REG_PWR_MGM_SLEEP, 0));
 
     /* wait 20 ms after power-up */
-    xtimer_usleep(20 * US_PER_MS);
+    xtimer_msleep(20);
 
     return ITG320X_OK;
 }
@@ -238,7 +238,7 @@ static int _reset(itg320x_t *dev)
     EXEC_RET(_update_reg(dev, ITG320X_REG_PWR_MGM, ITG320X_REG_PWR_MGM_H_RESET, 1));
 
     /* wait 20 ms after reset */
-    xtimer_usleep(20 * US_PER_MS);
+    xtimer_msleep(20);
 
     return ITG320X_OK;
 }

--- a/drivers/mhz19/mhz19_pwm.c
+++ b/drivers/mhz19/mhz19_pwm.c
@@ -61,26 +61,26 @@ int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm)
     DEBUG("%s: Waiting for high level to end\n", __func__);
     while (gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_usleep(US_PER_MS);
+        xtimer_msleep(1);
     }
 
     DEBUG("%s: Waiting for initial rising edge\n", __func__);
     while (!gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_usleep(US_PER_MS);
+        xtimer_msleep(1);
     }
 
     start = xtimer_now_usec() / US_PER_MS;
     DEBUG("%s: Waiting for falling edge\n", __func__);
     while (gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_usleep(US_PER_MS);
+        xtimer_msleep(1);
     }
     middle = xtimer_now_usec() / US_PER_MS;
     DEBUG("%s: Waiting for rising edge\n", __func__);
     while (!gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_usleep(US_PER_MS);
+        xtimer_msleep(1);
     }
 
     /* If we waited too long for flanks, something went wrong */

--- a/drivers/mhz19/mhz19_uart.c
+++ b/drivers/mhz19/mhz19_uart.c
@@ -137,7 +137,7 @@ static void mhz19_cmd(mhz19_t *dev, const uint8_t *in)
     uart_write(dev->params->uart, in, MHZ19_BUF_SIZE + 1);
 
     /* Add some delay after executing command */
-    xtimer_usleep(MHZ19_TIMEOUT_CMD * US_PER_MS);
+    xtimer_msleep(MHZ19_TIMEOUT_CMD);
 
     /* Unlock concurrency guard mutex */
     mutex_unlock(&dev->mutex);

--- a/drivers/ph_oem/ph_oem.c
+++ b/drivers/ph_oem/ph_oem.c
@@ -270,7 +270,7 @@ static int _new_reading_available(const ph_oem_t *dev)
             i2c_release(DEV_I2C);
             return PH_OEM_READ_ERR;
         }
-        xtimer_usleep(20 * US_PER_MS);
+        xtimer_msleep(20);
     } while (new_reading_available == 0);
 
     /* need to manually reset register back to 0x00 */

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -231,7 +231,7 @@ int rn2xx3_sys_sleep(rn2xx3_t *dev)
 
     /* Wait a little to check if the device could go to sleep. No answer means
        it worked. */
-    xtimer_usleep(US_PER_MS);
+    xtimer_msleep(1);
 
     DEBUG("[rn2xx3] RESP: %s\n", dev->resp_buf);
     if (rn2xx3_process_response(dev) == RN2XX3_ERR_INVALID_PARAM) {

--- a/drivers/sht2x/sht2x.c
+++ b/drivers/sht2x/sht2x.c
@@ -93,7 +93,7 @@ int sht2x_init(sht2x_t* dev, const sht2x_params_t* params)
         return SHT2X_ERR_I2C;
     }
     /* wait 15 ms for device to reset */
-    xtimer_usleep(15 * US_PER_MS);
+    xtimer_msleep(15);
 
     uint8_t userreg;
     uint8_t userreg2;
@@ -450,7 +450,7 @@ static void sleep_during_temp_measurement(sht2x_res_t res)
             amount_ms = 9;
             break;
     }
-    xtimer_usleep(amount_ms * US_PER_MS);
+    xtimer_msleep(amount_ms);
 }
 
 static void sleep_during_hum_measurement(sht2x_res_t resolution)
@@ -471,5 +471,5 @@ static void sleep_during_hum_measurement(sht2x_res_t resolution)
             amount_ms = 12;
             break;
     }
-    xtimer_usleep(amount_ms * US_PER_MS);
+    xtimer_msleep(amount_ms);
 }

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -169,7 +169,7 @@ int si70xx_init(si70xx_t *dev, const si70xx_params_t *params)
     i2c_release(SI70XX_I2C);
 
     /* sensor is ready after at most 25 ms */
-    xtimer_usleep(25 * US_PER_MS);
+    xtimer_msleep(25);
 
     DEBUG("[DEBUG] Device initialized with success.\n");
     return SI70XX_OK;

--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -41,14 +41,14 @@ static int _soft_reset(const stmpe811_t *dev)
         DEBUG("[stmpe811] soft reset: cannot write soft reset bit to SYS_CTRL1 register\n");
         return -STMPE811_ERR_I2C;
     }
-    xtimer_usleep(10 * US_PER_MS);
+    xtimer_msleep(10);
 
     if (i2c_write_reg(STMPE811_DEV_I2C, STMPE811_DEV_ADDR,
                       STMPE811_SYS_CTRL1, 0, 0) < 0) {
         DEBUG("[stmpe811] soft reset: cannot clear SYS_CTRL1 register\n");
         return -STMPE811_ERR_I2C;
     }
-    xtimer_usleep(2 * US_PER_MS);
+    xtimer_msleep(2);
 
     return STMPE811_OK;
 }

--- a/pkg/driver_bme680/contrib/bme680_hal.c
+++ b/pkg/driver_bme680/contrib/bme680_hal.c
@@ -45,7 +45,7 @@
 
 void bme680_ms_sleep(uint32_t msleep)
 {
-    xtimer_usleep(msleep * US_PER_MS);
+    xtimer_msleep(msleep);
 }
 
 #ifdef MODULE_PERIPH_I2C

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -215,7 +215,7 @@ void *mqtt_riot_run(void *arg)
         }
         MutexUnlock(&client->mutex);
         /* let other threads do their work */
-        xtimer_usleep(MQTT_YIELD_POLLING_MS * US_PER_MS);
+        xtimer_msleep(MQTT_YIELD_POLLING_MS);
     }
     return NULL;
 }

--- a/tests/driver_aip31068/main.c
+++ b/tests/driver_aip31068/main.c
@@ -387,11 +387,11 @@ int run_demo(int argc, char **argv)
     aip31068_clear(&aip31068_dev);
     aip31068_set_text_insertion_mode(&aip31068_dev, LEFT_TO_RIGHT);
     aip31068_print(&aip31068_dev, "scroll right");
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     for (int i = 0; i < 4; i++) {
         aip31068_scroll_display_right(&aip31068_dev);
-        xtimer_usleep(500 * US_PER_MS);
+        xtimer_msleep(500);
     }
 
     /* 2.b scroll left with text insertion following RIGHT_TO_LEFT */
@@ -399,11 +399,11 @@ int run_demo(int argc, char **argv)
     aip31068_set_text_insertion_mode(&aip31068_dev, RIGHT_TO_LEFT);
     aip31068_set_cursor_position(&aip31068_dev, 0, COL_COUNT - 1);
     aip31068_print(&aip31068_dev, "tfel llorcs");
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     for (int i = 0; i < 5; i++) {
         aip31068_scroll_display_left(&aip31068_dev);
-        xtimer_usleep(500 * US_PER_MS);
+        xtimer_msleep(500);
     }
     aip31068_set_text_insertion_mode(&aip31068_dev, LEFT_TO_RIGHT);
 
@@ -433,7 +433,7 @@ int run_demo(int argc, char **argv)
     char long_line[] = "This is a very long line";
     for (int i = 0; i < (int) strlen(long_line); i++) {
         aip31068_print_char(&aip31068_dev, long_line[i]);
-        xtimer_usleep(250 * US_PER_MS);
+        xtimer_msleep(250);
     }
     aip31068_set_auto_scroll_enabled(&aip31068_dev, false);
     xtimer_sleep(2);
@@ -458,11 +458,11 @@ int run_demo(int argc, char **argv)
         }
 
         aip31068_set_cursor_position(&aip31068_dev, 0, i);
-        xtimer_usleep(500 * US_PER_MS);
+        xtimer_msleep(500);
     }
     xtimer_sleep(1);
     aip31068_return_home(&aip31068_dev);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
     aip31068_set_cursor_blinking_enabled(&aip31068_dev, false);
 
     /* 7. show and move cursor */
@@ -471,18 +471,18 @@ int run_demo(int argc, char **argv)
     xtimer_sleep(1);
     for (int i = 0; i <= 9; i++) {
         aip31068_print_char(&aip31068_dev, '0' + i);
-        xtimer_usleep(250 * US_PER_MS);
+        xtimer_msleep(250);
     }
 
     aip31068_return_home(&aip31068_dev);
-    xtimer_usleep(100 * US_PER_MS);
+    xtimer_msleep(100);
     for (int i = 0; i < 50; i++) {
         aip31068_move_cursor_right(&aip31068_dev);
-        xtimer_usleep(100 * US_PER_MS);
+        xtimer_msleep(100);
     }
     for (int i = 50; i > 0 ; i--) {
         aip31068_move_cursor_left(&aip31068_dev);
-        xtimer_usleep(100 * US_PER_MS);
+        xtimer_msleep(100);
     }
 
     aip31068_set_cursor_visible(&aip31068_dev, false);
@@ -501,7 +501,7 @@ int run_demo(int argc, char **argv)
                 aip31068_print(&aip31068_dev, "B");
             }
 
-            xtimer_usleep(100 * US_PER_MS);
+            xtimer_msleep(100);
         }
 
         aip31068_clear(&aip31068_dev);
@@ -515,7 +515,7 @@ int run_demo(int argc, char **argv)
                 aip31068_print(&aip31068_dev, "Y");
             }
 
-            xtimer_usleep(100 * US_PER_MS);
+            xtimer_msleep(100);
         }
     }
 
@@ -536,7 +536,7 @@ int run_demo(int argc, char **argv)
         aip31068_print(&aip31068_dev, string_rep);
 
         _set_progress(&aip31068_dev, j);
-        xtimer_usleep(100 * US_PER_MS);
+        xtimer_msleep(100);
     }
     _set_progress_bar_enabled(&aip31068_dev, false);
     aip31068_clear(&aip31068_dev);

--- a/tests/driver_bme680/main.c
+++ b/tests/driver_bme680/main.c
@@ -76,7 +76,7 @@ int main(void)
             /* get the duration for the measurement */
             int duration = bme680_get_duration(&dev[i]);
             /* wait for the duration */
-            xtimer_usleep(duration * US_PER_MS);
+            xtimer_msleep(duration);
             /* read the data */
             int res = bme680_get_data(&dev[i], &data);
 

--- a/tests/driver_dfplayer/main.c
+++ b/tests/driver_dfplayer/main.c
@@ -90,7 +90,7 @@ static void playback_done_handler(event_t *_data)
             break;
     }
     print_str(".mp3: Playback completed\n");
-    xtimer_usleep(DFPLAYER_TIMEOUT_MS * US_PER_MS);
+    xtimer_msleep(DFPLAYER_TIMEOUT_MS);
     dfplayer_next(dev);
 }
 

--- a/tests/driver_dsp0401/main.c
+++ b/tests/driver_dsp0401/main.c
@@ -49,9 +49,9 @@ int main(void)
     while (loop < LOOPS) {
         puts("[INFO] Displaying 'THIS IS RIOT'");
         dsp0401_display_text(&dev, (char*)"THIS");
-        xtimer_usleep(WORD_DELAY * US_PER_MS);
+        xtimer_msleep(WORD_DELAY);
         dsp0401_display_text(&dev, (char*)" IS ");
-        xtimer_usleep(WORD_DELAY * US_PER_MS);
+        xtimer_msleep(WORD_DELAY);
         dsp0401_display_text(&dev, (char*)"RIOT");
         xtimer_sleep(TEST_DELAY);
 

--- a/tests/driver_jc42/main.c
+++ b/tests/driver_jc42/main.c
@@ -83,7 +83,7 @@ int main(void)
                 temperature / 100, temperature % 100);
 
         /* sleep between measurements */
-        xtimer_usleep(1000 * US_PER_MS);
+        xtimer_msleep(1000);
     }
 
     return 0;

--- a/tests/driver_pca9633/main.c
+++ b/tests/driver_pca9633/main.c
@@ -360,29 +360,29 @@ int run_demo(int argc, char **argv)
     pca9633_set_group_control_mode(&pca9633_dev,
                                    PCA9633_GROUP_CONTROL_MODE_DIMMING);
     pca9633_set_rgb(&pca9633_dev, 255, 255, 255);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     // 1. turn on/off
     puts("1. turn on/off");
     pca9633_turn_off(&pca9633_dev);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_turn_on(&pca9633_dev);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     // 2. individual dimming (pca9633_set_rgb() uses pca9633_set_pwm() internally)
     puts("2. individual dimming");
     pca9633_set_rgb(&pca9633_dev, 255, 255, 255);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_set_rgb(&pca9633_dev, 255, 0, 0);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_set_rgb(&pca9633_dev, 0, 255, 0);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_set_rgb(&pca9633_dev, 0, 0, 255);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     // 3. group dimming
     puts("3. group dimming");
@@ -391,7 +391,7 @@ int run_demo(int argc, char **argv)
 
     for (int pwm = 255; pwm >= 0; pwm--) {
         pca9633_set_grp_pwm(&pca9633_dev, pwm);
-        xtimer_usleep(20 * US_PER_MS);
+        xtimer_msleep(20);
     }
     xtimer_sleep(1);
 
@@ -401,25 +401,25 @@ int run_demo(int argc, char **argv)
     pca9633_set_rgb(&pca9633_dev, 255, 255, 255);
     pca9633_set_ldr_state(&pca9633_dev, PCA9633_LDR_STATE_OFF, PCA9633_PWM_CHANNEL_1);
     // color should be magenta
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_set_grp_pwm(&pca9633_dev, 0);
     pca9633_set_rgb(&pca9633_dev, 0, 0, 0);
     pca9633_set_ldr_state(&pca9633_dev, PCA9633_LDR_STATE_ON, PCA9633_PWM_CHANNEL_1);
     // color should be green
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_set_grp_pwm(&pca9633_dev, 255);
     pca9633_set_rgb(&pca9633_dev, 255, 128, 0);
     pca9633_set_ldr_state(&pca9633_dev,PCA9633_LDR_STATE_IND, PCA9633_PWM_CHANNEL_1);
     // color should be orange
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_set_grp_pwm(&pca9633_dev, 0);
     pca9633_set_rgb(&pca9633_dev, 255, 255, 255);
     pca9633_set_ldr_state(&pca9633_dev, PCA9633_LDR_STATE_IND_GRP, PCA9633_PWM_CHANNEL_1);
     // should be no color at all
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     // 5. test blinking
     puts("5. test blinking");
@@ -437,13 +437,13 @@ int run_demo(int argc, char **argv)
     // 6. sleep mode
     puts("6. sleep mode");
     pca9633_set_rgb(&pca9633_dev, 0, 255, 255);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     pca9633_sleep(&pca9633_dev);
     xtimer_sleep(2);
 
     pca9633_wakeup(&pca9633_dev);
-    xtimer_usleep(500 * US_PER_MS);
+    xtimer_msleep(500);
 
     puts("[DEMO END]");
 

--- a/tests/driver_si70xx/main.c
+++ b/tests/driver_si70xx/main.c
@@ -65,7 +65,7 @@ int main(void)
         printf("temperature: %d.%02d C\n", temperature / 100, temperature % 100);
 
         /* sleep between measurements */
-        xtimer_usleep(1000 * US_PER_MS);
+        xtimer_msleep(1000);
     }
 
     return 0;

--- a/tests/event_wait_timeout/main.c
+++ b/tests/event_wait_timeout/main.c
@@ -113,17 +113,17 @@ int main(void)
 
     thread_create(_stack, sizeof(_stack), PRIO, 0, _cnt_thread, NULL, "cnt");
     /* first, wait 155ms -> should lead to 3 timeout wakeups */
-    xtimer_usleep(155U * US_PER_MS);
+    xtimer_msleep(155U);
     /* post event 3 times -> should lead to 3 event wakeups */
     for (unsigned i = 0; i < 3; i++) {
         event_post(&_evtq, &_evt);
-        xtimer_usleep(5U * US_PER_MS);
+        xtimer_msleep(5U);
     }
     /* wait for 35ms and post another event -> +1 event wakeup */
-    xtimer_usleep(35U * US_PER_MS);
+    xtimer_msleep(35U);
     event_post(&_evtq, &_evt);
     /* finally, wait 60ms and collect results -> +1 timeout wakeup */
-    xtimer_usleep(60U * US_PER_MS);
+    xtimer_msleep(60U);
 
     unsigned events = atomic_load(&_wakeup_evt);
     unsigned timeouts = atomic_load(&_wakeup_timeout);

--- a/tests/evtimer_msg/main.c
+++ b/tests/evtimer_msg/main.c
@@ -111,7 +111,7 @@ int main(void)
            NEVENTS);
 
     /* The last offset is the largest, wait for it and a tiny bit more */
-    xtimer_usleep((offsets[3] + 10) * US_PER_MS);
+    xtimer_msleep((offsets[3] + 10));
     puts("By now all msgs should have been received");
     puts("If yes, the tests were successful");
 }

--- a/tests/pkg_umorse/main.c
+++ b/tests/pkg_umorse/main.c
@@ -23,7 +23,7 @@
 #include "led.h"
 #include "periph_conf.h"
 #include "xtimer.h"
-#define UMORSE_MSLEEP(m)    xtimer_usleep(m * US_PER_MS)
+#define UMORSE_MSLEEP(m)    xtimer_msleep(m)
 
 #include "umorse.h"
 #include "print.h"

--- a/tests/progress_bar/main.c
+++ b/tests/progress_bar/main.c
@@ -46,7 +46,7 @@ int main(void)
 
         progress_bar_update(&progress_bar);
 
-        xtimer_usleep(50 * US_PER_MS);
+        xtimer_msleep(50);
     }
 
     puts("\nDone!");
@@ -64,7 +64,7 @@ int main(void)
         }
 
         progress_bar_update_multi(progress_bar_list, PROGRESS_BAR_LIST_NUMOF);
-        xtimer_usleep(50 * US_PER_MS);
+        xtimer_msleep(50);
     }
 
     puts("Done!");

--- a/tests/thread_priority_inversion/main.c
+++ b/tests/thread_priority_inversion/main.c
@@ -70,7 +70,7 @@ void *t_high_handler(void *arg)
     (void) arg;
 
     /* starting working loop after 500 ms */
-    xtimer_usleep(500U * US_PER_MS);
+    xtimer_msleep(500U);
     while (1) {
         puts("t_high: allocating resource...");
         mutex_lock(&res_mtx);

--- a/tests/touch_dev/main.c
+++ b/tests/touch_dev/main.c
@@ -73,7 +73,7 @@ int main(void)
             printf("X: %i, Y:%i\n", touches[0].x, touches[0].y);
         }
 
-        xtimer_usleep(10 * US_PER_MS);
+        xtimer_msleep(10);
     }
 
     return 0;

--- a/tests/unittests/tests-fib_sr/tests-fib_sr.c
+++ b/tests/unittests/tests-fib_sr/tests-fib_sr.c
@@ -106,7 +106,7 @@ static void test_fib_sr_01_create_empty_sr(void)
      * Uncomment the following two lines if you want to test the temporal behaviour
      * @note this may fail since unittests are currently not thread-friendly
      */
-    //xtimer_usleep(5 * US_PER_MS);
+    //xtimer_msleep(5);
     //TEST_ASSERT(sr_lifetime<10000);
 
     fib_deinit(&test_fib_sr_table);
@@ -144,7 +144,7 @@ static void test_fib_sr_02_change_sr_parameters(void)
      * Uncomment the following three lines if you want to test the temporal behaviour
      * @note this may fail since unittests are currently not thread-friendly
      */
-    //xtimer_usleep(5 * US_PER_MS);
+    //xtimer_msleep(5);
     //TEST_ASSERT(sr_lifetime>10000);
     //TEST_ASSERT(sr_lifetime<20000);
 
@@ -184,7 +184,7 @@ static void test_fib_sr_03_read_sr_parameters(void)
      * @note this may fail since unittests are currently not thread-friendly
      */
     /*
-       xtimer_usleep(1 * US_PER_MS);
+       xtimer_msleep(1);
        TEST_ASSERT_EQUAL_INT(-ENOENT, fib_sr_read_head(&test_fib_sr_table, local_sourceroutes[0],
                                                     &sr_iface_id, &sr_flags,
                                                     &sr_lifetime)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use the `xtimer_msleep()` function instead of `xtimer_usleep(… * US_PER_MS)`.
This only does the obvious replacements where both `xtimer_usleep` and `US_PER_MS` appeared in the same line.

### Testing procedure

With `xtimer` nothing will change as `xtimer_msleep()` is just an inline wrapper function that multiplies the sleep time by 1000.
With `ztimer` however now there is the possibility to use the `ZTIMER_MSEC` timer for these sleeps.

Nonetheless, the code should look slightly cleaner.


### Issues/PRs references

#15076
