### PR TITLE
.murdock: run Kconfig compilation first when needed

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -2,7 +2,6 @@
 
 : ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 samr21-xpro"}
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
-# we can't use '-' in the variable names, convert them to '_' to add new boards
 : ${TEST_KCONFIG_samr21_xpro:="examples/hello-world tests/periph_*"}
 
 export RIOT_CI_BUILD=1
@@ -37,7 +36,7 @@ DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE
 
 get_kconfig_test_apps() {
     case "$1" in
-        "samr21_xpro") echo "${TEST_KCONFIG_samr21_xpro}" ;;
+        "samr21-xpro") echo "${TEST_KCONFIG_samr21_xpro}" ;;
     esac
 }
 
@@ -245,12 +244,9 @@ compile() {
     # list of board-application tuples that are currently modeled to
     # run with Kconfig
 
-    # we can't use '-' in variable names
-    _board=$(echo ${board} | tr '-' '_')
-
     should_check_kconfig_hash=0
 
-    for app in $(get_kconfig_test_apps "${_board}")
+    for app in $(get_kconfig_test_apps "${board}")
     do
         if [ "${appdir}" = "${app}" ]; then
             should_check_kconfig_hash=1

--- a/.murdock
+++ b/.murdock
@@ -240,37 +240,46 @@ compile() {
     [ $# -ne 2 ] && error "$0: compile: invalid parameters (expected \$appdir \$board:\$toolchain)"
     [ ! -d "$appdir" ] && error "$0: compile: error: application directory \"$appdir\" doesn't exist"
 
-    # compile
+    # We compile a first time with Kconfig based dependency
+    # resolution for regression purposes. $TEST_KCONFIG contains a
+    # list of board-application tuples that are currently modeled to
+    # run with Kconfig
+
+    # we can't use '-' in variable names
+    _board=$(echo ${board} | tr '-' '_')
+
+    should_check_kconfig_hash=0
+
+    for app in $(get_kconfig_test_apps "${_board}")
+    do
+        if [ "${appdir}" = "${app}" ]; then
+            should_check_kconfig_hash=1
+            BOARD=${board} make -C${appdir} clean
+            CCACHE_BASEDIR="$(pwd)" BOARD=${board} TOOLCHAIN=${toolchain} RIOT_CI_BUILD=1 TEST_KCONFIG=1 \
+                            make -C${appdir} all test-input-hash -j${JOBS:-4}
+            RES=$?
+            if [ $RES -eq 0 ]; then
+                kconfig_test_hash=$(test_hash_calc "${BINDIR}")
+            else
+                kconfig_test_hash=0
+                echo "An error occurred while compiling using Kconfig";
+            fi
+        fi
+    done
+
+    # compile without Kconfig
     CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 \
         make -C${appdir} clean all test-input-hash -j${JOBS:-4}
     RES=$?
 
     test_hash=$(test_hash_calc "$BINDIR")
 
-    # We compile a second time with Kconfig based dependency
-    # resolution for regression purposes. $TEST_KCONFIG contains a
-    # list of board-application tuples that are currently modeled to
-    # run with Kconfig
-    if [ $RES -eq 0 ]; then
-        # we can't use '-' in variable names
-        _board=$(echo ${board} | tr '-' '_')
-
-        for app in $(get_kconfig_test_apps "${_board}")
-        do
-            if [ "${appdir}" = "${app}" ]; then
-                BOARD=$board make -C${appdir} clean
-                CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 TEST_KCONFIG=1 \
-                              make -C${appdir} all test-input-hash -j${JOBS:-4}
-                RES=$?
-                if [ $RES -eq 0 ]; then
-                    new_test_hash=$(test_hash_calc "$BINDIR")
-                    if [ ${new_test_hash} != ${test_hash} ]; then
-                        echo "Hashes of binaries mismatch for ${app}";
-                        RES=1
-                    fi
-                fi
-            fi
-        done
+    if [ ${should_check_kconfig_hash} != 0 ]; then
+        if [ ${kconfig_test_hash} != ${test_hash} ]; then
+            echo "Hashes of binaries with and without Kconfig mismatch for ${app}";
+            echo "Please check that all used modules are modelled in Kconfig and enabled";
+            RES=1
+        fi
     fi
 
     # run tests


### PR DESCRIPTION
### Contribution description
This changes the CI script to compile with Kconfig first (when needed) and run the tests with the normal binary. This avoids having to test the `TEST_KCONFIG` flag during the test stage, and follows the previous behaviour.

### Testing procedure
Green CI

### Issues/PRs references
None
