### PR TITLE
mtd_spi_nor: Use SFDP for SPI NOR flash parameter autodiscovery

### DIFF
--- a/boards/common/weact-f4x1cx/board.c
+++ b/boards/common/weact-f4x1cx/board.c
@@ -29,18 +29,12 @@
 /* AT25SF041 */
 static const mtd_spi_nor_params_t _weact_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
-    .wait_chip_erase   = 4800LU * US_PER_MS,
-    .wait_32k_erase    = 300LU * US_PER_MS,
-    .wait_sector_erase = 70LU * US_PER_MS,
-    .wait_chip_wake_up = 1LU * US_PER_MS,
     .clk  = WEACT_4X1CX_NOR_SPI_CLK,
-    .flag = WEACT_4X1CX_NOR_FLAGS,
     .spi  = WEACT_4X1CX_NOR_SPI_DEV,
     .mode = WEACT_4X1CX_NOR_SPI_MODE,
     .cs   = WEACT_4X1CX_NOR_SPI_CS,
     .wp   = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t weact_nor_dev = {

--- a/boards/common/weact-f4x1cx/include/board.h
+++ b/boards/common/weact-f4x1cx/include/board.h
@@ -64,13 +64,12 @@ extern "C" {
  *       You have to solder a serial flash yourself and adjust the parameters.
  * @{
  */
-#define WEACT_4X1CX_NOR_PAGE_SIZE          (256)
-#define WEACT_4X1CX_NOR_PAGES_PER_SECTOR   (16)
-#define WEACT_4X1CX_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
-#define WEACT_4X1CX_NOR_SPI_DEV            SPI_DEV(0)
-#define WEACT_4X1CX_NOR_SPI_CLK            SPI_CLK_10MHZ
-#define WEACT_4X1CX_NOR_SPI_CS             GPIO_PIN(PORT_A, 4)
-#define WEACT_4X1CX_NOR_SPI_MODE           SPI_MODE_0
+#define WEACT_4X1CX_NOR_PAGE_SIZE           (256)
+#define WEACT_4X1CX_NOR_PAGES_PER_SECTOR    (16)
+#define WEACT_4X1CX_NOR_SPI_DEV             SPI_DEV(0)
+#define WEACT_4X1CX_NOR_SPI_CLK             SPI_CLK_10MHZ
+#define WEACT_4X1CX_NOR_SPI_CS              GPIO_PIN(PORT_A, 4)
+#define WEACT_4X1CX_NOR_SPI_MODE            SPI_MODE_0
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -27,18 +27,12 @@
 #ifdef MODULE_MTD
 static const mtd_spi_nor_params_t _ikea_tradfri_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
-    .wait_chip_erase = 2LU * US_PER_SEC,
-    .wait_32k_erase = 500LU *US_PER_MS,
-    .wait_sector_erase = 300LU * US_PER_MS,
-    .wait_chip_wake_up = 1LU * US_PER_MS,
     .clk = IKEA_TRADFRI_NOR_SPI_CLK,
-    .flag = IKEA_TRADFRI_NOR_FLAGS,
     .spi = IKEA_TRADFRI_NOR_SPI_DEV,
     .mode = IKEA_TRADFRI_NOR_SPI_MODE,
     .cs = IKEA_TRADFRI_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t ikea_tradfri_nor_dev = {

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -88,7 +88,6 @@ extern "C" {
 #define IKEA_TRADFRI_NOR_PAGE_SIZE          (256)
 #define IKEA_TRADFRI_NOR_PAGES_PER_SECTOR   (16)
 #define IKEA_TRADFRI_NOR_SECTOR_COUNT       (64)
-#define IKEA_TRADFRI_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
 #define IKEA_TRADFRI_NOR_SPI_DEV            SPI_DEV(0)
 #define IKEA_TRADFRI_NOR_SPI_CLK            SPI_CLK_1MHZ
 #define IKEA_TRADFRI_NOR_SPI_CS             GPIO_PIN(PB, 11)

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -50,12 +50,7 @@ static devfs_t mulle_nvram_devfs = {
 
 static const mtd_spi_nor_params_t mulle_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
-    .wait_chip_erase = 16LU * US_PER_SEC,
-    .wait_sector_erase = 10LU * US_PER_MS,
-    .wait_32k_erase = 20LU * US_PER_MS,
-    .wait_chip_wake_up = 1LU * US_PER_MS,
     .spi = MULLE_NOR_SPI_DEV,
-    .addr_width = 3,
     .mode = SPI_MODE_3,
     .cs = MULLE_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
@@ -71,6 +66,12 @@ static mtd_spi_nor_t mulle_nor_dev = {
         .sector_count = 32,
     },
     .params = &mulle_nor_params,
+    .wait_chip_erase = 16LU * US_PER_SEC,
+    .wait_sector_erase = 10LU * US_PER_MS,
+    .wait_32k_erase = 20LU * US_PER_MS,
+    .wait_chip_wake_up = 1LU * US_PER_MS,
+    .flag = SPI_NOR_F_NO_SFDP,
+    .addr_width = 3,
 };
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&mulle_nor_dev;

--- a/boards/nrf52840dk/mtd.c
+++ b/boards/nrf52840dk/mtd.c
@@ -29,18 +29,12 @@
 
 static const mtd_spi_nor_params_t _nrf52840dk_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
-    .wait_chip_erase = 50LU * US_PER_SEC,
-    .wait_32k_erase = 240LU *US_PER_MS,
-    .wait_sector_erase = 40LU * US_PER_MS,
-    .wait_chip_wake_up = 35LU * US_PER_MS,
     .clk = NRF52840DK_NOR_SPI_CLK,
-    .flag = NRF52840DK_NOR_FLAGS,
     .spi = NRF52840DK_NOR_SPI_DEV,
     .mode = NRF52840DK_NOR_SPI_MODE,
     .cs = NRF52840DK_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t nrf52840dk_nor_dev = {

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -32,18 +32,12 @@
 #ifdef MODULE_MTD
 static const mtd_spi_nor_params_t _pinetime_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
-    .wait_chip_erase = 9LU * US_PER_SEC,
-    .wait_32k_erase = 160LU *US_PER_MS,
-    .wait_sector_erase = 70LU * US_PER_MS,
-    .wait_chip_wake_up = 1LU * US_PER_MS,
     .clk = PINETIME_NOR_SPI_CLK,
-    .flag = PINETIME_NOR_FLAGS,
     .spi = PINETIME_NOR_SPI_DEV,
     .mode = PINETIME_NOR_SPI_MODE,
     .cs = PINETIME_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t pinetime_nor_dev = {

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -85,7 +85,6 @@ extern "C" {
 #define PINETIME_NOR_PAGE_SIZE          (256)
 #define PINETIME_NOR_PAGES_PER_SECTOR   (16)
 #define PINETIME_NOR_SECTOR_COUNT       (2048)
-#define PINETIME_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
 #define PINETIME_NOR_SPI_DEV            SPI_DEV(0)
 #define PINETIME_NOR_SPI_CLK            SPI_CLK_10MHZ
 #define PINETIME_NOR_SPI_CS             GPIO_PIN(0, 5)

--- a/boards/serpente/board.c
+++ b/boards/serpente/board.c
@@ -30,18 +30,12 @@
 /* GD25Q32C */
 static const mtd_spi_nor_params_t _serpente_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
-    .wait_chip_erase = 15LU * US_PER_SEC,
-    .wait_32k_erase = 250LU * US_PER_MS,
-    .wait_sector_erase = 50LU * US_PER_MS,
-    .wait_chip_wake_up = 1LU * US_PER_MS,
     .clk = SERPENTE_NOR_SPI_CLK,
-    .flag = SERPENTE_NOR_FLAGS,
     .spi = SERPENTE_NOR_SPI_DEV,
     .mode = SERPENTE_NOR_SPI_MODE,
     .cs = SERPENTE_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t serpente_nor_dev = {

--- a/boards/serpente/include/board.h
+++ b/boards/serpente/include/board.h
@@ -67,7 +67,6 @@ extern "C" {
 #define SERPENTE_NOR_PAGE_SIZE          (256)
 #define SERPENTE_NOR_PAGES_PER_SECTOR   (16)
 #define SERPENTE_NOR_SECTOR_COUNT       (1024)
-#define SERPENTE_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
 #define SERPENTE_NOR_SPI_DEV            SPI_DEV(0)
 #define SERPENTE_NOR_SPI_CLK            SPI_CLK_10MHZ
 #define SERPENTE_NOR_SPI_CS             GPIO_PIN(PA, 15)

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 
+#include "bitarithm.h"
 #include "periph_conf.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
@@ -97,23 +98,22 @@ typedef struct __attribute__((packed)) {
 #define SPI_NOR_F_SECT_64K  (4)
 
 /**
+ * @brief   Flag to set when the MCU should not attempt autoconfiguration using
+ *          SFDP
+ */
+#define SPI_NOR_F_NO_SFDP   (0x8000)
+
+/**
  * @brief Compile-time parameters for a serial flash device
  */
 typedef struct {
     const mtd_spi_nor_opcode_t *opcode; /**< Opcode table for the device */
-    uint32_t wait_chip_erase;   /**< Full chip erase wait time in µs */
-    uint32_t wait_64k_erase;    /**< 64KB page erase wait time in µs */
-    uint32_t wait_32k_erase;    /**< 32KB page erase wait time in µs */
-    uint32_t wait_sector_erase; /**< 4KB sector erase wait time in µs */
-    uint32_t wait_chip_wake_up; /**< Chip wake up time in µs */
-    spi_clk_t clk;           /**< SPI clock */
-    uint16_t flag;           /**< Config flags */
     spi_t spi;               /**< SPI bus the device is connected to */
+    spi_clk_t clk;           /**< SPI clock */
     spi_mode_t mode;         /**< SPI mode */
     gpio_t cs;               /**< CS pin GPIO handle */
     gpio_t wp;               /**< Write Protect pin GPIO handle */
     gpio_t hold;             /**< HOLD pin GPIO handle */
-    uint8_t addr_width;      /**< Number of bytes in addresses, usually 3 for small devices */
 } mtd_spi_nor_params_t;
 
 /**
@@ -124,7 +124,17 @@ typedef struct {
 typedef struct {
     mtd_dev_t base;          /**< inherit from mtd_dev_t object */
     const mtd_spi_nor_params_t *params; /**< SPI NOR params */
+
+    uint32_t wait_chip_erase;   /**< Full chip erase wait time in µs */
+    uint32_t wait_64k_erase;    /**< 64KB page erase wait time in µs */
+    uint32_t wait_32k_erase;    /**< 32KB page erase wait time in µs */
+    uint32_t wait_sector_erase; /**< 4KB sector erase wait time in µs */
+    uint32_t wait_chip_wake_up; /**< Chip wake up time in µs */
+    uint16_t flag;           /**< Config flags */
+
     mtd_jedec_id_t jedec_id; /**< JEDEC ID of the chip */
+
+    uint8_t addr_width;      /**< Number of bytes in addresses, usually 3 for small devices */
 
     /**
      * @brief   bitmask to corresponding to the page address

--- a/drivers/include/mtd_spi_nor/sfdp.h
+++ b/drivers/include/mtd_spi_nor/sfdp.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mtd_spi_nor_sfdp Serial Flash Discoverable Parameters
+ * @ingroup     drivers_mtd_spi_nor
+ * @brief       Driver for serial NOR flash memory technology devices attached via SPI
+ *
+ * @{
+ *
+ * @file
+ * @brief       Serial flash discoverable parameter definitions for SPI NOR
+ *              Flash devices
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MTD_SPI_NOR_SFDP_H
+#define MTD_SPI_NOR_SFDP_H
+
+#include <inttypes.h>
+#include <stddef.h>
+
+#include "bitarithm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define JEDEC_SFDP_SIGNATURE_VAL (0x50444653) /**< "SFDP" signature */
+
+/**
+ * @brief   Internal representation of JEDEC serial flash discoverable parameter
+ *          table header
+ *
+ * @see     JEDEC JESD216D
+ */
+typedef struct __attribute__((packed)) {
+    uint32_t signature;     /**< Magic number, always 0x50444653 */
+    uint8_t minor;          /**<< Minor version number */
+    uint8_t major;          /**< Major version number */
+    uint8_t num_headers;    /**< number of parameter headers, 0-based */
+    uint8_t protocol;       /**< Access protocol */
+} mtd_jedec_sfdp_header_t;
+
+/**
+ * @name    SFDP parameter table ID codes
+ * @{
+ */
+#define JEDEC_SFDP_PARAM_TABLE_BASIC_SPI    0xFF00 /**< Basic SPI protocol */
+#define JEDEC_SFDP_PARAM_TABLE_4_BYTE_ADDR  0xFF84 /**< Basic SPI protocol */
+/** @} */
+
+/**
+ * @brief   Internal representation of JEDEC serial flash discoverable parameter
+ *          table parameter header
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t id_lsb;         /**< LSB of the parameter ID */
+    uint8_t minor;          /**< Parameter table minor version */
+    uint8_t major;          /**< Parameter table major version */
+    uint8_t length;         /**< Length of the parameter table in 32 bit words*/
+    uint32_t table_ptr:24;  /**< Parameter table pointer */
+    uint8_t id_msb;         /**< MSB of the parameter ID */
+} mtd_jedec_param_header_t;
+
+/**
+ * @name    SFDP Basic SPI protocol content offsets in bytes
+ * @{
+ */
+#define JEDEC_SFDP_BASIC_SPI_FLAGS          0x00 /**< Access configuration flags */
+#define JEDEC_SFDP_BASIC_SPI_MEM_DENSITY    0x04 /**< Memory density */
+#define JEDEC_SFDP_BASIC_SPI_144_114_ACCESS 0x08 /**< 1-4-4 and 1-1-4 access */
+#define JEDEC_SFDP_BASIC_SPI_ERASE_12_INFO  0x1C /**< Erase type 1 and 2 info */
+#define JEDEC_SFDP_BASIC_SPI_ERASE_34_INFO  0x20 /**< Erase type 3 and 4 info */
+#define JEDEC_SFDP_BASIC_SPI_ERASE_TIMINGS  0x24 /**< Erase timings */
+#define JEDEC_SFDP_BASIC_SPI_OTHER_TIMINGS  0x28 /**< Chip erase and write timings */
+#define JEDEC_SFDP_BASIC_SPI_POWERDOWN_INFO 0x34 /**< Power down support */
+/** @} */
+
+/**
+ * @name JEDEC serial flash discoverable parameter table basic SPI first word
+ * content
+ * @{
+ */
+#define JEDEC_SFDP_PARAM_SUP_114_FAST_READ   (BIT22) /**< 1-1-4 Fast read */
+#define JEDEC_SFDP_PARAM_SUP_144_FAST_READ   (BIT21) /**< 1-4-4 Fast read */
+#define JEDEC_SFDP_PARAM_SUP_122_FAST_READ   (BIT20) /**< 1-2-2 Fast read */
+#define JEDEC_SFDP_PARAM_SUP_DTR_CLOCKING    (BIT19) /**< DTR Clocking */
+#define JEDEC_SFDP_PARAM_SUP_ADDRESS_4_ONLY  (BIT18) /**< Only 4 byte addressing */
+#define JEDEC_SFDP_PARAM_SUP_ADDRESS_BOTH    (BIT18 | BIT17) /**< Both address types supported */
+#define JEDEC_SFDP_PARAM_SUP_ADDRESS_3_ONLY  (BIT17) /**< 3 Byte only */
+#define JEDEC_SFDP_PARAM_SUP_112_FAST_READ   (BIT16) /**< 1-1-2 fast read */
+#define JEDEC_SFDP_PARAM_SUP_WREN_REQ_STATUS (BIT4) /**< WREN required for status writing */
+/** @} */
+
+/**
+ * @brief   Internal representation of JEDEC serial flash discoverable parameter
+ *          table basic SPI erase commands, sizes and timings
+ *
+ * Spans word 9 through 11 of the JEDEC SFDP Basic SPI table
+ */
+typedef struct __attribute__((packed)) {
+    struct __attribute__((packed)) {
+        uint8_t size;           /**< Power of 2 erase size */
+        uint8_t instruction;    /**< Instruction used to erase this size */
+    } erase[4]; /**< Erase sizes and instructions supported by the device */
+
+    union {
+        struct __attribute__((packed)) {
+            uint8_t erase_mult:4;       /**< Max erase multiplier for all erase types */
+            uint8_t erase1_time:7;      /**< Typical erase time for type 1 erase */
+            uint8_t erase2_time:7;      /**< Typical erase time for type 2 erase */
+            uint8_t erase3_time:7;      /**< Typical erase time for type 3 erase */
+            uint8_t erase4_time:7;      /**< Typical erase time for type 4 erase */
+        };
+        uint32_t erase_time;            /**< Erase time as uint32_t */
+    };
+
+    uint8_t program_mult:4;     /**< Max program multiplier for all program types */
+    uint8_t page_size:4;        /**< Power of 2 page size */
+    uint8_t page_time:6;        /**< Typical time for writing a full page */
+    uint8_t first_byte_time:5;  /**< Typical program time for first byte */
+    uint8_t add_byte_time:5;    /**< Typical program time for additional bytes */
+    uint8_t chip_erase_time:7;  /**< Typical erase time for chip erase */
+} mtd_jedec_basic_spi_access_info_t;
+
+/**
+ * @brief   Internal representation of JEDEC serial flash discoverable parameter
+ *          table basic SPI power down information
+ *
+ * Word 14 of the JEDEC SFDP Basic SPI table
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t reserved:2;     /**< Reserved bits */
+    uint8_t busy_reg:6;     /**< Busy flag in the status register */
+    uint8_t delay:7;        /**< Exit powerdown to next operation delay */
+    uint8_t exit;           /**< Exit Deep powerdown mode instruction */
+    uint8_t enter;          /**< Enter Deep powerdown mode instruction */
+    uint8_t supported:1;    /**< Deep powerdown supported flag */
+} mtd_jedec_basic_spi_powerdown_info_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_SPI_NOR_SFDP_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

JEDEC has a standardized device information tables for serial flash chips. This PR adds limited support for reading these tables and configure the flash parameters based on these tables. The number of address bytes, the chip size, and supported erase sizes with wait times are discovered from the flash.

A flag is added to disable this to allow for manual configuration. 

A downside of this change is that most SPI NOR flash parameters have to reside in the MCU memory.

### Testing procedure

This can be tested using `examples/filesystem`, the board should behave as before this PR, except that less compile time configuration is required.

Some SPI NOR flash chips, such as Winbond chips, do not support this. I've added a flag so that manual configuration is still possible. This is also the case for the Mulle board.

### Issues/PRs references

None.