### PR TITLE
tests/malloc: fail if allocation count does not match

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -47,7 +47,7 @@ struct node {
 
 static uint32_t total = 0;
 
-static void fill_memory(struct node *head)
+static uint32_t fill_memory(struct node *head)
 {
     uint32_t allocations = 0;
 
@@ -70,6 +70,8 @@ static void fill_memory(struct node *head)
     }
 
     printf("Allocations count: %"PRIu32"\n", allocations);
+
+    return allocations;
 }
 
 static void free_memory(struct node *head)
@@ -102,6 +104,8 @@ static void free_memory(struct node *head)
 
 int main(void)
 {
+    uint32_t allocations = 0;
+
     printf("CHUNK_SIZE: %"PRIu32"\n", (uint32_t)CHUNK_SIZE);
     printf("NUMBER_OF_TESTS: %d\n", NUMBER_OF_TESTS);
 
@@ -110,8 +114,16 @@ int main(void)
         struct node *head = malloc(sizeof(struct node));
         total += sizeof(struct node);
 
-        fill_memory(head);
+        uint32_t new_allocations = fill_memory(head);
         free_memory(head);
+
+        /* test if all memory was freed/can be allocated again */
+        if (allocations == 0) {
+            allocations = new_allocations;
+        } else if (allocations != new_allocations) {
+            puts("[FAILED]");
+            return -1;
+        }
     }
 
     puts("[SUCCESS]");


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If we can't allocate the same amount of buffers in the second run, fail the test.
This indicates that not all buffers have been properly freed.


### Testing procedure

`tests/malloc` should still work, but will fail if you use the `oneway_malloc` module (you'll have to delete `sys/oneway-malloc/include/malloc.h` for it to compile) 



### Issues/PRs references

discovered during #15474
