### PR TITLE
boards/common/silabs: define CPU=efm32

### DIFF
--- a/boards/common/silabs/Makefile.features
+++ b/boards/common/silabs/Makefile.features
@@ -1,3 +1,5 @@
+CPU = efm32
+
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += riotboot

--- a/boards/common/slwstk6000b/Makefile.features
+++ b/boards/common/slwstk6000b/Makefile.features
@@ -1,5 +1,3 @@
-CPU = efm32
-
 # The radio board connected to the slwstk6000b mainboard
 BOARD_MODULE = $(word 2, $(subst -, ,$(BOARD)))
 

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32pg1b
 CPU_MODEL = efm32pg1b200f256gm48
 

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32pg12b
 CPU_MODEL = efm32pg12b500f1024gl125
 

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efr32mg1p
 CPU_MODEL = efr32mg1p132f256gm48
 

--- a/boards/slwstk6220a/Makefile.features
+++ b/boards/slwstk6220a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = ezr32wg
 CPU_MODEL = ezr32wg330f256r60
 

--- a/boards/stk3200/Makefile.features
+++ b/boards/stk3200/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32zg
 CPU_MODEL = efm32zg222f32
 

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32lg
 CPU_MODEL = efm32lg990f256
 

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32gg
 CPU_MODEL = efm32gg990f1024
 


### PR DESCRIPTION
### Contribution description
This moved `CPU = efm32` to `boards/common/silabs`, as suggested by @leandrolanzieri.

### Testing procedure
The net change should be the same. Murdock should be happy.

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/15377#discussion_r517191364
