### PR TITLE
drivers/at24mac: fix dependency

### DIFF
--- a/drivers/at24mac/Makefile.dep
+++ b/drivers/at24mac/Makefile.dep
@@ -1,1 +1,1 @@
-USEMODULE += at24cxxx
+FEATURES_REQUIRED += periph_i2c


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The at24mac driver does not depend on at24cxxx, EEPROM and ID functionality are separate.


### Testing procedure

`tests/driver_at24mac` still works

```
2020-11-16 12:15:07,922 # main(): This is RIOT! (Version: 2021.01-devel-903-g96afd-drivers/at24mac-dep)
2020-11-16 12:15:07,926 # EUI-48: fc c2 3d 0d 2d 1f
2020-11-16 12:15:07,932 # ID-128: 0a 70 08 00 64 10 04 81 1c cd a0 00 a0 00 00 00
2020-11-16 12:15:07,933 # [SUCCESS]
```


### Issues/PRs references

