### PR TITLE
treewide: fix trailing whitespaces

### DIFF
--- a/dist/tools/packer/README.md
+++ b/dist/tools/packer/README.md
@@ -1,11 +1,11 @@
 # Packer
 
 ## About
-[Packer](https://www.packer.io/) is a command-line tool to create virtual machines 
+[Packer](https://www.packer.io/) is a command-line tool to create virtual machines
 based on a source configuration file.
 
 ## Requirements
-To use packer you need to download and install it (compare [Install Packer](https://www.packer.io/docs/installation.html)). 
+To use packer you need to download and install it (compare [Install Packer](https://www.packer.io/docs/installation.html)).
 
 ## Usage
 A simple build of the vagrant box can be done by:

--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -51,7 +51,7 @@ This feature allows you to conveniently develop code for RIOT with your preferre
 your host system and use the VM for compiling, flashing devices and running the native port of RIOT.
 
 ## Additional Information
-1. VirtualBox: For new boards it is necessary to add a usb filter (open VirtualBox, click on USB and add the new filter for your board). 
+1. VirtualBox: For new boards it is necessary to add a usb filter (open VirtualBox, click on USB and add the new filter for your board).
   * For Linux Guest Systems: For new boards it is necessary to add new udev rules in the Vagrant config (in `dist/tools/vagrant/udev_rules`) so that Vagrant can capture the device.
     The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.
   * For Linux Host Systems: Additionally, in order to allow USB access from within the guest system, the host system user

--- a/pkg/heatshrink/doc.txt
+++ b/pkg/heatshrink/doc.txt
@@ -5,12 +5,12 @@
  * @brief    Provides a lightweight compression library to RIOT
  *
  * # Introduction
- * 
+ *
  * This package provides a compression library specifically developed for
  * memory-constrained devices.
- * 
+ *
  * # License
- * 
+ *
  * The library is ISC licensed.
  *
  * @see https://github.com/atomicobject/heatshrink

--- a/pkg/micro-ecc/doc.txt
+++ b/pkg/micro-ecc/doc.txt
@@ -5,40 +5,40 @@
  * @brief    Micro-ECC for RIOT
  *
  * # Micro-ECC for RIOT
- * 
+ *
  * This port of Micro-ECC to RIOT is based on the Micro-ECC
  * [upstream](https://github.com/kmackay/micro-ecc) and adds `hwrng_read`
  * (provided by RIOT) as the default RNG function if it is available on the target
  * platform. This port also fixes a minor issue with unused variables in the
  * upstream code.
- * 
+ *
  * # Usage
- * 
+ *
  * ## Build
- * 
+ *
  * Add
  * ```Makefile
  * USEPKG += micro-ecc
  * ```
  * to your Makefile.
- * 
+ *
  * ## Choosing the right API
- * 
+ *
  * Before using the Micro-ECC library, you need to check the `Makefile.features`
  * of your target board to see if `periph_hwrng` is provided.
- * 
+ *
  * If it is provided, you may safely use `uECC_make_key` to generate ECDSA key
  * pairs and call `uECC_sign`/`uECC_verify` to sign/verify the ECDSA signatures.
- * 
+ *
  * If not, you cannot use `uECC_make_key` or `uECC_sign` APIs anymore. The ECDSA
  * keys have to be generated on a platform with HWRNG support (e.g., `native`) and
  * transferred to your target device. You need to use `uECC_sign_deterministic` to
  * perform ECDSA deterministic signing (standardized by RFC 6979). You can still
  * use `uECC_verify` to verify the signatures from both signing APIs.
- * 
+ *
  * **WARNING** Calling `uECC_make_key` and `uECC_sign` APIs on platforms without
  * HWRNG support will lead to compile failure.
- * 
+ *
  * Examples of using these uECC APIs can be found in the `test` folder of the
  * Micro-ECC upstream.
  *

--- a/pkg/minmea/doc.txt
+++ b/pkg/minmea/doc.txt
@@ -1,17 +1,17 @@
 /**
- * @defgroup pkg_minmea   GPS parser library 
+ * @defgroup pkg_minmea   GPS parser library
  * @ingroup  pkg
  * @ingroup  sys_serialization
  * @brief    Provides a GPS parser library to RIOT
  *
  * # Introduction
- * 
+ *
  * "Minmea is a minimalistic GPS parser library written in pure C intended for
  * resource-constrained platforms, especially microcontrollers and other embedded
  * systems."
- * 
+ *
  * # License
- * 
+ *
  * Licensed under WTFPL.
  *
  * @see      https://github.com/cloudyourcar/minmea

--- a/pkg/relic/doc.txt
+++ b/pkg/relic/doc.txt
@@ -10,9 +10,9 @@
  * ```
  * export RELIC_CONFIG_FLAGS=-DARCH=NONE -DQUIET=off -DWORD=32 -DFP_PRIME=255 -DWITH="BN;MD;DV;FP;EP;CP;BC;EC" -DSEED=ZERO
  * ```
- * 
+ *
  * This should happen before the ```USEPKG``` line.
- * 
+ *
  * # Usage
  * Just put
  * ```

--- a/pkg/tweetnacl/doc.txt
+++ b/pkg/tweetnacl/doc.txt
@@ -10,44 +10,44 @@
  * TweetNaCl fits into just 100 tweets while supporting all 25 of the C NaCl
  * functions used by applications. TweetNaCl is a self-contained public-domain C
  * library, so it can easily be integrated into applications.
- * 
+ *
  * NaCl (pronounced "salt") is a new easy-to-use high-speed software library for
  * network communication, encryption, decryption, signatures, etc. NaCl's goal is
  * to provide all of the core operations needed to build higher-level
  * cryptographic tools.
- * 
+ *
  * Of course, other libraries already exist for these core operations. NaCl
  * advances the state of the art by improving security, by improving usability,
  * and by improving speed.
- * 
+ *
  * (from https://nacl.cr.yp.to/ and http://tweetnacl.cr.yp.to/)
- * 
+ *
  * You can find the API and more information [here](https://nacl.cr.yp.to/), since
  * the sources are not documented due to the aim for fitting in 100 tweets.
- * 
+ *
  * ## Requirements
  *
  * TweetNaCl requires more than 2K of stack, so beware that you're allocating at
  * least `THREAD_STACKSIZE_DEFAULT + 2048` bytes.
- * 
+ *
  * You can do it easily by adding:
- * 
+ *
  * ```makefile
  * CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 2048)'
  * ```
- * 
+ *
  * to your makefile.
- * 
+ *
  * ## Usage
  *
  * Just add it as a package in your application:
- * 
+ *
  * ```makefile
  * USEPKG += tweetnacl
  * ```
- * 
+ *
  * And don't forget to include the header:
- * 
+ *
  * ```c
  * #include <tweetnacl.h>
  * ```


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Found while testing #15662. See e.g. https://github.com/miri64/RIOT/runs/1576784985#step:5:13667
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See if all trailing whitespaces are removed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found while testing #15662
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
