### PR TITLE
cpu/saml11: fix GPIO/IOBUS management

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -73,12 +73,18 @@ typedef uint32_t gpio_t;
  * @brief   Macro for accessing GPIO pins
  * @{
  */
-#ifdef CPU_FAM_SAML11
-#define GPIO_PIN(x, y)      (((gpio_t)(&PORT_SEC->Group[x])) | y)
-#elif defined(PORT_IOBUS)   /* Use IOBUS access when available */
+#ifdef MODULE_PERIPH_GPIO_FAST_READ
+#ifdef PORT_IOBUS_SEC
+#define GPIO_PIN(x, y)      (((gpio_t)(&PORT_IOBUS_SEC->Group[x])) | y)
+#else /* Use IOBUS access when available */
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT_IOBUS->Group[x])) | y)
+#endif /* PORT_IOBUS_SEC */
+#else
+#ifdef PORT_SEC
+#define GPIO_PIN(x, y)      (((gpio_t)(&PORT_SEC->Group[x])) | y)
 #else
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
+#endif /* PORT_IOBUS_SEC */
 #endif
 
 /**

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -109,12 +109,17 @@ static inline PortGroup *_port_iobus(gpio_t pin)
 
 static inline PortGroup *_port(gpio_t pin)
 {
-#ifdef PORT_IOBUS
+#ifdef MODULE_PERIPH_GPIO_FAST_READ
     /* Shift the PortGroup address back from the IOBUS region to the peripheral
      * region
      */
+#ifdef PORT_IOBUS_SEC
+    return (PortGroup *)((uintptr_t)_port_iobus(pin) -
+                         (uintptr_t)PORT_IOBUS_SEC + (uintptr_t)PORT_SEC);
+#else
     return (PortGroup *)((uintptr_t)_port_iobus(pin) -
                          (uintptr_t)PORT_IOBUS + (uintptr_t)PORT);
+#endif /* PORT_IOBUS_SEC */
 #else
     return _port_iobus(pin);
 #endif


### PR DESCRIPTION
### Contribution description

This PR fixes SAML11 MCU gpio/iobus management.
For SAML11, a shadow set of register exists for PORT and IOBUS called PORT_SEC and IOBUS_SEC because of the TrustZone presence. They should be used by default for SAML11 and this is the reason the board is currently broken in master.


### Testing procedure

Run any tests you want in master, the board is currently broken master.
With this PR, the board should works again.


### Issues/PRs references
bug introduced by  #14804
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
