### PR TITLE
boards/stm32l476g-disco: use connect_assert_srst with openocd

### DIFF
--- a/boards/stm32l476g-disco/Makefile.include
+++ b/boards/stm32l476g-disco/Makefile.include
@@ -4,3 +4,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd
 DEBUG_ADAPTER ?= stlink
+
+# This board can become un-flashable after a hardfault,
+# use connect_assert_srst to always be able to flash or reset the board.
+OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR should fix [the problem raise on the user mailing list](https://lists.riot-os.org/pipermail/users/2020-December/001674.html) by @keestux.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- The stm32l476g-disco is flashable, even after a crash:

```
$ make BOARD=stm32l476g-disco -C tests/ssp flash test
$ make BOARD=stm32l476g-disco -C tests/ssp flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes the [problem reported on the users mailing-list](https://lists.riot-os.org/pipermail/users/2020-December/001674.html)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
