### PR TITLE
sys/ztimer: fix xtimer_compat

### DIFF
--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -19,9 +19,13 @@
 #ifndef ZTIMER_XTIMER_COMPAT_H
 #define ZTIMER_XTIMER_COMPAT_H
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
+/* make sure to overwrite potentially conflicting XTIMER_WIDTH definition from
+ * board.h by eagerly including it */
+#include "board.h"
 #include "div.h"
 #include "timex.h"
 #ifdef MODULE_CORE_MSG
@@ -40,6 +44,13 @@ extern "C" {
  * so skip doxygen.
  */
 #ifndef DOXYGEN
+
+/* ztimer clocks with width lower than 32 bit get extended to 32 bit in software
+ * via ztimer_extend. So no matter what was defined elsewhere, we overwrite it
+ */
+#ifdef XTIMER_WIDTH
+#undef XTIMER_WIDTH
+#endif
 
 #define XTIMER_WIDTH    (32)
 #define XTIMER_MASK     (0)
@@ -185,6 +196,7 @@ static inline void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
 
 static inline void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
 {
+    assert(timeout <= UINT32_MAX);
     xtimer_set_timeout_flag(t, timeout);
 }
 


### PR DESCRIPTION
### Contribution description

- Eagerly include `board.h` so that potential definitions of `XTIMER_WIDTH` can be overwritten. Subsequent includes of `board.h` should hit the include guard
- `assert()` timeout value to be representable in 32 bit


### Testing procedure

See https://github.com/RIOT-OS/RIOT/pull/15605

### Issues/PRs references

Addresses comments to https://github.com/RIOT-OS/RIOT/pull/15605 made after merging