### PR TITLE
drivers/sx127x: use netdev_register()

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -292,6 +292,7 @@ typedef enum {
     NETDEV_NRF802154,
     NETDEV_STM32_ETH,
     NETDEV_CC110X,
+    NETDEV_SX127X,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -256,8 +256,10 @@ typedef void (sx127x_dio_irq_handler_t)(sx127x_t *dev);
  *
  * @param[in] dev                      Device descriptor
  * @param[in] params                   Parameters for device initialization
+ * @param[in] index                    Index of @p params in a global parameter struct array.
+ *                                     If initialized manually, pass a unique identifier instead.
  */
-void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params);
+void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params, uint8_t index);
 
 /**
  * @brief   Resets the SX127X

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -73,11 +73,12 @@ static void sx127x_on_dio1_isr(void *arg);
 static void sx127x_on_dio2_isr(void *arg);
 static void sx127x_on_dio3_isr(void *arg);
 
-void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params)
+void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params, uint8_t index)
 {
     netdev_t *netdev = (netdev_t*) dev;
     netdev->driver = &sx127x_driver;
     dev->params = *params;
+    netdev_register(&dev->netdev, NETDEV_SX127X, index);
 }
 
 int sx127x_reset(const sx127x_t *dev)

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -830,7 +830,7 @@ void *_semtech_loramac_event_loop(void *arg)
 
 int semtech_loramac_init(semtech_loramac_t *mac)
 {
-    sx127x_setup(&sx127x, &sx127x_params[0]);
+    sx127x_setup(&sx127x, &sx127x_params[0], 0);
     sx127x.netdev.driver = &sx127x_driver;
     sx127x.netdev.event_callback = _semtech_loramac_event_cb;
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
@@ -57,7 +57,7 @@ void auto_init_sx127x(void)
         LOG_DEBUG("[auto_init_netif] initializing sx1276 #%u\n", i);
 #endif
 
-        sx127x_setup(&sx127x_devs[i], &sx127x_params[i]);
+        sx127x_setup(&sx127x_devs[i], &sx127x_params[i], i);
         if (IS_USED(MODULE_GNRC_NETIF_LORAWAN)) {
             /* Currently only one lora device is supported */
             assert(SX127X_NUMOF == 1);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I added the call to `netdev_register()` in `sx127x_setup()`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The test `tests/driver_sx127x` runs.
```
2020-12-01 16:35:39,176 # main(): This is RIOT! (Version: 2021.01-devel-1206-gc526a-sx127x_netdev_register)
2020-12-01 16:35:39,209 # Initialization successful - starting the shell now
> help
2020-12-01 16:35:42,831 #  help
2020-12-01 16:35:42,834 # Command              Description
2020-12-01 16:35:42,838 # ---------------------------------------
2020-12-01 16:35:42,843 # setup                Initialize LoRa modulation settings
2020-12-01 16:35:42,846 # implicit             Enable implicit header
2020-12-01 16:35:42,849 # crc                  Enable CRC
2020-12-01 16:35:42,854 # payload              Set payload length (implicit header)
2020-12-01 16:35:42,859 # random               Get random number from sx127x
2020-12-01 16:35:42,862 # syncword             Get/Set the syncword
2020-12-01 16:35:42,866 # rx_timeout           Set the RX timeout
2020-12-01 16:35:42,871 # channel              Get/Set channel frequency (in Hz)
2020-12-01 16:35:42,876 # register             Get/Set value(s) of registers of sx127x
2020-12-01 16:35:42,880 # send                 Send raw payload string
2020-12-01 16:35:42,884 # listen               Start raw payload listener
2020-12-01 16:35:42,888 # reset                Reset the sx127x device
2020-12-01 16:35:42,891 # reboot               Reboot the node
2020-12-01 16:35:42,895 # version              Prints current RIOT_VERSION
2020-12-01 16:35:42,900 # pm                   interact with layered PM subsystem
2020-12-01 16:35:42,906 # ps                   Prints information about running threads.
> send
2020-12-01 16:35:55,850 #  send
2020-12-01 16:35:55,852 # usage: send <payload>
> send hi
2020-12-01 16:35:58,990 #  send hi
2020-12-01 16:35:58,993 # sending "hi" payload (3 bytes)
> 2020-12-01 16:35:59,028 #  Transmission completed

```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
To benefit from `gnrc_netif_get_by_type()` in #15120
see also: #15532
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
