### PR TITLE
cpu/efm32: RTC Series 0: use RTC helper functions

### DIFF
--- a/cpu/efm32/periph/rtc_series0.c
+++ b/cpu/efm32/periph/rtc_series0.c
@@ -34,7 +34,7 @@
 typedef struct {
     rtc_alarm_cb_t alarm_cb;        /**< callback called from RTC interrupt */
     void *alarm_arg;                /**< argument passed to the callback */
-    time_t alarm;                   /**< scheduled alarm (may be deferred) */
+    uint32_t alarm;                 /**< scheduled alarm (may be deferred) */
     uint8_t overflows;              /**< number of overflows */
 } rtc_state_t;
 
@@ -95,7 +95,7 @@ void rtc_init(void)
 
 int rtc_set_time(struct tm *time)
 {
-    time_t timestamp = mktime(time);
+    time_t timestamp = rtc_mktime(time);
 
     rtc_state.overflows = (timestamp >> RTC_SHIFT_VALUE);
     RTC->CNT = timestamp & RTC_MAX_VALUE;
@@ -109,7 +109,7 @@ int rtc_get_time(struct tm *time)
 
     timestamp = timestamp + (rtc_state.overflows << RTC_SHIFT_VALUE);
 
-    gmtime_r((time_t *) &timestamp, time);
+    rtc_localtime(timestamp, time);
 
     return 0;
 }
@@ -118,7 +118,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
     rtc_state.alarm_cb = cb;
     rtc_state.alarm_arg = arg;
-    rtc_state.alarm = mktime(time);
+    rtc_state.alarm = rtc_mktime(time);
 
     /* alarm may not be in reach of current time, so defer if needed */
     _set_alarm();
@@ -128,7 +128,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 
 int rtc_get_alarm(struct tm *time)
 {
-    gmtime_r((time_t *) &rtc_state.alarm, time);
+    rtc_localtime(rtc_state.alarm, time);
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

By using the RTC helper functions instead of POSIX `mktime()`/`gmtime()` we can not only extend the RTC range beyond Y2038, but also save some ROM.

For `tests/periph_rtc`:

#### before:

```
   text	   data	    bss	    dec	    hex	filename
  28028	    248	   2472	  30748	   781c stk3700/tests_periph_rtc.elf
```

#### after:

```
   text	   data	    bss	    dec	    hex	filename
  19400	    144	   2424	  21968	   55d0 stk3700/tests_periph_rtc.elf
```

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/periph_rtc` should still run on Series 0 MCUs.


### Issues/PRs references


fixes #13277

