### PR TITLE
net/emcute: fix MsgId for PUBLISH with QOS0

### DIFF
--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -66,6 +66,7 @@
  *              how to put / how to encode the IPv(4/6) address AND the port of
  *              a gateway in the GwAdd field of the GWINFO message
  * @todo        QOS level 2
+ * @todo        QOS level -1
  * @todo        put the node to sleep (send DISCONNECT with duration field set)
  * @todo        handle DISCONNECT messages initiated by the broker/gateway
  * @todo        support for pre-defined and short topic IDs

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -351,8 +351,15 @@ int emcute_pub(emcute_topic_t *topic, const void *data, size_t len,
     tbuf[pos++] = flags;
     byteorder_htobebufs(&tbuf[pos], topic->id);
     pos += 2;
-    byteorder_htobebufs(&tbuf[pos], id_next);
-    waitonid = id_next++;
+    /* set generated MessageId for QOS 1 and 2, else set it to 0 */
+    if (((flags & MQTTSN_QOS_MASK) == MQTTSN_QOS_1) ||
+        ((flags & MQTTSN_QOS_MASK) == MQTTSN_QOS_2)) {
+        byteorder_htobebufs(&tbuf[pos], id_next);
+        waitonid = id_next++;
+    }
+    else {
+        memset(&tbuf[pos], 0, 2);
+    }
     pos += 2;
     memcpy(&tbuf[pos], data, len);
 


### PR DESCRIPTION
### Contribution description
The same bug that effected `asymcute` (#15656) was also coded into `emcute`. When publishing with QOS level 0 the MsgId field in the header must be set to `0`. This PR fixes that for `emcute`.

### Testing procedure
Run the emcute example and publish some packets to a gateway. When inspecting the packets (e.g. using wireshark), you should see the `MsgId` field in the header of the PUBLISH message be set to `0` when using QOS level 0.

### Issues/PRs references
Same bug as in #15656