### PR TITLE
dist/tools/jlink: debugserver test_config prior test_version

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -233,9 +233,9 @@ do_debug() {
 }
 
 do_debugserver() {
+    test_config
     test_version
     test_ports
-    test_config
     test_serial
     # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Solves a tiny error preventing launching gdb server using jlink in the form:
```shell
make debug-server
```

### Testing procedure
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Run a jlink gdb server on any supported board with jlink. Example on the dwm1001 board (nrf52 chip):
```shell
$ make -C examples/twr_aloha debug-server
make: Entering directory '/private/tmp/sync_fork/RIOT/examples/twr_aloha'
/private/tmp/sync_fork/RIOT/dist/tools/jlink/jlink.sh debug-server
### Starting GDB Server ###
Error: J-Link appears not to be installed on your PATH
make: *** [/private/tmp/sync_fork/RIOT/examples/twr_aloha/../../Makefile.include:731: debug-server] Error 1
make: Leaving directory '/private/tmp/sync_fork/RIOT/examples/twr_aloha'
```
Once corrected, you get a normal output
```shell
$ make -C examples/twr_aloha debug-server
make: Entering directory '/private/tmp/sync_fork/RIOT/examples/twr_aloha'
/private/tmp/sync_fork/RIOT/dist/tools/jlink/jlink.sh debug-server
### Starting GDB Server ###
SEGGER J-Link GDB Server V6.86g Command Line Version

JLinkARM.dll V6.86g (DLL compiled Nov  6 2020 18:12:00)

Command line: -nogui -device nrf52 -speed 2000 -if SWD -port 3333 -telnetport 4444
-----GDB Server start settings-----
GDBInit file:                  none
GDB Server Listening port:     3333
SWO raw output listening port: 2332
Terminal I/O port:             4444
Accept remote connection:      yes
Generate logfile:              off
Verify download:               off
Init regs on start:            off
Silent mode:                   off
Single run mode:               off
Target connection timeout:     0 ms
------J-Link related settings------
J-Link Host interface:         USB
J-Link script:                 none
J-Link settings file:          none
------Target related settings------
Target device:                 nrf52
Target interface:              SWD
Target interface speed:        2000kHz
Target endian:                 little

Connecting to J-Link...
J-Link is connected.
Firmware: J-Link OB-STM32F072-128KB-CortexM compiled Jan 21 2020 17:32:07
Hardware: V1.00
S/N: 760103336
Checking target voltage...
Target voltage: 3.30 V
Listening on TCP/IP port 3333
Connecting to target...
Connected to target
Waiting for GDB connection...
```

<!--
### Issues/PRs references
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
