### PR TITLE
hacl: Patch to fix building where PRIx64 is absent

### DIFF
--- a/pkg/hacl/patches/0002-RIOT-Provide-PRIx64-if-needed.patch
+++ b/pkg/hacl/patches/0002-RIOT-Provide-PRIx64-if-needed.patch
@@ -1,0 +1,32 @@
+From e24924004bfa6914029a2db693fdb512c35f1785 Mon Sep 17 00:00:00 2001
+From: chrysn <chrysn@fsfe.org>
+Date: Sun, 8 Nov 2020 06:40:16 +0100
+Subject: [PATCH] RIOT: Provide PRIx64 if needed
+
+Not all RIOT platforms provide a PRIx64 or even 64-bit printing.
+
+As the debug routines that actually use this definition are unlikely to
+be used with RIOT, providing a definition that builds (and, depending on
+platform support, may or may not produce correct output) is a suitable
+fix.
+---
+ kremlib.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/kremlib.h b/kremlib.h
+index 138846a..2fce712 100644
+--- a/kremlib.h
++++ b/kremlib.h
+@@ -25,6 +25,9 @@
+ 
+ #include "kremlib_base.h"
+ 
++#ifndef PRIx64
++#define PRIx64 "llx"
++#endif
+ 
+ /* For tests only: we might need this function to be forward-declared, because
+  * the dependency on WasmSupport appears very late, after SimplifyWasm, and
+-- 
+2.29.2
+


### PR DESCRIPTION
### Contribution description

Quoting the inner commit:

> Not all RIOT platforms provide a PRIx64 or even 64-bit printing.
>
> As the debug routines that actually use this definition are unlikely to
> be used with RIOT, providing a definition that builds (and, depending on
> platform support, may or may not produce correct output) is a suitable
> fix.

### Testing procedure

```
$ make BOARD=nrf52840dongle -C tests/pkg_hacl all flash term
[...]
Help: Press s to start test, r to print it is ready
s
START
main(): This is RIOT! (Version: 2021.01-devel-726-g54078-hacl-provide-prix64)
.
OK (1 tests)
```

I'm wondering why this never came up during CI builds -- possibly it's due to differing versions of the C standard library.

### Issues/PRs references

This could certainly be fixed to use only 32-bit prints (as was in https://github.com/RIOT-OS/RIOT/pull/4405/files), and that can still be done, but honestly I don't even know what all I'd need to enable to actually test it (I don't expect that anyone debugs these innards of hacl on RIOT). Plus it'll need going through upstream and updating the package (maybe it isn't even there in the latest version), but this *right now* keeps applications that use hacl on embedded from upgrading RIOT, and the PR patches in a default PRIx64 to make things build.