### PR TITLE
ci/print_versions: don't print directory for make shell

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -82,7 +82,7 @@ get_sys_shell() {
 }
 
 _get_make_shell() {
-    ${MAKE} -sf - 2>/dev/null <<MAKEFILE
+    ${MAKE} -sf - --no-print-directory 2>/dev/null <<MAKEFILE
 \$(info \$(realpath \$(SHELL)))
 MAKEFILE
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a minor build system bug when the `print-versions` target is called from outside the RIOT code base.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- run `make print-versions` from within the RIOT base directory and from outside the RIOT base directory (using `-C`). On master the former works normally but with the latter the " Entering directory..." message is printed and mixed with the make shell version:

<details><summary>This PR:</summary>

```
$ make print-versions 

Operating System Environment
----------------------------
         Operating System: "Ubuntu" "20.10 (Groovy Gorilla)"
                   Kernel: Linux 5.8.0-28-generic x86_64 x86_64
             System shell: /usr/bin/dash (probably dash)
             make's shell: /usr/bin/dash (probably dash)

[...]
$ cd ..
$ make -C RIOT print-versions
make: Entering directory '/work/riot/RIOT'

Operating System Environment
----------------------------
         Operating System: "Ubuntu" "20.10 (Groovy Gorilla)"
                   Kernel: Linux 5.8.0-28-generic x86_64 x86_64
             System shell: /usr/bin/dash (probably dash)
             make's shell: /usr/bin/dash (probably dash)
[...]
```

</details>

<details><summary>master:</summary>

```
$ make print-versions 

Operating System Environment
----------------------------
         Operating System: "Ubuntu" "20.10 (Groovy Gorilla)"
                   Kernel: Linux 5.8.0-28-generic x86_64 x86_64
             System shell: /usr/bin/dash (probably dash)
             make's shell: /usr/bin/dash (probably dash)
[...]
$ cd ..
$ make -C RIOT print-versions
make: Entering directory '/work/riot/RIOT'

Operating System Environment
----------------------------
         Operating System: "Ubuntu" "20.10 (Groovy Gorilla)"
                   Kernel: Linux 5.8.0-28-generic x86_64 x86_64
             System shell: /usr/bin/dash (probably dash)
             make's shell: make[1]: Entering directory '/work/riot/RIOT'
/usr/bin/dash
make[1]: Leaving directory '/work/riot/RIOT' (probably dash)
[...]
```

</details>




<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
