### PR TITLE
tests/emcute: add check for message ID with PUBLISH QoS 0

### DIFF
--- a/tests/emcute/tests/01-run.py
+++ b/tests/emcute/tests/01-run.py
@@ -101,6 +101,11 @@ class MQTTSNServer(Automaton):
 
     def _check_pkt_qos(self, pkt):
         qos_types = [mqttsn.PUBLISH, mqttsn.SUBSCRIBE]
+        # see MQTT-SN 1.2 spec 5.4.12
+        if (pkt.type == mqttsn.PUBLISH) and \
+           (pkt.qos not in [mqttsn.QOS_1, mqttsn.QOS_2]) and \
+           (pkt.mid != 0):
+            return False
         return (pkt.type not in qos_types) or (pkt.qos == self._qos_flags)
 
     def _get_tid(self, topic_name):


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides a test for the bug uncovered in https://github.com/RIOT-OS/RIOT/pull/15656 and https://github.com/RIOT-OS/RIOT/pull/15661.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
sudo dist/tools/tapsetup/tapsetup
make -C tests/emcute -j clean flash test
```

Without #15661 this test should fail. When #15661 is merged it should succeed.

This test is not run by Murdock due to the TAP requirement.
<!--
Details step to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on https://github.com/RIOT-OS/RIOT/pull/15661.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
