### PR TITLE
sys/event: Allow single event_thread handling all queues

### DIFF
--- a/makefiles/dependency_resolution.inc.mk
+++ b/makefiles/dependency_resolution.inc.mk
@@ -38,4 +38,12 @@ else
   # Sort and de-duplicate used modules and default modules for readability
   USEMODULE := $(sort $(USEMODULE))
   DEFAULT_MODULE := $(sort $(DEFAULT_MODULE))
+
+  # Warn about used deprecated modules
+  include $(RIOTMAKE)/deprecated_modules.inc.mk
+  DEPRECATED_MODULES_USED := $(sort $(filter $(DEPRECATED_MODULES),$(USEMODULE)))
+  ifneq (,$(DEPRECATED_MODULES_USED))
+    $(shell $(COLOR_ECHO) "$(COLOR_RED)Deprecated modules are in use:$(COLOR_RESET)"\
+                          "$(DEPRECATED_MODULES_USED)" 1>&2)
+  endif
 endif

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,0 +1,3 @@
+# Add deprecated modules here
+# Keep this list ALPHABETICALLY SORTED!!!!111elven
+DEPRECATED_MODULES += event_thread_lowest

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -104,6 +104,7 @@
 #include "irq.h"
 #include "thread.h"
 #include "thread_flags.h"
+#include "ptrtag.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -147,11 +148,10 @@ struct event {
 /**
  * @brief   event queue structure
  */
-typedef struct {
+typedef struct PTRTAG {
     clist_node_t event_list;    /**< list of queued events              */
-    thread_t *waiter;           /**< thread ownning event queue         */
+    thread_t *waiter;           /**< thread owning event queue          */
 } event_queue_t;
-
 
 /**
  * @brief   Initialize an array of event queues

--- a/sys/include/event/thread.h
+++ b/sys/include/event/thread.h
@@ -12,6 +12,39 @@
  * @ingroup     sys_event
  * @brief       Provides utility functions for event handler threads
  *
+ * Usage
+ * =====
+ *
+ * By using the module `event_thread`, the event queues
+ * @ref EVENT_PRIO_HIGHEST, @ref EVENT_PRIO_MEDIUM, and
+ * @ref EVENT_PRIO_LOWEST are provided and declared in the header
+ * `event/thread.h`. With default settings, the `auto_init` module will
+ * automatically start one or more threads to handle these
+ * queues.
+ *
+ * By default, a single thread with priority `EVENT_THREAD_MEDIUM_PRIO`
+ * will handle all three event queues according to their priority.
+ * An already started event handler will not be preempted in this case by an
+ * incoming higher priority event. Still, lower priority event queues will only
+ * be worked on once the higher priority queues are empty. Hence, the worst case
+ * latency is increased by the worst case duration of any possible lower
+ * priority event in this configuration.
+ *
+ * By using module `event_thread_highest`, the highest priority queue gets its
+ * own thread. With this, events of the highest priority can preempt already
+ * running event handlers of medium and lowest priority.
+ *
+ * By using module `event_thread_medium`, the lowest priority events are handled
+ * in their own thread. With this, events of at least medium priority can
+ * preempt already running events of the lowest priority.
+ *
+ * By using both module `event_thread_highest` and `event_thread_medium`, each
+ * event queue gets its own thread. So higher priority events will always
+ * preempt events of lower priority in this case.
+ *
+ * Finally, the module `event_thread_lowest` is provided for backward
+ * compatibility and has no effect.
+ *
  * @{
  *
  * @file
@@ -33,29 +66,63 @@ extern "C" {
 
 /**
  * @brief   Convenience function for initializing an event queue thread
+ *          handling multiple queues
+ *
+ * @param[in]   queues          array of the preallocated queue objects
+ * @param[in]   queues_numof    number of elements in @p queues
+ * @param[in]   stack           ptr to stack space
+ * @param[in]   stack_size      size of stack
+ * @param[in]   priority        priority to use
+ *
+ * @pre     @p queues_numof is at most 4
+ */
+void event_thread_init_multi(event_queue_t *queues, size_t queues_numof,
+                             char *stack, size_t stack_size,
+                             unsigned priority);
+
+/**
+ * @brief   Convenience function for initializing an event queue thread
  *
  * @param[in]   queue       ptr to preallocated queue object
  * @param[in]   stack       ptr to stack space
  * @param[in]   stack_size  size of stack
  * @param[in]   priority    priority to use
  */
-void event_thread_init(event_queue_t *queue, char *stack, size_t stack_size,
-                       unsigned priority);
+static inline void event_thread_init(event_queue_t *queue,
+                                     char *stack, size_t stack_size,
+                                     unsigned priority)
+{
+    event_thread_init_multi(queue, 1, stack, stack_size, priority);
+}
 
-#ifdef MODULE_EVENT_THREAD_HIGHEST
-extern event_queue_t event_queue_highest;
-#define EVENT_PRIO_HIGHEST (&event_queue_highest)
-#endif
+/**
+ * @brief   Event queue priorities
+ *
+ * @details The lower the numeric value, the higher the priority. The highest
+ *          priority is 0, so that these priorities can be used as index to
+ *          access arrays.
+ */
+enum {
+    EVENT_QUEUE_PRIO_HIGHEST,   /**< Highest event queue priority */
+    EVENT_QUEUE_PRIO_MEDIUM,    /**< Medium event queue priority */
+    EVENT_QUEUE_PRIO_LOWEST,    /**< Lowest event queue priority */
+    EVENT_QUEUE_PRIO_NUMOF      /**< Number of event queue priorities */
+};
 
-#ifdef MODULE_EVENT_THREAD_MEDIUM
-extern event_queue_t event_queue_medium;
-#define EVENT_PRIO_MEDIUM (&event_queue_medium)
-#endif
+extern event_queue_t event_thread_queues[EVENT_QUEUE_PRIO_NUMOF];
 
-#ifdef MODULE_EVENT_THREAD_LOWEST
-extern event_queue_t event_queue_lowest;
-#define EVENT_PRIO_LOWEST (&event_queue_lowest)
-#endif
+/**
+ * @brief   Pointer to the event queue handling highest priority events
+ */
+#define EVENT_PRIO_HIGHEST  (&event_thread_queues[EVENT_QUEUE_PRIO_HIGHEST])
+/**
+ * @brief   Pointer to the event queue handling medium priority events
+ */
+#define EVENT_PRIO_MEDIUM   (&event_thread_queues[EVENT_QUEUE_PRIO_MEDIUM])
+/**
+ * @brief   Pointer to the event queue handling lowest priority events
+ */
+#define EVENT_PRIO_LOWEST   (&event_thread_queues[EVENT_QUEUE_PRIO_LOWEST])
 
 #ifdef __cplusplus
 }

--- a/tests/event_thread_shared/Makefile
+++ b/tests/event_thread_shared/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += event_thread
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/event_thread_shared/Makefile.ci
+++ b/tests/event_thread_shared/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/event_thread_shared/main.c
+++ b/tests/event_thread_shared/main.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2020 Freie Universität Berlin
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Event threads test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "thread.h"
+#include "event/thread.h"
+
+static void _handler_high(event_t *event) {
+    (void)event;
+    puts("high");
+}
+
+static event_t event_high = { .handler=_handler_high };
+
+static void _handler_medium(event_t *event) {
+    (void)event;
+    event_post(EVENT_PRIO_HIGHEST, &event_high);
+    puts("medium");
+}
+
+static event_t event_medium = { .handler=_handler_medium };
+
+static void _handler_low(event_t *event) {
+    (void)event;
+    event_post(EVENT_PRIO_MEDIUM, &event_medium);
+    event_post(EVENT_PRIO_HIGHEST, &event_high);
+    puts("low");
+}
+
+static event_t event_low = { .handler=_handler_low };
+
+int main(void)
+{
+    event_post(EVENT_PRIO_LOWEST, &event_low);
+
+    puts("main done");
+
+    return 0;
+}

--- a/tests/event_thread_shared/tests/01-run.py
+++ b/tests/event_thread_shared/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('low\r\n')
+    child.expect_exact('high\r\n')
+    child.expect_exact('medium\r\n')
+    child.expect_exact('high\r\n')
+    child.expect_exact('main done\r\n')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/event_threads/Makefile
+++ b/tests/event_threads/Makefile
@@ -1,5 +1,5 @@
 include ../Makefile.tests_common
 
-USEMODULE += event_thread_highest event_thread_medium event_thread_lowest
+USEMODULE += event_thread_highest event_thread_medium
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/event_threads/main.c
+++ b/tests/event_threads/main.c
@@ -34,6 +34,7 @@ static event_t event_high = { .handler=_handler_high };
 
 static void _handler_medium(event_t *event) {
     (void)event;
+    event_post(EVENT_PRIO_HIGHEST, &event_high);
     puts("medium");
 }
 
@@ -41,6 +42,7 @@ static event_t event_medium = { .handler=_handler_medium };
 
 static void _handler_low(event_t *event) {
     (void)event;
+    event_post(EVENT_PRIO_MEDIUM, &event_medium);
     puts("low");
 }
 
@@ -49,8 +51,6 @@ static event_t event_low = { .handler=_handler_low };
 int main(void)
 {
     event_post(EVENT_PRIO_LOWEST, &event_low);
-    event_post(EVENT_PRIO_MEDIUM, &event_medium);
-    event_post(EVENT_PRIO_HIGHEST, &event_high);
 
     puts("main done");
 

--- a/tests/event_threads/tests/01-run.py
+++ b/tests/event_threads/tests/01-run.py
@@ -5,9 +5,9 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect_exact('medium\r\n')
-    child.expect_exact('high\r\n')
     child.expect_exact('main done\r\n')
+    child.expect_exact('high\r\n')
+    child.expect_exact('medium\r\n')
     child.expect_exact('low\r\n')
 
 

--- a/tests/pkg_tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-client.c
@@ -171,7 +171,7 @@ static int client_send(char *addr_str, char *data)
     if (_sending) {
         puts("Already in the process of sending");
     }
-    event_timeout_init(&_timeouter, &event_queue_medium, &_timeout.super);
+    event_timeout_init(&_timeouter, EVENT_PRIO_MEDIUM, &_timeout.super);
     /* get interface */
     char* iface = ipv6_addr_split_iface(addr_str);
     if (iface) {
@@ -208,7 +208,7 @@ static int client_send(char *addr_str, char *data)
         return -1;
     }
 
-    sock_dtls_event_init(&_dtls_sock, &event_queue_medium, _dtls_handler,
+    sock_dtls_event_init(&_dtls_sock, EVENT_PRIO_MEDIUM, _dtls_handler,
                          data);
     res = credman_add(&credential);
     if (res < 0 && res != CREDMAN_EXIST) {

--- a/tests/pkg_tinydtls_sock_async/dtls-server.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-server.c
@@ -166,8 +166,7 @@ static int start_server(void)
     }
     _active = true;
 
-    sock_dtls_event_init(&_dtls_sock, &event_queue_medium, _dtls_handler,
-                         NULL);
+    sock_dtls_event_init(&_dtls_sock, EVENT_PRIO_MEDIUM, _dtls_handler, NULL);
     return 0;
 }
 
@@ -179,7 +178,7 @@ static int stop_server(void)
         return 1;
     }
 
-    event_post(&event_queue_medium, &_close.super);
+    event_post(EVENT_PRIO_MEDIUM, &_close.super);
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

Allow using `event_loop_multi()` to handle event queues of multiple priorities in an single thread. In the extreme case, all three event queues are handled by a single thread (thus saving two stacks). This comes for the price of increased worst case latency, as already running event handlers will no longer be preempted by higher priority events.

With this, all three event queue priorities are always provided. Using modules, the old behavior of one thread per event queue can be restored for better worst case latency at the expense of additional thread size.

See the added documentation on how to configure if the three priority queues should be handled by one, two, or three threads.

### Testing procedure

The old test (which, btw, was a bit spiced up) should still work and a new test (mostly copy-pasted from the old one) is provided specifically for the case of a single thread handling all queues.

### Issues/PRs references

None