### PR TITLE
sys/byteorder: add helpers to convert from little endian to host byte order

### DIFF
--- a/sys/include/byteorder.h
+++ b/sys/include/byteorder.h
@@ -121,6 +121,27 @@ typedef be_uint32_t network_uint32_t;
 typedef be_uint64_t network_uint64_t;
 
 /**
+ * @brief          Convert from little endian to host byte order, 16 bit.
+ * @param[in]      v   The integer in little endian.
+ * @returns        `v` converted to host byte order.
+ */
+static inline uint16_t byteorder_ltohs(le_uint16_t v);
+
+/**
+ * @brief          Convert from little endian to host byte order, 32 bit.
+ * @param[in]      v   The integer in little endian.
+ * @returns        `v` converted to host byte order.
+ */
+static inline uint32_t byteorder_ltohl(le_uint32_t v);
+
+/**
+ * @brief          Convert from little endian to host byte order, 64 bit.
+ * @param[in]      v   The integer in little endian.
+ * @returns        `v` converted to host byte order.
+ */
+static inline uint64_t byteorder_ltohll(le_uint64_t v);
+
+/**
  * @brief          Convert from little endian to big endian, 16 bit.
  * @param[in]      v   The integer in little endian.
  * @returns        `v` converted to big endian.
@@ -161,6 +182,27 @@ static inline le_uint32_t byteorder_btoll(be_uint32_t v);
  * @returns        `v` converted to little endian.
  */
 static inline le_uint64_t byteorder_btolll(be_uint64_t v);
+
+/**
+ * @brief          Convert from host byte order to little endian, 16 bit.
+ * @param[in]      v   The integer in host byte order.
+ * @returns        `v` converted to little endian.
+ */
+static inline le_uint16_t byteorder_htols(uint16_t v);
+
+/**
+ * @brief          Convert from host byte order to little endian, 32 bit.
+ * @param[in]      v   The integer in host byte order.
+ * @returns        `v` converted to little endian.
+ */
+static inline le_uint32_t byteorder_htoll(uint32_t v);
+
+/**
+ * @brief          Convert from host byte order to little endian, 64 bit.
+ * @param[in]      v   The integer in host byte order.
+ * @returns        `v` converted to little endian.
+ */
+static inline le_uint64_t byteorder_htolll(uint64_t v);
 
 /**
  * @brief          Convert from host byte order to network byte order, 16 bit.
@@ -381,6 +423,32 @@ static inline uint64_t byteorder_swapll(uint64_t v)
     return __builtin_bswap64(v);
 }
 
+/**
+ * @brief Swaps the byteorder according to the endianness (host -> le)
+ */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#   define _byteorder_swap_le(V, T) (V)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#   define _byteorder_swap_le(V, T) (byteorder_swap ## T((V)))
+#else
+#   error "Byte order is neither little nor big!"
+#endif
+
+static inline uint16_t byteorder_ltohs(le_uint16_t v)
+{
+    return _byteorder_swap_le(v.u16, s);
+}
+
+static inline uint32_t byteorder_ltohl(le_uint32_t v)
+{
+    return _byteorder_swap_le(v.u32, l);
+}
+
+static inline uint64_t byteorder_ltohll(le_uint64_t v)
+{
+    return _byteorder_swap_le(v.u64, ll);
+}
+
 static inline be_uint16_t byteorder_ltobs(le_uint16_t v)
 {
     be_uint16_t result = { byteorder_swaps(v.u16) };
@@ -423,8 +491,29 @@ static inline le_uint64_t byteorder_btolll(be_uint64_t v)
     return result;
 }
 
+static inline le_uint16_t byteorder_htols(uint16_t v)
+{
+    le_uint16_t result = { _byteorder_swap_le(v, s) };
+
+    return result;
+}
+
+static inline le_uint32_t byteorder_htoll(uint32_t v)
+{
+    le_uint32_t result = { _byteorder_swap_le(v, l) };
+
+    return result;
+}
+
+static inline le_uint64_t byteorder_htolll(uint64_t v)
+{
+    le_uint64_t result = { _byteorder_swap_le(v, ll) };
+
+    return result;
+}
+
 /**
- * @brief Swaps the byteorder according to the endianness
+ * @brief Swaps the byteorder according to the endianness (host -> BE)
  */
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #   define _byteorder_swap(V, T) (byteorder_swap ## T((V)))

--- a/tests/unittests/tests-core/tests-core-byteorder.c
+++ b/tests/unittests/tests-core/tests-core-byteorder.c
@@ -120,6 +120,30 @@ static void test_byteorder_htobebufl(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(bebuf, tmp, sizeof(tmp)));
 }
 
+static void test_byteorder_htols(void)
+{
+    static const uint16_t host = 0x1234;
+    le_uint16_t le = { .u8 = { 0x34, 0x12 } };
+    TEST_ASSERT_EQUAL_INT(le.u16, byteorder_htols(host).u16);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ltohs(le));
+}
+
+static void test_byteorder_htoll(void)
+{
+    static const uint32_t host = 0x12345678ul;
+    le_uint32_t le = { .u8 = { 0x78, 0x56, 0x34, 0x12, } };
+    TEST_ASSERT_EQUAL_INT(le.u32, byteorder_htoll(host).u32);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ltohl(le));
+}
+
+static void test_byteorder_htolll(void)
+{
+    static const uint64_t host = 0x123456789abcdef0ull;
+    le_uint64_t le = { .u8 = { 0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12 } };
+    TEST_ASSERT_EQUAL_INT(le.u64, byteorder_htolll(host).u64);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ltohll(le));
+}
+
 Test *tests_core_byteorder_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -136,6 +160,9 @@ Test *tests_core_byteorder_tests(void)
         new_TestFixture(test_byteorder_htobebufs),
         new_TestFixture(test_byteorder_bebuftohl),
         new_TestFixture(test_byteorder_htobebufl),
+        new_TestFixture(test_byteorder_htols),
+        new_TestFixture(test_byteorder_htoll),
+        new_TestFixture(test_byteorder_htolll),
     };
 
     EMB_UNIT_TESTCALLER(core_byteorder_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -23,11 +23,6 @@
 #include "unittests-constants.h"
 #include "tests-ieee802154.h"
 
-static inline le_uint16_t byteorder_htols(uint16_t v)
-{
-    return byteorder_btols(byteorder_htons(v));
-}
-
 static void test_ieee802154_set_frame_hdr_flags0(void)
 {
     const le_uint16_t src_pan = byteorder_htols(0);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is usually a NOP, but a helper functions to allow for writing code that would also work on mythical Big Endian machines.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
