### PR TITLE
pkg/hacl: switch upstream to backup copy

### DIFF
--- a/pkg/hacl/Makefile
+++ b/pkg/hacl/Makefile
@@ -1,5 +1,7 @@
 PKG_NAME=hacl
-PKG_URL=https://github.com/mitls/hacl-c
+# TODO: switch to https://github.com/project-everest/hacl-star
+# backup of last state before upstream was deleted
+PKG_URL=https://github.com/benpicco/hacl-c_archived
 PKG_VERSION=aac05f5094fc92569169d5a2af54c12387160634
 PKG_LICENSE=MIT
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The https://github.com/mitls/hacl-c repo was deleted.
Getting the new upstream (https://github.com/project-everest/hacl-star) to work nicely as a package requires some non-trivial work and in the meantime all CI jobs will fail. 

As a short-term solution, switch the upstream to a backup version of the original repository.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #15451
