### PR TITLE
cpu/sam0_common: flashpage: rename to sam0_flashpage_aux_write()

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1145,7 +1145,7 @@ void sam0_flashpage_aux_reset(const nvm_user_page_t *cfg);
  * @param   data    The data to write
  * @param   len     Size of the data
  */
-void sam0_flashpage_aux_write_raw(uint32_t offset, const void *data, size_t len);
+void sam0_flashpage_aux_write(uint32_t offset, const void *data, size_t len);
 
 /**
  * @brief   Get pointer to data in the user configuration area.

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -299,7 +299,7 @@ void flashpage_write(void *target_addr, const void *data, size_t len)
     _write_row(target_addr, data, len, NVMCTRL_PAGE_SIZE, _cmd_write_page);
 }
 
-void sam0_flashpage_aux_write_raw(uint32_t offset, const void *data, size_t len)
+void sam0_flashpage_aux_write(uint32_t offset, const void *data, size_t len)
 {
     uintptr_t dst = NVMCTRL_USER + sizeof(nvm_user_page_t) + offset;
 

--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -572,10 +572,10 @@ static int cmd_test_config(int argc, char **argv)
     }
 
     /* write test data */
-    sam0_flashpage_aux_write_raw(dst, test_data, sizeof(test_data));
+    sam0_flashpage_aux_write(dst, test_data, sizeof(test_data));
 
     /* write single half-word */
-    sam0_flashpage_aux_write_raw(dst + sizeof(test_data), &single_data, sizeof(single_data));
+    sam0_flashpage_aux_write(dst + sizeof(test_data), &single_data, sizeof(single_data));
 
     /* check if half-word was written correctly */
     uint16_t data_in = *(uint16_t*)sam0_flashpage_aux_get(dst + sizeof(test_data));


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`flashpage_write_raw()` got renamed to `flashpage_write()`.
Now `sam0_flashpage_aux_write_raw()` is the only remaining 'raw' function, even though it behaves just like `flashpage_write()`.

So let's also rename that for consistency.


### Testing procedure

textual replacements only


### Issues/PRs references

follow-up on #15412
