### PR TITLE
cpu/msp430_common: Prevent conflicting defines

### DIFF
--- a/cpu/msp430_common/include/irq_arch.h
+++ b/cpu/msp430_common/include/irq_arch.h
@@ -24,7 +24,6 @@
 #define IRQ_ARCH_H
 
 #include "irq.h"
-#include "cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +37,7 @@ extern "C" {
 
 
 extern volatile int __irq_is_in;
+#define _GENERAL_INTERRUPT_ENABLE   (0x0008)
 
 __attribute__((always_inline)) static inline unsigned int irq_disable(void)
 {
@@ -48,7 +48,7 @@ __attribute__((always_inline)) static inline unsigned int irq_disable(void)
         "nop"                               "\n\t"
         "and %[gie], %[state]"              "\n\t"
         : [state]   "=r"(state)
-        : [gie]     "i"(GIE)
+        : [gie]     "i"(_GENERAL_INTERRUPT_ENABLE)
         : "memory"
     );
 
@@ -65,7 +65,7 @@ __attribute__((always_inline)) static inline unsigned int irq_enable(void)
         "nop"                               "\n\t"
         "and %[gie], %[state]"              "\n\t"
         : [state]   "=r"(state)
-        : [gie]     "i"(GIE)
+        : [gie]     "i"(_GENERAL_INTERRUPT_ENABLE)
         : "memory"
     );
 


### PR DESCRIPTION
### Contribution description

`irq_arch.h` so far includes`cpu.h`, which in term includes the vendor header files. Those are needed to get the GIE `#define` (general interrupt enable bit). However, the vendor files use fancy defines like `#define N (0x0004)` that easily conflict with application code. Due to the widespread use of the IRQ API, it is better to not include the vendor files in `irq_arch.h`.

This PR adds a local `#define` for the GIE bit and uses this instead of including `cpu.h`.


### Testing procedure

Binaries shouldn't change.

### Issues/PRs references

Fixes compilation on MSP430 with https://github.com/RIOT-OS/RIOT/pull/15327