### PR TITLE
drivers/cc110x: use netdev_register

### DIFF
--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -26,7 +26,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
+int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params, uint8_t index)
 {
     if (!dev || !params) {
         return -EINVAL;
@@ -40,6 +40,7 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
     dev->params = *params;
     dev->netdev.driver = &cc110x_driver;
     dev->state = CC110X_STATE_OFF;
+    netdev_register(&dev->netdev, NETDEV_CC110X, index);
     return 0;
 }
 

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -558,11 +558,13 @@ typedef struct {
  *
  * @param   dev     Device descriptor to use
  * @param   params  Parameter of the device to setup
+ * @param   index   Index of @p params in a global parameter struct array.
+ *                  If initialized manually, pass a unique identifier instead.
  *
  * @retval  0       Device successfully set up
  * @retval  -EINVAL @p dev or @p params is `NULL`, or @p params is invalid
  */
-int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params);
+int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params, uint8_t index);
 
 /**
  * @brief Apply the given configuration and the given channel map and performs

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -274,6 +274,10 @@ typedef void (*netdev_event_cb_t)(netdev_t *dev, netdev_event_t event);
 
 /**
  * @brief   Driver types for netdev.
+ *
+ * @warning New entries must be added at the bottom of the list
+ *          because the values need to remain constant to
+ *          generate stable L2 addresses.
  * @{
  */
 typedef enum {
@@ -287,6 +291,7 @@ typedef enum {
     NETDEV_MRF24J40,
     NETDEV_NRF802154,
     NETDEV_STM32_ETH,
+    NETDEV_CC110X,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
@@ -73,7 +73,7 @@ void auto_init_cc110x(void)
     for (unsigned i = 0; i < CC110X_NUM; i++) {
         LOG_DEBUG("[auto_init_netif] initializing cc110x #%u\n", i);
 
-        cc110x_setup(&_cc110x_devs[i], &cc110x_params[i]);
+        cc110x_setup(&_cc110x_devs[i], &cc110x_params[i], i);
         gnrc_netif_cc1xxx_create(&_netif[i], stacks[i], CC110X_MAC_STACKSIZE, CC110X_MAC_PRIO,
                                  "cc110x", (netdev_t *)&_cc110x_devs[i]);
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I added  the call to `netdev_register()` in `cc110x_setup()`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The test in `tests/driver_cc110x` runs.
```
> ifconfig
2020-12-01 10:19:39,170 #  ifconfig
2020-12-01 10:19:39,173 # Iface  5  HWaddr: 22  Channel: 0 
2020-12-01 10:19:39,178 #            TX-Power: 0dBm L2-PDU:253  MTU:1280  HL:64  RTR  
2020-12-01 10:19:39,180 #           6LO  IPHC  
2020-12-01 10:19:39,183 #           Source address length: 1
2020-12-01 10:19:39,186 #           Link type: wireless
2020-12-01 10:19:39,191 #           inet6 addr: fe80::ff:fe00:22  scope: link  VAL
2020-12-01 10:19:39,194 #           inet6 group: ff02::2
2020-12-01 10:19:39,197 #           inet6 group: ff02::1
2020-12-01 10:19:39,200 #           inet6 group: ff02::1:ff00:22
2020-12-01 10:19:39,201 #           
2020-12-01 10:19:39,204 #           Statistics for Layer 2
2020-12-01 10:19:39,207 #             RX packets 0  bytes 0
2020-12-01 10:19:39,211 #             TX packets 2 (Multicast: 2)  bytes 44
2020-12-01 10:19:39,214 #             TX succeeded 2 errors 0
2020-12-01 10:19:39,217 #           Statistics for IPv6
2020-12-01 10:19:39,220 #             RX packets 0  bytes 0
2020-12-01 10:19:39,225 #             TX packets 2 (Multicast: 2)  bytes 112
2020-12-01 10:19:39,228 #             TX succeeded 2 errors 0
2020-12-01 10:19:39,228 # 

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
To benefit from `gnrc_netif_get_by_type()` in #15120
