### PR TITLE
pkg/libb2: update to latest release

### DIFF
--- a/pkg/libb2/Makefile
+++ b/pkg/libb2/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = libb2
 PKG_URL     = https://github.com/BLAKE2/libb2
-PKG_VERSION = 60ea749837362c226e8501718f505ab138e5c19d # v0.98
+PKG_VERSION = 2c5142f12a2cd52f3ee0a43e50a3a76f75badf85 # v0.98.1
 PKG_LICENSE = CC0-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libb2/Makefile.dep
+++ b/pkg/libb2/Makefile.dep
@@ -1,0 +1,2 @@
+# 8bit architectures are not supported by libb2.
+FEATURES_BLACKLIST += arch_8bit

--- a/pkg/libb2/include/libb2_config.h
+++ b/pkg/libb2/include/libb2_config.h
@@ -15,10 +15,6 @@ extern "C" {
 #define NATIVE_LITTLE_ENDIAN
 #endif
 
-#ifndef CPU_HAS_UNALIGNED_ACCESS
-#define HAVE_ALIGNED_ACCESS_REQUIRED
-#endif
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the libb2 package to the latest release 0.98.1. It also blacklist the package for AVR since I think it's not compatible with AVR and it removes a define that is not used anymore in the package.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- Automatic test is still functional:

<details><summary>board: native</summary>

```
$ BUILD_IN_DOCKER=1 make -C tests/pkg_libb2/ all test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/pkg_libb2/' 'riot/riotbuild:latest' make     all
Building application "tests_pkg_libb2" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/pkg/libb2
"make" -C /data/riotbuild/riotbase/build/pkg/libb2/src -f /data/riotbuild/riotbase/pkg/libb2/Makefile.libb2
"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/embunit
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
   text	   data	    bss	    dec	    hex	filename
  96124	    700	  47772	 144596	  234d4	/data/riotbuild/riotbase/tests/pkg_libb2/bin/native/tests_pkg_libb2.elf
r
/work/riot/RIOT/tests/pkg_libb2/bin/native/tests_pkg_libb2.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.01-devel-1132-gc3fa3-pr/pkg/libb2_update)
..
OK (2 tests)
```

</details>

<details><summary>board: iotlab-m3 (on iotlab)</summary>

```
$ IOTLAB_NODE=auto-ssh BUILD_IN_DOCKER=1 make BOARD=iotlab-m3 -C tests/pkg_libb2/ flash test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=iotlab-m3'  -w '/data/riotbuild/riotbase/tests/pkg_libb2/' 'riot/riotbuild:latest' make 'BOARD=iotlab-m3'    
Building application "tests_pkg_libb2" for "iotlab-m3" with MCU "stm32".

[INFO] updating stm32cmsis /data/riotbuild/riotbase/cpu/stm32/include/vendor/cmsis/f1/.pkg-state.git-downloaded
echo 2948138428461c0621fd53b269862c6e6bb043ce   > /data/riotbuild/riotbase/cpu/stm32/include/vendor/cmsis/f1/.pkg-state.git-downloaded
[INFO] patch stm32cmsis
"make" -C /data/riotbuild/riotbase/pkg/libb2
"make" -C /data/riotbuild/riotbase/build/pkg/libb2/src -f /data/riotbuild/riotbase/pkg/libb2/Makefile.libb2
"make" -C /data/riotbuild/riotbase/boards/iotlab-m3
"make" -C /data/riotbuild/riotbase/boards/common/iotlab
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/embunit
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  32408	    132	   2400	  34940	   887c	/data/riotbuild/riotbase/tests/pkg_libb2/bin/iotlab-m3/tests_pkg_libb2.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,10 --flash /work/riot/RIOT/tests/pkg_libb2/bin/iotlab-m3/tests_pkg_libb2.bin | grep 0
0
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-10.saclay.iot-lab.info:20000' 
READY
s
START
main(): This is RIOT! (Version: 2021.01-devel-1132-gc3fa3-pr/pkg/libb2_update)
..
OK (2 tests)

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
