### PR TITLE
memarray: Inline short alloc and free functions

### DIFF
--- a/sys/include/memarray.h
+++ b/sys/include/memarray.h
@@ -18,8 +18,10 @@
 #ifndef MEMARRAY_H
 #define MEMARRAY_H
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,7 +63,16 @@ void memarray_init(memarray_t *mem, void *data, size_t size, size_t num);
  * @return pointer to allocated structure, if enough memory was available
  * @return NULL, on failure
  */
-void *memarray_alloc(memarray_t *mem);
+static inline void *memarray_alloc(memarray_t *mem)
+{
+    assert(mem != NULL);
+
+    void *free = mem->free_data;
+    if (free) {
+        mem->free_data = *((void **)mem->free_data);
+    }
+    return free;
+}
 
 /**
  * @brief Allocate and clear memory chunk in memarray pool
@@ -73,7 +84,14 @@ void *memarray_alloc(memarray_t *mem);
  * @return pointer to allocated structure, if enough memory was available
  * @return NULL, on failure
  */
-void *memarray_calloc(memarray_t *mem);
+static inline void *memarray_calloc(memarray_t *mem)
+{
+    void *new = memarray_alloc(mem);
+    if (new) {
+        memset(new, 0, mem->size);
+    }
+    return new;
+}
 
 /**
  * @brief Free memory chunk in memarray pool
@@ -84,7 +102,13 @@ void *memarray_calloc(memarray_t *mem);
  * @param[in,out] mem   memarray pool to free block in
  * @param[in]     ptr   pointer to memarray chunk
  */
-void memarray_free(memarray_t *mem, void *ptr);
+static inline void memarray_free(memarray_t *mem, void *ptr)
+{
+    assert((mem != NULL) && (ptr != NULL));
+
+    memcpy(ptr, &mem->free_data, sizeof(void *));
+    mem->free_data = ptr;
+}
 
 #ifdef __cplusplus
 }

--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -31,34 +31,3 @@ void memarray_init(memarray_t *mem, void *data, size_t size, size_t num)
     }
     memset(((char *)mem->free_data) + ((mem->num - 1) * (mem->size)), 0, sizeof(void *));
 }
-
-void *memarray_alloc(memarray_t *mem)
-{
-    assert(mem != NULL);
-
-    if (mem->free_data == NULL) {
-        return NULL;
-    }
-    void *free = mem->free_data;
-    mem->free_data = *((void **)mem->free_data);
-    DEBUG("memarray: Allocate %u Bytes at %p\n", (unsigned)mem->size, free);
-    return free;
-}
-
-void *memarray_calloc(memarray_t *mem)
-{
-    void *new = memarray_alloc(mem);
-    if (new) {
-        memset(new, 0, mem->size);
-    }
-    return new;
-}
-
-void memarray_free(memarray_t *mem, void *ptr)
-{
-    assert((mem != NULL) && (ptr != NULL));
-
-    memcpy(ptr, &mem->free_data, sizeof(void *));
-    mem->free_data = ptr;
-    DEBUG("memarray: Free %u Bytes at %p\n", (unsigned)mem->size, ptr);
-}


### PR DESCRIPTION
### Contribution description

These functions are short enough that inlining them actually reduces the
flash footprint of the test on the samr21-xpro

### Testing procedure

The test application (`tests/memarray`) should succeed.

### Issues/PRs references

None