### PR TITLE
riotboot: quote PATH variable

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -59,7 +59,7 @@ $(HEADER_TOOL): FORCE
 	@echo "compiling $@..."
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) \
-		PATH=$(PATH) \
+		PATH="$(PATH)" \
 			$(MAKE) --no-print-directory -C $(HEADER_TOOL_DIR) all
 
 # Generate RIOT header and keep the original binary file
@@ -78,7 +78,7 @@ riotboot: $(SLOT_RIOT_BINS)
 riotboot/flash-bootloader: riotboot/bootloader/flash
 riotboot/bootloader/%:
 	$(Q)/usr/bin/env -i \
-		QUIET=$(QUIET) PATH=$(PATH)\
+		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
 		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID)\
 			$(MAKE) --no-print-directory -C $(RIOTBOOT_DIR) $*


### PR DESCRIPTION
### Contribution description
This PR resolves an issue, if your `PATH` contains directories with spaces. At least on macOS, some applications add themselves to the system-wide `PATH`.

This is a small portion of the build log without the fix (notice the last line being the last part of the `PATH`):

```
PATH=/usr/local/opt/binutils/bin:/usr/local/opt/make/libexec/gnubin:/usr/local/opt/grep/libexec/gnubin:/Users/basilfx/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion.app/Contents/Public:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Wireshark.app/Contents/MacOS \
		make --no-print-directory -C /Users/basilfx/Desktop/RIOT/RIOT_knx/RIOT/dist/tools/riotboot_gen_hdr all
make[1]: Leaving directory '/Users/basilfx/Desktop/RIOT/RIOT_knx/RIOT/pkg/littlefs'
env: Fusion.app/Contents/Public:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Wireshark.app/Contents/MacOS: No such file or directory
```

### Testing procedure
Add a directory to your `PATH` with a space, then compile `tests/riotboot`.

### Issues/PRs references
None