### PR TITLE
mbox: provide function to unset initialized mbox

### DIFF
--- a/core/include/mbox.h
+++ b/core/include/mbox.h
@@ -185,6 +185,17 @@ static inline size_t mbox_avail(mbox_t *mbox)
     return cib_avail(&mbox->cib);
 }
 
+/**
+ * @brief   Unset's the mbox, effectively deinitializing and invalidating it.
+ *
+ * @param[in] mbox  ptr to mailbox to operate on
+ */
+static inline void mbox_unset(mbox_t *mbox)
+{
+    mbox->msg_array = NULL;
+    mbox->cib.mask = 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -101,13 +101,13 @@ typedef struct {
 
 static inline bool sys_mbox_valid(sys_mbox_t *mbox)
 {
-    return (mbox != NULL) && (mbox->mbox.cib.mask != 0);
+    return (mbox != NULL) && (mbox_size(&mbox->mbox) != 0);
 }
 
 static inline void sys_mbox_set_invalid(sys_mbox_t *mbox)
 {
     if (mbox != NULL) {
-        mbox->mbox.cib.mask = 0;
+        mbox_unset(&mbox->mbox);
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Split out of https://github.com/RIOT-OS/RIOT/pull/15484, as suggested in https://github.com/RIOT-OS/RIOT/pull/15484#discussion_r527685477.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following tests should still compile and run successfully:

- `tests/lwip`
- `tests/lwip_sock_ip` (both with `LWIP_IPV4=1` and `LWIP_IPV6=1` and their combination)
- `tests/lwip_sock_tcp` (both with `LWIP_IPV4=1` and `LWIP_IPV6=1` and their combination)
- `tests/lwip_sock_udp` (both with `LWIP_IPV4=1` and `LWIP_IPV6=1` and their combination)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Split out of https://github.com/RIOT-OS/RIOT/pull/15484
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
