### PR TITLE
pkg/tinydtls: remove sock_udp_ep_t from sock_dtls_session_t

### DIFF
--- a/pkg/tinydtls/include/sock_dtls_types.h
+++ b/pkg/tinydtls/include/sock_dtls_types.h
@@ -82,8 +82,6 @@ struct sock_dtls {
  * @brief Information about remote client connected to the server
  */
 struct sock_dtls_session {
-    sock_udp_ep_t   ep;              /**< Remote endpoint the session
-                                         is connected to */
     session_t       dtls_session;    /**< TinyDTLS session */
 };
 


### PR DESCRIPTION
### Contribution description
This PR removes the `sock_udp_ep_t` endpoint from the `sock_dtls_session_t` struct in the implementation of tinyDTLS. 
Currently `sock_dtls_session_t` contains a `session_t` and `sock_udp_ep_t` struct which both provide the same information.
```
/* sock_udp_ep_t */
struct _sock_tl_ep {
    int family;
    union {
        uint8_t ipv6[16];
        uint8_t ipv4[4];        /**< IPv4 address mode */
        uint32_t ipv4_u32;      /**< IPv4 address *in network byte order* */
    } addr;                 /**< address */

    uint16_t netif;
    uint16_t port;          /**< transport layer port (in host byte order) */
};

/* session_t */
typedef struct {
    unsigned char size;
    ipv6_addr_t addr;
    unsigned short port;
    int ifindex;
} session_t;
```

`session_t` is the session object from tinyDTLS. By removing the `sock_udp_ep_t` we lower the needed memory size of a `sock_dtls_session_t` object to 24 bytes (upstream: 48 bytes). There are no functional changes or limitations.

A function to retrieve the endpoint from a session will come as a follow up.

### Testing procedure
No errors indicated by Murdock.

If you want to test it on your own: tests/pkg_tinydtls_sock_async.
* Flash the test on two devices (or native).
* Run `dtlss start` on one of them.
* Execute `dtlsc {ip} {data}` from the other node. `{ip}` should contain the IP from the node on which `dtlss start` was executed 

### Issues/PRs references
Resulted from #15615 

 