### PR TITLE
[RFC] GitHub Actions: Split static tests via matrix strategy

### DIFF
--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -11,6 +11,36 @@ on:
 jobs:
   static-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - commit-msg
+          - whitespacecheck
+          - doccheck
+          - externc
+          - cppcheck
+          - vera++
+          - pr_check
+          - coccinelle
+          - flake8
+          - headerguards
+          - buildsystem_sanity_check
+          - codespell
+          - uncrustify
+        include:
+          - test: commit-msg
+            params: master_upstream
+          - test: pr_check
+            params: master_upstream
+          - test: whitespacecheck
+            params: master_upstream
+          - env: modified and renamed files
+            test: licenses
+            diff-filter: MR
+          - env: added and copied files
+            test: licenses
+            diff-filter: AC
     steps:
     - uses: actions/checkout@v2
       with:
@@ -26,9 +56,12 @@ jobs:
     - name: Fetch riot/riotbuild Docker image
       run: docker pull riot/riotbuild:latest
     - name: Run static-tests
+      env:
+        DIFFFILTER: ${{ matrix.diff_filter }}
       run: |
         docker run --rm                     \
-          -e CI_BASE_BRANCH=master_upstream \
+          -e BASE_BRANCH=master_upstream    \
           -v $(pwd):/data/riotbuild         \
           riot/riotbuild:latest             \
-          make static-test
+          /data/riotbuild/dist/tools/${{ matrix.test }}/check.sh \
+              ${{ matrix.params }}

--- a/dist/tools/pr_check/check.sh
+++ b/dist/tools/pr_check/check.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+CURDIR="$(cd "$(dirname "$0")" && pwd)"
+
+${CURDIR}/pr_check.sh $@

--- a/dist/tools/uncrustify/check.sh
+++ b/dist/tools/uncrustify/check.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+CURDIR="$(cd "$(dirname "$0")" && pwd)"
+
+${CURDIR}/uncrustify.sh --check


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Before I spend more time on this little experiment, I want to know your opinion: Now that the static tests are a required GitHub action, what do you think about splitting them into individual build matrix items? While it has the disadvantage that  clutters the checks field quite a bit, it has some advantages:

- Seeing at once in both the check field and check tab, which test failed.
- More granularity which checks are required and which are not.
- Potential for slight speed up, since slower tests don't have to wait on each other.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
You can see how it could look like in https://github.com/miri64/RIOT/pull/33.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
