### PR TITLE
SECURITY.md: Add initial security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# RIOT Security Policy
+
+All security bugs reported will be silently fixed in `master` and backported
+to the previous release.
+
+## Reporting a Vulnerability
+
+If a security issue is discovered, please report it to security@riot-os.org.
+A response will be provided within one week.
+The issue will be tracked in the [security mailing list](security@riot-os.org).
+The original reporter will be included in the discussion of the issue.
+
+## Notification of a Vulnerability
+
+After a fix is provided the security issue will be privately disclosed to the
+original reporter, RIOT security maintainers, and "Trusted RIOT Users".
+A public announcement of the security fix will be made two weeks after the
+point release, though this may vary depending on the severity and ability of
+trusted RIOT users to provide the fix.
+
+## Trusted RIOT Users
+
+To access the "Trusted RIOT Users" notifications on the
+[RIOT forum](https://forum.riot-os.org) please send information
+on the RIOT based service or product as well as your
+[forum](https://forum.riot-os.org) username to the
+[security mailing list](security@riot-os.org).
+Early notification of security bugs will be available and should not be shared
+publicly.
+If done, it will result in access removal from the "Trusted RIOT Users"
+notifications.


### PR DESCRIPTION
### Contribution description

RIOT should have a defined policy on how to handle security released bugs.

After a small survey of other OSes, this seems to fit best with RIOT.
