### PR TITLE
makefiles/utils: add util to compare to software versions

### DIFF
--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -6,3 +6,30 @@
 lowercase = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 uppercase = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(subst g,G,$(subst h,H,$(subst i,I,$(subst j,J,$(subst k,K,$(subst l,L,$(subst m,M,$(subst n,N,$(subst o,O,$(subst p,P,$(subst q,Q,$(subst r,R,$(subst s,S,$(subst t,T,$(subst u,U,$(subst v,V,$(subst w,W,$(subst x,X,$(subst y,Y,$(subst z,Z,$1))))))))))))))))))))))))))
 uppercase_and_underscore = $(call uppercase,$(subst -,_,$1))
+
+# Padds $2 number to $1 digits
+_pad_number = $(shell printf '%0$1d' $2)
+
+# Gets major, minor, patch from 'major.minor.patch', e.g.: 4.2.1 by index
+#   $1: index
+#   $2: version
+_version = $(word $1, $(subst ., ,$2))
+
+# Returns padded version 'major.minor.patch' to 3 digits
+# eg: 4.2.1 -> 004.002.001
+#   $1: version
+_padded_version = $(subst $(space),.,$(foreach var,1 2 3,$(call _pad_number,3,$(call _version,$(var),$1))))
+
+# Checks if  $1 is greater than $2
+#   $1, $2: The values to compare must be padded to the same length
+#           otherwise when using '$(sort)' make will consider '2' larger
+#           than '19'
+#   Return 1 if $1 is greater than $2, nothing otherwise
+_is_greater = $(if $(filter $1,$(firstword $(sort $1 $2))),,1)
+
+# Checks if version $1 is greater than version $2
+#   $1: version to check, '.' separated version 'major.minor.patch'
+#   $2: minimum version, '.' separated version 'major.minor.patch'
+#   Return 1 if $1 is greater than $2, nothing otherwise
+version_is_greater = $(call _is_greater,$(call _padded_version,$1),\
+                        $(call _padded_version,$2))

--- a/makefiles/utils/test-strings.mk
+++ b/makefiles/utils/test-strings.mk
@@ -1,3 +1,4 @@
+include variables.mk
 include strings.mk
 
 STRING_LOWER = abcdefghijklmnopqrstuvwxyz-123456789
@@ -12,3 +13,15 @@ test-uppercase:
 
 test-uppercase_and_underscore:
 	$(Q)bash -c 'test "$(STRING_MACRO)" = "$(call uppercase_and_underscore,$(STRING_LOWER))" || { echo ERROR: "$(STRING_MACRO)" != "$(call uppercase_and_underscore,$(STRING_LOWER))"; exit 1; }'
+
+TEST_VERSION_1 = 4.1
+TEST_VERSION_2 = 3.10
+TEST_VERSION_3 = 4.2.3
+TEST_VERSION_4 = 4.19.3
+
+test-version_is_greater:
+	$(Q)bash -c 'test 1 = "$(call version_is_greater,$(TEST_VERSION_1),$(TEST_VERSION_2))" || { echo ERROR: "$(TEST_VERSION_2)" \< "$(TEST_VERSION_1)"; exit 1; }'
+	$(Q)bash -c 'test 1 = "$(call version_is_greater,$(TEST_VERSION_3),$(TEST_VERSION_1))" || { echo ERROR: "$(TEST_VERSION_1)" \< "$(TEST_VERSION_3)"; exit 1; }'
+	$(Q)bash -c 'test 1 = "$(call version_is_greater,$(TEST_VERSION_4),$(TEST_VERSION_3))" || { echo ERROR: "$(TEST_VERSION_3)" \< "$(TEST_VERSION_4)"; exit 1; }'
+	$(Q)bash -c 'test "" = "$(call version_is_greater,$(TEST_VERSION_3),$(TEST_VERSION_4))" || { echo ERROR: Test should fail, "$(TEST_VERSION_4)" is not \< "$(TEST_VERSION_3)"; exit 1; }'
+	$(Q)bash -c 'test "" = "$(call version_is_greater,$(TEST_VERSION_1),$(TEST_VERSION_4))" || { echo ERROR: Test should fail, "$(TEST_VERSION_1)" is not \< "$(TEST_VERSION_4)"; exit 1; }'

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -22,6 +22,7 @@ COMPILE_TESTS += test-memoized-variables
 COMPILE_TESTS += test-lowercase
 COMPILE_TESTS += test-uppercase
 COMPILE_TESTS += test-uppercase_and_underscore
+COMPILE_TESTS += test-version_is_greater
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
@@ -45,7 +46,12 @@ test-memoized-variables:
 
 test-lowercase:
 	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-lowercase)
+
 test-uppercase:
 	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-uppercase)
+
 test-uppercase_and_underscore:
 	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-uppercase_and_underscore)
+
+test-version_is_greater:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-version_is_greater)


### PR DESCRIPTION
### Contribution description

This PR adds an utility to compare to program versions, usefull to require a specific make function can be used for example in #15196 with the following patch:

```
# Fetch the number of jobs from the MAKEFLAGS
# With $MAKE_VERSION < 4.2, the amount of parallelism is not available in
# $MAKEFLAGS, only that parallelism is requested. So only -j, even if
# something like -j3 is specified. This can be unexpected and dangerous
# in older make so don't enable parallelism if $MAKE_VERSION < 4.2
MAKE_JOBS_NEEDS = 4.1.999
MAKE_VERSION_OK = $(call version_is_greater,$(MAKE_VERSION),$(MAKE_JOBS_NEEDS))
DOCKER_MAKE_JOBS = $(if $(MAKE_VERSION_OK),$(filter -j%,$(MAKEFLAGS)),)
DOCKER_MAKE_ARGS += $(DOCKER_MAKE_JOBS)
```

### Testing procedure

Automatic tests have been added, green murdock.

### Issues/PRs references

Useful for #15196.
