### PR TITLE
stm32/flashpage: use void pointer for flash address

### DIFF
--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -248,16 +248,7 @@ void flashpage_write(int page, const void *data)
     assert(page < (int)(FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
-    /* STM32L0/L1 only supports word sizes */
-    uint32_t *page_addr = flashpage_addr(page);
-#elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32G4) || \
-      defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5)
-    uint64_t *page_addr = flashpage_addr(page);
-#else
-    /* Default is to support half-word sizes */
-    uint16_t *page_addr = flashpage_addr(page);
-#endif
+    void *page_addr = flashpage_addr(page);
 
     /* ERASE sequence */
     _erase_page(page_addr);


### PR DESCRIPTION
### Contribution description

The stm32 flashpage implementation has a number of ifdefs to assign different pointer types to store the flashpage address. This address is only used as void pointers in the called functions. This PR removes the ifdefs with the different pointer sizes, replacing it with a single line using a void pointer.

### Testing procedure

Compilation should be enough. Testing can be done using `tests/periph_flashpage` on the various stm32 devices.

### Issues/PRs references

None