### PR TITLE
sys/inet/ieee802154/radio: fix wrong rssi conversions treewide

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -185,10 +185,15 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t size, ieee802154_rx_in
 
             /* The number of dB above maximum sensitivity detected for the
              * received packet */
-            info->rssi = -CC2538_RSSI_OFFSET + rssi_val + IEEE802154_RADIO_RSSI_OFFSET;
+            /* Make sure there is no overflow even if no signal with such
+               low sensitivity should be detected */
+            const int hw_rssi_min = IEEE802154_RADIO_RSSI_OFFSET -
+                                    CC2538_RSSI_OFFSET;
+            int8_t hw_rssi = rssi_val > hw_rssi_min ?
+                (CC2538_RSSI_OFFSET + rssi_val) : IEEE802154_RADIO_RSSI_OFFSET;
+            info->rssi = hw_rssi - IEEE802154_RADIO_RSSI_OFFSET;
 
             corr_val = rfcore_read_byte() & CC2538_CORR_VAL_MASK;
-
             if (corr_val < CC2538_CORR_VAL_MIN) {
                 corr_val = CC2538_CORR_VAL_MIN;
             }

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -230,11 +230,10 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t max_size,
             radio_info->lqi = (uint8_t)(hwlqi > UINT8_MAX/ED_RSSISCALE
                                        ? UINT8_MAX
                                        : hwlqi * ED_RSSISCALE);
-            /* Calculate RSSI by subtracting the offset from the datasheet.
-             * Intentionally using a different calculation than the one from
-             * figure 122 of the v1.1 product specification. This appears to
-             * match real world performance better */
-            radio_info->rssi = _hwval_to_ieee802154_dbm(hwlqi) + IEEE802154_RADIO_RSSI_OFFSET;
+            /* We calculate RSSI from LQI, since it's already 8-bit
+               saturated (see page 321 of product spec v1.1) */
+            radio_info->rssi = _hwval_to_ieee802154_dbm(radio_info->lqi)
+                               + IEEE802154_RADIO_RSSI_OFFSET;
         }
         memcpy(buf, &rxbuf[1], pktlen);
     }

--- a/pkg/openwsn/contrib/radio_hal.c
+++ b/pkg/openwsn/contrib/radio_hal.c
@@ -310,7 +310,7 @@ void radio_getReceivedFrame(uint8_t *bufRead,
        OpenWSN includes IEEE802154_FCS_LEN in its length value */
     *lenRead = size + IEEE802154_FCS_LEN;
     /* get rssi, lqi & crc */
-    *rssi = rx_info.rssi;
+    *rssi = ieee802154_rssi_to_dbm(rx_info.rssi);
     *lqi = rx_info.lqi;
     /* only valid crc frames are currently accepted */
     *crc = 1;


### PR DESCRIPTION
### Contribution description

I'm under the impression that the rssi conversion is wrongly done in many places involved with the `radio_hal`. The api says:

```
    /**
     * @brief RSSI of the received frame.
     *
     * The RSSI is a measure of the RF power in dBm for the received frame.
     * The minimum and maximum values are 0 (-174 dBm) and 254 (80 dBm).
     */
    uint8_t rssi;
``` 

But in practice what was being done for cc2538 was a wrong compensation (with some weird double negations) which led to a -28db penalty in the reported value.

A similar case happend for `nrf52840`.

Then all users of this reported value where using the value as `dB` and not adjusting by the offset.

I came across this issue when comparing Vanilla OpenWSN and RIOT OpenWSN side by side and realizing there was an unexplained penalty in the reported RSSI.

I went back in history to look at when these changes where made specially for `cc2538`, I honestly got quite confused with the whole discussion so maybe I'm wrong about the values?

### Testing procedure

- Look at the code

- ` tests/ieee802154_hal` should print correct rssi.

### Related Issues

Related to  #14672
Related to #14791
Related to #14791