### PR TITLE
follow-up: use byteorder_htoll()

### DIFF
--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -40,7 +40,7 @@ static int gnrc_lorawan_mic_is_valid(uint8_t *buf, size_t len, uint8_t *nwkskey)
 
     lorawan_hdr_t *lw_hdr = (lorawan_hdr_t *)buf;
 
-    uint32_t fcnt = byteorder_ntohs(byteorder_ltobs(lw_hdr->fcnt));
+    uint32_t fcnt = byteorder_ltohs(lw_hdr->fcnt);
     iolist_t iol =
     { .iol_base = buf, .iol_len = len - MIC_SIZE, .iol_next = NULL };
 
@@ -165,8 +165,8 @@ void gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, uint8_t *psdu,
             fopts = &_pkt.enc_payload;
         }
         gnrc_lorawan_encrypt_payload(&_pkt.enc_payload, &_pkt.hdr->addr,
-                                     byteorder_ntohs(byteorder_ltobs(
-                                                         _pkt.hdr->fcnt)), GNRC_LORAWAN_DIR_DOWNLINK,
+                                     byteorder_ltohs(_pkt.hdr->fcnt),
+                                     GNRC_LORAWAN_DIR_DOWNLINK,
                                      key);
     }
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -131,7 +131,7 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data,
 
     le_nid.u32 = 0;
     memcpy(&le_nid, ja_hdr->net_id, 3);
-    mac->mlme.nid = byteorder_ntohl(byteorder_ltobl(le_nid));
+    mac->mlme.nid = byteorder_ltohl(le_nid);
     /* Copy devaddr */
     memcpy(&mac->dev_addr, ja_hdr->dev_addr, sizeof(mac->dev_addr));
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -121,7 +121,7 @@ void gnrc_lorawan_process_cflist(gnrc_lorawan_t *mac, uint8_t *cflist)
         le_uint32_t cl;
         cl.u32 = 0;
         memcpy(&cl, cflist, GNRC_LORAWAN_CFLIST_ENTRY_SIZE);
-        mac->channel[i] = byteorder_ntohl(byteorder_ltobl(cl)) * 100;
+        mac->channel[i] = byteorder_ltohl(cl) * 100;
         cflist += GNRC_LORAWAN_CFLIST_ENTRY_SIZE;
         DEBUG("gnrc_lorawan_region: Mac -> Channel %u %" PRIu32 " \n", i, mac->channel[i]);
     }

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -157,7 +157,7 @@ static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
     ahr->scf = _scf(ctx->security_level, ctx->key_id_mode);
     /* If you look in the specification: Annex C,
        integers values are in little endian */
-    ahr->fc = byteorder_btoll(byteorder_htonl(ctx->frame_counter)).u32;
+    ahr->fc = byteorder_htoll(ctx->frame_counter).u32;
     size_t len = 5;
     switch (ctx->key_id_mode) {
         case IEEE802154_SCF_KEYMODE_IMPLICIT:
@@ -422,8 +422,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     uint8_t aux_size = _get_aux_hdr_size(security_level, key_mode);
     uint8_t mac_size = _mac_size(security_level);
     /* remember that the frame counter was stored in little endian */
-    uint32_t frame_counter = byteorder_ntohl(
-                                byteorder_ltobl((le_uint32_t){aux->fc}));
+    uint32_t frame_counter = byteorder_ltohl((le_uint32_t){aux->fc});
 
     if (security_level == IEEE802154_SCF_SECLEVEL_NONE) {
         *payload = header + *header_size;

--- a/tests/driver_at86rf2xx/recv.c
+++ b/tests/driver_at86rf2xx/recv.c
@@ -60,10 +60,10 @@ void recv(netdev_t *dev)
             break;
     }
     printf("Dest. PAN: 0x%04x, Dest. addr.: ",
-           byteorder_ntohs(byteorder_ltobs(dst_pan)));
+           byteorder_ltohs(dst_pan));
     print_addr(dst, dst_len);
     printf("\nSrc. PAN: 0x%04x, Src. addr.: ",
-           byteorder_ntohs(byteorder_ltobs(src_pan)));
+           byteorder_ltohs(src_pan));
     print_addr(src, src_len);
     printf("\nSecurity: ");
     if (buffer[0] & IEEE802154_FCF_SECURITY_EN) {

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -115,10 +115,10 @@ void recv(netdev_t *dev)
         break;
     }
     printf("Dest. PAN: 0x%04x, Dest. addr.: ",
-           byteorder_ntohs(byteorder_ltobs(dst_pan)));
+           byteorder_ltohs(dst_pan));
     _print_addr(dst, dst_len);
     printf("\nSrc. PAN: 0x%04x, Src. addr.: ",
-           byteorder_ntohs(byteorder_ltobs(src_pan)));
+           byteorder_ltohs(src_pan));
     _print_addr(src, src_len);
     printf("\nSecurity: ");
     if (buffer[0] & IEEE802154_FCF_SECURITY_EN) {


### PR DESCRIPTION
### Contribution description

Same pattern as in 374d032b821290074bae76a78b2bd1c896527d1a, we have a proper function for this now.


### Testing procedure

Binaries should not change, if this was not optimized away previously they might even be slightly smaller.



### Issues/PRs references

follow-up on #15583
