### PR TITLE
drivers/ili9341 : Expose configurations to Kconfig

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -19,17 +19,20 @@ rsource "motor_driver/Kconfig"
 rsource "my9221/Kconfig"
 endmenu # Actuator Device Drivers
 
+menu "Display Device Drivers"
+rsource "disp_dev/Kconfig"
+rsource "dsp0401/Kconfig"
+rsource "hd44780/Kconfig"
+rsource "ili9341/Kconfig"
+endmenu # Display Device Drivers
+
 menu "Miscellaneous Device Drivers"
 rsource "at/Kconfig"
 rsource "at24mac/Kconfig"
-rsource "disp_dev/Kconfig"
 rsource "ds1307/Kconfig"
 rsource "ds3231/Kconfig"
 rsource "ds3234/Kconfig"
-rsource "dsp0401/Kconfig"
 rsource "edbg_eui/Kconfig"
-rsource "hd44780/Kconfig"
-rsource "ili9341/Kconfig"
 rsource "io1_xplained/Kconfig"
 rsource "uart_half_duplex/Kconfig"
 endmenu # Miscellaneous Device Drivers

--- a/drivers/ili9341/Kconfig
+++ b/drivers/ili9341/Kconfig
@@ -13,3 +13,47 @@ config MODULE_ILI9341
     select MODULE_PERIPH_SPI
     select MODULE_PERIPH_GPIO
     select MODULE_XTIMER
+
+menuconfig KCONFIG_USEMODULE_ILI9341
+    bool "Configure ILI9341 driver"
+    depends on USEMODULE_ILI9341
+    help
+        Configure the ILI9341 display driver using Kconfig.
+
+if KCONFIG_USEMODULE_ILI9341
+
+config ILI9341_GVDD
+    int "GVDD voltage level (in millivolts)"
+    default 4800
+    range 3000 6000
+    help
+        Configure GVDD level, which is a reference level for the VCOM level and
+        the grayscale voltage level. GVDD should be ≦ (AVDD - 0.5) V .
+
+config ILI9341_VCOMH
+    int "VCOMH voltage level (in millivolts)"
+    default 4250
+    range 2700 5875
+    help
+        Configure the high level of VCOM AC voltage. VCOM needs to be adjusted
+        to match the capacitance and performance specifications of the TFT panel
+        to maximize contrast and minimize flickering
+
+config ILI9341_VCOML
+    int "VCOML voltage level (in millivolts)"
+    default -2000
+    range -2500 0
+    help
+        Configure the low level of VCOM AC voltage. VCOM needs to be adjusted to
+        match the capacitance and performance specifications of the TFT panel to
+        maximize contrast and minimize flickering
+
+config ILI9341_LE_MODE
+    bool "Enable little endian to big endian conversion"
+    help
+        Enable this configuration to convert little endian colors to big endian.
+        ILI9341 device requires colors to be send in big endian RGB-565 format.
+        Enabling this option allows for little endian colors. Enabling this
+        however will slow down the driver as it cannot use DMA anymore.
+
+endif # KCONFIG_USEMODULE_ILI9341

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -114,7 +114,7 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
     _write_cmd(dev, ILI9341_CMD_DISPOFF, NULL, 0);
 
     /* PWRCTL1/2 */
-    command_params[0] = _ili9341_calc_pwrctl1(ILI9341_GVDD);
+    command_params[0] = _ili9341_calc_pwrctl1(CONFIG_ILI9341_GVDD);
     _write_cmd(dev, ILI9341_CMD_PWCTRL1, command_params, 1);
 
     command_params[0] = 0x10; /* PWRCTL 0 0 0 */

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -121,7 +121,7 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
     _write_cmd(dev, ILI9341_CMD_PWCTRL2, command_params, 1);
 
     /* VCOMCTL */
-    command_params[0] = _ili9341_calc_vmh(ILI9341_VCOMH);
+    command_params[0] = _ili9341_calc_vmh(CONFIG_ILI9341_VCOMH);
     command_params[1] = _ili9341_calc_vml(ILI9341_VCOML);
     _write_cmd(dev, ILI9341_CMD_VMCTRL1, command_params, 2);
 

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -122,7 +122,7 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
 
     /* VCOMCTL */
     command_params[0] = _ili9341_calc_vmh(CONFIG_ILI9341_VCOMH);
-    command_params[1] = _ili9341_calc_vml(ILI9341_VCOML);
+    command_params[1] = _ili9341_calc_vml(CONFIG_ILI9341_VCOML);
     _write_cmd(dev, ILI9341_CMD_VMCTRL1, command_params, 2);
 
     command_params[0] = 0x86;

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -72,8 +72,8 @@ extern "C" {
  *
  * Default VCOMH voltage of -2V
  */
-#ifndef ILI9341_VCOML
-#define ILI9341_VCOML   -2000
+#ifndef CONFIG_ILI9341_VCOML
+#define CONFIG_ILI9341_VCOML            -2000
 #endif
 
 /**

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -52,7 +52,8 @@ extern "C" {
 /**
  * @brief ILI9341 gvdd level.
  *
- * Default GVDD voltage of 4.8V
+ * Default GVDD voltage of 4.8V. GVDD is reference level for the VCOM level and
+ * the grayscale voltage level. GVDD should be ≦ (AVDD - 0.5) V .
  */
 #ifndef CONFIG_ILI9341_GVDD
 #define CONFIG_ILI9341_GVDD             4800
@@ -61,7 +62,10 @@ extern "C" {
 /**
  * @brief ILI9341 VCOMH voltage level.
  *
- * Default VCOMH voltage of 4.25V
+ * Default VCOMH voltage of 4.25V. VCOMH represents the high level of VCOM AC
+ * voltage. VCOM levels needs to be adjusted to match the capacitance and
+ * performance specifications of the TFT panel to maximize contrast and minimize
+ * flickering.
  */
 #ifndef CONFIG_ILI9341_VCOMH
 #define CONFIG_ILI9341_VCOMH            4250
@@ -70,7 +74,10 @@ extern "C" {
 /**
  * @brief ILI9341 VCOML voltage level.
  *
- * Default VCOMH voltage of -2V
+ * Default VCOML voltage of -2V. VCOML represents the low level of VCOM AC
+ * voltage. VCOM levels needs to be adjusted to match the capacitance and
+ * performance specifications of the TFT panel to maximize contrast and minimize
+ * flickering
  */
 #ifndef CONFIG_ILI9341_VCOML
 #define CONFIG_ILI9341_VCOML            -2000

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -63,8 +63,8 @@ extern "C" {
  *
  * Default VCOMH voltage of 4.25V
  */
-#ifndef ILI9341_VCOMH
-#define ILI9341_VCOMH   4250
+#ifndef CONFIG_ILI9341_VCOMH
+#define CONFIG_ILI9341_VCOMH            4250
 #endif
 
 /**

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -54,8 +54,8 @@ extern "C" {
  *
  * Default GVDD voltage of 4.8V
  */
-#ifndef ILI9341_GVDD
-#define ILI9341_GVDD    4800
+#ifndef CONFIG_ILI9341_GVDD
+#define CONFIG_ILI9341_GVDD             4800
 #endif
 
 /**

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -23,7 +23,7 @@
  * implemented here operates over SPI to communicate with the device.
  *
  * The device requires colors to be send in big endian RGB-565 format. The
- * @ref ILI9341_LE_MODE compile time option can switch this, but only use this
+ * @ref CONFIG_ILI9341_LE_MODE compile time option can switch this, but only use this
  * when strictly necessary. This option will slow down the driver as it
  * certainly can't use DMA anymore, every short has to be converted before
  * transfer.
@@ -82,8 +82,8 @@ extern "C" {
  * Compile time switch to change the driver to convert little endian
  * colors to big endian.
  */
-#ifndef ILI9341_LE_MODE
-#define ILI9341_LE_MODE     (0)
+#ifdef DOXYGEN
+#define CONFIG_ILI9341_LE_MODE
 #endif
 /** @} */
 

--- a/tests/driver_ili9341/Makefile
+++ b/tests/driver_ili9341/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 USEMODULE += ili9341
 USEMODULE += xtimer
 
-CFLAGS += -DILI9341_LE_MODE
+CFLAGS += -DCONFIG_ILI9341_LE_MODE
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/driver_ili9341/Makefile
+++ b/tests/driver_ili9341/Makefile
@@ -4,9 +4,12 @@ include ../Makefile.tests_common
 USEMODULE += ili9341
 USEMODULE += xtimer
 
-CFLAGS += -DCONFIG_ILI9341_LE_MODE
-
 include $(RIOTBASE)/Makefile.include
+
+# Check if being configured via Kconfig
+ifndef CONFIG_KCONFIG_USEMODULE_ILI9341
+CFLAGS += -DCONFIG_ILI9341_LE_MODE
+endif
 
 # The AVR architecture stores the image in the RAM, this usually doesn't fit.
 # This flag excludes the image from the test


### PR DESCRIPTION
### Contribution description - 

This PR exposes compile configurations in **drivers/ili9341** to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were updated in tests/driver_ili9341

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/bfd28749db059fa4256f91c142e7b02b86e2ed61)

      Compiled binaries for b-l072z-lrwan1 and tested on the evaluation board. 

#### Default State:

##### Firmware Output
```
# main(): This is RIOT! (Version: 2021.01-devel-1336-g404dc7-Kconfig_driver_ili9341_tests)
# CONFIG_ILI9341_GVDD=4800
# CONFIG_ILI9341_VCOMH=4250
# CONFIG_ILI9341_VCOML=-2000
# CONFIG_ILI9341_LE_MODE=1

```

#### Usage with menuconfig :

`make menuconfig`

##### Default Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-1336-gbfd28-Kconfig_driver_ili9341_tests)
CONFIG_ILI9341_GVDD=4800
CONFIG_ILI9341_VCOMH=4250
CONFIG_ILI9341_VCOML=-2000
CONFIG_ILI9341_LE_MODE=CONFIG_ILI9341_LE_MODE
```

##### Configured Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-1336-gbfd28-Kconfig_driver_ili9341_tests)
CONFIG_ILI9341_GVDD=4700
CONFIG_ILI9341_VCOMH=4200
CONFIG_ILI9341_VCOML=-1000
CONFIG_ILI9341_LE_MODE=1
```

**MACROS were successfully configured.**

### Issues/PRs references
#12888 