### PR TITLE
tests/gnrc_ipv6_ext_frag: use gnrc_netif_hdr_set_netif()

### DIFF
--- a/tests/gnrc_ipv6_ext_frag/main.c
+++ b/tests/gnrc_ipv6_ext_frag/main.c
@@ -554,7 +554,7 @@ static gnrc_pktsnip_t *_build_udp_packet(const ipv6_addr_t *dst,
         return NULL;
     }
     netif_hdr = hdr->data;
-    netif_hdr->if_pid = eth_netif->pid;
+    gnrc_netif_hdr_set_netif(netif_hdr, eth_netif);
     netif_hdr->flags |= GNRC_NETIF_HDR_FLAGS_MULTICAST;
     hdr->next = payload;
     return hdr;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Noticed this while working on https://github.com/RIOT-OS/RIOT/pull/15526. There is a setter (giving the potential to some day not use `pid` to identify a `netif`), so why not use it.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Binary of that test should not change.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
