### PR TITLE
net/eui_provider: API cleanup

### DIFF
--- a/boards/avr-rss2/include/board.h
+++ b/boards/avr-rss2/include/board.h
@@ -23,9 +23,6 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 
-#include "at24mac.h"
-#include "net/eui_provider.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,26 +33,6 @@ extern "C" {
  */
 #define AT24MAC_PARAM_I2C_DEV   I2C_DEV(0)
 #define AT24MAC_PARAM_TYPE      AT24MAC6XX
-/** @} */
-
-/**
- * @brief    AT24Mac provides a EUI-64, this is also printed on the board
- */
-static inline int _at24mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
-{
-    (void) index;
-
-    return at24mac_get_eui64((uintptr_t)arg, addr);
-}
-
-/**
- * @name    EUI-64 sources on the board
- *          AT24Mac is present on the board
- * @{
- */
-#define EUI64_PROVIDER_FUNC   _at24mac_get_eui64
-#define EUI64_PROVIDER_TYPE   NETDEV_AT86RF2XX
-#define EUI64_PROVIDER_INDEX  0
 /** @} */
 
 /**

--- a/boards/avr-rss2/include/board.h
+++ b/boards/avr-rss2/include/board.h
@@ -41,8 +41,10 @@ extern "C" {
 /**
  * @brief    AT24Mac provides a EUI-64, this is also printed on the board
  */
-static inline int _at24mac_get_eui64(const void *arg, eui64_t *addr)
+static inline int _at24mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
 {
+    (void) index;
+
     return at24mac_get_eui64((uintptr_t)arg, addr);
 }
 

--- a/boards/avr-rss2/include/eui_provider_params.h
+++ b/boards/avr-rss2/include/eui_provider_params.h
@@ -27,10 +27,8 @@ extern "C" {
 /**
  * @brief    AT24Mac provides a EUI-64, this is also printed on the board
  */
-static inline int _at24mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
+static inline int _at24mac_get_eui64(uint8_t index, eui64_t *addr)
 {
-    (void) arg;
-
     return at24mac_get_eui64(index, addr);
 }
 

--- a/boards/avr-rss2/include/eui_provider_params.h
+++ b/boards/avr-rss2/include/eui_provider_params.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_avr-rss2
+ * @{
+ *
+ * @file
+ * @brief       EUI providers found on the board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef EUI_PROVIDER_PARAMS_H
+#define EUI_PROVIDER_PARAMS_H
+
+#include "at24mac.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    AT24Mac provides a EUI-64, this is also printed on the board
+ */
+static inline int _at24mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
+{
+    (void) arg;
+
+    return at24mac_get_eui64(index, addr);
+}
+
+/**
+ * @name    EUI-64 sources on the board
+ *          AT24Mac is present on the board
+ * @{
+ */
+#define EUI64_PROVIDER_FUNC   _at24mac_get_eui64
+#define EUI64_PROVIDER_TYPE   NETDEV_AT86RF2XX
+#define EUI64_PROVIDER_INDEX  0
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EUI_PROVIDER_PARAMS_H */
+/** @} */

--- a/boards/derfmega256/include/board.h
+++ b/boards/derfmega256/include/board.h
@@ -37,9 +37,10 @@ extern "C" {
 /**
  * @brief    Constant in EEPROM provides a EUI-64, this is also printed on the board
  */
-static inline int _eeprom_mac_get_eui64(const void *arg, eui64_t *addr)
+static inline int _eeprom_mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
 {
     (void) arg;
+    (void) index;
 
     if (eeprom_read(EEPROM_MAC_ADDR, addr, sizeof(eui64_t)) != sizeof(eui64_t)) {
         return -1;

--- a/boards/derfmega256/include/board.h
+++ b/boards/derfmega256/include/board.h
@@ -21,44 +21,9 @@
 
 #include "cpu.h"
 
-#include "periph/eeprom.h"
-#include "net/eui_provider.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    MAC configuration
- *          Offset of the MAC address in the EEPROM
- */
-#define EEPROM_MAC_ADDR (0x1fe4)
-
-/**
- * @brief    Constant in EEPROM provides a EUI-64, this is also printed on the board
- */
-static inline int _eeprom_mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
-{
-    (void) arg;
-    (void) index;
-
-    if (eeprom_read(EEPROM_MAC_ADDR, addr, sizeof(eui64_t)) != sizeof(eui64_t)) {
-        return -1;
-    }
-
-    addr->uint64.u64 = byteorder_htonll(addr->uint64.u64).u64;
-
-    return 0;
-}
-
-/**
- * @name    EUI-64 sources on the board
- * @{
- */
-#define EUI64_PROVIDER_FUNC   _eeprom_mac_get_eui64
-#define EUI64_PROVIDER_TYPE   NETDEV_AT86RF2XX
-#define EUI64_PROVIDER_INDEX  0
-/** @} */
 
 /**
  * @name xtimer configuration values

--- a/boards/derfmega256/include/eui_provider_params.h
+++ b/boards/derfmega256/include/eui_provider_params.h
@@ -34,9 +34,8 @@ extern "C" {
 /**
  * @brief    Constant in EEPROM provides a EUI-64, this is also printed on the board
  */
-static inline int _eeprom_mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
+static inline int _eeprom_mac_get_eui64(uint8_t index, eui64_t *addr)
 {
-    (void) arg;
     (void) index;
 
     if (eeprom_read(EEPROM_MAC_ADDR, addr, sizeof(eui64_t)) != sizeof(eui64_t)) {

--- a/boards/derfmega256/include/eui_provider_params.h
+++ b/boards/derfmega256/include/eui_provider_params.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_deRFmega256
+ * @{
+ *
+ * @file
+ * @brief       EUI providers found on the board
+ *
+ * @author      Alexander Chudov <chudov@gmail.com>
+ */
+#ifndef EUI_PROVIDER_PARAMS_H
+#define EUI_PROVIDER_PARAMS_H
+
+#include "net/eui64.h"
+#include "periph/eeprom.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    MAC configuration
+ *          Offset of the MAC address in the EEPROM
+ */
+#define EEPROM_MAC_ADDR (0x1fe4)
+
+/**
+ * @brief    Constant in EEPROM provides a EUI-64, this is also printed on the board
+ */
+static inline int _eeprom_mac_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
+{
+    (void) arg;
+    (void) index;
+
+    if (eeprom_read(EEPROM_MAC_ADDR, addr, sizeof(eui64_t)) != sizeof(eui64_t)) {
+        return -1;
+    }
+
+    addr->uint64.u64 = byteorder_htonll(addr->uint64.u64).u64;
+
+    return 0;
+}
+
+/**
+ * @name    EUI-64 sources on the board
+ * @{
+ */
+#define EUI64_PROVIDER_FUNC   _eeprom_mac_get_eui64
+#define EUI64_PROVIDER_TYPE   NETDEV_AT86RF2XX
+#define EUI64_PROVIDER_INDEX  0
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EUI_PROVIDER_PARAMS_H */
+/** @} */

--- a/boards/derfmega256/include/eui_provider_params.h
+++ b/boards/derfmega256/include/eui_provider_params.h
@@ -36,7 +36,7 @@ extern "C" {
  */
 static inline int _eeprom_mac_get_eui64(uint8_t index, eui64_t *addr)
 {
-    (void) index;
+    (void)index;
 
     if (eeprom_read(EEPROM_MAC_ADDR, addr, sizeof(eui64_t)) != sizeof(eui64_t)) {
         return -1;

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -48,8 +48,10 @@ extern "C" {
 /**
  * @brief    AT24Mac provides a EUI-48
  */
-static inline int _at24mac_get_eui48(const void *arg, eui48_t *addr)
+static inline int _at24mac_get_eui48(const void *arg, eui48_t *addr, uint8_t index)
 {
+    (void) index;
+
     return at24mac_get_eui48((uintptr_t)arg, addr);
 }
 

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -21,7 +21,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "at24mac.h"
 #include "mtd.h"
 
 #ifdef __cplusplus
@@ -43,24 +42,6 @@ extern "C" {
  * @{
  */
 #define ATCA_PARAM_I2C           I2C_DEV(1)
-/** @} */
-
-/**
- * @brief    AT24Mac provides a EUI-48
- */
-static inline int _at24mac_get_eui48(const void *arg, eui48_t *addr, uint8_t index)
-{
-    (void) index;
-
-    return at24mac_get_eui48((uintptr_t)arg, addr);
-}
-
-/**
- * @name    EUI-48 sources on the board
- *          AT24Mac is present on the board
- * @{
- */
-#define EUI48_PROVIDER_FUNC   _at24mac_get_eui48
 /** @} */
 
 /**

--- a/boards/same54-xpro/include/eui_provider_params.h
+++ b/boards/same54-xpro/include/eui_provider_params.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_same54-xpro
+ * @{
+ *
+ * @file
+ * @brief       EUI providers found on the board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef EUI_PROVIDER_PARAMS_H
+#define EUI_PROVIDER_PARAMS_H
+
+#include "at24mac.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    AT24Mac provides a EUI-48
+ */
+static inline int _at24mac_get_eui48(const void *arg, eui48_t *addr, uint8_t index)
+{
+    (void) arg;
+
+    return at24mac_get_eui48(index, addr);
+}
+
+/**
+ * @name    EUI-48 sources on the board
+ *          AT24Mac is present on the board
+ * @{
+ */
+#define EUI48_PROVIDER_FUNC   _at24mac_get_eui48
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EUI_PROVIDER_PARAMS_H */
+/** @} */

--- a/boards/same54-xpro/include/eui_provider_params.h
+++ b/boards/same54-xpro/include/eui_provider_params.h
@@ -27,10 +27,8 @@ extern "C" {
 /**
  * @brief    AT24Mac provides a EUI-48
  */
-static inline int _at24mac_get_eui48(const void *arg, eui48_t *addr, uint8_t index)
+static inline int _at24mac_get_eui48(uint8_t index, eui48_t *addr)
 {
-    (void) arg;
-
     return at24mac_get_eui48(index, addr);
 }
 

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -25,8 +25,6 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
-#include "edbg_eui.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,31 +56,6 @@ extern "C" {
 #define AT86RF2XX_PARAM_INT        GPIO_PIN(PB, 0)
 #define AT86RF2XX_PARAM_SLEEP      GPIO_PIN(PA, 20)
 #define AT86RF2XX_PARAM_RESET      GPIO_PIN(PB, 15)
-
-/**
- * @brief    EDBG provides a EUI-64, the same that is printed on the board
- */
-static inline int _edbg_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
-{
-    (void) arg;
-    (void) index;
-
-    /* EDBG can take a while to respond on cold boot */
-    unsigned tries = 10000;
-    while (--tries && edbg_get_eui64(addr)) {}
-    return tries ? 0 : -1;
-}
-
-/**
- * @name    EUI sources on the board
- *          EUI-64 inside EDBG for the internal radio
- * @{
- */
-#define EUI64_PROVIDER_FUNC   _edbg_get_eui64
-#define EUI64_PROVIDER_TYPE   NETDEV_AT86RF2XX
-#define EUI64_PROVIDER_INDEX  0
-/** @} */
-
 
 /**
  * @name    LED pin definitions and handlers

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -62,9 +62,10 @@ extern "C" {
 /**
  * @brief    EDBG provides a EUI-64, the same that is printed on the board
  */
-static inline int _edbg_get_eui64(const void *arg, eui64_t *addr)
+static inline int _edbg_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
 {
     (void) arg;
+    (void) index;
 
     /* EDBG can take a while to respond on cold boot */
     unsigned tries = 10000;

--- a/boards/samr21-xpro/include/eui_provider_params.h
+++ b/boards/samr21-xpro/include/eui_provider_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samr21-xpro
+ * @{
+ *
+ * @file
+ * @brief       EUI providers found on the board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef EUI_PROVIDER_PARAMS_H
+#define EUI_PROVIDER_PARAMS_H
+
+#include "edbg_eui.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    EDBG provides a EUI-64, the same that is printed on the board
+ */
+static inline int _edbg_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
+{
+    (void) arg;
+    (void) index;
+
+    /* EDBG can take a while to respond on cold boot */
+    unsigned tries = 10000;
+    while (--tries && edbg_get_eui64(addr)) {}
+    return tries ? 0 : -1;
+}
+
+/**
+ * @name    EUI sources on the board
+ *          EUI-64 inside EDBG for the internal radio
+ * @{
+ */
+#define EUI64_PROVIDER_FUNC   _edbg_get_eui64
+#define EUI64_PROVIDER_TYPE   NETDEV_AT86RF2XX
+#define EUI64_PROVIDER_INDEX  0
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EUI_PROVIDER_PARAMS_H */
+/** @} */

--- a/boards/samr21-xpro/include/eui_provider_params.h
+++ b/boards/samr21-xpro/include/eui_provider_params.h
@@ -27,9 +27,8 @@ extern "C" {
 /**
  * @brief    EDBG provides a EUI-64, the same that is printed on the board
  */
-static inline int _edbg_get_eui64(const void *arg, eui64_t *addr, uint8_t index)
+static inline int _edbg_get_eui64(uint8_t index, eui64_t *addr)
 {
-    (void) arg;
     (void) index;
 
     /* EDBG can take a while to respond on cold boot */

--- a/boards/samr21-xpro/include/eui_provider_params.h
+++ b/boards/samr21-xpro/include/eui_provider_params.h
@@ -29,7 +29,7 @@ extern "C" {
  */
 static inline int _edbg_get_eui64(uint8_t index, eui64_t *addr)
 {
-    (void) index;
+    (void)index;
 
     /* EDBG can take a while to respond on cold boot */
     unsigned tries = 10000;

--- a/cpu/cc2538/include/cc2538_eui_primary.h
+++ b/cpu/cc2538/include/cc2538_eui_primary.h
@@ -33,12 +33,14 @@ extern "C" {
  *
  * @param arg       unused
  * @param[out] addr The EUI-64
+ * @param index     unused
  *
  * @return  0
  */
-static inline int cc2538_get_eui64_primary(const void *arg, eui64_t *addr)
+static inline int cc2538_get_eui64_primary(const void *arg, eui64_t *addr, uint8_t index)
 {
     (void) arg;
+    (void) index;
 
     /*
      * The primary EUI-64 seems to be written to memory in a non-sequential

--- a/cpu/cc2538/include/cc2538_eui_primary.h
+++ b/cpu/cc2538/include/cc2538_eui_primary.h
@@ -39,8 +39,8 @@ extern "C" {
  */
 static inline int cc2538_get_eui64_primary(const void *arg, eui64_t *addr, uint8_t index)
 {
-    (void) arg;
-    (void) index;
+    (void)arg;
+    (void)index;
 
     /*
      * The primary EUI-64 seems to be written to memory in a non-sequential

--- a/sys/include/net/eui_provider.h
+++ b/sys/include/net/eui_provider.h
@@ -108,24 +108,26 @@ extern "C" {
  *
  * @param[in]   arg     Optional argument provided by eui48_conf_t
  * @param[out]  addr    Destination pointer for the EUI-48 address
+ * @param[in]   index   index of the netdev
  *
  * @return      0 on success, next provider in eui48_conf_t will be
  *              used otherwise.
  *              Will fall back to @see luid_get_eui48 eventually.
  */
-typedef int (*netdev_get_eui48_cb_t)(const void *arg, eui48_t *addr);
+typedef int (*netdev_get_eui48_cb_t)(const void *arg, eui48_t *addr, uint8_t index);
 
 /**
  * @brief   Function for providing a EUI-64 to a device
  *
  * @param[in]   arg     Optional argument provided by eui64_conf_t
  * @param[out]  addr    Destination pointer for the EUI-64 address
+ * @param[in]   index   index of the netdev
  *
  * @return      0 on success, next provider in eui64_conf_t will be
  *              used otherwise.
  *              Will fall back to @see luid_get_eui64 eventually.
  */
-typedef int (*netdev_get_eui64_cb_t)(const void *arg, eui64_t *addr);
+typedef int (*netdev_get_eui64_cb_t)(const void *arg, eui64_t *addr, uint8_t index);
 
 /**
  * @brief Structure to hold providers for EUI-48 addresses

--- a/sys/include/net/eui_provider.h
+++ b/sys/include/net/eui_provider.h
@@ -106,35 +106,32 @@ extern "C" {
 /**
  * @brief   Function for providing a EUI-48 to a device
  *
- * @param[in]   arg     Optional argument provided by eui48_conf_t
- * @param[out]  addr    Destination pointer for the EUI-48 address
  * @param[in]   index   index of the netdev
+ * @param[out]  addr    Destination pointer for the EUI-48 address
  *
  * @return      0 on success, next provider in eui48_conf_t will be
  *              used otherwise.
  *              Will fall back to @see luid_get_eui48 eventually.
  */
-typedef int (*netdev_get_eui48_cb_t)(const void *arg, eui48_t *addr, uint8_t index);
+typedef int (*netdev_get_eui48_cb_t)(uint8_t index, eui48_t *addr);
 
 /**
  * @brief   Function for providing a EUI-64 to a device
  *
- * @param[in]   arg     Optional argument provided by eui64_conf_t
- * @param[out]  addr    Destination pointer for the EUI-64 address
  * @param[in]   index   index of the netdev
+ * @param[out]  addr    Destination pointer for the EUI-64 address
  *
  * @return      0 on success, next provider in eui64_conf_t will be
  *              used otherwise.
  *              Will fall back to @see luid_get_eui64 eventually.
  */
-typedef int (*netdev_get_eui64_cb_t)(const void *arg, eui64_t *addr, uint8_t index);
+typedef int (*netdev_get_eui64_cb_t)(uint8_t index, eui64_t *addr);
 
 /**
  * @brief Structure to hold providers for EUI-48 addresses
  */
 typedef struct {
     netdev_get_eui48_cb_t provider; /**< function to provide an EUI-48                  */
-    const void *arg;                /**< argument to the provider function              */
     netdev_type_t type;             /**< device type to match or `NETDEV_ANY`           */
     uint8_t index;                  /**< device index to match or `NETDEV_INDEX_ANY`    */
 } eui48_conf_t;
@@ -144,7 +141,6 @@ typedef struct {
  */
 typedef struct {
     netdev_get_eui64_cb_t provider; /**< function to provide an EUI-64                  */
-    const void *arg;                /**< argument to the provider function              */
     netdev_type_t type;             /**< device type to match or `NETDEV_ANY`           */
     uint8_t index;                  /**< device index to match or `NETDEV_INDEX_ANY`    */
 } eui64_conf_t;

--- a/sys/net/link_layer/eui_provider/eui_provider.c
+++ b/sys/net/link_layer/eui_provider/eui_provider.c
@@ -35,7 +35,7 @@ void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
 #else
         (void) netdev;
 #endif
-        if (eui48_conf[i].provider(eui48_conf[i].arg, addr, i) == 0) {
+        if (eui48_conf[i].provider(i, addr) == 0) {
             return;
         }
     }
@@ -60,7 +60,7 @@ void netdev_eui64_get(netdev_t *netdev, eui64_t *addr)
 #else
         (void) netdev;
 #endif
-        if (eui64_conf[i].provider(eui64_conf[i].arg, addr, i) == 0) {
+        if (eui64_conf[i].provider(i, addr) == 0) {
             return;
         }
     }

--- a/sys/net/link_layer/eui_provider/eui_provider.c
+++ b/sys/net/link_layer/eui_provider/eui_provider.c
@@ -35,7 +35,7 @@ void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
 #else
         (void) netdev;
 #endif
-        if (eui48_conf[i].provider(eui48_conf[i].arg, addr) == 0) {
+        if (eui48_conf[i].provider(eui48_conf[i].arg, addr, i) == 0) {
             return;
         }
     }
@@ -60,7 +60,7 @@ void netdev_eui64_get(netdev_t *netdev, eui64_t *addr)
 #else
         (void) netdev;
 #endif
-        if (eui64_conf[i].provider(eui64_conf[i].arg, addr) == 0) {
+        if (eui64_conf[i].provider(eui64_conf[i].arg, addr, i) == 0) {
             return;
         }
     }

--- a/sys/net/link_layer/eui_provider/include/eui48_provider_params.h
+++ b/sys/net/link_layer/eui_provider/include/eui48_provider_params.h
@@ -41,13 +41,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Optional function argument to `netdev_get_eui48_cb_t`
- */
-#ifndef EUI48_PROVIDER_ARG
-#define EUI48_PROVIDER_ARG    NULL
-#endif
-
-/**
  * @brief Driver type to match with EUI-48 provider
  */
 #ifndef EUI48_PROVIDER_TYPE
@@ -68,7 +61,6 @@ extern "C" {
 #ifndef EUI48_PROVIDER_PARAMS
 #define EUI48_PROVIDER_PARAMS     {                                \
                                  .provider = EUI48_PROVIDER_FUNC,  \
-                                 .arg      = EUI48_PROVIDER_ARG,   \
                                  .type     = EUI48_PROVIDER_TYPE,  \
                                  .index    = EUI48_PROVIDER_INDEX, \
                                 },

--- a/sys/net/link_layer/eui_provider/include/eui48_provider_params.h
+++ b/sys/net/link_layer/eui_provider/include/eui48_provider_params.h
@@ -17,7 +17,9 @@
 #ifndef EUI48_PROVIDER_PARAMS_H
 #define EUI48_PROVIDER_PARAMS_H
 
-#include "board.h"
+#if __has_include("eui_provider_params.h")
+#include "eui_provider_params.h"
+#endif
 #include "net/eui_provider.h"
 
 #ifdef __cplusplus

--- a/sys/net/link_layer/eui_provider/include/eui64_provider_params.h
+++ b/sys/net/link_layer/eui_provider/include/eui64_provider_params.h
@@ -17,7 +17,9 @@
 #ifndef EUI64_PROVIDER_PARAMS_H
 #define EUI64_PROVIDER_PARAMS_H
 
-#include "board.h"
+#if __has_include("eui_provider_params.h")
+#include "eui_provider_params.h"
+#endif
 #include "net/eui_provider.h"
 
 #ifdef __cplusplus

--- a/sys/net/link_layer/eui_provider/include/eui64_provider_params.h
+++ b/sys/net/link_layer/eui_provider/include/eui64_provider_params.h
@@ -41,13 +41,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Optional function argument to `netdev_get_eui64_cb_t`
- */
-#ifndef EUI64_PROVIDER_ARG
-#define EUI64_PROVIDER_ARG    NULL
-#endif
-
-/**
  * @brief Driver type to match with EUI-64 provider
  */
 #ifndef EUI64_PROVIDER_TYPE
@@ -68,7 +61,6 @@ extern "C" {
 #ifndef EUI64_PROVIDER_PARAMS
 #define EUI64_PROVIDER_PARAMS     {                                \
                                  .provider = EUI64_PROVIDER_FUNC,  \
-                                 .arg      = EUI64_PROVIDER_ARG,   \
                                  .type     = EUI64_PROVIDER_TYPE,  \
                                  .index    = EUI64_PROVIDER_INDEX, \
                                 },


### PR DESCRIPTION
### Contribution description

 - move the board EUI provider definitions to `eui_provider_params.h`. This is done to avoid namespace collisions on `native`.
 - add an `index` parameter to the EUI provider function so it can handle multiple devices of the same type
 - drop the useless `arg` parameter. This was added in an attempt to future-proof the API, but it was never needed and `index` is much better replacement.

### Testing procedure

MAC addresses should not change.

#### samr21-xpro

```
2020-12-10 22:49:11,973 # Iface  6  HWaddr: 49:05  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-12-10 22:49:11,974 #           
2020-12-10 22:49:11,978 #           Long HWaddr: 00:04:25:19:18:01:C9:05 
2020-12-10 22:49:11,985 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-12-10 22:49:11,992 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-12-10 22:49:11,994 #           6LO  IPHC  
2020-12-10 22:49:11,997 #           Source address length: 8
2020-12-10 22:49:12,000 #           Link type: wireless
2020-12-10 22:49:12,006 #           inet6 addr: fe80::204:2519:1801:c905  scope: link  VAL
2020-12-10 22:49:12,009 #           inet6 group: ff02::2
2020-12-10 22:49:12,011 #           inet6 group: ff02::1
2020-12-10 22:49:12,015 #           inet6 group: ff02::1:ff01:c905
```

#### avr-rss2

```
2020-12-10 22:51:49,140 # Iface  7  HWaddr: 0B:B1  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-12-10 22:51:49,140 #           
2020-12-10 22:51:49,145 #           Long HWaddr: FC:C2:3D:00:00:00:0B:B1 
2020-12-10 22:51:49,151 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-12-10 22:51:49,159 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-12-10 22:51:49,162 #           6LO  IPHC  
2020-12-10 22:51:49,165 #           Source address length: 8
2020-12-10 22:51:49,168 #           Link type: wireless
2020-12-10 22:51:49,173 #           inet6 addr: fe80::fec2:3d00:0:bb1  scope: link  VAL
2020-12-10 22:51:49,176 #           inet6 group: ff02::2
2020-12-10 22:51:49,179 #           inet6 group: ff02::1
2020-12-10 22:51:49,182 #           inet6 group: ff02::1:ff00:bb1
```

### Issues/PRs references

needed for  #15562
