### PR TITLE
core/mutex: compatibility with non-C languages

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -105,10 +105,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "irq.h"
 #include "kernel_defines.h"
 #include "list.h"
 #include "thread.h"
+
+#ifndef __cplusplus
+#include "irq.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -190,6 +193,25 @@ static inline mutex_cancel_t mutex_cancel_init(mutex_t *mutex)
 /**
  * @brief   Tries to get a mutex, non-blocking.
  *
+ * @internal
+ * @note    This function is intended for use by languages incompatible
+ *          with C (such as C++). Code in C should use @ref mutex_trylock
+ *          instead
+ *
+ * @param[in,out]   mutex   Mutex object to lock.
+ *
+ * @retval  1               if mutex was unlocked, now it is locked.
+ * @retval  0               if the mutex was locked.
+ *
+ * @pre     @p mutex is not `NULL`
+ * @pre     Mutex at @p mutex has been initialized
+ * @pre     Must be called in thread context
+ */
+int mutex_trylock_ffi(mutex_t *mutex);
+
+/**
+ * @brief   Tries to get a mutex, non-blocking.
+ *
  * @param[in,out]   mutex   Mutex object to lock.
  *
  * @retval  1               if mutex was unlocked, now it is locked.
@@ -201,6 +223,9 @@ static inline mutex_cancel_t mutex_cancel_init(mutex_t *mutex)
  */
 static inline int mutex_trylock(mutex_t *mutex)
 {
+#ifdef __cplusplus
+    return mutex_trylock_ffi(mutex);
+#else
     unsigned irq_state = irq_disable();
     int retval = 0;
 
@@ -210,6 +235,7 @@ static inline int mutex_trylock(mutex_t *mutex)
     }
     irq_restore(irq_state);
     return retval;
+#endif
 }
 
 /**

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -211,3 +211,9 @@ void mutex_cancel(mutex_cancel_t *mc)
 
     irq_restore(irq_state);
 }
+
+/* Helper for compatibility with C++ or other non-C languages */
+int mutex_trylock_ffi(mutex_t *mutex)
+{
+    return mutex_trylock(mutex);
+}


### PR DESCRIPTION
### Contribution description

Due to limited compatibility with C, we cannot use the inline mutex_trylock implementation for C++. Instead, we provide a mutex_trylock_ffi() intended for foreign function interfaces. This should also benefit rust users.

### Testing procedure

C++ code should compile again with recent clang++ and C code shouldn't differ.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/15595