### PR TITLE
tests/pkg_hacl: blacklist on CI

### DIFF
--- a/pkg/hacl/Makefile.dep
+++ b/pkg/hacl/Makefile.dep
@@ -2,3 +2,6 @@ USEMODULE+=random
 
 # HACL is only supported by 32 bit architectures
 FEATURES_REQUIRED += arch_32bit
+
+# upstream has moved and repo structure changed
+FEATURES_REQUIRED += working_upstream

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -5,8 +5,8 @@ TEST_ON_CI_WHITELIST += native
 USEPKG += libcose
 # By default we use hacl as crypto backend, uncomment to use a different
 # crypto backend.
-USEMODULE += libcose_crypt_hacl
-# USEMODULE += libcose_crypt_c25519
+# USEMODULE += libcose_crypt_hacl
+USEMODULE += libcose_crypt_c25519
 USEMODULE += memarray
 USEMODULE += embunit
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The upstream hacl repo has been removed.
The new version can be found at [hacl*](https://github.com/project-everest/hacl-star/tree/master/dist/) but requires some work on the pkg.

As a quick fix, blacklist the test so CI can work again.

### Testing procedure

CI should succeed again.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
