### PR TITLE
boards/remote-revb: add arduino feature

### DIFF
--- a/boards/remote-revb/Kconfig
+++ b/boards/remote-revb/Kconfig
@@ -11,5 +11,6 @@ config BOARD_REMOTE_REVB
     bool
     default y
     select BOARD_COMMON_REMOTE
+    select HAS_ARDUINO
 
 source "$(RIOTBOARD)/common/remote/Kconfig"

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -1,1 +1,3 @@
 include $(RIOTBOARD)/common/remote/Makefile.features
+
+FEATURES_PROVIDED += arduino

--- a/boards/remote-revb/include/arduino_board.h
+++ b/boards/remote-revb/include/arduino_board.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup    boards_remote-revb
+ * @{
+ *
+ * @file
+ * @brief       Configuration of the Arduino API for Remote revision B board
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+#include "periph/pwm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ */
+#define ARDUINO_LED         (1)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    GPIO_UNDEF,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    ARDUINO_PIN_17,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    ARDUINO_PIN_21,
+    ARDUINO_PIN_22,
+    ARDUINO_PIN_23,
+    ARDUINO_PIN_24,
+    ARDUINO_PIN_25,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    ARDUINO_PIN_28,
+    ARDUINO_PIN_29,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    ARDUINO_PIN_32,
+    ARDUINO_PIN_33,
+    ARDUINO_PIN_34,
+    ARDUINO_PIN_35,
+    ARDUINO_PIN_36,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ADC_UNDEF,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/remote-revb/include/arduino_pinmap.h
+++ b/boards/remote-revb/include/arduino_pinmap.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_remote-revb
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins for Remote revision B board
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ *
+ * @warning Beware: Despite an Arudino pin mapping being available, Arduino shields
+ *          are mechanically not compatible with the board. Check header file
+ *          https://github.com/RIOT-OS/RIOT/blob/master/boards/remote-revb/include/arduino_pinmap.h#L43
+ *          for the exact mapping.
+ *
+ * @{
+ */
+
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_D, 4) // LED1.R
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_B, 7) // LED2.G/JTAG.TDO
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_B, 6) // LED3.B/JTAG.TDI
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_A, 0) // UART0.RX
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_A, 1) // UART0.TX
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_D, 0) // I2C.INT
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_C, 2) // I2C.SDA
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_C, 3) // I2C.SCL
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_B, 4) // CC1200.GPIO0
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_B, 0) // CC1200.GPIO2
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_C, 1) // UART1.RX
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_C, 0) // UART1.TX
+#define ARDUINO_PIN_17          GPIO_PIN(PORT_B, 5) // CC1200.CSN
+#define ARDUINO_PIN_21          GPIO_PIN(PORT_A, 3) // USER.BUTTON
+#define ARDUINO_PIN_22          GPIO_PIN(PORT_B, 2) // CC1200.CLK
+#define ARDUINO_PIN_23          GPIO_PIN(PORT_B, 1) // CC1200.MOSI
+#define ARDUINO_PIN_24          GPIO_PIN(PORT_B, 3) // CC1200.MISO
+#define ARDUINO_PIN_25          GPIO_PIN(PORT_A, 7) // ADC5/AIN7
+#define ARDUINO_PIN_28          GPIO_PIN(PORT_A, 5) // ADC1/AIN5
+#define ARDUINO_PIN_29          GPIO_PIN(PORT_A, 4) // ADC2/AIN4
+#define ARDUINO_PIN_32          GPIO_PIN(PORT_A, 2) // ADC3/AIN2
+#define ARDUINO_PIN_33          GPIO_PIN(PORT_A, 6) // USD.SEL/ADC4
+#define ARDUINO_PIN_34          GPIO_PIN(PORT_C, 6) // USD.MISO
+#define ARDUINO_PIN_35          GPIO_PIN(PORT_C, 5) // USD.MOSI
+#define ARDUINO_PIN_36          GPIO_PIN(PORT_C, 4) // USD.SCLK
+#define ARDUINO_PIN_A1          ARDUINO_PIN_28
+#define ARDUINO_PIN_A2          ARDUINO_PIN_29
+#define ARDUINO_PIN_A3          ARDUINO_PIN_32
+#define ARDUINO_PIN_A4          ARDUINO_PIN_33
+#define ARDUINO_PIN_A5          ARDUINO_PIN_25
+
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adds the arduino feature to the remote-revb board.

The pins can bee seen in this image https://github.com/Zolertia/Resources/wiki/RE-Mote#re-mote-revision-b-pin-out


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've tested with the following programs: `examples/arduino_hello-world`, `tests/periph_gpio_arduino` (toggling the leds, pins 22, 23 and 24), `tests/sys_arduino` and `tests/sys_arduino_lib`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
