### PR TITLE
sys/include/ztimer/xtimer_compat: fix wrong variable name

### DIFF
--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -95,7 +95,7 @@ static inline void xtimer_msleep(uint32_t milliseconds)
     if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
         ztimer_sleep(ZTIMER_MSEC, milliseconds);
     } else {
-        _ztimer_sleep_scale(ZTIMER_USEC, seconds, 1000);
+        _ztimer_sleep_scale(ZTIMER_USEC, milliseconds, 1000);
     }
 }
 


### PR DESCRIPTION
### Contribution description

This PR fixes a wrong variable name.

### Testing procedure

Should be evident, but can be seen by compiling `tests/xtimer_usleep` with `ztimer_xtimer_compat`
