### PR TITLE
core: move scheduler defines

### DIFF
--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -45,58 +45,5 @@ typedef signed ssize_t;
 #   endif
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @def MAXTHREADS
- * @brief The maximum number of threads to be scheduled
- */
-#ifndef MAXTHREADS
-#define MAXTHREADS 32
-#endif
-
-/**
- * Canonical identifier for an invalid PID.
- */
-#define KERNEL_PID_UNDEF 0
-
-/**
- * The first valid PID (inclusive).
- */
-#define KERNEL_PID_FIRST (KERNEL_PID_UNDEF + 1)
-
-/**
- * The last valid PID (inclusive).
- */
-#define KERNEL_PID_LAST (KERNEL_PID_FIRST + MAXTHREADS - 1)
-
-/**
- * Macro for printing formatter
- */
-#define PRIkernel_pid PRIi16
-
-/**
- * Unique process identifier
- */
-typedef int16_t kernel_pid_t;
-
-/**
- * @brief   Determine if the given pid is valid
- *
- * @param[in]   pid     The pid to check
- *
- * @return      true if the pid is valid, false otherwise
- */
-static inline int pid_is_valid(kernel_pid_t pid)
-{
-    return ((KERNEL_PID_FIRST <= pid) && (pid <= KERNEL_PID_LAST));
-}
-
-#ifdef __cplusplus
-}
-#endif
-
 #endif /* KERNEL_TYPES_H */
 /** @} */

--- a/core/include/kernel_types.h
+++ b/core/include/kernel_types.h
@@ -45,5 +45,13 @@ typedef signed ssize_t;
 #   endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* KERNEL_TYPES_H */
 /** @} */

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -167,7 +167,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "kernel_types.h"
+
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/include/rmutex.h
+++ b/core/include/rmutex.h
@@ -31,7 +31,7 @@
 #endif
 
 #include "mutex.h"
-#include "kernel_types.h"
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -81,6 +81,8 @@
 #define SCHED_H
 
 #include <stddef.h>
+#include <inttypes.h>
+
 #include "kernel_defines.h"
 #include "native_sched.h"
 #include "clist.h"

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -82,7 +82,6 @@
 
 #include <stddef.h>
 #include "kernel_defines.h"
-#include "kernel_types.h"
 #include "native_sched.h"
 #include "clist.h"
 
@@ -90,6 +89,50 @@
 extern "C" {
 #endif
 
+/**
+ * @def MAXTHREADS
+ * @brief The maximum number of threads to be scheduled
+ */
+#ifndef MAXTHREADS
+#define MAXTHREADS 32
+#endif
+
+/**
+ * Canonical identifier for an invalid PID.
+ */
+#define KERNEL_PID_UNDEF 0
+
+/**
+ * The first valid PID (inclusive).
+ */
+#define KERNEL_PID_FIRST (KERNEL_PID_UNDEF + 1)
+
+/**
+ * The last valid PID (inclusive).
+ */
+#define KERNEL_PID_LAST (KERNEL_PID_FIRST + MAXTHREADS - 1)
+
+/**
+ * Macro for printing formatter
+ */
+#define PRIkernel_pid PRIi16
+
+/**
+ * Unique process identifier
+ */
+typedef int16_t kernel_pid_t;
+
+/**
+ * @brief   Determine if the given pid is valid
+ *
+ * @param[in]   pid     The pid to check
+ *
+ * @return      true if the pid is valid, false otherwise
+ */
+static inline int pid_is_valid(kernel_pid_t pid)
+{
+    return ((KERNEL_PID_FIRST <= pid) && (pid <= KERNEL_PID_LAST));
+}
 /**
  * @brief forward declaration for thread_t, defined in thread.h
  */

--- a/cpu/esp_common/include/freertos/task.h
+++ b/cpu/esp_common/include/freertos/task.h
@@ -13,6 +13,8 @@
 
 #ifndef DOXYGEN
 
+#include <limits.h> /* for INT_MAX */
+
 #include "thread.h"
 #include "freertos/FreeRTOS.h"
 

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -21,6 +21,8 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
+#include <limits.h>
+
 #include "cpu.h"
 #include "macros/units.h"
 

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -22,7 +22,7 @@
 #ifndef PIR_H
 #define PIR_H
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "periph/gpio.h"
 #include "stdbool.h"
 

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 #include "cib.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "mbox.h"
 #include "mutex.h"
 #include "random.h"

--- a/pkg/ndn-riot/patches/0003-adapt-to-moved-kernel_pid_t-location.patch
+++ b/pkg/ndn-riot/patches/0003-adapt-to-moved-kernel_pid_t-location.patch
@@ -1,0 +1,39 @@
+From 51d973f2a0a04a716af8260c62fb5045356a30a5 Mon Sep 17 00:00:00 2001
+From: Kaspar Schleiser <kaspar@schleiser.de>
+Date: Mon, 23 Nov 2020 12:44:54 +0100
+Subject: [PATCH] adapt to moved kernel_pid_t location
+
+---
+ face-table.h | 2 +-
+ ndn.h        | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/face-table.h b/face-table.h
+index 28b44a5c02..fb0c39b083 100644
+--- a/face-table.h
++++ b/face-table.h
+@@ -20,7 +20,7 @@
+ #ifndef NDN_FACE_TABLE_H_
+ #define NDN_FACE_TABLE_H_
+ 
+-#include <kernel_types.h>
++#include "sched.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/ndn.h b/ndn.h
+index d8d148c7f7..47d2032301 100644
+--- a/ndn.h
++++ b/ndn.h
+@@ -20,7 +20,7 @@
+ #ifndef NDN_H_
+ #define NDN_H_
+ 
+-#include <kernel_types.h>
++#include "sched.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {
+-- 
+2.29.2
+

--- a/pkg/uwb-core/include/dpl/dpl_tasks.h
+++ b/pkg/uwb-core/include/dpl/dpl_tasks.h
@@ -22,7 +22,7 @@
 
 #include "dpl_types.h"
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "thread.h"
 
 #ifdef __cplusplus

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #include "can/candev.h"
-#include "kernel_types.h"
+#include "sched.h"
 
 #ifdef MODULE_CAN_PM
 #include "xtimer.h"

--- a/sys/include/can/raw.h
+++ b/sys/include/can/raw.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "can/can.h"
 #include "can/common.h"
 #include "can/device.h"

--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -28,7 +28,7 @@
 #include <stdint.h>
 
 #include "net/fib/table.h"
-#include "kernel_types.h"
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -21,7 +21,7 @@
 
 #include <stdint.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "universal_address.h"
 #include "mutex.h"
 

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -99,7 +99,7 @@
 #ifndef NET_GNRC_IPV6_H
 #define NET_GNRC_IPV6_H
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "net/gnrc.h"
 #include "thread.h"
 

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "msg.h"
 #ifdef MODULE_GNRC_NETIF_BUS
 #include "msg_bus.h"

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -23,7 +23,7 @@
 
 #include <inttypes.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "net/gnrc/nettype.h"
 #include "net/gnrc/pkt.h"
 

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -25,7 +25,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "net/gnrc/nettype.h"
 #include "list.h"
 

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -22,7 +22,7 @@
 #ifndef NET_GNRC_PKTDUMP_H
 #define NET_GNRC_PKTDUMP_H
 
-#include "kernel_types.h"
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -137,7 +137,7 @@
 
 #include <stdbool.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 
 #include "net/gnrc/sixlowpan/config.h"
 #include "net/gnrc/sixlowpan/frag.h"

--- a/sys/include/net/gnrc/sixlowpan/frag/fb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/fb.h
@@ -88,7 +88,7 @@ gnrc_sixlowpan_frag_fb_t *gnrc_sixlowpan_frag_fb_get_by_tag(uint16_t tag);
 uint16_t gnrc_sixlowpan_frag_fb_next_tag(void);
 
 #if defined(TEST_SUITES) && !defined(DOXYGEN)
-#include "kernel_types.h"
+#include "sched.h"
 
 /* can't include `net/sixlowpan.h` as this would create a cyclical include */
 extern kernel_pid_t gnrc_sixlowpan_get_pid(void);

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -28,7 +28,7 @@
 
 #include "clist.h"
 #include "event.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "kernel_defines.h"
 #include "msg.h"
 #include "thread.h"

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -66,7 +66,7 @@
 #include <sys/types.h> /* for off_t etc. */
 #include <sys/statvfs.h> /* for struct statvfs */
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "clist.h"
 
 #ifdef __cplusplus

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -36,7 +36,7 @@
 #include "msg.h"
 #endif /* MODULE_CORE_MSG */
 #include "mutex.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "rmutex.h"
 
 #ifdef MODULE_ZTIMER_XTIMER_COMPAT

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -234,7 +234,7 @@
 
 #include <stdint.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "msg.h"
 
 #ifdef __cplusplus

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -28,7 +28,7 @@
 #include "msg.h"
 #endif /* MODULE_CORE_MSG */
 #include "mutex.h"
-#include "kernel_types.h"
+#include "sched.h"
 
 #include "ztimer.h"
 

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -19,7 +19,7 @@
 
 #include "byteorder.h"
 #include "cpu_conf.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "net/gnrc.h"
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/sixlowpan/ctx.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -27,7 +27,7 @@
 
 #include "bitfield.h"
 #include "evtimer_msg.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "mutex.h"
 #include "net/eui64.h"
 #include "net/ipv6/addr.h"

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -14,7 +14,7 @@
 
 #include <assert.h>
 
-#include "kernel_types.h"
+#include "sched.h"
 #include "net/gnrc.h"
 #include "thread.h"
 #include "utlist.h"

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -21,7 +21,7 @@
 #include "thread.h"
 #include "sched.h"
 #include "thread.h"
-#include "kernel_types.h"
+#include "sched.h"
 
 #ifdef MODULE_SCHEDSTATISTICS
 #include "schedstatistics.h"

--- a/sys/sema/sema.c
+++ b/sys/sema/sema.c
@@ -16,6 +16,8 @@
  */
 
 #include <errno.h>
+#include <limits.h>
+
 #include "irq.h"
 #include "assert.h"
 #include "sema.h"

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -26,7 +26,7 @@
 
 #include "bitfield.h"
 #include "byteorder.h"
-#include "kernel_types.h"
+#include "sched.h"
 #ifdef MODULE_LUID
 #include "luid.h"
 #endif

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -26,7 +26,7 @@
 #include "vfs.h"
 #include "mutex.h"
 #include "thread.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "clist.h"
 
 #define ENABLE_DEBUG 0

--- a/tests/bench_sizeof_coretypes/main.c
+++ b/tests/bench_sizeof_coretypes/main.c
@@ -25,7 +25,7 @@
 #include "cib.h"
 #include "clist.h"
 #include "panic.h"
-#include "kernel_types.h"
+#include "sched.h"
 #include "list.h"
 #include "mbox.h"
 #include "msg.h"

--- a/tests/bitarithm_timings/main.c
+++ b/tests/bitarithm_timings/main.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <limits.h>
 
 #include "bitarithm.h"
 #include "xtimer.h"

--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -25,7 +25,7 @@
 #include <stdio.h>
 
 #include "thread.h"
-#include "kernel_types.h"
+#include "sched.h"
 
 /* One stack for all threads. DON'T TRY THIS AT HOME!! */
 static char dummy_stack[THREAD_STACKSIZE_IDLE];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves some defines that clearly belong to scheduler/threading into from kernel_types.h to sched.h.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Only moved code, successful CI run should be sufficient.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
