### PR TITLE
socket_zep: register with netdev, provide EUI-64 as command line parameter

### DIFF
--- a/boards/native/include/eui_provider_params.h
+++ b/boards/native/include/eui_provider_params.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_native
+ * @{
+ *
+ * @file
+ * @brief       EUI providers found on the board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef EUI_PROVIDER_PARAMS_H
+#define EUI_PROVIDER_PARAMS_H
+
+#include "native_cli_eui_provider.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    EUI sources on the board
+ *          EUI-64 can be provided with the -Z command line argument
+ * @{
+ */
+#define EUI64_PROVIDER_FUNC   native_cli_get_eui64
+#define EUI64_PROVIDER_TYPE   NETDEV_ANY
+#define EUI64_PROVIDER_INDEX  NETDEV_INDEX_ANY
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EUI_PROVIDER_PARAMS_H */
+/** @} */

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -30,6 +30,10 @@ ifneq (,$(filter backtrace,$(USEMODULE)))
   DIRS += backtrace
 endif
 
+ifneq (,$(filter native_cli_eui_provider,$(USEMODULE)))
+  DIRS += cli_eui_provider
+endif
+
 include $(RIOTBASE)/Makefile.base
 
 INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -21,6 +21,14 @@ ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter eui_provider,$(USEMODULE)))
+  USEMODULE += native_cli_eui_provider
+endif
+
+ifneq (,$(filter native_cli_eui_provider,$(USEMODULE)))
+  USEMODULE += l2util
+endif
+
 USEMODULE += periph
 
 # UART is needed by startup.c

--- a/cpu/native/cli_eui_provider/Makefile
+++ b/cpu/native/cli_eui_provider/Makefile
@@ -1,0 +1,3 @@
+MODULE := native_cli_eui_provider
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/native/cli_eui_provider/eui_provider.c
+++ b/cpu/native/cli_eui_provider/eui_provider.c
@@ -1,0 +1,65 @@
+/**
+ * Native CPU EUI provider
+ *
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup cpu_native
+ * @{
+ * @file
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "net/l2util.h"
+#include "native_cli_eui_provider.h"
+#include "list.h"
+
+#include "native_internal.h"
+
+/* list of user supplied EUI-64s */
+typedef struct {
+    list_node_t node;
+    eui64_t addr;
+} native_eui64_list_t;
+
+static list_node_t head;
+
+/* parse EUI-64 from command line */
+void native_cli_add_eui64(const char *s)
+{
+    _native_syscall_enter();
+    native_eui64_list_t *e = real_malloc(sizeof(native_eui64_list_t));
+    _native_syscall_leave();
+
+    size_t res = l2util_addr_from_str(s, e->addr.uint8);
+    assert(res <= sizeof(eui64_t));
+
+    /* if the provided address exceeds eui64_t, l2util_addr_from_str()
+     * *will* corrupt memory. */
+    if (res > sizeof(eui64_t)) {
+        exit(-1);
+    }
+
+    list_add(&head, &e->node);
+}
+
+/* callback for EUI provider */
+int native_cli_get_eui64(uint8_t index, eui64_t *addr)
+{
+    uint8_t cnt = 0;
+    for (list_node_t *e = head.next; e != NULL; e = e->next) {
+        if (cnt++ == index) {
+            *addr = container_of(e, native_eui64_list_t, node)->addr;
+            return 0;
+        }
+    }
+
+    return -1;
+}

--- a/cpu/native/include/native_cli_eui_provider.h
+++ b/cpu/native/include/native_cli_eui_provider.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     cpu_native
+ * @{
+ *
+ * @file
+ * @brief       Command-line EUI provider for native
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef NATIVE_CLI_EUI_PROVIDER_H
+#define NATIVE_CLI_EUI_PROVIDER_H
+
+#include "net/eui64.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    parse a string as an EUI-64 and add it to the list of EUI-64s
+ *
+ * @param s[in]     EUI-64 as hexadecimal string representation
+ */
+void native_cli_add_eui64(const char *s);
+
+/**
+ * @name    Get a command-line provided EUI-64
+ *
+ * @param index     index of ZEP device
+ * @param addr[out] user supplied EUI-64
+ *
+ * @return 0 on success, negatvie if no more EUIs are available.
+ */
+int native_cli_get_eui64(uint8_t index, eui64_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NATIVE_CLI_EUI_PROVIDER_H */
+/** @} */

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -181,8 +181,6 @@ int register_interrupt(int sig, _native_callback_t handler);
  */
 int unregister_interrupt(int sig);
 
-//#include <sys/param.h>
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -98,8 +98,10 @@ typedef struct {
  *
  * @param[in] dev       the preallocated socket_zep_t device handle to setup
  * @param[in] params    initialization parameters
+ * @param[in] index     index of @p params in a global parameter struct array.
+ *                      If initialized manually, pass a unique identifier instead.
  */
-void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params);
+void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params, uint8_t index);
 
 /**
  * @brief Cleanup socket resources

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -408,7 +408,7 @@ static void _send_zep_hello(socket_zep_t *dev)
     }
 }
 
-void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params)
+void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params, uint8_t index)
 {
     int res;
 
@@ -417,6 +417,8 @@ void socket_zep_setup(socket_zep_t *dev, const socket_zep_params_t *params)
 
     memset(dev, 0, sizeof(socket_zep_t));
     dev->netdev.netdev.driver = &socket_zep_driver;
+
+    netdev_register(&dev->netdev.netdev, NETDEV_SOCKET_ZEP, index);
 
     res = _bind_local(params);
 

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -84,6 +84,9 @@ netdev_tap_params_t netdev_tap_params[NETDEV_TAP_MAX];
 #ifdef MODULE_PERIPH_GPIO_LINUX
 #include "gpiodev_linux.h"
 #endif
+#ifdef MODULE_NATIVE_CLI_EUI_PROVIDER
+#include "native_cli_eui_provider.h"
+#endif
 #ifdef MODULE_SOCKET_ZEP
 #include "socket_zep_params.h"
 
@@ -106,6 +109,9 @@ static const char short_opts[] = ":hi:s:deEoc:"
 #endif
 #ifdef MODULE_SOCKET_ZEP
     "z:"
+#endif
+#ifdef MODULE_NATIVE_CLI_EUI_PROVIDER
+    "U:"
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     "p:"
@@ -132,6 +138,9 @@ static const struct option long_opts[] = {
 #endif
 #ifdef MODULE_SOCKET_ZEP
     { "zep", required_argument, NULL, 'z' },
+#endif
+#ifdef MODULE_NATIVE_CLI_EUI_PROVIDER
+    { "eui64", required_argument, NULL, 'U' },
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     { "spi", required_argument, NULL, 'p' },
@@ -281,6 +290,9 @@ void usage_exit(int status)
         real_printf(" -z <laddr>:<lport>,<raddr>:<rport>");
     }
 #endif
+#ifdef MODULE_NATIVE_CLI_EUI_PROVIDER
+    real_printf(" [--eui64 <eui64> …]");
+#endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     real_printf(" [-p <b>:<d>:<spidev>]");
 #endif
@@ -323,6 +335,11 @@ void usage_exit(int status)
 "        The ZEP interface connects to the remote address and may listen\n"
 "        on a local address.\n"
 "        Required to be provided SOCKET_ZEP_MAX times\n"
+#endif
+#ifdef MODULE_NATIVE_CLI_EUI_PROVIDER
+"    -U <eui64>, --eui64=<eui64>\n"
+"        provide a ZEP interface with EUI-64 (MAC address)\n"
+"        This argument can be provided multiple times\n"
 #endif
     );
 #ifdef MODULE_MTD_NATIVE
@@ -414,6 +431,7 @@ static void _zep_params_setup(char *zep_str, int zep)
                       &socket_zep_params[zep].remote_port);
     }
 }
+
 #endif
 
 /** @brief Initialization function pointer type */
@@ -529,6 +547,11 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
 #ifdef MODULE_SOCKET_ZEP
             case 'z':
                 _zep_params_setup(optarg, zeps++);
+                break;
+#endif
+#ifdef MODULE_NATIVE_CLI_EUI_PROVIDER
+            case 'U':
+                native_cli_add_eui64(optarg);
                 break;
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -268,23 +268,26 @@ void usage_exit(int status)
         real_printf(" <tap interface %d>", i + 1);
     }
 #endif
-    real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]\n");
+    real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]");
 #ifdef MODULE_PERIPH_GPIO_LINUX
-    real_printf(" [-g <gpiochip>]\n");
+    real_printf(" [-g <gpiochip>]");
 #endif
+    real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]");
 #if defined(MODULE_SOCKET_ZEP) && (SOCKET_ZEP_MAX > 0)
-    real_printf(" -z [[<laddr>:<lport>,]<raddr>:<rport>]\n");
+    real_printf(" -z [[<laddr>:<lport>,]<raddr>:<rport>]");
     for (int i = 0; i < SOCKET_ZEP_MAX - 1; i++) {
         /* for further interfaces the local address must be different so we omit
          * the braces (marking them as optional) to be 100% clear on that */
-        real_printf(" -z <laddr>:<lport>,<raddr>:<rport>\n");
+        real_printf(" -z <laddr>:<lport>,<raddr>:<rport>");
     }
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
-    real_printf(" [-p <b>:<d>:<spidev>]\n");
+    real_printf(" [-p <b>:<d>:<spidev>]");
 #endif
 
-    real_printf(" help: %s -h\n\n", _progname);
+    real_printf("\n\n");
+
+    real_printf("help: %s -h\n", _progname);
 
     real_printf("\nOptions:\n"
 "    -h, --help\n"

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -317,6 +317,7 @@ typedef enum {
     NETDEV_SAM0_ETH,
     NETDEV_ESP_NOW,
     NETDEV_NRF24L01P_NG,
+    NETDEV_SOCKET_ZEP,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -227,7 +227,7 @@ void lwip_bootstrap(void)
     }
 #elif defined(MODULE_SOCKET_ZEP)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i]);
+        socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
         if (netif_add(&netif[i], &socket_zep_devs[i], lwip_netdev_init,
                       tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add socket_zep device\n");

--- a/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
@@ -46,7 +46,7 @@ void auto_init_socket_zep(void)
     for (int i = 0; i < SOCKET_ZEP_MAX; i++) {
         LOG_DEBUG("[auto_init_netif: initializing socket ZEP device #%u\n", i);
         /* setup netdev device */
-        socket_zep_setup(&_socket_zeps[i], &socket_zep_params[i]);
+        socket_zep_setup(&_socket_zeps[i], &socket_zep_params[i], i);
         gnrc_netif_ieee802154_create(&_netif[i], _socket_zep_stacks[i],
                                      SOCKET_ZEP_MAC_STACKSIZE,
                                      SOCKET_ZEP_MAC_PRIO, "socket_zep",

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -52,7 +52,7 @@ static void test_init(void)
 
     printf("Initializing socket ZEP with (local: [%s]:%s, remote: [%s]:%s)\n",
            p->local_addr, p->local_port, p->remote_addr, p->remote_port);
-    socket_zep_setup(&_dev, p);
+    socket_zep_setup(&_dev, p, 0);
     netdev->event_callback = _event_cb;
     expect(netdev->driver->init(netdev) >= 0);
     _print_info(netdev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This registers `socket_zep` with netdev to use eui_provider to generate a L2 address for the ZEP device.
Consequently an EUI provider for the `native` board is added that is sourced from command-line supplied addresses.

This contains an API change in which an additional `index` parameter is supplied to the eui provider callback function.
I can move this to a separate PR.

### Testing procedure 

Add `TERMFLAGS += -U 00:AA:BB:CC:DD:EE:FF:11` to the `Makefile` of `examples/gnrc_networking`, then run

    make -C examples/gnrc_networking USE_ZEP=1 all term

```
Iface  7  HWaddr: 7F:11  Channel: 26  NID: 0x23 
          Long HWaddr: 00:AA:BB:CC:DD:EE:FF:11 
          L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::2aa:bbcc:ddee:ff11  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffee:ff11
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 43
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0
```

The address should stay constant across a reboot

```
reboot


		!! REBOOT !!

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.01-devel-1372-g8ceae-socket_zep_register)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  7  HWaddr: 7F:11  Channel: 26  NID: 0x23 
          Long HWaddr: 00:AA:BB:CC:DD:EE:FF:11 
          L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::2aa:bbcc:ddee:ff11  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffee:ff11
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 43
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #14758