### PR TITLE
add error check of aes_encrypt()

### DIFF
--- a/sys/random/fortuna/fortuna.c
+++ b/sys/random/fortuna/fortuna.c
@@ -53,6 +53,7 @@ static void fortuna_reseed(fortuna_state_t *state, const uint8_t *seed,
 
 /*
  * Corresponds to section 9.4.3.
+ * Returns 0 on success; A negative value otherwise
  */
 static int fortuna_generate_blocks(fortuna_state_t *state, uint8_t *out,
                                    size_t blocks)
@@ -75,7 +76,10 @@ static int fortuna_generate_blocks(fortuna_state_t *state, uint8_t *out,
     }
 
     for (size_t i = 0; i < blocks; i++) {
-        aes_encrypt(&cipher, state->gen.counter.bytes, out + (i * 16));
+        res = aes_encrypt(&cipher, state->gen.counter.bytes, out + (i * 16));
+        if (res != 1) {
+            return -3;
+        }
         fortuna_increment_counter(state);
     }
 


### PR DESCRIPTION
### Contribution description

sys/random/fortuna/fortuna.c:add error check of aes_encrypt()
I'm not sure which exact value should be returned when aes_encrypt() is not on success. I just return the return value of it. 


### Issues/PRs references

Addresses parts of #15524

