### PR TITLE
pkg/tinydtls: set endpoint of session after complete handshake

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -488,6 +488,7 @@ static ssize_t _complete_handshake(sock_dtls_t *sock,
                                    const session_t *session)
 {
     memcpy(&remote->dtls_session, session, sizeof(remote->dtls_session));
+    _session_to_ep(&remote->dtls_session, &remote->ep);
 #ifdef SOCK_HAS_ASYNC
     if (sock->async_cb) {
         sock_async_flags_t flags = SOCK_ASYNC_CONN_RDY;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Quite similar to #15416.

When using tinydtls the session endpoint is not set when a handshake completes and the session is received via `sock_dtls_recv`. This fixes it by simply calling `_session_to_ep` which creates the endpoint out of the tinydtls session.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
[This](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_tinydtls_sock_async) test can be used as application together with this patch for the server:
```
diff --git a/tests/pkg_tinydtls_sock_async/dtls-server.c b/tests/pkg_tinydtls_sock_async/dtls-server.c
index 13ac2bce8..0b8b62d7e 100644
--- a/tests/pkg_tinydtls_sock_async/dtls-server.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-server.c
@@ -114,6 +114,20 @@ static void _dtls_handler(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
             puts("Error creating session");
             return;
         }
+        printf("Session.ep.family: ");
+        switch(session.ep.family) {
+            case (AF_INET6):
+                printf("AF_INET6\n");
+                break;
+        case (AF_UNSPEC):
+                printf("AF_UNSPEC\n");
+                break;
+        }
+        printf("Session.ep.addr: ");
+        for (uint8_t i=0; i < sizeof(ipv6_addr_t); i++) {
+            printf("%02X:", session.ep.addr.ipv6[i]);
+        }
+        puts("");
         puts("New client connected");
     }
     if (type & SOCK_ASYNC_CONN_FIN) {

```
(Same changes can be applied on the same spot in the client to test the fix. But the problem is independent whether DTLS client or server)
- Create two tap interfaces (e.g. with [tapsetup](https://github.com/RIOT-OS/RIOT/tree/master/dist/tools/tapsetup)) and run the application on both interfaces
- Start DTLS server on one of the instances: `dtlss start`
- Send DTLS message from the other instance: `dtlsc {addr} {data}`

Without the fix 
```
Session.ep.family: AF_UNSPEC 
Session.ep.addr: 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:
``` 
should be printed since the endpoint is not set. (Yes, the ipv6 address it not printed correctly this way)

With the fix the result should be a proper endpoint.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
