### PR TITLE
sys/ztimer: increase xtimer_compat coverage

### DIFF
--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -41,9 +41,17 @@ extern "C" {
  */
 #ifndef DOXYGEN
 
+#define XTIMER_WIDTH    (32)
+#define XTIMER_MASK     (0)
+
 typedef ztimer_t xtimer_t;
 typedef uint32_t xtimer_ticks32_t;
 typedef uint64_t xtimer_ticks64_t;
+
+static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks)
+{
+    return ticks;
+}
 
 static inline xtimer_ticks32_t xtimer_now(void)
 {
@@ -170,20 +178,35 @@ static inline int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us)
     return 0;
 }
 
+static inline void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+{
+    ztimer_set_timeout_flag(ZTIMER_USEC, t, timeout);
+}
+
+static inline void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
+{
+    xtimer_set_timeout_flag(t, timeout);
+}
+
+static inline void xtimer_spin(xtimer_ticks32_t ticks)
+{
+    assert(ticks < US_PER_MS);
+    ztimer_now_t start = ztimer_now(ZTIMER_USEC);
+    while (ztimer_now(ZTIMER_USEC) - start < ticks) {
+        /* busy waiting */
+    }
+}
+
 /*
    static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
    static inline void xtimer_tsleep32(xtimer_ticks32_t ticks);
    static inline void xtimer_tsleep64(xtimer_ticks64_t ticks);
-   static inline void xtimer_spin(xtimer_ticks32_t ticks);
-   static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup,
-                                          uint32_t period);
    static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
                                        kernel_pid_t pid);
    static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec);
    static inline xtimer_ticks64_t xtimer_ticks_from_usec64(uint64_t usec);
    static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks);
    static inline uint64_t xtimer_usec_from_ticks64(xtimer_ticks64_t ticks);
-   static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks);
    static inline xtimer_ticks64_t xtimer_ticks64(uint64_t ticks);
    static inline xtimer_ticks32_t xtimer_diff(xtimer_ticks32_t a,
                                            xtimer_ticks32_t b);
@@ -193,7 +216,6 @@ static inline int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us)
                                                 xtimer_ticks64_t b);
    static inline bool xtimer_less(xtimer_ticks32_t a, xtimer_ticks32_t b);
    static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
-   void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 
  #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
    static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,


### PR DESCRIPTION
### Contribution description

- add some xtimer specific defines some tests rely on
- provide the following missing functions:
    - `xtimer_ticks()`
    - `xtimer_set_timeout_flag()`
    - `xtimer_set_timeout_flag64()`
    - `xtimer_spin()`

### Testing procedure

- `USEMODULE=ztimer_xtimer_compat make flash text -C tests/thread_flags`
- `USEMODULE=ztimer_xtimer_compat make flash text -C tests/xtimer_now_irq`

Should now compile and pass, but fail to compile with `master`.

### Issues/PRs references

None