### PR TITLE
net/gnrc/sock: Implement sock_aux_timestamp for RX

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -43,6 +43,7 @@ PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_bus
 PSEUDOMODULES += gnrc_netif_events
+PSEUDOMODULES += gnrc_netif_timestamp
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_ipv6

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -179,6 +179,9 @@ endif
 
 ifneq (,$(filter gnrc_sock_%,$(USEMODULE)))
   USEMODULE += gnrc_sock
+  ifneq (,$(filter sock_aux_timestamp,$(USEMODULE)))
+    USEMODULE += gnrc_netif_timestamp
+  endif
 endif
 
 ifneq (,$(filter gnrc_sock_async,$(USEMODULE)))

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -70,17 +70,16 @@ typedef struct {
      */
     sock_ip_ep_t *local;
 #endif
-#if !IS_USED(MODULE_SOCK_AUX_LOCAL) || DOXYGEN
-    /**
-     * @brief   Workaround in case no `sock_aux_%` module is used
-     *
-     * Empty structures are only allowed with a GNU extension. For portability,
-     * this member is present if and only if this structure would be otherwise
-     * empty.
-     */
-    uint8_t this_struct_is_not_empty;
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP) || DOXYGEN
+    uint64_t *timestamp;    /**< timestamp PDU was received at in nanoseconds */
 #endif
+    /**
+     * @brief   Flags
+     */
+    uint8_t flags;
 } gnrc_sock_recv_aux_t;
+
+#define GNRC_SOCK_RECV_AUX_FLAG_TIMESTAMP   0x01    /**< Timestamp valid */
 
 /**
  * @brief   Internal helper functions for GNRC
@@ -143,7 +142,7 @@ void gnrc_sock_create(gnrc_sock_reg_t *reg, gnrc_nettype_t type, uint32_t demux_
  * @internal
  */
 ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt, uint32_t timeout,
-                       sock_ip_ep_t *remote, gnrc_sock_recv_aux_t aux);
+                       sock_ip_ep_t *remote, gnrc_sock_recv_aux_t *aux);
 
 /**
  * @brief   Send a packet internally

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -224,7 +224,12 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
         _aux.local = (sock_ip_ep_t *)&aux->local;
     }
 #endif
-    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp, _aux);
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_TIMESTAMP)) {
+        _aux.timestamp = &aux->timestamp;
+    }
+#endif
+    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp, &_aux);
     if (res < 0) {
         return res;
     }
@@ -250,6 +255,16 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
     if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_LOCAL)) {
         aux->flags &= ~SOCK_AUX_GET_LOCAL;
         aux->local.port = sock->local.port;
+    }
+#endif
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_TIMESTAMP)) {
+        /* check if network interface did provide a timestamp; this depends on
+         * hardware support. A timestamp of zero is used to indicate a missing
+         * timestamp */
+        if (_aux.flags & GNRC_SOCK_RECV_AUX_FLAG_TIMESTAMP) {
+            aux->flags &= ~SOCK_AUX_GET_TIMESTAMP;
+        }
     }
 #endif
     *data = pkt->data;

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,9 +1,14 @@
 include ../Makefile.tests_common
 
 AUX_LOCAL ?= 1
+AUX_TIMESTAMP ?= 1
 
 ifeq (1, $(AUX_LOCAL))
   USEMODULE += sock_aux_local
+endif
+
+ifeq (1, $(AUX_LOCAL))
+  USEMODULE += sock_aux_timestamp
 endif
 
 USEMODULE += sock_ip

--- a/tests/gnrc_sock_ip/stack.h
+++ b/tests/gnrc_sock_ip/stack.h
@@ -40,6 +40,31 @@ void _net_init(void);
 void _prepare_send_checks(void);
 
 /**
+ * @brief   Structure containing auxiliary data to inject
+ */
+typedef struct {
+    uint64_t timestamp;     /**< Timestamp of reception */
+} inject_aux_t;
+
+/**
+ * @brief   Injects a received IPv6 packet into the stack
+ *
+ * @param[in] src       The source address of the IPv6 packet
+ * @param[in] dst       The destination address of the IPv6 packet
+ * @param[in] proto     The next header field of the IPv6 packet
+ * @param[in] data      The payload of the IPv6 packet
+ * @param[in] data_len  The payload length of the IPv6 packet
+ * @param[in] netif     The interface the packet came over
+ * @param[in] aux       Auxiliary data to inject
+ *
+ * @return  true, if packet was successfully injected
+ * @return  false, if an error occurred during injection
+ */
+bool _inject_packet_aux(const ipv6_addr_t *src, const ipv6_addr_t *dst,
+                        uint8_t proto, void *data, size_t data_len,
+                        uint16_t netif, const inject_aux_t *aux);
+
+/**
  * @brief   Injects a received IPv6 packet into the stack
  *
  * @param[in] src       The source address of the IPv6 packet
@@ -52,9 +77,13 @@ void _prepare_send_checks(void);
  * @return  true, if packet was successfully injected
  * @return  false, if an error occurred during injection
  */
-bool _inject_packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
-                    uint8_t proto, void *data, size_t data_len,
-                    uint16_t netif);
+static inline bool _inject_packet(const ipv6_addr_t *src,
+                                  const ipv6_addr_t *dst,
+                                  uint8_t proto, void *data, size_t data_len,
+                                  uint16_t netif)
+{
+    return _inject_packet_aux(src, dst, proto, data, data_len, netif, NULL);
+}
 
 /**
  * @brief   Checks networking state (e.g. packet buffer state)

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,9 +1,14 @@
 include ../Makefile.tests_common
 
 AUX_LOCAL ?= 1
+AUX_TIMESTAMP ?= 1
 
 ifeq (1, $(AUX_LOCAL))
   USEMODULE += sock_aux_local
+endif
+
+ifeq (1, $(AUX_LOCAL))
+  USEMODULE += sock_aux_timestamp
 endif
 
 USEMODULE += gnrc_sock_check_reuse

--- a/tests/gnrc_sock_udp/stack.c
+++ b/tests/gnrc_sock_udp/stack.c
@@ -47,9 +47,10 @@ static gnrc_pktsnip_t *_build_udp_packet(const ipv6_addr_t *src,
                                          const ipv6_addr_t *dst,
                                          uint16_t src_port, uint16_t dst_port,
                                          void *data, size_t data_len,
-                                         uint16_t netif)
+                                         uint16_t netif,
+                                         const inject_aux_t *aux)
 {
-    gnrc_pktsnip_t *netif_hdr, *ipv6, *udp;
+    gnrc_pktsnip_t *netif_hdr_snip, *ipv6, *udp;
     udp_hdr_t *udp_hdr;
     ipv6_hdr_t *ipv6_hdr;
     uint16_t csum = 0;
@@ -86,21 +87,25 @@ static gnrc_pktsnip_t *_build_udp_packet(const ipv6_addr_t *src,
         udp_hdr->checksum = byteorder_htons(~csum);
     }
     udp = gnrc_pkt_append(udp, ipv6);
-    netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
-    if (netif_hdr == NULL) {
+    netif_hdr_snip = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
+    if (netif_hdr_snip == NULL) {
         return NULL;
     }
-    ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = (kernel_pid_t)netif;
-    return gnrc_pkt_append(udp, netif_hdr);
+    gnrc_netif_hdr_t *netif_hdr = netif_hdr_snip->data;
+    netif_hdr->if_pid = (kernel_pid_t)netif;
+    if (aux) {
+        gnrc_netif_hdr_set_timestamp(netif_hdr, aux->timestamp);
+    }
+    return gnrc_pkt_append(udp, netif_hdr_snip);
 }
 
-
-bool _inject_packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
-                    uint16_t src_port, uint16_t dst_port,
-                    void *data, size_t data_len, uint16_t netif)
+bool _inject_packet_aux(const ipv6_addr_t *src, const ipv6_addr_t *dst,
+                        uint16_t src_port, uint16_t dst_port,
+                        void *data, size_t data_len, uint16_t netif,
+                        const inject_aux_t *aux)
 {
     gnrc_pktsnip_t *pkt = _build_udp_packet(src, dst, src_port, dst_port,
-                                            data, data_len, netif);
+                                            data, data_len, netif, aux);
 
     if (pkt == NULL) {
         return false;

--- a/tests/gnrc_sock_udp/stack.h
+++ b/tests/gnrc_sock_udp/stack.h
@@ -40,6 +40,13 @@ void _net_init(void);
 void _prepare_send_checks(void);
 
 /**
+ * @brief   Auxiliary data to inject
+ */
+typedef struct {
+    uint64_t timestamp; /**< Timestamp of reception */
+} inject_aux_t;
+
+/**
  * @brief   Injects a received UDP packet into the stack
  *
  * @param[in] src       The source address of the UDP packet
@@ -53,9 +60,33 @@ void _prepare_send_checks(void);
  * @return  true, if packet was successfully injected
  * @return  false, if an error occurred during injection
  */
-bool _inject_packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
-                    uint16_t src_port, uint16_t dst_port,
-                    void *data, size_t data_len, uint16_t netif);
+bool _inject_packet_aux(const ipv6_addr_t *src, const ipv6_addr_t *dst,
+                        uint16_t src_port, uint16_t dst_port,
+                        void *data, size_t data_len, uint16_t netif,
+                        const inject_aux_t *aux);
+
+/**
+ * @brief   Injects a received UDP packet into the stack
+ *
+ * @param[in] src       The source address of the UDP packet
+ * @param[in] dst       The destination address of the UDP packet
+ * @param[in] src_port  The source port of the UDP packet
+ * @param[in] dst_port  The destination port of the UDP packet
+ * @param[in] data      The payload of the UDP packet
+ * @param[in] data_len  The payload length of the UDP packet
+ * @param[in] netif     The interface the packet came over
+ *
+ * @return  true, if packet was successfully injected
+ * @return  false, if an error occurred during injection
+ */
+static inline bool _inject_packet(const ipv6_addr_t *src,
+                                  const ipv6_addr_t *dst,
+                                  uint16_t src_port, uint16_t dst_port,
+                                  void *data, size_t data_len, uint16_t netif)
+{
+    return _inject_packet_aux(src, dst, src_port, dst_port, data, data_len,
+                              netif, NULL);
+}
 
 /**
  * @brief   Checks networking state (e.g. packet buffer state)


### PR DESCRIPTION
### Contribution description

This PR adds the infrastructure needed to pass through RX timestamps from a GNRC netif to a SOCK. It will not be useful until network drivers starts adding those timestamps, tough. I'll add a follow up PR adding this, so that this PR can be tested.

### Testing procedure

The unit tests in `tests/gnrc_sock_udp` and `tests/gnrc_sock_ip` have been extended to also cover the RX timestamps.

### Issues/PRs references

Depends on https://github.com/RIOT-OS/RIOT/pull/14704