### PR TITLE
core/mutex: Add mutex_cancel

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -127,6 +127,18 @@ typedef struct {
 } mutex_t;
 
 /**
+ * @brief   A cancellation structure for use with @ref mutex_lock_cancelable
+ *          and @ref mutex_cancel
+ *
+ * @note    The contents of this structure are internal.
+ */
+typedef struct {
+    mutex_t *mutex;     /**< The mutex to lock */
+    thread_t *thread;   /**< The thread trying to lock the mutex */
+    uint8_t cancelled;  /**< Flag whether the mutex has been cancelled */
+} mutex_cancel_t;
+
+/**
  * @brief Static initializer for mutex_t.
  * @details This initializer is preferable to mutex_init().
  */
@@ -156,6 +168,22 @@ typedef struct {
 static inline void mutex_init(mutex_t *mutex)
 {
     mutex->queue.next = NULL;
+}
+
+/**
+ * @brief   Initialize a mutex cancellation structure
+ * @param   mutex       The mutex that the calling thread wants to lock
+ * @return  The cancellation structure for use with @ref mutex_lock_cancelable
+ *          and @ref mutex_cancel
+ *
+ * @note    This function is considered internal. Out of tree users should be
+ *          aware that breaking API changes or removal of this API without
+ *          an deprecation period might happen.
+ */
+static inline mutex_cancel_t mutex_cancel_init(mutex_t *mutex)
+{
+    mutex_cancel_t result = { mutex, thread_get_active(), 0 };
+    return result;
 }
 
 /**
@@ -196,6 +224,30 @@ static inline int mutex_trylock(mutex_t *mutex)
 void mutex_lock(mutex_t *mutex);
 
 /**
+ * @brief   Locks a mutex, blocking. This function can be canceled.
+ *
+ * @param[in,out]   mc      Mutex cancellation structure to work on
+ *
+ * @retval  0               The mutex was locked by the caller
+ * @retval  -ECANCELED      The mutex was ***NOT*** locked, operation was
+ *                          canceled. See @ref mutex_cancel
+ *
+ * @note    This function is considered internal. Out of tree users should be
+ *          aware that breaking API changes or removal of this API without
+ *          an deprecation period might happen.
+ *
+ * @pre     Must be called in thread context
+ * @pre     @p mc has been initialized with @ref mutex_cancel_init by the
+ *          calling thread.
+ * @pre     @p mc has ***NOT*** been used for previous calls to
+ *          this function. (Reinitialize before reusing!)
+ *
+ * @post    The mutex referred to by @p mc is locked and held by the calling
+ *          thread, unless `-ECANCELED` was returned.
+ */
+int mutex_lock_cancelable(mutex_cancel_t *mc);
+
+/**
  * @brief   Unlocks the mutex.
  *
  * @param[in,out]   mutex   Mutex object to unlock.
@@ -214,6 +266,71 @@ void mutex_unlock(mutex_t *mutex);
  * @pre     Must be called in thread context.
  */
 void mutex_unlock_and_sleep(mutex_t *mutex);
+
+/**
+ * @brief   Cancels a call to @ref mutex_lock_cancelable
+ *
+ * @param[in,out]   mc      Mutex cancellation structure referring to the
+ *                          thread calling @ref mutex_lock_cancelable and to
+ *                          the mutex to cancel the operation on
+ *
+ * @note    This function is considered internal. Out of tree users should be
+ *          aware that breaking API changes or removal of this API without
+ *          an deprecation period might happen.
+ *
+ * @pre     @p mc is used to cancel at most one call to
+ *          @ref mutex_lock_cancelable. (You can reinitialize the same memory
+ *          to safely reuse it.)
+ * @warning You ***MUST NOT*** call this function once the thread referred to by
+ *          @p mc re-uses the mutex object referred to by @p mc (not counting
+ *          the call to @ref mutex_lock_cancelable @p mc was used in).
+ * @note    It is safe to call this function from IRQ context, e.g. from a timer
+ *          interrupt.
+ * @note    It is safe to call this function more than once on the same @p mc
+ *          while it is still valid (see the warning above). The first call will
+ *          cancel the operation and subsequent calls will have no effect.
+ *
+ * @details If @p thread is currently running (or pending), a subsequent call
+ *          from @p thread to @ref mutex_lock_cancelable will also fail
+ *
+ * Canonical use:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * static void timeout_cb(void *_arg) {
+ *     mutex_cancel(arg);
+ * }
+ *
+ * int ztimer_mutex_lock_timeout(ztimer_clock_t *clock, mutex_t *mutex,
+ *                               uint32_t timeout)
+ * {
+ *     mutex_cancel_t mc = mutex_cancel_init(mutex);
+ *     ztimer_t t;
+ *     t.callback = timeout_cb;
+ *     t.arg = &mc;
+ *     ztimer_set(clock, &t, timeout);
+ *     if (0 == mutex_lock_cancelable(mutex)) {
+ *         ztimer_remove(clock, &t);
+ *         return 0;
+ *     }
+ *     return -ECANCELED;
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * In the above example a simple implementation of how to implement mutex
+ * locking with a timeout is given. There are two corner cases:
+ *
+ * 1. The call to @ref mutex_cancel could occur *before* the call to
+ *    @ref mutex_lock_cancelable. (E.g. for `timeout == 0`.)
+ * 2. The call to @ref mutex_cancel could occur right after the mutex was
+ *    *successfully* obtained, but before `ztimer_remove()` was executed.
+ *
+ * In the first corner case the cancellation is stored in @p mc. Hence, the
+ * subsequent call to @ref mutex_lock_cancelable gets indeed canceled. In the
+ * second corner case the cancellation is also stored in @p mc but never used -
+ * the mutex cancellation structure @p mc is not allowed to be reused without
+ * reinitialization.
+ */
+void mutex_cancel(mutex_cancel_t *mc);
 
 #ifdef __cplusplus
 }

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -183,6 +183,7 @@ static inline void mutex_init(mutex_t *mutex)
 static inline mutex_cancel_t mutex_cancel_init(mutex_t *mutex)
 {
     mutex_cancel_t result = { mutex, thread_get_active(), 0 };
+
     return result;
 }
 
@@ -202,10 +203,11 @@ static inline int mutex_trylock(mutex_t *mutex)
 {
     unsigned irq_state = irq_disable();
     int retval = 0;
+
     if (mutex->queue.next == NULL) {
         mutex->queue.next = MUTEX_LOCKED;
         retval = 1;
-    };
+    }
     irq_restore(irq_state);
     return retval;
 }

--- a/tests/mutex_cancel/Makefile
+++ b/tests/mutex_cancel/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_cancel/main.c
+++ b/tests/mutex_cancel/main.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing the mutex_cancel function in
+ *              core_mutex
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "mutex.h"
+#include "test_utils/expect.h"
+#include "thread.h"
+#include "xtimer.h"
+
+static mutex_t testlock = MUTEX_INIT;
+
+static void cb_unlock(void *mutex)
+{
+    mutex_unlock(mutex);
+}
+
+static void cb_cancel(void *mc)
+{
+    mutex_cancel(mc);
+}
+
+int main(void)
+{
+    xtimer_t xt;
+    puts(
+        "Test Application for mutex_cancel / mutex_lock_cancelable\n"
+        "=========================================================\n"
+    );
+
+    printf("%s: ", "Test without cancellation");
+    mutex_cancel_t mc = mutex_cancel_init(&testlock);
+    expect(mutex_lock_cancelable(&mc) == 0);
+    puts("OK");
+
+    printf("%s: ", "Test early cancellation");
+    mc = mutex_cancel_init(&testlock);
+    mutex_cancel(&mc);
+    expect(mutex_lock_cancelable(&mc) == -ECANCELED);
+    puts("OK");
+
+    printf("%s: ", "Verify no side effects on subsequent calls");
+    mc = mutex_cancel_init(&testlock);
+    xt.callback = cb_unlock;
+    xt.arg = &testlock;
+    xtimer_set(&xt, US_PER_MS * 10);
+    expect(mutex_lock_cancelable(&mc) == 0);
+    puts("OK");
+
+    printf("%s: ", "Test late cancellation");
+    mc = mutex_cancel_init(&testlock);
+    xt.callback = cb_cancel;
+    xt.arg = &mc;
+    xtimer_set(&xt, US_PER_MS * 10);
+    expect(mutex_lock_cancelable(&mc) == -ECANCELED);
+    puts("OK");
+
+    puts("TEST PASSED");
+
+    return 0;
+}

--- a/tests/mutex_cancel/tests/01-run.py
+++ b/tests/mutex_cancel/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This commit adds the (pseudo)-module `mutex_cancel`, which unlocks the likewise named function. With this function, a thread blocked with `mutex_lock()` can be unblocked without it obtaining the mutex. A caller of `mutex_lock()` is notified via an `-ECANCELED` return code.

This is intended to simplify the implementation of `xtimer_mutex_lock_timeout()` and to implement `ztimer_mutex_lock_timeout()`.

### Testing procedure

With `tests/mutex_cancel` a test application is provided that must succeed.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/15052