### PR TITLE
pkg/nimble/netif: use global MSYS memory pool

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -51,15 +51,6 @@
 #define NETTYPE                 GNRC_NETTYPE_UNDEF
 #endif
 
-/* buffer configuration
- * - we need one RX and one TX buffer per connection */
-#define MTU_SIZE                (NIMBLE_NETIF_MTU)
-#define MBUF_OVHD               (sizeof(struct os_mbuf) + \
-                                 sizeof(struct os_mbuf_pkthdr))
-#define MBUF_SIZE               (MBUF_OVHD + MYNEWT_VAL_BLE_L2CAP_COC_MPS)
-#define MBUF_CNT                (NIMBLE_NETIF_MAX_CONN * 2 * \
-                                 ((MTU_SIZE + (MBUF_SIZE - 1)) / MBUF_SIZE))
-
 /* thread flag used for signaling transmit readiness */
 #define FLAG_TX_UNSTALLED       (1u << 13)
 #define FLAG_TX_NOTCONN         (1u << 12)
@@ -75,11 +66,6 @@ static gnrc_nettype_t _nettype = NETTYPE;
 
 /* keep a reference to the event callback */
 static nimble_netif_eventcb_t _eventcb;
-
-/* allocation of memory for buffering IP packets when handing them to NimBLE */
-static os_membuf_t _mem[OS_MEMPOOL_SIZE(MBUF_CNT, MBUF_SIZE)];
-static struct os_mempool _mem_pool;
-static struct os_mbuf_pool _mbuf_pool;
 
 /* notify the user about state changes for a connection context */
 static void _notify(int handle, nimble_netif_event_t event, uint8_t *addr)
@@ -114,7 +100,7 @@ static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)
     }
 
     /* copy the data into a newly allocated mbuf */
-    struct os_mbuf *sdu = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+    struct os_mbuf *sdu = os_msys_get_pkthdr(gnrc_pkt_len(pkt), 0);
     if (sdu == NULL) {
         return -ENOBUFS;
     }
@@ -229,7 +215,7 @@ static inline int _netdev_get(netdev_t *dev, netopt_t opt,
             break;
         case NETOPT_MAX_PDU_SIZE:
             assert(max_len >= sizeof(uint16_t));
-            *((uint16_t *)value) = MTU_SIZE;
+            *((uint16_t *)value) = NIMBLE_NETIF_MTU;
             res = sizeof(uint16_t);
             break;
         case NETOPT_PROTO:
@@ -320,7 +306,7 @@ static void _on_data(nimble_netif_conn_t *conn, struct ble_l2cap_event *event)
 end:
     /* free the mbuf and allocate a new one for receiving new data */
     os_mbuf_free_chain(rxb);
-    rxb = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+    rxb = os_msys_get_pkthdr(MYNEWT_VAL_BLE_L2CAP_COC_MPS, 0);
     /* due to buffer provisioning, there should always be enough space */
     assert(rxb != NULL);
     ble_l2cap_recv_ready(event->receive.chan, rxb);
@@ -395,7 +381,8 @@ static int _on_l2cap_server_evt(struct ble_l2cap_event *event, void *arg)
             conn->state &= ~NIMBLE_NETIF_L2CAP_CONNECTED;
             break;
         case BLE_L2CAP_EVENT_COC_ACCEPT: {
-            struct os_mbuf *sdu_rx = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
+            struct os_mbuf *sdu_rx = os_msys_get_pkthdr(
+                                            MYNEWT_VAL_BLE_L2CAP_COC_MPS, 0);
             /* there should always be enough buffer space */
             assert(sdu_rx != NULL);
             ble_l2cap_recv_ready(event->accept.chan, sdu_rx);
@@ -445,13 +432,18 @@ static int _on_gap_master_evt(struct ble_gap_event *event, void *arg)
             _on_gap_connected(conn, event->connect.conn_handle);
             conn->state |= NIMBLE_NETIF_GAP_MASTER;
 
-            struct os_mbuf *sdu_rx = os_mbuf_get_pkthdr(&_mbuf_pool, 0);
-            /* we should never run out of buffer space... */
-            assert(sdu_rx != NULL);
+            struct os_mbuf *sdu_rx = os_msys_get_pkthdr(
+                                            MYNEWT_VAL_BLE_L2CAP_COC_MPS, 0);
+            /* in the rare case that we run out of buffers, we close the new
+             * connection right away */
+            if (sdu_rx == NULL) {
+                ble_gap_terminate(handle, BLE_ERR_REM_USER_CONN_TERM);
+                break;
+            }
             res = ble_l2cap_connect(event->connect.conn_handle,
-                                    NIMBLE_NETIF_CID, MTU_SIZE, sdu_rx,
+                                    NIMBLE_NETIF_CID, NIMBLE_NETIF_MTU, sdu_rx,
                                     _on_l2cap_client_evt, (void *)handle);
-            /* should always success as well */
+            /* should always be successful */
             assert(res == 0);
             break;
         }
@@ -530,12 +522,7 @@ void nimble_netif_init(void)
     /* setup the connection context table */
     nimble_netif_conn_init();
 
-    /* initialize of BLE related buffers */
-    res = mem_init_mbuf_pool(_mem, &_mem_pool, &_mbuf_pool,
-                             MBUF_CNT, MBUF_SIZE, "nim_gnrc");
-    assert(res == 0);
-
-    res = ble_l2cap_create_server(NIMBLE_NETIF_CID, MTU_SIZE,
+    res = ble_l2cap_create_server(NIMBLE_NETIF_CID, NIMBLE_NETIF_MTU,
                                   _on_l2cap_server_evt, NULL);
     assert(res == 0);
     (void)res;


### PR DESCRIPTION
### Contribution description
In my initial implementation of `nimble_netif` I decided for using a local memory pool for buffering IP packets when transferring them from GNRC `pktbuf` to NimBLEs own (`mbuf`) memory pool. Now after more understanding and a lot of more experience using NimBLE, I come to the conclusion that it is far sufficient to use NimBLE global memory pool for this step as well. 

This saves quite a bit of otherwise over provisioned memory. Example - building `gnrc_networking` for `nrf52dk`:
without this PR:
```
   text    data     bss     dec 
 155788     288   46620  202696
```
with this PR:
```
   text    data     bss     dec 
 155796     288   38180  194264  
```
--> So for the default configuration (max connections := 3, mbuf-pool size := 35) **we save >8kb RAM!**

To further justify this change, the following diagram shows NimBLEs maximum buffer usage per node over time in an IP-over-BLE multi-hop experiment with 15 nodes:
![em6_putnon_statconn-static_1s1h39b_i2000_20201201-191422_buf_msys](https://user-images.githubusercontent.com/620834/102329441-b3d33e80-3f88-11eb-858b-b5a275f9153f.png)
This chart was taken with the memory-wise most demanding parameters that I used so far and it can clearly be seen that no Node ever used more than ~27 of its available buffers in the pool.

If ever running into trouble of exceeding buffer space, this change makes it also much more simple to increase the overvall memory size, as one has only to change a single value instead of tuning MSYS and the local memory pool individually...

Bottom line: we should be save with removing the local buffers in `nimble_netif` in favor of using NimBLEs global `MSYS` pool instead.

### Testing procedure
I recommend running the `gnrc_networking` example with 2 or more `nrf52dk` nodes and verify that IP communication between the nodes still works as expected (remember to use the `ble` shell command for connecting nodes...). This can nicely be done in the `iotlab`.

Alternatively one could verify this change also by running the `tests/nimble_l2cap` test using two supported nodes.

### Issues/PRs references
nonde