### PR TITLE
gh_actions: fix rebase issue with static-test

### DIFF
--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '*'
   pull_request:
     branches:
       - '*'
@@ -20,12 +18,17 @@ jobs:
         # in master (default behavior in GH actions)
         # See https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
         ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
     - name: Setup git
       run: |
-        git fetch origin master:master --no-tags
+        git fetch origin master:master_upstream --no-tags
         git config apply.whitespace nowarn
     - name: Fetch riot/riotbuild Docker image
       run: docker pull riot/riotbuild:latest
     - name: Run static-tests
       run: |
-        docker run --rm -v $(pwd):/data/riotbuild riot/riotbuild:latest make static-test
+        docker run --rm                     \
+          -e CI_BASE_BRANCH=master_upstream \
+          -v $(pwd):/data/riotbuild         \
+          riot/riotbuild:latest             \
+          make static-test


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix the static tests performed by github actions when they are run on master.

After #15437 was merged the actions failed on master: https://github.com/RIOT-OS/RIOT/runs/1411760887?check_suite_focus=true.
This is because one of the steps fetch the master branch locally but this is not allowed when git is already on branch master.

The proposed solution of this PR is to fetch master in a separate branch and set this branch in `CI_BASE_BRANCH` env.

Another solution could be to not run the static-test on push to master but if we could avoid that, it's better IMHO.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- a green static test for the PR
- the result of this PR can only be checked once merged in master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

bug introduced by #15437

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
