### PR TITLE
dist/tools/kconfig/genconfig: fix printing of range condition

### DIFF
--- a/dist/tools/kconfiglib/genconfig.py
+++ b/dist/tools/kconfiglib/genconfig.py
@@ -293,8 +293,10 @@ def get_sym_applying_range(sym):
         (low, high, cond) = rng
         # get the first active one
         if kconfiglib.expr_value(cond):
-            return (low.str_value, high.str_value,
-                    "(if {})".format(cond.name) if not cond.is_constant else "")
+            cond_str = ""
+            if cond is not sym.kconfig.y:
+                cond_str = "if {}".format(kconfiglib.expr_str(cond))
+            return (low.str_value, high.str_value, cond_str)
     return None
 
 


### PR DESCRIPTION
### Contribution description
As reported [here](https://github.com/RIOT-OS/RIOT/pull/15001#discussion_r538593967) by @aabadie there seems to be a problem with the `genconfig` script when trying to print the conditions of ranges. I got to reproduce the problem with the following patch and running `make menuconfig -C examples/hello-world`:

```diff
diff --git a/Kconfig b/Kconfig
index 75fb259853..82b80f8ab9 100644
--- a/Kconfig
+++ b/Kconfig
@@ -46,3 +46,15 @@ config TEST_KCONFIG
         This is used during the Kconfig migration to test the module dependency
         modelling. Don't change the default value unless you know what you are
         doing.
+
+config TEST_BOOL_A
+    bool "A"
+
+config TEST_BOOL_B
+    bool "B"
+    default y
+
+config TEST_VALUE
+    int "Test value"
+    default 2
+    range 1 10 if TEST_BOOL_B && !TEST_BOOL_A
diff --git a/examples/hello-world/app.config b/examples/hello-world/app.config
new file mode 100644
index 0000000000..d12a5e8931
--- /dev/null
+++ b/examples/hello-world/app.config
@@ -0,0 +1 @@
+CONFIG_TEST_VALUE=11
```

### Testing procedure
- Without this PR you should see some error `AttributeError: 'tuple' object has no attribute 'is_constant'`, this patch should fix that.
- Kconfig checks should work as usual.


### Issues/PRs references
Fixes the issue reported here: https://github.com/RIOT-OS/RIOT/pull/15001#discussion_r538593967
