### PR TITLE
core/clist: fix clist_lpush() on empty list

### DIFF
--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -139,7 +139,7 @@ static inline void clist_lpush(clist_node_t *list, clist_node_t *new_node)
         list->next->next = new_node;
     }
     else {
-        new_node->next = new_node;
+        new_node->next = NULL;
         list->next = new_node;
     }
 }

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -143,6 +143,17 @@ static void test_clist_lpop(void)
     TEST_ASSERT_NULL(clist_lpop(list));
 }
 
+static void test_clist_lpush_empty(void)
+{
+    list_node_t *list = &test_clist;
+
+    clist_lpush(list, &tests_clist_buf[2]);
+
+    TEST_ASSERT_NOT_NULL(list->next);
+    TEST_ASSERT(list->next == &tests_clist_buf[2]);
+    TEST_ASSERT(list->next->next == NULL);
+}
+
 static void test_clist_lpush(void)
 {
     list_node_t *list = &test_clist;
@@ -339,6 +350,7 @@ Test *tests_core_clist_tests(void)
         new_TestFixture(test_clist_lpop),
         new_TestFixture(test_clist_rpop),
         new_TestFixture(test_clist_lpush),
+        new_TestFixture(test_clist_lpush_empty),
         new_TestFixture(test_clist_remove_two),
         new_TestFixture(test_clist_add_three),
         new_TestFixture(test_clist_find),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`clist_lpush()` will create a loop when called on an empty list.
Fix this by setting the next pointer to `NULL` instead to the new element.


### Testing procedure

Run `make -C tests/unittests tests-core all term`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
