### PR TITLE
dist/tools/changed_files: fix default list of exclude

### DIFF
--- a/dist/tools/ci/changed_files.sh
+++ b/dist/tools/ci/changed_files.sh
@@ -8,7 +8,7 @@
 
 changed_files() {
     : ${FILEREGEX:='\.([CcHh]|[ch]pp)$'}
-    : ${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|boards/common/msba2/tools/src)'}
+    : ${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|dist/tools/lpc2k_pgm/src)'}
     : ${DIFFFILTER:='ACMR'}
 
     DIFFFILTER="--diff-filter=${DIFFFILTER}"

--- a/dist/tools/externc/check.sh
+++ b/dist/tools/externc/check.sh
@@ -18,8 +18,7 @@ cd $RIOTBASE
 ROOT=$(git rev-parse --show-toplevel)
 EXIT_CODE=0
 
-EXCLUDE='^(dist/tools/)'
-FILES=$(FILEREGEX='\.h$' EXCLUDE=${EXCLUDE} changed_files)
+FILES=$(FILEREGEX='\.h$' changed_files)
 
 # check files
 for FILE in ${FILES}; do


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In #15535, there were issues with the `externc` check that were badly fixed by editing the check and now it broken with vendor files. This PR fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

regression introduced by #15535

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
