### PR TITLE
cpu/arm7_common: use malloc_thread_safe

### DIFF
--- a/cpu/arm7_common/Kconfig
+++ b/cpu/arm7_common/Kconfig
@@ -11,6 +11,7 @@ config CPU_ARCH_ARMV4T
     select HAS_ARCH_ARM
     select HAS_CPP
     select HAS_LIBSTDCPP
+    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
 
 config CPU_CORE_ARM7TDMI_S
     bool

--- a/cpu/arm7_common/Makefile.dep
+++ b/cpu/arm7_common/Makefile.dep
@@ -10,3 +10,6 @@ else
   # use the nano-specs of Newlib when available
   USEMODULE += newlib_nano
 endif
+
+# Make calls to malloc and friends thread-safe
+USEMODULE += malloc_thread_safe


### PR DESCRIPTION
### Contribution description

This should fix concurrent dynamic memory allocation.

### Testing procedure

1. Run `make BOARD=mcb2388 -C tests/malloc_thread_safety flash test` on `master`
2. Same on this PR

It should fail on `master` but get fixed by this PR.

### Issues/PRs references

None