### PR TITLE
boards/native: allow to use ZEP instead of tap

### DIFF
--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -1,5 +1,7 @@
 ifneq (,$(filter netdev_default,$(USEMODULE)))
-  USEMODULE += netdev_tap
+  ifeq (,$(filter socket_zep,$(USEMODULE)))
+    USEMODULE += netdev_tap
+  endif
 endif
 
 ifneq (,$(filter mtd,$(USEMODULE)))

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -69,7 +69,7 @@ endif
 LINKFLAGS += -ffunction-sections
 
 # set the tap interface for term/valgrind
-ifneq (,$(filter netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_tap,$(USEMODULE)))
   PORT ?= tap0
 endif
 

--- a/examples/gnrc_border_router/Makefile.board.dep
+++ b/examples/gnrc_border_router/Makefile.board.dep
@@ -13,6 +13,7 @@ ifeq (,$(filter native,$(BOARD)))
     endif
   endif
 else
+  USEMODULE += netdev_tap
   USEMODULE += socket_zep
   USEMODULE += socket_zep_hello
 endif

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.board.dep
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.board.dep
@@ -1,5 +1,6 @@
 # Put board specific dependencies here
 ifeq (native,$(BOARD))
+  USEMODULE += netdev_tap
   USEMODULE += socket_zep
 else
   USEMODULE += stdio_ethos


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If `native` is compiled with `USEMODULE=socket_zep` and networking, don't also include `netdev_tap` automatically.

This mirrors the behavior on nrf52 and esp* where the default netdev can be 'overwritten' by another option.


### Testing procedure

Compile `examples/gnrc_networking` with `socket_zep` support:

    make -C examples/gnrc_networking BOARD=native USE_ZEP=1 all term 

You should only have one (socket ZEP) interface, no second `netdev_tap` interface.


### Issues/PRs references

split off #14755
