### PR TITLE
sys/net/gnrc/netif/ethernet: Support RX timestamp

### DIFF
--- a/drivers/include/net/netdev/eth.h
+++ b/drivers/include/net/netdev/eth.h
@@ -30,6 +30,25 @@ extern "C" {
 #endif
 
 /**
+ * @name    Flags for use in @ref netdev_eth_rx_info_t::flags
+ * @{
+ */
+#define NETDEV_ETH_RX_INFO_FLAG_TIMESTAMP       (0x01)  /**< Timestamp valid */
+/** @} */
+
+/**
+ * @brief   Received frame status information for Ethernet devices
+ */
+typedef struct {
+    /**
+     * @brief   Time of the reception of the start of frame delimiter in
+     *          nanoseconds since epoch
+     */
+    uint64_t timestamp;
+    uint8_t flags;      /**< Flags e.g. used to mark other fields as valid */
+} netdev_eth_rx_info_t;
+
+/**
  * @brief   Fallback function for netdev ethernet devices' _get function
  *
  * Supposed to be used by netdev drivers as default case.


### PR DESCRIPTION
### Contribution description

This PR extends gnrc_netif to provide the infrastructure needed to pass an RX timestamp (e.g. for PTP) from the network driver through GNRC up to the SOCK API.

### Testing procedure

https://github.com/RIOT-OS/RIOT/pull/15610 provides a driver integration on top of this and a trivial test application. With those, this PR can be tested.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/15610 is a follow up that can be used to test this.