### PR TITLE
tests/driver_bmx280: fix address define in README

### DIFF
--- a/tests/driver_bmx280/README.md
+++ b/tests/driver_bmx280/README.md
@@ -22,7 +22,7 @@ After initialization, every 2 seconds, the application:
 If your device is at a different I2C address than the default (0x77) you
 can build the test as follows:
 
-    export CFLAGS=-DBME280_PARAM_I2C_ADDR=0x76
+    export CFLAGS=-DBMX280_PARAM_I2C_ADDR=0x76
     BOARD=sodaq-autonomo make -C tests/driver_bmx280
 
 By default, the test application is built to use the bme280 module, to build it for


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The DBME280_PARAM_I2C_ADDR define, which is mentioned in the readme of the bmx280 test is outdated and was replaced by DBMX280_PARAM_I2C_ADDR. So fixed that.

See: https://github.com/RIOT-OS/RIOT/blob/3234b918e361d273b9cfef3c123653b174f0abc0/drivers/bmx280/include/bmx280_params.h#L55