### PR TITLE
usbus: add usbus_add_interface_alt() helper function

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -450,6 +450,15 @@ uint16_t usbus_add_string_descriptor(usbus_t *usbus, usbus_string_t *desc,
 uint16_t usbus_add_interface(usbus_t *usbus, usbus_interface_t *iface);
 
 /**
+ * @brief Add alternate settings to a given interface
+ *
+ * @param[in] iface   USB interface
+ * @param[in] alt     alternate settings interface to add
+ */
+void usbus_add_interface_alt(usbus_interface_t *iface,
+                                 usbus_interface_alt_t *alt);
+
+/**
  * @brief Find an endpoint from an interface based on the endpoint properties
  *
  * This iterates over the endpoints in an interface and will return the first

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -229,7 +229,7 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     usbus_add_interface(usbus, &cdcecm->iface_ctrl);
     usbus_add_interface(usbus, &cdcecm->iface_data);
 
-    cdcecm->iface_data.alts = &cdcecm->iface_data_alt;
+    usbus_add_interface_alt(&cdcecm->iface_data, &cdcecm->iface_data_alt);
 
     usbus_enable_endpoint(cdcecm->ep_out);
     usbus_enable_endpoint(cdcecm->ep_in);

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -121,6 +121,16 @@ uint16_t usbus_add_interface(usbus_t *usbus, usbus_interface_t *iface)
     return idx;
 }
 
+void usbus_add_interface_alt(usbus_interface_t *iface,
+                             usbus_interface_alt_t *alt)
+{
+    usbus_interface_alt_t **last = &iface->alts;
+    while (*last) {
+        last = &(*last)->next;
+    }
+    *last = alt;
+}
+
 void usbus_register_event_handler(usbus_t *usbus, usbus_handler_t *handler)
 {
     /* See note above for reasons against clist.h */


### PR DESCRIPTION
### Contribution description

This PR add a helper function to easily add one (or more) `usbus_interface_alt_t` to a given interface.
The alternate settings is not that much used in USBUS yet so there is no direct impact for now.
However, having multiple alternate settings for a given interface can be useful in some applications (like USB DFU).

### Testing procedure
We don't use more than one alternate settings at this time so we cannot test this with our current codebase.
CDC ECM use one alternate setting, this should still work with this PR.

### Issues/PRs references
None
