### PR TITLE
pkg/openthread: bump version to 20191113

### DIFF
--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=thread-reference-20180926
+PKG_VERSION=thread-reference-20191113
 PKG_LICENSE=BSD-3-Clause
 
 # OpenThread build system doesn't support (yet) out-of-source builds
@@ -28,6 +28,7 @@ CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"platform_config.h\"'
 OPENTHREAD_COMMON_FLAGS = -fdata-sections -ffunction-sections -Os
 OPENTHREAD_COMMON_FLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter
 OPENTHREAD_CXXFLAGS += -Wno-class-memaccess
+OPENTHREAD_CXXFLAGS += -DOPENTHREAD_TARGET_RIOT=1
 
 OT_LIB_DIR = $(PKG_BUILD_DIR)/output/lib
 MODULE_LIBS = mbedcrypto.a openthread-$(TD).a

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -73,9 +73,6 @@ static char ot_thread_stack[2 * THREAD_STACKSIZE_MAIN];
 
 void openthread_bootstrap(void)
 {
-    /* init random */
-    ot_random_init();
-
     /* setup netdev modules */
 #ifdef MODULE_AT86RF2XX
     at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0], 0);

--- a/pkg/openthread/contrib/platform_random.c
+++ b/pkg/openthread/contrib/platform_random.c
@@ -16,46 +16,11 @@
  * @}
  */
 
-#include <stdint.h>
-
-#include "openthread/platform/random.h"
-#include "periph/cpuid.h"
+#include "openthread/platform/entropy.h"
 #include "random.h"
 
-#define ENABLE_DEBUG 0
-#include "debug.h"
-
-/* init random */
-void ot_random_init(void)
+otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 {
-#ifdef CPUID_LEN
-    char cpu_id[CPUID_LEN];
-    cpuid_get(cpu_id);
-    uint32_t seed = 0;
-    for (unsigned i = 0; i < CPUID_LEN; i++) {
-        seed += cpu_id[i];
-    }
-    random_init(seed);
-#else
-    #error "CPU not supported (current CPU doesn't provide CPUID, required for entropy)"
-#endif
-}
-
-/* OpenThread will call this to get a random number */
-uint32_t otPlatRandomGet(void)
-{
-    uint32_t rand_val = random_uint32();
-
-    DEBUG("otPlatRandomGet: %i\n", (int) rand_val);
-    return rand_val;
-}
-
-otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
-{
-    for (uint16_t index = 0; index < aOutputLength; index++) {
-        aOutput[index] = 0;
-        uint32_t rand_val = random_uint32();
-        aOutput[index] = (uint8_t) rand_val;
-    }
+    random_bytes(aOutput, aOutputLength);
     return OT_ERROR_NONE;
 }

--- a/pkg/openthread/contrib/platform_uart.c
+++ b/pkg/openthread/contrib/platform_uart.c
@@ -101,3 +101,8 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 
     return OT_ERROR_NONE;
 }
+
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NONE;
+}

--- a/pkg/openthread/patches/0001-RIOT-use-assert.h.patch
+++ b/pkg/openthread/patches/0001-RIOT-use-assert.h.patch
@@ -1,0 +1,25 @@
+From 51cf02a0ee4d6dd441edbc5e20f58eb1ee4c28f4 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@googlemail.com>
+Date: Thu, 17 Dec 2020 14:33:22 +0100
+Subject: [PATCH] [RIOT] use <assert.h>
+
+---
+ src/core/common/debug.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/common/debug.hpp b/src/core/common/debug.hpp
+index 3ab0eb21b..6e48f7d0d 100644
+--- a/src/core/common/debug.hpp
++++ b/src/core/common/debug.hpp
+@@ -40,7 +40,7 @@
+ #include <stdio.h>
+ #include "utils/wrap_string.h"
+ 
+-#if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX)
++#if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX) || defined(OPENTHREAD_TARGET_RIOT)
+ 
+ #include <assert.h>
+ 
+-- 
+2.27.0
+

--- a/pkg/openthread/patches/0001-xxx-define-UINT16_MAX.patch
+++ b/pkg/openthread/patches/0001-xxx-define-UINT16_MAX.patch
@@ -1,0 +1,27 @@
+From 1586e89e4e8ec7b102cc1e5180ff13ab9bb6bb26 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@googlemail.com>
+Date: Thu, 17 Dec 2020 14:40:54 +0100
+Subject: [PATCH] xxx: define UINT16_MAX
+
+---
+ src/core/common/message.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/core/common/message.cpp b/src/core/common/message.cpp
+index 496aef7f1..a309831d7 100644
+--- a/src/core/common/message.cpp
++++ b/src/core/common/message.cpp
+@@ -40,6 +40,10 @@
+ #include "common/logging.hpp"
+ #include "net/ip6.hpp"
+ 
++#ifndef UINT16_MAX
++#define UINT16_MAX  0xFFFF
++#endif
++
+ namespace ot {
+ 
+ MessagePool::MessagePool(Instance &aInstance)
+-- 
+2.27.0
+


### PR DESCRIPTION
### Contribution description

I noticed the OpenThread package is quite old, so I bumped it to the latest tagged upstream release.
Only minor API changes.
Somehow it would not find `UINT16_MAX` (and `<cstdint>` would call for C++11) so I added a hacky patch.

### Testing procedure

Compile tested only (and flashed onto `nrf52840dk`).
I don't know how to properly test this.

I only tried `ping` between two nodes, this worked.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
