### PR TITLE
sock/dtls: add getter/setter for the remote UDP endpoint of sock_dtls_session_t

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -345,6 +345,15 @@ void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote)
     dtls_close(sock->dtls_ctx, &remote->dtls_session);
 }
 
+void sock_dtls_session_get_udp_ep(const sock_dtls_session_t *session,
+                                  sock_udp_ep_t *ep)
+{
+    assert(session);
+    assert(ep);
+
+    _session_to_ep(&session->dtls_session, ep);
+}
+
 ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
                            const void *data, size_t len, uint32_t timeout,
                            sock_dtls_aux_tx_t *aux)

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -354,6 +354,15 @@ void sock_dtls_session_get_udp_ep(const sock_dtls_session_t *session,
     _session_to_ep(&session->dtls_session, ep);
 }
 
+void sock_dtls_session_set_udp_ep(sock_dtls_session_t *session,
+                                  const sock_udp_ep_t *ep)
+{
+    assert(session);
+    assert(ep);
+
+    _ep_to_session(ep, &session->dtls_session);
+}
+
 ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
                            const void *data, size_t len, uint32_t timeout,
                            sock_dtls_aux_tx_t *aux)

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -665,6 +665,17 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
 void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote);
 
 /**
+ * @brief Get the remote UDP endpoint from a session.
+ *
+ * @pre `(session != NULL) && (ep != NULL)`
+ *
+ * @param[in]  session   DTLS session
+ * @param[out] ep        UDP endpoint
+ */
+void sock_dtls_session_get_udp_ep(const sock_dtls_session_t *session,
+                                  sock_udp_ep_t *ep);
+
+/**
  * @brief Receive handshake messages and application data from remote peer.
  *
  * @param[in]   sock    DTLS sock to use.

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -676,6 +676,20 @@ void sock_dtls_session_get_udp_ep(const sock_dtls_session_t *session,
                                   sock_udp_ep_t *ep);
 
 /**
+ * @brief Set the remote UDP endpoint from a session.
+ *
+ * @pre `(session != NULL) && (ep != NULL)`
+ *
+ * @param[in]   session   DTLS session
+ * @param[in]   ep        UDP endpoint
+ *
+ * @note Function should only be needed when doing a blocking handshake with
+ *       @ref sock_dtls_send() to set the remote UDP endpoint.
+ */
+void sock_dtls_session_set_udp_ep(sock_dtls_session_t *session,
+                                  const sock_udp_ep_t *ep);
+
+/**
  * @brief Receive handshake messages and application data from remote peer.
  *
  * @param[in]   sock    DTLS sock to use.

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -907,6 +907,14 @@ ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
  * @note    When blocking, we will need an extra thread to call
  *          @ref sock_dtls_recv() function to handle the incoming handshake
  *          messages.
+ *          An example for a blocking handshake is:
+ *              1. Create an empty @ref sock_dtls_session_t object.
+ *              2. Set the UDP endpoint of the peer you want to connect to in the
+ *                 session object with @ref sock_dtls_session_set_udp_ep().
+ *              3. Call @ref sock_dtls_send() with a timeout greater than 0.
+ *                 The send function blocks until the handshake completes or the
+ *                 timeout expires. If the handshake was successful the data has
+ *                 been sent.
  *
  * @return The number of bytes sent on success
  * @return  -ENOTCONN, if `timeout == 0` and no existing session exists with


### PR DESCRIPTION
### Contribution description
This PR adds two new functions to the DTLS sock API: `sock_dtls_session_get_udp_ep()` and `sock_dtls_session_set_udp_ep()`.
Those functions add the ability to add or get the remote UDP endpoint from a session object (`sock_dtls_session_t`). 

__Necessity of the setter:__
When using `sock_dtls_session_init()` to initiate a handshake there is no need to set the remote endpoint because the function has the endpoint as parameter and sets the endpoint itself. But there is another legitimate way to initiate a handshake: by using `sock_dtls_send()`/`sock_dtls_send_aux()`. 

These functions start a handshake when no session exists and the timeout is > 0. But for that the endpoint needs to be set since it is not done by the function (since there is no endpoint parameter and it would not make sense to add it to that function).

From the documentation: 
```
timeout             Handshake timeout in microseconds.
 *                      If `timeout > 0`, will start a new handshake if no
 *                      session exists yet. The function will block until
 *                      handshake completed or timed out.
```

### Testing procedure
Implementation in tinyDTLS can be tested with the test [pkg_tinydtls_sock_async](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_tinydtls_sock_async) together with this patch:
```
diff --git a/tests/pkg_tinydtls_sock_async/dtls-client.c b/tests/pkg_tinydtls_sock_async/dtls-client.c
index 2aefc75856..b03ac19ed7 100644
--- a/tests/pkg_tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-client.c
@@ -200,6 +200,22 @@ static int client_send(char *addr_str, char *data)
         return -1;
     }
 
+    sock_dtls_session_t test_session;
+    sock_dtls_session_set_udp_ep(&test_session, &remote);
+
+    sock_udp_ep_t test_ep;
+    sock_dtls_session_get_udp_ep(&test_session, &test_ep);
+
+    printf("\n\nAddress: ");
+    for (uint8_t i=0; i < sizeof(ipv6_addr_t); i++) {
+        printf("%02x:", test_ep.addr.ipv6[i]);
+    }
+    puts("");
+    printf("Port: %d\n", test_ep.port);
+    printf("Family: %d\n", test_ep.family);
+    printf("Interface: %d\n", test_ep.netif);
+    puts("\n");
+
     if (sock_dtls_create(&_dtls_sock, &_udp_sock,
                          SOCK_DTLS_CLIENT_TAG,
                          SOCK_DTLS_1_2, SOCK_DTLS_CLIENT) < 0) {

```

To run it: 
* Flash and run on one device (e.g. native)
* Execute `dtlsc {ip} {some data}`
The printed UDP endpoint should be the valid remote endpoint. (Send fails because we have no server device)

### Issues/PRs references
Fixes #15615