### PR TITLE
pkg/nanocbor: fix decoding of indefinite arrays and maps

### DIFF
--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nanocbor
 PKG_URL     = https://github.com/bergzand/nanocbor
-PKG_VERSION = 3a672f79b2458a96393447e50a41174f741eadc5
+PKG_VERSION = 16e5a838b97fc3c912b8f419497e3fff2210994e
 PKG_LICENSE = LGPL-2.1
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanocbor/patches/0001-decoder-fix-decoding-of-indefinite-arrays-and-maps.patch
+++ b/pkg/nanocbor/patches/0001-decoder-fix-decoding-of-indefinite-arrays-and-maps.patch
@@ -1,0 +1,37 @@
+From 8f7e2123998b5444128ea907aaba0d847c502cde Mon Sep 17 00:00:00 2001
+From: Nishchay-sopho <nagrawal@ibr.cs.tu-bs.de>
+Date: Tue, 18 Aug 2020 14:34:55 +0200
+Subject: [PATCH] decoder: fix decoding of indefinite arrays and maps
+
+---
+ src/decoder.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/decoder.c b/src/decoder.c
+index 244a6b1..9cd27b8 100644
+--- a/src/decoder.c
++++ b/src/decoder.c
+@@ -76,9 +76,9 @@ bool nanocbor_at_end(const nanocbor_value_t *it)
+     if (_over_end(it) || /* Number of items exhausted */
+         /* Indefinite container and the current item is the end marker */
+         ((nanocbor_container_indefinite(it) &&
+-         *it->cur == (NANOCBOR_TYPE_FLOAT | NANOCBOR_SIZE_INDEFINITE))) ||
++         *it->cur == (NANOCBOR_TYPE_FLOAT << NANOCBOR_TYPE_OFFSET | NANOCBOR_VALUE_MASK))) ||
+         /* Or the remaining number of items is zero */
+-        (nanocbor_in_container(it) && it->remaining == 0)
++        (!nanocbor_container_indefinite(it) && nanocbor_in_container(it) && it->remaining == 0)
+             ) {
+         end = true;
+     }
+@@ -279,7 +279,7 @@ int _enter_container(nanocbor_value_t *it, nanocbor_value_t *container,
+     container->end = it->end;
+     container->remaining = 0;
+ 
+-    if (_value_match_exact(it, type | NANOCBOR_VALUE_MASK) == 1) {
++    if (_value_match_exact(it, (((unsigned)type << NANOCBOR_TYPE_OFFSET) | NANOCBOR_SIZE_INDEFINITE)) == 1) {
+         container->flags = NANOCBOR_DECODER_FLAG_INDEFINITE |
+                            NANOCBOR_DECODER_FLAG_CONTAINER;
+         container->cur = it->cur;
+-- 
+2.25.1
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There is a bug in NanoCBOR that prevents decoding of indefinite elements. 
An out-of-tree patch exists to fix that, include this in our pkg.


### Testing procedure

A test was added to `tests/pkg_nanocbor` to test encoding / decoding of an indefinite map.
The test will fail on `master`.


### Issues/PRs references

upstream PR https://github.com/bergzand/NanoCBOR/pull/21