### PR TITLE
core/mutex: Minor cleanup

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -187,15 +187,13 @@ static inline int mutex_trylock(mutex_t *mutex)
  *
  * @param[in,out]   mutex   Mutex object to lock.
  *
- * @retval  0               The mutex was locked by the caller
- *
  * @pre     @p mutex is not `NULL`
  * @pre     Mutex at @p mutex has been initialized
  * @pre     Must be called in thread context
  *
  * @post    The mutex @p is locked and held by the calling thread.
  */
-int mutex_lock(mutex_t *mutex);
+void mutex_lock(mutex_t *mutex);
 
 /**
  * @brief   Unlocks the mutex.


### PR DESCRIPTION
### Contribution description

- Split out handling of the blocking code path of mutex_lock() into a static  `_block()` function. This improves readability a bit and will ease review of  a follow up PR.
- Return `void` instead of `int`.
- Made debug output more consistent

### Testing procedure

All the mutex test applications (`cpp11_mutex`, `mutex_order`, `mutex_unlock_and_sleep`, `rmutex`, `rmutex_cpp`, `xtimer_mutex_lock_timeout`, `xtimer_rmutex_lock_timeout`) should still work and `bench_mutex_pingpong` should still yield the same performance.


### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/15442, which was split out of https://github.com/RIOT-OS/RIOT/pull/15052