### PR TITLE
boards/bluepill-stm32f030c8: add STM32F030C8 based bluepill board

### DIFF
--- a/boards/bluepill-stm32f030c8/Kconfig
+++ b/boards/bluepill-stm32f030c8/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Benjamin Valentin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "bluepill-stm32f030c8" if BOARD_BLUEPILL_STM32F030C8
+
+config BOARD_BLUEPILL_STM32F030C8
+    bool
+    default y
+    select CPU_MODEL_STM32F030C8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_RTC

--- a/boards/bluepill-stm32f030c8/Makefile
+++ b/boards/bluepill-stm32f030c8/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/bluepill-stm32f030c8/Makefile.dep
+++ b/boards/bluepill-stm32f030c8/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/bluepill-stm32f030c8/Makefile.features
+++ b/boards/bluepill-stm32f030c8/Makefile.features
@@ -1,0 +1,11 @@
+CPU = stm32
+CPU_MODEL = stm32f030c8
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_rtc

--- a/boards/bluepill-stm32f030c8/Makefile.include
+++ b/boards/bluepill-stm32f030c8/Makefile.include
@@ -1,0 +1,4 @@
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/bluepill-stm32f030c8/board.c
+++ b/boards/bluepill-stm32f030c8/board.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bluepill-stm32f030c8
+ * @{
+ *
+ * @file
+ * @brief       Board initialization code for the bluepill-stm32f030c8 board.
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    cpu_init();
+    gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
+}

--- a/boards/bluepill-stm32f030c8/doc.txt
+++ b/boards/bluepill-stm32f030c8/doc.txt
@@ -1,0 +1,65 @@
+/**
+@defgroup    boards_bluepill-stm32f030c8 STM32F030C8 based Bluepill
+@ingroup     boards
+@brief       Support for the STM32F030C8 based Bluepill
+
+## Overview
+
+The STM32F030C8 based Bluepill is a very cheap breakout board for the STM32F030C8 MCU.
+
+## Hardware
+
+![STM32F030C8 based Bluepill](https://camo.githubusercontent.com/f33ec5f4068e1dcc4c549dbe3dc70d2ed784c19abf1c177f9640835180f88005/68747470733a2f2f696d616765732d6e612e73736c2d696d616765732d616d617a6f6e2e636f6d2f696d616765732f492f3631474765592532424c306a4c2e5f41435f534c313030305f2e6a7067)
+
+### MCU
+| MCU        | STM32F030C8T6         |
+|:---------- |:--------------------- |
+| Family     | ARM Cortex-M0         |
+| Vendor     | ST Microelectronics   |
+| RAM        | 8 KiB                 |
+| Flash      | 64 KiB                |
+| Frequency  | up to 48MHz           |
+| FPU        | no                    |
+| Timers     | 8 (2x watchdog, 1 SysTick, 5x 16-bit) |
+| ADCs       | 1x 12-bit             |
+| UARTs      | 2                     |
+| SPIs       | 2                     |
+| I2Cs       | 2                     |
+| RTC        | 1                     |
+| Vcc        | 2.0V - 3.6V           |
+| Datasheet  | [Datasheet](https://www.st.com/en/microcontrollers-microprocessors/stm32f030f4.html) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/datasheet/stm32f030f4.pdf) |
+| Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
+
+## Flashing the device
+
+The STM32F030C8 based Bluepill board does not include a programmer.
+You have to connect a separate ST-Link programmer to the (SW)DIO, (SW)CLK and GND
+pins on the board.
+
+If you want a serial terminal, you have to connect a separate USB-Serial adapter to
+the PA09 (TX) and PA10 (RX) pins on the board.
+
+The easiest way to program the board is to use OpenOCD. Once you have installed
+OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
+installation instructions), you can flash the board simply by typing
+
+```
+make BOARD=bluepill-stm32f030c8 flash
+```
+and debug via GDB by simply typing
+```
+make BOARD=bluepill-stm32f030c8 debug
+```
+
+## Known Issues
+
+### Flashing fails
+
+The board does not expose a pin for the reset signal but wires it only to the
+reset button.
+You can work around this by pressing the reset button when OpenOCD wants to connect
+to the Blue Pill, or keep it pressed until OpenOCD tries to connect.
+Hit the reset button again after flashing in order to boot the newly flashed image.
+
+ */

--- a/boards/bluepill-stm32f030c8/include/board.h
+++ b/boards/bluepill-stm32f030c8/include/board.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bluepill-stm32f030c8
+ *
+ * This board can be bought very cheaply (< 2€) on sites like eBay or
+ * AliExpress.
+ *
+ * @brief       Support for the STM32F030C8 based Bluepill
+ * @{
+ *
+ * @file
+ * @brief       Pin definitions and board configuration options
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PORT           GPIOC
+#define LED0_PIN            GPIO_PIN(PORT_C, 13)
+#define LED0_MASK           (1 << 13)
+
+#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
+#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK <<  0))
+#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/bluepill-stm32f030c8/include/gpio_params.h
+++ b/boards/bluepill-stm32f030c8/include/gpio_params.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bluepill-stm32f030c8
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/bluepill-stm32f030c8/include/periph_conf.h
+++ b/boards/bluepill-stm32f030c8/include/periph_conf.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bluepill-stm32f030c8
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the bluepill-stm32f030c8 board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* This board provides a LSE */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE        1
+#endif
+
+/* This board provides an HSE */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE        1
+#endif
+
+#include "clk_conf.h"
+#include "cfg_i2c1_pb8_pb9.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM1,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .bus      = APB2,
+        .irqn     = TIM1_CC_IRQn
+    },
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    },
+};
+
+#define TIMER_0_ISR         (isr_tim1_cc)
+#define TIMER_1_ISR         (isr_tim3)
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A,  6), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_A,  7), .cc_chan = 1},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF1,
+        .bus      = APB1
+    }
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_B, 1),
+        .mosi_af  = GPIO_AF0,
+        .miso_af  = GPIO_AF0,
+        .sclk_af  = GPIO_AF0,
+        .cs_af    = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name   ADC configuration
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 2), 2 },
+    { GPIO_PIN(PORT_A, 3), 3 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_A, 5), 5 }
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     chronos \
     derfmega128 \
     hifive1 \

--- a/examples/dtls-echo/Makefile.ci
+++ b/examples/dtls-echo/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     b-l072z-lrwan1 \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     b-l072z-lrwan1 \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     derfmega128 \
     hifive1 \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2538dk \
     cc2650-launchpad \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/micropython/Makefile.ci
+++ b/examples/micropython/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     i-nucleo-lrwan1 \
     microbit \

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     microduino-corerf \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/examples/paho-mqtt/Makefile.ci
+++ b/examples/paho-mqtt/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     hifive1 \
     hifive1b \

--- a/examples/posix_select/Makefile.ci
+++ b/examples/posix_select/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     im880b \

--- a/examples/twr_aloha/Makefile.ci
+++ b/examples/twr_aloha/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     b-l072z-lrwan1 \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     im880b \
     nucleo-l011k4 \
     olimexino-stm32 \

--- a/tests/cond_order/Makefile.ci
+++ b/tests/cond_order/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030 \
     nucleo-f030r8 \

--- a/tests/driver_at86rf215/Makefile.ci
+++ b/tests/driver_at86rf215/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/driver_atwinc15x0/Makefile.ci
+++ b/tests/driver_atwinc15x0/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/driver_dose/Makefile.ci
+++ b/tests/driver_dose/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/driver_kw2xrf/Makefile.ci
+++ b/tests/driver_kw2xrf/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/driver_mrf24j40/Makefile.ci
+++ b/tests/driver_mrf24j40/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/driver_netdev_common/Makefile.ci
+++ b/tests/driver_netdev_common/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/driver_nrf24l01p_ng/Makefile.ci
+++ b/tests/driver_nrf24l01p_ng/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega128rfa1 \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/driver_w5100/Makefile.ci
+++ b/tests/driver_w5100/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_opt/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
+++ b/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_dns/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     mega-xplained \

--- a/tests/gnrc_mac_timeout/Makefile.ci
+++ b/tests/gnrc_mac_timeout/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/gnrc_rpl_p2p/Makefile.ci
+++ b/tests/gnrc_rpl_p2p/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_sixlowpan/Makefile.ci
+++ b/tests/gnrc_sixlowpan/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \
     hifive1b \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     derfmega128 \
     hifive1 \

--- a/tests/ieee802154_security/Makefile.ci
+++ b/tests/ieee802154_security/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/lwip_sock_ip/Makefile.ci
+++ b/tests/lwip_sock_ip/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/lwip_sock_tcp/Makefile.ci
+++ b/tests/lwip_sock_tcp/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/lwip_sock_udp/Makefile.ci
+++ b/tests/lwip_sock_udp/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/mutex_order/Makefile.ci
+++ b/tests/mutex_order/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/nanocoap_cli/Makefile.ci
+++ b/tests/nanocoap_cli/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     mega-xplained \
     microduino-corerf \

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     avr-rss2 \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     derfmega128 \
     derfmega256 \
     i-nucleo-lrwan1 \

--- a/tests/pkg_libcoap/Makefile.ci
+++ b/tests/pkg_libcoap/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/pkg_libcose/Makefile.ci
+++ b/tests/pkg_libcose/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg_libfixmath_unittests/Makefile.ci
+++ b/tests/pkg_libfixmath_unittests/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg_littlefs2/Makefile.ci
+++ b/tests/pkg_littlefs2/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg_lvgl/Makefile.ci
+++ b/tests/pkg_lvgl/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/pkg_lvgl_touch/Makefile.ci
+++ b/tests/pkg_lvgl_touch/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \
     nucleo-f042k6 \

--- a/tests/pkg_microcoap/Makefile.ci
+++ b/tests/pkg_microcoap/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     microduino-corerf \

--- a/tests/pkg_relic/Makefile.ci
+++ b/tests/pkg_relic/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pkg_spiffs/Makefile.ci
+++ b/tests/pkg_spiffs/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/pkg_tensorflow-lite/Makefile.ci
+++ b/tests/pkg_tensorflow-lite/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     b-l072z-lrwan1 \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     calliope-mini \
     feather-m0 \
     frdm-kw41z \

--- a/tests/pkg_tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg_tinydtls_sock_async/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/pkg_wolfssl/Makefile.ci
+++ b/tests/pkg_wolfssl/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     blackpill \
     bluepill \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/posix_semaphore/Makefile.ci
+++ b/tests/posix_semaphore/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     mbed_lpc1768 \
     msb-430 \

--- a/tests/ps_schedstatistics/Makefile.ci
+++ b/tests/ps_schedstatistics/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/pthread_rwlock/Makefile.ci
+++ b/tests/pthread_rwlock/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/rmutex/Makefile.ci
+++ b/tests/rmutex/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/rmutex_cpp/Makefile.ci
+++ b/tests/rmutex_cpp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/slip/Makefile.ci
+++ b/tests/slip/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/sntp/Makefile.ci
+++ b/tests/sntp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \
     microduino-corerf \

--- a/tests/sock_udp_aux/Makefile.ci
+++ b/tests/sock_udp_aux/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    bluepill-stm32f030c8 \
     calliope-mini \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/suit_manifest/Makefile.ci
+++ b/tests/suit_manifest/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
     chronos \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/thread_cooperation/Makefile.ci
+++ b/tests/thread_cooperation/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     blackpill-128kib \
     bluepill \
     bluepill-128kib \
+    bluepill-stm32f030c8 \
     calliope-mini \
     cc1312-launchpad \
     cc1352-launchpad \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like 
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

![STM32F030C8 based Bluepill](https://camo.githubusercontent.com/f33ec5f4068e1dcc4c549dbe3dc70d2ed784c19abf1c177f9640835180f88005/68747470733a2f2f696d616765732d6e612e73736c2d696d616765732d616d617a6f6e2e636f6d2f696d616765732f492f3631474765592532424c306a4c2e5f41435f534c313030305f2e6a7067)

This board is sold by several vendors on [AliExpress](https://aliexpress.com/item/4001132135566.html), [Amazon](https://www.amazon.de/ILS-STM32F030C8T6-Coreboard-Systemplatine-Development/dp/B07ZP1C7L7/) and [ebay](https://www.ebay.de/itm/STM32F030C8T6-Core-Board-System-Board-STM32-F0-ARM-Development-Board/123949949952).
It does not have name, but since it comes in the same form-factor and color as the Bluepill line of boards, I think it makes sense to use that name.

Flashing is a bit cumbersome as I always had to press the reset button in time when OpenOCD tries to connect to the CPU.
There is no dedicated reset pin exposed on the board.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
