### PR TITLE
boards/stm32f4discovery: Add initial renode support

### DIFF
--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -5,6 +5,9 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
+# setup emulator
+include $(RIOTMAKE)/tools/renode.inc.mk
+
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/stm32f4discovery/dist/board.resc
+++ b/boards/stm32f4discovery/dist/board.resc
@@ -1,0 +1,20 @@
+:name: STM32F4 Discovery
+:description: This script runs the stm32f4_discovery on RIOT.
+
+using sysbus
+$name?="STM32F4_Discovery"
+mach create $name
+machine LoadPlatformDescription @platforms/boards/stm32f4_discovery-kit.repl
+
+cpu PerformanceInMips 125
+
+showAnalyzer sysbus.uart2
+
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+"""
+
+runMacro $reset
+start

--- a/boards/stm32f4discovery/doc.txt
+++ b/boards/stm32f4discovery/doc.txt
@@ -166,6 +166,15 @@ The board is now flashed with your RIOT binary
    - **PA2** is connected with **RX** on the UART converter
 2. done
 
+# Emulator
+
+To emulate this board you need an updated version of
+[renode](https://github.com/renode/renode) installed, at least version 1.11.
+
+```
+BOARD=stm32f4discovery make all emulate
+```
+
 ## Known Issues / Problems
 
 ### I2C


### PR DESCRIPTION
### Contribution description

Initial support for renode emulator for the stm32f4discovery board.

This allows `make emulate` to start a emulated version of the board.

### Testing procedure

- Read through the documentation update
- Install or update [renode](https://github.com/renode/renode/releases/tag/v1.11.0) since the `rcc` module was added recently and is what is needed for RIOT to work
- run `BOARD=stm32f4discovery make all emulate -C tests/shell`

### Issues/PRs references

None