### PR TITLE
periph/rtt: fix overflow in tick conversion macros

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -106,35 +106,35 @@ extern "C" {
  * @param[in]   us      number of microseconds
  * @return              rtt ticks
  */
-#define RTT_US_TO_TICKS(us)     ((uint32_t)((uint64_t)(us) * RTT_FREQUENCY / 1000000UL))
+#define RTT_US_TO_TICKS(us)     (RTT_SEC_TO_TICKS(us) / 1000000UL)
 
 /**
  * @brief       Convert milliseconds to rtt ticks
  * @param[in]   ms      number of milliseconds
  * @return              rtt ticks
  */
-#define RTT_MS_TO_TICKS(ms)     ( RTT_US_TO_TICKS((ms) * 1000) )
+#define RTT_MS_TO_TICKS(ms)     (RTT_SEC_TO_TICKS(ms) / 1000UL)
 
 /**
  * @brief       Convert seconds to rtt ticks
  * @param[in]   sec     number of seconds
  * @return              rtt ticks
  */
-#define RTT_SEC_TO_TICKS(sec)   ( RTT_MS_TO_TICKS((sec) * 1000) )
+#define RTT_SEC_TO_TICKS(sec)   (sec * RTT_FREQUENCY)
 
 /**
  * @brief       Convert minutes to rtt ticks
  * @param[in]   min     number of minutes
  * @return              rtt ticks
  */
-#define RTT_MIN_TO_TICKS(min)   ( RTT_SEC_TO_TICKS((min) * 60) )
+#define RTT_MIN_TO_TICKS(min)   (RTT_SEC_TO_TICKS((min) * 60))
 
 /**
  * @brief       Convert rtt ticks to microseconds
  * @param[in]   ticks   rtt ticks
  * @return              number of microseconds
  */
-#define RTT_TICKS_TO_US(ticks)  ((uint32_t)((uint64_t)(ticks) * 1000000UL / RTT_FREQUENCY))
+#define RTT_TICKS_TO_US(ticks)  ((uint64_t)(ticks) * 1000000UL / RTT_FREQUENCY)
 
 /**
  * @brief       Convert rtt ticks to milliseconds

--- a/tests/periph_rtt/main.c
+++ b/tests/periph_rtt/main.c
@@ -33,6 +33,8 @@
 
 static volatile uint32_t last;
 
+static const uint32_t _ticktest[] = { 1, 256, 65536, 16777216, 2147483648 };
+
 void cb(void *arg)
 {
     (void)arg;
@@ -47,11 +49,29 @@ void cb(void *arg)
 int main(void)
 {
     puts("\nRIOT RTT low-level driver test");
-    puts("This test will display 'Hello' every 5 seconds\n");
+
+    puts("RTT configuration:");
+    printf("RTT_MAX_VALUE: 0x%08x\n", (unsigned)RTT_MAX_VALUE);
+    printf("RTT_FREQUENCY: %u\n\n", (unsigned)RTT_FREQUENCY);
+
+    puts("Testing the tick conversion");
+    for (unsigned i = 0; i < ARRAY_SIZE(_ticktest); i++) {
+        uint32_t sec = RTT_TICKS_TO_SEC(_ticktest[i]);
+        uint32_t ticks = RTT_SEC_TO_TICKS(sec);
+        printf("Trying to convert %" PRIu32 " to seconds and back\n",
+               _ticktest[i]);
+        /* account for rounding errors... */
+        if ((ticks != 0) && (ticks != _ticktest[i])) {
+            puts("error: TICK conversion not working as expected\n");
+            return 1;
+        }
+    }
+    puts("All ok\n");
 
     puts("Initializing the RTT driver");
     rtt_init();
 
+    puts("This test will now display 'Hello' every 5 seconds\n");
     uint32_t now = rtt_get_counter();
     printf("RTT now: %" PRIu32 "\n", now);
 

--- a/tests/periph_rtt/tests/01-run.py
+++ b/tests/periph_rtt/tests/01-run.py
@@ -16,9 +16,12 @@ MAX_HELLOS = 5
 
 
 def testfunc(child):
-    child.expect(r'This test will display \'Hello\' every (\d+) seconds')
-    period = int(child.match.group(1))
+    child.expect_exact('Testing the tick conversion')
+    child.expect_exact('All ok')
+
     child.expect_exact('Initializing the RTT driver')
+    child.expect(r'This test will now display \'Hello\' every (\d+) seconds')
+    period = int(child.match.group(1))
     child.expect(r'RTT now: \d+')
     child.expect(r'Setting initial alarm to now \+ {} s \(\d+\)'
                  .format(period))


### PR DESCRIPTION
### Contribution description
The tick conversion macros provided by the `periph/rtt` driver are subject to overflow for large values. E.g. when doing something like 
```
uint32_t ticks = RTT_TICKS_TO_MS(RTT_MAX_VALUE + 1);
// with RTT_MAX_VALUE = 0x00ffffff -> 24 bit counter
// and RTT_FREQUENCY 1024 -> e.g. on the nrf52dk
```
the resulting tick value will be wrong. Reason is this line:
```
#define RTT_TICKS_TO_US(ticks)  ((uint32_t)((uint64_t)(ticks) * 1000000UL / RTT_FREQUENCY))
```
-> the value of `ticks * 10000000 / RTT_FREQUENCY` is larger then `UINT32_MAX`, and therefore overflows. And as this macro is used in a `RTT_TICKS_TO_MIN() -> RTT_TICKS_TO_SEC() -> RTT_TICKS_TO_MS() -> RTT_TICKS_TO_US()` cascade, all resulting values will be flawed.

The same goes for the time-to-tick conversion the other way around...

This PR fixes this by omitting the explicit cast to `uint32_t` in both directions. Now when assiging `uint32_t foo = RTT_TICKS_TO_US()` with a (static) value larger then `UINT32_MAX` the compiler will shout at you :-)

Also added some basic tests for the tick conversion to the test application.


### Testing procedure
Run the included version of the test application on any platform of your choice, it should fail. Run it with the fix included in this PR -> it should run successfully..

### Issues/PRs references
none