### PR TITLE
sys/bit: move bit.h header to sys/

### DIFF
--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -7,11 +7,11 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     sys
  * @{
  *
  * @file
- * @brief       Bit access macros for Cortex-M based CPUs
+ * @brief       Bit access macros with bit-banding support for Cortex-M based CPUs
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
@@ -32,7 +32,7 @@ extern "C" {
 
 #if DOXYGEN
 /** @brief Flag for telling if the CPU has hardware bit band support */
-#define CPU_HAS_BITBAND 1 || 0 (1 for Cortex-M3 and up, 0 for Cortex-M0)
+#define CPU_HAS_BITBAND 1 || 0 (1 if CPU implements bit-banding, 0 if not)
 #endif
 
 #if CPU_HAS_BITBAND || DOXYGEN


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The bit access functions are not tied to Cortex-M CPUs, here they only provide optimizations via bit-banding.

But the functions are generally useful - so move them to an arch independent location.



### Testing procedure

Everything should still compile.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
