### PR TITLE
tests: remove unused driver_mpu9150 directory

### DIFF
--- a/tests/driver_mpu9150/Makefile.ci
+++ b/tests/driver_mpu9150/Makefile.ci
@@ -1,7 +1,0 @@
-BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-leonardo \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
-    #


### PR DESCRIPTION
### Contribution description
The driver and the test application had been renamed to mpu9x50 in 2df5d6048d589b26b7b015f1387fdbb8067c3a29, but c01eae32398a07ec225c0a09a0e68a37cdb883db added a Makefile.ci for it.
The folder is no longer used, so this removes it together with the Makefile.

### Testing procedure
- Check that the directory is not needed

### Issues/PRs references
#12103
#12411