### PR TITLE
suit/transport/coap: make blocksize configurable

### DIFF
--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -122,6 +122,13 @@ typedef enum {
 } coap_blksize_t;
 
 /**
+ * @brief Coap block-wise-transfer size used for SUIT
+ */
+#ifndef CONFIG_SUIT_COAP_BLOCKSIZE
+#define CONFIG_SUIT_COAP_BLOCKSIZE  COAP_BLOCKSIZE_64
+#endif
+
+/**
  * @brief    Performs a blockwise coap get request to the specified url.
  *
  * This function will fetch the content of the specified resource path via

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -358,7 +358,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     if (0) {}
 #ifdef MODULE_SUIT_TRANSPORT_COAP
     else if (strncmp(manifest->urlbuf, "coap://", 7) == 0) {
-        res = suit_coap_get_blockwise_url(manifest->urlbuf, COAP_BLOCKSIZE_64,
+        res = suit_coap_get_blockwise_url(manifest->urlbuf, CONFIG_SUIT_COAP_BLOCKSIZE,
                                           suit_storage_helper,
                                           manifest);
     }

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -346,7 +346,7 @@ ssize_t suit_coap_get_blockwise_url_buf(const char *url,
 static void _suit_handle_url(const char *url)
 {
     LOG_INFO("suit_coap: downloading \"%s\"\n", url);
-    ssize_t size = suit_coap_get_blockwise_url_buf(url, COAP_BLOCKSIZE_64,
+    ssize_t size = suit_coap_get_blockwise_url_buf(url, CONFIG_SUIT_COAP_BLOCKSIZE,
                                                    _manifest_buf,
                                                    SUIT_MANIFEST_BUFSIZE);
     if (size >= 0) {


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When using SUIT over a link-layer that supports larger PDU, a larger CoAP blocksize is desirable to speed up firmware downloads.

To support this, make the CoAP blocksize used by SUIT configurable.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
