### PR TITLE
drivers/network devices: remove unused netif dependency

### DIFF
--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -1,6 +1,5 @@
 ifneq (,$(filter cc2538_rf,$(USEMODULE)))
   USEMODULE += netdev_ieee802154
-  USEMODULE += netif
 endif
 
 ifneq (,$(filter periph_rtc,$(USEMODULE)))

--- a/drivers/at86rf215/Makefile.dep
+++ b/drivers/at86rf215/Makefile.dep
@@ -21,6 +21,5 @@ FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_spi
 
 USEMODULE += xtimer
-USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154

--- a/drivers/at86rf2xx/Makefile.dep
+++ b/drivers/at86rf2xx/Makefile.dep
@@ -2,7 +2,6 @@ DEFAULT_MODULE += auto_init_at86rf2xx
 DEFAULT_MODULE += netdev_ieee802154_oqpsk
 
 USEMODULE += xtimer
-USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 

--- a/drivers/cc110x/Makefile.dep
+++ b/drivers/cc110x/Makefile.dep
@@ -1,6 +1,5 @@
 USEMODULE += cc1xxx_common
 USEMODULE += luid
-USEMODULE += netif
 USEMODULE += xtimer
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/cc2420/Makefile.dep
+++ b/drivers/cc2420/Makefile.dep
@@ -1,6 +1,5 @@
 USEMODULE += xtimer
 USEMODULE += luid
-USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 FEATURES_REQUIRED += periph_gpio

--- a/drivers/kw2xrf/Makefile.dep
+++ b/drivers/kw2xrf/Makefile.dep
@@ -1,5 +1,4 @@
 USEMODULE += luid
-USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 USEMODULE += core_thread_flags

--- a/drivers/kw41zrf/Makefile.dep
+++ b/drivers/kw41zrf/Makefile.dep
@@ -1,4 +1,3 @@
-USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 USEMODULE += core_thread_flags

--- a/drivers/mrf24j40/Makefile.dep
+++ b/drivers/mrf24j40/Makefile.dep
@@ -1,6 +1,5 @@
 USEMODULE += xtimer
 USEMODULE += luid
-USEMODULE += netif
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 FEATURES_REQUIRED += periph_gpio

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -21,7 +21,6 @@
  */
 
 #include "byteorder.h"
-#include "net/gnrc.h"
 #include "mrf24j40_registers.h"
 #include "mrf24j40_internal.h"
 #include "mrf24j40_netdev.h"

--- a/drivers/sx127x/Makefile.dep
+++ b/drivers/sx127x/Makefile.dep
@@ -12,7 +12,6 @@ ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
   USEMODULE += ztimer_periph_rtt
 endif
 
-USEMODULE += netif
 USEMODULE += lora
 
 ifneq (,$(filter gnrc,$(USEMODULE)))

--- a/drivers/xbee/Makefile.dep
+++ b/drivers/xbee/Makefile.dep
@@ -2,4 +2,3 @@ FEATURES_REQUIRED += periph_uart
 FEATURES_REQUIRED += periph_gpio
 USEMODULE += ieee802154
 USEMODULE += xtimer
-USEMODULE += netif


### PR DESCRIPTION
### Contribution description
This removes the unused dependency on `netif` from multiple network device drivers. Also a GNRC header inclusion is removed from the mrf24j40 radio driver.

### Testing procedure
- The binaries on the tests applications should be the same (here only makes sense to check the ones that no longer pull `netif`)
- Check for references to netif in the drivers
 
### Issues/PRs references
None