### PR TITLE
examples/suit_update: use interactive sync in test

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -57,6 +57,9 @@ FEATURES_OPTIONAL += periph_gpio_irq
 # Default COAP manifest resource location when fetched through gpio trigger
 CFLAGS += -DSUIT_MANIFEST_RESOURCE=\"$(SUIT_COAP_ROOT)/$(SUIT_NOTIFY_MANIFEST)\"
 
+# Enable test_utils_interactive_sync, only used when running automatic test
+DEFAULT_MODULE += test_utils_interactive_sync
+
 # Change this to 0 to not use ethos
 USE_ETHOS ?= 1
 

--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -465,22 +465,24 @@ displayed during this step:
 Once the new image is written, a final validation is performed and, in case of
 success, the application reboots on the new slot:
 
+    Finalizing payload store
     Verifying image digest
-    riotboot: verifying digest at 0x1fffbd15 (img at: 0x1000 size: 77448)
+    Starting digest verification against image
+    Install correct payload
     Verifying image digest
-    riotboot: verifying digest at 0x1fffbd15 (img at: 0x1000 size: 77448)
-    suit_parse() success
-    SUIT policy check OK.
-    suit_coap: finalizing image flash
-    riotboot_flashwrite: riotboot flashing completed successfully
+    Starting digest verification against image
+    Install correct payload
     Image magic_number: 0x544f4952
-    Image Version: 0x5e71f662
-    Image start address: 0x00001100
-    Header chksum: 0x745a0376
+    Image Version: 0x5fa52bcc
+    Image start address: 0x00201400
+    Header chksum: 0x53bb3d33
+    suit_coap: rebooting...
 
-    main(): This is RIOT! (Version: 2020.04)
+    main(): This is RIOT! (Version: <version xx>))
     RIOT SUIT update example application
-    running from slot 1
+    Running from slot 1
+    ...
+
 
 The slot number should have changed from after the application reboots.
 You can do the publish-notify sequence several times to verify this.


### PR DESCRIPTION
### Contribution description

If the device under test opens in terminal to slow the application will already have printed riotboot hdr info. This adapts the test to use `tests_utils_interactive_sync` and recover the same information via shell commands.


### Testing procedure

- `examples/suit_update` still passes.

```
Image Version: 0x5fa57970
Image start address: 0x00201400
Header chksum: 0x8a4c8ad7

suit_coap: started.
Starting the shell
>
>
> ifconfig
current-slot
Running from slot 0
> ifconfig
Iface  4  HWaddr: AE:8B:6E:51:70:9C
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::ac8b:6eff:fe51:709c  scope: link  VAL
pinging node...
PING fe80::ac8b:6eff:fe51:709c%riot0(fe80::ac8b:6eff:fe51:709c%riot0) 56 data bytes

--- fe80::ac8b:6eff:fe51:709c%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 61.526/61.526/61.526/0.000 ms
pinging node succeeded.
TEST PASSED
```

### Issues/PRs references

Adapted to test suit on `cc2538` with `cc2538.bsl` script
