### PR TITLE
drivers/{bmx280, itg320x}: fix Kconfig deps

### DIFF
--- a/drivers/bmx280/Kconfig
+++ b/drivers/bmx280/Kconfig
@@ -8,6 +8,7 @@
 choice
     bool "BMx280 Temperature, pressure and humidity sensors"
     optional
+    depends on TEST_KCONFIG
     help
         The driver supports both BME280 and BMP280 connected either via SPI or
         I2C bus. Select one combination.

--- a/drivers/itg320x/Kconfig
+++ b/drivers/itg320x/Kconfig
@@ -16,6 +16,7 @@ menuconfig MODULE_ITG320X
 
 config MODULE_ITG320X_INT
     bool "Interrupt mode"
+    depends on MODULE_ITG320X
     depends on HAS_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_GPIO_IRQ
     help


### PR DESCRIPTION
### Contribution description
This adds two missing dependencies in the modelling of bmx280 and itg320x. In the first case the dependency to `TEST_KCONFIG` was missing, so the symbol shows up even when `TEST_KCONFIG` is not set. In the second case the interrupt submodule was missing the dependency to the main driver symbol.

### Testing procedure
- Check that the module symbols only appear when using `TEST_KCONFIG`
- Check that dependencies are correct
- Green CI

### Issues/PRs references
Introduced in #15466 and #15515