### PR TITLE
cpu/cortexm_common: fix select in Kconfig

### DIFF
--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -9,7 +9,7 @@ config MODULE_CORTEXM_COMMON
     default y if CPU_CORE_CORTEX_M
     depends on TEST_KCONFIG
     select MODULE_PERIPH
-    select MODULE_MALLOC_THREAD_SAFE
+    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
     help
         Common code for Cortex-M cores.
 


### PR DESCRIPTION
### Contribution description

Only select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG is true.

### Testing procedure

Green Murdock

### Issues/PRs references

Introduced with https://github.com/RIOT-OS/RIOT/pull/15606