### PR TITLE
drivers/at86rf215: fix dependency resolution for 2.4 GHz

### DIFF
--- a/drivers/at86rf215/Makefile.dep
+++ b/drivers/at86rf215/Makefile.dep
@@ -1,6 +1,6 @@
 DEFAULT_MODULE += auto_init_at86rf215
 
-ifeq (,$(filter at86rf215m,$(USEMODULE)))
+ifneq (,$(filter at86rf215m,$(USEMODULE)))
   USEMODULE += at86rf215_subghz
 endif
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

With the last cleanup an error sneaked in:
Now the 2.4 GHz interface is disabled, when the `at86rf215m` module (chip with sub-GHz radio only) is *not* used.

This is the reverse of what should happen.


### Testing procedure

Flash e.g. `examples/gnrc_networking` on a board with the `at86rf215` radio.

You should again have two radio interfaces instead of only the sub-GHz one as it is on `master`.

```
2020-11-15 16:33:30,768 # Iface  7  HWaddr: 11:F1  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-11-15 16:33:30,769 #           
2020-11-15 16:33:30,783 #           Long HWaddr: AE:8D:FE:E1:60:41:91:F1 
2020-11-15 16:33:30,785 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-11-15 16:33:30,786 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-11-15 16:33:30,799 #           6LO  IPHC  
2020-11-15 16:33:30,800 #           Source address length: 8
2020-11-15 16:33:30,800 #           Link type: wireless
2020-11-15 16:33:30,802 #           inet6 addr: fe80::ac8d:fee1:6041:91f1  scope: link  VAL
2020-11-15 16:33:30,814 #           inet6 group: ff02::2
2020-11-15 16:33:30,815 #           inet6 group: ff02::1
2020-11-15 16:33:30,816 #           inet6 group: ff02::1:ff41:91f1
2020-11-15 16:33:30,817 #           
2020-11-15 16:33:30,818 #           Statistics for Layer 2
2020-11-15 16:33:30,819 #             RX packets 0  bytes 0
2020-11-15 16:33:30,831 #             TX packets 2 (Multicast: 2)  bytes 112
2020-11-15 16:33:30,832 #             TX succeeded 2 errors 0
2020-11-15 16:33:30,832 #           Statistics for IPv6
2020-11-15 16:33:30,833 #             RX packets 0  bytes 0
2020-11-15 16:33:30,834 #             TX packets 2 (Multicast: 2)  bytes 128
2020-11-15 16:33:30,847 #             TX succeeded 2 errors 0
2020-11-15 16:33:30,847 # 
2020-11-15 16:33:30,849 # Iface  6  HWaddr: 11:F0  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK 
2020-11-15 16:33:30,850 #           
2020-11-15 16:33:30,851 #           Long HWaddr: AE:8D:FE:E1:60:41:91:F0 
2020-11-15 16:33:30,864 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-11-15 16:33:30,865 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-11-15 16:33:30,866 #           6LO  IPHC  
2020-11-15 16:33:30,879 #           Source address length: 8
2020-11-15 16:33:30,880 #           Link type: wireless
2020-11-15 16:33:30,882 #           inet6 addr: fe80::ac8d:fee1:6041:91f0  scope: link  VAL
2020-11-15 16:33:30,883 #           inet6 group: ff02::2
2020-11-15 16:33:30,894 #           inet6 group: ff02::1
2020-11-15 16:33:30,895 #           inet6 group: ff02::1:ff41:91f0
2020-11-15 16:33:30,896 #           
2020-11-15 16:33:30,896 #           Statistics for Layer 2
2020-11-15 16:33:30,897 #             RX packets 0  bytes 0
2020-11-15 16:33:30,898 #             TX packets 2 (Multicast: 2)  bytes 112
2020-11-15 16:33:30,911 #             TX succeeded 2 errors 0
2020-11-15 16:33:30,912 #           Statistics for IPv6
2020-11-15 16:33:30,917 #             RX packets 0  bytes 0
2020-11-15 16:33:30,919 #             TX packets 2 (Multicast: 2)  bytes 128
2020-11-15 16:33:30,919 #             TX succeeded 2 errors 0
```


### Issues/PRs references

introduced by #15266
