### PR TITLE
sys/ztimer: add ztimer_mutex_lock_timeout()

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -236,6 +236,7 @@
 
 #include "sched.h"
 #include "msg.h"
+#include "mutex.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -506,6 +507,19 @@ void ztimer_set_wakeup(ztimer_clock_t *clock, ztimer_t *timer, uint32_t offset,
  */
 void ztimer_set_timeout_flag(ztimer_clock_t *clock, ztimer_t *timer,
                              uint32_t timeout);
+
+/**
+ * @brief   Try to lock the given mutex, but give up after @p timeout
+ *
+ * @param[in]       clock       ztimer clock to operate on
+ * @param[in,out]   mutex       Mutex object to lock
+ * @param[in]       timeout     timeout after which to give up
+ *
+ * @retval  0               Success, caller has the mutex
+ * @retval  -ECANCELED      Failed to obtain mutex within @p timeout
+ */
+int ztimer_mutex_lock_timeout(ztimer_clock_t *clock, mutex_t *mutex,
+                              uint32_t timeout);
 
 /**
  * @brief   Update ztimer clock head list offset

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -160,6 +160,16 @@ static inline void xtimer_set_wakeup(xtimer_t *timer, uint32_t offset,
     ztimer_set_wakeup(ZTIMER_USEC, timer, offset, pid);
 }
 
+static inline int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us)
+{
+    assert(us <= UINT32_MAX);
+    if (ztimer_mutex_lock_timeout(ZTIMER_USEC, mutex, (uint32_t)us)) {
+        /* Impedance matching required: Convert -ECANCELED error code to -1: */
+        return -1;
+    }
+    return 0;
+}
+
 /*
    static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
    static inline void xtimer_tsleep32(xtimer_ticks32_t ticks);
@@ -183,7 +193,6 @@ static inline void xtimer_set_wakeup(xtimer_t *timer, uint32_t offset,
                                                 xtimer_ticks64_t b);
    static inline bool xtimer_less(xtimer_ticks32_t a, xtimer_ticks32_t b);
    static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
-   int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
    void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 
  #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -28,12 +28,6 @@
 #include "thread.h"
 #include "ztimer.h"
 
-typedef struct {
-    mutex_t *mutex;
-    thread_t *thread;
-    int timeout;
-} mutex_thread_t;
-
 static void _callback_unlock_mutex(void *arg)
 {
     mutex_t *mutex = (mutex_t *)arg;

--- a/tests/ztimer_mutex_lock_timeout/Makefile
+++ b/tests/ztimer_mutex_lock_timeout/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += ztimer_usec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_mutex_lock_timeout/main.c
+++ b/tests/ztimer_mutex_lock_timeout/main.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing ztimer_mutex_lock_timeout_timeout
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "mutex.h"
+#include "test_utils/expect.h"
+#include "timex.h"
+#include "ztimer.h"
+
+#ifndef TEST_CLOCK
+#define TEST_CLOCK      ZTIMER_USEC
+#endif
+
+#ifndef TIMEOUT_SMALL
+#define TIMEOUT_SMALL   (100U)
+#endif
+
+#ifndef TIMEOUT_LARGE
+#define TIMEOUT_LARGE   (US_PER_SEC / 2)
+#endif
+
+static mutex_t testlock = MUTEX_INIT;
+
+int main(void)
+{
+    ztimer_now_t pre, post;
+    puts(
+        "Test Application for ztimer_mutex_lock_timeout_timeout()\n"
+        "================================================\n"
+    );
+
+    printf("%s: ", "Test on unlocked mutex with zero timeout");
+    expect(ztimer_mutex_lock_timeout(TEST_CLOCK, &testlock, 0) == 0);
+    puts("OK");
+
+    printf("%s: ", "Test on unlocked mutex with small timeout");
+    mutex_unlock(&testlock);
+    expect(ztimer_mutex_lock_timeout(TEST_CLOCK, &testlock, TIMEOUT_SMALL) == 0);
+    puts("OK");
+
+    printf("%s: ", "Test on unlocked mutex with large timeout");
+    mutex_unlock(&testlock);
+    pre = ztimer_now(TEST_CLOCK);
+    expect(ztimer_mutex_lock_timeout(TEST_CLOCK, &testlock, US_PER_SEC / 2) == 0);
+    post = ztimer_now(TEST_CLOCK);
+    /* Call shouldn't block on unlocked mutex. So the duration spent on the
+    * function call should be short. Let's take a very generous definition of
+    * "short duration" here to not get false failures on slow boards */
+    expect(post - pre < TIMEOUT_LARGE);
+    puts("OK");
+
+    printf("%s: ", "Test on locked mutex with zero timeout");
+    pre = ztimer_now(TEST_CLOCK);
+    expect(ztimer_mutex_lock_timeout(TEST_CLOCK, &testlock, 0) == -ECANCELED);
+    post = ztimer_now(TEST_CLOCK);
+    expect(post - pre < TIMEOUT_LARGE);
+    puts("OK");
+
+    printf("%s: ", "Test on locked mutex with small timeout");
+    pre = ztimer_now(TEST_CLOCK);
+    expect(ztimer_mutex_lock_timeout(TEST_CLOCK, &testlock, TIMEOUT_SMALL) == -ECANCELED);
+    post = ztimer_now(TEST_CLOCK);
+    expect((post - pre > TIMEOUT_SMALL) && (post - pre < TIMEOUT_LARGE));
+    puts("OK");
+
+    printf("%s: ", "Test on locked mutex with large timeout");
+    pre = ztimer_now(TEST_CLOCK);
+    expect(ztimer_mutex_lock_timeout(TEST_CLOCK, &testlock, TIMEOUT_LARGE) == -ECANCELED);
+    post = ztimer_now(TEST_CLOCK);
+    expect(post - pre > TIMEOUT_LARGE);
+    puts("OK");
+
+
+    puts("TEST PASSED");
+
+    return 0;
+}

--- a/tests/ztimer_mutex_lock_timeout/tests/01-run.py
+++ b/tests/ztimer_mutex_lock_timeout/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

As the title says. Additionally, a test application is provided and a `ztimer_xtimer_compat` is extended to also provide `xtimer_mutex_lock_timeout()` via `ztimer_mutex_lock_timeout()`.

### Testing procedure

- `make -C tests/ztimer_mutex_lock_timeout flash test`
- `USEMODULE=ztimer_xtimer_compat make -C tests/xtimer_mutex_lock_timeout flash test`

### Issues/PRs references

None