### PR TITLE
cpu/fe310: use malloc_thread_safe

### DIFF
--- a/cpu/fe310/Kconfig
+++ b/cpu/fe310/Kconfig
@@ -9,6 +9,7 @@ config CPU_ARCH_RISCV
     bool
     select HAS_ARCH_RISCV
     select HAS_PICOLIBC if '$(RIOT_CI_BUILD)' != '1'
+    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
 
 config CPU_CORE_RV32M
     bool

--- a/cpu/fe310/Makefile.dep
+++ b/cpu/fe310/Makefile.dep
@@ -15,3 +15,6 @@ FEATURES_REQUIRED += periph_plic
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif
+
+# Make calls to malloc and friends thread-safe
+USEMODULE += malloc_thread_safe


### PR DESCRIPTION
### Contribution description

This should fix concurrent dynamic memory allocation.

### Testing procedure

1. Run `make BOARD=hifive1(b) -C tests/malloc_thread_safety flash test` on `master`
2. Same on this PR

It should fail on `master` but get fixed by this PR.

### Issues/PRs references

None