### PR TITLE
sys/suit: fix use w/o progress bar

### DIFF
--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -96,6 +96,8 @@ static inline void _print_download_progress(suit_manifest_t *manifest,
             puts("");
         }
     }
+#else
+    (void) image_size;
 #endif
 }
 #endif


### PR DESCRIPTION
- `sys/suit/transport/coap.c` : If `MODULE_PROGRESS_BAR` is not defined, `image_size` variable will be unused.