### PR TITLE
core/mbox: add mbox_size(), mbox_avail()

### DIFF
--- a/core/include/mbox.h
+++ b/core/include/mbox.h
@@ -159,6 +159,32 @@ static inline int mbox_try_get(mbox_t *mbox, msg_t *msg)
     return _mbox_get(mbox, msg, NON_BLOCKING);
 }
 
+/**
+ * @brief Get mbox queue size (capacity)
+ *
+ * @param[in] mbox  ptr to mailbox to operate on
+ *
+ * @return  size of mbox queue (or 0 if there's no queue)
+ */
+static inline size_t mbox_size(mbox_t *mbox)
+{
+    return mbox->cib.mask ? mbox->cib.mask + 1 : 0;
+}
+
+/**
+ * @brief Get messages available in mbox
+ *
+ * Returns the number of messages that can be retrieved without blocking.
+ *
+ * @param[in] mbox  ptr to mailbox to operate on
+ *
+ * @return  number of available messages
+ */
+static inline size_t mbox_avail(mbox_t *mbox)
+{
+    return cib_avail(&mbox->cib);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -107,7 +107,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     }
 #endif
 
-    if (reg->mbox.cib.mask != (GNRC_SOCK_MBOX_SIZE - 1)) {
+    if (mbox_size(&reg->mbox) != GNRC_SOCK_MBOX_SIZE) {
         return -EINVAL;
     }
 #ifdef MODULE_XTIMER
@@ -162,7 +162,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     *pkt_out = pkt; /* set out parameter */
 
 #if IS_ACTIVE(SOCK_HAS_ASYNC)
-    if (reg->async_cb.generic && cib_avail(&reg->mbox.cib)) {
+    if (reg->async_cb.generic && mbox_avail(&reg->mbox)) {
         reg->async_cb.generic(reg, SOCK_ASYNC_MSG_RECV, reg->async_cb_arg);
     }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, gnrc_sock directly accessed members of mbox_t to get the size of an mbox queue or availability of mbox messages.
This PR provides an API for that. Another commit makes gnrc_sock use the new API.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The change is rather small, but probably some gnrc_sock tests should be done.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
