### PR TITLE
pkg/tinydtls: set address family of session endpoint on sock_dtls_recv

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -573,6 +573,7 @@ static void _session_to_ep(const session_t *session, sock_udp_ep_t *ep)
 {
     ep->port = session->port;
     ep->netif = session->ifindex;
+    ep->family = AF_INET6;
     memcpy(&ep->addr.ipv6, &session->addr, sizeof(ipv6_addr_t));
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When using tinydtls with asynchronous events the address family of the session endpoint is not set when a `SOCK_ASNYC_MSG_RECV` event occurs and the session is received via `sock_dtls_recv`. This fixes the bug by setting the address family when the endpoint is created out of the session in tinydtls.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
[This](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_tinydtls_sock_async) test can be used as application together with this patch:
```
diff --git a/tests/pkg_tinydtls_sock_async/dtls-client.c b/tests/pkg_tinydtls_sock_async/dtls-client.c
index 2cafecc18..f3c833c90 100644
--- a/tests/pkg_tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-client.c
@@ -147,6 +147,15 @@ static void _dtls_handler(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
             printf("Received %d bytes: \"%.*s\"\n", (int)res, (int)res,
                    (char *)_recv_buf);
         }
+        printf("Session.ep.family: ");
+        switch (session.ep.family) {
+            case (AF_INET6):
+                printf("AF_INET6\n");
+                break;
+            case (AF_UNSPEC):
+                printf("AF_UNSPEC\n");
+                break;
+        }
         puts("Terminating session");
         sock_dtls_session_destroy(sock, &session);
         _close_sock(sock);
```
- Create two tap interfaces (e.g. with [tapsetup](https://github.com/RIOT-OS/RIOT/tree/master/dist/tools/tapsetup)) and run the application on both interfaces
- Start DTLS server on one of the instances: `dtlss start`
- Send DTLS message from the other instance: `dtlsc {addr} {data}`

Without the fix `Session.ep.family: AF_UNSPEC` should be printed since no address family is set after receiving
With fix the result should be `Session.ep.family: AF_INET6`  

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
