### PR TITLE
drivers/rn2xx3 : Kconfig updates.

### DIFF
--- a/drivers/include/rn2xx3.h
+++ b/drivers/include/rn2xx3.h
@@ -67,6 +67,23 @@ extern "C" {
 #ifndef CONFIG_RN2XX3_DEFAULT_SLEEP
 #define CONFIG_RN2XX3_DEFAULT_SLEEP            (5000U)
 #endif
+
+/**
+ * @brief   Default automatic reply status
+ *
+ * Set to 1 to enable the automatic reply. The module will transmit a packet without a
+ * payload immediately after a confirmed downlink is received, or when the Frame
+ * Pending bit has been set by the server.
+ *
+ * @note If all enabled channels are busy due to duty cycle limitations, the
+ * module will wait for the first channel that will become free to transmit. The
+ * user will not be able to initiate uplink transmissions until the automatic
+ * transmissions are done. Refer RN2483 LoRa™ Technology Module Command
+ * Reference User’s Guide for more information.
+ */
+#ifdef DOXYGEN
+#define CONFIG_RN2XX3_DEFAULT_AR
+#endif
 /** @} */
 
 #if defined(MODULE_RN2903)

--- a/drivers/rn2xx3/Kconfig
+++ b/drivers/rn2xx3/Kconfig
@@ -20,4 +20,13 @@ config RN2XX3_DEFAULT_SLEEP
         Set the sleep duration (in ms).
         The value should be greater than RN2XX3_SLEEP_MIN (100 ms)
 
+config RN2XX3_DEFAULT_AR
+    bool "Enable automatic reply"
+    help
+        Enable/disable Automatic Reply (AR) for rn2xx3 module. By enabling the
+        automatic reply, the module will transmit a packet without a payload
+        immediately after a confirmed downlink is received, or when the
+        Frame Pending bit has been set by the server. Refer RN2483 LoRa™
+        Technology Module Command Reference User’s Guide for more information.
+
 endif # KCONFIG_USEMODULE_RN2XX3

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -24,6 +24,8 @@
 #include "assert.h"
 #include "xtimer.h"
 #include "fmt.h"
+#include "kernel_defines.h"
+
 #include "rn2xx3_params.h"
 #include "rn2xx3.h"
 #include "rn2xx3_internal.h"
@@ -255,7 +257,7 @@ int rn2xx3_mac_init(rn2xx3_t *dev)
     rn2xx3_mac_set_retx(dev, LORAMAC_DEFAULT_RETX);
     rn2xx3_mac_set_linkchk_interval(dev, LORAMAC_DEFAULT_LINKCHK);
     rn2xx3_mac_set_rx1_delay(dev, LORAMAC_DEFAULT_RX1_DELAY);
-    rn2xx3_mac_set_ar(dev, LORAMAC_DEFAULT_AR);
+    rn2xx3_mac_set_ar(dev, IS_ACTIVE(CONFIG_RN2XX3_DEFAULT_AR));
     rn2xx3_mac_set_rx2_dr(dev, LORAMAC_DEFAULT_RX2_DR);
     rn2xx3_mac_set_rx2_freq(dev, LORAMAC_DEFAULT_RX2_FREQ);
 

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -203,13 +203,6 @@ extern "C" {
 #define LORAMAC_DEFAULT_RX2_DELAY              (1000U + LORAMAC_DEFAULT_RX1_DELAY)
 
 /**
- * @brief   Default automatic reply status
- */
-#ifndef LORAMAC_DEFAULT_AR
-#define LORAMAC_DEFAULT_AR                     (false)
-#endif
-
-/**
  * @brief   Default second RX window datarate index
  */
 #ifndef LORAMAC_DEFAULT_RX2_DR


### PR DESCRIPTION
### Contribution description - 

This PR replaces LORAMAC_DEFAULT_AR with CONFIG_RN2XX3_DEFAULT_AR and expose the same to Kconfig. Auto reply is a device-specific feature and not part of LoRaWAN specification.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were updated in tests/driver_rn2xx3

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/08b766e5ee54c52191bbce7a0b1a0f0f9e62c6a6)

      Compiled binaries for sam21 and tested on FIT-IoT Test bed.

#### Default State:

##### Firmware Output
```
main(): This is RIOT! (Version: 2021.01-devel-1397-g150a85-Kconfig_rn2xx3_update)
RN2XX3 device driver test
CONFIG_RN2XX3_DEFAULT_SLEEP=(5000U)
CONFIG_RN2XX3_DEFAULT_AR=CONFIG_RN2XX3_DEFAULT_AR
```

#### Usage with menuconfig :

`make menuconfig`

##### Default Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-1397-g150a85-Kconfig_rn2xx3_update)
RN2XX3 device driver test
CONFIG_RN2XX3_DEFAULT_SLEEP=5000
CONFIG_RN2XX3_DEFAULT_AR=CONFIG_RN2XX3_DEFAULT_AR
```

##### Configured Firmware Output

```
main(): This is RIOT! (Version: 2021.01-devel-1397-g150a85-Kconfig_rn2xx3_update)
RN2XX3 device driver test
CONFIG_RN2XX3_DEFAULT_SLEEP=6000
CONFIG_RN2XX3_DEFAULT_AR=1
```

**MACROS were successfully configured.**

### Issues/PRs references
#12888 
#15507 