### PR TITLE
.murdock: don't run static-tests on Murdock

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -16,7 +16,7 @@ tests/driver_h* tests/driver_i* tests/driver_j* tests/driver_my9221"}
 
 export RIOT_CI_BUILD=1
 export CC_NOCOLOR=1
-export STATIC_TESTS=${STATIC_TESTS:-1}
+export STATIC_TESTS=0
 export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes the static test performed on Murdock since they are also performed using GH action. This specialized more the Murdock job to build and eventually test on hardware (when `CI: run tests` label is set).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI (A code review must be done before enabling Murdock I think)
- Make sure that the Murdock is still doing his build job correctly
- The static-test GH action must be set as required before we merge this PR

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
