### PR TITLE
boards/firefly: add renode configuration

### DIFF
--- a/boards/firefly/dist/board.resc
+++ b/boards/firefly/dist/board.resc
@@ -1,0 +1,32 @@
+:name: Zolertia Firefly
+:description: This script runs Zolertia Firefly on RIOT.
+
+$name?="Zolertia-Firefly"
+using sysbus
+mach create $name
+
+machine LoadPlatformDescription @platforms/boards/zolertia-firefly.repl
+
+machine PyDevFromFile @scripts/pydev/rolling-bit.py 0x400D2004 0x4 True "sysctrl"
+
+showAnalyzer uart0
+
+$id = `next_value 1`
+
+macro reset
+"""
+    #set node address. 0x00 0x12 0x4B is TI OUI
+    sysbus WriteDoubleWord 0x00280028 $id
+    sysbus WriteDoubleWord 0x0028002C 0x00
+    sysbus WriteDoubleWord 0x00280030 0xAB
+    sysbus WriteDoubleWord 0x00280034 0x89
+    sysbus WriteDoubleWord 0x00280038 0x00
+    sysbus WriteDoubleWord 0x0028003C 0x4B
+    sysbus WriteDoubleWord 0x00280040 0x12
+    sysbus WriteDoubleWord 0x00280044 0x00
+
+    sysbus LoadELF $image_file
+"""
+
+runMacro $reset
+start

--- a/boards/firefly/doc.txt
+++ b/boards/firefly/doc.txt
@@ -107,6 +107,16 @@ On Linux:
 - Firefly over CP2104: `ttyUSB0`
 - Firefly over USB driver (in CDC-ACM): `ttyACMn` (n=0, 1, ....)
 
+Emulator
+========
+
+To emulate this board you need an updated version of
+[renode](https://github.com/renode/renode) installed, at least version 1.9.
+
+```
+BOARD=firefly make all emulate
+```
+
 More Reading
 ============
 1. [Zolertia Firefly website][remote-site]


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a renode config file for the Zolertia firefly board. Since the hardware description (board and cpu) are already provided in Renode repository, the addition is pretty straight-forward.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Install Renode (at least 0.9 is required), like [1.11 release](https://github.com/renode/renode/releases/tag/v1.11.0)
- Run `make BOARD=firefly -C examples/hello-world all emulate`

<p align=center>
<img src="https://user-images.githubusercontent.com/1375137/99880206-4bf03900-2c12-11eb-91ac-2306587c96df.png" width=400px/>

<img src="https://user-images.githubusercontent.com/1375137/99880200-4266d100-2c12-11eb-850e-f5a644c485ab.png" width=400px/>
</p>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on #15486 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
