### PR TITLE
b/c/particle-mesh: Switch default stdio to USB

### DIFF
--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -13,5 +13,6 @@ config BOARD_COMMON_PARTICLE_MESH
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/common/particle-mesh/Makefile.dep
+++ b/boards/common/particle-mesh/Makefile.dep
@@ -7,5 +7,7 @@ ifeq (1,$(PARTICLE_MONOFIRMWARE))
   USEMODULE += usb_board_reset
 endif
 
+include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk
+
 # include common nrf52 dependencies
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -9,4 +9,6 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 
+FEATURES_PROVIDED += highlevel_stdio
+
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -2,10 +2,6 @@
 BOARD_NRFANTENNA_DEFAULT ?= BUILTIN
 CFLAGS += -DBOARD_NRFANTENNA_DEFAULT=BOARD_NRFANTENNA_$(BOARD_NRFANTENNA_DEFAULT)
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # add the common header files to the include path
 INCLUDES += -I$(RIOTBOARD)/common/particle-mesh/include
 

--- a/boards/common/particle-mesh/doc.txt
+++ b/boards/common/particle-mesh/doc.txt
@@ -75,12 +75,14 @@ the `reset` target with `make`:
     make BOARD=<board name> -C examples/hello-world reset
 ```
 
-### Accessing STDIO via UART
+### STDIO configuration
 
-The STDIO is not accessible via the USB port.
+By default, the board uses USB to expose a serial terminal.
+Other stdio options can be enabled as modules to replace that.
 
-To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
-the RX/TX pins on the board.
+When the `stdio_uart` module is used,
+it defaults to using UART0,
+which is configured for the board's RX/TX pin pair.
 
 ### nRF antenna selection
 


### PR DESCRIPTION
### Contribution description

The particle boards have their on-board USB connector wired into the CPU; since CDC-ACM stdio is now readily available, and because while there is a pair of RX/TX pins but no shipped hardware that connects them to the host, it makes the better default.

### Testing procedure

* Connect to USB
* Ready bootloader (when using PARTICLE_MONOFIRMWARE=1: by keeping mode pressed at powerup until things blink yelllow)
* Flash a regular example, eg. `make BOARD=particle-xenon PARTICLE_MONOFIRMWARE=1 -C examples/saul all flash term`
* Observe that RIOT's CDC-ACM comes up on USB, manifests itself in a /dev/ttyACM0 and the board connects there.
* When using monofirmware, observe that a different example can now be flashed on withouot any physical interaction.

### Issues/PRs references

Some of this PRs usefulness is from the bootloader entering work in #12751.

[edit: ctr-return is bad for a non-undoable submission]