### PR TITLE
tests/pkg_lvgl: fix sysmon task creation

### DIFF
--- a/tests/pkg_lvgl/README.md
+++ b/tests/pkg_lvgl/README.md
@@ -3,7 +3,7 @@ LittlevGL sample application
 
 This application shows a basic usage of LittlevGL with RIOT. It's simply an
 adaption of one of the upstream examples: the
-[sysmon example](https://github.com/littlevgl/lv_examples/tree/master/lv_apps/sysmon).
+[sysmon example](https://github.com/lvgl/lv_apps/tree/master/src/lv_sysmon).
 
 ### Flashing the application
 

--- a/tests/pkg_lvgl/main.c
+++ b/tests/pkg_lvgl/main.c
@@ -90,8 +90,6 @@ static void sysmon_task(lv_task_t *param)
 
 void sysmon_create(void)
 {
-    refr_task = lv_task_create(sysmon_task, REFR_TIME, LV_TASK_PRIO_LOW, NULL);
-
     lv_coord_t hres = lv_disp_get_hor_res(NULL);
     lv_coord_t vres = lv_disp_get_ver_res(NULL);
 
@@ -123,6 +121,7 @@ void sysmon_create(void)
     lv_label_set_recolor(info_label, true);
 
     /* Refresh the chart and label manually at first */
+    refr_task = lv_task_create(sysmon_task, REFR_TIME, LV_TASK_PRIO_LOW, NULL);
     sysmon_task(NULL);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes a bug on the `pkg_lvgl` test when running on the esp32. When `sysmon_task`
was created it ran too early before any widget was created causing
Store/LoadProhibited exceptions on the esp32, I assume it's noticeable on the
esp32 due to the code being fetched from external flash memory adding a delay
higher than `REFR_TIME`.


### Testing procedure

- `make -C tests/pkg_lvgl BOARD=esp32-wrover-kit flash`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
