### PR TITLE
pkg/openwsn/sock: fix doxygen group doc

### DIFF
--- a/pkg/openwsn/sock/sock_types.h
+++ b/pkg/openwsn/sock/sock_types.h
@@ -7,7 +7,10 @@
  */
 
 /**
- * @addtogroup pkg_openwsn_sock
+ * @defgroup pkg_openwsn_sock OpenWSN-specific implementation of the sock API
+ * @ingroup  pkg_openwsn
+ * @brief    Provides an implementation of the @ref net_sock by the
+ *           @ref pkg_openwsn
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Only noticed, that the documentation group for `openwsn_sock` [is broken](https://5975-7370241-gh.circle-artifacts.com/0/doc/group__pkg__openwsn__sock.html) after I hit the merge button. This fixes the group definition of that module.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Circle CI should now show a nicely formatted group under `OpenWSN network stack`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/15536
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
