### PR TITLE
Kconfig: add modules to test on native

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -4,6 +4,7 @@
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 # we can't use '-' in the variable names, convert them to '_' to add new boards
 : ${TEST_KCONFIG_samr21_xpro:="examples/hello-world tests/periph_*"}
+: ${TEST_KCONFIG_native:="examples/hello-world tests/periph_*"}
 
 export RIOT_CI_BUILD=1
 export CC_NOCOLOR=1
@@ -38,6 +39,9 @@ DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE
 get_kconfig_test_apps() {
     case "$1" in
         "samr21_xpro") echo "${TEST_KCONFIG_samr21_xpro}" ;;
+    esac
+    case "$1" in
+        "native") echo "${TEST_KCONFIG_native}" ;;
     esac
 }
 

--- a/boards/native/Kconfig
+++ b/boards/native/Kconfig
@@ -24,3 +24,5 @@ config BOARD_NATIVE
     # Various other features (if any)
     select HAS_ETHERNET
     select HAS_MOTOR_DRIVER
+
+rsource "drivers/Kconfig"

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -19,4 +19,4 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += random
 endif
 
-USEMODULE += native-drivers
+USEMODULE += native_drivers

--- a/boards/native/drivers/Kconfig
+++ b/boards/native/drivers/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_NATIVE_DRIVERS
+    bool
+    depends on BOARD_NATIVE
+    depends on TEST_KCONFIG
+    default y
+    help
+        Drivers for Native board.

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -1,3 +1,3 @@
-MODULE = native-drivers
+MODULE = native_drivers
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -19,6 +19,9 @@ config CPU_ARCH_NATIVE
     select HAS_PERIPH_PWM
     select HAS_SSP
 
+    # needed modules
+    select MODULE_PERIPH if TEST_KCONFIG
+
 config CPU_CORE_NATIVE
     bool
     select CPU_ARCH_NATIVE

--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -77,3 +77,10 @@ config CPU_MODEL
 
 config CPU
     default "native" if CPU_MODEL_NATIVE
+
+menu "Native modules"
+    depends on CPU_ARCH_NATIVE
+
+rsource "backtrace/Kconfig"
+
+endmenu # Native modules

--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -84,3 +84,5 @@ menu "Native modules"
 rsource "backtrace/Kconfig"
 
 endmenu # Native modules
+
+rsource "periph/Kconfig"

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -25,3 +25,9 @@ ifeq ($(OS),Linux)
   # CAN is only supported on Linux through socketCAN
   FEATURES_PROVIDED += periph_can
 endif
+
+# This configuration enables modules that are only available when using Kconfig
+# module modelling
+ifeq (1, $(TEST_KCONFIG))
+  KCONFIG_ADD_CONFIG += $(RIOTCPU)/native/native.config
+endif

--- a/cpu/native/backtrace/Kconfig
+++ b/cpu/native/backtrace/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_BACKTRACE
+    bool "Stack backtrace"
+    depends on CPU_ARCH_NATIVE
+    depends on TEST_KCONFIG

--- a/cpu/native/native.config
+++ b/cpu/native/native.config
@@ -1,0 +1,2 @@
+# UART is needed by startup.c
+CONFIG_MODULE_PERIPH_UART=y

--- a/cpu/native/periph/Kconfig
+++ b/cpu/native/periph/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_PERIPH_SPIDEV_LINUX
+    bool
+    default y if MODULE_PERIPH_SPI
+    depends on NATIVE_OS_LINUX
+
+config MODULE_PERIPH_INIT_SPIDEV_LINUX
+    bool
+    default y
+    depends on MODULE_PERIPH_SPIDEV_LINUX

--- a/cpu/native/periph/Kconfig.gpio
+++ b/cpu/native/periph/Kconfig.gpio
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+choice NATIVE_GPIO_IMPLEMENTATION
+    bool "Native GPIO peripheral implementation"
+    depends on MODULE_PERIPH_GPIO
+    depends on CPU_ARCH_NATIVE
+    depends on TEST_KCONFIG
+    default MODULE_PERIPH_GPIO_LINUX if NATIVE_OS_LINUX
+
+config MODULE_PERIPH_GPIO_LINUX
+    bool "Linux GPIO"
+    depends on NATIVE_OS_LINUX
+
+config MODULE_PERIPH_GPIO_MOCK
+    bool "Mock"
+
+endchoice
+
+# TODO: these modules are actually just artifacts from the way periph_init_%
+# modules are handled in Makefile. We need to define them to keep the list the
+# same for now. We should be able to remove them later on.
+
+config MODULE_PERIPH_INIT_GPIO_LINUX
+    bool
+    default y if MODULE_PERIPH_INIT
+    depends on MODULE_PERIPH_GPIO_LINUX
+
+config MODULE_PERIPH_INIT_GPIO_MOCK
+    bool
+    default y if MODULE_PERIPH_INIT
+    depends on MODULE_PERIPH_GPIO_MOCK

--- a/cpu/native/periph/Kconfig.rtc
+++ b/cpu/native/periph/Kconfig.rtc
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_PERIPH_RTC
+    select MODULE_XTIMER if CPU_ARCH_NATIVE
+    depends on HAS_PERIPH_RTC

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -115,15 +115,7 @@ config MODULE_PERIPH_INIT_QDEC
     default y if MODULE_PERIPH_INIT
     depends on MODULE_PERIPH_QDEC
 
-config MODULE_PERIPH_RTC
-    bool "RTC peripheral driver"
-    depends on HAS_PERIPH_RTC
-    select MODULE_PERIPH_COMMON
-
-config MODULE_PERIPH_INIT_RTC
-    bool "Auto initialize RTC peripheral"
-    default y if MODULE_PERIPH_INIT
-    depends on MODULE_PERIPH_RTC
+rsource "Kconfig.rtc"
 
 config MODULE_PERIPH_RTT
     bool "RTT peripheral driver"

--- a/drivers/periph_common/Kconfig.gpio
+++ b/drivers/periph_common/Kconfig.gpio
@@ -44,3 +44,5 @@ config MODULE_PERIPH_INIT_GPIO_FAST_READ
     depends on MODULE_PERIPH_GPIO_FAST_READ
 
 endif # MODULE_PERIPH_GPIO
+
+osource "$(RIOTCPU)/$(CPU)/periph/Kconfig.gpio"

--- a/drivers/periph_common/Kconfig.rtc
+++ b/drivers/periph_common/Kconfig.rtc
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_PERIPH_RTC
+    bool "RTC peripheral driver"
+    depends on HAS_PERIPH_RTC
+    select MODULE_PERIPH_COMMON
+
+config MODULE_PERIPH_INIT_RTC
+    bool "Auto initialize RTC peripheral"
+    default y if MODULE_PERIPH_INIT
+    depends on MODULE_PERIPH_RTC
+
+# Include CPU specific configurations
+osource "$(RIOTCPU)/$(CPU)/periph/Kconfig.rtc"

--- a/sys/Kconfig.stdio
+++ b/sys/Kconfig.stdio
@@ -10,10 +10,11 @@ menu "Standard Input/Output (STDIO)"
 
 choice
     bool "STDIO implementation"
+    default MODULE_STDIO_NATIVE if CPU_ARCH_NATIVE
     default MODULE_STDIO_UART
 
 # TODO: Add MODULE_STDIO_CDC_ACM, MODULE_STDIO_RTT, MODULE_SLIPDEV_STDIO,
-# MODULE_STDIO_NATIVE and MODULE_STDIO_ETHOS
+# and MODULE_STDIO_ETHOS
 
 config MODULE_STDIO_NULL
     bool "Null"
@@ -24,6 +25,10 @@ config MODULE_STDIO_UART
     bool "UART"
     depends on HAS_PERIPH_UART
     select MODULE_PERIPH_UART
+
+config MODULE_STDIO_NATIVE
+    bool "Native"
+    depends on CPU_ARCH_NATIVE
 
 endchoice
 

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -12,6 +12,10 @@ USEMODULE += benchmark
 # disable native GPIOs for automatic test
 ifeq (native,$(BOARD))
   USEMODULE += periph_gpio_mock
+  # the same for Kconfig
+  ifeq (1,$(TEST_KCONFIG))
+    KCONFIG_ADD_CONFIG += $(APPDIR)/app.config.test.native
+  endif
 endif
 
 BOARDS_BENCH_PORT_1 = \

--- a/tests/periph_gpio/app.config.test.native
+++ b/tests/periph_gpio/app.config.test.native
@@ -1,0 +1,2 @@
+# disable native GPIOs for automatic test
+CONFIG_MODULE_PERIPH_GPIO_MOCK=y


### PR DESCRIPTION
### Contribution description
This continues modelling modules in Kconfig and adds `native` to the same Kconfig tests that we run for the `samr21-xpro`.

### Testing procedure
- Green CI
- Check that the dependencies are correctly modelled
- Peripheral test applications should still work as usual when using `TEST_KCONFIG=1`
- Non-supported applications should explain the missing features/modules.
- Usage of Kconfig as usual (without `TEST_KCONFIG=1`) should still work normally

### Issues/PRs references
Related to #14055