### PR TITLE
tools/goodfet: define variables in common makefile

### DIFF
--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -6,6 +6,5 @@ BAUD ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # flash tool configuration
-FLASHER = $(RIOTTOOLS)/goodfet/goodfet.bsl
-FLASHFILE ?= $(HEXFILE)
-FFLAGS = --telosb -c $(PROG_DEV) -r -e -I -p $(FLASHFILE)
+PROGRAMMER ?= goodfet
+GOODFET_FLAGS ?= --telosb

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -5,6 +5,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
-FLASHER = $(RIOTTOOLS)/goodfet/goodfet.bsl
-FLASHFILE ?= $(HEXFILE)
-FFLAGS = --z1 -I -c $(PROG_DEV) -r -e -p $(FLASHFILE)
+PROGRAMMER ?= goodfet
+GOODFET_FLAGS ?= --z1

--- a/makefiles/tools/goodfet.inc.mk
+++ b/makefiles/tools/goodfet.inc.mk
@@ -1,0 +1,5 @@
+FLASHER ?= $(RIOTTOOLS)/goodfet/goodfet.bsl
+FLASHFILE ?= $(HEXFILE)
+
+GOODFET_FLAGS += -c $(PROG_DEV) -r -e -I -p $(FLASHFILE)
+FFLAGS ?= $(GOODFET_FLAGS)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces a common Makefile for the goodfet programmer and adapt the related boards - telosb, z1 - accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- telosb and z1 can still be flashed as usual (who has the hardware to test this ?)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Needed for #15477 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
