### PR TITLE
tools/emulator: allow use with *term targets + introduce EMULATE=1 instead of emulate target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -747,7 +747,7 @@ debug-server:
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
 emulate: all $(EMULATORDEPS)
-ifeq (,$(filter debug%,$(MAKECMDGOALS)))
+ifeq (,$(filter term cleanterm debug%,$(MAKECMDGOALS)))
 	$(call check_cmd,$(EMULATOR),Emulation program)
 	$(EMULATOR) $(EMULATOR_FLAGS)
 else
@@ -755,7 +755,7 @@ else
 endif
 
 emulate-only: $(EMULATORDEPS)
-ifeq (,$(filter debug%,$(MAKECMDGOALS)))
+ifeq (,$(filter term cleanterm debug%,$(MAKECMDGOALS)))
 	$(call check_cmd,$(EMULATOR),Emulation program)
 	$(EMULATOR) $(EMULATOR_FLAGS)
 else

--- a/Makefile.include
+++ b/Makefile.include
@@ -397,11 +397,13 @@ include $(BOARDDIR)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
-# Include emulator code if available and if emulate target is used
-ifneq (,$(filter emulate%,$(MAKECMDGOALS)))
+# Include emulator code when required and if available
+ifeq (1,$(EMULATE))
   # Use renode as default emulator
   RIOT_EMULATOR ?= renode
   -include $(RIOTMAKE)/tools/$(RIOT_EMULATOR).inc.mk
+  TERMDEPS += $(EMULATORDEPS)
+  DEBUGDEPS += $(EMULATORDEPS)
 endif
 
 # Include common serial logic to define TERMPROG, TERMFLAGS variables based on
@@ -746,20 +748,10 @@ debug-server:
 	$(call check_cmd,$(DEBUGSERVER),Debug server program)
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
-emulate: all $(EMULATORDEPS)
-ifeq (,$(filter term cleanterm debug%,$(MAKECMDGOALS)))
+ifeq (1,$(EMULATE))
+emulate:
 	$(call check_cmd,$(EMULATOR),Emulation program)
 	$(EMULATOR) $(EMULATOR_FLAGS)
-else
-	@:
-endif
-
-emulate-only: $(EMULATORDEPS)
-ifeq (,$(filter term cleanterm debug%,$(MAKECMDGOALS)))
-	$(call check_cmd,$(EMULATOR),Emulation program)
-	$(EMULATOR) $(EMULATOR_FLAGS)
-else
-	@:
 endif
 
 reset:

--- a/Makefile.include
+++ b/Makefile.include
@@ -397,6 +397,10 @@ include $(BOARDDIR)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
+# Include common serial logic to define TERMPROG, TERMFLAGS variables based on
+# the content of RIOT_TERMINAL
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 # Include emulator code when required and if available
 ifeq (1,$(EMULATE))
   # Use renode as default emulator
@@ -405,10 +409,6 @@ ifeq (1,$(EMULATE))
   TERMDEPS += $(EMULATORDEPS)
   DEBUGDEPS += $(EMULATORDEPS)
 endif
-
-# Include common serial logic to define TERMPROG, TERMFLAGS variables based on
-# the content of RIOT_TERMINAL
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # Include common programmer logic if available
 -include $(RIOTMAKE)/tools/$(PROGRAMMER).inc.mk

--- a/boards/microbit/doc.txt
+++ b/boards/microbit/doc.txt
@@ -94,6 +94,6 @@ Use it like this:
 
     $ cd examples/hello-world
     $ BOARD=microbit make clean all -j4
-    $ BOARD=microbit make emulate
+    $ EMULATE=1 BOARD=microbit make term
 
  */

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -9,3 +9,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink
 STLINK_VERSION ?= 2
+
+# Tell renode on which UART stdio is available
+RENODE_SYSBUS_UART ?= sysbus.uart2

--- a/boards/stm32f4discovery/doc.txt
+++ b/boards/stm32f4discovery/doc.txt
@@ -172,7 +172,7 @@ To emulate this board you need an updated version of
 [renode](https://github.com/renode/renode) installed, at least version 1.11.
 
 ```
-BOARD=stm32f4discovery make all emulate
+EMULATE=1 BOARD=stm32f4discovery make all term
 ```
 
 ## Known Issues / Problems

--- a/dist/tools/emulator/debug.sh
+++ b/dist/tools/emulator/debug.sh
@@ -45,9 +45,10 @@ trap '' INT
 # start emulator GDB server
 sh -c "\
     GDB_PORT=${GDB_PORT} \
+    EMULATE=1 \
     EMULATOR_PIDFILE=${EMULATOR_PIDFILE} \
     BOARD=${BOARD} \
-    make -C ${APPDIR} emulate-only debug-server & \
+    make -C ${APPDIR} debug-server & \
     echo \$! > ${EMULATOR_PIDFILE}" &
 # Start the debugger and connect to the GDB server
 sh -c "${DBG} ${DBG_FLAGS} ${ELFFILE}"

--- a/dist/tools/emulator/term.sh
+++ b/dist/tools/emulator/term.sh
@@ -45,8 +45,9 @@ trap "cleanup terminal for ${EMULATOR} emulator" EXIT
 # start emulator in background
 sh -c "\
     EMULATOR_PIDFILE=${EMULATOR_PIDFILE} \
+    EMULATE=1 \
     BOARD=${BOARD} \
-    make -C ${APPDIR} emulate-only & \
+    make -C ${APPDIR} emulate & \
     echo \$! > ${EMULATOR_PIDFILE}" &
 
 # with qemu, start socat redirector in background

--- a/dist/tools/emulator/term.sh
+++ b/dist/tools/emulator/term.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# This script wraps an emulator (renode or qemu) and a terminal client
+# in a single command and takes 6 arguments:
+# 1. the type of emulator (renode or qemu)
+# 2. the board to emulate,
+# 3. the application directory of the the current application
+# 4. the terminal client tool
+# 5. the options of the terminal client
+# 6. the serial port to connect to the terminal client to
+
+# This script is supposed to be called from RIOTs make system when using the
+# "term" or "cleanterm" targets.
+
+# @author       Alexandre Abadie <alexandre.abadie@inria.fr>
+
+EMULATOR=$1
+BOARD=$2
+APPDIR=$3
+TERMPROG=$4
+TERMFLAGS=$5
+PORT=$6
+
+# temporary file that contains the emulator pid
+EMULATOR_PIDFILE=$(mktemp -t "emulator_pid.XXXXXXXXXX")
+SOCAT_PIDFILE=$(mktemp -t "socat_pid.XXXXXXXXXX")
+
+# will be called by trap
+cleanup() {
+    if [ ${EMULATOR} = "qemu" ]
+    then
+        echo "cleanup ${SOCAT_PIDFILE}"
+        kill "$(cat ${SOCAT_PIDFILE})"
+        rm -f "${SOCAT_PIDFILE}"
+    fi
+    echo "cleanup ${EMULATOR_PIDFILE}"
+    kill "$(cat ${EMULATOR_PIDFILE})"
+    rm -f "${EMULATOR_PIDFILE}"
+    rm -f ${PORT}
+    exit 0
+}
+# cleanup after script terminates
+trap "cleanup terminal for ${EMULATOR} emulator" EXIT
+
+# start emulator in background
+sh -c "\
+    EMULATOR_PIDFILE=${EMULATOR_PIDFILE} \
+    BOARD=${BOARD} \
+    make -C ${APPDIR} emulate-only & \
+    echo \$! > ${EMULATOR_PIDFILE}" &
+
+# with qemu, start socat redirector in background
+if [ ${EMULATOR} = "qemu" ]
+then
+    sleep 1
+    sh -c "\
+        socat pty,link=${PORT},raw,echo=0 TCP:localhost:5555 & \
+        echo \$! > ${SOCAT_PIDFILE}" &
+fi
+
+# Start the terminal client after PORT is available. PORT can be a symlink.
+while [ ! -L "${PORT}" ]
+do
+    sleep 1
+done
+
+sh -c "${TERMPROG} ${TERMFLAGS}"

--- a/makefiles/tools/qemu.inc.mk
+++ b/makefiles/tools/qemu.inc.mk
@@ -4,17 +4,19 @@ EMULATOR_MONITOR_PORT ?= 45454
 EMULATOR_MONITOR_FLAGS ?= telnet::$(EMULATOR_MONITOR_PORT),server,nowait
 FLASHFILE ?= $(ELFFILE)
 
+QEMU_SERIAL_TCP_PORT ?= 5555
 EMULATOR_FLAGS = -machine $(EMULATOR_MACHINE) -device loader,file=$(ELFFILE) \
-                 -serial telnet::5555,server,nowait,nodelay \
+                 -serial telnet::$(QEMU_SERIAL_TCP_PORT),server,nowait,nodelay \
                  -monitor $(EMULATOR_MONITOR_FLAGS) \
                  -nographic
 
 # Configure the qemu terminal access
-PORT = /tmp/riot_$(APPLICATION)_$(BOARD)_uart
+EMULATOR_SERIAL_PORT ?= /tmp/riot_$(APPLICATION)_$(BOARD)_uart
+PORT = $(EMULATOR_SERIAL_PORT)
 RIOT_TERMPROG := $(TERMPROG)
 RIOT_TERMFLAGS := $(TERMFLAGS)
 TERMPROG := $(RIOTTOOLS)/emulator/term.sh
-TERMFLAGS := $(RIOT_EMULATOR) $(BOARD) $(APPDIR) $(RIOT_TERMPROG) '$(RIOT_TERMFLAGS)' $(PORT)
+TERMFLAGS := $(RIOT_EMULATOR) $(BOARD) $(APPDIR) $(RIOT_TERMPROG) '$(RIOT_TERMFLAGS)' $(EMULATOR_SERIAL_PORT)
 
 # Configure the debugger
 GDB_PORT ?= 3333
@@ -26,3 +28,7 @@ DEBUGSERVER_FLAGS ?= $(QEMU_DEBUG_FLAGS)
 
 DEBUGGER_FLAGS ?= $(BOARD) $(APPDIR) $(ELFFILE) $(GDB_PORT)
 DEBUGGER ?= $(RIOTTOOLS)/emulator/debug.sh
+
+# No flasher available with qemu emulator
+FLASHER ?=
+FFLAGS ?=

--- a/makefiles/tools/qemu.inc.mk
+++ b/makefiles/tools/qemu.inc.mk
@@ -5,9 +5,16 @@ EMULATOR_MONITOR_FLAGS ?= telnet::$(EMULATOR_MONITOR_PORT),server,nowait
 FLASHFILE ?= $(ELFFILE)
 
 EMULATOR_FLAGS = -machine $(EMULATOR_MACHINE) -device loader,file=$(ELFFILE) \
-                 -serial stdio \
+                 -serial telnet::5555,server,nowait,nodelay \
                  -monitor $(EMULATOR_MONITOR_FLAGS) \
                  -nographic
+
+# Configure the qemu terminal access
+PORT = /tmp/riot_$(APPLICATION)_$(BOARD)_uart
+RIOT_TERMPROG := $(TERMPROG)
+RIOT_TERMFLAGS := $(TERMFLAGS)
+TERMPROG := $(RIOTTOOLS)/emulator/term.sh
+TERMFLAGS := $(RIOT_EMULATOR) $(BOARD) $(APPDIR) $(RIOT_TERMPROG) '$(RIOT_TERMFLAGS)' $(PORT)
 
 # Configure the debugger
 GDB_PORT ?= 3333

--- a/makefiles/tools/qemu.inc.mk
+++ b/makefiles/tools/qemu.inc.mk
@@ -1,14 +1,17 @@
-EMULATOR ?= qemu-system-arm
-EMULATOR_MACHINE ?= $(BOARD)
-EMULATOR_MONITOR_PORT ?= 45454
-EMULATOR_MONITOR_FLAGS ?= telnet::$(EMULATOR_MONITOR_PORT),server,nowait
+QEMU ?= qemu-system-arm
+QEMU_MACHINE ?= $(BOARD)
+QEMU_MONITOR_PORT ?= 45454
+QEMU_MONITOR_FLAGS ?= telnet::$(QEMU_MONITOR_PORT),server,nowait
 FLASHFILE ?= $(ELFFILE)
 
 QEMU_SERIAL_TCP_PORT ?= 5555
-EMULATOR_FLAGS = -machine $(EMULATOR_MACHINE) -device loader,file=$(ELFFILE) \
-                 -serial telnet::$(QEMU_SERIAL_TCP_PORT),server,nowait,nodelay \
-                 -monitor $(EMULATOR_MONITOR_FLAGS) \
-                 -nographic
+
+# Configure emulator variables
+EMULATOR ?= $(QEMU)
+EMULATOR_FLAGS ?= -machine $(QEMU_MACHINE) -device loader,file=$(ELFFILE) \
+                  -serial telnet::$(QEMU_SERIAL_TCP_PORT),server,nowait,nodelay \
+                  -monitor $(QEMU_MONITOR_FLAGS) \
+                  -nographic
 
 # Configure the qemu terminal access
 EMULATOR_SERIAL_PORT ?= /tmp/riot_$(APPLICATION)_$(BOARD)_uart

--- a/makefiles/tools/renode.inc.mk
+++ b/makefiles/tools/renode.inc.mk
@@ -15,6 +15,20 @@ ifneq (,$(EMULATOR_PIDFILE))
   RENODE_CONFIG_FLAGS += --pid-file $(EMULATOR_PIDFILE)
 endif
 
+# Renode logging configuration
+RENODE_SHOW_LOG ?= 0
+ifneq (1,$(RENODE_SHOW_LOG))
+  RENODE_CONFIG_FLAGS += --hide-log
+endif
+RENODE_LOG_LEVEL ?= 2  # Warning level
+RENODE_CONFIG_FLAGS += -e "logLevel $(RENODE_LOG_LEVEL)"
+
+# Renode GUI
+RENODE_SHOW_GUI ?= 0
+ifneq (1,$(RENODE_SHOW_GUI))
+  RENODE_CONFIG_FLAGS += --disable-xwt
+endif
+
 # Configure local serial port
 PORT = /tmp/riot_$(APPLICATION)_$(BOARD)_uart
 RENODE_CONFIG_FLAGS += -e "emulation CreateUartPtyTerminal \"term\" \"$(PORT)\" true"

--- a/makefiles/tools/renode.inc.mk
+++ b/makefiles/tools/renode.inc.mk
@@ -30,19 +30,21 @@ ifneq (1,$(RENODE_SHOW_GUI))
 endif
 
 # Configure local serial port
-PORT = /tmp/riot_$(APPLICATION)_$(BOARD)_uart
-RENODE_CONFIG_FLAGS += -e "emulation CreateUartPtyTerminal \"term\" \"$(PORT)\" true"
-RENODE_CONFIG_FLAGS += -e "connector Connect sysbus.uart0 term"
+RENODE_SYSBUS_UART ?= sysbus.uart0
+EMULATOR_SERIAL_PORT ?= /tmp/riot_$(APPLICATION)_$(BOARD)_uart
+RENODE_CONFIG_FLAGS += -e "emulation CreateUartPtyTerminal \"term\" \"$(EMULATOR_SERIAL_PORT)\" true"
+RENODE_CONFIG_FLAGS += -e "connector Connect $(RENODE_SYSBUS_UART) term"
 
 # Set emulator variables
 EMULATOR_FLAGS ?= $(RENODE_CONFIG_FLAGS) -e start
 EMULATOR ?= $(RENODE)
 
 # Configure the terminal
+PORT = $(EMULATOR_SERIAL_PORT)
 RIOT_TERMPROG := $(TERMPROG)
 RIOT_TERMFLAGS := $(TERMFLAGS)
 TERMPROG := $(RIOTTOOLS)/emulator/term.sh
-TERMFLAGS := $(RIOT_EMULATOR) $(BOARD) $(APPDIR) $(RIOT_TERMPROG) '$(RIOT_TERMFLAGS)' $(PORT)
+TERMFLAGS := $(RIOT_EMULATOR) $(BOARD) $(APPDIR) $(RIOT_TERMPROG) '$(RIOT_TERMFLAGS)' $(EMULATOR_SERIAL_PORT)
 
 # Configure the debugger
 GDB_PORT ?= 3333
@@ -54,3 +56,7 @@ DEBUGSERVER_FLAGS ?= $(RENODE_DEBUG_FLAGS)
 
 DEBUGGER_FLAGS ?= $(BOARD) $(APPDIR) $(ELFFILE) $(GDB_PORT) "-ex \"monitor start\""
 DEBUGGER ?= $(RIOTTOOLS)/emulator/debug.sh
+
+# No flasher available with renode emulator
+FLASHER ?=
+FFLAGS ?=


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR contains several enhancements and a fundamental change with the emulators. IMHO, this change is required if we want to nicely integrate the use of emulators with existing features provided by the build system, such as the `test` target.

- add the possibility to use `term` with emulators: this is achieved in a similar fashion that is used with debug% targets, using `term` will spawn the emulator in background and then regular terminal client can connect to the application running in the emulator. Some changes are required with the emulators:
  - renode can expose locally a pty file connected to the virtual UART of the emulated board, so this was quite straight-forward here
  - with qemu, things were a little more complicated. In master, the serial port is directly sent to the current stdio, which is fine as is but not if we want to connect a terminal to it. There are several possible devices available with the `-serial` option, like pipe, but none were really compatible with the tools we usually use. So I went for configuring a small TCP server exposing the UART in qemu and use my favorite tool (socat) to redirect it to a local pty
  - with renode and qemu, the serial port is exposed in `/tmp/riot_$(APPLICATION)_$(BOARD)_uart`. Maybe this can improved but it already avoids name collisions if several emulators are running in parallel.
- the fundamental change is about the `emulate` target which is now not supposed to be used directly by the user and the introduction of the `EMULATE` variable. Using a separate variable, instead of a dedicated target, integrate better with existing targets like debug or term. With this PR, one can now do:

```
EMULATE=1 make BOARD=microbit -C examples/hello-world all term
```

and even more use the `test` target without modifications:

```
EMULATE=1 make BOARD=microbit -C tests/pkg_cayenne-lpp all test
```

- one last change is about renode: by default the GUI and the log are now hidden. The GUI because it's not needed since stdio is available via `term` and the log to make the output of renode less verbose. Both can be enabled using respectively the `RENODE_SHOW_GUI` and `RENODE_SHOW_LOG` variables in the command line.

There's probably still room for improvement but I think the integration level of emulator is at a very good point with this PR. It's really becoming transparent: just add `EMULATE=1` to the command line and it's there (for the boards that can be emulated of course)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Ensure that things behave like they should with both renode and qemu (e.g cc2538dk and microbit):

<details><summary>microbit debug</summary>

```
$ EMULATE=1 make BOARD=microbit -C examples/hello-world all debug
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "microbit" with MCU "nrf51".

"make" -C /work/riot/RIOT/boards/microbit
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf51
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf51/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8116	    108	   2296	  10520	   2918	/work/riot/RIOT/examples/hello-world/bin/microbit/hello-world.elf
/work/riot/RIOT/dist/tools/emulator/debug.sh microbit /work/riot/RIOT/examples/hello-world /work/riot/RIOT/examples/hello-world/bin/microbit/hello-world.elf 3333
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/microbit/hello-world.elf...
qemu-system-arm -S -gdb tcp::3333 -machine microbit -device loader,file=/work/riot/RIOT/examples/hello-world/bin/microbit/hello-world.elf -serial telnet::5555,server,nowait,nodelay -monitor telnet::45454,server,nowait -nographic
Remote debugging using :3333
reset_handler_default () at /work/riot/RIOT/cpu/cortexm_common/vectors_cortexm.c:103
103	    pre_startup();
(gdb) load
Loading section .text, size 0x1fb4 lma 0x0
Loading section .relocate, size 0x6c lma 0x1fb4
Start address 0x00000640, load size 8224
Transfer rate: 2677 KB/sec, 1644 bytes/write.
(gdb) b main
Breakpoint 1 at 0xa8: file /work/riot/RIOT/examples/hello-world/main.c, line 26.
(gdb) c
Continuing.

Breakpoint 1, main () at /work/riot/RIOT/examples/hello-world/main.c:26
26	    puts("Hello World!");
(gdb) l
21	
22	#include <stdio.h>
23	
24	int main(void)
25	{
26	    puts("Hello World!");
27	
28	    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
29	    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
30	
(gdb) n
28	    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
(gdb) n
29	    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
(gdb) quit
A debugging session is active.

	Inferior 1 [process 1] will be detached.

Quit anyway? (y or n) EOF [assumed Y]
Detaching from program: /work/riot/RIOT/examples/hello-world/bin/microbit/hello-world.elf, process 1
Ending remote debugging.
[Inferior 1 (process 1) detached]
qemu-system-arm: terminating on signal 15 from pid 625699 (make)
```

</details>

<details><summary>microbit term</summary>

```
$ EMULATE=1 make BOARD=microbit -C examples/saul all term
make: Entering directory '/work/riot/RIOT/examples/saul'
Building application "saul_example" for "microbit" with MCU "nrf51".

"make" -C /work/riot/RIOT/boards/microbit
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf51
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf51/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/mma8x5x
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  17920	    128	   2444	  20492	   500c	/work/riot/RIOT/examples/saul/bin/microbit/saul_example.elf
/work/riot/RIOT/dist/tools/emulator/term.sh qemu microbit /work/riot/RIOT/examples/saul /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_saul_example_microbit_uart" -b "115200" ' /tmp/riot_saul_example_microbit_uart 
qemu-system-arm -machine microbit -device loader,file=/work/riot/RIOT/examples/saul/bin/microbit/saul_example.elf -serial telnet::5555,server,nowait,nodelay -monitor telnet::45454,server,nowait -nographic
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-11-26 14:45:40,650 # Connect to serial port /tmp/riot_saul_example_microbit_uart
Welcome to pyterm!
Type '/exit' to exit.
help
2020-11-26 14:45:43,624 # help
2020-11-26 14:45:43,626 # Command              Description
2020-11-26 14:45:43,627 # ---------------------------------------
2020-11-26 14:45:43,629 # reboot               Reboot the node
2020-11-26 14:45:43,631 # version              Prints current RIOT_VERSION
2020-11-26 14:45:43,633 # pm                   interact with layered PM subsystem
2020-11-26 14:45:43,635 # ps                   Prints information about running threads.
2020-11-26 14:45:43,637 # saul                 interact with sensors and actuators using SAUL
> ps
2020-11-26 14:45:44,402 #  ps
2020-11-26 14:45:44,403 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2020-11-26 14:45:44,404 # 	  - | isr_stack            | -        - |   - |    512 (  172) (  340) | 0x20000000 | 0x200001c0
2020-11-26 14:45:44,405 # 	  1 | main                 | running  Q |   7 |   1536 (  688) (  848) | 0x20000280 | 0x20000804 
2020-11-26 14:45:44,405 # 	    | SUM                  |            |     |   2048 (  860) ( 1188)
> version
2020-11-26 14:45:46,028 #  version
2020-11-26 14:45:46,030 # 2021.01-devel-1104-ga87ae-pr/tools/emulator_term
> 2020-11-26 14:45:48,050 # Exiting Pyterm
cleanup /tmp/socat_pid.apTLNR3MLv
cleanup /tmp/emulator_pid.wPjcE8tSTS
qemu-system-arm: terminating on signal 15 from pid 626673 (make)
```

</details>

<details><summary>cc2538dk debug</summary>

```
$ EMULATE=1 make BOARD=cc2538dk -C examples/hello-world all debug
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "cc2538dk" with MCU "cc2538".

"make" -C /work/riot/RIOT/boards/cc2538dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8848	    112	   2296	  11256	   2bf8	/work/riot/RIOT/examples/hello-world/bin/cc2538dk/hello-world.elf
/work/riot/RIOT/dist/tools/emulator/debug.sh cc2538dk /work/riot/RIOT/examples/hello-world /work/riot/RIOT/examples/hello-world/bin/cc2538dk/hello-world.elf 3333 "-ex \"monitor start\""
Using Renode pid file /tmp/emulator_pid.Aiqk96f8dC
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/cc2538dk/hello-world.elf...
renode -e "set image_file '/work/riot/RIOT/examples/hello-world/bin/cc2538dk/hello-world.elf'" -e "include @/work/riot/RIOT/boards/cc2538dk/dist/board.resc" --pid-file /tmp/emulator_pid.Aiqk96f8dC --hide-log -e "logLevel 2  " --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_hello-world_cc2538dk_uart\" true" -e "connector Connect sysbus.uart0 term" -e "machine StartGdbServer 3333 true"
Remote debugging using :3333
0x00000000 in ?? ()
Starting emulation...
(gdb) load
Loading section .text, size 0x2264 lma 0x200000
Loading section .relocate, size 0x70 lma 0x202264
Loading section .flashcca, size 0x2c lma 0x27ffd4
Start address 0x00200830, load size 8960
Transfer rate: 132 KB/sec, 1792 bytes/write.
(gdb) b main
Breakpoint 1 at 0x20028c: file /work/riot/RIOT/examples/hello-world/main.c, line 26.
(gdb) c
Continuing.

Breakpoint 1, main () at /work/riot/RIOT/examples/hello-world/main.c:26
26	    puts("Hello World!");
(gdb) l
21	
22	#include <stdio.h>
23	
24	int main(void)
25	{
26	    puts("Hello World!");
27	
28	    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
29	    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
30	
(gdb) n
28	    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
(gdb) 
29	    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
(gdb) quit
A debugging session is active.

	Inferior 1 [Remote target] will be killed.

Quit anyway? (y or n) EOF [assumed Y]
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
Terminated
```

</details>

<details><summary>cc2538dk term</summary>

```
$ EMULATE=1 make BOARD=cc2538dk -C examples/saul all term
make: Entering directory '/work/riot/RIOT/examples/saul'
Building application "saul_example" for "cc2538dk" with MCU "cc2538".

"make" -C /work/riot/RIOT/boards/cc2538dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  17556	    132	   2364	  20052	   4e54	/work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.elf
/work/riot/RIOT/dist/tools/emulator/term.sh renode cc2538dk /work/riot/RIOT/examples/saul /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_saul_example_cc2538dk_uart" -b "115200" ' /tmp/riot_saul_example_cc2538dk_uart 
Using Renode pid file /tmp/emulator_pid.0q2N98HIbQ
renode -e "set image_file '/work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.elf'" -e "include @/work/riot/RIOT/boards/cc2538dk/dist/board.resc" --pid-file /tmp/emulator_pid.0q2N98HIbQ --hide-log -e "logLevel 2  " --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_saul_example_cc2538dk_uart\" true" -e "connector Connect sysbus.uart0 term" -e start
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-11-26 14:47:06,280 # Connect to serial port /tmp/riot_saul_example_cc2538dk_uart
Welcome to pyterm!
Type '/exit' to exit.
help
2020-11-26 14:47:08,496 # help
2020-11-26 14:47:08,502 # Command              Description
2020-11-26 14:47:08,504 # ---------------------------------------
2020-11-26 14:47:08,512 # reboot               Reboot the node
2020-11-26 14:47:08,515 # version              Prints current RIOT_VERSION
2020-11-26 14:47:08,517 # pm                   interact with layered PM subsystem
2020-11-26 14:47:08,519 # ps                   Prints information about running threads.
2020-11-26 14:47:08,521 # saul                 interact with sensors and actuators using SAUL
> ps
2020-11-26 14:47:09,196 #  ps
2020-11-26 14:47:09,203 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2020-11-26 14:47:09,213 # 	  - | isr_stack            | -        - |   - |    512 (  180) (  332) | 0x20000000 | 0x200001c8
2020-11-26 14:47:09,219 # 	  1 | main                 | running  Q |   7 |   1536 (  644) (  892) | 0x20000284 | 0x2000080c 
2020-11-26 14:47:09,222 # 	    | SUM                  |            |     |   2048 (  824) ( 1224)
> version
2020-11-26 14:47:10,628 #  version
2020-11-26 14:47:10,632 # 2021.01-devel-1104-ga87ae-pr/tools/emulator_term
> 2020-11-26 14:47:11,625 # Exiting Pyterm
cleanup /tmp/emulator_pid.0q2N98HIbQ
make: Leaving directory '/work/riot/RIOT/examples/saul'
Terminated
```

</details>

Here an example of this PR used with the `test`, it works out of the box !

<details><summary>microbit test</summary>

```
$ EMULATE=1 make BOARD=microbit -C tests/pkg_cayenne-lpp all test
make: Entering directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
Building application "tests_pkg_cayenne-lpp" for "microbit" with MCU "nrf51".

"make" -C /work/riot/RIOT/pkg/cayenne-lpp
"make" -C /work/riot/RIOT/build/pkg/cayenne-lpp -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/microbit
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf51
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf51/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  10988	    128	   2404	  13520	   34d0	/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/microbit/tests_pkg_cayenne-lpp.elf
r
/work/riot/RIOT/dist/tools/emulator/term.sh qemu microbit /work/riot/RIOT/tests/pkg_cayenne-lpp /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_tests_pkg_cayenne-lpp_microbit_uart" -b "115200" ' /tmp/riot_tests_pkg_cayenne-lpp_microbit_uart 
qemu-system-arm -machine microbit -device loader,file=/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/microbit/tests_pkg_cayenne-lpp.elf -serial telnet::5555,server,nowait,nodelay -monitor telnet::45454,server,nowait -nographic
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-11-26 14:51:02,398 # Connect to serial port /tmp/riot_tests_pkg_cayenne-lpp_microbit_uart
Welcome to pyterm!
Type '/exit' to exit.
2020-11-26 14:51:03,404 # READY
s
2020-11-26 14:51:03,457 # START
2020-11-26 14:51:03,460 # main(): This is RIOT! (Version: 2021.01-devel-1104-ga87ae-pr/tools/emulator_term)
2020-11-26 14:51:03,462 # Cayenne LPP test application
2020-11-26 14:51:03,462 # 
2020-11-26 14:51:03,462 # Test 1:
2020-11-26 14:51:03,462 # -------
2020-11-26 14:51:03,463 # Result: 03670110056700FF SUCCESS
2020-11-26 14:51:03,463 # 
2020-11-26 14:51:03,463 # Test 2:
2020-11-26 14:51:03,464 # -------
2020-11-26 14:51:03,464 # Result: 0167FFD7067104D2FB2E0000 SUCCESS
2020-11-26 14:51:03,464 # 
2020-11-26 14:51:03,464 # Test 3:
2020-11-26 14:51:03,464 # -------
2020-11-26 14:51:03,465 # Result: 018806765EF2960A0003E8 SUCCESS

make: Leaving directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
```

</details>

<details><summary>cc2538dk test</summary>

```
$ EMULATE=1 make BOARD=cc2538dk -C tests/pkg_cayenne-lpp all test
make: Entering directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
Building application "tests_pkg_cayenne-lpp" for "cc2538dk" with MCU "cc2538".

"make" -C /work/riot/RIOT/pkg/cayenne-lpp
"make" -C /work/riot/RIOT/build/pkg/cayenne-lpp -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/cc2538dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  11332	    132	   2404	  13868	   362c	/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/cc2538dk/tests_pkg_cayenne-lpp.elf
r
/work/riot/RIOT/dist/tools/emulator/term.sh renode cc2538dk /work/riot/RIOT/tests/pkg_cayenne-lpp /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_tests_pkg_cayenne-lpp_cc2538dk_uart" -b "115200" ' /tmp/riot_tests_pkg_cayenne-lpp_cc2538dk_uart 
Using Renode pid file /tmp/emulator_pid.G3eD0WORRH
renode -e "set image_file '/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/cc2538dk/tests_pkg_cayenne-lpp.elf'" -e "include @/work/riot/RIOT/boards/cc2538dk/dist/board.resc" --pid-file /tmp/emulator_pid.G3eD0WORRH --hide-log -e "logLevel 2  " --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_tests_pkg_cayenne-lpp_cc2538dk_uart\" true" -e "connector Connect sysbus.uart0 term" -e start
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-11-26 14:51:31,817 # Connect to serial port /tmp/riot_tests_pkg_cayenne-lpp_cc2538dk_uart
r
Welcome to pyterm!
Type '/exit' to exit.
2020-11-26 14:51:32,833 # READY
s
2020-11-26 14:51:32,833 # READY
2020-11-26 14:51:32,885 # START
2020-11-26 14:51:32,893 # main(): This is RIOT! (Version: 2021.01-devel-1104-ga87ae-pr/tools/emulator_term)
2020-11-26 14:51:32,897 # Cayenne LPP test application
2020-11-26 14:51:32,897 # 
2020-11-26 14:51:32,898 # Test 1:
2020-11-26 14:51:32,898 # -------
2020-11-26 14:51:32,911 # Result: 03670110056700FF SUCCESS
2020-11-26 14:51:32,912 # 
2020-11-26 14:51:32,912 # Test 2:
2020-11-26 14:51:32,912 # -------
2020-11-26 14:51:32,916 # Result: 0167FFD7067104D2FB2E0000 SUCCESS
2020-11-26 14:51:32,916 # 
2020-11-26 14:51:32,917 # Test 3:
2020-11-26 14:51:32,917 # -------
2020-11-26 14:51:32,920 # Result: 018806765EF2960A0003E8 SUCCESS

make: Leaving directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #15491 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
