### PR TITLE
pkg/openthread: deprecate ot_command related functions

### DIFF
--- a/examples/openthread/main.c
+++ b/examples/openthread/main.c
@@ -16,15 +16,37 @@
 #include <stdio.h>
 
 #include "ot.h"
+#include "openthread/thread.h"
+
+static void _panid_handler(event_t *event);
+
+static event_t event_panid = {
+    .handler = _panid_handler
+};
+
+static void _panid_handler(event_t *event)
+{
+    (void) event;
+
+    /* It's safe here to call any OpenThread specific API, since this code runs
+     * in the same thread as the OpenThread tasklet handler */
+
+    /* Get PanID from OpenThread API */
+    uint16_t panid = otLinkGetPanId(openthread_get_instance());
+    printf("Current panid: 0x%x\n", panid);
+}
 
 int main(void)
 {
-    puts("This a test for OpenThread");
     /* Example of how to call OpenThread stack functions */
-    puts("Get PANID ");
-    uint16_t panid = 0;
-    uint8_t res = ot_call_command("panid", NULL, (void*)&panid);
-    printf("Current panid: 0x%x (res:%x)\n", panid, res);
+    puts("This is an OpenThread example");
+
+    /** OpenThread needs to synchronize otApi calls
+     * with its tasklet scheduler. This
+     * synchronization is handled by RIOT using an
+     * event queue (accessible via openthread_get_evq())
+     */
+    event_post(openthread_get_evq(), &event_panid);
 
     return 0;
 }

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -13,6 +13,35 @@
  * @see         https://github.com/openthread/openthread
  *
  * Thread is a mesh oriented network stack running for IEEE802.15.4 networks.
+ *
+ * The RIOT port allows to directly call OpenThread API functions using
+ * @ref sys_event. For example:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
+ * #include "ot.h"
+ * #include "openthread/thread.h"
+ *
+ * static void _panid_handler(event_t *event);
+ * static event_t event_panid = {
+ *     .handler = _panid_handler
+ * };
+ *
+ * static void _panid_handler(event_t *event)
+ * {
+ *     (void) event;
+ *     uint16_t panid = otLinkGetPanId(openthread_get_instance());
+ *     do_something_with_panid(panid);
+ * }
+ *
+ * int main(void)
+ * {
+ *     event_post(openthread_get_evq(), &event_panid);
+ *     return 0;
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * @see https://openthread.io/releases/thread-reference-20180619
+ *
  * @{
  *
  * @file

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -73,6 +73,10 @@ typedef struct {
 
 /**
  * @brief   Struct containing an OpenThread job
+ *
+ * @deprecated   This structure is not needed anymore since it's possible to
+ *               run OpenThread code via @ref sys_event (see @ref openthread_get_evq).
+ *               Therefore it will be removed after the 2022.01 release.
  */
 typedef struct {
     event_t ev;                             /**< Event associated to the OpenThread job */
@@ -157,6 +161,10 @@ void ot_random_init(void);
 /**
  * @brief   Execute OpenThread command. Call this function only in OpenThread thread
  *
+ * @deprecated   This function is not needed anymore since it's possible to
+ *               run OpenThread code via @ref sys_event (see @ref openthread_get_evq).
+ *               Therefore it will be removed after the 2022.01 release.
+ *
  * @param[in]   ot_instance     OpenThread instance
  * @param[in]   command         OpenThread command name
  * @param[in]   arg             arg for the command
@@ -171,6 +179,10 @@ uint8_t ot_exec_command(otInstance *ot_instance, const char* command, void *arg,
  *
  * @note    An OpenThread command allows direct calls to OpenThread API (otXXX functions) without worrying about concurrency
  * issues. All API calls should be made in OT_JOB type functions.
+ *
+ * @deprecated   This function is not needed anymore since it's possible to
+ *               run OpenThread code via @ref sys_event (see @ref openthread_get_evq).
+ *               Therefore it will be removed after the 2022.01 release.
  *
  * @param[in]   command         name of the command to call
  * @param[in]   arg             arg for the command

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -147,13 +147,6 @@ void openthread_radio_init(netdev_t *dev, uint8_t *tb, uint8_t *rb);
 int openthread_netdev_init(char *stack, int stacksize, char priority, const char *name, netdev_t *netdev);
 
 /**
- * @brief   get PID of OpenThread thread.
- *
- * @return  PID of OpenThread thread
- */
-kernel_pid_t openthread_get_pid(void);
-
-/**
  * @brief   Init OpenThread random
  */
 void ot_random_init(void);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Since #15038 saw the light, the current "ot_command" wrapper is only limiting OpenThread usage. The Event Queue makes it possible now to call OpenThread API functions directly when posting an event to the OpenThread queue.

This PR removes the `ot_command` calls from `examples/openthread`, improve Doxygen documentation and deprecate the "ot_command" related functions
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test if `examples/openthread` still works ok. Note that it's possible to run OpenThread with any board that supports the Radio HAL if using `netdev_ieee802154_submac`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
