### PR TITLE
xtimer, ztimer: add some missing includes

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "xtimer.h"
+#include "msg.h"
 #include "mutex.h"
 #include "rmutex.h"
 #include "thread.h"

--- a/sys/ztimer/convert.c
+++ b/sys/ztimer/convert.c
@@ -21,6 +21,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "ztimer/convert.h"
 

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdint.h>
+#include <inttypes.h>
 
 #include "frac.h"
 #include "assert.h"

--- a/sys/ztimer/convert_shift.c
+++ b/sys/ztimer/convert_shift.c
@@ -21,6 +21,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "ztimer/convert.h"
 #include "ztimer/convert_shift.h"

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -24,6 +24,7 @@
  */
 #include <assert.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #include "kernel_defines.h"
 #include "irq.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- xtimer.c was using msg_*, but not including msg.h
- ztimer was using PRIfoo inttypes in DEBUG() statements, but not including inttypes.h

Both fixed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Binaries should not change.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
