### PR TITLE
net/asymcute: fix MsgId when publishing with QOS0

### DIFF
--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -30,6 +30,7 @@
  * - Gateway discovery process not implemented
  * - Last will feature not implemented
  * - No support for QoS level 2
+ * - No support for QoS level -1
  * - No support for wildcard characters in topic names when subscribing
  * - Actual granted QoS level on subscription is ignored
  *

--- a/sys/include/net/mqttsn.h
+++ b/sys/include/net/mqttsn.h
@@ -50,6 +50,7 @@ enum {
     MQTTSN_QOS_MASK   = 0x60,       /**< QoS level mask */
     MQTTSN_QOS_2      = 0x40,       /**< QoS level 2 */
     MQTTSN_QOS_1      = 0x20,       /**< QoS level 1 */
+    MQTTSN_QOS_NEG1   = 0x60,       /**< QoS level -1 (negative 1) */
     MQTTSN_QOS_0      = 0x00,       /**< QoS level 0 */
     MQTTSN_RETAIN     = 0x10,       /**< retain flag */
     MQTTSN_WILL       = 0x08,       /**< will flag, used during CONNECT */

--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -879,8 +879,14 @@ int asymcute_publish(asymcute_con_t *con, asymcute_req_t *req,
         goto end;
     }
 
-    /* get message id */
-    req->msg_id = _msg_id_next(con);
+    /* set MsgId only for QoS 1 and 2, else it must be set to 0 */
+    if (((flags & MQTTSN_QOS_MASK) == MQTTSN_QOS_1) ||
+        ((flags & MQTTSN_QOS_MASK) == MQTTSN_QOS_2)) {
+        req->msg_id = _msg_id_next(con);
+    }
+    else {
+        req->msg_id = 0;
+    }
 
     /* assemble message */
     size_t pos = _len_set(req->data, data_len + 6);


### PR DESCRIPTION
### Contribution description
The MQTT-SN standard states in 5.4.12 for `PUBLISH` messages: "MsgId: same meaning as the MQTT “Message ID”; only relevant in case of QoS levels 1 and 2, otherwise coded 0x0000.". So far we do this wrong and set the MsgId to an incrementing value every time we send a `PUBLISH` message. This PR fixes that...

I found this when using the Paho MQTT-SN gateway (https://github.com/eclipse/paho.mqtt-sn.embedded-c/tree/master/MQTTSNGateway), where the gateway did not want to forward my PUBLISH messages with the reason of `Invalid MsgId`...

### Testing procedure
Run the `examples/asymcute` example application on native and observe the tap interface using wirshark. When looking into the payload of publish messages, the MsgId field should be set to `0` when sending QOS0, and to some number when sending QOS1.

### Issues/PRs references
none