### PR TITLE
radio/nrf802154: fix set_cca_threshold range

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -280,15 +280,6 @@ static int _request_cca(ieee802154_dev_t *dev)
 }
 
 /**
- * @brief   Set CCA threshold value in internal represetion
- */
-static void _set_cca_thresh(uint8_t thresh)
-{
-    NRF_RADIO->CCACTRL &= ~RADIO_CCACTRL_CCAEDTHRES_Msk;
-    NRF_RADIO->CCACTRL |= thresh << RADIO_CCACTRL_CCAEDTHRES_Pos;
-}
-
-/**
  * @brief   Convert from dBm to the internal representation, when the
  *          radio operates as a IEEE802.15.4 transceiver.
  */
@@ -300,7 +291,15 @@ static inline uint8_t _dbm_to_ieee802154_hwval(int8_t dbm)
 static int set_cca_threshold(ieee802154_dev_t *dev, int8_t threshold)
 {
     (void) dev;
-    _set_cca_thresh(_dbm_to_ieee802154_hwval(threshold));
+
+    if (threshold < ED_RSSIOFFS) {
+        return -EINVAL;
+    }
+
+    uint8_t hw_val = _dbm_to_ieee802154_hwval(threshold);
+
+    NRF_RADIO->CCACTRL &= ~RADIO_CCACTRL_CCAEDTHRES_Msk;
+    NRF_RADIO->CCACTRL |= hw_val << RADIO_CCACTRL_CCAEDTHRES_Pos;
     return 0;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This commit fixes the CCA threshold range for set_cca_threshold.
Without this commit the threshold overflows when using values below
the receiver sensitivity.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`BOARD=<nrf802154_board> make -C tests/ieee802154_hal flash term`. Make sure the `config_cca` command fails with a CCA threshold below the receiver sensitivity (-92):
```
config_cca ed -93
2020-12-15 13:37:44,851 #  config_cca ed -93
2020-12-15 13:37:44,852 # CCA mode set.
2020-12-15 13:37:44,855 # Error setting the threshold
> config_cca ed -92
2020-12-15 13:37:45,977 #  config_cca ed -92
2020-12-15 13:37:45,978 # CCA mode set.
2020-12-15 13:37:45,980 # Set threshold to -92
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
