### PR TITLE
sock/dtls: remove sock_dtls_session_create due to deprecation

### DIFF
--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -38,7 +38,7 @@
  *      @ref SOCK_DTLS_CLIENT
  *   3. Start handshake session to server @ref sock_dtls_session_init()
  *   4. Handle incoming handshake packets with @ref sock_dtls_recv()
- *   4. Send packet to server @ref sock_dtls_send()
+ *   5. Send packet to server @ref sock_dtls_send()
  *
  * ## Makefile Includes
  *

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -918,50 +918,6 @@ static inline ssize_t sock_dtls_send(sock_dtls_t *sock,
  */
 void sock_dtls_close(sock_dtls_t *sock);
 
-/**
- * @brief Creates a new DTLS session
- *
- *  Initiates a handshake with a DTLS server at @p ep and wait until it
- * completes or timed out.
- *
- * @deprecated Will not be available after the 2020.10 release.
- *             Please use @ref sock_dtls_session_init() and
- *             @ref sock_dtls_recv() instead.
- *
- * @param[in]  sock     DLTS sock to use
- * @param[in]  ep       Remote endpoint of the session
- * @param[out] remote   The created session, cannot be NULL
- * @param[in]  timeout  Timeout to wait for handshake to finish.
- *                      Returns immediately if 0.
- *                      May be SOCK_NO_TIMEOUT to wait indefinitely until
- *                      handshake complete.
- *
- * @return  0 on success
- * @return  -ENOMEM, if no memory to allocate for new peer
- * @return  -EADDRNOTAVAIL, if the local endpoint of @p sock is not set.
- * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
- *          initialized (or closed while sock_udp_recv() blocks).
- */
-static inline int sock_dtls_session_create(sock_dtls_t *sock,
-                                           const sock_udp_ep_t *ep,
-                                           sock_dtls_session_t *remote,
-                                           unsigned timeout)
-{
-    int res;
-    uint8_t buf[DTLS_HANDSHAKE_BUFSIZE];
-
-    assert(sock);
-    assert(remote);
-
-    res = sock_dtls_session_init(sock, ep, remote);
-    if (res <= 0) {
-        return res;
-    }
-
-    res = sock_dtls_recv(sock, remote, buf, sizeof(buf), timeout);
-    return res == -SOCK_DTLS_HANDSHAKE ? 0 : res;
-}
-
 #include "sock_dtls_types.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the as deprecated marked function `sock_dtls_session_create`. I didn't see any leftover of the function. `pkg/wolfssl/sock_tls` contains a function with the same name but does not rely on `sock/dtls.h` and has completely other parameters.


Because it is small and in the same file: Also added a commit which fixes the wrong numbering in the documentation of the client operations.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
* Murdock should be green
* No leftover of `sock_dtls_session_create`
* Numbering in the rendered documentation should be correct
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow up of #15551
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
