### PR TITLE
boards/hifive*: add renode support

### DIFF
--- a/boards/hifive1/dist/board.resc
+++ b/boards/hifive1/dist/board.resc
@@ -1,0 +1,24 @@
+:name: SiFive-FE310
+:description: This script runs the Sifive Hifive1 on RIOT.
+
+$name?="SiFive-FE310"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/cpus/sifive-fe310.repl
+
+showAnalyzer uart0
+
+cpu PerformanceInMips 320
+
+sysbus Tag <0x10008000 4> "PRCI_HFROSCCFG" 0xFFFFFFFF
+sysbus Tag <0x10008004 4> "PRCI_HFXOSCCFG" 0xFFFFFFFF
+sysbus Tag <0x10008008 4> "PRCI_PLLCFG" 0xFFFFFFFF
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+"""
+
+runMacro $reset
+start

--- a/boards/hifive1b/dist/board.resc
+++ b/boards/hifive1b/dist/board.resc
@@ -1,0 +1,24 @@
+:name: SiFive-FE310
+:description: This script runs the Sifive Hifive1b on RIOT.
+
+$name?="SiFive-FE310"
+
+using sysbus
+mach create $name
+machine LoadPlatformDescription @platforms/cpus/sifive-fe310.repl
+
+showAnalyzer uart0
+
+cpu PerformanceInMips 320
+
+sysbus Tag <0x10008000 4> "PRCI_HFROSCCFG" 0xFFFFFFFF
+sysbus Tag <0x10008004 4> "PRCI_HFXOSCCFG" 0xFFFFFFFF
+sysbus Tag <0x10008008 4> "PRCI_PLLCFG" 0xFFFFFFFF
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+"""
+
+runMacro $reset
+start


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Just found out how to add support for the hifive1* boards in renode. Just tested some basic applications (hello-world, default) with success.
It's not perfect (lots of warnings in the renode output) but it works :)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<details><summary>BUILD_IN_DOCKER=1 make BOARD=hifive1b -C examples/hello-world all emulate --no-print-directory</summary>

<p align=center>
<img src="https://user-images.githubusercontent.com/1375137/100066237-1b3c1980-2e35-11eb-97ba-fecf1a758093.png" width=400px/>
<img src="https://user-images.githubusercontent.com/1375137/100066250-21ca9100-2e35-11eb-9c16-dd0720607728.png" width=400px/>
</p>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C examples/hello-world all emulate --no-print-directory 
Falling back to legacy riscv-none-embed toolchain
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    all
Falling back to legacy riscv-none-embed toolchain
Building application "hello-world" for "hifive1b" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/boards/hifive1b
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/nano
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8582	    104	   2252	  10938	   2aba	/data/riotbuild/riotbase/examples/hello-world/bin/hifive1b/hello-world.elf
/work/riot/RIOT/dist/tools/renode/run-renode.sh start
### Starting Renode ###
Gtk-Message: 09:08:58.213: Failed to load module "canberra-gtk-module"
09:08:59.5799 [INFO] Loaded monitor commands from: /opt/renode/./scripts/monitor.py
09:09:00.5849 [INFO] Including script: /work/riot/RIOT/examples/hello-world/bin/hifive1b/board.resc
09:09:00.6320 [INFO] System bus created.
09:09:01.8448 [INFO] sysbus: Loaded SVD: /tmp/renode-462203/64cf356d-90ed-43f3-9d88-c32ee9e11efd.tmp. Name: FE310. Description: E31 CPU Coreplex, high-performance, 32-bit RV32IMAC core
      .
09:09:02.6908 [INFO] sysbus: Loading segment of 8584 bytes length at 0x20010000.
09:09:02.7141 [INFO] sysbus: Loading segment of 104 bytes length at 0x20012188.
09:09:02.7967 [INFO] cpu: Setting PC value to 0x20010000.
09:09:02.8237 [INFO] SiFive-FE310: Machine started.
09:09:02.9881 [WARNING] sysbus: [cpu: 0x200103D4] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:09:02.9902 [WARNING] sysbus: Write of value 0x40100004 to an unimplemented register PRIC:HFROSCCFG (0x10008000) generated from SVD.
09:09:02.9903 [WARNING] sysbus: [cpu: 0x200103EA] (tag: 'PRCI_HFROSCCFG') ReadDoubleWord from non existing peripheral at 0x10008000, returning 0xFFFFFFFF.
09:09:02.9904 [WARNING] sysbus: [cpu: 0x200103F0] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:09:02.9905 [WARNING] sysbus: Write of value 0xFFFEFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:09:02.9906 [WARNING] sysbus: Write of value 0x40000000 to an unimplemented register PRIC:HFXOSCCFG (0x10008004) generated from SVD.
09:09:02.9906 [WARNING] sysbus: [cpu: 0x20010404] (tag: 'PRCI_HFXOSCCFG') ReadDoubleWord from non existing peripheral at 0x10008004, returning 0xFFFFFFFF.
09:09:02.9907 [WARNING] sysbus: Write of value 0x60000 to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:09:02.9908 [WARNING] sysbus: Write of value 0x100 to an unimplemented register PRIC:PLLOUTDIV (0x1000800C) generated from SVD.
09:09:02.9909 [WARNING] sysbus: [cpu: 0x20010416] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:09:02.9909 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:09:02.9910 [WARNING] sysbus: [cpu: 0x20010424] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:09:02.9911 [WARNING] sysbus: Write of value 0xFFFBFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:09:02.9912 [WARNING] sysbus: [cpu: 0x2001042E] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:09:02.9913 [WARNING] sysbus: [cpu: 0x20010434] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:09:02.9913 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:09:02.9914 [WARNING] sysbus: [cpu: 0x20010440] (tag: 'PRCI_HFROSCCFG') ReadDoubleWord from non existing peripheral at 0x10008000, returning 0xFFFFFFFF.
09:09:02.9915 [WARNING] sysbus: Write of value 0xBFFFFFFF to an unimplemented register PRIC:HFROSCCFG (0x10008000) generated from SVD.
09:09:03.0445 [WARNING] plic: Unhandled write to offset 0x200000, value 0x0.
09:09:03.0497 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:09:03.0502 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:09:03.0504 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:09:03.0506 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x20000.
09:09:03.0640 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:09:03.0643 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:09:03.0644 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:09:03.0646 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:09:03.0647 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:09:03.0648 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:09:03.0650 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:09:03.0651 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:09:03.0652 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:09:03.0654 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:09:03.0655 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:09:03.0656 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:09:03.0657 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:09:03.0658 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:09:03.0659 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:09:03.0661 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:09:03.0662 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:09:03.0663 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
```

</details>


<details><summary>BUILD_IN_DOCKER=1 make BOARD=hifive1 -C examples/hello-world all emulate --no-print-directory</summary>

<p align=center>
<img src="https://user-images.githubusercontent.com/1375137/100066368-4d4d7b80-2e35-11eb-8a21-4a3d3e43ab5a.png" width=400px/>
<img src="https://user-images.githubusercontent.com/1375137/100066393-550d2000-2e35-11eb-9054-3518f0db4f40.png" width=400px/>
</p>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1 -C examples/hello-world all emulate --no-print-directory 
Falling back to legacy riscv-none-embed toolchain
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=hifive1'    all
Falling back to legacy riscv-none-embed toolchain
Building application "hello-world" for "hifive1" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/boards/hifive1
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/nano
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8578	    104	   2252	  10934	   2ab6	/data/riotbuild/riotbase/examples/hello-world/bin/hifive1/hello-world.elf
/work/riot/RIOT/dist/tools/renode/run-renode.sh start
### Starting Renode ###
Gtk-Message: 09:12:50.239: Failed to load module "canberra-gtk-module"
09:12:51.5288 [INFO] Loaded monitor commands from: /opt/renode/./scripts/monitor.py
09:12:52.3327 [INFO] Including script: /work/riot/RIOT/examples/hello-world/bin/hifive1/board.resc
09:12:52.3447 [INFO] System bus created.
09:12:53.0052 [INFO] sysbus: Loaded SVD: /tmp/renode-463462/009455c4-a7f4-49a2-b58b-effeab54d2e7.tmp. Name: FE310. Description: E31 CPU Coreplex, high-performance, 32-bit RV32IMAC core
      .
09:12:53.4016 [INFO] sysbus: Loading segment of 8580 bytes length at 0x20400000.
09:12:53.4116 [INFO] sysbus: Loading segment of 104 bytes length at 0x20402184.
09:12:53.4288 [INFO] cpu: Setting PC value to 0x20400000.
09:12:53.4442 [INFO] SiFive-FE310: Machine started.
09:12:53.5458 [WARNING] sysbus: [cpu: 0x204003D4] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:12:53.5476 [WARNING] sysbus: Write of value 0x40100004 to an unimplemented register PRIC:HFROSCCFG (0x10008000) generated from SVD.
09:12:53.5477 [WARNING] sysbus: [cpu: 0x204003EA] (tag: 'PRCI_HFROSCCFG') ReadDoubleWord from non existing peripheral at 0x10008000, returning 0xFFFFFFFF.
09:12:53.5477 [WARNING] sysbus: [cpu: 0x204003F0] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:12:53.5478 [WARNING] sysbus: Write of value 0xFFFEFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:12:53.5478 [WARNING] sysbus: Write of value 0x40000000 to an unimplemented register PRIC:HFXOSCCFG (0x10008004) generated from SVD.
09:12:53.5478 [WARNING] sysbus: [cpu: 0x20400404] (tag: 'PRCI_HFXOSCCFG') ReadDoubleWord from non existing peripheral at 0x10008004, returning 0xFFFFFFFF.
09:12:53.5479 [WARNING] sysbus: Write of value 0x60000 to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:12:53.5480 [WARNING] sysbus: Write of value 0x100 to an unimplemented register PRIC:PLLOUTDIV (0x1000800C) generated from SVD.
09:12:53.5480 [WARNING] sysbus: [cpu: 0x20400416] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:12:53.5481 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:12:53.5481 [WARNING] sysbus: [cpu: 0x20400424] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:12:53.5481 [WARNING] sysbus: Write of value 0xFFFBFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:12:53.5482 [WARNING] sysbus: [cpu: 0x2040042E] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:12:53.5482 [WARNING] sysbus: [cpu: 0x20400434] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:12:53.5483 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:12:53.5483 [WARNING] sysbus: [cpu: 0x20400440] (tag: 'PRCI_HFROSCCFG') ReadDoubleWord from non existing peripheral at 0x10008000, returning 0xFFFFFFFF.
09:12:53.5483 [WARNING] sysbus: Write of value 0xBFFFFFFF to an unimplemented register PRIC:HFROSCCFG (0x10008000) generated from SVD.
09:12:53.5841 [WARNING] plic: Unhandled write to offset 0x200000, value 0x0.
09:12:53.5894 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:12:53.5898 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:12:53.5899 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:12:53.5900 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x20000.
09:12:53.6016 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:12:53.6019 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:12:53.6020 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:12:53.6021 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:12:53.6021 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:12:53.6022 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:12:53.6024 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:12:53.6025 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:12:53.6026 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:12:53.6027 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:12:53.6027 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:12:53.6028 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:12:53.6030 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:12:53.6030 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:12:53.6031 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:12:53.6031 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:12:53.6032 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:12:53.6032 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
```

</details>

<details><summary>BUILD_IN_DOCKER=1 make BOARD=hifive1b -C examples/default all emulate --no-print-directory</summary>

<p align=center>
<img src="https://user-images.githubusercontent.com/1375137/100066515-7d951a00-2e35-11eb-9bc3-9fe79a5ba556.png" width=400px/>
<img src="https://user-images.githubusercontent.com/1375137/100066536-82f26480-2e35-11eb-8238-416ca8e8b120.png" width=400px/>
</p>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C examples/default all emulate --no-print-directory 
Falling back to legacy riscv-none-embed toolchain
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/examples/default/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    all
Falling back to legacy riscv-none-embed toolchain
Building application "default" for "hifive1b" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/boards/hifive1b
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/nano
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/drivers/saul/init_devs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  20177	    488	   2344	  23009	   59e1	/data/riotbuild/riotbase/examples/default/bin/hifive1b/default.elf
/work/riot/RIOT/dist/tools/renode/run-renode.sh start
### Starting Renode ###
Gtk-Message: 09:14:14.711: Failed to load module "canberra-gtk-module"
09:14:16.3559 [INFO] Loaded monitor commands from: /opt/renode/./scripts/monitor.py
09:14:17.3471 [INFO] Including script: /work/riot/RIOT/examples/default/bin/hifive1b/board.resc
09:14:17.3593 [INFO] System bus created.
09:14:18.3018 [INFO] sysbus: Loaded SVD: /tmp/renode-464263/3caa57fa-9071-4551-b839-5cf6996c91a6.tmp. Name: FE310. Description: E31 CPU Coreplex, high-performance, 32-bit RV32IMAC core
      .
09:14:18.7755 [INFO] sysbus: Loading segment of 20180 bytes length at 0x20010000.
09:14:18.7878 [INFO] sysbus: Loading segment of 488 bytes length at 0x20014ED4.
09:14:18.8130 [INFO] cpu: Setting PC value to 0x20010000.
09:14:18.8344 [INFO] SiFive-FE310: Machine started.
09:14:19.0162 [WARNING] sysbus: [cpu: 0x200104C2] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:14:19.0190 [WARNING] sysbus: Write of value 0x40100004 to an unimplemented register PRIC:HFROSCCFG (0x10008000) generated from SVD.
09:14:19.0191 [WARNING] sysbus: [cpu: 0x200104D8] (tag: 'PRCI_HFROSCCFG') ReadDoubleWord from non existing peripheral at 0x10008000, returning 0xFFFFFFFF.
09:14:19.0192 [WARNING] sysbus: [cpu: 0x200104DE] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:14:19.0193 [WARNING] sysbus: Write of value 0xFFFEFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:14:19.0193 [WARNING] sysbus: Write of value 0x40000000 to an unimplemented register PRIC:HFXOSCCFG (0x10008004) generated from SVD.
09:14:19.0194 [WARNING] sysbus: [cpu: 0x200104F2] (tag: 'PRCI_HFXOSCCFG') ReadDoubleWord from non existing peripheral at 0x10008004, returning 0xFFFFFFFF.
09:14:19.0194 [WARNING] sysbus: Write of value 0x60000 to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:14:19.0195 [WARNING] sysbus: Write of value 0x100 to an unimplemented register PRIC:PLLOUTDIV (0x1000800C) generated from SVD.
09:14:19.0196 [WARNING] sysbus: [cpu: 0x20010504] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:14:19.0196 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:14:19.0197 [WARNING] sysbus: [cpu: 0x20010512] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:14:19.0198 [WARNING] sysbus: Write of value 0xFFFBFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:14:19.0198 [WARNING] sysbus: [cpu: 0x2001051C] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:14:19.0199 [WARNING] sysbus: [cpu: 0x20010522] (tag: 'PRCI_PLLCFG') ReadDoubleWord from non existing peripheral at 0x10008008, returning 0xFFFFFFFF.
09:14:19.0200 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register PRIC:PLLCFG (0x10008008) generated from SVD.
09:14:19.0201 [WARNING] sysbus: [cpu: 0x2001052E] (tag: 'PRCI_HFROSCCFG') ReadDoubleWord from non existing peripheral at 0x10008000, returning 0xFFFFFFFF.
09:14:19.0201 [WARNING] sysbus: Write of value 0xBFFFFFFF to an unimplemented register PRIC:HFROSCCFG (0x10008000) generated from SVD.
09:14:19.0564 [WARNING] plic: Unhandled write to offset 0x200000, value 0x0.
09:14:19.0581 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:14:19.0582 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:14:19.0582 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:14:19.0583 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x20000.
09:14:19.0586 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:14:19.0587 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:14:19.0587 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:14:19.0588 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x10000.
09:14:19.0607 [WARNING] uart0: Trying to read data from empty receive fifo
09:14:19.0724 [WARNING] sysbus: Write of value 0xF to an unimplemented register RTC:CONFIG (0x10000040) generated from SVD.
09:14:19.0725 [WARNING] sysbus: Write of value 0x0 to an unimplemented register RTC:LO (0x10000048) generated from SVD.
09:14:19.0725 [WARNING] sysbus: Write of value 0x0 to an unimplemented register RTC:HI (0x1000004C) generated from SVD.
09:14:19.0726 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register RTC:COMPARE (0x10000060) generated from SVD.
09:14:19.0733 [WARNING] sysbus: Read from an unimplemented register RTC:CONFIG (0x10000040), returning a value from SVD: 0x0.
09:14:19.0733 [WARNING] sysbus: Write of value 0x1000 to an unimplemented register RTC:CONFIG (0x10000040) generated from SVD.
09:14:19.0739 [WARNING] sysbus: Write of value 0xF to an unimplemented register RTC:CONFIG (0x10000040) generated from SVD.
09:14:19.0740 [WARNING] sysbus: Write of value 0x0 to an unimplemented register RTC:LO (0x10000048) generated from SVD.
09:14:19.0740 [WARNING] sysbus: Write of value 0x0 to an unimplemented register RTC:HI (0x1000004C) generated from SVD.
09:14:19.0741 [WARNING] sysbus: Write of value 0xFFFFFFFF to an unimplemented register RTC:COMPARE (0x10000060) generated from SVD.
09:14:19.0741 [WARNING] sysbus: Read from an unimplemented register RTC:CONFIG (0x10000040), returning a value from SVD: 0x0.
09:14:19.0742 [WARNING] sysbus: Write of value 0x1000 to an unimplemented register RTC:CONFIG (0x10000040) generated from SVD.
09:14:19.0752 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:14:19.0752 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:14:19.0753 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:14:19.0754 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:14:19.0754 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:14:19.0754 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:14:19.0756 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:14:19.0756 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:14:19.0756 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:14:19.0757 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:14:19.0757 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:14:19.0757 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:14:19.0759 [WARNING] gpioInputs: Unhandled read from offset 0x10.
09:14:19.0759 [WARNING] gpioInputs: Unhandled write to offset 0x10, value 0x0.
09:14:19.0760 [WARNING] gpioInputs: Unhandled read from offset 0x38.
09:14:19.0760 [WARNING] gpioInputs: Unhandled write to offset 0x38, value 0x0.
09:14:19.0760 [WARNING] gpioInputs: Unhandled read from offset 0x3C.
09:14:19.0761 [WARNING] gpioInputs: Unhandled write to offset 0x3C, value 0x0.
09:14:24.7833 [WARNING] uart0: Trying to read data from empty receive fifo (8)
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on #15486 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
