### PR TITLE
Add MUD URL option to DHCPv6 client

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -26,6 +26,7 @@ PSEUDOMODULES += evtimer_mbox
 PSEUDOMODULES += evtimer_on_ztimer
 PSEUDOMODULES += fmt_%
 PSEUDOMODULES += gnrc_dhcpv6_%
+PSEUDOMODULES += gnrc_dhcpv6_client_mud_url
 PSEUDOMODULES += gnrc_ipv6_default
 PSEUDOMODULES += gnrc_ipv6_ext_frag_stats
 PSEUDOMODULES += gnrc_ipv6_router

--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -69,6 +69,7 @@ extern "C" {
                                              *   delegation (IA_PD) option */
 #define DHCPV6_OPT_IAPFX            (26U)   /**< IA prefix option */
 #define DHCPV6_OPT_SMR              (82U)   /**< SOL_MAX_RT option */
+#define DHCPV6_OPT_MUD_URL          (112U)  /**< MUD URL option (see RFC 8520) */
 /** @} */
 
 /**

--- a/sys/include/net/dhcpv6/client.h
+++ b/sys/include/net/dhcpv6/client.h
@@ -45,7 +45,7 @@ extern "C" {
  * @brief   Static length of the DUID
  */
 #define DHCPV6_CLIENT_DUID_LEN      (sizeof(dhcpv6_duid_l2_t) + 8U)
-#define DHCPV6_CLIENT_BUFLEN        (256)   /**< length for send and receive buffer */
+#define DHCPV6_CLIENT_BUFLEN        (256)   /**< default length for send and receive buffer */
 
 /**
  * @defgroup net_dhcpv6_conf DHCPv6 client compile configurations
@@ -58,6 +58,15 @@ extern "C" {
 #ifndef CONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX
 #define CONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX (1U)
 #endif
+
+/**
+ * @brief   MUD URL (must use the https:// scheme)
+ * For more info, see the [definitions](@ref net_dhcpv6_mud_url_option) below
+ */
+#ifndef CONFIG_DHCPV6_CLIENT_MUD_URL
+#define CONFIG_DHCPV6_CLIENT_MUD_URL "https://example.org"
+#endif
+
 /** @} */
 
 /**
@@ -165,6 +174,31 @@ void dhcpv6_client_conf_prefix(unsigned netif, const ipv6_addr_t *pfx,
 uint32_t dhcpv6_client_prefix_valid_until(unsigned netif,
                                           const ipv6_addr_t *pfx,
                                           unsigned pfx_len);
+/** @} */
+
+/**
+ * @name DHCPv6 Manufacturer Usage Description (MUD) URL option definitions
+ * @see [RFC 8520, section 10](https://tools.ietf.org/html/rfc8520#section-10)
+ * @anchor  net_dhcpv6_mud_url_option
+ * @{
+ */
+
+/**
+ * @brief   Length for the send buffer if a MUD URL is included in the DHCP client's packets
+ *
+ * @note    Only (re)defined by the `gnrc_dhcpv6_client_mud_url` pseudo-module.
+ */
+#if defined(MODULE_GNRC_DHCPV6_CLIENT_MUD_URL) || defined(DOXYGEN)
+#define DHCPV6_CLIENT_SEND_BUFLEN        (DHCPV6_CLIENT_BUFLEN + 256)
+#else
+#define DHCPV6_CLIENT_SEND_BUFLEN        (DHCPV6_CLIENT_BUFLEN)
+#endif
+
+/**
+ * @brief   Maximal length of a MUD URL
+ */
+#define MAX_MUD_URL_LENGTH (0xFF - sizeof(dhcpv6_opt_mud_url_t))
+
 /** @} */
 
 #ifdef __cplusplus

--- a/sys/net/application_layer/dhcpv6/Kconfig
+++ b/sys/net/application_layer/dhcpv6/Kconfig
@@ -16,4 +16,19 @@ config DHCPV6_CLIENT_PFX_LEASE_MAX
     int "Maximum number of prefix leases to be stored"
     default 1
 
+menuconfig KCONFIG_USEMODULE_GNRC_DHCPV6_CLIENT_MUD_URL
+    bool "Enable DHCPv6 Client MUD URL"
+    help
+        Enable the inclusion of a MUD URL in DHCPv6 packets
+        as specified in RFC 8520, section 10. This URL
+        has to point to a MUD file containing YANG-based JSON
+        with a description of the device and its suggested
+        network behavior. The URL must use the "https" scheme.
+
+if KCONFIG_USEMODULE_GNRC_DHCPV6_CLIENT_MUD_URL
+
+config CONFIG_DHCPV6_CLIENT_MUD_URL
+    string "URL pointing to a Manufacturer Usage Description file"
+
+endif # KCONFIG_USEMODULE_GNRC_DHCPV6_CLIENT_MUD_URL
 endif # KCONFIG_USEMODULE_DHCPv6

--- a/sys/net/application_layer/dhcpv6/_dhcpv6.h
+++ b/sys/net/application_layer/dhcpv6/_dhcpv6.h
@@ -28,7 +28,6 @@
 extern "C" {
 #endif
 
-
 /**
  * @name    DHCPv6 multicast addresses
  * @see [RFC 8415, section 7.1]
@@ -213,6 +212,17 @@ typedef struct __attribute__((packed)) {
     network_uint16_t len;           /**< always 4 */
     network_uint32_t value;         /**< overriding value for SOL_MAX_RT (in sec) */
 } dhcpv6_opt_smr_t;
+
+/**
+ * @brief   MUD URL DHCPv6 option format
+ * @see [RFC 8520, section 10]
+ *      (https://tools.ietf.org/html/rfc8520#section-10)
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t type;  /**< @ref DHCPV6_OPT_MUD_URL */
+    network_uint16_t len;   /**< length of the MUDstring in octets. */
+    char mudString[];       /**< MUD URL using the "https" scheme */
+} dhcpv6_opt_mud_url_t;
 
 #ifdef __cplusplus
 }

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -65,7 +65,7 @@ typedef struct {
     uint8_t duid_len;
 } server_t;
 
-static uint8_t send_buf[DHCPV6_CLIENT_BUFLEN];
+static uint8_t send_buf[DHCPV6_CLIENT_SEND_BUFLEN];
 static uint8_t recv_buf[DHCPV6_CLIENT_BUFLEN];
 static uint8_t best_adv[DHCPV6_CLIENT_BUFLEN];
 static uint8_t duid[DHCPV6_CLIENT_DUID_LEN];
@@ -245,6 +245,22 @@ static inline size_t _compose_elapsed_time_opt(dhcpv6_opt_elapsed_time_t *time)
     time->len = byteorder_htons(len);
     time->elapsed_time = byteorder_htons(_get_elapsed_time());
     return len + sizeof(dhcpv6_opt_t);
+}
+
+static inline size_t _compose_mud_url_opt(dhcpv6_opt_mud_url_t *mud_url_opt,
+                                          const char *mud_url, size_t len_max)
+{
+    uint16_t len = strlen(mud_url);
+
+    if (len > len_max) {
+        assert(0);
+        return 0;
+    }
+
+    mud_url_opt->type = byteorder_htons(DHCPV6_OPT_MUD_URL);
+    mud_url_opt->len = byteorder_htons(len);
+    strncpy(mud_url_opt->mudString, mud_url, len_max);
+    return len + sizeof(dhcpv6_opt_mud_url_t);
 }
 
 static inline size_t _compose_oro_opt(dhcpv6_opt_oro_t *oro, uint16_t *opts,
@@ -707,6 +723,15 @@ static void _solicit_servers(event_t *event)
     msg_len += _compose_elapsed_time_opt(time);
     msg_len += _compose_oro_opt((dhcpv6_opt_oro_t *)&send_buf[msg_len], oro_opts,
                                 ARRAY_SIZE(oro_opts));
+
+    if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_MUD_URL)) {
+        const char mud_url[] = CONFIG_DHCPV6_CLIENT_MUD_URL;
+        assert(strlen(mud_url) <= MAX_MUD_URL_LENGTH);
+        assert(strncmp(mud_url, "https://", 8) == 0);
+        msg_len += _compose_mud_url_opt((dhcpv6_opt_mud_url_t *)&send_buf[msg_len],
+                                        mud_url, sizeof(send_buf) - msg_len);
+    }
+
     msg_len += _add_ia_pd_from_config(&send_buf[msg_len]);
     DEBUG("DHCPv6 client: send SOLICIT\n");
     _flush_stale_replies(&sock);

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile
@@ -5,6 +5,7 @@ export TAP ?= tap0
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_dhcpv6_client_6lbr
+USEMODULE += gnrc_dhcpv6_client_mud_url
 USEMODULE += gnrc_netdev_default
 USEMODULE += gnrc_pktdump
 USEMODULE += gnrc_sixlowpan_border_router_default

--- a/tests/gnrc_dhcpv6_client_6lbr/tests/01-run.py
+++ b/tests/gnrc_dhcpv6_client_6lbr/tests/01-run.py
@@ -14,12 +14,18 @@ import time
 
 from scapy.all import AsyncSniffer, sendp, Ether, IPv6, UDP
 from scapy.all import DHCP6_Solicit, DHCP6_Advertise, DHCP6_Request, DHCP6_Reply
-from scapy.all import DHCP6OptClientId, DHCP6OptServerId, DHCP6OptIA_PD
+from scapy.all import DHCP6OptClientId, DHCP6OptServerId, DHCP6OptIA_PD, DHCP6OptUnknown
 from scapy.all import DUID_LL, DHCP6OptIAPrefix
 from testrunner import run
 
 
 TIMEOUT = 1
+
+MUD_OPTION_CODE = 112
+MUD_TEST_URL = b'https://example.org'
+
+# MUD URL option in DHCPv6 is not yet supported by scapy
+DHCP6OptMUD = DHCP6OptUnknown
 
 
 def get_upstream_netif(child):
@@ -122,6 +128,12 @@ def testfunc(child):
     assert pkt[DHCP6OptClientId].duid[DUID_LL].lladdr in upstream_hwaddrs
     # and it is asking for a prefix delegation
     assert DHCP6OptIA_PD in pkt
+
+    assert DHCP6OptMUD in pkt
+    mud_packet = pkt[DHCP6OptMUD]
+    assert mud_packet.optcode == 112
+    assert mud_packet.optlen == len(MUD_TEST_URL)
+    assert mud_packet.data == MUD_TEST_URL
 
     # reply to solicit with advertise and a prefix provided
     trid = pkt[DHCP6_Solicit].trid


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This contribution adds MUD (Manufacturer Usage Description) support to RIOTs DHCPv6-Client (as defined in [RFC 8520, section 10](https://tools.ietf.org/html/rfc8520#section-10)). If a MUD URL pointing to a MUD file is defined in the makefile, a MUD URL option is added to the DHCP packages sent by the client. This option contains the option code 112, the length of the URL, and the URL itself. 

This information can then be used by a MUD manager at the receiving end to retrieve a so called MUD file (using the MUD URL) and to extract information about the device's intended behavior, especially when it comes to communicating via the internet. Integrating MUD support into RIOT can enhance its capabilities for achieving a more secure Internet of Things.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Using `scapy`, we added a test case under `tests/gnrc_dhcpv6_client_6lbr` that asserts a correct emission of a MUD URL as part of a DHCP option by checking for the corresponding option code (112), the specified `mudString` and the correct option length. The tests can be performed by executing the shell commands `make flash` (or `make all`), followed by `sudo make test` in the `tests/gnrc_dhcpv6_client_6lbr` directory. 

So far, `scapy` does not supported a direct check for the MUD URL option (hence the use of the generic `DHCP6OptUnknown` class) but we succesfully suggested its inclusion in `scapy`'s DHCP module in a [Pull Request](https://github.com/secdev/scapy/pull/2964). We will integrate the new class for the MUD option once a new version of scapy has been released. 

Furthermore, our changes can be tested manually by defining a MUD URL in the makefile under `tests/gnrc_dhcpv6_client_6lbr` or `tests/gnrc_dhcpv6_client/`, running `make all` and `make term`, and verifying the DHCP packages sent using software like Wireshark. When analyzing the packages sent in a network, RIOT devices should emit DHCP packages that contain the MUD option (see the screenshot below) when they are using the DHCP module and have a MUD URL defined.

![Example wireshark DHCP package analysis.](https://hackmd.informatik.uni-bremen.de/uploads/upload_e1e78fa9b24f6f6da4f73d45d4349954.png)

Before performing one of the tests described above, it is necessary to create a tap bridge by running 

```
sudo ./dist/tools/tapsetup/tapsetup
```

inside of RIOT's root directory.

### Issues/PRs references

To our knowledge, MUD or RFC 8520 in general have not been mentioned in any issues or pull requests so far.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->