### PR TITLE
cpu/mips32r2_common: use malloc_thread_safe

### DIFF
--- a/cpu/mips32r2_common/Kconfig
+++ b/cpu/mips32r2_common/Kconfig
@@ -12,6 +12,7 @@ config CPU_ARCH_MIPS32R2
     select HAS_CPP
     select HAS_LIBSTDCPP
     select HAS_PERIPH_PM
+    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
 
 config CPU_CORE_M4K
     bool

--- a/cpu/mips32r2_common/Makefile.dep
+++ b/cpu/mips32r2_common/Makefile.dep
@@ -9,3 +9,6 @@ FEATURES_REQUIRED += periph_timer
 ifeq (,$(filter newlib_syscalls_mips_uhi,$(USEMODULE)))
   USEMODULE += newlib_syscalls_default
 endif
+
+# Make calls to malloc and friends thread-safe
+USEMODULE += malloc_thread_safe


### PR DESCRIPTION
### Contribution description

This should fix concurrent dynamic memory allocation.

### Testing procedure

1. Run `make BOARD=6lowpan-clicker -C tests/malloc_thread_safety flash test` on `master`
2. Same on this PR

It should fail on `master` but get fixed by this PR.

### Issues/PRs references

None