### PR TITLE
makefiles/arch/riscv: redirect 'which' error message to /dev/null

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -25,7 +25,7 @@ TARGET_ARCH_RISCV ?= \
     $(subst -gcc,,\
       $(notdir \
         $(word 1,\
-          $(foreach triple,$(_TRIPLES_TO_TEST),$(shell which $(triple)-gcc))))))
+          $(foreach triple,$(_TRIPLES_TO_TEST),$(shell which $(triple)-gcc 2> /dev/null))))))
 
 TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
 


### PR DESCRIPTION
### Contribution description
This redirects the possible error message that `which` returns to `/dev/null`. In my case I did not have the toolchain installed and was building in docker, but my terminal was flooded with error messages of `which` not finding the binaries in my path. 

### Testing procedure
Same as #15391:
make BOARD=hifive1 -C exampes/default should work if you have a GCC cross compiler able of generating RISC-V binaries for embedded systems, no matter what variant of the target triple you chose.

### Issues/PRs references
#15391