### PR TITLE
 tests/riotboot: make automatic script work with cc2538-bsl 

### DIFF
--- a/dist/tools/cc2538-bsl/Makefile
+++ b/dist/tools/cc2538-bsl/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=cc2538-bsl
 PKG_URL=https://github.com/JelmerT/cc2538-bsl.git
-PKG_VERSION=733e6f5b496402e40ad6d12df3d0372e205b8883
+PKG_VERSION=11de8cb2933d23ce001a1af14225ff4f5cd1983c
 PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -13,68 +13,93 @@ from testrunner import run
 from testrunner.spawn import MAKE
 
 
-def flash_slot(slotnum, version):
-    cmd = [
-        MAKE,
-        "RIOTBOOT_SKIP_COMPILE=1",
-        "riotboot/flash-slot{}".format(slotnum),
-        "APP_VER={}".format(version),
-    ]
-    assert subprocess.call(cmd) == 0
+class RiotbootDevice:
+    def __init__(self):
+        self.slot_num = None
+        self.app_ver = None
+
+    def flash_current_slot_and_app_ver(self):
+        cmd = [
+            MAKE,
+            "RIOTBOOT_SKIP_COMPILE=1",
+            "riotboot/flash-slot{}".format(self.slot_num),
+            "APP_VER={}".format(self.app_ver),
+        ]
+        assert(self.slot_num is not None)
+        assert(self.app_ver is not None)
+        assert subprocess.call(cmd) == 0
+
+    def get_current_slot_and_app_ver(self, child):
+        # Ask for current slot, should be 0 or 1
+        child.expect_exact('>')
+        child.sendline("curslotnr")
+        child.expect(r"Current slot=([0-1])")
+        self.slot_num = int(child.match.group(1))
+
+        # Ask for current APP_VER
+        child.expect_exact('>')
+        child.sendline("curslothdr")
+        child.expect(r"Image Version: (?P<app_ver>0x[0-9a-fA-F]{8})\r\n")
+        self.app_ver = int(child.match.group("app_ver"), 16)
+
+    def check_current_slot_and_app_ver(self, child):
+        # Check if it's running on the expected slot
+        child.expect_exact('>')
+        child.sendline("curslotnr")
+        child.expect_exact("Current slot={}".format(self.slot_num))
+
+        # Ask for current slot header info and check for basic output integrity
+        child.expect_exact('>')
+        child.sendline("curslothdr")
+        # Magic number is "RIOT" (always in little endian)
+        child.expect_exact("Image magic_number: 0x544f4952")
+        # Other info is hardware/app dependent so we just check basic compliance
+        child.expect_exact("Image Version: {0:#0{1}x}".format(self.app_ver, 10))
+        child.expect(r"Image start address: 0x[0-9a-fA-F]{8}\r\n")
+        child.expect(r"Header chksum: 0x[0-9a-fA-F]{8}\r\n")
+
+        # Ask for address of slot 0
+        child.expect_exact('>')
+        child.sendline("getslotaddr 0")
+        child.expect(r"Slot 0 address=0x[0-9a-fA-F]{8}\r\n")
+
+        # Ask for data of all slots
+        child.expect_exact('>')
+        child.sendline("dumpaddrs")
+        child.expect(r"slot 0: metadata: 0x[0-9a-fA-F]{1,8} "
+                     r"image: 0x[0-9a-fA-F]{8}\r\n")
+        child.expect(r"slot 1: metadata: 0x[0-9a-fA-F]{1,8} "
+                     r"image: 0x[0-9a-fA-F]{8}\r\n")
+        child.expect_exact('>')
 
 
-def assert_check_slot(child, slotnum, version):
-    # Check if it's running on the expected slot
-    child.expect_exact('>')
-    child.sendline("curslotnr")
-    child.expect_exact("Current slot={}".format(slotnum))
+def testfunc():
+    # This test requires flashing slot binaries. Some flashers like
+    # cc2538-bsl need to attach to the serial terminal in order to be
+    # able to flash. Since `run(func)` spawns a terminal a different
+    # `run(func)` is called after every flash in order to detach and
+    # re-attach the terminal between flashes
+    dev = RiotbootDevice()
+    # Get the current slot number and application version
+    ret = run(dev.get_current_slot_and_app_ver)
+    if ret != 0:
+        return ret
 
-    # Ask for current slot header info and check for basic output integrity
-    child.expect_exact('>')
-    child.sendline("curslothdr")
-    # Magic number is "RIOT" (always in little endian)
-    child.expect_exact("Image magic_number: 0x544f4952")
-    # Other info is hardware/app dependent so we just check basic compliance
-    child.expect_exact("Image Version: {0:#0{1}x}".format(version, 10))
-    child.expect(r"Image start address: 0x[0-9a-fA-F]{8}\r\n")
-    child.expect(r"Header chksum: 0x[0-9a-fA-F]{8}\r\n")
-
-    # Ask for address of slot 0
-    child.expect_exact('>')
-    child.sendline("getslotaddr 0")
-    child.expect(r"Slot 0 address=0x[0-9a-fA-F]{8}\r\n")
-
-    # Ask for data of all slots
-    child.expect_exact('>')
-    child.sendline("dumpaddrs")
-    child.expect(r"slot 0: metadata: 0x[0-9a-fA-F]{1,8} "
-                 r"image: 0x[0-9a-fA-F]{8}\r\n")
-    child.expect(r"slot 1: metadata: 0x[0-9a-fA-F]{1,8} "
-                 r"image: 0x[0-9a-fA-F]{8}\r\n")
-    child.expect_exact('>')
-
-
-def testfunc(child):
-    # Ask for current slot, should be 0 or 1
-    child.expect_exact('>')
-    child.sendline("curslotnr")
-    child.expect(r"Current slot=([0-1])")
-    slotnum = int(child.match.group(1))
-
-    # Ask for current APP_VER
-    child.expect_exact('>')
-    child.sendline("curslothdr")
-    child.expect(r"Image Version: (?P<app_ver>0x[0-9a-fA-F]{8})\r\n")
-    current_app_ver = int(child.match.group("app_ver"), 16)
-
-    # Flash to both slots and verify basic functions
-    for version in [current_app_ver + 1, current_app_ver + 2]:
-        slotnum = slotnum ^ 1
-        flash_slot(slotnum, version)
-        assert_check_slot(child, slotnum, version)
+    # flash to both slots and verify
+    for version in [dev.app_ver + 1, dev.app_ver + 2]:
+        # update slot number and application version
+        dev.slot_num = dev.slot_num ^ 1
+        dev.app_ver = version
+        # flash
+        dev.flash_current_slot_and_app_ver()
+        # verify its running from the correct slot with the right version
+        ret = run(dev.check_current_slot_and_app_ver)
+        if ret != 0:
+            return ret
 
     print("TEST PASSED")
+    return 0
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc))
+    sys.exit(testfunc())


### PR DESCRIPTION
### Contribution description

cc2538-bsl can't flash if the terminal is attached, refactor the test so the terminal is detached between flashes.

I'm not really happy with the use of global, feels dirt, but not sure how to do it otherwise, suggestions?


### Testing procedure

On a board using `cc2538-bsl` run the riotboot test:

`BOARD=openmote-b make -C tests/riotboot flash test`

```
...
> getslotaddr 0
 getslotaddr 0
Slot 0 address=0x00201400
> dumpaddrs
 dumpaddrs
slot 0: metadata: 0x201000 image: 0x00201400
slot 1: metadata: 0x240000 image: 0x00240400
> TEST PASSED
```

### Issues/PRs references

~~Depends on #15396~~
