### PR TITLE
dist/tools/doccheck: annotate errors in Github Action

### DIFF
--- a/dist/tools/ci/github_annotate.sh
+++ b/dist/tools/ci/github_annotate.sh
@@ -9,7 +9,7 @@ LOGFILE=
 OUTFILE=github_annotate_outfile.log
 ECHO_ESC=echo
 
-if ps -p $$ | grep -q '\<bash\>'; then
+if [ -n "${BASH_VERSION}" ]; then
     # workaround when included in bash to escape newlines and carriage returns
     # properly in _escape
     ECHO_ESC='echo -e'

--- a/dist/tools/ci/github_annotate.sh
+++ b/dist/tools/ci/github_annotate.sh
@@ -37,7 +37,7 @@ _github_annotate() {
     MESSAGE="$(_escape "${1}")"
     LEVEL="${2:-error}"
     OPTS="${3:-}"
-    echo "::${LEVEL} ${OPTS}::${DETAILS}" >> ${OUTFILE}
+    echo "::${LEVEL} ${OPTS}::${MESSAGE}" >> ${OUTFILE}
 }
 
 github_annotate_error() {
@@ -60,7 +60,7 @@ github_annotate_warning() {
     if [ -n "${GITHUB_RUN_ID}" ]; then
         FILENAME="${1}"
         LINENUM="${2}"
-        DETAILS="$(_escape "${3}")"
+        DETAILS="${3}"
         _github_annotate "${DETAILS}" warning "file=${FILENAME},line=${LINENUM}"
     fi
 }

--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -22,17 +22,19 @@ fi
 
 DOXY_OUTPUT=$(make -C "${RIOTBASE}" doc 2>&1)
 DOXY_ERRCODE=$?
+RESULT=0
+
 
 if [ "${DOXY_ERRCODE}" -ne 0 ] ; then
     echo "'make doc' exited with non-zero code (${DOXY_ERRCODE})"
     echo "${DOXY_OUTPUT}"
-    exit 2
+    RESULT=2
 else
     ERRORS=$(echo "${DOXY_OUTPUT}" | grep '.*warning' | sed "s#${PWD}/\([^:]*\)#\1#g")
     if [ -n "${ERRORS}" ] ; then
         echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
         echo "${ERRORS}"
-        exit 2
+        RESULT=2
     fi
 fi
 
@@ -62,7 +64,7 @@ UNDEFINED_GROUPS=$( \
 if [ -n "${UNDEFINED_GROUPS}" ]
 then
     COUNT=$(echo "${UNDEFINED_GROUPS}" | wc -l)
-    echo -ne "${CERROR}ERROR${CRESET} "
+    echo -ne "\n\n${CERROR}ERROR${CRESET} "
     echo -e "There are ${CWARN}${COUNT}${CRESET} undefined Doxygen groups:"
     for group in ${UNDEFINED_GROUPS};
     do
@@ -70,7 +72,7 @@ then
         echo "${ALL_RAW_INGROUP}" | grep "\<${group}\>$" | sort -u |
                 awk -F: '{ print "\t" $1 }';
     done
-    exit 2
+    RESULT=2
 fi
 
 # Check for groups defined multiple times:
@@ -79,7 +81,7 @@ MULTIPLE_DEFINED_GROUPS=$(echo "${DEFINED_GROUPS}" | uniq -d)
 if [ -n "${MULTIPLE_DEFINED_GROUPS}" ]
 then
     COUNT=$(echo "${MULTIPLE_DEFINED_GROUPS}" | wc -l)
-    echo -ne "${CERROR}ERROR${CRESET} "
+    echo -ne "\n\n${CERROR}ERROR${CRESET} "
     echo -e "There are ${CWARN}${COUNT}${CRESET} Doxygen groups defined multiple times:"
     for group in ${MULTIPLE_DEFINED_GROUPS};
     do
@@ -89,5 +91,6 @@ then
             grep "\<${group}\>$" | sort -u |
             awk -F: '{ print "\t" $1 }';
     done
-    exit 2
+    RESULT=2
 fi
+exit ${RESULT}

--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -10,6 +10,10 @@
 
 RIOTBASE="$(cd $(dirname $0)/../../..; pwd)"
 
+. ${RIOTBASE}/dist/tools/ci/github_annotate.sh
+
+github_annotate_setup
+
 if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
     CERROR="\e[1;31m"
     CWARN="\033[1;33m"
@@ -32,8 +36,19 @@ if [ "${DOXY_ERRCODE}" -ne 0 ] ; then
 else
     ERRORS=$(echo "${DOXY_OUTPUT}" | grep '.*warning' | sed "s#${PWD}/\([^:]*\)#\1#g")
     if [ -n "${ERRORS}" ] ; then
-        echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
-        echo "${ERRORS}"
+        if github_annotate_is_on; then
+            echo "${ERRORS}" | grep "^.\+:[0-9]\+: warning:" | while read error_line
+            do
+                FILENAME=$(echo "${error_line}" | cut -d: -f1)
+                LINENR=$(echo "${error_line}" | cut -d: -f2)
+                DETAILS=$(echo "${error_line}" | cut -d: -f4- |
+                          sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+                github_annotate_error "${FILENAME}" "${LINENR}" "${DETAILS}"
+            done
+        else
+            echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
+            echo "${ERRORS}"
+        fi
         RESULT=2
     fi
 fi
@@ -44,8 +59,8 @@ exclude_filter() {
 
 # Check groups are correctly defined (e.g. no undefined groups and no group
 # defined multiple times)
-ALL_RAW_DEFGROUP=$(git grep @defgroup -- '*.h' '*.c' '*.txt' | exclude_filter)
-ALL_RAW_INGROUP=$(git grep '@ingroup' -- '*.h' '*.c' '*.txt' | exclude_filter)
+ALL_RAW_DEFGROUP=$(git grep -n @defgroup -- '*.h' '*.c' '*.txt' | exclude_filter)
+ALL_RAW_INGROUP=$(git grep -n '@ingroup' -- '*.h' '*.c' '*.txt' | exclude_filter)
 DEFINED_GROUPS=$(echo "${ALL_RAW_DEFGROUP}" | \
                     grep -oE '@defgroup[ ]+[^ ]+' | \
                     grep -oE '[^ ]+$' | \
@@ -65,12 +80,26 @@ if [ -n "${UNDEFINED_GROUPS}" ]
 then
     COUNT=$(echo "${UNDEFINED_GROUPS}" | wc -l)
     echo -ne "\n\n${CERROR}ERROR${CRESET} "
-    echo -e "There are ${CWARN}${COUNT}${CRESET} undefined Doxygen groups:"
+    echo -ne "There are ${CWARN}${COUNT}${CRESET} undefined Doxygen groups"
+    if github_annotate_is_on; then
+        echo ""
+    else
+        echo ":"
+    fi
     for group in ${UNDEFINED_GROUPS};
     do
-        echo -e "\n${CWARN}${group}${CRESET} found in:";
-        echo "${ALL_RAW_INGROUP}" | grep "\<${group}\>$" | sort -u |
-                awk -F: '{ print "\t" $1 }';
+        INGROUPS=$(echo "${ALL_RAW_INGROUP}" | grep "\<${group}\>$" | sort -u)
+        if github_annotate_is_on; then
+            echo "${INGROUPS}" | while read ingroup;
+            do
+                github_annotate_error \
+                    $(echo ${ingroup} | awk -F: '{ print $1,$2 }') \
+                    "Undefined doxygen group '${group}'"
+            done
+        else
+            echo -e "\n${CWARN}${group}${CRESET} found in:";
+            echo "${INGROUPS}" | awk -F: '{ print "\t" $1 }';
+        fi
     done
     RESULT=2
 fi
@@ -82,15 +111,30 @@ if [ -n "${MULTIPLE_DEFINED_GROUPS}" ]
 then
     COUNT=$(echo "${MULTIPLE_DEFINED_GROUPS}" | wc -l)
     echo -ne "\n\n${CERROR}ERROR${CRESET} "
-    echo -e "There are ${CWARN}${COUNT}${CRESET} Doxygen groups defined multiple times:"
+    echo -ne "There are ${CWARN}${COUNT}${CRESET} Doxygen groups defined multiple times"
+    if github_annotate_is_on; then
+        echo ""
+    else
+        echo ":"
+    fi
     for group in ${MULTIPLE_DEFINED_GROUPS};
     do
-        echo -e "\n${CWARN}${group}${CRESET} defined in:";
-        echo "${ALL_RAW_DEFGROUP}" | \
+        DEFGROUPS=$(echo "${ALL_RAW_DEFGROUP}" |
             awk -F@ '{ split($2, end, " "); printf("%s%s\n",$1,end[2]) }' |
-            grep "\<${group}\>$" | sort -u |
-            awk -F: '{ print "\t" $1 }';
+            grep "\<${group}\>$" | sort -u)
+        DEFGROUPFILES=$(echo "${DEFGROUPS}" | awk -F: '{ print "\t" $1 }')
+        if github_annotate_is_on; then
+            echo "${DEFGROUPS}" | while read defgroup;
+            do
+                github_annotate_error $(echo ${defgroup} | awk -F: '{ print $1,$2 }') \
+                    "Multiple doxygen group definitions of '${group}' in\n${DEFGROUPFILES}"
+            done
+        else
+            echo -e "\n${CWARN}${group}${CRESET} defined in:";
+            echo "${DEFGROUPFILES}"
+        fi
     done
     RESULT=2
 fi
+github_annotate_teardown
 exit ${RESULT}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Provides Github annotations from the `doccheck` script, using the harness provided in https://github.com/RIOT-OS/RIOT/pull/15640. It also changes the script not to early exit on error, but to accumulate the errors. This was mostly done so I don't have to teardown the annotation harness in multiple places, but I think, since the static tests run isolated anyways and `doxygen` takes ages to finish anyways, it does not hurt to run the checks after all the time as well.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided a test commit that will cause some annotations.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~~Depends on https://github.com/RIOT-OS/RIOT/pull/15640~~
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
