### PR TITLE
drivers, sys: use byteorder_htols() 

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -221,7 +221,7 @@ uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
 {
-    le_uint16_t le_pan = byteorder_btols(byteorder_htons(pan));
+    le_uint16_t le_pan = byteorder_htols(pan);
 
     DEBUG("pan0: %u, pan1: %u\n", le_pan.u8[0], le_pan.u8[1]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PAN_ID_0, le_pan.u8[0]);

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -260,7 +260,7 @@ uint16_t mrf24j40_get_pan(mrf24j40_t *dev)
 
 void mrf24j40_set_pan(mrf24j40_t *dev, uint16_t pan)
 {
-    le_uint16_t le_pan = byteorder_btols(byteorder_htons(pan));
+    le_uint16_t le_pan = byteorder_htols(pan);
 
     DEBUG("pan0: %u, pan1: %u\n", le_pan.u8[0], le_pan.u8[1]);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_PANIDL, le_pan.u8[0]);

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -56,7 +56,7 @@ int _gnrc_gomach_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     size_t src_len, dst_len;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
     uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
-    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
+    le_uint16_t dev_pan = byteorder_htols(state->pan);
 
     flags |= IEEE802154_FCF_TYPE_DATA;
     if (pkt == NULL) {

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
@@ -67,7 +67,7 @@ void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
 
     memcpy(&block.dev_addr, dev_addr, sizeof(le_uint32_t));
 
-    block.fcnt = byteorder_btoll(byteorder_htonl(fcnt));
+    block.fcnt = byteorder_htoll(fcnt);
 
     block.u32_pad = 0;
 
@@ -103,7 +103,7 @@ void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
     block->dir = dir & DIR_MASK;
 
     block->dev_addr = *dev_addr;
-    block->fcnt = byteorder_btoll(byteorder_htonl(fcnt));
+    block->fcnt = byteorder_htoll(fcnt);
 
     block->u32_pad = 0;
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -221,7 +221,7 @@ size_t gnrc_lorawan_build_hdr(uint8_t mtype, le_uint32_t *dev_addr,
     lorawan_hdr_set_ack(lw_hdr, ack);
     lorawan_hdr_set_frame_opts_len(lw_hdr, fopts_length);
 
-    lw_hdr->fcnt = byteorder_btols(byteorder_htons(fcnt));
+    lw_hdr->fcnt = byteorder_htols(fcnt);
 
     buf->index += sizeof(lorawan_hdr_t);
 
@@ -248,7 +248,7 @@ size_t gnrc_lorawan_build_uplink(gnrc_lorawan_t *mac, iolist_t *payload,
 
     lorawan_hdr_set_ack(lw_hdr, mac->mcps.ack_requested);
 
-    lw_hdr->fcnt = byteorder_btols(byteorder_htons(mac->mcps.fcnt));
+    lw_hdr->fcnt = byteorder_htols(mac->mcps.fcnt);
 
     buf.index += sizeof(lorawan_hdr_t);
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -43,7 +43,7 @@ int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     size_t src_len, dst_len;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
     uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
-    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
+    le_uint16_t dev_pan = byteorder_htols(state->pan);
 
     flags |= IEEE802154_FCF_TYPE_DATA;
     if (pkt == NULL) {

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -224,7 +224,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     size_t src_len, dst_len;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
     uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
-    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
+    le_uint16_t dev_pan = byteorder_htols(state->pan);
 
     flags |= IEEE802154_FCF_TYPE_DATA;
     if (pkt == NULL) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Same pattern as in 374d032b821290074bae76a78b2bd1c896527d1a, we have a proper function for this now.


### Testing procedure

Binaries should not change, if this was not optimized away previously they might even be slightly smaller.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
