### PR TITLE
usbus: Add USB peripheral serial string support

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -950,6 +950,8 @@ ifneq (,$(filter usbus,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_usbus
   USEMODULE += core_thread_flags
   USEMODULE += event
+  USEMODULE += luid
+  USEMODULE += fmt
   ifeq (,$(filter usbdev_mock,$(USEMODULE)))
     FEATURES_REQUIRED += periph_usbdev
   endif

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -97,6 +97,32 @@ extern "C" {
 #endif
 
 /**
+ * @brief USB peripheral serial string
+ *
+ * Compile-time value to override the serial string with. An LUID-based hex
+ * string is generated when this value is not used.
+ *
+ * This string does not have to be a number, but it must be unique between
+ * devices with identical VID:PID combination.
+ */
+#ifdef DOXYGEN
+#define CONFIG_USB_SERIAL_STR           "RIOT-12345"
+#endif
+
+/**
+ * @brief USB peripheral serial string length
+ *
+ * Maximum value is 63. Sensible values are between 8 to 32 depending on the
+ * number of expected devices.
+ *
+ * The length here is in bytes. The generated hex string is twice as many chars
+ * in length due to conversion from bytes to hex chars.
+ */
+#if !defined(CONFIG_USB_SERIAL_STR) && !defined(CONFIG_USB_SERIAL_BYTE_LENGTH)
+#define CONFIG_USB_SERIAL_BYTE_LENGTH 8
+#endif
+
+/**
  * @brief USB peripheral device version
  *
  * This is the version number of this peripheral

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -399,6 +399,7 @@ struct usbus {
     usbus_string_t manuf;                           /**< Manufacturer string                   */
     usbus_string_t product;                         /**< Product string                        */
     usbus_string_t config;                          /**< Configuration string                  */
+    usbus_string_t serial;                          /**< serial string                  */
     usbus_endpoint_t ep_out[USBDEV_NUM_ENDPOINTS];  /**< USBUS OUT endpoints                   */
     usbus_endpoint_t ep_in[USBDEV_NUM_ENDPOINTS];   /**< USBUS IN endpoints                    */
     event_queue_t queue;                            /**< Event queue                           */
@@ -415,6 +416,12 @@ struct usbus {
     usbus_state_t state;                            /**< Current state                         */
     usbus_state_t pstate;                           /**< state to recover to from suspend      */
     uint8_t addr;                                   /**< Address of the USB peripheral         */
+#ifndef CONFIG_USB_SERIAL_STR
+    /**
+     * @brief Hex representation of the device serial number
+     */
+    char serial_str[2 * CONFIG_USB_SERIAL_BYTE_LENGTH + 1];
+#endif
 };
 
 /**

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -81,6 +81,32 @@ config USB_DEFAULT_LANGID
     help
         The default value is EN-US (0x0409).
 
+config USB_CUSTOM_SERIAL_STR
+    bool "Configure a custom USB serial string"
+
+config USB_SERIAL_STR
+    string "Serial string"
+    depends on USB_CUSTOM_SERIAL_STR
+    help
+        USB peripheral serial string
+
+        Compile-time value to override the serial string with. An LUID-based hex
+        string is generated when this value is not used.
+
+        This string does not have to be a number, but it must be unique between
+        devices with identical VID:PID combination.
+
+config USB_SERIAL_BYTE_LENGTH
+    int "USB peripheral serial string length"
+    depends on !USB_CUSTOM_SERIAL_STR
+    range 0 63
+    default 8
+    help
+        The length here is in bytes. The generated hex string is twice as many chars
+        in length due to conversion from bytes to hex chars.
+
+comment "WARNING: The serial string is empty!"
+    depends on USB_SERIAL_STR = "" && USB_CUSTOM_SERIAL_STR
 
 rsource "usbus/Kconfig"
 endif # KCONFIG_USB

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -288,6 +288,7 @@ size_t usbus_fmt_descriptor_dev(usbus_t *usbus)
     desc.product_id = CONFIG_USB_PID;
     desc.manufacturer_idx = usbus->manuf.idx;
     desc.product_idx = usbus->product.idx;
+    desc.serial_idx = usbus->serial.idx;
     /* USBUS supports only a single config at the moment */
     desc.num_configurations = 1;
     usbus_control_slicer_put_bytes(usbus, (uint8_t *)&desc,


### PR DESCRIPTION
### Contribution description

This adds compile-time options to configure the serial of an USB
peripheral. The serial be autogenerated with a configured number of
bytes. It is also possible to configure a fixed serial string for a
device and disable the autogeneration of the serial.

I've added Kconfig support for the new options. @leandrolanzieri: Could you verify that what I have created is the right way if I want `CONFIG_USB_SERIAL_STR` only emitted if it has a non-zero value.

### Testing procedure

usbus_minimal and some `lsusb -v -d 1209:7d01` can be used to verify the reported serial.

### Issues/PRs references

None