### PR TITLE
sys/oneway-malloc: export oneway_malloc()

### DIFF
--- a/sys/oneway-malloc/include/oneway_malloc.h
+++ b/sys/oneway-malloc/include/oneway_malloc.h
@@ -29,8 +29,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef MALLOC_H
-#define MALLOC_H
+#ifndef ONEWAY_MALLOC_H
+#define ONEWAY_MALLOC_H
 
 #include <stdlib.h>
 
@@ -39,47 +39,30 @@ extern "C" {
 #endif
 
 /**
- * @brief       Allocation a block of memory.
- * @param[in]   size   Size of the block to allocate in bytes.
- * @returns     The new memory block. `NULL` if the "heap" is exhausted.
- */
-void *malloc(size_t size);
-
-/**
- * @brief       Allocated a new block of memory and move the existing content.
- * @details     This function allocates a new block of memory and memcpy()s the content of the one `ptr` there.
+ * @brief       Allocation a block of memory that can not be freed.
  *
- *              We do not know the size of the old block, so illegal reads would be likely,
- *              if it was not for the fact that the memory heap up.
- * @param[in]   ptr    Old memory block that was allocated with malloc(), calloc() or realloc().
- * @param[in]   size   Size of the new block to allocated in bytes.
+ * @param[in]   size   Size of the block to allocate in bytes.
+ *
  * @returns     The new memory block. `NULL` if the "heap" is exhausted.
  */
-void *realloc(void *ptr, size_t size);
+void *oneway_malloc(size_t size);
 
 /**
  * @brief       Allocate a memory block and set all its content to zeroes.
- * @details     Please see malloc() for more information.
- * @note        This implementation of calloc() does not catch integer overflows
+ *              The memory block can not be freed.
+ *
  * @param[in]   size   One factor of the number of bytes to allocated.
  * @param[in]   cnt    The other factor of the number of bytes to allocated.
+ *
  * @returns     The new memory block. `NULL` if the "heap" is exhausted.
  */
-void *calloc(size_t size, size_t cnt);
-
-/**
- * @brief       This is a no-op.
- * @details     You read correctly: This function does noting.
- * @note        Keep in mind that this function does not free the memory. It does nothing.
- * @param[in]   ptr   The ignored argument.
- */
-void free(void *ptr);
+void *oneway_calloc(size_t size, size_t cnt);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* MALLOC_H */
+#endif /* ONEWAY_MALLOC_H */
 
 /**
  * @}

--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -19,64 +19,48 @@
  */
 
 #include <string.h>
-
-#include "malloc.h"
+#include "architecture.h"
+#include "oneway_malloc.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#ifndef ARCHITECTURE_WORD_MASK
+#define ARCHITECTURE_WORD_MASK (ARCHITECTURE_WORD_BYTES - 1)
+#endif
+
 extern void *sbrk(int incr);
 
-void __attribute__((weak)) *malloc(size_t size)
+void *oneway_malloc(size_t size)
 {
+    /* ensure we always allocate word-aligned blocks */
+    if (size & ARCHITECTURE_WORD_MASK) {
+        size += ARCHITECTURE_WORD_BYTES - (size & ARCHITECTURE_WORD_MASK);
+    }
+
     if (size != 0) {
         void *ptr = sbrk(size);
 
-        DEBUG("malloc(): allocating block of size %u at %p.\n", (unsigned int) size, ptr);
+        DEBUG("malloc(): allocating block of size %u at %p.\n",
+              (unsigned int)size, ptr);
 
-        if (ptr != (void*) -1) {
+        if (ptr != (void *)-1) {
             return ptr;
         }
     }
     return NULL;
 }
 
-void __attribute__((weak)) *realloc(void *ptr, size_t size)
-{
-    if (ptr == NULL) {
-        return malloc(size);
-    }
-    else if (size == 0) {
-        free(ptr);
-        return NULL;
-    }
-    else {
-        void *newptr = malloc(size);
-        if (newptr) {
-            memcpy(newptr, ptr, size);
-        }
-        return newptr;
-    }
-}
-
-void __attribute__((weak)) *calloc(size_t size, size_t cnt)
+void *oneway_calloc(size_t size, size_t cnt)
 {
     /* ensure size * cnt doesn't overflow size_t */
     if (cnt && size > (size_t)-1 / cnt) {
         return NULL;
     }
 
-    void *mem = malloc(size * cnt);
+    void *mem = oneway_malloc(size * cnt);
     if (mem) {
         memset(mem, 0, size * cnt);
     }
     return mem;
-}
-
-void __attribute__((weak)) free(void *ptr)
-{
-    /* who cares about pointers? */
-    (void) ptr;
-
-    DEBUG("free(): block at %p lost.\n", ptr);
 }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The one-way malloc() implementation is not used and fails to build with libc.

For some situations however it is useful to allocate a block of memory on init, that is not going to be freed.
Here we don't need to pay the additional accounting overhead of `malloc()`, a one-way malloc would be entirely sufficient.

For this, make the one-way malloc implementation accessible as `oneway_malloc()` and remove the obsolete functions that now interfere with libc malloc.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14448#issuecomment-730476564
