### PR TITLE
usbus: add optional string descriptor for alt interface

### DIFF
--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -294,6 +294,7 @@ typedef struct usbus_interface_alt {
                                              descriptor generators */
     usbus_endpoint_t *ep;               /**< List of associated endpoints for
                                              this alternative setting */
+    usbus_string_t *descr;              /**< Descriptor string */
 } usbus_interface_alt_t;
 
 /**

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -205,6 +205,13 @@ static size_t _fmt_descriptors_iface_alts(usbus_t *usbus,
         len += sizeof(usb_descriptor_interface_t);
         usb_iface.alternate_setting = alts++;
         usb_iface.num_endpoints = _num_endpoints_alt(alt);
+        if (alt->descr) {
+            usb_iface.idx = alt->descr->idx;
+        } else {
+            /* If there is no string descriptor for a given alt interface
+               set the index to 0 to advertise it */
+            usb_iface.idx = 0;
+        }
         usbus_control_slicer_put_bytes(usbus, (uint8_t *)&usb_iface,
                                        sizeof(usb_descriptor_interface_t));
         len += _fmt_descriptors_post(usbus, alt->descr_gen);


### PR DESCRIPTION
### Contribution description

This PR adds support for the optional string descriptor for alternate settings (alt interface).
lsusb won't show string descriptor attached to an interface but the following python script can:
```
import usb
dev = usb.core.find(idVendor=0x1209, idProduct=0x7d00)
_name = usb.util.get_string(dev, 4)
print(_name)
```
Note: replace the 4 by the index of string descriptor but for USBUS, 4 should point to the first newly add string descriptor (the first 3 index are iManufacturer, iProduct, iSerial).


### Testing procedure

Not used anywhere yet so this not really testable but I have some pending work which will use this.


### Issues/PRs references
Needed by #15460 
