### PR TITLE
gnrc_ipv6_ext_frag: check return value of msg_try_send()

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
@@ -14,6 +14,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 #include <stdbool.h>
 
 #include "byteorder.h"
@@ -85,8 +86,9 @@ static gnrc_ipv6_ext_frag_send_t *_snd_buf_alloc(void);
  *          datagrams and fragments.
  *
  * @param[in] snd_buf   A fragmentation send buffer entry
+ * @param[in] error     Error number for the error causing the release
  */
-static void _snd_buf_free(gnrc_ipv6_ext_frag_send_t *snd_buf);
+static void _snd_buf_free(gnrc_ipv6_ext_frag_send_t *snd_buf, int error);
 
 /**
  * @brief   Removes a fragmentation send buffer without releasing the stored
@@ -175,7 +177,7 @@ void gnrc_ipv6_ext_frag_send(gnrc_ipv6_ext_frag_send_t *snd_buf)
                     gnrc_pktbuf_release(ptr);
                 }
             }
-            _snd_buf_free(snd_buf);
+            _snd_buf_free(snd_buf, ENOSPC);
             return;
         }
         ptr = tmp;
@@ -212,7 +214,7 @@ void gnrc_ipv6_ext_frag_send(gnrc_ipv6_ext_frag_send_t *snd_buf)
     if (ptr == NULL) {
         DEBUG("ipv6_ext_frag: unable to create fragmentation header\n");
         gnrc_pktbuf_release(to_send);
-        _snd_buf_free(snd_buf);
+        _snd_buf_free(snd_buf, ENOSPC);
         return;
     }
     remaining -= sizeof(ipv6_ext_frag_t);
@@ -237,7 +239,7 @@ void gnrc_ipv6_ext_frag_send(gnrc_ipv6_ext_frag_send_t *snd_buf)
             if (ptr == NULL) {
                 DEBUG("ipv6_ext_frag: packet buffer full, canceling fragmentation\n");
                 gnrc_pktbuf_release(to_send);
-                _snd_buf_free(snd_buf);
+                _snd_buf_free(snd_buf, ENOSPC);
                 return;
             }
             assert(snd_buf->pkt->next == ptr);  /* we just created it with mark */
@@ -258,7 +260,7 @@ void gnrc_ipv6_ext_frag_send(gnrc_ipv6_ext_frag_send_t *snd_buf)
     if (msg_try_send(&msg, gnrc_ipv6_pid) <= 0) {
         DEBUG("ipv6_ext_frag: Unable to send fragment, canceling fragmentation\n");
         gnrc_pktbuf_release(to_send);
-        _snd_buf_free(snd_buf);
+        _snd_buf_free(snd_buf, ENOMEM);
         return;
     }
     if (last_fragment) {
@@ -274,7 +276,7 @@ void gnrc_ipv6_ext_frag_send(gnrc_ipv6_ext_frag_send_t *snd_buf)
         msg.content.ptr = snd_buf;
         if (msg_try_send(&msg, gnrc_ipv6_pid) <= 0) {
             DEBUG("ipv6_ext_frag: Unable to continue fragmentation, canceling\n");
-            _snd_buf_free(snd_buf);
+            _snd_buf_free(snd_buf, ENOMEM);
         }
     }
 }
@@ -299,13 +301,13 @@ static void _snd_buf_del(gnrc_ipv6_ext_frag_send_t *snd_buf)
     snd_buf->pkt = NULL;
 }
 
-static void _snd_buf_free(gnrc_ipv6_ext_frag_send_t *snd_buf)
+static void _snd_buf_free(gnrc_ipv6_ext_frag_send_t *snd_buf, int error)
 {
     if (snd_buf->per_frag) {
         gnrc_pktbuf_release(snd_buf->per_frag);
     }
     if (snd_buf->pkt) {
-        gnrc_pktbuf_release(snd_buf->pkt);
+        gnrc_pktbuf_release_error(snd_buf->pkt, error);
     }
     _snd_buf_del(snd_buf);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Addresses parts of #15521. Not checking the return value of `msg_try_send()` could indeed lead to a leak in the packet buffer.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I tried to provide tests for the corner case, but RIOT makes it quite hard to mock filled message queues :-/. However, `tests/gnrc_ipv6_ext_frag` should still pass never the less **NOTE THE SUDO! This test is not run on Murdock**:

```sh
sudo ./dist/tools/tapsetup/tapsetup   # if you haven't already opened a TAP interface
make -C tests/gnrc_ipv6_ext_frag -j
sudo make -C tests/gnrc_ipv6_ext_frag test
```

Of course this also should work with any board supporting `ethos`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses parts of #15521
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
