### PR TITLE
riotboot: don't always return error in riotboot_flashwrite_finish_raw()

### DIFF
--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -155,8 +155,6 @@ int riotboot_flashwrite_finish_raw(riotboot_flashwrite_t *state,
 {
     assert(len <= FLASHPAGE_SIZE);
 
-    int res = -1;
-
     uint8_t *slot_start = (uint8_t *)riotboot_slot_get_hdr(state->target_slot);
 
 #if CONFIG_RIOTBOOT_FLASHWRITE_RAW
@@ -179,11 +177,11 @@ int riotboot_flashwrite_finish_raw(riotboot_flashwrite_t *state,
     int flashpage = flashpage_page((void *)slot_start);
     if (flashpage_write_and_verify(flashpage, firstpage) == FLASHPAGE_OK) {
         LOG_INFO(LOG_PREFIX "riotboot flashing completed successfully\n");
-        res = 0;
     }
     else {
         LOG_WARNING(LOG_PREFIX "re-flashing first block failed!\n");
+        return -1;
     }
 #endif /* !CONFIG_RIOTBOOT_FLASHWRITE_RAW */
-    return res;
+    return 0;
 }

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -151,7 +151,7 @@ int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
 }
 
 int riotboot_flashwrite_finish_raw(riotboot_flashwrite_t *state,
-                               const uint8_t *bytes, size_t len)
+                                   const uint8_t *bytes, size_t len)
 {
     assert(len <= FLASHPAGE_SIZE);
 
@@ -179,7 +179,7 @@ int riotboot_flashwrite_finish_raw(riotboot_flashwrite_t *state,
         LOG_INFO(LOG_PREFIX "riotboot flashing completed successfully\n");
     }
     else {
-        LOG_WARNING(LOG_PREFIX "re-flashing first block failed!\n");
+        LOG_ERROR(LOG_PREFIX "re-flashing first block failed!\n");
         return -1;
     }
 #endif /* !CONFIG_RIOTBOOT_FLASHWRITE_RAW */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If `CONFIG_RIOTBOOT_FLASHWRITE_RAW` is set, `riotboot_flashwrite_finish_raw()` will always return `-1` as `res` is not set anywhere else.

Fix this by only returning -1 in the error case.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
