### PR TITLE
boards: move DfuSe specific argument at board level

### DIFF
--- a/boards/common/blxxxpill/Makefile.include
+++ b/boards/common/blxxxpill/Makefile.include
@@ -5,23 +5,17 @@ ifeq (dfu-util,$(PROGRAMMER))
   # For older versions of the DFU bootloader, set DFU_USB_ID to 1d50:6017
   DFU_USB_ID ?= 1eaf:0003
   DFU_ALT ?= 2
-
+  DFU_USE_DFUSE = 1
   # Leave some space at the beginning of the flash for the bootloader
   ROM_OFFSET ?= 0x2000
-
   # If using STM32duino bootloader, this change is necessary.
   # Bootloader available at
   # github.com/rogerclarkmelbourne/STM32duino-bootloader/tree/master/binaries
   ifeq (stm32duino,$(BOOTLOADER))
-    FFLAGS_OPTS ?= -R
-    FFLAGS ?= --device $(DFU_USB_ID) \
-              --alt $(DFU_ALT) \
-              --download $(FLASHFILE) \
-              $(FFLAGS_OPTS)
-
     # Flashing may be easier if using a software USB reset.
     # Future updates may provide USB support for stm32f1 which benefits
     # from this software reset.
+    FFLAGS_OPTS += --reset
   endif
 
 else ifeq (openocd,$(PROGRAMMER))

--- a/boards/common/weact-f4x1cx/Makefile.include
+++ b/boards/common/weact-f4x1cx/Makefile.include
@@ -4,7 +4,7 @@ INCLUDES += -I$(RIOTBOARD)/common/weact-f4x1cx/include
 # default to flashing over USB
 PROGRAMMER ?= dfu-util
 DFU_USB_ID ?= 0483:df11
-DFU_FLAGS  ?= -a 0 -s 0x08000000:leave
+DFU_USE_DFUSE = 1
 ROM_OFFSET ?= 0x0
 
 # CDC ACM is available faster on STM32

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -8,3 +8,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util
 DFU_USB_ID = 0483:df11
+DFU_USE_DFUSE = 1

--- a/boards/pyboard/Makefile.include
+++ b/boards/pyboard/Makefile.include
@@ -8,4 +8,4 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util
 DFU_USB_ID = 1d50:607f
-FFLAGS_OPTS = --reset
+DFU_USE_DFUSE = 1

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -11,3 +11,4 @@ ROM_OFFSET ?= 0x5000
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util
 DFU_USB_ID = 1d50:607f
+DFU_USE_DFUSE = 1

--- a/makefiles/tools/dfu-util.inc.mk
+++ b/makefiles/tools/dfu-util.inc.mk
@@ -7,12 +7,15 @@ ROM_OFFSET ?= 0
 
 _ROM_ADDR_WITH_OFFSET ?= $(shell printf "0x%x" $$(($(ROM_START_ADDR) + $(ROM_OFFSET))))
 FLASH_ADDR ?= $(if $(ROM_OFFSET),$(_ROM_ADDR_WITH_OFFSET),$(ROM_START_ADDR))
-
+DFU_USE_DFUSE ?= 0
 # Optional flasher flags
 FFLAGS_OPTS ?=
 
 FFLAGS ?= --device $(DFU_USB_ID) \
           --alt $(DFU_ALT) \
-          --dfuse-address $(FLASH_ADDR):leave \
           --download $(FLASHFILE) \
           $(FFLAGS_OPTS)
+
+ifeq ($(DFU_USE_DFUSE),1)
+  FFLAGS += --dfuse-address $(FLASH_ADDR):leave
+endif


### PR DESCRIPTION
### Contribution description
Move this specific argument at board level in order to be able to flash with a DFU compatible bootloader, otherwise `dfu-util` will only flash DfuSe (not DFU compliant) compatible bootloader because of the `-s | --dfuse-address` argument

I did NOT test this PR on hardware because I don't have those boards. I have only compared the `dfu-util` call by RIOT with this PR and master. Arguments call order is sometimes not the same but it doesn't matter. All arguments must still be there.

In the current state, RIOT build system can only handle DfuSe compatible bootloader, this PR allow us to flash board with a DFU compliant DFU bootloader.

Note: DfuSe is a custom USB DFU made by ST which is NOT compliant with DFU 1.1 spec

### Testing procedure
There is nothing to test yet, so only ensure I did not break things
Try to flash any modified boards by this PR, the flashing procedure must succeed.

### Issues/PRs references
None but will be useful for USBUS DFU integration.
