### PR TITLE
cpu/efm32: model efm32_coretemp as a feature

### DIFF
--- a/boards/common/silabs/Kconfig
+++ b/boards/common/silabs/Kconfig
@@ -7,4 +7,5 @@
 config BOARD_COMMON_SILABS
     bool
     select HAS_ARDUINO
+    select HAS_EFM32_CORETEMP
     select HAS_RIOTBOOT

--- a/boards/common/silabs/Makefile.features
+++ b/boards/common/silabs/Makefile.features
@@ -2,4 +2,5 @@ CPU = efm32
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += efm32_coretemp
 FEATURES_PROVIDED += riotboot

--- a/boards/ikea-tradfri/Kconfig
+++ b/boards/ikea-tradfri/Kconfig
@@ -18,4 +18,5 @@ config BOARD_IKEA_TRADFRI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_MODECFG
+    select HAS_EFM32_CORETEMP
     select HAS_RIOTBOOT

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -12,3 +12,4 @@ FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += efm32_coretemp

--- a/cpu/efm32/Kconfig
+++ b/cpu/efm32/Kconfig
@@ -33,6 +33,12 @@ config HAS_CPU_EFM32
     help
         Indicates that the CPU being used is an EFM32.
 
+## Definition of EFM32-specific drivers ##
+config HAS_EFM32_CORETEMP
+    bool
+    help
+        Indicates that the EFM32 coretemp driver is being used.
+
 ## Common CPU symbols
 config CPU
     default "efm32" if CPU_COMMON_EFM32

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -44,3 +44,6 @@ endif
 ifneq (,$(filter cortexm_mpu,$(FEATURES_USED)))
   USEMODULE += mpu_stack_guard
 endif
+
+# use efm32_coretemp if the feature is used
+USEMODULE += $(filter efm32_coretemp, $(FEATURES_USED))

--- a/tests/cpu_efm32_drivers/Makefile
+++ b/tests/cpu_efm32_drivers/Makefile
@@ -1,17 +1,6 @@
 BOARD ?= sltb001a
 include ../Makefile.tests_common
 
-BOARD_WHITELIST := ikea-tradfri \
-                   slstk3401a \
-                   slstk3402a \
-                   sltb001a \
-                   slwstk6000b-slwrb4150a \
-                   slwstk6000b-slwrb4162a \
-                   slwstk6220a \
-                   stk3200 \
-                   stk3600 \
-                   stk3700
-
-USEMODULE += efm32_coretemp
+FEATURES_REQUIRED += efm32_coretemp
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description
Follow-up of #15461 that models `efm32_coretemp` as a feature.

### Testing procedure
Test `tests/cpu_efm32_drivers` for EFM32 boards (should compile), and other boards (should not compile because of missing feature).

### Issues/PRs references
#15461