### PR TITLE
tools/stm32loader: introduce common makefile

### DIFF
--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -8,13 +8,12 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-FLASHER = $(RIOTTOOLS)/stm32loader/stm32loader.py
-FLASHFILE ?= $(BINFILE)
+# Configure programmer
+PROGRAMMER ?= stm32loader
 
-# -e: erase
 # -u: use sector by sector erase
 # -S: swap RTS and DTR
 # -l 0x1ff: amount of sectors to erase
-FFLAGS += -p $(PROG_DEV) -e -u -S -l 0x1ff -w $(FLASHFILE)
+STM32LOADER_FLAGS ?= -u -S -l 0x1ff
 
 PYTERMFLAGS +=  --set-rts 0

--- a/makefiles/tools/stm32loader.inc.mk
+++ b/makefiles/tools/stm32loader.inc.mk
@@ -1,0 +1,7 @@
+FLASHFILE ?= $(BINFILE)
+
+# -e: erase
+STM32LOADER_FLAGS += -p $(PROG_DEV) -e -w $(FLASHFILE)
+
+FLASHER ?= $(RIOTTOOLS)/stm32loader/stm32loader.py
+FFLAGS ?= $(STM32LOADER_FLAGS)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Similar to #15535 and #15533, this PR introduces a common makefile to define the stm32loader flasher variables. Only the lobaro-lorabox is using it for the moment, but it might be possible to extend support for other STM32 apparently.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- lobaro-lorabox can still be flashed

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will help with #15477 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
