### PR TITLE
net/asymcute: fix handling of short and pre-defined topics

### DIFF
--- a/examples/asymcute_mqttsn/main.c
+++ b/examples/asymcute_mqttsn/main.c
@@ -89,51 +89,37 @@ static asymcute_sub_t *_find_sub(const char *name)
     return NULL;
 }
 
-static uint16_t _topic_parse_pre(const char *name)
+static uint16_t _parse_predef_id(const char *name)
 {
-    if (strncmp(name, "pre_", 4) == 0) {
-        return (uint16_t)atoi(&name[4]);
+    uint16_t id = 0;
+    if ((strlen(name) > 4) && (strncmp(name, "pre_", 4) == 0)) {
+        id = (uint16_t)atoi(&name[4]);
     }
-    return 0;
+    return id;
 }
 
-static int _topic_init(asymcute_topic_t *t, const char *name)
+static asymcute_topic_t *_topic_init(asymcute_topic_t *t, const char *name)
 {
-    uint16_t id = _topic_parse_pre(name);
-
+    uint16_t id = _parse_predef_id(name);
     if (id != 0) {
         name = NULL;
     }
 
     if (asymcute_topic_init(t, name, id) != ASYMCUTE_OK) {
-        return 1;
+        return NULL;
     }
-    return 0;
+    return t;
 }
-
-static int _topic_find(asymcute_topic_t *t, const char *name)
+static asymcute_topic_t *_topic_find(const char *name)
 {
-    size_t len = strlen(name);
-    uint16_t id = _topic_parse_pre(name);
-
-    if ((id != 0) || (len == 2)) {
-        if (t) {
-            return _topic_init(t, name);
-        }
-        return 0;
-    }
-
-    /* need to find topic in list of registered ones */
+    uint16_t id = _parse_predef_id(name);
     for (unsigned i = 0; i < TOPIC_BUF_NUMOF; i++) {
-        if (asymcute_topic_is_reg(&_topics[i]) &&
+        if ((asymcute_topic_is_predef(&_topics[i]) && (id == _topics[i].id)) ||
             (strncmp(name, _topics[i].name, sizeof(_topics[i].name)) == 0)) {
-            if (t) {
-                *t = _topics[i];
-            }
-            return 0;
+            return &_topics[i];
         }
     }
-    return 1;
+    return NULL;
 }
 
 static void _topics_clear(void)
@@ -149,6 +135,18 @@ static asymcute_topic_t *_topic_get_free(void)
         }
     }
     return NULL;
+}
+
+static void _topic_print_info(const asymcute_topic_t *topic)
+{
+    printf(" id: %u, name: %s", (unsigned)topic->id, topic->name);
+    if (asymcute_topic_is_short(topic)) {
+        printf(" (SHORT)");
+    }
+    else if (asymcute_topic_is_predef(topic)) {
+        printf(" (PREDEF)");
+    }
+    puts("");
 }
 
 static void _topic_print_help(void)
@@ -300,34 +298,35 @@ static int _cmd_reg(int argc, char **argv)
         return 1;
     }
 
-    if (_topic_find(NULL, argv[1]) == 0) {
-        puts("success: topic already registered (or no registration needed)\n");
+    asymcute_topic_t *t = _topic_find(argv[1]);
+    if ((t != NULL) && (asymcute_topic_is_reg(t))) {
+        puts("success: topic already registered");
         return 0;
     }
 
-    /* find unused slot */
-    asymcute_topic_t *t = NULL;
-    for (unsigned i = 0; i < TOPIC_BUF_NUMOF; i++) {
-        if (!asymcute_topic_is_reg(&_topics[i])) {
-            t = &_topics[i];
-            break;
-        }
-    }
-    if (t == NULL) {
-        puts("error: no empty slot left for storing the topic\n");
+    /* get registration request context */
+    asymcute_req_t *req = _get_req_ctx();
+    if (req == NULL) {
+        puts("error: unable to allocate request context");
         return 1;
     }
 
-    /* send registration request */
-    asymcute_req_t *req = _get_req_ctx();
-    if (req == NULL) {
-        return 1;
+    /* find unused slot */
+    if (t == NULL) {
+        t = _topic_get_free();
+        if (t == NULL) {
+            puts("error: no empty slot left for storing the topic\n");
+            return 1;
+        }
+        if (_topic_init(t, argv[1]) == NULL) {
+            puts("error: unable to initialize topic");
+            return 1;
+        }
     }
-    if (_topic_init(t, argv[1]) != 0) {
-        puts("error: unable to initialize topic");
-        return 1;
-    }
-    if (asymcute_register(&_connection, req, t) != ASYMCUTE_OK) {
+
+    int res = asymcute_register(&_connection, req, t);
+    if (res != ASYMCUTE_OK) {
+        printf("res: %i\n", res);
         puts("error: unable to send REGISTER request\n");
         return 1;
     }
@@ -341,21 +340,18 @@ static int _cmd_unreg(int argc, char **argv)
         return 1;
     }
 
-    unsigned i = 0;
-    for (; i < TOPIC_BUF_NUMOF; i++) {
-        if (strcmp(argv[1], _topics[i].name) == 0) {
-            for (unsigned s = 0; s < SUB_CTX_NUMOF; s++) {
-                if (_subscriptions[i].topic == &_topics[i]) {
-                    puts("error: topic used in active subscription");
-                    return 1;
-                }
+    asymcute_topic_t *t = _topic_find(argv[1]);
+    if (t) {
+        for (unsigned s = 0; s < SUB_CTX_NUMOF; s++) {
+            if (_subscriptions[s].topic == t) {
+                puts("error: topic used in active subscription");
+                return 1;
             }
-            memset(&_topics[i], 0, sizeof(asymcute_topic_t));
-            puts("success: removed local entry for given topic");
-            break;
         }
+        asymcute_topic_reset(t);
+        puts("success: removed local entry for given topic");
     }
-    if (i == TOPIC_BUF_NUMOF) {
+    else {
         puts("error: unable to find topic in list of registered topics");
     }
 
@@ -370,13 +366,6 @@ static int _cmd_pub(int argc, char **argv)
         return 1;
     }
 
-    /* parse and register topic */
-    asymcute_topic_t t;
-    if (_topic_find(&t, argv[1]) != 0) {
-        puts("error: given topic is not registered");
-        return 1;
-    }
-
     /* parse QoS level */
     unsigned flags = 0;
     int qos = _qos_parse(argc, argv, 3, &flags);
@@ -388,12 +377,20 @@ static int _cmd_pub(int argc, char **argv)
     /* get request context */
     asymcute_req_t *req = _get_req_ctx();
     if (req == NULL) {
+        puts("error: unable to obtain request context");
+        return 1;
+    }
+
+    /* get topic */
+    asymcute_topic_t *t = _topic_find(argv[1]);
+    if (t == NULL) {
+        puts("error: given topic is not registered");
         return 1;
     }
 
     /* publish data */
     size_t len = strlen(argv[2]);
-    if (asymcute_publish(&_connection, req, &t, argv[2], len, flags) !=
+    if (asymcute_publish(&_connection, req, t, argv[2], len, flags) !=
         ASYMCUTE_OK) {
         puts("error: unable to send PUBLISH message");
         return 1;
@@ -424,6 +421,7 @@ static int _cmd_sub(int argc, char **argv)
     /* get request context */
     asymcute_req_t *req = _get_req_ctx();
     if (req == NULL) {
+        puts("error: unable to obtain request context");
         return 1;
     }
 
@@ -434,23 +432,39 @@ static int _cmd_sub(int argc, char **argv)
         return 1;
     }
 
-    /* parse topic */
-    asymcute_topic_t *t = _topic_get_free();
+    /* parse topic, see if it exists, otherwise take empty topic */
+    asymcute_topic_t *t = _topic_find(argv[1]);
     if (t == NULL) {
-        puts("error: no free topic memory");
-        return 1;
+        puts("info: given topic does not exist, creating it now");
+        t = _topic_get_free();
+        if (t == NULL) {
+            puts("error: no free topic memory");
+            return 1;
+        }
+        if (_topic_init(t, argv[1]) == 0) {
+            puts("error: unable to initialize topic");
+            return 1;
+        }
     }
-    if (_topic_init(t, argv[1]) != 0) {
-        puts("error: unable to initialize topic");
-        return 1;
+    else {
+        if (!asymcute_topic_is_reg(t)) {
+            puts("error: given topic is not registered\n");
+            return 1;
+        }
     }
 
-    printf("using req %p, sub %p\n", (void *)req, (void *)sub);
-
-    if (asymcute_subscribe(&_connection, req, sub, t, _on_pub_evt, NULL, flags)
-        != ASYMCUTE_OK) {
-        asymcute_topic_reset(t);
-        puts("error: unable to send SUBSCRIBE request");
+    int res = asymcute_subscribe(&_connection, req, sub, t, _on_pub_evt,
+                                 NULL, flags);
+    if (res != ASYMCUTE_OK) {
+        if (!asymcute_topic_is_reg(t)) {
+            asymcute_topic_reset(t);
+        }
+        if (res == ASYMCUTE_SUBERR) {
+            puts("error: already subscribed to given topic");
+        }
+        else {
+            puts("error: unable to send SUBSCRIBE request");
+        }
         return 1;
     }
 
@@ -496,8 +510,12 @@ static int _cmd_info(int argc, char **argv)
     for (unsigned i = 0; i < TOPIC_BUF_NUMOF; i++) {
         printf("topic #%2u - ", i);
         if (asymcute_topic_is_reg(&_topics[i])) {
-            printf("[registered] id: %u, name: %s\n",
-                    (unsigned)_topics[i].id, _topics[i].name);
+            printf("[registered] ");
+            _topic_print_info(&_topics[i]);
+        }
+        else if (asymcute_topic_is_init(&_topics[i])) {
+            printf("[initialized] ");
+            _topic_print_info(&_topics[i]);
         }
         else {
             puts("[unused]");
@@ -508,9 +526,8 @@ static int _cmd_info(int argc, char **argv)
     for (unsigned i = 0; i < SUB_CTX_NUMOF; i++) {
         printf("sub   #%2u - ", i);
         if (asymcute_sub_active(&_subscriptions[i])) {
-            printf("[subscribed] id: %u, name: %s\n",
-                   (unsigned)_subscriptions[i].topic->id,
-                   _subscriptions[i].topic->name);
+            printf("[subscribed]");
+            _topic_print_info(_subscriptions[i].topic);
         }
         else {
             puts("[unused]");

--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -395,6 +395,34 @@ static inline bool asymcute_topic_is_reg(const asymcute_topic_t *topic)
 }
 
 /**
+ * @brief   Check if a given topic is a short topic
+ *
+ * @param[in] topic     topic to check
+ *
+ * @return  true if topic is a short topic
+ * @return  false if topic is not short topic
+ */
+static inline bool asymcute_topic_is_short(const asymcute_topic_t *topic)
+{
+    assert(topic);
+    return ((topic->flags & MQTTSN_TIT_SHORT) != 0);
+}
+
+/**
+ * @brief   Check if a given topic is a pre-defined topic
+ *
+ * @param[in] topic     topic to check
+ *
+ * @return  true if topic is pre-defined
+ * @return  false if topic is not pre-defined
+ */
+static inline bool asymcute_topic_is_predef(const asymcute_topic_t *topic)
+{
+    assert(topic);
+    return ((topic->flags & MQTTSN_TIT_PREDEF) != 0);
+}
+
+/**
  * @brief   Check if a given topic is initialized
  *
  * @param[in] topic     topic to check


### PR DESCRIPTION
### Contribution description
When testing #15652, I discovered that the handling for `short` and `pre-defined` topics was severely buggy. E.g. publishing to short topics did not work, there was no way to delete `pre-defined` topics from the list of topics in the example application, subscribing to neither of those two topics didn't work, etc.

This PR should fix all those issues.

### Testing procedure
Run the ~~`tests/asymcute`~~ `examples/asymcute` example application and try to register some `short` and `pre-defined` topics with a gateway. On the RIOT node, you should see something like:
```
> ifconfig 6 add affe::123
ifconfig 6 add affe::123
success: added affe::123/64 to interface 6
> connect hugo [affe::1]
connect hugo [affe::1]
Request 0x566712a0: issued
> Request 0x566712a0: Connection to gateway established

> sub aa
sub aa
info: given topic does not exist, creating it now
Request 0x566712a0: issued
> Request 0x566712a0: Subscribed topic
reg pre_123
reg pre_123
Request 0x566712a0: issued
> pub aa moin_hugo
pub aa moin_hugo
Request 0x566712a0: issued (one way)
> subscription to topic #24929 [aa]: NEW DATA
         data -> moin_hugo
              -> 9 bytes
info
info
--- Asymcute MQTT-SN client state ---
Topics:
topic # 0 - [registered]  id: 24929, name: aa (SHORT)
topic # 1 - [registered]  id: 123, name: .. (PREDEF)
...
Subscriptions:
sub   # 0 - [subscribed] id: 24929, name: aa (SHORT)
...
```
The gateways corresponding output should then look something like:
```
20201216 182604.345 CWNAN0300I MQTT-S protocol starting, listening on port 1883
20201216 182604.345 CWNAN0014I MQTT protocol starting, listening on port 1883
20201216 182656.186 3 affe::123:49429  <- MQTT-S CONNECT cleansession: 1
20201216 182656.186 -1136129792 affe::123:49429 hugo -> MQTT-S CONNACK returncode 0 (0)
20201216 182656.186 CWNAN0000I Client connected to udp port 1883 from hugo (affe::123:49429)
20201216 182703.586 3 affe::123:49429 hugo <- MQTT-S SUBSCRIBE msgid: 27734 qos: 0 topicIdType 2
20201216 182703.586 3 affe::123:49429 hugo -> MQTT-S SUBACK msgid: 27734 topicid: 0 returncode: 0 (0)
20201216 182725.609 3 affe::123:49429 hugo <- MQTT-S PUBLISH msgid: 0 qos: 0 retained: 0
20201216 182726.143 3 affe::123:49429 hugo -> MQTT-S PUBLISH msgid: 0 qos: 0 retained: 0 (0)
```

Note: from the example/asymcute directory you can simply run make mosquitto_rsmb to start a local MQTT-SN Gateway/Broker for testing. Also remember to use global addresses for the Mosquitto RSMB to work properly :-)


### Issues/PRs references
Detected bugs when tesing #15652