### PR TITLE
tools/esptool: add common makefile to define esptool variables

### DIFF
--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -2,7 +2,3 @@
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
-
-# reset tool configuration
-RESET ?= $(RIOTTOOLS)/esptool/espreset.py
-RESET_FLAGS ?= --port $(PROG_DEV)

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -2,7 +2,3 @@
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
-
-# reset tool configuration
-RESET ?= $(RIOTTOOLS)/esptool/espreset.py
-RESET_FLAGS ?= --port $(PROG_DEV)

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -88,61 +88,11 @@ LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 # LINKFLAGS += -Wl,--verbose
 # LINKFLAGS += -Wl,--print-gc-sections
 
-ifneq (,$(filter esp_log_colored,$(USEMODULE)))
-  BOOTLOADER_COLOR = _colors
-endif
-ifneq (,$(filter esp_log_startup,$(USEMODULE)))
-  BOOTLOADER_INFO = _info
-endif
-
-BOOTLOADER_BIN = bootloader$(BOOTLOADER_COLOR)$(BOOTLOADER_INFO).bin
-
-ESPTOOL ?= $(RIOTTOOLS)/esptool/esptool.py
-
-# The ELFFILE is the base one used for flashing
-FLASHFILE ?= $(ELFFILE)
-
-# configure preflasher to convert .elf to .bin before flashing
-PREFLASHER = $(ESPTOOL)
-PREFFLAGS  = --chip $(FLASH_CHIP) elf2image
-PREFFLAGS += --flash_mode $(FLASH_MODE) --flash_size $(FLASH_SIZE)MB
-PREFFLAGS += --flash_freq $(FLASH_FREQ) $(FLASH_OPTS)
-PREFFLAGS += -o $(FLASHFILE).bin $(FLASHFILE);
-PREFFLAGS += printf "\n" > $(BINDIR)/partitions.csv;
-PREFFLAGS += printf "nvs, data, nvs, 0x9000, 0x6000\n" >> $(BINDIR)/partitions.csv;
-PREFFLAGS += printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $(BINDIR)/partitions.csv;
-PREFFLAGS += printf "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv;
-PREFFLAGS += ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv;
-
-PREFFLAGS += python3 $(RIOTTOOLS)/esptool/gen_esp32part.py
-PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
-FLASHDEPS += preflash
-
-# flasher configuration
-ifneq (,$(filter esp_qemu,$(USEMODULE)))
-  FLASHER = dd
-  FFLAGS += if=/dev/zero bs=1M count=$(FLASH_SIZE) |
-  FFLAGS += tr "\\000" "\\377" > tmp.bin && cat tmp.bin |
-  FFLAGS += head -c $$(($(BOOTLOADER_POS))) |
-  FFLAGS += cat - $(RIOTCPU)/$(CPU)/bin/$(BOOTLOADER_BIN) tmp.bin |
-  FFLAGS += head -c $$((0x8000)) |
-  FFLAGS += cat - $(BINDIR)/partitions.bin tmp.bin |
-  FFLAGS += head -c $$((0x10000)) |
-  FFLAGS += cat - $(FLASHFILE).bin tmp.bin |
-  FFLAGS += head -c $(FLASH_SIZE)MB > $(BINDIR)/$(CPU)flash.bin && rm tmp.bin;
-else
-  PROGRAMMER_SPEED ?= 460800
-  FLASHER = $(ESPTOOL)
-  FFLAGS += --chip $(FLASH_CHIP) --port $(PROG_DEV) --baud $(PROGRAMMER_SPEED)
-  FFLAGS += --before default_reset write_flash -z
-  FFLAGS += --flash_mode $(FLASH_MODE) --flash_freq $(FLASH_FREQ)
-  FFLAGS += $(BOOTLOADER_POS) $(RIOTCPU)/$(CPU)/bin/$(BOOTLOADER_BIN)
-  FFLAGS += 0x8000 $(BINDIR)/partitions.bin
-  FFLAGS += 0x10000 $(FLASHFILE).bin
-endif
-
 # increase the test timeout for file system tests that use the SPI flash drive
 ifneq (,$(filter spiffs littlefs,$(USEMODULE)))
   RIOT_TEST_TIMEOUT = 20
   $(call target-export-variables,test,RIOT_TEST_TIMEOUT)
 endif
+
+# All ESP are flashed using esptool
+PROGRAMMER ?= esptool

--- a/makefiles/tools/esptool.inc.mk
+++ b/makefiles/tools/esptool.inc.mk
@@ -1,0 +1,56 @@
+ifneq (,$(filter esp_log_colored,$(USEMODULE)))
+  BOOTLOADER_COLOR = _colors
+endif
+ifneq (,$(filter esp_log_startup,$(USEMODULE)))
+  BOOTLOADER_INFO = _info
+endif
+
+BOOTLOADER_BIN = bootloader$(BOOTLOADER_COLOR)$(BOOTLOADER_INFO).bin
+
+ESPTOOL ?= $(RIOTTOOLS)/esptool/esptool.py
+
+# The ELFFILE is the base one used for flashing
+FLASHFILE ?= $(ELFFILE)
+
+# configure preflasher to convert .elf to .bin before flashing
+PREFLASHER = $(ESPTOOL)
+PREFFLAGS  = --chip $(FLASH_CHIP) elf2image
+PREFFLAGS += --flash_mode $(FLASH_MODE) --flash_size $(FLASH_SIZE)MB
+PREFFLAGS += --flash_freq $(FLASH_FREQ) $(FLASH_OPTS)
+PREFFLAGS += -o $(FLASHFILE).bin $(FLASHFILE);
+PREFFLAGS += printf "\n" > $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "nvs, data, nvs, 0x9000, 0x6000\n" >> $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $(BINDIR)/partitions.csv;
+PREFFLAGS += printf "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv;
+PREFFLAGS += ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv;
+
+PREFFLAGS += python3 $(RIOTTOOLS)/esptool/gen_esp32part.py
+PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
+FLASHDEPS += preflash
+
+# flasher configuration
+ifneq (,$(filter esp_qemu,$(USEMODULE)))
+  FLASHER = dd
+  FFLAGS += if=/dev/zero bs=1M count=$(FLASH_SIZE) |
+  FFLAGS += tr "\\000" "\\377" > tmp.bin && cat tmp.bin |
+  FFLAGS += head -c $$(($(BOOTLOADER_POS))) |
+  FFLAGS += cat - $(RIOTCPU)/$(CPU)/bin/$(BOOTLOADER_BIN) tmp.bin |
+  FFLAGS += head -c $$((0x8000)) |
+  FFLAGS += cat - $(BINDIR)/partitions.bin tmp.bin |
+  FFLAGS += head -c $$((0x10000)) |
+  FFLAGS += cat - $(FLASHFILE).bin tmp.bin |
+  FFLAGS += head -c $(FLASH_SIZE)MB > $(BINDIR)/$(CPU)flash.bin && rm tmp.bin;
+else
+  PROGRAMMER_SPEED ?= 460800
+  FLASHER = $(ESPTOOL)
+  FFLAGS += --chip $(FLASH_CHIP) --port $(PROG_DEV) --baud $(PROGRAMMER_SPEED)
+  FFLAGS += --before default_reset write_flash -z
+  FFLAGS += --flash_mode $(FLASH_MODE) --flash_freq $(FLASH_FREQ)
+  FFLAGS += $(BOOTLOADER_POS) $(RIOTCPU)/$(CPU)/bin/$(BOOTLOADER_BIN)
+  FFLAGS += 0x8000 $(BINDIR)/partitions.bin
+  FFLAGS += 0x10000 $(FLASHFILE).bin
+endif
+
+# reset tool configuration
+RESET ?= $(RIOTTOOLS)/esptool/espreset.py
+RESET_FLAGS ?= --port $(PROG_DEV)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

With this PR, esptool variables are included in the main `Makefile.include` from

https://github.com/RIOT-OS/RIOT/blob/c44d77e5284f2ed928cc806a35b8de7793bc16f9/Makefile.include#L407-L408

It will also make things easier with #15477 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI

- Flashing/resetting esp boards still works:

<details><summary>esp32-wroom-32</summary>

- flashing:

```
$ BUILD_IN_DOCKER=1 make BOARD=esp32-wroom-32 -C examples/hello-world flash term --no-print-directory 
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=esp32-wroom-32'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=esp32-wroom-32'    
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
Building application "hello-world" for "esp32-wroom-32" with MCU "esp32".

"make" -C /data/riotbuild/riotbase/boards/esp32-wroom-32
"make" -C /data/riotbuild/riotbase/boards/common/esp32
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/esp32
"make" -C /data/riotbuild/riotbase/cpu/esp32/freertos
"make" -C /data/riotbuild/riotbase/cpu/esp32/periph
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/driver
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/esp32
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/soc
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/spi_flash
"make" -C /data/riotbuild/riotbase/cpu/esp_common
"make" -C /data/riotbuild/riotbase/cpu/esp_common/freertos
"make" -C /data/riotbuild/riotbase/cpu/esp_common/periph
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor/xtensa
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/log
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
  54126	   3628	   6312	  64066	   fa42	/data/riotbuild/riotbase/examples/hello-world/bin/esp32-wroom-32/hello-world.elf
/work/riot/RIOT/dist/tools/esptool/esptool.py --chip esp32 elf2image --flash_mode dout --flash_size 4MB --flash_freq 40m     -o /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf; printf "\n" > /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "nvs, data, nvs, 0x9000, 0x6000\n" >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "phy_init, data, phy, 0xf000, 0x1000\n" >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "factory, app, factory, 0x10000, " >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; ls -l /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin | awk '{ print $5 }' >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; python3 /work/riot/RIOT/dist/tools/esptool/gen_esp32part.py --verify /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.bin
esptool.py v2.4.0
Parsing CSV input...
/work/riot/RIOT/dist/tools/esptool/esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 460800 --before default_reset write_flash -z --flash_mode dout --flash_freq 40m    0x1000 /work/riot/RIOT/cpu/esp32/bin/bootloader.bin 0x8000 /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.bin 0x10000 /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin
esptool.py v2.4.0
Connecting.....
Chip is ESP32D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse
MAC: 80:7d:3a:fd:d9:90
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash params set to 0x0320
Compressed 18640 bytes to 11444...
Wrote 18640 bytes (11444 compressed) at 0x00001000 in 0.3 seconds (effective 572.8 kbit/s)...
Hash of data verified.
Compressed 3072 bytes to 85...
Wrote 3072 bytes (85 compressed) at 0x00008000 in 0.0 seconds (effective 6655.0 kbit/s)...
Hash of data verified.
Compressed 91024 bytes to 38749...
Wrote 91024 bytes (38749 compressed) at 0x00010000 in 1.1 seconds (effective 682.3 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-12-01 10:41:22,662 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
2020-12-01 10:41:25,196 # ets Jun  8 2016 00:22:57
2020-12-01 10:41:25,196 # 
2020-12-01 10:41:25,201 # rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
2020-12-01 10:41:25,203 # configsip: 0, SPIWP:0xee
2020-12-01 10:41:25,209 # clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
2020-12-01 10:41:25,211 # mode:DOUT, clock div:2
2020-12-01 10:41:25,213 # load:0x3fff0018,len:4
2020-12-01 10:41:25,216 # load:0x3fff001c,len:4004
2020-12-01 10:41:25,218 # load:0x40078000,len:7304
2020-12-01 10:41:25,220 # load:0x40080000,len:7224
2020-12-01 10:41:25,222 # entry 0x40080350
2020-12-01 10:41:25,317 # 
2020-12-01 10:41:25,327 # main(): This is RIOT! (Version: 2021.01-devel-1175-gd527a-pr/tools/esptool_common)
2020-12-01 10:41:25,328 # Hello World!
2020-12-01 10:41:25,333 # You are running RIOT on a(n) esp32-wroom-32 board.
2020-12-01 10:41:25,336 # This board features a(n) esp32 MCU.
2020-12-01 10:41:26,492 # Exiting Pyterm
```

- reset:

```
$ BUILD_IN_DOCKER=1 make BOARD=esp32-wroom-32 -C examples/hello-world reset --no-print-directory 
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
/work/riot/RIOT/dist/tools/esptool/espreset.py --port /dev/ttyUSB0
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will help in #15477 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
