### PR TITLE
cpu/cc2538: enable UART IRQ only if cb is not NULL

### DIFF
--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -145,14 +145,12 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     /* Configure line control for 8-bit, no parity, 1 stop bit and enable  */
     u->cc2538_uart_lcrh.LCRH = (WLEN_8_BITS << 5) | FEN;
 
-    /* register callbacks */
+    /* register callbacks and enable UART irq */
     if (rx_cb) {
         uart_ctx[uart].rx_cb = rx_cb;
         uart_ctx[uart].arg = arg;
+        NVIC_EnableIRQ(UART_IRQ(uart_num));
     }
-
-    /* enable UART interrupt */
-    NVIC_EnableIRQ(UART_IRQ(uart_num));
 
     /* UART Enable */
     u->cc2538_uart_ctl.CTLbits.UARTEN = 1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix a bug encountered in #15489 (especially https://github.com/RIOT-OS/RIOT/pull/15489#issuecomment-733858763): on cc2538 cpus, the UART IRQ is always enabled even if the firmware doesn't set a callback function to process received data.

For example, in #15489, pressing enter with `examples/hello-world` crashes the application.

The solution proposed by this PR is to enable the IRQ only if cb is not NULL, like it's done on STM32.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Verify that the initial bug is fixed with renode:

```
make BOARD=firefly -C examples/hello-world emulate
```
Then press enter in the renode terminal window => no crash with this PR

- Test on hardware (there are some on iot-lab, so one could submit an experiment and use IOTLAB_NODE=auto-ssh):
```
$ iotlab-experiment submit -d 120 -l 1,archi=firefly:multi+site=lille
$ iotlab-experiment wait
$ IOTLAB_NODE=auto-ssh make BOARD=firefly -C examples/hello-world flash term
```

=> I'm not able to reproduce the bug on master but with this PR I don't see any regression (also tested `examples/default`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Discovered in #15489

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
