### PR TITLE
cpu/cortexm_common: fix r12 clobber in pendsv for Cortex-M3+

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -317,20 +317,21 @@ void __attribute__((naked)) __attribute__((used)) isr_pendsv(void) {
 
     /* skip context saving if sched_active_thread == NULL */
     "ldr    r1, =sched_active_thread  \n" /* r1 = &sched_active_thread  */
-    "ldr    r12, [r1]                 \n" /* r12 = sched_active_thread   */
-    "push   {lr}                      \n" /* push exception return code */
+    "push   {r4, lr}                  \n" /* push r4 and exception return code */
+    "ldr    r4, [r1]                  \n" /* r4 = sched_active_thread   */
 
     "cpsid  i                         \n" /* Disable IRQs during sched_run */
     "bl     sched_run                 \n" /* perform scheduling */
     "cpsie  i                         \n" /* Re-enable interrupts */
 
-    "cmp    r0, r12                   \n" /* if r0 == 0: (no switch required) */
+    "cmp    r0, r4                    \n" /* if r0 == r1: (new thread == old
+                                               thread, no switch required) */
     "it     eq                        \n"
-    "popeq  {pc}                      \n" /* Pop exception to pc to return */
+    "popeq  {r4, pc}                  \n" /* Pop exception to pc to return */
 
-    "pop    {lr}                      \n" /* Pop exception from the exception stack */
+    "mov    r1, r4                    \n" /* save sched_active_thread in r1 */
+    "pop    {r4, lr}                  \n" /* Pop exception from the exception stack */
 
-    "mov    r1,r12                    \n" /* r1 = sched_active_thread */
     "cbz    r1, restore_context       \n" /* goto restore_context if r1 == 0 */
 
     "mrs    r2, psp                   \n" /* get stack pointer from user mode */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, `isr_pendsv()` was relying on r12 not being clobbered by `sched_run()` which is [not correct](https://github.com/RIOT-OS/RIOT/issues/15538).

This PR fixes the issue by saving and restoring the scratch register used to save the previous sched_active_thread value, in the full thumb (Cortex-M3+) case.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Not sure, I tried some threading tests on nrf52.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/15538.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
