### PR TITLE
sys/net/link_layer/ieee802154/submac: fix type

### DIFF
--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -403,7 +403,7 @@ int ieee802154_set_state(ieee802154_submac_t *submac, ieee802154_submac_state_t 
         res = ieee802154_radio_off(dev);
     }
     else {
-        ieee802154_submac_state_t new_state =
+        ieee802154_trx_state_t new_state =
                     state == IEEE802154_STATE_IDLE
                     ? IEEE802154_TRX_STATE_TRX_OFF
                     : IEEE802154_TRX_STATE_RX_ON;


### PR DESCRIPTION
### Contribution description

This PR fixes the typed used, pops up on newer gcc

```
/home/francisco/workspace/RIOT3/sys/net/link_layer/ieee802154/submac.c: In function 'ieee802154_set_state':
/home/francisco/workspace/RIOT3/sys/net/link_layer/ieee802154/submac.c:407:21: error: implicit conversion from 'enum <anonymous>' to 'ieee802154_submac_state_t' [-Werror=enum-conversion]
  407 |                     state == IEEE802154_STATE_IDLE
      |                     ^~~~~
/home/francisco/workspace/RIOT3/sys/net/link_layer/ieee802154/submac.c:411:64: error: implicit conversion from 'ieee802154_submac_state_t' to 'ieee802154_trx_state_t' [-Werror=enum-conversion]
  411 |         if ((res = ieee802154_radio_request_set_trx_state(dev, new_state)) < 0) {
      |                                                                ^~~~~~~~~
cc1: all warnings being treated as errors
make[3]: *** [/home/francisco/workspace/RIOT3/Makefile.base:107: /home/francisco/workspace/RIOT3/examples/gnrc_networking/bin/openmote-b/ieee802154/submac.o] Error 1
make[2]: *** [/home/francisco/workspace/RIOT3/Makefile.base:30: ALL--/home/francisco/workspace/RIOT3/sys/net/link_layer/ieee802154] Error 2
make[2]: *** Waiting for unfinished jobs....
"make" -C /home/francisco/workspace/RIOT3/sys/net/gnrc/network_layer/icmpv6/echo

```

### Testing procedure

Compile with `arm-none-eabi-gcc-10.1.1`

look at the code

### Issues/PRs references

Found in #15534
