### PR TITLE
sys/net/gnrc/tx_sync: new module

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -331,6 +331,10 @@ ifneq (,$(filter gnrc_sixlowpan_frag_sfr,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_frag_rb
   USEMODULE += evtimer
   USEMODULE += xtimer
+  ifneq (,$(filter gnrc_tx_sync,$(USEMODULE)))
+    # TODO: Implement gnrc_tx_sync for gnrc_sixlowpand_frag_sfr
+    $(error module gnrc_tx_sync conflicts with gnrc_sixlowpand_frag_sfr)
+  endif
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_frag_sfr_stats,$(USEMODULE)))

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -49,6 +49,11 @@ extern "C" {
  */
 typedef enum {
     /**
+     * @brief   TX synchronization data for passing up error data or
+     *          auxiliary data
+     */
+    GNRC_NETTYPE_TX_SYNC = -3,
+    /**
      * @brief   Protocol is as defined in @ref gnrc_netif_hdr_t. Not usable with
      *          @ref net_gnrc_netreg
      */

--- a/sys/include/net/gnrc/tx_sync.h
+++ b/sys/include/net/gnrc/tx_sync.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_tx_sync    Helpers for synchronizing with transmission.
+ * @ingroup     net_gnrc
+ * @brief       This allows upper layers to wait for a transmission to complete
+ *              (or fail) and for passing up data about the transmission.
+ * @{
+ *
+ * @file
+ * @brief   Definitions for TX sync.
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+#ifndef NET_GNRC_TX_SYNC_H
+#define NET_GNRC_TX_SYNC_H
+
+#include <errno.h>
+#include <stdint.h>
+
+#include "mutex.h"
+#include "net/gnrc/pktbuf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   TX synchronization data */
+typedef struct {
+    mutex_t signal;     /**< Mutex used for synchronization */
+} gnrc_tx_sync_t;
+
+/**
+ * @brief   Helper to initialize a gnrc_tx_sync_t structure
+ */
+static inline gnrc_tx_sync_t gnrc_tx_sync_init(void)
+{
+    gnrc_tx_sync_t result = { .signal = MUTEX_INIT_LOCKED };
+    return result;
+}
+
+/**
+ * @brief   Build a TX sync snip
+ *
+ * @param[in,out]   tx_sync     TX sync structure the snip should hold
+ *
+ * @return  The TX sync snip holing @p tx_sync
+ * @retval  NULL    Allocation Failed
+ *
+ * @note    No need to initialize @p tx_sync, this function will do it for you.
+ */
+static inline gnrc_pktsnip_t * gnrc_tx_sync_build(gnrc_tx_sync_t *tx_sync)
+{
+    *tx_sync = gnrc_tx_sync_init();
+    gnrc_pktsnip_t *snip = gnrc_pktbuf_add(NULL, NULL, 0, GNRC_NETTYPE_TX_SYNC);
+    if (!snip) {
+        return NULL;
+    }
+    snip->data = tx_sync;
+    return snip;
+}
+
+/**
+ * @brief   Appends a newly allocated tx sync pktsnip to the end of the packet
+ *
+ * @param[in]       pkt     Packet to append TX sync pktsnip to
+ * @param[in,out]   tx_sync TX sync structure to initialize and append
+ *
+ * @retval  0       Success
+ * @retval  -ENOMEM Allocation failed
+ *
+ * @note    No need to initialize @p tx_sync, this function will do it for you.
+ */
+static inline int gnrc_tx_sync_append(gnrc_pktsnip_t *pkt,
+                                      gnrc_tx_sync_t *tx_sync)
+{
+    gnrc_pktsnip_t *snip = gnrc_tx_sync_build(tx_sync);
+    if (!snip) {
+        return -ENOMEM;
+    }
+    gnrc_pkt_append(pkt, snip);
+    return 0;
+}
+
+/**
+ * @brief   Split off the TX sync snip and return it
+ * @param[in,out]   pkt     Packet to split off the TX sync snip
+ * @return  The TX sync snip that no longer is part of @p pkt
+ * @retval  NULL            @p pkt contains no TX sync snip
+ */
+gnrc_pktsnip_t * gnrc_tx_sync_split(gnrc_pktsnip_t *pkt);
+
+/**
+ * @brief   Signal TX completion via the given tx sync packet snip
+ *
+ * @param[in]       pkt     The tx sync packet snip of the packet that was transmitted
+ *
+ * @pre     Module gnrc_netttype_tx_sync is sued
+ * @pre     `pkt->type == GNRC_NETTYPE_TX_SYNC`
+ */
+static inline void gnrc_tx_complete(gnrc_pktsnip_t *pkt)
+{
+    assert(IS_USED(MODULE_GNRC_TX_SYNC) && (pkt->type == GNRC_NETTYPE_TX_SYNC));
+    gnrc_tx_sync_t *sync = pkt->data;
+    mutex_unlock(&sync->signal);
+}
+
+/**
+ * @brief   Block until transmission of the corresponding packet has completed
+ *          or failed
+ *
+ * @param[in,out]   sync    TX sync structure used for synchronization
+ *
+ * @pre     @p sync has been added to the packet to synchronize with, e.g. via
+ *          @ref gnrc_tx_sync_append
+ * @pre     The packet linked to @p sync has been passed to the network stack
+ *          for transmission. Otherwise this will block forever.
+ *
+ * @note    If the transmission has already completed, this function will not
+ *          block and return immediately instead.
+ */
+static inline void gnrc_tx_sync(gnrc_tx_sync_t *sync)
+{
+    mutex_lock(&sync->signal);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_TX_SYNC_H */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -136,5 +136,8 @@ endif
 ifneq (,$(filter gnrc_tcp,$(USEMODULE)))
   DIRS += transport_layer/tcp
 endif
+ifneq (,$(filter gnrc_tx_sync,$(USEMODULE)))
+  DIRS += tx_sync
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/tx_sync/Makefile
+++ b/sys/net/gnrc/tx_sync/Makefile
@@ -1,0 +1,3 @@
+MODULE := gnrc_tx_sync
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/tx_sync/gnrc_tx_sync.c
+++ b/sys/net/gnrc/tx_sync/gnrc_tx_sync.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief   Implementation of the TX synchronization helpers
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <assert.h>
+
+#include "net/gnrc/tx_sync.h"
+
+gnrc_pktsnip_t * gnrc_tx_sync_split(gnrc_pktsnip_t *pkt)
+{
+    if (!pkt) {
+        return NULL;
+    }
+    gnrc_pktsnip_t *next;
+
+    while ((next = pkt->next) != NULL) {
+        if (next->type == GNRC_NETTYPE_TX_SYNC) {
+            pkt->next = NULL;
+            /* TX sync snip must be last snip in packet */
+            assert(next->next == NULL);
+            return next;
+        }
+        pkt = next;
+    }
+
+    return NULL;
+}

--- a/tests/gnrc_tx_sync/Makefile
+++ b/tests/gnrc_tx_sync/Makefile
@@ -1,0 +1,22 @@
+include ../Makefile.tests_common
+
+TEST_6LO ?= 1
+
+ifeq (1,$(TEST_6LO))
+  USEMODULE += gnrc_sixlowpan_default
+  USEMODULE += netdev_ieee802154
+else
+  USEMODULE += gnrc_ipv6_default
+  USEMODULE += netdev_eth
+endif
+
+USEMODULE += gnrc_tx_sync
+USEMODULE += netdev_test
+USEMODULE += sock_udp
+USEMODULE += xtimer
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += iolist
+
+include $(RIOTBASE)/Makefile.include
+
+CFLAGS += -DDEBUG_ASSERT_VERBOSE=1

--- a/tests/gnrc_tx_sync/Makefile.ci
+++ b/tests/gnrc_tx_sync/Makefile.ci
@@ -1,0 +1,22 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
+    i-nucleo-lrwan1 \
+    msb-430 \
+    msb-430h  \
+    nucleo-f030r8 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-f303k8 \
+    nucleo-f334r8 \
+    nucleo-l011k4 \
+    nucleo-l031k6 \
+    nucleo-l053r8 \
+    samd10-xmini \
+    slstk3400a \
+    stk3200 \
+    stm32f030f4-demo \
+    stm32f0discovery \
+    stm32l0538-disco \
+    telosb \
+    z1 \
+    #

--- a/tests/gnrc_tx_sync/main.c
+++ b/tests/gnrc_tx_sync/main.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief       Text application for gnrc_tx_sync
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+/* keep include of stdint.h before stdatomic.h for compatibility with broken
+ * toolchains */
+#include <stdint.h>
+#include <stdatomic.h>
+#include <stdio.h>
+
+#include "net/af.h"
+#include "net/gnrc/netif/raw.h"
+#include "net/ipv6/addr.h"
+#include "net/netdev_test.h"
+#include "net/sock/udp.h"
+#include "net/gnrc/pkt.h"
+#include "test_utils/expect.h"
+#include "xtimer.h"
+
+#define NETIF_STACKSIZE     THREAD_STACKSIZE_DEFAULT
+#define NETIF_PRIO          (THREAD_PRIORITY_MAIN - 4)
+#define MAIN_QUEUE_SIZE     (8)
+
+static char netif_stack[NETIF_STACKSIZE];
+static msg_t main_msg_queue[MAIN_QUEUE_SIZE];
+
+static atomic_int sends_completed = ATOMIC_VAR_INIT(0);
+static gnrc_netif_t netif;
+static netdev_test_t netdev_test;
+static netdev_t *netdev =
+#if IS_USED(MODULE_NETDEV_IEEE802154)
+    &netdev_test.netdev.netdev;
+#else
+    &netdev_test.netdev;
+#endif
+
+static bool carries_test_message(const iolist_t *iolist)
+{
+    /* This is dark magic, don't do this at home.
+     * We rely on two things here:
+     * 1.)  As we're testing gnrc_tx_sync, we can be sure that the used network stack is GNRC.
+     *      Hence, iolist actually is of type gnrc_pktsnip_t * and we can just cast it back
+     * 2.)  There are only two types of messages being send in this test: ICMPv6 messages and
+     *      our UDP test message (or fragments of it).
+     *
+     * Detecting (unfragmented) ICMPv6 messages is trivial, so we just do this. All other frames
+     * must be carrying our test message.
+     */
+    for (const gnrc_pktsnip_t *iter = (const gnrc_pktsnip_t *)iolist; iter; iter = iter->next) {
+        if (iter->type == GNRC_NETTYPE_ICMPV6) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static int netdev_send(netdev_t *dev, const iolist_t *iolist)
+{
+    (void)dev;
+    if (carries_test_message(iolist)) {
+        /* sending part of UDP datagram */
+        xtimer_msleep(100);
+        atomic_fetch_add(&sends_completed, 1);
+    }
+    return iolist_size(iolist);
+}
+
+static int netdev_get_device_type(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    const uint16_t type_ipv6 = NETDEV_TYPE_ETHERNET;
+    const uint16_t type_6lo = NETDEV_TYPE_IEEE802154;
+    assert(max_len == sizeof(uint16_t));
+    if (IS_USED(MODULE_NETDEV_IEEE802154)) {
+        memcpy(value, &type_6lo, sizeof(type_6lo));
+    }
+    else {
+        memcpy(value, &type_ipv6, sizeof(type_ipv6));
+    }
+    return sizeof(uint16_t);
+}
+
+static int netdev_get_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    const uint16_t pdu_size_ethernet = 1500;
+    const uint16_t pdu_size_6lo = 32;
+    assert(max_len == sizeof(uint16_t));
+    if (IS_USED(MODULE_NETDEV_IEEE802154)) {
+        memcpy(value, &pdu_size_6lo, sizeof(pdu_size_6lo));
+    }
+    else {
+        memcpy(value, &pdu_size_ethernet, sizeof(pdu_size_ethernet));
+    }
+    return sizeof(uint16_t);
+}
+
+static int netdev_get_proto(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    const gnrc_nettype_t proto =
+#if IS_USED(MODULE_NETDEV_IEEE802154)
+        GNRC_NETTYPE_SIXLOWPAN;
+#else
+        GNRC_NETTYPE_IPV6;
+#endif
+    assert(max_len == sizeof(proto));
+    memcpy(value, &proto, sizeof(proto));
+    return sizeof(proto);
+}
+
+static int netdev_get_address(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    const uint8_t addr[] = {
+#if IS_USED(MODULE_NETDEV_IEEE802154)
+        0x13, 0x37
+#else
+        0x13, 0x37, 0xac, 0xdc, 0xbe, 0xef
+#endif
+    };
+    assert(max_len >= sizeof(addr));
+    memcpy(value, addr, sizeof(addr));
+    return sizeof(addr);
+}
+
+static int netdev_get_address_long(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    const uint8_t addr[] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
+    if (!IS_USED(MODULE_NETDEV_IEEE802154)) {
+        return -ENOTSUP;
+    }
+    assert(max_len >= sizeof(addr));
+    memcpy(value, addr, sizeof(addr));
+    return sizeof(addr);
+}
+
+static int netdev_get_src_len(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    const uint16_t src_len = 2;
+    if (!IS_USED(MODULE_NETDEV_IEEE802154)) {
+        return -ENOTSUP;
+    }
+    assert(max_len == sizeof(src_len));
+    memcpy(value, &src_len, sizeof(src_len));
+    return sizeof(src_len);
+}
+
+int main(void)
+{
+    puts(
+        "Test application for gnrc_tx_sync\n"
+        "=================================\n"
+        "\n"
+        "This application sends a single UDP datagram over a virtual Ethernet\n"
+        "or 802.15.4 device. (Set TEST_6LO to 1 for 802.15.4 and to 0 for\n"
+        "Ethernet.) The simulated network devices blocks for 100ms - more than\n"
+        "enough time for sock_upd_send() to return if no synchronization is done.\n"
+        "If an 802.15.4 device is simulated, the test datagram will be transmitted\n"
+        "in two fragments. In that case sock_udp_send() must only return after both\n"
+        "fragments are out. In the Ethernet case, only a single frame is send.\n"
+    );
+
+    if (IS_USED(MODULE_NETDEV_IEEE802154)) {
+        puts("IEEE 802.15.4 mode (TEST_6LO=1), sending 2 6LoWPAN fragments");
+    }
+    else {
+        puts("Ethernet mode (TEST_6LO=0), sending 1 IPv6 packet");
+    }
+    msg_init_queue(main_msg_queue, MAIN_QUEUE_SIZE);
+    netdev_test_setup(&netdev_test, NULL);
+    netdev_test_set_send_cb(&netdev_test, netdev_send);
+    netdev_test_set_get_cb(&netdev_test, NETOPT_DEVICE_TYPE, netdev_get_device_type);
+    netdev_test_set_get_cb(&netdev_test, NETOPT_MAX_PDU_SIZE, netdev_get_max_pdu_size);
+    netdev_test_set_get_cb(&netdev_test, NETOPT_PROTO, netdev_get_proto);
+    netdev_test_set_get_cb(&netdev_test, NETOPT_ADDRESS, netdev_get_address);
+    netdev_test_set_get_cb(&netdev_test, NETOPT_ADDRESS_LONG, netdev_get_address_long);
+    netdev_test_set_get_cb(&netdev_test, NETOPT_SRC_LEN, netdev_get_src_len);
+    gnrc_netif_raw_create(&netif, netif_stack, sizeof(netif_stack), NETIF_PRIO,
+                          "netdev_test", netdev);
+
+    sock_udp_t sock;
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = { .family = AF_INET6 };
+    remote.port = 12345;
+    ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+                                      IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
+    expect(sock_udp_create(&sock, &local, NULL, 0) == 0);
+    /* With 6LoWPAN, This test message needs exactly two fragments to be transmitted due
+     * to the maximum L2 PDU of 32 bytes */
+    static const char test_msg[33] = { 'T', 'e', 's', 't' };
+    /* with gnrc_tx_sync, we expect sock_udp_send() to block until transmission is done */
+    expect(sock_udp_send(&sock, test_msg, sizeof(test_msg), &remote) > 0);
+    /* the virtual netdev device increments sends_completed for each frame carrying the test
+     * payload. If this value has not reached the value of 1 (or 2 for 6LoWPAN fragmentation),
+     * the test has failed. */
+    int sends = atomic_load(&sends_completed);
+    int sends_expected = (IS_USED(MODULE_NETDEV_IEEE802154)) ? 2 : 1;
+    printf("transmissions expected = %d, transmissions completed = %d\n", sends_expected, sends);
+    expect(sends == sends_expected);
+
+    puts("TEST PASSED");
+
+    return 0;
+}

--- a/tests/gnrc_tx_sync/tests/01-run.py
+++ b/tests/gnrc_tx_sync/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

The new `gnrc_tx_sync` module allows users of the GNRC network stack to synchronize with the actual transmission of outgoing packets. This is directly integrated into gnrc_sock. Hence, if `gnrc_tx_sync` is used, calls to e.g. sock_udp_send() will block until the network stack has processed the message.

Use cases:
1. Prevent packet drop when sending at high rate
    - If the application is sending faster than the stack can handle, the message queues will overflow and outgoing packets are lost
2. Passing auxiliary data about the transmission back the stack
    - When e.g. the number of required retransmissions, the transmission time stamp, etc. should be made available to a user of an UDP sock, a synchronization mechanism is needed
3. Simpler error reporting without footguns
    - The current approach of using `core/msg` for passing up error messages is difficult to use if other message come in. Currently, gnrc_sock is busy-waiting and fetching messages from the message queue until the number of expected status reports is received. It will enqueue all non-status-report messages again at the end of the queue. This has multiple issues:
        - Busy waiting is especially in lower power scenarios with time slotted MAC protocols harmful, as the CPU will remain active and consume power even though the it could sleep until the TX slot is reached
        - The status reports from the network stack are send to the user thread blocking. If the message queue of the user thread is full, the network stack would block until the user stack can fetch the messages. If another higher priority thread would start sending a message, it would busy wait for its status reports to completely come in. Hence, the first thread doesn't get CPU time to fetch messages and unblock the network stack. As a result, the system would lock up completely.
    - Just adding the error/status code to the gnrc_tx_sync_t would preallocate and reserve memory for the error reporting. That way gnrc_sock does not need to search through the message queue for status reports and the network stack does not need to block for the user thread fetching it.

### Testing procedure

1. Run the test provided as `tests/gnrc_tx_sync` as is. It should pass.
2. Run the test again, but comment out `USEMODULE += gnrc_tx_sync` in the test's `Makefile`. The test should fail now.

### State

- [x] Integrate into link layer fragmentation. (I think only 6LoWPAN has this, right?) But that shouldn't be too hard to add. Just split of the TX sync snip before creating the fragments, send out all fragments as before, and finally release the TX sync snip.
- [x] Get https://github.com/RIOT-OS/RIOT/pull/14660 merged, so that this can not only sync with GNRC but also with the actual transmission of the hardware.

The first should be handled before merging, the second could be a follow up.

### Issues/PRs references

None