### PR TITLE
sys/architecture: add UWORD_MIN, UWORD_MAX, SWORD_MIN, SWORD_MAX

### DIFF
--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -58,6 +58,9 @@ typedef uint<num>_t uword_t;
  *
  * @details Synonym to `int8_t`, `int16_t` or `int32_t` depending on
  *          architecture
+ *
+ * @note    This type is pronounce es-word-tea. When slaying dragons, this is
+ *          not the tool you're looking for.
  */
 typedef int<num>_t  sword_t;
 #elif (ARCHITECTURE_WORD_BITS == 8)

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -87,6 +87,26 @@ typedef int32_t     sword_t;
  */
 #define WORD_ALIGNED __attribute__((aligned(ARCHITECTURE_WORD_BYTES)))
 
+/**
+ * @brief   Smallest number an uword_t can hold
+ */
+#define UWORD_MIN                   0
+
+/**
+ * @brief   Highest number an uword_t can hold
+ */
+#define UWORD_MAX                   ((1ULL << ARCHITECTURE_WORD_BITS) - 1)
+
+/**
+ * @brief   Smallest number an sword_t can hold
+ */
+#define SWORD_MIN                   (-(1LL << (ARCHITECTURE_WORD_BITS - 1)))
+
+/**
+ * @brief   Highest number an sword_t can hold
+ */
+#define SWORD_MAX                   ((1LL << (ARCHITECTURE_WORD_BITS - 1)) - 1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/sys_architecture/main.c
+++ b/tests/sys_architecture/main.c
@@ -52,7 +52,17 @@ int main(void)
         (ARCHITECTURE_WORD_BITS == CORRECT_WORD_BITS) &&
         (ARCHITECTURE_WORD_BYTES == CORRECT_WORD_BITS / 8) &&
         (sizeof(uword_t) == ARCHITECTURE_WORD_BYTES) &&
-        (sizeof(sword_t) == ARCHITECTURE_WORD_BYTES),
+        (sizeof(sword_t) == ARCHITECTURE_WORD_BYTES) &&
+        (UWORD_MIN == 0) &&
+        ((ARCHITECTURE_WORD_BITS != 8) || (UWORD_MAX == 255)) &&
+        ((ARCHITECTURE_WORD_BITS != 8) || (SWORD_MIN == -128)) &&
+        ((ARCHITECTURE_WORD_BITS != 8) || (SWORD_MAX == 127)) &&
+        ((ARCHITECTURE_WORD_BITS != 16) || (UWORD_MAX == 65535)) &&
+        ((ARCHITECTURE_WORD_BITS != 16) || (SWORD_MIN == -32768)) &&
+        ((ARCHITECTURE_WORD_BITS != 16) || (SWORD_MAX == 32767)) &&
+        ((ARCHITECTURE_WORD_BITS != 32) || (UWORD_MAX == 4294967295)) &&
+        ((ARCHITECTURE_WORD_BITS != 32) || (SWORD_MIN == -2147483648)) &&
+        ((ARCHITECTURE_WORD_BITS != 32) || (SWORD_MAX == 2147483647)),
         "word size details are incorrect"
     );
 


### PR DESCRIPTION
### Contribution description

This PR adds preprocessor macros for `UWORD_MIN`, `UWORD_MAX`, `SWORD_MIN`, `SWORD_MAX`. The related to `uword_t` and `sword_t`, respectively, the same way as `UINT8_MAX` and `UINT8_MIN` behaves to `uint8_t`.

### Testing procedure

The test application has been extended. As those are covered with a `static_assert()`, a successful compilation already counts as pass.

### Issues/PRs references

None