### PR TITLE
cpu/nrf52: Add i2c reconfigure feature

### DIFF
--- a/cpu/nrf52/Kconfig
+++ b/cpu/nrf52/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_NRF52
     select HAS_BLE_NIMBLE_NETIF
     select HAS_CORTEXM_MPU
     select HAS_CPU_NRF52
+    select HAS_PERIPH_I2C_RECONFIGURE
 
 ## CPU Models
 config CPU_MODEL_NRF52805XXAA

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -20,4 +20,6 @@ FEATURES_PROVIDED += ble_nimble_netif
 # all nrf52 have an MPU
 FEATURES_PROVIDED += cortexm_mpu
 
+FEATURES_PROVIDED += periph_i2c_reconfigure
+
 include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -138,6 +138,14 @@ typedef struct {
 /** @} */
 
 /**
+ * @name    Define macros for sda and scl pin to be able to reinitialize them
+ * @{
+ */
+#define i2c_pin_sda(dev) i2c_config[dev].sda
+#define i2c_pin_scl(dev) i2c_config[dev].scl
+/** @} */
+
+/**
  * @name    The PWM unit on the nRF52 supports 4 channels per device
  */
 #define PWM_CHANNELS        (4U)


### PR DESCRIPTION
### Contribution description
This PR adds the i2c reconfigure feature to the nrf52 cpu.

### Testing procedure
1. Run the `tests/periph_i2c` test application.
`i2c_gpio` command should available and usable.

2. Connect a Microchip CryptoAuth device to the board with nrf52 cpu and change default i2c_speed in `boards/common/nrf52/include/cfg_i2c_default.h` to `I2C_SPEED_FAST`. When  the feature is provided in `cpu/nrf5x_common/Makefile.features` the application should execute successfully. If the feature is removed from `Makefile.features`, the execution should fail.