### PR TITLE
boards/common/qn908x: cleanup Makefile.include

### DIFF
--- a/boards/common/qn908x/Makefile.include
+++ b/boards/common/qn908x/Makefile.include
@@ -1,3 +1,8 @@
+# This board uses OpenOCD. Note that support for QN908x in OpenOCD at the time
+# of writing has not been merged in the tree and is only available at
+# http://openocd.zylin.com/#/c/5584/ .
+PROGRAMMER ?= openocd
+
 # Using dap or jlink depends on which firmware the OpenSDA debugger is running
 #DEBUG_ADAPTER ?= dap
 DEBUG_ADAPTER ?= jlink
@@ -9,18 +14,3 @@ OPENOCD_CONFIG ?= $(RIOTBOARD)/common/qn908x/dist/openocd.cfg
 # verify the image, which needs to have the WDT disabled but it is normally
 # enabled after a 'reset halt' command.
 OPENOCD_PRE_FLASH_CMDS += "-c qn908x disable_wdog"
-
-# Set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
-# OpenOCD is able to handle .elf files and is the preferred way.
-FLASHFILE ?= $(ELFFILE)
-
-# Setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
-# This board uses OpenOCD. Note that support for QN908x in OpenOCD at the time
-# of writing has not been merged in the tree and is only available at
-# http://openocd.zylin.com/#/c/5584/ .
-include $(RIOTMAKE)/tools/openocd.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

After #15477 and #15475 are merged, there's no need to include `openocd.inc.mk` and `serial.inc.mk` at board level. This PR is cleaning up all this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- Board `qn9080dk` can still be flashed and terminal is working (I don't have the hardware). So the following command is successful:

```
$ make BOARD=qn9080dk -C examples/hello-world flash term
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#13855 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
