### PR TITLE
boards/nucleo*: move HSE/LSE configuration for Kconfig to common

### DIFF
--- a/boards/common/nucleo144/Kconfig
+++ b/boards/common/nucleo144/Kconfig
@@ -9,4 +9,8 @@ config BOARD_COMMON_NUCLEO144
     bool
     select HAS_ARDUINO
 
+    # Clock configuration
+    select BOARD_HAS_HSE if !CPU_FAM_L4 && !CPU_FAM_L5
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/common/nucleo32/Kconfig
+++ b/boards/common/nucleo32/Kconfig
@@ -9,4 +9,7 @@ config BOARD_COMMON_NUCLEO32
     bool
     select HAS_ARDUINO
 
+    # Clock configuration
+    select BOARD_HAS_LSE if (CPU_FAM_L0 || CPU_FAM_L4) && !BOARD_NUCLEO_L011K4
+
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/common/nucleo64/Kconfig
+++ b/boards/common/nucleo64/Kconfig
@@ -9,4 +9,8 @@ config BOARD_COMMON_NUCLEO64
     bool
     select HAS_ARDUINO
 
+    # Clock configuration
+    select BOARD_HAS_HSE if !CPU_FAM_G0 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4
+    select BOARD_HAS_LSE if !BOARD_NUCLE0_L152RE
+
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/nucleo-f030r8/Kconfig
+++ b/boards/nucleo-f030r8/Kconfig
@@ -21,8 +21,4 @@ config BOARD_NUCLEO_F030R8
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f070rb/Kconfig
+++ b/boards/nucleo-f070rb/Kconfig
@@ -22,8 +22,4 @@ config BOARD_NUCLEO_F070RB
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f072rb/Kconfig
+++ b/boards/nucleo-f072rb/Kconfig
@@ -23,8 +23,4 @@ config BOARD_NUCLEO_F072RB
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f091rc/Kconfig
+++ b/boards/nucleo-f091rc/Kconfig
@@ -22,8 +22,4 @@ config BOARD_NUCLEO_F091RC
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f103rb/Kconfig
+++ b/boards/nucleo-f103rb/Kconfig
@@ -22,8 +22,4 @@ config BOARD_NUCLEO_F103RB
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f207zg/Kconfig
+++ b/boards/nucleo-f207zg/Kconfig
@@ -28,8 +28,4 @@ config BOARD_NUCLEO_F207ZG
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
-source "$(RIOTBOARD)/common/nucleo64/Kconfig"
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f207zg/Kconfig
+++ b/boards/nucleo-f207zg/Kconfig
@@ -11,7 +11,7 @@ config BOARD
 config BOARD_NUCLEO_F207ZG
     bool
     default y
-    select BOARD_COMMON_NUCLEO64
+    select BOARD_COMMON_NUCLEO144
     select CPU_MODEL_STM32F207ZG
 
     # Put defined MCU peripherals here (in alphabetical order)

--- a/boards/nucleo-f302r8/Kconfig
+++ b/boards/nucleo-f302r8/Kconfig
@@ -26,8 +26,4 @@ config BOARD_NUCLEO_F302R8
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f303re/Kconfig
+++ b/boards/nucleo-f303re/Kconfig
@@ -26,8 +26,4 @@ config BOARD_NUCLEO_F303RE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f303ze/Kconfig
+++ b/boards/nucleo-f303ze/Kconfig
@@ -11,7 +11,7 @@ config BOARD
 config BOARD_NUCLEO_F303ZE
     bool
     default y
-    select BOARD_COMMON_NUCLEO64
+    select BOARD_COMMON_NUCLEO144
     select CPU_MODEL_STM32F303ZE
 
     # Put defined MCU peripherals here (in alphabetical order)

--- a/boards/nucleo-f303ze/Kconfig
+++ b/boards/nucleo-f303ze/Kconfig
@@ -25,8 +25,4 @@ config BOARD_NUCLEO_F303ZE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
-source "$(RIOTBOARD)/common/nucleo64/Kconfig"
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f334r8/Kconfig
+++ b/boards/nucleo-f334r8/Kconfig
@@ -26,8 +26,4 @@ config BOARD_NUCLEO_F334R8
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f401re/Kconfig
+++ b/boards/nucleo-f401re/Kconfig
@@ -25,8 +25,4 @@ config BOARD_NUCLEO_F401RE
     select HAS_PERIPH_UART
     select HAS_PERIPH_QDEC
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f410rb/Kconfig
+++ b/boards/nucleo-f410rb/Kconfig
@@ -23,8 +23,4 @@ config BOARD_NUCLEO_F410RB
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f411re/Kconfig
+++ b/boards/nucleo-f411re/Kconfig
@@ -24,8 +24,4 @@ config BOARD_NUCLEO_F411RE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f412zg/Kconfig
+++ b/boards/nucleo-f412zg/Kconfig
@@ -25,8 +25,4 @@ config BOARD_NUCLEO_F412ZG
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f413zh/Kconfig
+++ b/boards/nucleo-f413zh/Kconfig
@@ -28,8 +28,4 @@ config BOARD_NUCLEO_F413ZH
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f429zi/Kconfig
+++ b/boards/nucleo-f429zi/Kconfig
@@ -25,8 +25,4 @@ config BOARD_NUCLEO_F429ZI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f446re/Kconfig
+++ b/boards/nucleo-f446re/Kconfig
@@ -30,8 +30,4 @@ config BOARD_NUCLEO_F446RE
     select HAS_MOTOR_DRIVER
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f446ze/Kconfig
+++ b/boards/nucleo-f446ze/Kconfig
@@ -25,8 +25,4 @@ config BOARD_NUCLEO_F446ZE
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f722ze/Kconfig
+++ b/boards/nucleo-f722ze/Kconfig
@@ -25,8 +25,4 @@ config BOARD_NUCLEO_F722ZE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f746zg/Kconfig
+++ b/boards/nucleo-f746zg/Kconfig
@@ -29,8 +29,4 @@ config BOARD_NUCLEO_F746ZG
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f767zi/Kconfig
+++ b/boards/nucleo-f767zi/Kconfig
@@ -31,8 +31,4 @@ config BOARD_NUCLEO_F767ZI
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-g070rb/Kconfig
+++ b/boards/nucleo-g070rb/Kconfig
@@ -23,7 +23,4 @@ config BOARD_NUCLEO_G070RB
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g071rb/Kconfig
+++ b/boards/nucleo-g071rb/Kconfig
@@ -23,7 +23,5 @@ config BOARD_NUCLEO_G071RB
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
-    # Clock configuration
-    select BOARD_HAS_LSE
 
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g431rb/Kconfig
+++ b/boards/nucleo-g431rb/Kconfig
@@ -26,8 +26,4 @@ config BOARD_NUCLEO_G431RB
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g474re/Kconfig
+++ b/boards/nucleo-g474re/Kconfig
@@ -26,8 +26,4 @@ config BOARD_NUCLEO_G474RE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_HSE
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l031k6/Kconfig
+++ b/boards/nucleo-l031k6/Kconfig
@@ -24,7 +24,4 @@ config BOARD_NUCLEO_L031K6
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l053r8/Kconfig
+++ b/boards/nucleo-l053r8/Kconfig
@@ -22,7 +22,4 @@ config BOARD_NUCLEO_L053R8
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l073rz/Kconfig
+++ b/boards/nucleo-l073rz/Kconfig
@@ -32,7 +32,4 @@ config BOARD_NUCLEO_L073RZ
     # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l412kb/Kconfig
+++ b/boards/nucleo-l412kb/Kconfig
@@ -28,7 +28,4 @@ config BOARD_NUCLEO_L412KB
     # https://github.com/RIOT-OS/RIOT/pull/12144#issuecomment-527090161
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l432kc/Kconfig
+++ b/boards/nucleo-l432kc/Kconfig
@@ -30,7 +30,4 @@ config BOARD_NUCLEO_L432KC
     # https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l433rc/Kconfig
+++ b/boards/nucleo-l433rc/Kconfig
@@ -31,7 +31,4 @@ config BOARD_NUCLEO_L433RC
     # https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l452re/Kconfig
+++ b/boards/nucleo-l452re/Kconfig
@@ -26,7 +26,4 @@ config BOARD_NUCLEO_L452RE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l476rg/Kconfig
+++ b/boards/nucleo-l476rg/Kconfig
@@ -29,7 +29,4 @@ config BOARD_NUCLEO_L476RG
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l496zg/Kconfig
+++ b/boards/nucleo-l496zg/Kconfig
@@ -27,7 +27,4 @@ config BOARD_NUCLEO_L496ZG
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-l4r5zi/Kconfig
+++ b/boards/nucleo-l4r5zi/Kconfig
@@ -26,7 +26,4 @@ config BOARD_NUCLEO_L4R5ZI
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-l552ze-q/Kconfig
+++ b/boards/nucleo-l552ze-q/Kconfig
@@ -24,7 +24,4 @@ config BOARD_NUCLEO_L552ZE_Q
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
-    # Clock configuration
-    select BOARD_HAS_LSE
-
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Most of the nucleo boards share the same HSE/LSE hardware configuration:
- nucleo64/144 boards (non L0/L1/L4) provide an HSE and an LSE
- nucleo32 boards (L0 and L4) provide an LSE but no HSE

Instead of describing this for each nucleo boards, move the selection of `BOARD_HAS_HSE`/`BOARD_HAS_LSE` config to boards/common/nucleo32/64/144 Kconfig files.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Nucleo boards are still functional when Kconfig is used and the configuration is as expected.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#14975 
based on #15632 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
