### PR TITLE
[PoC] sys/atomic_utils: optimize Cortex-M implementation with inline-asm

### DIFF
--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -276,29 +276,34 @@ static inline void atomic_store_u64(volatile uint64_t *dest, uint64_t val);
  * @brief   Atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value atomically in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_add_u8(volatile uint8_t *dest, uint8_t summand);
+static inline uint8_t atomic_fetch_add_u8(volatile uint8_t *dest,
+                                          uint8_t summand);
 /**
  * @brief   Atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value atomically in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_add_u16(volatile uint16_t *dest,
-                                        uint16_t summand);
+static inline uint16_t atomic_fetch_add_u16(volatile uint16_t *dest,
+                                            uint16_t summand);
 /**
  * @brief   Atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value atomically in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_add_u32(volatile uint32_t *dest,
-                                        uint32_t summand);
+static inline uint32_t atomic_fetch_add_u32(volatile uint32_t *dest,
+                                            uint32_t summand);
 /**
  * @brief   Atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value atomically in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_add_u64(volatile uint64_t *dest,
-                                        uint64_t summand);
+static inline uint64_t atomic_fetch_add_u64(volatile uint64_t *dest,
+                                            uint64_t summand);
 /** @} */
 
 /**
@@ -310,33 +315,37 @@ static inline void atomic_fetch_add_u64(volatile uint64_t *dest,
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_sub_u8(volatile uint8_t *dest,
-                                       uint8_t subtrahend);
+static inline uint8_t atomic_fetch_sub_u8(volatile uint8_t *dest,
+                                          uint8_t subtrahend);
 /**
  * @brief   Atomically subtract a value from a given value
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_sub_u16(volatile uint16_t *dest,
-                                        uint16_t subtrahend);
+static inline uint16_t atomic_fetch_sub_u16(volatile uint16_t *dest,
+                                            uint16_t subtrahend);
 /**
  * @brief   Atomically subtract a value from a given value
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_sub_u32(volatile uint32_t *dest,
-                                        uint32_t subtrahend);
+static inline uint32_t atomic_fetch_sub_u32(volatile uint32_t *dest,
+                                            uint32_t subtrahend);
 /**
  * @brief   Atomically subtract a value from a given value
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_sub_u64(volatile uint64_t *dest,
-                                        uint64_t subtrahend);
+static inline uint64_t atomic_fetch_sub_u64(volatile uint64_t *dest,
+                                            uint64_t subtrahend);
 /** @} */
 
 /**
@@ -348,29 +357,36 @@ static inline void atomic_fetch_sub_u64(volatile uint64_t *dest,
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_or_u8(volatile uint8_t *dest, uint8_t val);
+static inline uint8_t atomic_fetch_or_u8(volatile uint8_t *dest, uint8_t val);
 /**
  * @brief   Atomic version of `*dest |= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_or_u16(volatile uint16_t *dest, uint16_t val);
+static inline uint16_t atomic_fetch_or_u16(volatile uint16_t *dest,
+                                           uint16_t val);
 /**
  * @brief   Atomic version of `*dest |= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_or_u32(volatile uint32_t *dest, uint32_t val);
+static inline uint32_t atomic_fetch_or_u32(volatile uint32_t *dest,
+                                           uint32_t val);
 /**
  * @brief   Atomic version of `*dest |= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_or_u64(volatile uint64_t *dest, uint64_t val);
+static inline uint64_t atomic_fetch_or_u64(volatile uint64_t *dest,
+                                           uint64_t val);
 /** @} */
 
 /**
@@ -382,29 +398,36 @@ static inline void atomic_fetch_or_u64(volatile uint64_t *dest, uint64_t val);
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_xor_u8(volatile uint8_t *dest, uint8_t val);
+static inline uint8_t atomic_fetch_xor_u8(volatile uint8_t *dest, uint8_t val);
 /**
  * @brief   Atomic version of `*dest ^= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_xor_u16(volatile uint16_t *dest, uint16_t val);
+static inline uint16_t atomic_fetch_xor_u16(volatile uint16_t *dest,
+                                            uint16_t val);
 /**
  * @brief   Atomic version of `*dest ^= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_xor_u32(volatile uint32_t *dest, uint32_t val);
+static inline uint32_t atomic_fetch_xor_u32(volatile uint32_t *dest,
+                                            uint32_t val);
 /**
  * @brief   Atomic version of `*dest ^= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_xor_u64(volatile uint64_t *dest, uint64_t val);
+static inline uint64_t atomic_fetch_xor_u64(volatile uint64_t *dest,
+                                            uint64_t val);
 /** @} */
 
 /**
@@ -416,29 +439,36 @@ static inline void atomic_fetch_xor_u64(volatile uint64_t *dest, uint64_t val);
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_and_u8(volatile uint8_t *dest, uint8_t val);
+static inline uint8_t atomic_fetch_and_u8(volatile uint8_t *dest, uint8_t val);
 /**
  * @brief   Atomic version of `*dest &= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_and_u16(volatile uint16_t *dest, uint16_t val);
+static inline uint16_t atomic_fetch_and_u16(volatile uint16_t *dest,
+                                            uint16_t val);
 /**
  * @brief   Atomic version of `*dest &= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_and_u32(volatile uint32_t *dest, uint32_t val);
+static inline uint32_t atomic_fetch_and_u32(volatile uint32_t *dest,
+                                            uint32_t val);
 /**
  * @brief   Atomic version of `*dest &= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void atomic_fetch_and_u64(volatile uint64_t *dest, uint64_t val);
+static inline uint64_t atomic_fetch_and_u64(volatile uint64_t *dest,
+                                            uint64_t val);
 /** @} */
 
 /**
@@ -539,33 +569,37 @@ static inline void atomic_clear_bit_u64(atomic_bit_u64_t bit);
  * @param[in,out]   dest    Add @p summand onto this value semi-atomically
  *                          in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_add_u8(volatile uint8_t *dest,
-                                            uint8_t summand);
+static inline uint8_t semi_atomic_fetch_add_u8(volatile uint8_t *dest,
+                                               uint8_t summand);
 /**
  * @brief   Semi-atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value semi-atomically
  *                          in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_add_u16(volatile uint16_t *dest,
-                                             uint16_t summand);
+static inline uint16_t semi_atomic_fetch_add_u16(volatile uint16_t *dest,
+                                                 uint16_t summand);
 /**
  * @brief   Semi-atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value semi-atomically
  *                          in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_add_u32(volatile uint32_t *dest,
-                                             uint32_t summand);
+static inline uint32_t semi_atomic_fetch_add_u32(volatile uint32_t *dest,
+                                                 uint32_t summand);
 /**
  * @brief   Semi-atomically add a value onto a given value
  * @param[in,out]   dest    Add @p summand onto this value semi-atomically
  *                          in-place
  * @param[in]       summand Value to add onto @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_add_u64(volatile uint64_t *dest,
-                                             uint64_t summand);
+static inline uint64_t semi_atomic_fetch_add_u64(volatile uint64_t *dest,
+                                                 uint64_t summand);
 /** @} */
 
 /**
@@ -577,33 +611,37 @@ static inline void semi_atomic_fetch_add_u64(volatile uint64_t *dest,
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              semi-atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_sub_u8(volatile uint8_t *dest,
-                                            uint8_t subtrahend);
+static inline uint8_t semi_atomic_fetch_sub_u8(volatile uint8_t *dest,
+                                               uint8_t subtrahend);
 /**
  * @brief   Semi-atomically subtract a value from a given value
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              semi-atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
-                                             uint16_t subtrahend);
+static inline uint16_t semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
+                                                 uint16_t subtrahend);
 /**
  * @brief   Semi-atomically subtract a value from a given value
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              semi-atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
-                                             uint32_t subtrahend);
+static inline uint32_t semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
+                                                 uint32_t subtrahend);
 /**
  * @brief   Semi-atomically subtract a value from a given value
  * @param[in,out]   dest        Subtract @p subtrahend from this value
  *                              semi-atomically in-place
  * @param[in]       subtrahend  Value to subtract from @p dest
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
-                                             uint64_t subtrahend);
+static inline uint64_t semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
+                                                 uint64_t subtrahend);
 /** @} */
 
 /**
@@ -615,32 +653,36 @@ static inline void semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_or_u8(volatile uint8_t *dest, uint8_t val);
+static inline uint8_t semi_atomic_fetch_or_u8(volatile uint8_t *dest, uint8_t val);
 /**
  * @brief   Semi-atomic version of `*dest |= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_or_u16(volatile uint16_t *dest,
-                                            uint16_t val);
+static inline uint16_t semi_atomic_fetch_or_u16(volatile uint16_t *dest,
+                                                uint16_t val);
 /**
  * @brief   Semi-atomic version of `*dest |= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_or_u32(volatile uint32_t *dest,
-                                            uint32_t val);
+static inline uint32_t semi_atomic_fetch_or_u32(volatile uint32_t *dest,
+                                                uint32_t val);
 /**
  * @brief   Semi-atomic version of `*dest |= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest | val`
  * @param[in]       val         Value to bitwise or into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_or_u64(volatile uint64_t *dest,
-                                            uint64_t val);
+static inline uint64_t semi_atomic_fetch_or_u64(volatile uint64_t *dest,
+                                                uint64_t val);
 /** @} */
 
 /**
@@ -652,33 +694,37 @@ static inline void semi_atomic_fetch_or_u64(volatile uint64_t *dest,
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_xor_u8(volatile uint8_t *dest,
-                                            uint8_t val);
+static inline uint8_t semi_atomic_fetch_xor_u8(volatile uint8_t *dest,
+                                               uint8_t val);
 /**
  * @brief   Semi-atomic version of `*dest ^= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
-                                             uint16_t val);
+static inline uint16_t semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
+                                                 uint16_t val);
 /**
  * @brief   Semi-atomic version of `*dest ^= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
-                                             uint32_t val);
+static inline uint32_t semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
+                                                 uint32_t val);
 /**
  * @brief   Semi-atomic version of `*dest ^= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest ^ val`
  * @param[in]       val         Value to bitwise xor into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
-                                             uint64_t val);
+static inline uint64_t semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
+                                                 uint64_t val);
 /** @} */
 
 /**
@@ -690,33 +736,37 @@ static inline void semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_and_u8(volatile uint8_t *dest,
-                                            uint8_t val);
+static inline uint8_t semi_atomic_fetch_and_u8(volatile uint8_t *dest,
+                                               uint8_t val);
 /**
  * @brief   Semi-atomic version of `*dest &= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_and_u16(volatile uint16_t *dest,
-                                             uint16_t val);
+static inline uint16_t semi_atomic_fetch_and_u16(volatile uint16_t *dest,
+                                                 uint16_t val);
 /**
  * @brief   Semi-atomic version of `*dest &= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_and_u32(volatile uint32_t *dest,
-                                             uint32_t val);
+static inline uint32_t semi_atomic_fetch_and_u32(volatile uint32_t *dest,
+                                                 uint32_t val);
 /**
  * @brief   Semi-atomic version of `*dest &= val`
  * @param[in,out]   dest        Replace this value with the result of
  *                              `*dest & val`
  * @param[in]       val         Value to bitwise and into @p dest in-place
+ * @return  The value previously stored @p dest
  */
-static inline void semi_atomic_fetch_and_u64(volatile uint64_t *dest,
-                                             uint64_t val);
+static inline uint64_t semi_atomic_fetch_and_u64(volatile uint64_t *dest,
+                                                 uint64_t val);
 /** @} */
 
 /* Fallback implementations of atomic utility functions: */
@@ -799,12 +849,14 @@ ATOMIC_STORE_IMPL(u64, uint64_t)
  * @param   type    Variable type, e.g. `uint8_t`
  */
 #define ATOMIC_FETCH_OP_IMPL(opname, op, name, type)                           \
-    static inline void CONCAT4(atomic_fetch_, opname, _, name)                 \
+    static inline type CONCAT4(atomic_fetch_, opname, _, name)                 \
             (volatile type *dest, type val)                                    \
     {                                                                          \
         unsigned state = irq_disable();                                        \
-        *dest = *dest op val;                                                  \
+        const type result = *dest;                                             \
+        *dest = result op val;                                                 \
         irq_restore(state);                                                    \
+        return result;                                                         \
     }
 
 #ifndef HAS_ATOMIC_FETCH_ADD_U8
@@ -945,54 +997,62 @@ static inline void atomic_clear_bit_u64(atomic_bit_u64_t bit)
 
 /* FETCH_ADD */
 #if defined(HAS_ATOMIC_FETCH_ADD_U8) || !defined(HAS_ATOMIC_STORE_U8)
-static inline void semi_atomic_fetch_add_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_add_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_fetch_add_u8(dest, val);
+    return atomic_fetch_add_u8(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_add_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_add_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_store_u8(dest, *dest + val);
+    uint8_t result = atomic_load_u8(dest);
+    atomic_store_u8(dest, result + val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_ADD_U8 || !HAS_ATOMIC_STORE_U8 */
 
 #if defined(HAS_ATOMIC_FETCH_ADD_U16) || !defined(HAS_ATOMIC_STORE_U16)
-static inline void semi_atomic_fetch_add_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_add_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_fetch_add_u16(dest, val);
+    return atomic_fetch_add_u16(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_add_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_add_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_store_u16(dest, *dest + val);
+    uint16_t result = atomic_load_u16(dest);
+    atomic_store_u16(dest, result + val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_ADD_U16 || !HAS_ATOMIC_STORE_U16 */
 
 #if defined(HAS_ATOMIC_FETCH_ADD_U32) || !defined(HAS_ATOMIC_STORE_U32)
-static inline void semi_atomic_fetch_add_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_add_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_fetch_add_u32(dest, val);
+    return atomic_fetch_add_u32(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_add_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_add_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_store_u32(dest, *dest + val);
+    uint32_t result = atomic_load_u32(dest);
+    atomic_store_u32(dest, result + val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_ADD_U32 || !HAS_ATOMIC_STORE_U32 */
 
 #if defined(HAS_ATOMIC_FETCH_ADD_U64) || !defined(HAS_ATOMIC_STORE_U64)
-static inline void semi_atomic_fetch_add_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_add_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_fetch_add_u64(dest, val);
+    return atomic_fetch_add_u64(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_add_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_add_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
     atomic_store_u64(dest, *dest + val);
 }
@@ -1000,221 +1060,261 @@ static inline void semi_atomic_fetch_add_u64(volatile uint64_t *dest,
 
 /* FETCH_SUB */
 #if defined(HAS_ATOMIC_FETCH_SUB_U8) || !defined(HAS_ATOMIC_STORE_U8)
-static inline void semi_atomic_fetch_sub_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_sub_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_fetch_sub_u8(dest, val);
+    return atomic_fetch_sub_u8(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_sub_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_sub_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_store_u8(dest, *dest - val);
+    uint8_t result = atomic_load_u8(dest);
+    atomic_store_u8(dest, result - val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_SUB_U8 || !HAS_ATOMIC_STORE_U8 */
 
 #if defined(HAS_ATOMIC_FETCH_SUB_U16) || !defined(HAS_ATOMIC_STORE_U16)
-static inline void semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_fetch_sub_u16(dest, val);
+    return atomic_fetch_sub_u16(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_store_u16(dest, *dest - val);
+    uint16_t result = atomic_load_u16(dest);
+    atomic_store_u16(dest, result - val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_SUB_U16 || !HAS_ATOMIC_STORE_U16 */
 
 #if defined(HAS_ATOMIC_FETCH_SUB_U32) || !defined(HAS_ATOMIC_STORE_U32)
-static inline void semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_fetch_sub_u32(dest, val);
+    return atomic_fetch_sub_u32(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_store_u32(dest, *dest - val);
+    uint32_t result = atomic_load_u32(dest);
+    atomic_store_u32(dest, result - val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_SUB_U32 || !HAS_ATOMIC_STORE_U64 */
 
 #if defined(HAS_ATOMIC_FETCH_SUB_U64) || !defined(HAS_ATOMIC_STORE_U64)
-static inline void semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_fetch_sub_u64(dest, val);
+    return atomic_fetch_sub_u64(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_store_u64(dest, *dest - val);
+    uint64_t result = atomic_load_u64(dest);
+    atomic_store_u64(dest, result - val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_SUB_U64 || !HAS_ATOMIC_STORE_U64 */
 
 /* FETCH_OR */
 #if defined(HAS_ATOMIC_FETCH_OR_U8) || !defined(HAS_ATOMIC_STORE_U8)
-static inline void semi_atomic_fetch_or_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_or_u8(volatile uint8_t *dest,
+                                              uint8_t val)
 {
-    atomic_fetch_or_u8(dest, val);
+    return atomic_fetch_or_u8(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_or_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_or_u8(volatile uint8_t *dest,
+                                              uint8_t val)
 {
-    atomic_store_u8(dest, *dest | val);
+    uint8_t result = atomic_load_u8(dest);
+    atomic_store_u8(dest, result | val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_OR_U8 || !HAS_ATOMIC_STORE_U8 */
 
 #if defined(HAS_ATOMIC_FETCH_OR_U16) || !defined(HAS_ATOMIC_STORE_U16)
-static inline void semi_atomic_fetch_or_u16(volatile uint16_t *dest,
-                                            uint16_t val)
+static inline uint16_t semi_atomic_fetch_or_u16(volatile uint16_t *dest,
+                                                uint16_t val)
 {
-    atomic_fetch_or_u16(dest, val);
+    return atomic_fetch_or_u16(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_or_u16(volatile uint16_t *dest,
-                                            uint16_t val)
+static inline uint16_t semi_atomic_fetch_or_u16(volatile uint16_t *dest,
+                                                uint16_t val)
 {
-    atomic_store_u16(dest, *dest | val);
+    uint16_t result = atomic_load_u16(dest);
+    atomic_store_u16(dest, result | val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_OR_U16 || !HAS_ATOMIC_STORE_U16 */
 
 #if defined(HAS_ATOMIC_FETCH_OR_U32) || !defined(HAS_ATOMIC_STORE_U32)
-static inline void semi_atomic_fetch_or_u32(volatile uint32_t *dest,
-                                            uint32_t val)
+static inline uint32_t semi_atomic_fetch_or_u32(volatile uint32_t *dest,
+                                                uint32_t val)
 {
-    atomic_fetch_or_u32(dest, val);
+    return atomic_fetch_or_u32(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_or_u32(volatile uint32_t *dest,
-                                            uint32_t val)
+static inline uint32_t semi_atomic_fetch_or_u32(volatile uint32_t *dest,
+                                                uint32_t val)
 {
-    atomic_store_u32(dest, *dest | val);
+    uint32_t result = atomic_load_u32(dest);
+    atomic_store_u32(dest, result | val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_OR_U32 || !HAS_ATOMIC_STORE_U32 */
 
 #if defined(HAS_ATOMIC_FETCH_OR_U64) || !defined(HAS_ATOMIC_STORE_U64)
-static inline void semi_atomic_fetch_or_u64(volatile uint64_t *dest,
-                                            uint64_t val)
+static inline uint64_t semi_atomic_fetch_or_u64(volatile uint64_t *dest,
+                                                uint64_t val)
 {
-    atomic_fetch_or_u64(dest, val);
+    return atomic_fetch_or_u64(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_or_u64(volatile uint64_t *dest,
-                                            uint64_t val)
+static inline uint64_t semi_atomic_fetch_or_u64(volatile uint64_t *dest,
+                                                uint64_t val)
 {
-    atomic_store_u64(dest, *dest | val);
+    uint64_t result = atomic_load_u64(dest);
+    atomic_store_u64(dest, result | val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_OR_U64 || !HAS_ATOMIC_STORE_U64 */
 
 /* FETCH_XOR */
 #if defined(HAS_ATOMIC_FETCH_XOR_U8) || !defined(HAS_ATOMIC_STORE_U8)
-static inline void semi_atomic_fetch_xor_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_xor_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_fetch_xor_u8(dest, val);
+    return atomic_fetch_xor_u8(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_xor_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_xor_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_store_u8(dest, *dest ^ val);
+    uint8_t result = atomic_load_u8(dest);
+    atomic_store_u8(dest, result ^ val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_XOR_U8 || !HAS_ATOMIC_STORE_U8 */
 
 #if defined(HAS_ATOMIC_FETCH_XOR_U16) || !defined(HAS_ATOMIC_STORE_U16)
-static inline void semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_fetch_xor_u16(dest, val);
+    return atomic_fetch_xor_u16(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_store_u16(dest, *dest ^ val);
+    uint16_t result = atomic_load_u16(dest);
+    atomic_store_u16(dest, result ^ val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_XOR_U16 || !HAS_ATOMIC_STORE_U16 */
 
 #if defined(HAS_ATOMIC_FETCH_XOR_U32) || !defined(HAS_ATOMIC_STORE_U32)
-static inline void semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_fetch_xor_u32(dest, val);
+    return atomic_fetch_xor_u32(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_store_u32(dest, *dest ^ val);
+    uint32_t result = atomic_load_u32(dest);
+    atomic_store_u32(dest, result ^ val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_XOR_U32 || !HAS_ATOMIC_STORE_U32 */
 
 #if defined(HAS_ATOMIC_FETCH_XOR_U64) || !defined(HAS_ATOMIC_STORE_U64)
-static inline void semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_fetch_xor_u64(dest, val);
+    return atomic_fetch_xor_u64(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_store_u64(dest, *dest ^ val);
+    uint64_t result = atomic_load_u64(dest);
+    atomic_store_u64(dest, result ^ val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_XOR_U64 || !HAS_ATOMIC_STORE_U64 */
 
 /* FETCH_AND */
 #if defined(HAS_ATOMIC_FETCH_AND_U8) || !defined(HAS_ATOMIC_STORE_U8)
-static inline void semi_atomic_fetch_and_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_and_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_fetch_and_u8(dest, val);
+    return atomic_fetch_and_u8(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_and_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t semi_atomic_fetch_and_u8(volatile uint8_t *dest,
+                                               uint8_t val)
 {
-    atomic_store_u8(dest, *dest & val);
+    uint8_t result = atomic_load_u8(dest);
+    atomic_store_u8(dest, result & val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_AND_U8 || !HAS_ATOMIC_STORE_U8 */
 
 #if defined(HAS_ATOMIC_FETCH_AND_U16) || !defined(HAS_ATOMIC_STORE_U16)
-static inline void semi_atomic_fetch_and_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_and_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_fetch_and_u16(dest, val);
+    return atomic_fetch_and_u16(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_and_u16(volatile uint16_t *dest,
-                                             uint16_t val)
+static inline uint16_t semi_atomic_fetch_and_u16(volatile uint16_t *dest,
+                                                 uint16_t val)
 {
-    atomic_store_u16(dest, *dest & val);
+    uint16_t result = atomic_load_u16(dest);
+    atomic_store_u16(dest, result & val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_AND_U16 || !HAS_ATOMIC_STORE_U16 */
 
 #if defined(HAS_ATOMIC_FETCH_AND_U32) || !defined(HAS_ATOMIC_STORE_U32)
-static inline void semi_atomic_fetch_and_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_and_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_fetch_and_u32(dest, val);
+    return atomic_fetch_and_u32(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_and_u32(volatile uint32_t *dest,
-                                             uint32_t val)
+static inline uint32_t semi_atomic_fetch_and_u32(volatile uint32_t *dest,
+                                                 uint32_t val)
 {
-    atomic_store_u32(dest, *dest & val);
+    uint32_t result = atomic_load_u32(dest);
+    atomic_store_u32(dest, result & val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_AND_U32 || !HAS_ATOMIC_STORE_U32 */
 
 #if defined(HAS_ATOMIC_FETCH_AND_U64) || !defined(HAS_ATOMIC_STORE_U64)
-static inline void semi_atomic_fetch_and_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_and_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_fetch_and_u64(dest, val);
+    return atomic_fetch_and_u64(dest, val);
 }
 #else
-static inline void semi_atomic_fetch_and_u64(volatile uint64_t *dest,
-                                             uint64_t val)
+static inline uint64_t semi_atomic_fetch_and_u64(volatile uint64_t *dest,
+                                                 uint64_t val)
 {
-    atomic_store_u64(dest, *dest & val);
+    uint64_t result = atomic_load_u64(dest);
+    atomic_store_u64(dest, result & val);
+    return result;
 }
 #endif /* HAS_ATOMIC_FETCH_AND_U64 || !HAS_ATOMIC_STORE_U64 */
 

--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -985,18 +985,16 @@ static inline void atomic_clear_bit_u64(atomic_bit_u64_t bit)
 
 /* Provide semi_atomic_*() functions on top.
  *
- * - If atomic_<FOO>() is provided: Use this for semi_atomic_<FOO>() as well
- * - Else:
- *      - If matching `atomic_store_u<BITS>()` is provided: Only make final
- *        store atomic, as we can avoid touching the IRQ state register that
- *        way
- *      - Else: We need to disable and re-enable IRQs anyway, we just use the
- *        fallback implementation of `atomic_<FOO>()` for `semi_atomic<FOO>()`
- *        as well
+ * - If matching `atomic_store_u<BITS>()` is provided: Only make final
+ *   store atomic, as we can avoid touching the IRQ state register that
+ *   way
+ * - Otherwise, we need to disable and re-enable IRQs anyway, we just use the
+ *   fallback implementation of `atomic_<FOO>()` for `semi_atomic<FOO>()`
+ *   as well
  */
 
 /* FETCH_ADD */
-#if defined(HAS_ATOMIC_FETCH_ADD_U8) || !defined(HAS_ATOMIC_STORE_U8)
+#if !defined(HAS_ATOMIC_STORE_U8)
 static inline uint8_t semi_atomic_fetch_add_u8(volatile uint8_t *dest,
                                                uint8_t val)
 {
@@ -1010,9 +1008,9 @@ static inline uint8_t semi_atomic_fetch_add_u8(volatile uint8_t *dest,
     atomic_store_u8(dest, result + val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_ADD_U8 || !HAS_ATOMIC_STORE_U8 */
+#endif /* !HAS_ATOMIC_STORE_U8 */
 
-#if defined(HAS_ATOMIC_FETCH_ADD_U16) || !defined(HAS_ATOMIC_STORE_U16)
+#if !defined(HAS_ATOMIC_STORE_U16)
 static inline uint16_t semi_atomic_fetch_add_u16(volatile uint16_t *dest,
                                                  uint16_t val)
 {
@@ -1026,9 +1024,9 @@ static inline uint16_t semi_atomic_fetch_add_u16(volatile uint16_t *dest,
     atomic_store_u16(dest, result + val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_ADD_U16 || !HAS_ATOMIC_STORE_U16 */
+#endif /* !HAS_ATOMIC_STORE_U16 */
 
-#if defined(HAS_ATOMIC_FETCH_ADD_U32) || !defined(HAS_ATOMIC_STORE_U32)
+#if !defined(HAS_ATOMIC_STORE_U32)
 static inline uint32_t semi_atomic_fetch_add_u32(volatile uint32_t *dest,
                                                  uint32_t val)
 {
@@ -1042,9 +1040,9 @@ static inline uint32_t semi_atomic_fetch_add_u32(volatile uint32_t *dest,
     atomic_store_u32(dest, result + val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_ADD_U32 || !HAS_ATOMIC_STORE_U32 */
+#endif /* !HAS_ATOMIC_STORE_U32 */
 
-#if defined(HAS_ATOMIC_FETCH_ADD_U64) || !defined(HAS_ATOMIC_STORE_U64)
+#if !defined(HAS_ATOMIC_STORE_U64)
 static inline uint64_t semi_atomic_fetch_add_u64(volatile uint64_t *dest,
                                                  uint64_t val)
 {
@@ -1056,10 +1054,10 @@ static inline uint64_t semi_atomic_fetch_add_u64(volatile uint64_t *dest,
 {
     atomic_store_u64(dest, *dest + val);
 }
-#endif /* HAS_ATOMIC_FETCH_ADD_U32 || !HAS_ATOMIC_STORE_U32 */
+#endif /* !HAS_ATOMIC_STORE_U32 */
 
 /* FETCH_SUB */
-#if defined(HAS_ATOMIC_FETCH_SUB_U8) || !defined(HAS_ATOMIC_STORE_U8)
+#if !defined(HAS_ATOMIC_STORE_U8)
 static inline uint8_t semi_atomic_fetch_sub_u8(volatile uint8_t *dest,
                                                uint8_t val)
 {
@@ -1073,9 +1071,9 @@ static inline uint8_t semi_atomic_fetch_sub_u8(volatile uint8_t *dest,
     atomic_store_u8(dest, result - val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_SUB_U8 || !HAS_ATOMIC_STORE_U8 */
+#endif /* !HAS_ATOMIC_STORE_U8 */
 
-#if defined(HAS_ATOMIC_FETCH_SUB_U16) || !defined(HAS_ATOMIC_STORE_U16)
+#if !defined(HAS_ATOMIC_STORE_U16)
 static inline uint16_t semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
                                                  uint16_t val)
 {
@@ -1089,9 +1087,9 @@ static inline uint16_t semi_atomic_fetch_sub_u16(volatile uint16_t *dest,
     atomic_store_u16(dest, result - val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_SUB_U16 || !HAS_ATOMIC_STORE_U16 */
+#endif /* !HAS_ATOMIC_STORE_U16 */
 
-#if defined(HAS_ATOMIC_FETCH_SUB_U32) || !defined(HAS_ATOMIC_STORE_U32)
+#if !defined(HAS_ATOMIC_STORE_U32)
 static inline uint32_t semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
                                                  uint32_t val)
 {
@@ -1105,9 +1103,9 @@ static inline uint32_t semi_atomic_fetch_sub_u32(volatile uint32_t *dest,
     atomic_store_u32(dest, result - val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_SUB_U32 || !HAS_ATOMIC_STORE_U64 */
+#endif /* !HAS_ATOMIC_STORE_U64 */
 
-#if defined(HAS_ATOMIC_FETCH_SUB_U64) || !defined(HAS_ATOMIC_STORE_U64)
+#if !defined(HAS_ATOMIC_STORE_U64)
 static inline uint64_t semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
                                                  uint64_t val)
 {
@@ -1121,10 +1119,10 @@ static inline uint64_t semi_atomic_fetch_sub_u64(volatile uint64_t *dest,
     atomic_store_u64(dest, result - val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_SUB_U64 || !HAS_ATOMIC_STORE_U64 */
+#endif /* !HAS_ATOMIC_STORE_U64 */
 
 /* FETCH_OR */
-#if defined(HAS_ATOMIC_FETCH_OR_U8) || !defined(HAS_ATOMIC_STORE_U8)
+#if !defined(HAS_ATOMIC_STORE_U8)
 static inline uint8_t semi_atomic_fetch_or_u8(volatile uint8_t *dest,
                                               uint8_t val)
 {
@@ -1138,9 +1136,9 @@ static inline uint8_t semi_atomic_fetch_or_u8(volatile uint8_t *dest,
     atomic_store_u8(dest, result | val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_OR_U8 || !HAS_ATOMIC_STORE_U8 */
+#endif /* !HAS_ATOMIC_STORE_U8 */
 
-#if defined(HAS_ATOMIC_FETCH_OR_U16) || !defined(HAS_ATOMIC_STORE_U16)
+#if !defined(HAS_ATOMIC_STORE_U16)
 static inline uint16_t semi_atomic_fetch_or_u16(volatile uint16_t *dest,
                                                 uint16_t val)
 {
@@ -1154,9 +1152,9 @@ static inline uint16_t semi_atomic_fetch_or_u16(volatile uint16_t *dest,
     atomic_store_u16(dest, result | val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_OR_U16 || !HAS_ATOMIC_STORE_U16 */
+#endif /* !HAS_ATOMIC_STORE_U16 */
 
-#if defined(HAS_ATOMIC_FETCH_OR_U32) || !defined(HAS_ATOMIC_STORE_U32)
+#if !defined(HAS_ATOMIC_STORE_U32)
 static inline uint32_t semi_atomic_fetch_or_u32(volatile uint32_t *dest,
                                                 uint32_t val)
 {
@@ -1170,9 +1168,9 @@ static inline uint32_t semi_atomic_fetch_or_u32(volatile uint32_t *dest,
     atomic_store_u32(dest, result | val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_OR_U32 || !HAS_ATOMIC_STORE_U32 */
+#endif /* !HAS_ATOMIC_STORE_U32 */
 
-#if defined(HAS_ATOMIC_FETCH_OR_U64) || !defined(HAS_ATOMIC_STORE_U64)
+#if !defined(HAS_ATOMIC_STORE_U64)
 static inline uint64_t semi_atomic_fetch_or_u64(volatile uint64_t *dest,
                                                 uint64_t val)
 {
@@ -1186,10 +1184,10 @@ static inline uint64_t semi_atomic_fetch_or_u64(volatile uint64_t *dest,
     atomic_store_u64(dest, result | val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_OR_U64 || !HAS_ATOMIC_STORE_U64 */
+#endif /* !HAS_ATOMIC_STORE_U64 */
 
 /* FETCH_XOR */
-#if defined(HAS_ATOMIC_FETCH_XOR_U8) || !defined(HAS_ATOMIC_STORE_U8)
+#if !defined(HAS_ATOMIC_STORE_U8)
 static inline uint8_t semi_atomic_fetch_xor_u8(volatile uint8_t *dest,
                                                uint8_t val)
 {
@@ -1203,9 +1201,9 @@ static inline uint8_t semi_atomic_fetch_xor_u8(volatile uint8_t *dest,
     atomic_store_u8(dest, result ^ val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_XOR_U8 || !HAS_ATOMIC_STORE_U8 */
+#endif /* !HAS_ATOMIC_STORE_U8 */
 
-#if defined(HAS_ATOMIC_FETCH_XOR_U16) || !defined(HAS_ATOMIC_STORE_U16)
+#if !defined(HAS_ATOMIC_STORE_U16)
 static inline uint16_t semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
                                                  uint16_t val)
 {
@@ -1219,9 +1217,9 @@ static inline uint16_t semi_atomic_fetch_xor_u16(volatile uint16_t *dest,
     atomic_store_u16(dest, result ^ val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_XOR_U16 || !HAS_ATOMIC_STORE_U16 */
+#endif /* !HAS_ATOMIC_STORE_U16 */
 
-#if defined(HAS_ATOMIC_FETCH_XOR_U32) || !defined(HAS_ATOMIC_STORE_U32)
+#if !defined(HAS_ATOMIC_STORE_U32)
 static inline uint32_t semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
                                                  uint32_t val)
 {
@@ -1235,9 +1233,9 @@ static inline uint32_t semi_atomic_fetch_xor_u32(volatile uint32_t *dest,
     atomic_store_u32(dest, result ^ val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_XOR_U32 || !HAS_ATOMIC_STORE_U32 */
+#endif /* !HAS_ATOMIC_STORE_U32 */
 
-#if defined(HAS_ATOMIC_FETCH_XOR_U64) || !defined(HAS_ATOMIC_STORE_U64)
+#if !defined(HAS_ATOMIC_STORE_U64)
 static inline uint64_t semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
                                                  uint64_t val)
 {
@@ -1251,10 +1249,10 @@ static inline uint64_t semi_atomic_fetch_xor_u64(volatile uint64_t *dest,
     atomic_store_u64(dest, result ^ val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_XOR_U64 || !HAS_ATOMIC_STORE_U64 */
+#endif /* !HAS_ATOMIC_STORE_U64 */
 
 /* FETCH_AND */
-#if defined(HAS_ATOMIC_FETCH_AND_U8) || !defined(HAS_ATOMIC_STORE_U8)
+#if !defined(HAS_ATOMIC_STORE_U8)
 static inline uint8_t semi_atomic_fetch_and_u8(volatile uint8_t *dest,
                                                uint8_t val)
 {
@@ -1268,9 +1266,9 @@ static inline uint8_t semi_atomic_fetch_and_u8(volatile uint8_t *dest,
     atomic_store_u8(dest, result & val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_AND_U8 || !HAS_ATOMIC_STORE_U8 */
+#endif /* !HAS_ATOMIC_STORE_U8 */
 
-#if defined(HAS_ATOMIC_FETCH_AND_U16) || !defined(HAS_ATOMIC_STORE_U16)
+#if !defined(HAS_ATOMIC_STORE_U16)
 static inline uint16_t semi_atomic_fetch_and_u16(volatile uint16_t *dest,
                                                  uint16_t val)
 {
@@ -1284,9 +1282,9 @@ static inline uint16_t semi_atomic_fetch_and_u16(volatile uint16_t *dest,
     atomic_store_u16(dest, result & val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_AND_U16 || !HAS_ATOMIC_STORE_U16 */
+#endif /* !HAS_ATOMIC_STORE_U16 */
 
-#if defined(HAS_ATOMIC_FETCH_AND_U32) || !defined(HAS_ATOMIC_STORE_U32)
+#if !defined(HAS_ATOMIC_STORE_U32)
 static inline uint32_t semi_atomic_fetch_and_u32(volatile uint32_t *dest,
                                                  uint32_t val)
 {
@@ -1300,9 +1298,9 @@ static inline uint32_t semi_atomic_fetch_and_u32(volatile uint32_t *dest,
     atomic_store_u32(dest, result & val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_AND_U32 || !HAS_ATOMIC_STORE_U32 */
+#endif /* !HAS_ATOMIC_STORE_U32 */
 
-#if defined(HAS_ATOMIC_FETCH_AND_U64) || !defined(HAS_ATOMIC_STORE_U64)
+#if !defined(HAS_ATOMIC_STORE_U64)
 static inline uint64_t semi_atomic_fetch_and_u64(volatile uint64_t *dest,
                                                  uint64_t val)
 {
@@ -1316,7 +1314,7 @@ static inline uint64_t semi_atomic_fetch_and_u64(volatile uint64_t *dest,
     atomic_store_u64(dest, result & val);
     return result;
 }
-#endif /* HAS_ATOMIC_FETCH_AND_U64 || !HAS_ATOMIC_STORE_U64 */
+#endif /* !HAS_ATOMIC_STORE_U64 */
 
 #ifdef __cplusplus
 }

--- a/sys/include/volatile_utils.h
+++ b/sys/include/volatile_utils.h
@@ -113,45 +113,55 @@ static inline void volatile_store_u64(volatile uint64_t *dest, uint64_t val)
  * @param   dest    Address of the value to add to
  * @param   val     Value to add
  */
-static inline void volatile_fetch_add_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t volatile_fetch_add_u8(volatile uint8_t *dest, uint8_t val)
 {
-    *dest += val;
+    uint8_t result = *dest;
+    *dest = result + val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest -= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_sub_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t volatile_fetch_sub_u8(volatile uint8_t *dest, uint8_t val)
 {
-    *dest -= val;
+    uint8_t result = *dest;
+    *dest = result - val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest |= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_or_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t volatile_fetch_or_u8(volatile uint8_t *dest, uint8_t val)
 {
-    *dest |= val;
+    uint8_t result = *dest;
+    *dest = result | val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest ^= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_xor_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t volatile_fetch_xor_u8(volatile uint8_t *dest, uint8_t val)
 {
-    *dest ^= val;
+    uint8_t result = *dest;
+    *dest = result ^ val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest &= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_and_u8(volatile uint8_t *dest, uint8_t val)
+static inline uint8_t volatile_fetch_and_u8(volatile uint8_t *dest, uint8_t val)
 {
-    *dest &= val;
+    uint8_t result = *dest;
+    *dest = result & val;
+    return result;
 }
 
 /**
@@ -159,45 +169,60 @@ static inline void volatile_fetch_and_u8(volatile uint8_t *dest, uint8_t val)
  * @param   dest    Address of the value to add to
  * @param   val     Value to add
  */
-static inline void volatile_fetch_add_u16(volatile uint16_t *dest, uint16_t val)
+static inline uint16_t volatile_fetch_add_u16(volatile uint16_t *dest,
+                                              uint16_t val)
 {
-    *dest += val;
+    uint16_t result = *dest;
+    *dest = result + val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest -= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_sub_u16(volatile uint16_t *dest, uint16_t val)
+static inline uint16_t volatile_fetch_sub_u16(volatile uint16_t *dest,
+                                              uint16_t val)
 {
-    *dest -= val;
+    uint16_t result = *dest;
+    *dest = result - val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest |= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_or_u16(volatile uint16_t *dest, uint16_t val)
+static inline uint16_t volatile_fetch_or_u16(volatile uint16_t *dest,
+                                             uint16_t val)
 {
-    *dest |= val;
+    uint16_t result = *dest;
+    *dest = result | val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest ^= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_xor_u16(volatile uint16_t *dest, uint16_t val)
+static inline uint16_t volatile_fetch_xor_u16(volatile uint16_t *dest,
+                                              uint16_t val)
 {
-    *dest ^= val;
+    uint16_t result = *dest;
+    *dest = result ^ val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest &= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_and_u16(volatile uint16_t *dest, uint16_t val)
+static inline uint16_t volatile_fetch_and_u16(volatile uint16_t *dest,
+                                              uint16_t val)
 {
-    *dest &= val;
+    uint16_t result = *dest;
+    *dest = result & val;
+    return result;
 }
 
 /**
@@ -205,45 +230,60 @@ static inline void volatile_fetch_and_u16(volatile uint16_t *dest, uint16_t val)
  * @param   dest    Address of the value to add to
  * @param   val     Value to add
  */
-static inline void volatile_fetch_add_u32(volatile uint32_t *dest, uint32_t val)
+static inline uint32_t volatile_fetch_add_u32(volatile uint32_t *dest,
+                                              uint32_t val)
 {
-    *dest += val;
+    uint32_t result = *dest;
+    *dest = result + val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest -= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_sub_u32(volatile uint32_t *dest, uint32_t val)
+static inline uint32_t volatile_fetch_sub_u32(volatile uint32_t *dest,
+                                              uint32_t val)
 {
-    *dest -= val;
+    uint32_t result = *dest;
+    *dest = result - val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest |= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_or_u32(volatile uint32_t *dest, uint32_t val)
+static inline uint32_t volatile_fetch_or_u32(volatile uint32_t *dest,
+                                             uint32_t val)
 {
-    *dest |= val;
+    uint32_t result = *dest;
+    *dest = result | val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest ^= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_xor_u32(volatile uint32_t *dest, uint32_t val)
+static inline uint32_t volatile_fetch_xor_u32(volatile uint32_t *dest,
+                                              uint32_t val)
 {
-    *dest ^= val;
+    uint32_t result = *dest;
+    *dest = result ^ val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest &= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_and_u32(volatile uint32_t *dest, uint32_t val)
+static inline uint32_t volatile_fetch_and_u32(volatile uint32_t *dest,
+                                              uint32_t val)
 {
-    *dest &= val;
+    uint32_t result = *dest;
+    *dest = result & val;
+    return result;
 }
 
 /**
@@ -251,45 +291,60 @@ static inline void volatile_fetch_and_u32(volatile uint32_t *dest, uint32_t val)
  * @param   dest    Address of the value to add to
  * @param   val     Value to add
  */
-static inline void volatile_fetch_add_u64(volatile uint64_t *dest, uint64_t val)
+static inline uint64_t volatile_fetch_add_u64(volatile uint64_t *dest,
+                                              uint64_t val)
 {
-    *dest += val;
+    uint64_t result = *dest;
+    *dest = result + val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest -= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_sub_u64(volatile uint64_t *dest, uint64_t val)
+static inline uint64_t volatile_fetch_sub_u64(volatile uint64_t *dest,
+                                              uint64_t val)
 {
-    *dest -= val;
+    uint64_t result = *dest;
+    *dest = result - val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest |= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_or_u64(volatile uint64_t *dest, uint64_t val)
+static inline uint64_t volatile_fetch_or_u64(volatile uint64_t *dest,
+                                             uint64_t val)
 {
-    *dest |= val;
+    uint64_t result = *dest;
+    *dest = result | val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest ^= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_xor_u64(volatile uint64_t *dest, uint64_t val)
+static inline uint64_t volatile_fetch_xor_u64(volatile uint64_t *dest,
+                                              uint64_t val)
 {
-    *dest ^= val;
+    uint64_t result = *dest;
+    *dest = result ^ val;
+    return result;
 }
 /**
  * @brief   Unoptimized version of `*dest &= val`
  * @param   dest    Address of the value to apply the operation on
  * @param   val     Second operand
  */
-static inline void volatile_fetch_and_u64(volatile uint64_t *dest, uint64_t val)
+static inline uint64_t volatile_fetch_and_u64(volatile uint64_t *dest,
+                                              uint64_t val)
 {
-    *dest &= val;
+    uint64_t result = *dest;
+    *dest = result & val;
+    return result;
 }
 
 #ifdef __cplusplus

--- a/tests/bench_sys_atomic_utils/Makefile.ci
+++ b/tests/bench_sys_atomic_utils/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/sys_atomic_utils/main.c
+++ b/tests/sys_atomic_utils/main.c
@@ -47,10 +47,10 @@ typedef enum {
     TEST_WIDTH_NUMOF
 } test_width_t;
 
-typedef void (*fetch_op_u8_t)(volatile uint8_t *dest, uint8_t val);
-typedef void (*fetch_op_u16_t)(volatile uint16_t *dest, uint16_t val);
-typedef void (*fetch_op_u32_t)(volatile uint32_t *dest, uint32_t val);
-typedef void (*fetch_op_u64_t)(volatile uint64_t *dest, uint64_t val);
+typedef uint8_t (*fetch_op_u8_t)(volatile uint8_t *dest, uint8_t val);
+typedef uint16_t (*fetch_op_u16_t)(volatile uint16_t *dest, uint16_t val);
+typedef uint32_t (*fetch_op_u32_t)(volatile uint32_t *dest, uint32_t val);
+typedef uint64_t (*fetch_op_u64_t)(volatile uint64_t *dest, uint64_t val);
 
 typedef struct {
     const char *name;

--- a/tests/sys_atomic_utils_unittests/main.c
+++ b/tests/sys_atomic_utils_unittests/main.c
@@ -29,10 +29,10 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-typedef void (*fetch_op_u8_t)(volatile uint8_t *dest, uint8_t val);
-typedef void (*fetch_op_u16_t)(volatile uint16_t *dest, uint16_t val);
-typedef void (*fetch_op_u32_t)(volatile uint32_t *dest, uint32_t val);
-typedef void (*fetch_op_u64_t)(volatile uint64_t *dest, uint64_t val);
+typedef uint8_t (*fetch_op_u8_t)(volatile uint8_t *dest, uint8_t val);
+typedef uint16_t (*fetch_op_u16_t)(volatile uint16_t *dest, uint16_t val);
+typedef uint32_t (*fetch_op_u32_t)(volatile uint32_t *dest, uint32_t val);
+typedef uint64_t (*fetch_op_u64_t)(volatile uint64_t *dest, uint64_t val);
 
 static void test_load_store(void)
 {
@@ -58,9 +58,10 @@ static void test_fetch_op_u8(fetch_op_u8_t atomic_op, fetch_op_u8_t op)
     uint8_t i = 0;
     do {
         uint8_t state1 = 0x55, state2 = 0x55;
-        atomic_op(&state1, i);
-        op(&state2, i);
+        uint8_t res1 = atomic_op(&state1, i);
+        uint8_t res2 = op(&state2, i);
         TEST_ASSERT_EQUAL_INT(state1, state2);
+        TEST_ASSERT_EQUAL_INT(res1, res2);
         i++;
     } while (i);
 }
@@ -85,9 +86,10 @@ static void test_fetch_op_u16(fetch_op_u16_t atomic_op, fetch_op_u16_t op)
     do {
         uint16_t state1 = 0x5555, state2 = 0x5555;
         uint16_t num = random_uint32();
-        atomic_op(&state1, num);
-        op(&state2, num);
+        uint16_t res1 = atomic_op(&state1, num);
+        uint16_t res2 = op(&state2, num);
         TEST_ASSERT_EQUAL_INT(state1, state2);
+        TEST_ASSERT_EQUAL_INT(res1, res2);
         i++;
     } while (i);
 }
@@ -112,9 +114,10 @@ static void test_fetch_op_u32(fetch_op_u32_t atomic_op, fetch_op_u32_t op)
     do {
         uint32_t state1 = 0x55555555, state2 = 0x55555555;
         uint32_t num = random_uint32();
-        atomic_op(&state1, num);
-        op(&state2, num);
+        uint32_t res1 = atomic_op(&state1, num);
+        uint32_t res2 = op(&state2, num);
         TEST_ASSERT_EQUAL_INT(state1, state2);
+        TEST_ASSERT_EQUAL_INT(res1, res2);
         i++;
     } while (i);
 }
@@ -141,9 +144,10 @@ static void test_fetch_op_u64(fetch_op_u64_t atomic_op, fetch_op_u64_t op)
         state1 = state2 = 0x5555555555555555;
         uint64_t num;
         random_bytes((void *)&num, sizeof(num));
-        atomic_op(&state1, num);
-        op(&state2, num);
+        uint64_t res1 = atomic_op(&state1, num);
+        uint64_t res2 = op(&state2, num);
         TEST_ASSERT_EQUAL_INT(state1, state2);
+        TEST_ASSERT_EQUAL_INT(res1, res2);
         i++;
     } while (i);
 }


### PR DESCRIPTION
### Contribution description

https://github.com/RIOT-OS/RIOT/pull/15643 fixes an issue with the atomic utils API, but as side effect increase the ROM size quite a bit. This is to some degree due to GCC not optimizing the machine code as I had hoped: Unlike `clang`, (potentially) register allocated variables are not optimized through the `irq_restore()` command, which contains a memory barrier. (`clang` interprets the memory barrier as affecting RAM only, and anything that theoretically could be allocated in a register in still optimized.)

Also, GCC does some stupid stuff. E.g. when loading a byte via `ldrb` in ARM, the least significant byte is set to whatever was load from memory and the remaining 24 bits of the register is zeroed out. Still, GCC emits an `uxtb` to zero out the most significant 24 bits again. Or sometimes it zeros out the most significant 24 bits via `uxtb` right before an `strb`, even though the store byte instruction only saves bits [0:7] anyway.

This PR includes https://github.com/RIOT-OS/RIOT/pull/15643, but adds an extend asm implementation for Cortex M boards that only relies on plain loads and stores being atomic and uses IRQ disabling to achieve atomically for read-modify-write operations. This can still be improved upon for if a CPU supports atomic operations in hardware.

Finally, for the semi-atomic operations the implementation using plain operations is picked more aggressively, which should have been like this from the start.

### Testing procedure

The two test applications and the benchmark should cover everything.

### Issues/PRs references

Contains https://github.com/RIOT-OS/RIOT/pull/15643