### PR TITLE
cpu/stm32: periph_eth: register with netdev

### DIFF
--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -248,7 +248,6 @@ static const adc_conf_t adc_config[] = {
  */
 static const eth_conf_t eth_config = {
     .mode = RMII,
-    .addr = { 0 },
     .speed = MII_BMCR_SPEED_100 | MII_BMCR_FULL_DPLX,
     .dma = 6,
     .dma_chan = 8,

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -219,7 +219,6 @@ static const spi_conf_t spi_config[] = {
  */
 static const eth_conf_t eth_config = {
     .mode = RMII,
-    .addr = { 0 },
     .speed = MII_BMCR_SPEED_100 | MII_BMCR_FULL_DPLX,
     .dma = 7,
     .dma_chan = 8,

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -167,7 +167,6 @@ static const spi_conf_t spi_config[] = {
  */
 static const eth_conf_t eth_config = {
     .mode = RMII,
-    .addr = { 0 },
     .speed = MII_BMCR_SPEED_100 | MII_BMCR_FULL_DPLX,
     .dma = 3,
     .dma_chan = 8,

--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -24,7 +24,6 @@ ifneq (,$(filter stm32_eth,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eth
   USEMODULE += netdev_eth
   USEMODULE += iolist
-  USEMODULE += luid
   USEMODULE += xtimer
 endif
 

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -1049,7 +1049,6 @@ typedef enum {
  */
 typedef struct {
     eth_mode_t mode;            /**< Select configuration mode */
-    uint8_t addr[6];            /**< Ethernet MAC address */
     uint16_t speed;             /**< Speed selection */
     uint8_t dma;                /**< Locical CMA Descriptor used for TX */
     uint8_t dma_chan;           /**< DMA channel used for TX */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -286,6 +286,7 @@ typedef enum {
     NETDEV_KW41ZRF,
     NETDEV_MRF24J40,
     NETDEV_NRF802154,
+    NETDEV_STM32_ETH,
     /* add more if needed */
 } netdev_type_t;
 /** @} */


### PR DESCRIPTION
### Contribution description

Instead of providing a hard-coded MAC address per board, allow to supply a MAC address using EUI provider for `stm32_eth`.

### Testing procedure

The Ethernet interface should still get a stable address across reboots.
If a board defines an EUI provider, that address should be used instead. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
