### PR TITLE
drivers/periph/uart: add uart_set_rx_cb() to uart_reconfigure API

### DIFF
--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -182,6 +182,20 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
 
 #if defined(MODULE_PERIPH_UART_RECONFIGURE) || DOXYGEN
 /**
+ * @brief   Set the UART RX callback
+ *
+ * If no callback parameter is given (rx_cb := NULL), the UART will be
+ * initialized in TX only mode.
+ *
+ * @param[in] uart          UART device to configure
+ * @param[in] rx_cb         receive callback, executed in interrupt context once
+ *                          for every byte that is received (RX buffer filled),
+ *                          set to NULL for TX only mode
+ * @param[in] arg           optional context passed to the callback functions
+ */
+void uart_set_rx_cb(uart_t uart, uart_rx_cb_t rx_cb, void *arg);
+
+/**
  * @brief   Change the pins of the given UART back to plain GPIO functionality
  *
  * The pin mux of the RX and TX pins of the bus will be changed back to


### PR DESCRIPTION
### Contribution description

I discovered that we have no way to re-configure the UART RX callback after `uart_init()` has been called as it is not guaranteed that we can call `uart_init()` again. (And that is pretty much overkill just to set a pointer)

So add a `uart_set_rx_cb()` function that does just that.

To not having to implement this for all architectures, I added it to the `periph_uart_reconfigure` API which is currently only implemented by sam0.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
