### PR TITLE
dist/tools/jlink: add -nogui to version test, fix for OSX

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -157,7 +157,9 @@ test_term() {
 
 test_version() {
     JLINK_MINIMUM_VERSION="6.74"
-    JLINK_VERSION=$(echo q | "$JLINK" 2> /dev/null | grep "^DLL version*" | grep -oP "\d+\.\d+")
+    # Adding '-nogui 1' will simply return 'Unknown command line option -nogui'
+    # on older versions, JLINK_VERSION will still be parsed correctly.
+    JLINK_VERSION=$(echo q | "${JLINK}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oP "\d+\.\d+")
 
     if [ $? -ne 0 ]; then
         echo "Error: J-Link appears not to be installed on your PATH"

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -159,7 +159,7 @@ test_version() {
     JLINK_MINIMUM_VERSION="6.74"
     # Adding '-nogui 1' will simply return 'Unknown command line option -nogui'
     # on older versions, JLINK_VERSION will still be parsed correctly.
-    JLINK_VERSION=$(echo q | "${JLINK}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oP "\d+\.\d+")
+    JLINK_VERSION=$(echo q | "${JLINK}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oE "[0-9]+\.[0-9]+")
 
     if [ $? -ne 0 ]; then
         echo "Error: J-Link appears not to be installed on your PATH"


### PR DESCRIPTION
### Contribution description

If multiple debuggers are present when testing for JLinkExe version
a GUI will open to select the debugger to attach, so add -nogui
when testing for version as well.


### Testing procedure

Attempt flashing with multiple jlink devices connected a gui will open. With this PR it does not.