### PR TITLE
makefiles/pseudomodules.inc.mk: netdev_ieee802154_legacy is a pseudomodule

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -146,7 +146,6 @@ PSEUDOMODULES += ztimer%
 # ztimer's main module is called "ztimer_core"
 NO_PSEUDOMODULES += ztimer_core
 NO_PSEUDOMODULES += netdev_ieee802154_submac
-NO_PSEUDOMODULES += netdev_ieee802154_legacy
 
 # print ascii representation in function od_hex_dump()
 PSEUDOMODULES += od_string


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`netdev_ieee802154_legacy` is not a real module, don't add it to `NO_PSEUDOMODULES`.


### Testing procedure

    USEMODULE=netdev_ieee802154_legacy make -C examples/gnrc_networking BOARD=nrf52840dk -j

fails to build on master

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
