### PR TITLE
gh_actions: give a name to the circleci doc artifact action

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,3 +1,4 @@
+name: doc-build-artifact
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is just giving a name to the doc-build artifact action that is used to retrieve the direct link to the generated documentation on circle ci. This is purely cosmetic.

For the moment, the action is reported as `.github/workflow/circleci.yml` in the list of actions:

<p align="center"><img src="https://user-images.githubusercontent.com/1375137/99373971-592fbf80-28c2-11eb-93a2-9037d0b8ef11.png" width="250px"></p>
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check that the `doc-build artifact` action is still linked to the generated documentation
- Check the list of action names

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
