### PR TITLE
schedstatistics: Log sleep tick statistics

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -74,6 +74,9 @@ void ps(void)
 
 #ifdef MODULE_SCHEDSTATISTICS
     uint64_t rt_sum = 0;
+    if (!IS_ACTIVE(MODULE_CORE_IDLE_THREAD)) {
+        rt_sum = sched_pidlist[KERNEL_PID_UNDEF].runtime_ticks;
+    }
     for (kernel_pid_t i = KERNEL_PID_FIRST; i <= KERNEL_PID_LAST; i++) {
         thread_t *p = thread_get(i);
         if (p != NULL) {

--- a/sys/schedstatistics/schedstatistics.c
+++ b/sys/schedstatistics/schedstatistics.c
@@ -26,6 +26,10 @@
 #include "thread.h"
 #include "xtimer.h"
 
+/**
+ * When core_idle_thread is not active, the KERNEL_PID_UNDEF is used to track
+ * the idle time
+ */
 schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
 
 void sched_statistics_cb(kernel_pid_t active_thread, kernel_pid_t next_thread)
@@ -33,13 +37,13 @@ void sched_statistics_cb(kernel_pid_t active_thread, kernel_pid_t next_thread)
     uint32_t now = xtimer_now().ticks32;
 
     /* Update active thread stats */
-    if (active_thread != KERNEL_PID_UNDEF) {
+    if (!IS_USED(MODULE_CORE_IDLE_THREAD) || active_thread != KERNEL_PID_UNDEF) {
         schedstat_t *active_stat = &sched_pidlist[active_thread];
         active_stat->runtime_ticks += now - active_stat->laststart;
     }
 
     /* Update next_thread stats */
-    if (next_thread != KERNEL_PID_UNDEF) {
+    if (!IS_USED(MODULE_CORE_IDLE_THREAD) || next_thread != KERNEL_PID_UNDEF) {
         schedstat_t *next_stat = &sched_pidlist[next_thread];
         next_stat->laststart = now;
         next_stat->schedules++;


### PR DESCRIPTION
### Contribution description

This PR modifies the schedstatistics module to also log the time sleeping when the idle thread is removed. The time spent sleeping is stored in the entry for `KERNEL_PID_UNDEF`. 

### Testing procedure

Without idle thread and with schedstatistics, `ps` shows the relative time spend on each thread when the CPU is running:

```
> ps
2020-12-15 16:34:14,950 #       pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     | runtime  | switches
2020-12-15 16:34:14,955 #         - | isr_stack            | -        - |   - |    512 (  196) (  316) | 0x20000000 | 0x200001c0
2020-12-15 16:34:14,961 #         1 | main                 | running  Q |   7 |   1536 (  812) (  724) | 0x200007d8 | 0x20000be4  | 54.586% |       145
2020-12-15 16:34:14,966 #         2 | usbus                | bl anyfl _ |   1 |   1024 (  432) (  592) | 0x20000288 | 0x20000594  | 47.630% |       193
2020-12-15 16:34:14,968 #           | SUM                  |            |     |   3072 ( 1440) ( 1632)
```

 With this PR, the time sleeping is also logged, the numbers now show the percentage of time spend on each thread including the sleep time in this calculation:

```
> ps
2020-12-15 16:38:07,756 #       pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     | runtime  | switches
2020-12-15 16:38:07,761 #         - | isr_stack            | -        - |   - |    512 (  196) (  316) | 0x20000000 | 0x200001c0
2020-12-15 16:38:07,768 #         1 | main                 | running  Q |   7 |   1536 (  812) (  724) | 0x200007d8 | 0x20000be4  |  0.033% |        42
2020-12-15 16:38:07,774 #         2 | usbus                | bl anyfl _ |   1 |   1024 (  432) (  592) | 0x20000288 | 0x20000594  |  0.045% |        90
2020-12-15 16:38:07,777 #           | SUM                  |            |     |   3072 ( 1440) ( 1632)
```

I've tested this with `tests/usbus_cdc_acm_stdio` on the samr21-xpro.

### Issues/PRs references

None
