### PR TITLE
gnrc/netif_bus: generate distinct events for global and link-local addresses

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -91,9 +91,9 @@ typedef enum {
  */
 typedef enum {
     /**
-     * @brief   Address becomes valid
+     * @brief   Link-Local Address becomes valid
      *
-     * The event is generated when an address on the interface becomes valid.
+     * The event is generated when a link-local address on the interface becomes valid.
      * The message payload contains a pointer to the respective
      * @ref ipv6_addr_t struct.
      *
@@ -101,7 +101,19 @@ typedef enum {
      * the event and processing it, the pointer will point to the new address
      * which might *not* be valid.
      */
-    GNRC_IPV6_EVENT_ADDR_VALID,
+    GNRC_IPV6_EVENT_LOCAL_ADDR_VALID,
+    /**
+     * @brief   Global Address becomes valid
+     *
+     * The event is generated when a global address on the interface becomes valid.
+     * The message payload contains a pointer to the respective
+     * @ref ipv6_addr_t struct.
+     *
+     * @note If the address on the interface changed between sending
+     * the event and processing it, the pointer will point to the new address
+     * which might *not* be valid.
+     */
+    GNRC_IPV6_EVENT_GLOBAL_ADDR_VALID,
 } gnrc_ipv6_event_t;
 
 /**

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -583,7 +583,10 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
                                  UINT32_MAX, UINT32_MAX);
         }
 
-        gnrc_netif_ipv6_bus_post(netif, GNRC_IPV6_EVENT_ADDR_VALID, &netif->ipv6.addrs[idx]);
+        gnrc_ipv6_event_t event = ipv6_addr_is_link_local(addr)
+                                ? GNRC_IPV6_EVENT_LOCAL_ADDR_VALID
+                                : GNRC_IPV6_EVENT_GLOBAL_ADDR_VALID;
+        gnrc_netif_ipv6_bus_post(netif, event, &netif->ipv6.addrs[idx]);
     }
     else if (IS_USED(MODULE_GNRC_IPV6) &&
              IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) &&

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -120,8 +120,12 @@ uint8_t _handle_aro(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                                  GNRC_IPV6_NIB_REREG_ADDRESS,
                                  &netif->ipv6.addrs_timers[idx],
                                  rereg_time);
-                    gnrc_netif_ipv6_bus_post(netif, GNRC_IPV6_EVENT_ADDR_VALID,
-                                  &netif->ipv6.addrs[idx]);
+
+                    gnrc_ipv6_event_t event = ipv6_addr_is_link_local(&ipv6->dst)
+                                            ? GNRC_IPV6_EVENT_LOCAL_ADDR_VALID
+                                            : GNRC_IPV6_EVENT_GLOBAL_ADDR_VALID;
+                    gnrc_netif_ipv6_bus_post(netif, event, &netif->ipv6.addrs[idx]);
+
                     break;
                 }
                 case SIXLOWPAN_ND_STATUS_DUP:

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -79,7 +79,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
          *    locked here) */
         netif->ipv6.addrs_flags[idx] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
         netif->ipv6.addrs_flags[idx] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
-        gnrc_netif_ipv6_bus_post(netif, GNRC_IPV6_EVENT_ADDR_VALID, &netif->ipv6.addrs[idx]);
+        gnrc_netif_ipv6_bus_post(netif, GNRC_IPV6_EVENT_LOCAL_ADDR_VALID, &netif->ipv6.addrs[idx]);
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
@@ -213,7 +213,11 @@ void _handle_valid_addr(const ipv6_addr_t *addr)
     if (idx >= 0) {
         netif->ipv6.addrs_flags[idx] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
         netif->ipv6.addrs_flags[idx] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
-        gnrc_netif_ipv6_bus_post(netif, GNRC_IPV6_EVENT_ADDR_VALID, &netif->ipv6.addrs[idx]);
+
+        gnrc_ipv6_event_t event = ipv6_addr_is_link_local(addr)
+                                ? GNRC_IPV6_EVENT_LOCAL_ADDR_VALID
+                                : GNRC_IPV6_EVENT_GLOBAL_ADDR_VALID;
+        gnrc_netif_ipv6_bus_post(netif, event, &netif->ipv6.addrs[idx]);
     }
     if (netif != NULL) {
         /* was acquired in `_get_netif_state()` */


### PR DESCRIPTION

### Contribution description

The `GNRC_IPV6_EVENT_ADDR_VALID event would be generated for *both* link-local and global addresses.

So if a user wants to be notified about a global address, they have to do

```C
    msg_bus_subscribe(&sub, GNRC_IPV6_EVENT_ADDR_VALID);
    msg_t m;
    do {
        if (xtimer_msg_receive_timeout(&m, ADDR_TIMEOUT_US) < 0) {
            return -1;
        }
    } while (ipv6_addr_is_link_local(m.content.ptr));
```

This is cumbersome and error-prone.

Instead, introduce a two separate events for link-local and global addresses.
Now we don't have to loop anymore until the 'proper' message is received, we
can simply do

```C
    msg_bus_subscribe(&sub, GNRC_IPV6_EVENT_GLOBAL_ADDR_VALID);
    return xtimer_msg_receive_timeout(&m, ADDR_TIMEOUT_US);
```
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
