### PR TITLE
boards/efm32: update channel_numof with correct values

### DIFF
--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -148,7 +148,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 4
+        .channel_numof = 3
     },
     {
         .prescaler = {

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -125,7 +125,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 4
+        .channel_numof = 3
     },
     {
         .prescaler = {

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -155,7 +155,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 4
+        .channel_numof = 3
     },
     {
         .prescaler = {

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -146,7 +146,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_WTIMER1
         },
         .irq = WTIMER1_IRQn,
-        .channel_numof = 4
+        .channel_numof = 3
     },
     {
         .prescaler = {
@@ -158,7 +158,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 4
+        .channel_numof = 3
     },
     {
         .prescaler = {

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -155,7 +155,7 @@ static const timer_conf_t timer_config[] = {
             .cmu = cmuClock_TIMER1
         },
         .irq = TIMER1_IRQn,
-        .channel_numof = 4
+        .channel_numof = 3
     },
     {
         .prescaler = {

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -14,6 +14,7 @@ BOARDS_TIMER_250kHz := \
 BOARDS_TIMER_32kHz := \
     hifive1 \
     hifive1b \
+    ikea-tradfri \
     %-kw41z \
     openlabs-kw41z-mini \
     frdm-k64f \
@@ -21,6 +22,7 @@ BOARDS_TIMER_32kHz := \
     slstk3401a \
     slstk3402a \
     sltb001a \
+    slwstk6000b-% \
     slwstk6220a \
     stk3600 \
     stk3700 \


### PR DESCRIPTION
### Contribution description
In #15368 I changed the number of channels for some EFM32-based boards to 4. This is only true for TIMER1 or higher, not for TIMER0. The documentation and vendor files threw me off, unfortunately. This PR reverts this.

Series 0 boards are unaffected, because they have only three channels. #15377 and #15299 are correct.

While at it, I also added some boards to `tests/periph_timer`, otherwise the tests halts.

### Testing procedure
Test `tests/periph_timer` with a SLTB001a, SLSTK3401a, SLSTK3402a or SLWSTK6000b. Without this patch, the application won't pass.

### Issues/PRs references
#15368