### PR TITLE
gnrc_ipv6_nib: prevent NULL pointer dereference on nib exhaustion

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
@@ -84,8 +84,15 @@ uint8_t _reg_addr_upstream(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_DAD */
             if (aro->ltime.u16 != 0) {
                 _handle_sl2ao(netif, ipv6, icmpv6, sl2ao);
+
                 /* re-get NCE in case it was updated */
                 nce = _nib_onl_get(&ipv6->src, netif->pid);
+
+                /* NIB is full */
+                if (nce == NULL) {
+                    return SIXLOWPAN_ND_STATUS_NC_FULL;
+                }
+
                 /* and re-check EUI-64 in case nce was not an NC before */
                 if ((memcmp(&nce->eui64, &aro->eui64,
                             sizeof(aro->eui64)) != 0) &&


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If the NIB is full and a new node tries to register with the border router, `_nib_onl_get()` returns NULL.
`_reg_addr_upstream()` will then dereference the result without if it is valid.


### Testing procedure

I stumbled across this because `socket_zep` will have a new MAC address with every reboot.

This makes it easy to reproduce the issue:

 - start the `native` border router:
```
make -C examples/gnrc_border_router BOARD=native all term
```

 - run the [`sleepy_mode`](https://github.com/benpicco/sleepy_node) demo on `native`
```
make BOARD=native USE_ZEP=1 all term
```

after a couple of iterations the `gnrc_border_router` will segfault (and the `sleepy_node` will not get a prefix anymore).

With this patch the `gnrc_border_router` no longer segfaults, but `sleepy_node` still gets no prefix - ideally, the oldest NIB entry should be evicted, but before doing so I'd like to get some feedback on the issue.

```
nib neigh
fe80::1 dev #6 lladdr 02:64:BF:0E:85:28 router REACHABLE GC
2001:db8::25a:4550:a00:af9d dev #7 lladdr 00:5A:45:50:0A:00:AF:9D  STALE REGISTERED
2001:db8::25a:4550:a00:c711 dev #7 lladdr 00:5A:45:50:0A:00:C7:11  STALE REGISTERED
2001:db8::25a:4550:a00:8c4a dev #7 lladdr 00:5A:45:50:0A:00:8C:4A  STALE REGISTERED
2001:db8::25a:4550:a00:c9c2 dev #7 lladdr 00:5A:45:50:0A:00:C9:C2  STALE REGISTERED
2001:db8::25a:4550:a00:8352 dev #7 lladdr 00:5A:45:50:0A:00:83:52  STALE REGISTERED
2001:db8::25a:4550:a00:9319 dev #7 lladdr 00:5A:45:50:0A:00:93:19  STALE REGISTERED
2001:db8::25a:4550:a00:c4e6 dev #7 lladdr 00:5A:45:50:0A:00:C4:E6  STALE REGISTERED
2001:db8::25a:4550:a00:a8f6 dev #7 lladdr 00:5A:45:50:0A:00:A8:F6  STALE REGISTERED
2001:db8::25a:4550:a00:e04f dev #7 lladdr 00:5A:45:50:0A:00:E0:4F  STALE REGISTERED
2001:db8::25a:4550:a00:ae88 dev #7 lladdr 00:5A:45:50:0A:00:AE:88  PROBE REGISTERED
2001:db8::25a:4550:a00:90ef dev #7 lladdr 00:5A:45:50:0A:00:90:EF  STALE REGISTERED
2001:db8::25a:4550:a00:bf7a dev #7 lladdr 00:5A:45:50:0A:00:BF:7A  STALE REGISTERED
2001:db8::25a:4550:a00:d733 dev #7 lladdr 00:5A:45:50:0A:00:D7:33  STALE REGISTERED
2001:db8::25a:4550:a00:90a7 dev #7 lladdr 00:5A:45:50:0A:00:90:A7  STALE REGISTERED
2001:db8::25a:4550:a00:d758 dev #7 lladdr 00:5A:45:50:0A:00:D7:58  STALE REGISTERED
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
