### PR TITLE
gh-actions: make the release tests a matrix build

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -38,16 +38,38 @@ on:
 env:
   DOCKER_MAKE_ARGS: -j
 # split up native and IoT-LAB tasks to parallelize somewhat and prevent
-# to hit Github Limit of 6h per job, can't use matrix because there seems to be
-# some sync happening and the longer running job is killed.
+# to hit Github Limit of 6h per job.
 jobs:
-  native-tasks:
+  tasks:
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        pytest_mark:
+          - "iotlab_creds"
+        include:
+          - pytest_mark: "not iotlab_creds"
+            sudo: "sudo"
     steps:
     - name: Generate .riotgithubtoken
       run: |
         echo '${{ secrets.RIOT_CI_ACCESS_TOKEN }}' > ~/.riotgithubtoken
+    - name: Setup IoT-LAB credentials
+      if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
+      run: |
+        echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
+    - name: Setup SSH agent
+      if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
+    - name: Fetch host key from IoT-LAB saclay site
+      if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
+      run: |
+        IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
+        ssh -oStrictHostKeyChecking=accept-new \
+          ${IOTLAB_USER}@saclay.iot-lab.info exit
     - name: Checkout Release-Specs
       uses: actions/checkout@v2
       with:
@@ -93,7 +115,7 @@ jobs:
         cd Release-Specs
         # definition in env does not work since $GITHUB_WORKSPACE seems not to
         # be accessible
-        sudo \
+        ${{ matrix.sudo }} \
           BUILD_IN_DOCKER=1 \
           DOCKER_MAKE_ARGS=${DOCKER_MAKE_ARGS} \
           DOCKER_ENV_VARS=USEMODULE \
@@ -101,7 +123,7 @@ jobs:
           GITHUB_RUN_ID=${GITHUB_RUN_ID} \
           GITHUB_SERVER_URL=${GITHUB_SERVER_URL} \
           RIOTBASE=${RIOTBASE} \
-          $(which tox) -- ${TOX_ARGS} -m "not iotlab_creds"
+          $(which tox) -- ${TOX_ARGS} -m "${{ matrix.pytest_mark }}"
     - name: junit2html and XML deploy
       if: always()
       run: |
@@ -117,90 +139,6 @@ jobs:
           test-reports/test-report-native-$VER-$DATE.html
         cp $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
           test-reports/test-report-native-$VER-$DATE.xml
-    - uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: Test Reports
-        path: test-reports/*
-  iotlab-tasks:
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    steps:
-    - name: Generate .riotgithubtoken
-      run: |
-        echo '${{ secrets.RIOT_CI_ACCESS_TOKEN }}' > ~/.riotgithubtoken
-    - name: Checkout Release-Specs
-      uses: actions/checkout@v2
-      with:
-        repository: RIOT-OS/Release-Specs
-        path: Release-Specs
-        fetch-depth: 1
-        ref: ${{ github.event.inputs.release_specs_version }}
-    - name: Checkout RIOT
-      uses: actions/checkout@v2
-      with:
-        repository: RIOT-OS/RIOT
-        path: RIOT
-        fetch-depth: 1
-        ref: ${{ github.event.inputs.riot_version }}
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.x
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox junit2html
-    - name: Pull riotbuild docker image
-      run: |
-        DOCKER_VERSION="${{ github.event.inputs.docker_version }}"
-        if [ -z "$DOCKER_VERSION" ]; then
-          DOCKER_VERSION="latest"
-        fi
-        docker pull riot/riotbuild:$DOCKER_VERSION
-    - name: Setup IoT-LAB credentials
-      run: |
-        echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
-    - name: Setup SSH agent
-      uses: webfactory/ssh-agent@v0.4.1
-      with:
-        ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
-    - name: Fetch host key from IoT-LAB saclay site
-      run: |
-        IOTLAB_USER=$(cat ~/.iotlabrc | cut -f1 -d:)
-        ssh -oStrictHostKeyChecking=accept-new \
-          ${IOTLAB_USER}@saclay.iot-lab.info exit
-    - name: Run release tests
-      timeout-minutes: 350
-      run: |
-        # definition in env does not work since $GITHUB_WORKSPACE seems not to
-        # be accessible
-        export RIOTBASE="$GITHUB_WORKSPACE/RIOT"
-        TOX_ARGS=""
-        if ! echo ${{ github.event.inputs.riot_version }} | \
-              grep -q "[0-9]\{4\}.[0-9]\{2\}-RC[0-9]\+"; then
-          TOX_ARGS+="--non-RC "
-        fi
-
-        cd Release-Specs
-        BUILD_IN_DOCKER=1 \
-          DOCKER_ENV_VARS=USEMODULE \
-          $(which tox) -- ${TOX_ARGS} -m "iotlab_creds"
-    - name: junit2html and XML deploy
-      if: always()
-      run: |
-        DATE=$(date +"%Y-%m-%d-%H-%M-%S")
-        if echo ${{ github.event.inputs.riot_version }} | \
-              grep -q "[0-9]\{4\}.[0-9]\{2\}"; then
-          VER=${{ github.event.inputs.riot_version }}
-        else
-          VER=$(git -C $GITHUB_WORKSPACE/RIOT rev-parse --short HEAD)
-        fi
-        mkdir test-reports/
-        junit2html $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
-          test-reports/test-report-iotlab-$VER-$DATE.html
-        cp $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
-          test-reports/test-report-iotlab-$VER-$DATE.xml
     - uses: actions/upload-artifact@v2
       if: always()
       with:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This reduces some code duplication within the release-tests workflow, by utilizing the matrix strategy to divide the tests into those that run on the IoT-LAB and those that run on `native` instead of writing out everything by hand. I used to have it like that in the early days of the release-tests, but the slower job always got cancelled. Only due to https://github.com/RIOT-OS/RIOT/pull/15563 I learned, that [`fail-fast` is true by default](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast), which explains the canceled job. By setting `fail-fast` to `false`, both jobs finish.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I started a [test run on by fork](https://github.com/miri64/RIOT/actions/runs/422966558). As it succeeds, I think we can safely say that it works.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
