### PR TITLE
drivers/stm32_eth: add RX timestamps

### DIFF
--- a/boards/nucleo-f767zi/Kconfig
+++ b/boards/nucleo-f767zi/Kconfig
@@ -28,6 +28,7 @@ config BOARD_NUCLEO_F767ZI
     select HAS_PERIPH_PTP
     select HAS_PERIPH_PTP_SPEED_ADJUSTMENT
     select HAS_PERIPH_PTP_TIMER
+    select HAS_PERIPH_PTP_TXRX_TIMESTAMPS
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -9,6 +9,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_ptp
 FEATURES_PROVIDED += periph_ptp_speed_adjustment
 FEATURES_PROVIDED += periph_ptp_timer
+FEATURES_PROVIDED += periph_ptp_txrx_timestamps
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -220,6 +220,12 @@ config HAS_PERIPH_PTP_TIMER
     help
         Indicates that the PTP clock can be used as timer.
 
+config HAS_PERIPH_PTP_TXRX_TIMESTAMPS
+    bool
+    help
+        Indicates that the PTP clock can provide exact time stamps of the
+        reception and transmission of frames.
+
 config HAS_PERIPH_PWM
     bool
     help


### PR DESCRIPTION
### Contribution description

Extends the STM32 Ethernet driver to pass through reception timestamps recorded by the Ethernet chip from the PTP clock. Those timestamps are taken without directly in hardware, so that they remain highly accurate and low jitter even when the CPU is under load.


### Testing procedure

A test application is provided that extends the basic UDP echo server example by printing RX and TX timestamps. (As TX timestamps are not yet recorded due to the missing netdev API, the application will always complain about missing TX timestamps. But RX timestamps should be reliably provided for every incoming frame.)

Steps for testing:

0. Rebase this PR on top of https://github.com/RIOT-OS/RIOT/pull/15760
1. `make BOARD=nucleo-f767zi flash term -C tests/sock_udp_aux`
2. Type `ifconfig` into the shell to get the Nucleo's IPv6 address
3. Send an UDP datagram to that address at port `12345` via Ethernet
4. The Nucleo should print the reception time stamp and echo the frame. It is expected that the test will complain about missing TX timestamps (not yet implemented).

### Issues/PRs references

- [x] Depends on and includes: https://github.com/RIOT-OS/RIOT/pull/15609
- [x] Depends on: https://github.com/RIOT-OS/RIOT/pull/15760