### PR TITLE
tests/pkg_cryptoauthlib: remove efm32 from blacklist

### DIFF
--- a/cpu/efm32/include/cpu_conf.h
+++ b/cpu/efm32/include/cpu_conf.h
@@ -24,6 +24,12 @@
 
 #include "em_device.h"
 
+/* avoid namespace conflict */
+#ifdef AES_COUNT
+#define EFM32_AES_COUNT AES_COUNT
+#undef AES_COUNT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -27,7 +27,6 @@
 
 #include "em_adc.h"
 #include "em_cmu.h"
-#include "em_device.h"
 #include "em_gpio.h"
 #include "em_timer.h"
 #include "em_usart.h"

--- a/tests/pkg_cryptoauthlib_compare_sha256/Makefile
+++ b/tests/pkg_cryptoauthlib_compare_sha256/Makefile
@@ -1,10 +1,5 @@
 include ../Makefile.tests_common
 
-# Test fails to build for these boards fails due to
-# redefinition of define AES_COUNT in library, which
-# is also defined in efm32 header files
-BOARD_BLACKLIST := stk3200 stk3600 stk3700
-
 USEPKG += cryptoauthlib
 USEMODULE += hashes
 

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile
@@ -1,10 +1,5 @@
 include ../Makefile.tests_common
 
-# Test fails to build for these boards fails due to
-# redefinition of define AES_COUNT in library, which
-# is also defined in board header files
-BOARD_BLACKLIST := stk3200 stk3600 stk3700
-
 # due to memory constrains we ignore the cert test
 CFLAGS += -DDO_NOT_TEST_CERT
 USEPKG += cryptoauthlib


### PR DESCRIPTION
### Contribution description

Both efm32 and cryptoauthlib define `AES_COUNT`.
Since the efm32 name would only be used in vendor code (which would not use our `cpu_conf.h`) we should be able to get away with redefining this with an `EFM32_` prefix.

This solves the namespace conflict between the package and the CPU.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
