### PR TITLE
drivers/periph/uart: add uart_write_byte() & uart_write_string() functions

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -57,6 +57,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @name   UART implements writing single bytes
+ * @{
+ */
+#define PERIPH_UART_NEEDS_WRITE_BYTE    (0)
+/** @} */
+
+/**
  * @brief   Override GPIO type
  * @{
  */

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -290,10 +290,6 @@ void uart_write_byte(uart_t uart, uint8_t data)
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
-    if (!gpio_is_valid(uart_config[uart].tx_pin)) {
-        return;
-    }
-
     for (const void* end = data + len; data != end; ++data) {
         _write_byte(uart, *data);
     }

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -91,6 +91,30 @@ typedef unsigned int uart_t;
 #endif
 
 /**
+ * @brief   Set to 1 if the CPU does not provide an implementation
+ *          for @ref uart_write
+ */
+#ifndef PERIPH_UART_NEEDS_WRITE
+#define PERIPH_UART_NEEDS_WRITE         (0)
+#endif
+
+/**
+ * @brief   Set to 1 if the CPU does not provide an implementation
+ *          for @ref uart_write_byte
+ */
+#ifndef PERIPH_UART_NEEDS_WRITE_BYTE
+#define PERIPH_UART_NEEDS_WRITE_BYTE    (1)
+#endif
+
+/**
+ * @brief   Set to 1 if the CPU does not provide an implementation
+ *          for @ref uart_write_string
+ */
+#ifndef PERIPH_UART_NEEDS_WRITE_STRING
+#define PERIPH_UART_NEEDS_WRITE_STRING  (1)
+#endif
+
+/**
  * @brief   Signature for receive interrupt callback
  *
  * @param[in] arg           context to the callback (optional)
@@ -270,6 +294,38 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
  *
  */
 void uart_write(uart_t uart, const uint8_t *data, size_t len);
+
+/**
+ * @brief   Write a single byte of data to the specified UART device
+ *
+ * This function is blocking, as it will only return after @p data
+ * has been send.
+ *
+ * @param[in] uart          UART device to use for transmission
+ * @param[in] data          byte to write
+ *
+ */
+#if PERIPH_UART_NEEDS_WRITE_BYTE
+static inline void uart_write_byte(uart_t uart, uint8_t data)
+{
+    uart_write(uart, &data, 1);
+}
+#else
+void uart_write_byte(uart_t uart, uint8_t data);
+#endif
+
+/**
+ * @brief   Write a NULL-terminated string to the specified UART device
+ *
+ * This function is blocking, as it will only return after all characters
+ * of the given string have been send. The way this data is send is up to the
+ * implementation: active waiting, interrupt driven, DMA, etc.
+ *
+ * @param[in] uart          UART device to use for transmission
+ * @param[in] s             string to send (NULL-terminated)
+ *
+ */
+void uart_write_string(uart_t uart, const char *s);
 
 /**
  * @brief   Power on the given UART device

--- a/drivers/periph_common/uart.c
+++ b/drivers/periph_common/uart.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph_uart
+ * @{
+ *
+ * @file
+ * @brief       common UART function fallback implementations
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+#include <stddef.h>
+#include <string.h>
+
+#include "board.h"
+#include "cpu.h"
+#include "kernel_defines.h"
+#include "periph/uart.h"
+
+#if PERIPH_UART_NEEDS_WRITE_STRING
+void uart_write_string(uart_t uart, const char *s)
+{
+    if (!PERIPH_UART_NEEDS_WRITE_BYTE) {
+        while (*s) {
+            uart_write_byte(uart, (uint8_t)*s++);
+        }
+    } else {
+        uart_write(uart, (uint8_t*)s, strlen(s));
+    }
+}
+#endif
+
+#if PERIPH_UART_NEEDS_WRITE && !PERIPH_UART_NEEDS_WRITE_BYTE
+void uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+    for (const uint8_t *end = data + len; data != end; ++data) {
+        uart_write_byte(uart, *data);
+    }
+}
+#endif

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -241,7 +241,6 @@ static int cmd_mode(int argc, char **argv)
 static int cmd_send(int argc, char **argv)
 {
     int dev;
-    uint8_t endline = (uint8_t)'\n';
 
     if (argc < 3) {
         printf("usage: %s <dev> <data (string)>\n", argv[0]);
@@ -254,8 +253,8 @@ static int cmd_send(int argc, char **argv)
     }
 
     printf("UART_DEV(%i) TX: %s\n", dev, argv[2]);
-    uart_write(UART_DEV(dev), (uint8_t *)argv[2], strlen(argv[2]));
-    uart_write(UART_DEV(dev), &endline, 1);
+    uart_write_string(UART_DEV(dev), argv[2]);
+    uart_write_byte(UART_DEV(dev), '\n');
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description

When implementing the serial bootloader feature, I added some UART convenience functions. 

 - `uart_write_byte()` to send a single byte over UART
 - `uart_write_string()` to send a string of text. This is especially useful for debugging with no stdio

Both are implemented as common fallback functions in `drivers/periph_common` but can be implemented by the CPU.
An implementation for sam0 is provided for `uart_write_byte()`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
