### PR TITLE
tools: add common makefile for mspdebug programmer

### DIFF
--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -1,3 +1,5 @@
+INCLUDES += -I$(RIOTBOARD)/common/msb-430/include
+
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
@@ -5,23 +7,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
-PROGRAMMER ?= olimex
-MSPDEBUGFLAGS += -j $(PROGRAMMER)
-ifeq ($(strip $(PROGRAMMER)),uif)
-  MSPDEBUGFLAGS += -d $(PROG_DEV)
-endif
-FLASHER ?= mspdebug
-FLASHFILE ?= $(HEXFILE)
-FFLAGS = $(MSPDEBUGFLAGS) "prog $(FLASHFILE)"
-
-# setup debugger
-DEBUGSERVER = $(FLASHER)
-DEBUGSERVER_FLAGS = $(MSPDEBUGFLAGS) gdb
-DEBUGGER = $(PREFIX)gdb
-DEBUGGER_FLAGS = --ex="target remote localhost:2000" --ex "monitor reset halt" --ex load -ex "monitor reset halt"  $(ELFFILE)
-
-INCLUDES += -I$(RIOTBOARD)/common/msb-430/include
-
-# setup reset tool
-RESET ?= mspdebug
-RESET_FLAGS ?= $(MSPDEBUGFLAGS) reset
+PROGRAMMER ?= mspdebug
+MSPDEBUG_PROGRAMMER ?= olimex

--- a/makefiles/tools/mspdebug.inc.mk
+++ b/makefiles/tools/mspdebug.inc.mk
@@ -1,0 +1,17 @@
+MSPDEBUGFLAGS += -j $(MSPDEBUG_PROGRAMMER)
+ifeq ($(strip $(MSPDEBUG_PROGRAMMER)),uif)
+  MSPDEBUGFLAGS += -d $(PROG_DEV)
+endif
+FLASHER ?= mspdebug
+FLASHFILE ?= $(HEXFILE)
+FFLAGS = $(MSPDEBUGFLAGS) "prog $(FLASHFILE)"
+
+# setup debugger
+DEBUGSERVER = $(FLASHER)
+DEBUGSERVER_FLAGS = $(MSPDEBUGFLAGS) gdb
+DEBUGGER = $(PREFIX)gdb
+DEBUGGER_FLAGS = --ex="target remote localhost:2000" --ex "monitor reset halt" --ex load -ex "monitor reset halt"  $(ELFFILE)
+
+# setup reset tool
+RESET ?= mspdebug
+RESET_FLAGS ?= $(MSPDEBUGFLAGS) reset


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces a common makefile for defining the mspdebug programmer variables. Related boards (only msb430 and msb430h apparently) are adapted to make use of it.

Be careful, now the programmer is called `mspdebug` before it was `olimex` but it was a confusion with the mspdebug internal programmer used.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- msb430* boards are still flashable (I don't have the hardware to test this)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will help in #15477 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
