### PR TITLE
sys/frac/frac.c: add missing inttypes.h include

### DIFF
--- a/sys/frac/frac.c
+++ b/sys/frac/frac.c
@@ -17,6 +17,8 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <inttypes.h>
+
 #include "assert.h"
 #include "frac.h"
 #include "bitarithm.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The DEBUG() messages are using e.g., PRIu32. Those need inttypes.h. (I think they're included by some other header frac.c includes, but it should be explicit.)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
