### PR TITLE
cpu/qn908x: Fix triggering GPIO IRQ.

### DIFF
--- a/cpu/qn908x/periph/gpio.c
+++ b/cpu/qn908x/periph/gpio.c
@@ -117,6 +117,9 @@ typedef struct {
  */
 #define TOTAL_GPIO_PINS     (35)
 
+/* The IRQ number in the NVIC for each GPIO port. */
+static const uint32_t gpio_nvic_irqs[GPIO_PORTS_NUMOF] = GPIO_IRQS;
+
 static gpio_isr_cb_state_t gpio_isr_state[TOTAL_GPIO_PINS] = {};
 
 int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
@@ -162,6 +165,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
             /* Handled above */
             break;
     }
+    NVIC_EnableIRQ(gpio_nvic_irqs[GPIO_T_PORT(pin)]);
     gpio_irq_enable(pin);
     return 0;
 }


### PR DESCRIPTION
### Contribution description

The IRQ for each GPIO port needs to be enabled in the NVIC on top of
enabling the corresponding bit in the GPIO port.

This was not caught in tests before because I was testing with a larger
stack of commits (including UART and timers) which also had this fix.

Manually poking the GPIOs while using tests/periph_gpio now properly
fires the interrupts.

### Testing procedure

`make BOARD=qn9080dk -C tests/periph_gpio all flash`

Manual verification in the terminal poking the GPIOs after a "init_int" command.

### Issues/PRs references

This is part of #13852.