### PR TITLE
cc2538_rf: default to netdev_ieee802154_submac

### DIFF
--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -1,5 +1,8 @@
 ifneq (,$(filter cc2538_rf,$(USEMODULE)))
   USEMODULE += netdev_ieee802154
+  ifeq (,$(filter netdev_ieee802154_legacy,$(USEMODULE)))
+    USEMODULE += netdev_ieee802154_submac
+  endif
 endif
 
 ifneq (,$(filter periph_rtc,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Following #15132, this PR makes `netdev_ieee802154_submac` default for `cc2538_rf`. The basic driver doesn't support ACK handling and retransmissions, so the SubMAC fixes this lack.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compare ping statistics (with 1kb packets) for any cc2538_rf board between current master and this PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#15132 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
