### PR TITLE
dist/tools: don't redefine EXCLUDE when not necessary

### DIFF
--- a/dist/tools/codespell/check.sh
+++ b/dist/tools/codespell/check.sh
@@ -23,8 +23,7 @@ cd $RIOTBASE
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 FILEREGEX='\.([CcHh]|[ch]pp|sh|py|md|txt)$'
-EXCLUDE='^(.+/vendor/)'
-FILES=$(FILEREGEX=${FILEREGEX} EXCLUDE=${EXCLUDE} changed_files)
+FILES=$(FILEREGEX=${FILEREGEX} changed_files)
 
 if [ -z "${FILES}" ]; then
     exit 0

--- a/dist/tools/vera++/check.sh
+++ b/dist/tools/vera++/check.sh
@@ -12,9 +12,7 @@ CURDIR=$(cd "$(dirname "$0")" && pwd)
 : "${WARNING:=1}"
 
 . "$RIOTBASE"/dist/tools/ci/changed_files.sh
-FILEREGEX='\.([CcHh]|[ch]pp)$'
-EXCLUDE='^(.+/vendor/)'
-FILES=$(FILEREGEX=${FILEREGEX} EXCLUDE=${EXCLUDE} changed_files)
+FILES=$(changed_files)
 
 if [ -z "${FILES}" ]; then
     exit 0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There's no need to redefine the EXCLUDE variables in vera++ and codespell checks. This PR fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI (when the REMOVEME commit is removed, otherwise false)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #15660 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
