### PR TITLE
drivers/itg320x: pass arg to gpio_init_int

### DIFF
--- a/drivers/itg320x/itg320x.c
+++ b/drivers/itg320x/itg320x.c
@@ -96,11 +96,11 @@ int itg320x_init_int(const itg320x_t *dev, itg320x_drdy_int_cb_t cb, void *arg)
 
     if (dev->params.int_level == ITG320X_INT_HIGH) {
         /* for high active interrupt signal (default) */
-        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, cb, 0);
+        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, cb, arg);
     }
     else {
         /* for low active interrupt signal (default) */
-        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, 0);
+        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, arg);
     }
 
     /*


### PR DESCRIPTION
### Contribution description

Fixes a minor bug on the itg320x driver.

### Testing procedure

- `make -C tests/driver_itg320x flash term` with the proper hardware (which I don't have, just noted the bug).

### Issues/PRs references
None
