### PR TITLE
makefiles/tools/cc2538-bsl: use --write-erase to avoid mass erase

### DIFF
--- a/dist/tools/cc2538-bsl/Makefile
+++ b/dist/tools/cc2538-bsl/Makefile
@@ -2,9 +2,13 @@ PKG_NAME=cc2538-bsl
 PKG_URL=https://github.com/JelmerT/cc2538-bsl.git
 PKG_VERSION=733e6f5b496402e40ad6d12df3d0372e205b8883
 PKG_LICENSE=BSD-3-Clause
-PKG_BUILDDIR=$(CURDIR)/bin
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all:
+all: $(CURDIR)/cc2538-bsl.py
+
+$(CURDIR)/cc2538-bsl.py: $(PKG_SOURCE_DIR)/cc2538-bsl.py
 	cp $(PKG_SOURCE_DIR)/cc2538-bsl.py .
+
+clean::
+	rm -f $(CURDIR)/cc2538-bsl.py

--- a/dist/tools/cc2538-bsl/patches/0001-cc2538-bsl-add-W-write-erase-to-write-and-erase.patch
+++ b/dist/tools/cc2538-bsl/patches/0001-cc2538-bsl-add-W-write-erase-to-write-and-erase.patch
@@ -1,0 +1,141 @@
+From bb97c5e6aaaca2f1d667a6ba1c3be0d774aacd8e Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Thu, 5 Nov 2020 16:44:43 +0100
+Subject: [PATCH] cc2538-bsl: add -W,--write-erase to write and erase
+
+-W, --write-erase will erase flash pages where data will be written,
+this avoids performing a mass erase.
+---
+ cc2538-bsl.py | 45 ++++++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 38 insertions(+), 7 deletions(-)
+
+diff --git a/cc2538-bsl.py b/cc2538-bsl.py
+index efdab3d..506401c 100755
+--- a/cc2538-bsl.py
++++ b/cc2538-bsl.py
+@@ -42,6 +42,7 @@ from subprocess import Popen, PIPE
+ import sys
+ import getopt
+ import glob
++import math
+ import time
+ import os
+ import struct
+@@ -688,6 +689,15 @@ class Chip(object):
+         self.has_cmd_set_xosc = False
+         self.page_size = 2048
+
++
++    def page_align_up(self, value):
++        return int(math.ceil(value / self.page_size) * self.page_size)
++
++
++    def page_align_down(self, value):
++        return int(math.floor(value / self.page_size) * self.page_size)
++
++
+     def page_to_addr(self, pages):
+         addresses = []
+         for page in pages:
+@@ -1032,6 +1042,8 @@ def usage():
+                                  eg: -E a,0x00000000,0x00001000,
+                                      -E p,1,4
+     -w                           Write
++    -W, --write-erase            Write and erase (Only section to write, rounds
++                                 up if not page aligned)
+     -v                           Verify (CRC32 check)
+     -r                           Read
+     -l length                    Length of read
+@@ -1060,6 +1072,7 @@ if __name__ == "__main__":
+             'force': 0,
+             'erase': 0,
+             'write': 0,
++            'write_erase': 0,
+             'erase_page': 0,
+             'verify': 0,
+             'read': 0,
+@@ -1075,8 +1088,9 @@ if __name__ == "__main__":
+
+     try:
+         opts, args = getopt.getopt(sys.argv[1:],
+-                                   "DhqVfeE:wvrp:b:a:l:i:",
+-                                   ['help', 'ieee-address=','erase-page=',
++                                   "DhqVfeE:wWvrp:b:a:l:i:",
++                                   ['help', 'ieee-address=','write-erase=',
++                                    'erase-page=',
+                                     'disable-bootloader',
+                                     'bootloader-active-high',
+                                     'bootloader-invert-lines', 'version'])
+@@ -1100,6 +1114,8 @@ if __name__ == "__main__":
+             conf['erase'] = 1
+         elif o == '-w':
+             conf['write'] = 1
++        elif o == '-W' or o == '--write-erase':
++            conf['write_erase'] = 1
+         elif o == '-E' or o == '--erase-page':
+             conf['erase_page'] = str(a)
+         elif o == '-v':
+@@ -1132,25 +1148,27 @@ if __name__ == "__main__":
+     try:
+         # Sanity checks
+         # check for input/output file
+-        if conf['write'] or conf['read'] or conf['verify']:
++        if conf['write'] or conf['write_erase'] or conf['read'] or conf['verify']:
+             try:
+                 args[0]
+             except:
+                 raise Exception('No file path given.')
+
+-        if conf['write'] and conf['read']:
++        if (conf['write'] and conf['read']) or (conf['write_erase'] and conf['read']):
+             if not (conf['force'] or
+                     query_yes_no("You are reading and writing to the same "
+                                  "file. This will overwrite your input file. "
+                                  "Do you want to continue?", "no")):
+                 raise Exception('Aborted by user.')
+-        if (conf['erase'] and conf['read']) or (conf['erase_page'] and conf['read']) and not conf['write']:
++        if ((conf['erase'] and conf['read']) or (conf['erase_page'] and conf['read'])
++            and not (conf['write'] or conf['write_erase'])):
+             if not (conf['force'] or
+                     query_yes_no("You are about to erase your target before "
+                                  "reading. Do you want to continue?", "no")):
+                 raise Exception('Aborted by user.')
+
+-        if conf['read'] and not conf['write'] and conf['verify']:
++        if (conf['read'] and not (conf['write']  or conf['write_erase'])
++            and conf['verify']):
+             raise Exception('Verify after read not implemented.')
+
+         if conf['len'] < 0:
+@@ -1183,7 +1201,7 @@ if __name__ == "__main__":
+                               conf['bootloader_invert_lines'])
+         mdebug(5, "Opening port %(port)s, baud %(baud)d"
+                % {'port': conf['port'], 'baud': conf['baud']})
+-        if conf['write'] or conf['verify']:
++        if conf['write'] or conf['write_erase'] or conf['verify']:
+             mdebug(5, "Reading data from %s" % args[0])
+             firmware = FirmwareFile(args[0])
+
+@@ -1249,6 +1267,19 @@ if __name__ == "__main__":
+             else:
+                 raise CmdException("Write failed                       ")
+
++        if conf['write_erase']:
++            # TODO: check if boot loader back-door is open, need to read
++            #       flash size first to get address
++            # Round up to ensure page alignment
++            erase_len = device.page_align_up(len(firmware.bytes))
++            erase_len = min(erase_len, device.size)
++            if cmd.cmdEraseMemory(conf['address'], erase_len):
++                mdebug(5, "    Erase before write done                 ")
++            if cmd.writeMemory(conf['address'], firmware.bytes):
++                mdebug(5, "    Write done                              ")
++            else:
++                raise CmdException("Write failed                       ")
++
+         if conf['verify']:
+             mdebug(5, "Verifying by comparing CRC32 calculations.")
+
+--
+2.28.0
+

--- a/makefiles/tools/cc2538-bsl.inc.mk
+++ b/makefiles/tools/cc2538-bsl.inc.mk
@@ -2,7 +2,9 @@ FLASHFILE ?= $(BINFILE)
 FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
 FFLAGS_OPTS ?=
 PROG_BAUD ?= 500000	# default value in cc2538-bsl
-FFLAGS  = -p "$(PROG_DEV)" $(FFLAGS_OPTS) -e -w -v -b $(PROG_BAUD) $(FLASHFILE)
+
+FFLAGS  = $(if $(IMAGE_OFFSET), -a $(shell printf "0x%08x" $$(($(IMAGE_OFFSET) + $(ROM_START_ADDR)))))
+FFLAGS += -p "$(PROG_DEV)" $(FFLAGS_OPTS) --write-erase -v -b $(PROG_BAUD) $(FLASHFILE)
 
 RESET ?= $(FLASHER) -p "$(PROG_DEV)" $(FFLAGS_OPTS) -b $(PROG_BAUD)
 

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -17,9 +17,9 @@ $(RIOTTOOLS)/pic32prog/pic32prog: $(RIOTTOOLS)/pic32prog/Makefile
 	$(MAKE) -C $(@D)
 	@echo "[INFO] $(@F) binary successfully built!"
 
-$(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py:
+$(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py: $(RIOTTOOLS)/cc2538-bsl/Makefile
 	@echo "[INFO] cc2538-bsl.py not found - fetching it from GitHub now"
-	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/cc2538-bsl
+	@CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/cc2538-bsl
 	@echo "[INFO] cc2538-bsl.py successfully fetched!"
 
 $(RIOTTOOLS)/edbg/edbg: $(RIOTTOOLS)/edbg/Makefile


### PR DESCRIPTION
### Contribution description

This PR makes the `cc2538-bsl` script use `--write-erase` option which will only erase the section
of flash where the write operation will be performed. This avoids using mass-erase which allows using `cc2538-bsl` for #15392.

### Testing procedure

- flashing should still work on cc2538 boards using the script

- rebase on #15392 and  #15395 and run `examples/suit_update`

`BOARD=openmote-b make -C examples/suit_update/ flash test -j3`

```
Image Version: 0x5fa57970
Image start address: 0x00201400
Header chksum: 0x8a4c8ad7

suit_coap: started.
Starting the shell
>
>
> ifconfig
current-slot
Running from slot 0
> ifconfig
Iface  4  HWaddr: AE:8B:6E:51:70:9C
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::ac8b:6eff:fe51:709c  scope: link  VAL
pinging node...
PING fe80::ac8b:6eff:fe51:709c%riot0(fe80::ac8b:6eff:fe51:709c%riot0) 56 data bytes

--- fe80::ac8b:6eff:fe51:709c%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 61.526/61.526/61.526/0.000 ms
pinging node succeeded.
TEST PASSED
```

### Issues/PRs references

Useful for #15392
Upstream PR, can remove patch afterwards: https://github.com/JelmerT/cc2538-bsl/pull/102