### PR TITLE
make: handle emulator backend in Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -395,6 +395,13 @@ include $(BOARDDIR)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
+# Include emulator code if available and if emulate target is used
+ifneq (,$(filter emulate,$(MAKECMDGOALS)))
+  # Use renode as default emulator
+  RIOT_EMULATOR ?= renode
+  -include $(RIOTMAKE)/tools/$(RIOT_EMULATOR).inc.mk
+endif
+
 # Assume GCC/GNU as supported toolchain if CPU's Makefile.include doesn't
 # provide this macro
 TOOLCHAINS_SUPPORTED ?= gnu

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -6,7 +6,4 @@ PROGRAMMER_SERIAL ?= 06EB
 PORT_LINUX ?= $(word 2,$(shell $(RIOTTOOLS)/usb-serial/find-tty.sh '^$(PROGRAMMER_SERIAL)'))
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
-# setup emulator
-include $(RIOTMAKE)/tools/renode.inc.mk
-
 include $(RIOTBOARD)/common/cc2538/Makefile.include

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -12,7 +12,7 @@ else ifeq (pyocd,$(PROGRAMMER))
 endif
 
 # QEMU 4.0 added microbit system emulation.
-include $(RIOTMAKE)/tools/qemu.inc.mk
+RIOT_EMULATOR ?= qemu
 
 # include nrf51 boards common configuration
 include $(RIOTBOARD)/common/nrf51/Makefile.include

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -12,11 +12,7 @@ else ifeq (pyocd,$(PROGRAMMER))
 endif
 
 # QEMU 4.0 added microbit system emulation.
-EMULATOR = qemu-system-arm
-EMULATOR_FLAGS = -M microbit -device loader,file=$(ELFFILE) \
-                 -serial stdio \
-                 -monitor telnet::45454,server,nowait \
-                 -nographic
+include $(RIOTMAKE)/tools/qemu.inc.mk
 
 # include nrf51 boards common configuration
 include $(RIOTBOARD)/common/nrf51/Makefile.include

--- a/makefiles/tools/qemu.inc.mk
+++ b/makefiles/tools/qemu.inc.mk
@@ -1,0 +1,9 @@
+EMULATOR ?= qemu-system-arm
+EMULATOR_MACHINE ?= $(BOARD)
+EMULATOR_MONITOR_PORT ?= 45454
+EMULATOR_MONITOR_FLAGS ?= telnet::$(EMULATOR_MONITOR_PORT),server,nowait
+
+EMULATOR_FLAGS = -machine $(EMULATOR_MACHINE) -device loader,file=$(ELFFILE) \
+                 -serial stdio \
+                 -monitor $(EMULATOR_MONITOR_FLAGS) \
+                 -nographic


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR contains several changes to improve the handling of multiple emulators in the build system. It introduces the RIOT_EMULATOR variable, similar to the RIOT_TERMINAL which will allow (in the future maybe) to select the emulator to use.

The inclusion of an emulator related variables is done from Makefile.include after the boards Makefile.include are parsed. This avoid having to include in each board that provides support for an emulator (as suggested in https://github.com/RIOT-OS/RIOT/pull/15459#discussion_r525507044).

By default renode is the default emulator, since it provides the widest hardware abstraction.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- The emulator logic should still work with microbit (qemu) and cc2538dk (renode):

<details><summary>microbit</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=microbit -C examples/hello-world all emulate --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=microbit'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=microbit'    all
Building application "hello-world" for "microbit" with MCU "nrf51".

"make" -C /data/riotbuild/riotbase/boards/microbit
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/nrf51
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf51/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8116	    108	   2296	  10520	   2918	/data/riotbuild/riotbase/examples/hello-world/bin/microbit/hello-world.elf
qemu-system-arm -machine microbit -device loader,file=/work/riot/RIOT/examples/hello-world/bin/microbit/hello-world.elf -serial stdio -monitor telnet::45454,server,nowait -nographic
main(): This is RIOT! (Version: 2021.01-devel-1009-gba882-pr/make/emulator_enh)
Hello World!
You are running RIOT on a(n) microbit board.
This board features a(n) nrf51 MCU.
```

</details>

<details><summary>cc2538dk</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=cc2538dk -C examples/hello-world all emulate --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=cc2538dk'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=cc2538dk'    all
Building application "hello-world" for "cc2538dk" with MCU "cc2538".

"make" -C /data/riotbuild/riotbase/boards/cc2538dk
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/cc2538
"make" -C /data/riotbuild/riotbase/cpu/cc2538/periph
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8852	    112	   2296	  11260	   2bfc	/data/riotbuild/riotbase/examples/hello-world/bin/cc2538dk/hello-world.elf
/work/riot/RIOT/dist/tools/renode/run-renode.sh start
### Starting Renode ###
sh: 1: renode: not found
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will limit the changes required in #15459.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
