### PR TITLE
ieee802154/hal: adapt frame filter and source address matching changes

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -107,7 +107,10 @@ extern "C" {
 #define CC2538_RSSI_OFFSET          (-73)  /**< Signal strength offset value */
 #define CC2538_RF_SENSITIVITY       (-97)  /**< dBm typical, normal conditions */
 
+#define CC2538_ACCEPT_FT_0_BEACON        (1 << 3) /**< enable or disable the BEACON filter */
+#define CC2538_ACCEPT_FT_1_DATA          (1 << 4) /**< enable or disable the DATA filter */
 #define CC2538_ACCEPT_FT_2_ACK           (1 << 5) /**< enable or disable the ACK filter */
+#define CC2538_ACCEPT_FT_3_CMD           (1 << 6) /**< enable or disable the CMD filter */
 #define CC2538_STATE_SFD_WAIT_RANGE_MIN  (0x03U)  /**< min range value of SFD wait state */
 #define CC2538_STATE_SFD_WAIT_RANGE_MAX  (0x06U)  /**< max range value of SFD wait state */
 #define CC2538_FRMCTRL1_PENDING_OR_MASK  (0x04)   /**< mask for enabling or disabling the

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -174,6 +174,9 @@ void cc2538_init(void)
     /* setup mac timer */
     _cc2538_setup_mac_timer();
 
+    /* Enable Auto ACK */
+    RFCORE->XREG_FRMCTRL0bits.AUTOACK = !IS_ACTIVE(CONFIG_IEEE802154_AUTO_ACK_DISABLE);
+
     /* Flush the receive and transmit FIFOs */
     RFCORE_SFR_RFST = ISFLUSHTX;
     RFCORE_SFR_RFST = ISFLUSHRX;

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -91,6 +91,7 @@ static struct {
     bool cca_send   : 1;    /**< whether the next transmission uses CCA or not */
     bool ack_filter : 1;    /**< whether the ACK filter is activated or not */
     bool promisc    : 1;    /**< whether the device is in promiscuous mode or not */
+    bool pending    : 1;    /**< whether there pending bit should be set in the ACK frame or not */
 } cfg = {
     .cca_send   = true,
     .ack_filter = true,
@@ -431,6 +432,11 @@ static void _timer_cb(void *arg, int chan)
 
     if (chan == MAC_TIMER_CHAN_ACK) {
         /* Copy sqn */
+        ack[1] = IEEE802154_FCF_TYPE_ACK;
+        if (cfg.pending) {
+            ack[1] |= IEEE802154_FCF_FRAME_PEND;
+        }
+
         ack[3] = rxbuf[3];
 
         NRF_RADIO->PACKETPTR = (uint32_t) &ack;
@@ -517,7 +523,7 @@ void isr_radio(void)
         case STATE_RX:
             if (NRF_RADIO->CRCSTATUS) {
                 bool l2filter_passed = _l2filter(rxbuf+1);
-                bool is_auto_ack_en = ack[1];
+                bool is_auto_ack_en = !IS_ACTIVE(CONFIG_IEEE802154_AUTO_ACK_DISABLE);
                 bool is_ack = rxbuf[1] & IEEE802154_FCF_TYPE_ACK;
                 bool ack_req = rxbuf[1] & IEEE802154_FCF_ACK_REQ;
 
@@ -699,26 +705,41 @@ int _set_cca_mode(ieee802154_dev_t *dev, ieee802154_cca_mode_t mode)
     return 0;
 }
 
-static int _set_hw_addr_filter(ieee802154_dev_t *dev, const network_uint16_t *short_addr,
-                              const eui64_t *ext_addr, const uint16_t *pan_id)
+static int _config_addr_filter(ieee802154_dev_t *dev, ieee802154_af_cmd_t cmd, const void *value)
 {
     (void) dev;
-    if (short_addr) {
-        memcpy(nrf802154_short_addr, short_addr, IEEE802154_SHORT_ADDRESS_LEN);
-    }
-
-    if (ext_addr) {
-        memcpy(nrf802154_long_addr, ext_addr, IEEE802154_LONG_ADDRESS_LEN);
-    }
-
-    if (pan_id) {
-        nrf802154_pan_id = *pan_id;
+    const uint16_t *pan_id = value;
+    switch(cmd) {
+        case IEEE802154_AF_SHORT_ADDR:
+            memcpy(nrf802154_short_addr, value, IEEE802154_SHORT_ADDRESS_LEN);
+            break;
+        case IEEE802154_AF_EXT_ADDR:
+            memcpy(nrf802154_long_addr, value, IEEE802154_LONG_ADDRESS_LEN);
+            break;
+        case IEEE802154_AF_PANID:
+            nrf802154_pan_id = *pan_id;
+            break;
+        case IEEE802154_AF_PAN_COORD:
+            return -ENOTSUP;
     }
 
     return 0;
 }
 
-static int _set_rx_mode(ieee802154_dev_t *dev, ieee802154_rx_mode_t mode)
+static int _config_src_addr_match(ieee802154_dev_t *dev, ieee802154_src_match_t cmd, const void *value)
+{
+    (void) dev;
+    switch(cmd) {
+        case IEEE802154_SRC_MATCH_EN:
+            cfg.pending = *((const bool*) value);
+            break;
+        default:
+            return -ENOTSUP;
+    }
+    return 0;
+}
+
+static int _set_frame_filter_mode(ieee802154_dev_t *dev, ieee802154_filter_mode_t mode)
 {
     (void) dev;
 
@@ -726,21 +747,16 @@ static int _set_rx_mode(ieee802154_dev_t *dev, ieee802154_rx_mode_t mode)
     bool _promisc = false;
 
     switch (mode) {
-    case IEEE802154_RX_AACK_DISABLED:
-        ack[1] = 0;
-        break;
-    case IEEE802154_RX_AACK_ENABLED:
-        ack[1] = IEEE802154_FCF_TYPE_ACK;
-        break;
-    case IEEE802154_RX_AACK_FRAME_PENDING:
-        ack[1] = IEEE802154_FCF_TYPE_ACK | IEEE802154_FCF_FRAME_PEND;
-        break;
-    case IEEE802154_RX_PROMISC:
-        _promisc = true;
-        break;
-    case IEEE802154_RX_WAIT_FOR_ACK:
-        ackf = false;
-        break;
+        case IEEE802154_FILTER_ACCEPT:
+            break;
+        case IEEE802154_FILTER_PROMISC:
+            _promisc = true;
+            break;
+        case IEEE802154_FILTER_ACK_ONLY:
+            ackf = false;
+            break;
+        default:
+            return -ENOTSUP;
     }
 
     cfg.ack_filter = ackf;
@@ -800,7 +816,8 @@ static const ieee802154_radio_ops_t nrf802154_ops = {
     .set_cca_threshold = set_cca_threshold,
     .set_cca_mode = _set_cca_mode,
     .config_phy = _config_phy,
-    .set_hw_addr_filter = _set_hw_addr_filter,
     .set_csma_params = _set_csma_params,
-    .set_rx_mode = _set_rx_mode,
+    .config_addr_filter = _config_addr_filter,
+    .config_src_addr_match = _config_src_addr_match,
+    .set_frame_filter_mode = _set_frame_filter_mode,
 };

--- a/pkg/openwsn/Makefile.include
+++ b/pkg/openwsn/Makefile.include
@@ -72,5 +72,10 @@ ifneq (,$(filter at86rf2xx,$(USEMODULE)))
   CFLAGS += -DAT86RF2XX_BASIC_MODE
 endif
 
+# Auto ACK should be disabled in order to run OpenWSN
+ifndef CONFIG_KCONFIG_USEMODULE_IEEE802154
+  CFLAGS += -DCONFIG_IEEE802154_AUTO_ACK_DISABLE
+endif
+
 # LLVM ARM shows issues with missing definitions for stdatomic
 TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/openwsn/contrib/radio_hal.c
+++ b/pkg/openwsn/contrib/radio_hal.c
@@ -71,9 +71,12 @@ void _idmanager_addr_override(void)
 
     /* Set all IEEE addresses */
     uint16_t panid = OPENWSN_PANID;
-    ieee802154_radio_set_hw_addr_filter(openwsn_radio.dev, &short_addr,
-                                        &eui64, &panid);
-
+    ieee802154_radio_config_addr_filter(openwsn_radio.dev, IEEE802154_AF_SHORT_ADDR,
+                                        &short_addr);
+    ieee802154_radio_config_addr_filter(openwsn_radio.dev, IEEE802154_AF_EXT_ADDR,
+                                        &eui64);
+    ieee802154_radio_config_addr_filter(openwsn_radio.dev, IEEE802154_AF_PANID,
+                                        &panid);
 }
 
 static void _hal_radio_cb(ieee802154_dev_t *dev, ieee802154_trx_ev_t status)

--- a/pkg/openwsn/contrib/radio_hal.c
+++ b/pkg/openwsn/contrib/radio_hal.c
@@ -140,8 +140,8 @@ int openwsn_radio_init(void *radio_dev)
     /* If the radio is still not in TRX_OFF state, spin */
     while (ieee802154_radio_confirm_on(dev) == -EAGAIN) {}
 
-    /* Enable basic mode, no AUTOACK. no CSMA */
-    ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_AACK_DISABLED);
+    /* Enable basic mode (no AUTOACK. no CSMA-CA).
+     * Auto ACK is disabled via CONFIG_IEEE802154_AUTO_ACK_DISABLE. */
     /* MAC layer retransmissions are disabled by _set_csma_params() */
     ieee802154_radio_set_csma_params(dev, NULL, -1);
 
@@ -150,7 +150,7 @@ int openwsn_radio_init(void *radio_dev)
         where the destination-address mode is 0 (no destination address).
         per rfc8180 4.5.1 the destination address must be set, which means
         the destination-address mode can't be 0 */
-        ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_PROMISC);
+        ieee802154_radio_set_frame_filter_mode(dev, IEEE802154_FILTER_PROMISC);
     }
 
     /* Configure PHY settings (channel, TX power) */

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -302,6 +302,13 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
 #endif
 
 /**
+ * @brief Disable Auto ACK support
+ */
+#ifdef DOXYGEN
+#define CONFIG_IEEE802154_AUTO_ACK_DISABLE 0
+#endif
+
+/**
  * @brief   Initializes an IEEE 802.15.4 MAC frame header in @p buf.
  *
  * @pre Resulting header must fit in memory allocated at @p buf.

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -339,6 +339,36 @@ typedef enum {
 } ieee802154_src_match_t;
 
 /**
+ * @brief Frame Filter mode
+ */
+typedef enum {
+    /**
+     * @brief accept all valid frames that match address filter configuration
+     */
+    IEEE802154_FILTER_ACCEPT,
+    /**
+     * @brief accept only ACK frames
+     *
+     * @note This mode should only be implemented if the transceiver doesn't
+     * handle ACK frame reception (when @ref IEEE802154_CAP_FRAME_RETRANS and
+     * @ref IEEE802154_CAP_IRQ_ACK_TIMEOUT are not present).
+     */
+    IEEE802154_FILTER_ACK_ONLY,
+    /**
+     * @brief accept all valid frames
+     *
+     * @note This mode is optional
+     */
+    IEEE802154_FILTER_PROMISC,
+    /**
+     * @brief accept all frames, regardless of FCS
+     *
+     * @note This mode is optional
+     */
+    IEEE802154_FILTER_SNIFFER,
+} ieee802154_filter_mode_t;
+
+/**
  * @brief CSMA-CA exponential backoff parameters.
  */
 typedef struct {
@@ -618,6 +648,7 @@ struct ieee802154_radio_ops {
      * - @ref set_csma_params
      * - @ref set_rx_mode
      * - @ref set_hw_addr_filter
+     * - @ref set_frame_filter_mode
      * - @ref config_src_addr_match
      * - @ref set_frame_retrans (if available)
      *
@@ -818,6 +849,19 @@ struct ieee802154_radio_ops {
     int (*set_rx_mode)(ieee802154_dev_t *dev, ieee802154_rx_mode_t mode);
 
     /**
+     * @brief Set the frame filter moder.
+     *
+     * @pre the device is on
+     *
+     * @param[in] dev IEEE802.15.4 device descriptor
+     * @param[in] mode address filter mode
+     *
+     * @return 0 on success
+     * @return negative errno on error
+     */
+    int (*set_frame_filter_mode)(ieee802154_dev_t *dev, ieee802154_filter_mode_t mode);
+
+    /**
      * @brief Set the source address match configuration.
      *
      * This function configures the source address match filter in order to set
@@ -1005,6 +1049,22 @@ static inline int ieee802154_radio_set_hw_addr_filter(ieee802154_dev_t *dev,
                                                       const uint16_t *pan_id)
 {
     return dev->driver->set_hw_addr_filter(dev, short_addr, ext_addr, pan_id);
+}
+
+/**
+ * @brief Shortcut to @ref ieee802154_radio_ops::set_frame_filter_mode
+ *
+ * @pre the device is on
+ *
+ * @param[in] dev IEEE802.15.4 device descriptor
+ * @param[in] mode frame filter mode
+ *
+ * @return result of @ref ieee802154_radio_ops::set_frame_filter_mode
+ */
+static inline int ieee802154_radio_set_frame_filter_mode(ieee802154_dev_t *dev,
+                                                    ieee802154_filter_mode_t mode)
+{
+    return dev->driver->set_frame_filter_mode(dev, mode);
 }
 
 /**

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -463,40 +463,6 @@ typedef enum {
 } ieee802154_cca_mode_t;
 
 /**
- * @brief RX mode configuration
- */
-typedef enum {
-    /**
-     * @brief Auto ACK is disabled
-     */
-    IEEE802154_RX_AACK_DISABLED,
-    /**
-     * @brief Auto ACK is enabled
-     */
-    IEEE802154_RX_AACK_ENABLED,
-    /**
-     * @brief Auto ACK is enabled and frame pending bit set in the next ACK frame
-     */
-    IEEE802154_RX_AACK_FRAME_PENDING,
-    /**
-     * @brief Radio is in promiscuous mode
-     */
-    IEEE802154_RX_PROMISC,
-    /**
-     * @brief Radio is ready to receive ACK frames
-     *
-     * This mode is optional. If a radio decides to implement it, the radio
-     * should allow ACK frames (and block ACK frames in all other RX modes).
-     * Note that this mode cannot guarantee that only ACK frames will be
-     * received.
-     *
-     * Expected to be implemented when either @ref IEEE802154_CAP_FRAME_RETRANS
-     * or @ref IEEE802154_CAP_IRQ_ACK_TIMEOUT is not there.
-     */
-    IEEE802154_RX_WAIT_FOR_ACK,
-} ieee802154_rx_mode_t;
-
-/**
  * @brief Holder of the PHY configuration
  */
 typedef struct {
@@ -657,7 +623,6 @@ struct ieee802154_radio_ops {
      * - @ref config_phy
      * - @ref config_addr_filter
      * - @ref set_csma_params
-     * - @ref set_rx_mode
      * - @ref set_frame_filter_mode
      * - @ref config_src_addr_match
      * - @ref set_frame_retrans (if available)
@@ -826,17 +791,6 @@ struct ieee802154_radio_ops {
      */
     int (*set_csma_params)(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd,
                            int8_t retries);
-
-    /**
-     * @brief Set the RX mode.
-     *
-     * @param[in] dev IEEE802.15.4 device descriptor
-     * @param[in] mode RX mode
-     *
-     * @return 0 on success
-     * @return negative errno on error
-     */
-    int (*set_rx_mode)(ieee802154_dev_t *dev, ieee802154_rx_mode_t mode);
 
     /**
      * @brief Set the frame filter moder.
@@ -1454,20 +1408,6 @@ static inline bool ieee802154_radio_has_phy_mr_fsk(ieee802154_dev_t *dev)
 static inline uint32_t ieee802154_radio_get_phy_modes(ieee802154_dev_t *dev)
 {
     return (dev->driver->caps & IEEE802154_RF_CAPS_PHY_MASK);
-}
-
-/**
- * @brief Shortcut to @ref ieee802154_radio_ops::set_rx_mode
- *
- * @param[in] dev IEEE802.15.4 device descriptor
- * @param[in] mode RX mode
- *
- * @return result of @ref ieee802154_radio_ops::set_rx_mode
- */
-static inline int ieee802154_radio_set_rx_mode(ieee802154_dev_t *dev,
-                                               ieee802154_rx_mode_t mode)
-{
-    return dev->driver->set_rx_mode(dev, mode);
 }
 
 /**

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -658,7 +658,6 @@ struct ieee802154_radio_ops {
      * - @ref config_addr_filter
      * - @ref set_csma_params
      * - @ref set_rx_mode
-     * - @ref set_hw_addr_filter
      * - @ref set_frame_filter_mode
      * - @ref config_src_addr_match
      * - @ref set_frame_retrans (if available)
@@ -790,26 +789,6 @@ struct ieee802154_radio_ops {
      * @return <0       error, return value is negative errno indicating the cause.
      */
     int (*config_phy)(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf);
-
-    /**
-     * @brief Set IEEE802.15.4 addresses in hardware address filter
-     *
-     * @pre the device is on
-     *
-     * @param[in] dev IEEE802.15.4 device descriptor
-     * @param[in] short_addr the IEEE802.15.4 short address. If NULL, the short
-     *            address is not altered..
-     * @param[in] ext_addr the IEEE802.15.4 extended address (Network Byte Order).
-     *            If NULL, the extended address is not altered.
-     * @param[in] pan_id the IEEE802.15.4 PAN ID. If NULL, the PAN ID is not altered.
-     *
-     * @return 0 on success
-     * @return negative errno on error
-     */
-    int (*set_hw_addr_filter)(ieee802154_dev_t *dev,
-                              const network_uint16_t *short_addr,
-                              const eui64_t *ext_addr,
-                              const uint16_t *pan_id);
 
     /**
      * @brief Set number of frame retransmissions
@@ -1055,28 +1034,6 @@ static inline int ieee802154_radio_config_src_address_match(ieee802154_dev_t *de
 static inline int ieee802154_radio_off(ieee802154_dev_t *dev)
 {
     return dev->driver->off(dev);
-}
-
-/**
- * @brief Shortcut to @ref ieee802154_radio_ops::set_hw_addr_filter
- *
- * @pre the device is on
- *
- * @param[in] dev IEEE802.15.4 device descriptor
- * @param[in] short_addr the IEEE802.15.4 short address. If NULL, the short
- *            address is not altered..
- * @param[in] ext_addr the IEEE802.15.4 extended address (Network Byte Order).
- *            If NULL, the extended address is not altered.
- * @param[in] pan_id the IEEE802.15.4 PAN ID. If NULL, the PAN ID is not altered.
- *
- * @return result of @ref ieee802154_radio_ops::set_hw_addr_filter
- */
-static inline int ieee802154_radio_set_hw_addr_filter(ieee802154_dev_t *dev,
-                                                      const network_uint16_t *short_addr,
-                                                      const eui64_t *ext_addr,
-                                                      const uint16_t *pan_id)
-{
-    return dev->driver->set_hw_addr_filter(dev, short_addr, ext_addr, pan_id);
 }
 
 /**

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -339,6 +339,16 @@ typedef enum {
 } ieee802154_src_match_t;
 
 /**
+ * @brief Address filter command
+ */
+typedef enum {
+    IEEE802154_AF_SHORT_ADDR, /**< Set short IEEE 802.15.4 address (network_uint16_t) */
+    IEEE802154_AF_EXT_ADDR,   /**< Set extended IEEE 802.15.4 address (eui64_t) */
+    IEEE802154_AF_PANID,      /**< Set PAN ID (uint16_t) */
+    IEEE802154_AF_PAN_COORD,  /**< Set device as PAN coordinator (bool) */
+} ieee802154_af_cmd_t;
+
+/**
  * @brief Frame Filter mode
  */
 typedef enum {
@@ -645,6 +655,7 @@ struct ieee802154_radio_ops {
      * - @ref set_cca_threshold
      * - @ref set_cca_mode
      * - @ref config_phy
+     * - @ref config_addr_filter
      * - @ref set_csma_params
      * - @ref set_rx_mode
      * - @ref set_hw_addr_filter
@@ -862,6 +873,23 @@ struct ieee802154_radio_ops {
     int (*set_frame_filter_mode)(ieee802154_dev_t *dev, ieee802154_filter_mode_t mode);
 
     /**
+     * @brief Configure the address filter.
+     *
+     * This functions is used for configuring the address filter parameters
+     * required by the IEEE 802.15.4 standard.
+     *
+     * @pre the device is on
+     *
+     * @param[in] dev IEEE802.15.4 device descriptor
+     * @param[in] cmd command for the address filter
+     * @param[in] value value for @p cmd.
+     *
+     * @return 0 on success
+     * @return negative errno on error
+     */
+    int (*config_addr_filter)(ieee802154_dev_t *dev, ieee802154_af_cmd_t cmd, const void *value);
+
+    /**
      * @brief Set the source address match configuration.
      *
      * This function configures the source address match filter in order to set
@@ -1049,6 +1077,24 @@ static inline int ieee802154_radio_set_hw_addr_filter(ieee802154_dev_t *dev,
                                                       const uint16_t *pan_id)
 {
     return dev->driver->set_hw_addr_filter(dev, short_addr, ext_addr, pan_id);
+}
+
+/**
+ * @brief Shortcut to @ref ieee802154_radio_ops::config_addr_filter
+ *
+ * @pre the device is on
+ *
+ * @param[in] dev IEEE802.15.4 device descriptor
+ * @param[in] cmd command for the address filter
+ * @param[in] value value for @p cmd.
+ *
+ * @return result of @ref ieee802154_radio_ops::config_addr_filter
+ */
+static inline int ieee802154_radio_config_addr_filter(ieee802154_dev_t *dev,
+                                                  ieee802154_af_cmd_t cmd,
+                                                  const void* value)
+{
+    return dev->driver->config_addr_filter(dev, cmd, value);
 }
 
 /**

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -173,8 +173,8 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist);
 static inline int ieee802154_set_short_addr(ieee802154_submac_t *submac,
                                             const network_uint16_t *short_addr)
 {
-    int res = ieee802154_radio_set_hw_addr_filter(submac->dev, short_addr, NULL,
-                                                  NULL);
+
+    int res = ieee802154_radio_config_addr_filter(submac->dev, IEEE802154_AF_SHORT_ADDR, short_addr);
 
     if (res >= 0) {
         memcpy(&submac->short_addr, short_addr, IEEE802154_SHORT_ADDRESS_LEN);
@@ -195,8 +195,7 @@ static inline int ieee802154_set_short_addr(ieee802154_submac_t *submac,
 static inline int ieee802154_set_ext_addr(ieee802154_submac_t *submac,
                                           const eui64_t *ext_addr)
 {
-    int res = ieee802154_radio_set_hw_addr_filter(submac->dev, NULL, ext_addr,
-                                                  NULL);
+    int res = ieee802154_radio_config_addr_filter(submac->dev, IEEE802154_AF_EXT_ADDR, ext_addr);
 
     if (res >= 0) {
         memcpy(&submac->ext_addr, ext_addr, IEEE802154_LONG_ADDRESS_LEN);
@@ -216,8 +215,7 @@ static inline int ieee802154_set_ext_addr(ieee802154_submac_t *submac,
 static inline int ieee802154_set_panid(ieee802154_submac_t *submac,
                                        const uint16_t *panid)
 {
-    int res = ieee802154_radio_set_hw_addr_filter(submac->dev, NULL, NULL,
-                                                  panid);
+    int res = ieee802154_radio_config_addr_filter(submac->dev, IEEE802154_AF_PANID, panid);
 
     if (res >= 0) {
         submac->panid = *panid;

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -82,6 +82,9 @@ if KCONFIG_USEMODULE_IEEE802154
     config IEEE802154_DEFAULT_CSMA_CA_MAX
         int "IEEE802.15.4 default CSMA-CA maximum backoff exponent"
         default 5
+    config IEEE802154_AUTO_ACK_DISABLE
+        bool "Disable Auto ACK support" if !USEPKG_OPENWSN
+        default y if USEPKG_OPENWSN
 
 menuconfig KCONFIG_USEMODULE_IEEE802154_SECURITY
     bool "Configure IEEE802.15.4 Security"

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -363,12 +363,10 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
     /* If the radio is still not in TRX_OFF state, spin */
     while (ieee802154_radio_confirm_on(dev) == -EAGAIN) {}
 
-    /* Enable Auto ACK */
-    ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_AACK_ENABLED);
-
     /* Configure address filter */
-    ieee802154_radio_set_hw_addr_filter(dev, &submac->short_addr,
-                                        &submac->ext_addr, &submac->panid);
+    ieee802154_radio_config_addr_filter(dev, IEEE802154_AF_SHORT_ADDR, &submac->short_addr);
+    ieee802154_radio_config_addr_filter(dev, IEEE802154_AF_EXT_ADDR, &submac->ext_addr);
+    ieee802154_radio_config_addr_filter(dev, IEEE802154_AF_PANID, &submac->panid);
 
     /* Configure PHY settings (mode, channel, TX power) */
     ieee802154_phy_conf_t conf =

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -76,7 +76,7 @@ static int _perform_csma_ca(ieee802154_submac_t *submac)
         submac->csma_retries_nb++;
     }
     else {
-        ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_AACK_ENABLED);
+        ieee802154_radio_set_frame_filter_mode(dev, IEEE802154_FILTER_ACCEPT);
         _tx_end(submac, TX_STATUS_MEDIUM_BUSY, NULL);
     }
 
@@ -134,7 +134,7 @@ static void _perform_retrans(ieee802154_submac_t *submac)
         ieee802154_csma_ca_transmit(submac);
     }
     else {
-        ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_AACK_ENABLED);
+        ieee802154_radio_set_frame_filter_mode(dev, IEEE802154_FILTER_ACCEPT);
         _tx_end(submac, TX_STATUS_NO_ACK, NULL);
     }
 }
@@ -169,8 +169,7 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
             ieee802154_tx_info_t tx_info;
             tx_info.retrans = submac->retrans;
             bool fp = (ack[0] & IEEE802154_FCF_FRAME_PEND);
-            ieee802154_radio_set_rx_mode(submac->dev,
-                                         IEEE802154_RX_AACK_ENABLED);
+            ieee802154_radio_set_frame_filter_mode(submac->dev, IEEE802154_FILTER_ACCEPT);
             _tx_end(submac, fp ? TX_STATUS_FRAME_PENDING : TX_STATUS_SUCCESS,
                     &tx_info);
         }
@@ -216,7 +215,7 @@ static void _handle_tx_success(ieee802154_submac_t *submac,
         _tx_end(submac, info->status, info);
     }
     else {
-        ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_WAIT_FOR_ACK);
+        ieee802154_radio_set_frame_filter_mode(dev, IEEE802154_FILTER_ACK_ONLY);
 
         /* Handle ACK reception */
         ieee802154_submac_ack_timer_set(submac, ACK_TIMEOUT_US);

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -246,7 +246,12 @@ static int _init(void)
 
     uint16_t panid = CONFIG_IEEE802154_DEFAULT_PANID;
     /* Set all IEEE addresses */
-    ieee802154_radio_set_hw_addr_filter(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID), &short_addr, &ext_addr, &panid);
+    ieee802154_radio_config_addr_filter(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID),
+                                        IEEE802154_AF_SHORT_ADDR, &short_addr);
+    ieee802154_radio_config_addr_filter(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID),
+                                        IEEE802154_AF_EXT_ADDR, &ext_addr);
+    ieee802154_radio_config_addr_filter(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID),
+                                        IEEE802154_AF_PANID, &panid);
 
     /* Set PHY configuration */
     ieee802154_phy_conf_t conf = {.channel=CONFIG_IEEE802154_DEFAULT_CHANNEL, .page=CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE, .pow=CONFIG_IEEE802154_DEFAULT_TXPOWER};


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR implements the proposal from https://github.com/RIOT-OS/RIOT/pull/13943#issuecomment-724699696 (in a slightly different way, as described above).

This removes the `set_rx_mode` and `set_hw_addr_filter` and replace them with 3 functions:
- `config_addr_filter`
- `set_frame_filter_mode`
- `config_src_addr_match`

The original proposal didn't include the `set_frame_filter_mode`, but it turns out to be much better IMO to split the original proposal of `config_addr_filter` because there's indeed a mode for the frame filter (promisc, sniffer, accept only ACK frames, etc). This also adds a "reject all frames" mode, that might be useful for certain stacks (e.g OpenWSN).

Also, a `CONFIG_IEEE802154_AUTO_ACK_DISABLE macro was added in order to disable Auto ACK in radios (required for OpenWSN)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Test that `examples/gnrc_networking` runs properly with `netdev_ieee802154_submac`.
- OpenWSN should also be tested to ensure that everything works ok

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#13943 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
