### PR TITLE
sys/oneway-malloc: check calloc args

### DIFF
--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -61,6 +61,11 @@ void __attribute__((weak)) *realloc(void *ptr, size_t size)
 
 void __attribute__((weak)) *calloc(size_t size, size_t cnt)
 {
+    /* ensure size * cnt doesn't overflow size_t */
+    if (cnt && size > (size_t)-1 / cnt) {
+        return NULL;
+    }
+
     void *mem = malloc(size * cnt);
     if (mem) {
         memset(mem, 0, size * cnt);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`calloc()` args were not checked for validity.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Not sure if this code is used in master at all ...
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
