### PR TITLE
cpu/sam0_common: DAC: wait for DAC to be ready

### DIFF
--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -128,6 +128,12 @@ int8_t dac_init(dac_t line)
     DAC->CTRLA.bit.ENABLE = 1;
     _sync();
 
+#ifdef DAC_STATUS_READY
+    /* wait for DAC startup */
+    const uint32_t mask = 1 << (DAC_STATUS_READY_Pos + line);
+    while (!(DAC->STATUS.reg & mask)) {}
+#endif
+
     return DAC_OK;
 }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The DAC can have some start-up delay.
If we try to write to it before it's ready, it will get stuck.

This happens now that `tests/driver_dac_dds` immediately sets a DAC value after init.

The samd2x class of MCUs doesn't have this bit, but a quick test on samd10 shows that it might not be nececary there - the DAC does not get stuck when writing to it immediately after init.


### Testing procedure

Run `tests/driver_dac_dds` on a sam0 MCU.
On master, attempting to play any sound (e.g. `sine 440 1`) will block indefinitely on SYNCBUSY.

With this patch, the sound should be played and the test does not get stuck.

### Issues/PRs references

triggered by 057de665f1f1898ab1ba47fa70e34519f98b89c7
