### PR TITLE
sys/riotboot: add stddef.h for size_t

### DIFF
--- a/sys/include/riotboot/slot.h
+++ b/sys/include/riotboot/slot.h
@@ -29,6 +29,8 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+
 #include "riotboot/hdr.h"
 
 /**


### PR DESCRIPTION
### Contribution description
The sys/include/riotboot/slot.h uses `size_t`, but does not include `stddef.h`.

This leads to compile errors like these:

```
In file included from RIOT/examples/gnrc_knx_taster/ota.c:9:
RIOT/sys/include/riotboot/slot.h:99:1: error: unknown type name 'size_t'
   99 | size_t riotboot_slot_offset(unsigned slot);
      | ^~~~~~
RIOT/sys/include/riotboot/slot.h:33:1: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
   32 | #include "riotboot/hdr.h"
  +++ |+#include <stddef.h>
   33 |
RIOT/sys/include/riotboot/slot.h:114:15: error: unknown type name 'size_t'
  114 | static inline size_t riotboot_slot_size(unsigned slot)
      |               ^~~~~~
make[1]: *** [RIOT/Makefile.base:107: RIOT/examples/gnrc_knx_taster/bin/basilfx-taster/application_gnrc_knx_taster/ota.o] Error 1
```

### Testing procedure
There is no test to verify this, but my own application now compiles.

### Issues/PRs references
None