### PR TITLE
dist/tools/ci: add harness to annotate static tests in Github Actions

### DIFF
--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         docker run --rm                     \
           -e CI_BASE_BRANCH=master_upstream \
+          -e GITHUB_RUN_ID=${GITHUB_RUN_ID} \
           -v $(pwd):/data/riotbuild         \
           riot/riotbuild:latest             \
           make static-test

--- a/dist/tools/ci/README.md
+++ b/dist/tools/ci/README.md
@@ -1,0 +1,84 @@
+CI specific scripts
+===================
+
+Static tests
+------------
+
+The [static_tests.sh] script runs all static tests and outputs them in a unified
+output. You can also run this script by running `make static-test` in the base
+directory.
+
+To add a new static test, just write a `check.sh` script or call your static
+checker directly and add it to the list of static tests in [static_tests.sh]:
+
+```sh
+ENV1=foobar ENV2=snafu run <your test command> --args
+```
+
+Github annotations
+------------------
+Using [github_annotate.sh] you can generate [Github annotations] for your
+tests. You can generate both warnings and errors. Before doing anything however,
+you include [github_annotate.sh]\ (assuming `${RIOTTOOLS is set to}` [dist/tools/])
+
+```sh
+. "${RIOTTOOLS}"/ci/github_annotate.sh
+```
+
+and set-up the mechanism
+
+```sh
+github_annotate_setup
+```
+
+If your tests generate output you now can pipe that to the file `${LOGFILE}` by
+using `${LOG}`, e.g.
+
+```sh
+my_awesome_test | ${LOG}
+```
+
+Don't worry, your test will function normal still, if you don't run it in a
+Github Action!
+
+Now you can use `github_annotate_error` and `github_annotate_warning` to
+generate the actual errors and warnings. Both commands expect 3 parameters:
+1. `FILENAME`: The name of the file the warning or error occurred in,
+2. `LINENUM`: The number of the line the warning or error occurred in, and
+3. `DETAILS`: Some descriptive details or the message of your warning or error.
+
+You can parse those from `${LOGFILE}` (e.g. using tools such as `grep`, `sed`,
+or `awk`) or generate them on the fly, if your script allows for that. E.g.
+
+```sh
+cat ${LOGFILE} | grep '^.*:[0-9]\+:' | while read error; do
+    github_annotate_error \
+        $(echo "${error}" | cut -d: -f1) \
+        $(echo "${error}" | cut -d: -f2) \
+        $(echo "${error}" | cut -d: -f3-)
+done
+```
+
+If your output has the common output format `<filename>:<lineno>:<details>` you
+can also use the function `github_annotate_parse_log_default`. It takes the
+annotation function it should call on every line as an optional parameter with
+`github_annotate_error` being the default. E.g.
+
+```sh
+github_annotate_parse_log_default github_annotate_warning
+```
+
+does the same as the last example snippet, but uses `github_annotate_warning`
+instead.
+
+After all errors or warnings are annotated, call `github_annotate_teardown` to
+finish annotations.
+
+**Note:** `github_annotate_report_last_run` is called within [static_tests.sh]
+to attach the actual annotations to your PR. You don't need to call it from
+within your test if you are adding that test to [static_tests.sh].
+
+[static_tests.sh]: ./static_tests.sh
+[Github annotations]: https://github.blog/2018-12-14-introducing-check-runs-and-annotations/
+[github_annotate.sh]: ./github_annotate.sh
+[dist/tools]: ../

--- a/dist/tools/ci/github_annotate.sh
+++ b/dist/tools/ci/github_annotate.sh
@@ -1,0 +1,83 @@
+# Copyright 2020 Martine S. Lenders <m.lenders@fu-berlin.sh>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+LOG=cat
+LOGFILE=
+OUTFILE=github_annotate_outfile.log
+ECHO_ESC=echo
+
+if ps -p $$ | grep -q '\<bash\>'; then
+    # workaround when included in bash to escape newlines and carriage returns
+    # properly in _escape
+    ECHO_ESC='echo -e'
+fi
+
+github_annotate_setup() {
+    if [ -n "${GITHUB_RUN_ID}" ]; then
+        LOGFILE=run-${GITHUB_RUN_ID}.log
+        LOG="tee -a ${LOGFILE}"
+    fi
+}
+
+github_annotate_is_on() {
+    test -n "${LOGFILE}"
+    return $?
+}
+
+_escape() {
+    # see https://stackoverflow.com/a/1252191/11921757
+    ${ECHO_ESC} "$1" | sed -e ':a' -e 'N' -e '$!ba' \
+        -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g'
+}
+
+github_annotate_error() {
+    if [ -n "${GITHUB_RUN_ID}" ]; then
+        FILENAME="${1}"
+        LINENUM="${2}"
+        DETAILS="$(_escape "${3}")"
+        echo "::error file=${FILENAME},line=${LINENUM}::${DETAILS}" >> ${OUTFILE}
+    fi
+}
+
+github_annotate_warning() {
+    if [ -n "${GITHUB_RUN_ID}" ]; then
+        FILENAME="${1}"
+        LINENUM="${2}"
+        DETAILS="$(_escape "${3}")"
+        echo "::warning file=${FILENAME},line=${LINENUM}::${DETAILS}" >> ${OUTFILE}
+    fi
+}
+
+github_annotate_parse_log_default() {
+    ANNOTATE_FUNC="${1:-github_annotate_error}"
+
+    if github_annotate_is_on; then
+        PATTERN='^.\+:[0-9]\+:'
+
+        grep "${PATTERN}" "${LOGFILE}" | while read line; do
+            FILENAME=$(echo "${line}" | cut -d: -f1)
+            LINENUM=$(echo "${line}" | cut -d: -f2)
+            DETAILS=$(echo "${line}" | cut -d: -f3- |
+                      sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+            ${ANNOTATE_FUNC} "${FILENAME}" "${LINENUM}" "${DETAILS}"
+        done
+    fi
+}
+
+github_annotate_teardown() {
+    if [ -n "${LOGFILE}" ]; then
+        rm -f ${LOGFILE}
+        LOGFILE=
+    fi
+}
+
+github_annotate_report_last_run() {
+    if [ -n "${GITHUB_RUN_ID}" -a -f "${OUTFILE}" ]; then
+        # de-duplicate errors
+        sort -u ${OUTFILE} >&2
+    fi
+    rm -f ${OUTFILE}
+}

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -10,6 +10,8 @@
 # directory for more details.
 #
 
+. $(dirname "$0")/github_annotate.sh
+
 function print_result {
     local RED="\033[0;31m"
     local GREEN="\033[0;32m"
@@ -47,6 +49,7 @@ function run {
         (printf "%s\n" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
         echo ""
     fi
+    github_annotate_report_last_run
 }
 
 RESULT=0

--- a/dist/tools/whitespacecheck/check.sh
+++ b/dist/tools/whitespacecheck/check.sh
@@ -6,6 +6,8 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+. "$(dirname "$0")/../ci/github_annotate.sh"
+
 IGNORE=$(awk '{ printf ":!%s ", $0 }' "$(dirname "$0")/ignore_list.txt")
 
 # If no branch but an option is given, unset BRANCH.
@@ -23,6 +25,10 @@ else
     fi
 fi
 
+# sets
+# - LOG to tee output into for later parsing
+# - LOGFILE to parse GitHub annotations into
+github_annotate_setup
 
 # select files to check
 if [ -z "${BRANCH}" ]; then
@@ -30,16 +36,21 @@ if [ -z "${BRANCH}" ]; then
 fi
 
 git -c core.whitespace="tab-in-indent,tabwidth=4" \
-    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- *.[ch] ${IGNORE}
-
+    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- *.[ch] ${IGNORE} \
+            | ${LOG}
 RESULT=$?
 
 # Git regards any trailing white space except `\n` as an error so `\r` is
 # checked here, too
 git -c core.whitespace="trailing-space" \
-    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- . ${IGNORE}
+    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- . ${IGNORE} \
+            | ${LOG}
 
 TRAILING_RESULT=$?
+
+github_annotate_parse_log_default
+
+github_annotate_teardown
 
 if [ ${TRAILING_RESULT} -ne 0 ] || [ ${RESULT} -ne 0 ]
 then


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While #14889 itself was a dud, I learned via `pytest_github_actions_annotate_failures` that there seems to be an undocumented magic string (at least I wasn't able to find any documentation on that) that one can print to `stderr` which results in an annotation being generated:

```
::error <file>:<line> <details>
```

Utilizing that I wrote a shell-script-based harness for our static tests, so such annotations can be created without much change to the current version of the static tests.

I also ported the `whitespacecheck` to this harness to have some examples. Further tests can then be ported in later PRs (I also can move the `whitespacecheck` to its own PR if desired).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided a test commit, that generates some whitespace errors. Those will be annotated in the "Files" tab.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Powered by knowledge acquired in #14889, but not depending on it
Alternative to #15563
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
