### PR TITLE
cpu/efm32/periph/timer: fix timer_t -> tim_t

### DIFF
--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -50,7 +50,7 @@ static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 /**
  * @brief   Check whether device is a using a WTIMER device (32-bit)
  */
-static inline bool _is_wtimer(timer_t dev)
+static inline bool _is_wtimer(tim_t dev)
 {
 #if defined(WTIMER_COUNT) && WTIMER_COUNT > 0
     return ((uint32_t) timer_config[dev].timer.dev) >= WTIMER0_BASE;
@@ -63,7 +63,7 @@ static inline bool _is_wtimer(timer_t dev)
 /**
  * @brief   Check whether dev is using a LETIMER device
  */
-static inline bool _is_letimer(timer_t dev)
+static inline bool _is_letimer(tim_t dev)
 {
 #if defined(LETIMER_COUNT) && LETIMER_COUNT > 0
     return ((uint32_t) timer_config[dev].timer.dev) == LETIMER0_BASE;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The static functions `_is_wtimer()` and `_is_letimer()` were taking a timer_t argument, but they were also called with a tim_t argument in that file. I think that was a typo that just happened to work because "sys/types.h" ~~was~~ is included somewhere up the include dependency path.

This PR fixes the arguments to `tim_t`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Only file-local changes, so successful CI run should be sufficient.
 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while working on #15481.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
