### PR TITLE
riotctrl_shell.gnrc: fix documentation for GNRCICMPv6EchoParser.parse()

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/gnrc.py
+++ b/dist/pythonlibs/riotctrl_shell/gnrc.py
@@ -73,7 +73,7 @@ class GNRCICMPv6EchoParser(ShellInteractionParser):
 
     def parse(self, cmd_output):
         """
-        Parses output of GNRCIPv6NIB::nib_neigh_show()
+        Parses output of GNRCICMPv6Echo::ping6()
 
         >>> parser = GNRCICMPv6EchoParser()
         >>> res = parser.parse(


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This seems to be a copy-paste error. The `GNRCICMPv6EchoParser` `parse()` function parses of course the output of the `ping6` command, not the `nib neigh show` command.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read and make sure this makes sense ;-).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
