### PR TITLE
boards/common/particle-mesh: default to stdio via CDC ACM

### DIFF
--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -13,5 +13,6 @@ config BOARD_COMMON_PARTICLE_MESH
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/common/particle-mesh/Makefile.dep
+++ b/boards/common/particle-mesh/Makefile.dep
@@ -6,5 +6,8 @@ ifeq (1,$(PARTICLE_MONOFIRMWARE))
   USEMODULE += usb_board_reset
 endif
 
+# default to stdio over CDC ACM
+include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
+
 # include common nrf52 dependencies
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -8,5 +8,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -2,10 +2,6 @@
 BOARD_NRFANTENNA_DEFAULT ?= BUILTIN
 CFLAGS += -DBOARD_NRFANTENNA_DEFAULT=BOARD_NRFANTENNA_$(BOARD_NRFANTENNA_DEFAULT)
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # add the common header files to the include path
 INCLUDES += -I$(RIOTBOARD)/common/particle-mesh/include
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The paricle mesh boards are all USB based, so default to stdio via CDC ACM for a more seamless user experience.



### Testing procedure

Once flashed, subsequent flashing should work by just running `make flash` by virtue of `usb_board_reset`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
