### PR TITLE
stm32/flashpage: Add common stm32_flashpage_block_t type

### DIFF
--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -21,6 +21,7 @@
 #ifndef CPU_CONF_H
 #define CPU_CONF_H
 
+#include <stdint.h>
 #include "cpu_conf_common.h"
 
 #if defined(CPU_LINE_STM32F030x4)
@@ -124,10 +125,13 @@ extern "C" {
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
     defined(CPU_FAM_STM32L5)
 #define FLASHPAGE_WRITE_BLOCK_SIZE      (8U)
+typedef uint64_t stm32_flashpage_block_t;
 #elif defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
 #define FLASHPAGE_WRITE_BLOCK_SIZE      (4U)
+typedef uint32_t stm32_flashpage_block_t;
 #else
 #define FLASHPAGE_WRITE_BLOCK_SIZE      (2U)
+typedef uint16_t stm32_flashpage_block_t;
 #endif
 
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \

--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -38,9 +38,7 @@
 #define CNTRL_REG              (FLASH->PECR)
 #define CNTRL_REG_LOCK         (FLASH_PECR_PELOCK)
 #define FLASH_CR_PER           (FLASH_PECR_ERASE | FLASH_PECR_PROG)
-#define FLASHPAGE_DIV          (4U) /* write 4 bytes in one go */
 #elif defined(CPU_FAM_STM32L5)
-#define FLASHPAGE_DIV          (8U)
 #define CNTRL_REG              (FLASH->NSCR)
 #define CNTRL_REG_LOCK         (FLASH_NSCR_NSLOCK)
 #define FLASH_CR_PNB           (FLASH_NSCR_NSPNB)
@@ -50,13 +48,6 @@
 #define FLASH_CR_BKER          (FLASH_NSCR_NSBKER)
 #define FLASH_CR_PG            (FLASH_NSCR_NSPG)
 #else
-#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5)
-#define FLASHPAGE_DIV          (8U)
-#else
-#define FLASHPAGE_DIV          (2U)
-#endif
 #define CNTRL_REG              (FLASH->CR)
 #define CNTRL_REG_LOCK         (FLASH_CR_LOCK)
 #endif
@@ -192,18 +183,8 @@ void flashpage_write(void *target_addr, const void *data, size_t len)
     assert(((unsigned)target_addr + len) <
            (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)) + 1);
 
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
-    uint32_t *dst = target_addr;
-    const uint32_t *data_addr = data;
-#elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-      defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-      defined(CPU_FAM_STM32L5)
-    uint64_t *dst = target_addr;
-    const uint64_t *data_addr = data;
-#else
-    uint16_t *dst = (uint16_t *)target_addr;
-    const uint16_t *data_addr = data;
-#endif
+    stm32_flashpage_block_t *dst = target_addr;
+    const stm32_flashpage_block_t *data_addr = data;
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3)
@@ -226,7 +207,7 @@ void flashpage_write(void *target_addr, const void *data, size_t len)
     /* set PG bit and program page to flash */
     CNTRL_REG |= FLASH_CR_PG;
 #endif
-    for (size_t i = 0; i < (len / FLASHPAGE_DIV); i++) {
+    for (size_t i = 0; i < (len / sizeof(stm32_flashpage_block_t)); i++) {
         DEBUG("[flashpage_raw] writing %c to %p\n", (char)data_addr[i], dst);
         *dst++ = data_addr[i];
         /* wait as long as device is busy */

--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -80,14 +80,6 @@ static void _unlock_flash(void)
 
 static void _erase_page(void *page_addr)
 {
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5)
-    uint32_t *dst = page_addr;
-#else
-    uint16_t *dst = page_addr;
-#endif
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3)
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
@@ -107,16 +99,16 @@ static void _erase_page(void *page_addr)
     DEBUG("address to erase: %p\n", page_addr);
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
     DEBUG("[flashpage] erase: trigger the page erase\n");
-    *dst = (uint32_t)0;
+    *(uint32_t *)page_addr = 0;
 #elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
       defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
       defined(CPU_FAM_STM32L5)
     DEBUG("[flashpage] erase: setting the page address\n");
     uint8_t pn;
 #if (FLASHPAGE_NUMOF <= MAX_PAGES_PER_BANK) || defined(CPU_FAM_STM32WB)
-    pn = (uint8_t)flashpage_page(dst);
+    pn = (uint8_t)flashpage_page(page_addr);
 #else
-    uint16_t page = flashpage_page(dst);
+    uint16_t page = flashpage_page(page_addr);
     if (page > MAX_PAGES_PER_BANK - 1) {
         CNTRL_REG |= FLASH_CR_BKER;
     }
@@ -130,7 +122,7 @@ static void _erase_page(void *page_addr)
     CNTRL_REG |= FLASH_CR_STRT;
 #else /* CPU_FAM_STM32F0 || CPU_FAM_STM32F1 || CPU_FAM_STM32F3 */
     DEBUG("[flashpage] erase: setting the page address\n");
-    FLASH->AR = (uint32_t)dst;
+    FLASH->AR = (uint32_t)page_addr;
     /* trigger the page erase and wait for it to be finished */
     DEBUG("[flashpage] erase: trigger the page erase\n");
     CNTRL_REG |= FLASH_CR_STRT;


### PR DESCRIPTION
### Contribution description

This commits adds a common type for the block writes to the flash of the
stm32. Depending on the family, the type has a different size. This
allows the removal of a number of ifdefs to track the differences
between families, simplifying the flashpage code

### Testing procedure

flashpage should still work on all supported stm32 families. Binaries should, in theory, not change with this.

### Issues/PRs references

None
