### PR TITLE
gh-actions/release-test: bump ssh-agent to v0.4.1

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -162,7 +162,7 @@ jobs:
       run: |
         echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
     - name: Setup SSH agent
-      uses: webfactory/ssh-agent@v0.4.0
+      uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
     - name: Fetch host key from IoT-LAB saclay site

--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Configure credentials
         run: echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
       - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.4.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
       - name: Fetch host key from IoT-LAB ${{ matrix.boards.iotlab.site }} site


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Version 0.4.0 of the `ssh-agent` action still uses the [deprecated `set-env` command](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) which is why the release tests [are currently failing](https://github.com/RIOT-OS/RIOT/runs/1434608834?check_suite_focus=true#step:9:11). Version 0.4.1 fixes that and [does not use the `set-env` command anymore](https://github.com/webfactory/ssh-agent/blob/master/CHANGELOG.md#v041-2020-10-07). 

This PR also bumps the version in the `test-on-iotlab` action, as it also uses the deprecated version of `ssh-agent`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
