### PR TITLE
dist/tools/ci/github_annotate.sh: allow annotations without files 

### DIFF
--- a/dist/tools/ci/README.md
+++ b/dist/tools/ci/README.md
@@ -71,6 +71,14 @@ github_annotate_parse_log_default github_annotate_warning
 does the same as the last example snippet, but uses `github_annotate_warning`
 instead.
 
+If you do not need to provide a file with your error or warning, you can also
+use `github_annotate_error_no_file` or `github_annotate_warning_no_file`,
+respectively. Both take a just message as single parameter:
+
+```sh
+github_annotate_error_no_file "Something is wrong!"
+```
+
 After all errors or warnings are annotated, call `github_annotate_teardown` to
 finish annotations.
 

--- a/dist/tools/ci/github_annotate.sh
+++ b/dist/tools/ci/github_annotate.sh
@@ -33,12 +33,26 @@ _escape() {
         -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g'
 }
 
+_github_annotate() {
+    MESSAGE="$(_escape "${1}")"
+    LEVEL="${2:-error}"
+    OPTS="${3:-}"
+    echo "::${LEVEL} ${OPTS}::${DETAILS}" >> ${OUTFILE}
+}
+
 github_annotate_error() {
     if [ -n "${GITHUB_RUN_ID}" ]; then
         FILENAME="${1}"
         LINENUM="${2}"
-        DETAILS="$(_escape "${3}")"
-        echo "::error file=${FILENAME},line=${LINENUM}::${DETAILS}" >> ${OUTFILE}
+        DETAILS="${3}"
+        _github_annotate "${DETAILS}" error "file=${FILENAME},line=${LINENUM}"
+    fi
+}
+
+github_annotate_error_no_file() {
+    if [ -n "${GITHUB_RUN_ID}" ]; then
+        DETAILS="${1}"
+        _github_annotate "${DETAILS}" error
     fi
 }
 
@@ -47,7 +61,14 @@ github_annotate_warning() {
         FILENAME="${1}"
         LINENUM="${2}"
         DETAILS="$(_escape "${3}")"
-        echo "::warning file=${FILENAME},line=${LINENUM}::${DETAILS}" >> ${OUTFILE}
+        _github_annotate "${DETAILS}" warning "file=${FILENAME},line=${LINENUM}"
+    fi
+}
+
+github_annotate_warning_no_file() {
+    if [ -n "${GITHUB_RUN_ID}" ]; then
+        DETAILS="${1}"
+        _github_annotate "${DETAILS}" warning
     fi
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides two new commands to `dist/tools/ci/github_annotate.sh`:

- `github_annotate_error_no_file`
- `github_annotate_warning_no_file`

Both take a single argument: the message to be annotated but don't require a file and line as an argument. This can be used to annotate errors and warnings that don't have file lines attached to it, like e.g. about wrong commit messages.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
A test commit is provided. The annotations should show up in the `static-tests` check.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
