### PR TITLE
Makefile.include: only include serial.inc.mk once in Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -404,6 +404,10 @@ ifneq (,$(filter emulate%,$(MAKECMDGOALS)))
   -include $(RIOTMAKE)/tools/$(RIOT_EMULATOR).inc.mk
 endif
 
+# Include common serial logic to define TERMPROG, TERMFLAGS variables based on
+# the content of RIOT_TERMINAL
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 # Include common programmer logic if available
 -include $(RIOTMAKE)/tools/$(PROGRAMMER).inc.mk
 

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -1,6 +1,4 @@
 # configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 ARDUINO_MEGA2560_BOOTLOADER ?= stk500v2

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -1,6 +1,4 @@
 # configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 ARDUINO_UNO_BOOTLOADER ?= optiboot

--- a/boards/atmega256rfr2-xpro/Makefile.include
+++ b/boards/atmega256rfr2-xpro/Makefile.include
@@ -1,7 +1,3 @@
-# configure the terminal program
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-BAUD ?= 115200
 # Use EDBG (xplainedpro) programmer with avrdude
 AVRDUDE_PROGRAMMER ?= xplainedpro
 

--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board has an on-board ST-link adapter
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board has an on-board ST-link adapter
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/b-l475e-iot01a/Makefile.include
+++ b/boards/b-l475e-iot01a/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board has an on-board ST-link adapter
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/b-l475e-iot01a/Makefile.include
+++ b/boards/b-l475e-iot01a/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board has an on-board ST-link adapter
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -1,7 +1,3 @@
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # for this board we support flashing via openocd or pyocd
 PROGRAMMER ?= openocd
 

--- a/boards/cc1312-launchpad/Makefile.include
+++ b/boards/cc1312-launchpad/Makefile.include
@@ -1,8 +1,4 @@
 XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # configure the flash tool
 include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1312-launchpad/Makefile.include
+++ b/boards/cc1312-launchpad/Makefile.include
@@ -4,8 +4,5 @@ XDEBUGGER = XDS110
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # configure the flash tool
 include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1352-launchpad/Makefile.include
+++ b/boards/cc1352-launchpad/Makefile.include
@@ -1,8 +1,4 @@
 XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # configure the flash tool
 include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1352-launchpad/Makefile.include
+++ b/boards/cc1352-launchpad/Makefile.include
@@ -4,8 +4,5 @@ XDEBUGGER = XDS110
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # configure the flash tool
 include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1352p-launchpad/Makefile.include
+++ b/boards/cc1352p-launchpad/Makefile.include
@@ -1,8 +1,4 @@
 XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # configure the flash tool
 include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1352p-launchpad/Makefile.include
+++ b/boards/cc1352p-launchpad/Makefile.include
@@ -4,8 +4,5 @@ XDEBUGGER = XDS110
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # configure the flash tool
 include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -4,8 +4,5 @@ XDEBUGGER = XDS110
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # configure the flash tool
 PROGRAMMER ?= uniflash

--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -1,8 +1,4 @@
 XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # configure the flash tool
 PROGRAMMER ?= uniflash

--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -4,8 +4,5 @@ XDEBUGGER = XDS110
 PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # configure the flash tool
 PROGRAMMER ?= uniflash

--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -1,8 +1,4 @@
 XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # configure the flash tool
 PROGRAMMER ?= uniflash

--- a/boards/common/arduino-due/Makefile.include
+++ b/boards/common/arduino-due/Makefile.include
@@ -1,10 +1,6 @@
 # export this module and its includes
 INCLUDES  += -I$(RIOTBOARD)/common/arduino-due/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup flasher (using BOSSA)
 PROGRAMMER ?= bossa
 BOSSA_VERSION = 1.8

--- a/boards/common/arduino-due/Makefile.include
+++ b/boards/common/arduino-due/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES  += -I$(RIOTBOARD)/common/arduino-due/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup flasher (using BOSSA)
 PROGRAMMER ?= bossa
 BOSSA_VERSION = 1.8

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -1,9 +1,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -1,6 +1,3 @@
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model

--- a/boards/common/atmega/Makefile.include
+++ b/boards/common/atmega/Makefile.include
@@ -51,5 +51,3 @@ endif
 
 BOOTLOADER_SIZE ?= 0
 ROM_RESERVED ?= $(BOOTLOADER_SIZE)
-
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/cc2538/Makefile.include
+++ b/boards/common/cc2538/Makefile.include
@@ -1,9 +1,6 @@
 # define the default flash-tool
 PROGRAMMER ?= cc2538-bsl
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # For backward compatibility
 ifneq (,$(PORT_BSL))
   $(warning Warning! PORT_BSL is deprecated use PROG_DEV)

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -1,4 +1,3 @@
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -1,4 +1,3 @@
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Use OpenOCD by default
 PROGRAMMER ?= openocd
 
@@ -28,6 +24,3 @@ PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield.sh
 # The board can become un-flashable after some execution,
 # use connect_assert_srst to always be able to flash or reset the board.
 OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -4,7 +4,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 
 # setup serial terminal
 BAUD ?= 500000
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # Use openocd by default
 PROGRAMMER ?= openocd

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -3,8 +3,6 @@ INCLUDES += -I$(RIOTBOARD)/common/msb-430/include
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
 PROGRAMMER ?= mspdebug

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -10,4 +10,3 @@ PROGRAMMER ?= lpc2k_pgm
 MINITERMFLAGS += --rts 0 --dtr 0
 
 PYTERMFLAGS += -tg
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/common/nrf51/Makefile.include
+++ b/boards/common/nrf51/Makefile.include
@@ -1,6 +1,3 @@
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # include common nrf51 headers
 INCLUDES += -I$(RIOTBOARD)/common/nrf51/include
 

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -6,10 +6,6 @@ ifeq (bmp,$(PROGRAMMER))
   # the second is the BMP's UART interface
   PORT_LINUX ?= /dev/ttyACM1
   PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
-else
-  # configure the serial terminal
-  PORT_LINUX ?= /dev/ttyACM0
-  PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 endif
 
 PROGRAMMER ?= jlink

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -12,9 +12,6 @@ else
   PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 endif
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 PROGRAMMER ?= jlink
 ifeq (jlink,$(PROGRAMMER))
   # setup JLink for flashing

--- a/boards/common/slwstk6000b/Makefile.include
+++ b/boards/common/slwstk6000b/Makefile.include
@@ -2,10 +2,6 @@ INCLUDES += -I$(RIOTBOARD)/common/slwstk6000b/include
 # add BOARD_MODULE specific includes
 INCLUDES += -I$(RIOTBOARD)/common/slwstk6000b/modules/$(BOARD_MODULE)/include
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 include $(RIOTBOARD)/common/slwstk6000b/slwstk6000b.info.mk
 JLINK_DEVICE = $(word 2, $(SLWSTK6000B_MAINBOARD_VARS_$(BOARD_MODULE)))

--- a/boards/common/slwstk6000b/Makefile.include
+++ b/boards/common/slwstk6000b/Makefile.include
@@ -6,9 +6,6 @@ INCLUDES += -I$(RIOTBOARD)/common/slwstk6000b/modules/$(BOARD_MODULE)/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 include $(RIOTBOARD)/common/slwstk6000b/slwstk6000b.info.mk
 JLINK_DEVICE = $(word 2, $(SLWSTK6000B_MAINBOARD_VARS_$(BOARD_MODULE)))

--- a/boards/common/sodaq/Makefile.include
+++ b/boards/common/sodaq/Makefile.include
@@ -1,9 +1,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # Add board common includes
 INCLUDES += -I$(RIOTBOARD)/common/sodaq/include
 

--- a/boards/common/sodaq/Makefile.include
+++ b/boards/common/sodaq/Makefile.include
@@ -1,6 +1,3 @@
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Add board common includes
 INCLUDES += -I$(RIOTBOARD)/common/sodaq/include
 

--- a/boards/e180-zg120b-tb/Makefile.include
+++ b/boards/e180-zg120b-tb/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_DEVICE = EFR32MG1BxxxF256
 JLINK_PRE_FLASH = r

--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -1,6 +1,2 @@
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -2,8 +2,5 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # st-flash
 FLASHER = st-flash
 DEBUGGER = $(RIOTBOARD)/f4vi1/dist/debug.sh

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -1,9 +1,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -1,6 +1,3 @@
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model

--- a/boards/feather-nrf52840/Makefile.include
+++ b/boards/feather-nrf52840/Makefile.include
@@ -5,6 +5,4 @@ ifeq (,$(filter stdio_%,$(DISABLE_MODULE) $(USEMODULE)))
   RIOT_TERMINAL ?= jlink
 endif
 
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -5,8 +5,5 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/hamilton/Makefile.include
+++ b/boards/hamilton/Makefile.include
@@ -6,4 +6,3 @@ OFLAGS := --gap-fill 0xff
 
 # use JLink Segger RTT by default
 RIOT_TERMINAL ?= jlink
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with a custom reset command
 PROGRAMMER ?= openocd
 OPENOCD_CMD_RESET_RUN =-c _reset

--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Set default programmer as jlink
 PROGRAMMER ?= jlink
 

--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # Set default programmer as jlink
 PROGRAMMER ?= jlink
 

--- a/boards/i-nucleo-lrwan1/Makefile.include
+++ b/boards/i-nucleo-lrwan1/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # to flash this board, use an ST-link adapter
 DEBUG_ADAPTER ?= stlink
 

--- a/boards/i-nucleo-lrwan1/Makefile.include
+++ b/boards/i-nucleo-lrwan1/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # to flash this board, use an ST-link adapter
 DEBUG_ADAPTER ?= stlink
 

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -6,6 +6,3 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 PROGRAMMER ?= jlink
 JLINK_DEVICE = EFR32MG1PxxxF256
 JLINK_PRE_FLASH = r
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 PROGRAMMER ?= jlink
 JLINK_DEVICE = EFR32MG1PxxxF256

--- a/boards/im880b/Makefile.include
+++ b/boards/im880b/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 CFLAGS+=-DSX127X_TX_SWITCH
 CFLAGS+=-DSX127X_RX_SWITCH
 

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # Configure programmer
 PROGRAMMER ?= stm32loader
 

--- a/boards/lsn50/Makefile.include
+++ b/boards/lsn50/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 # this board can become un-flashable after a hardfault,

--- a/boards/lsn50/Makefile.include
+++ b/boards/lsn50/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 # this board can become un-flashable after a hardfault,

--- a/boards/maple-mini/Makefile.include
+++ b/boards/maple-mini/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/maple-mini/Makefile.include
+++ b/boards/maple-mini/Makefile.include
@@ -1,10 +1,6 @@
 # Include shared STM32 headers
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -9,6 +9,3 @@ DEBUGGER_FLAGS =
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -7,5 +7,4 @@ FFLAGS = $(FLASHFILE)
 DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -18,8 +18,6 @@ else ifeq ($(OS),Darwin)
 endif
 
 # configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -1,5 +1,4 @@
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
 # for this board we support flashing via openocd or pyocd

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -24,6 +24,3 @@ DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
 # Define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/nrf51dk/Makefile.include
+++ b/boards/nrf51dk/Makefile.include
@@ -1,5 +1,4 @@
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
 # use openocd by default to program this board

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -1,5 +1,4 @@
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
 # use jlink to program this board

--- a/boards/nucleo-l496zg/Makefile.include
+++ b/boards/nucleo-l496zg/Makefile.include
@@ -1,7 +1,2 @@
-# stdio is not available over st-link but on the Arduino TX/RX pins
-# A serial to USB converter plugged to the host is required
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-l4r5zi/Makefile.include
+++ b/boards/nucleo-l4r5zi/Makefile.include
@@ -1,6 +1,2 @@
-# stdio is available over st-link
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -8,6 +8,3 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util
 DFU_USB_ID = 0483:df11
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -4,8 +4,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # custom flasher to use with the bootloader
 PROGRAMMER ?= robotis-loader

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -1,10 +1,6 @@
 # Include shared STM32 headers
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # custom flasher to use with the bootloader
 PROGRAMMER ?= robotis-loader
 

--- a/boards/p-l496g-cell02/Makefile.include
+++ b/boards/p-l496g-cell02/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/p-l496g-cell02/Makefile.include
+++ b/boards/p-l496g-cell02/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -15,9 +15,6 @@ ifneq (,$(SERIAL))
   PORT_LINUX := $(SERIAL_TTY)
 endif
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Add board selector (USB serial) to OpenOCD options if specified.
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage: SERIAL="0200..." BOARD="pba-d-01-kw2x" make flash

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,5 +1,4 @@
 PORT_LINUX ?= /dev/ttyUSB0
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # use pic32prog by default to program this board
 PROGRAMMER ?= pic32prog

--- a/boards/pinetime/Makefile.include
+++ b/boards/pinetime/Makefile.include
@@ -1,6 +1,5 @@
 # use JLink Segger RTT by default
 RIOT_TERMINAL ?= jlink
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # define pyocd as programmer to program with stlink
 ifeq (pyocd,$(PROGRAMMER))

--- a/boards/pyboard/Makefile.include
+++ b/boards/pyboard/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util
 DFU_USB_ID = 1d50:607f

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -5,7 +5,5 @@ ifeq (,$(filter stdio_%,$(DISABLE_MODULE) $(USEMODULE)))
   RIOT_TERMINAL ?= jlink
 endif
 
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -2,10 +2,6 @@
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
-
 # this board uses openocd with an HEXFILE
 PROGRAMMER ?= openocd
 FLASHFILE ?= $(HEXFILE)

--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -1,6 +1,3 @@
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # by default, we use BOSSA to flash this board to take into account the
 # pre-flashed Arduino bootloader
 PROGRAMMER ?= bossa

--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -1,9 +1,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # by default, we use BOSSA to flash this board to take into account the
 # pre-flashed Arduino bootloader
 PROGRAMMER ?= bossa

--- a/boards/slstk3401a/Makefile.include
+++ b/boards/slstk3401a/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/slstk3401a/Makefile.include
+++ b/boards/slstk3401a/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/slstk3402a/Makefile.include
+++ b/boards/slstk3402a/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/slstk3402a/Makefile.include
+++ b/boards/slstk3402a/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_DEVICE = EFR32MG1PxxxF256
 JLINK_PRE_FLASH = r

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_DEVICE = EFR32MG1PxxxF256
 JLINK_PRE_FLASH = r

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -5,8 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # Skip the space needed by the embedded bootloader
 ROM_OFFSET ?= 0x5000
 

--- a/boards/stk3200/Makefile.include
+++ b/boards/stk3200/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/stk3200/Makefile.include
+++ b/boards/stk3200/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/stk3600/Makefile.include
+++ b/boards/stk3600/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/stk3600/Makefile.include
+++ b/boards/stk3600/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH = r
 

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/stm32f429i-disc1/Makefile.include
+++ b/boards/stm32f429i-disc1/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 # this board has an on-board ST-link adapter

--- a/boards/stm32f429i-disc1/Makefile.include
+++ b/boards/stm32f429i-disc1/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 # this board has an on-board ST-link adapter

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/stm32f723e-disco/Makefile.include
+++ b/boards/stm32f723e-disco/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 

--- a/boards/stm32f723e-disco/Makefile.include
+++ b/boards/stm32f723e-disco/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # this board uses openocd
 PROGRAMMER ?= openocd
 

--- a/boards/stm32f769i-disco/Makefile.include
+++ b/boards/stm32f769i-disco/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 

--- a/boards/stm32f769i-disco/Makefile.include
+++ b/boards/stm32f769i-disco/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 

--- a/boards/stm32l0538-disco/Makefile.include
+++ b/boards/stm32l0538-disco/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 

--- a/boards/stm32l476g-disco/Makefile.include
+++ b/boards/stm32l476g-disco/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/stm32l476g-disco/Makefile.include
+++ b/boards/stm32l476g-disco/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink

--- a/boards/stm32mp157c-dk2/Makefile.include
+++ b/boards/stm32mp157c-dk2/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board has an on-board ST-link adapter
 DEBUG_ADAPTER = stlink-dap
 OPENOCD_CORE = stm32mp15x.cm4

--- a/boards/stm32mp157c-dk2/Makefile.include
+++ b/boards/stm32mp157c-dk2/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # this board has an on-board ST-link adapter
 DEBUG_ADAPTER = stlink-dap
 OPENOCD_CORE = stm32mp15x.cm4

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -10,7 +10,6 @@ ifeq ($(TEENSY_LOADER),$(FLASHER))
 endif
 
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-*)))
 
 $(TEENSY_LOADER):

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -17,6 +17,3 @@ $(TEENSY_LOADER):
 	@echo "[INFO] teensy_loader binary not found - building it from source now"
 	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/teensy-loader-cli
 	@echo "[INFO] teensy_loader binary successfully build!"
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -3,7 +3,6 @@ PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))
 # setup serial terminal
 BAUD ?= 9600
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # flash tool configuration
 PROGRAMMER ?= goodfet

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -5,7 +5,5 @@ ifeq (,$(filter stdio_%,$(DISABLE_MODULE) $(USEMODULE)))
   RIOT_TERMINAL ?= jlink
 endif
 
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/ublox-c030-u201/Makefile.include
+++ b/boards/ublox-c030-u201/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 

--- a/boards/ublox-c030-u201/Makefile.include
+++ b/boards/ublox-c030-u201/Makefile.include
@@ -1,10 +1,6 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -1,5 +1,4 @@
 # configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 BAUD        ?= 9600
 WASPMOTE_PRO_BOOTLOADER ?= stk500v1

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -1,8 +1,6 @@
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
 PROGRAMMER ?= goodfet

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -18,9 +18,6 @@ ifneq (,$(filter debug% flash% %term test,$(MAKECMDGOALS)))
   endif
 endif
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # Default for these boards is to use a CMSIS-DAP programmer
 DEBUG_ADAPTER ?= dap
 

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -1,6 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
 # DEBUG_ADAPTER_ID="ATML..."
 

--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -11,10 +11,6 @@ ifeq (bmp,$(PROGRAMMER))
   # the second is the BMP's UART interface
   PORT_LINUX ?= /dev/ttyACM1
   PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
-else
-  # configure the serial terminal
-  PORT_LINUX ?= /dev/ttyACM0
-  PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 endif
 
 ifeq (openocd,$(PROGRAMMER))

--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -17,9 +17,6 @@ else
   PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 endif
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 ifeq (openocd,$(PROGRAMMER))
   # STM32 boards can become un-flashable after a hardfault,
   # use connect_assert_srst to always be able to flash or reset the boards.

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,8 +1,12 @@
+# Use as default the most commonly used ports on Linux and OSX
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
 # set default port depending on operating system
 ifeq ($(OS),Linux)
-  PORT ?= $(call ensure_value,$(PORT_LINUX),No port set)
+  PORT ?= $(PORT_LINUX)
 else ifeq ($(OS),Darwin)
-  PORT ?= $(call ensure_value,$(PORT_DARWIN),No port set)
+  PORT ?= $(PORT_DARWIN)
 endif
 
 # Default PROG_DEV is the same as PORT


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is done after all boards/cpu Makefile.includes are parsed so any board specific serial port (PORT_LINUX/PORT_DARWIN), default terminal (RIOT_TERMINAL) are already defined by the boards.

Then (unconditionally) including `serial.inc.mk` in the board code is not needed anymore, so this PR also removed all these includes.

The idea behind this PR is to have a declarative-like way of configuring the serial at board level. The main Makefile.include should be responsible of determining if the serial (or programmer, or emulator) logic should be included or not and there's already a common serial makefile. So this keeps a good flexibility while reducing code duplication.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- term and cleanterm targets should still work (tested on nucleo-l412kb and adafruit-clue)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Had this idea while reviewing #15459 (in #15459 (comment) exactly)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
