### PR TITLE
sys/net/gnrc/neterr: use gnrc_tx_sync 

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -111,6 +111,10 @@ ifneq (,$(filter gnrc_mac,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter gnrc_neterr,$(USEMODULE)))
+  USEMODULE += gnrc_tx_sync
+endif
+
 ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += gnrc_nettype_gomach

--- a/sys/include/net/gnrc/neterr.h
+++ b/sys/include/net/gnrc/neterr.h
@@ -20,69 +20,20 @@
 #ifndef NET_GNRC_NETERR_H
 #define NET_GNRC_NETERR_H
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 
-#include "msg.h"
 #include "net/gnrc/pkt.h"
-#include "thread.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief   @ref core_msg type for reporting an error.
- */
-#define GNRC_NETERR_MSG_TYPE        (0x0206)
-
-/**
  * @brief   Error code to signalise success (no error occurred) to an gnrc_neterr subscriber.
  */
 #define GNRC_NETERR_SUCCESS         (0)
-
-/**
- * @brief   Reports an error to all subscribers of errors to @p pkt.
- *
- * @param[in] pkt   Packet snip to report on.
- * @param[in] err   The error code for the packet.
- */
-#ifdef MODULE_GNRC_NETERR
-static inline void gnrc_neterr_report(gnrc_pktsnip_t *pkt, uint32_t err)
-{
-    if (pkt->err_sub != KERNEL_PID_UNDEF) {
-        msg_t msg;
-
-        msg.type = GNRC_NETERR_MSG_TYPE;
-        msg.content.value = err;
-
-        msg_send(&msg, pkt->err_sub);
-    }
-}
-#else
-#define gnrc_neterr_report(pkt, err)  (void)pkt; (void)err
-#endif
-
-/**
- * @brief   Registers the current thread for errors on a @ref gnrc_pktsnip_t.
- *
- * @param[in] pkt   Packet snip to register for errors.
- *
- * @return  0, on success.
- * @return  EALREADY, if there already someone registered to errors on @p pkt.
- */
-#ifdef MODULE_GNRC_NETERR
-static inline int gnrc_neterr_reg(gnrc_pktsnip_t *pkt)
-{
-    if (pkt->err_sub != KERNEL_PID_UNDEF) {
-        return EALREADY;
-    }
-    pkt->err_sub = thread_getpid();
-    return 0;
-}
-#else
-#define gnrc_neterr_reg(pkt)  (0)
-#endif
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -49,6 +49,11 @@ extern "C" {
  */
 typedef enum {
     /**
+     * @brief   TX synchronization data for passing up error data or
+     *          auxiliary data
+     */
+    GNRC_NETTYPE_TX_SYNC = -2,
+    /**
      * @brief   Protocol is as defined in @ref gnrc_netif_hdr_t. Not usable with
      *          @ref net_gnrc_netreg
      */

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -117,10 +117,6 @@ typedef struct gnrc_pktsnip {
      */
     unsigned int users;
     gnrc_nettype_t type;            /**< protocol of the packet snip */
-#ifdef MODULE_GNRC_NETERR
-    kernel_pid_t err_sub;           /**< subscriber to errors related to this
-                                     *   packet snip */
-#endif
 } gnrc_pktsnip_t;
 
 /**

--- a/sys/include/net/gnrc/tx_sync.h
+++ b/sys/include/net/gnrc/tx_sync.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_tx_sync    Helpers for synchronizing with transmission.
+ * @ingroup     net_gnrc
+ * @brief       This allows upper layers to wait for a transmission to complete
+ *              (or fail) and for passing up data about the transmission.
+ * @{
+ *
+ * @file
+ * @brief   Definitions for TX sync.
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+#ifndef NET_GNRC_TX_SYNC_H
+#define NET_GNRC_TX_SYNC_H
+
+#include <errno.h>
+#include <stdint.h>
+
+#include "mutex.h"
+#include "net/gnrc/pktbuf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @brief   TX synchronization data */
+typedef struct {
+    mutex_t signal;     /**< Mutex used for synchronization */
+} gnrc_tx_sync_t;
+
+/**
+ * @brief   Helper to initialize a gnrc_tx_sync_t structure
+ */
+static inline gnrc_tx_sync_t gnrc_tx_sync_init(void)
+{
+    gnrc_tx_sync_t result = { .signal = MUTEX_INIT_LOCKED };
+    return result;
+}
+
+/**
+ * @brief   Build a TX sync snip
+ *
+ * @param[in,out]   tx_sync     TX sync structure the snip should hold
+ *
+ * @return  The TX sync snip holing @p tx_sync
+ * @retval  NULL    Allocation Failed
+ *
+ * @note    No need to initialize @p tx_sync, this function will do it for you.
+ */
+static inline gnrc_pktsnip_t * gnrc_tx_sync_build(gnrc_tx_sync_t *tx_sync)
+{
+    *tx_sync = gnrc_tx_sync_init();
+    gnrc_pktsnip_t *snip = gnrc_pktbuf_add(NULL, NULL, 0, GNRC_NETTYPE_TX_SYNC);
+    if (!snip) return NULL;
+    snip->data = tx_sync;
+    return snip;
+}
+
+/**
+ * @brief   Appends a newly allocated tx sync pktsnip to the end of the packet
+ *
+ * @param[in]       pkt     Packet to append TX sync pktsnip to
+ * @param[in,out]   tx_sync TX sync structure to initialize and append
+ *
+ * @retval  0       Success
+ * @retval  -ENOMEM Allocation failed
+ *
+ * @note    No need to initialize @p tx_sync, this function will do it for you.
+ */
+static inline int gnrc_tx_sync_append(gnrc_pktsnip_t *pkt,
+                                      gnrc_tx_sync_t *tx_sync)
+{
+    gnrc_pktsnip_t *snip = gnrc_tx_sync_build(tx_sync);
+    if (!snip) return -ENOMEM;
+    gnrc_pkt_append(pkt, snip);
+    return 0;
+}
+
+/**
+ * @brief   Split off the TX sync snip and return it
+ * @param[in,out]   pkt     Packet to split off the TX sync snip
+ * @return  The TX sync snip that no longer is part of @p pkt
+ * @retval  NULL            @p pkt contains no TX sync snip
+ */
+gnrc_pktsnip_t * gnrc_tx_sync_split(gnrc_pktsnip_t *pkt);
+
+/**
+ * @brief   Signal TX completion via the given tx sync packet snip
+ *
+ * @pre     Module gnrc_netttype_tx_sync is sued
+ * @pre     `pkt->type == GNRC_NETTYPE_TX_SYNC`
+ *
+ * @param   The tx sync packet snip of the packet that was transmitted
+ */
+static inline void gnrc_tx_complete(gnrc_pktsnip_t *pkt)
+{
+    assert(IS_USED(MODULE_GNRC_TX_SYNC) && (pkt->type == GNRC_NETTYPE_TX_SYNC));
+    gnrc_tx_sync_t *sync = pkt->data;
+    mutex_unlock(&sync->signal);
+}
+
+/**
+ * @brief   Block until transmission of the corresponding packet has completed
+ *          or failed
+ *
+ * @param[in,out]   sync    TX sync structure used for synchronization
+ *
+ * @pre     @p sync has been added to the packet to synchronize with, e.g. via
+ *          @ref gnrc_tx_sync_append
+ * @pre     The packet linked to @p sync has been passed to the network stack
+ *          for transmission. Otherwise this will block forever.
+ *
+ * @note    If the transmission has already completed, this function will not
+ *          block and return immediately instead.
+ */
+static inline void gnrc_tx_sync(gnrc_tx_sync_t *sync)
+{
+    mutex_lock(&sync->signal);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_TX_SYNC_H */
+/** @} */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -136,5 +136,8 @@ endif
 ifneq (,$(filter gnrc_tcp,$(USEMODULE)))
   DIRS += transport_layer/tcp
 endif
+ifneq (,$(filter gnrc_tx_sync,$(USEMODULE)))
+  DIRS += tx_sync
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -100,6 +100,8 @@ void gnrc_pktbuf_release_error(gnrc_pktsnip_t *pkt, uint32_t err)
                 gnrc_pktbuf_free_internal(pkt->data, pkt->size);
             }
             else {
+                DEBUG("pktbuf: report status code %" PRIu32 "\n", err);
+                gnrc_neterr_report(pkt, err);
                 gnrc_tx_complete(pkt);
             }
             gnrc_pktbuf_free_internal(pkt, sizeof(gnrc_pktsnip_t));
@@ -107,8 +109,6 @@ void gnrc_pktbuf_release_error(gnrc_pktsnip_t *pkt, uint32_t err)
         else {
             pkt->users--;
         }
-        DEBUG("pktbuf: report status code %" PRIu32 "\n", err);
-        gnrc_neterr_report(pkt, err);
         pkt = tmp;
     }
     mutex_unlock(&gnrc_pktbuf_mutex);

--- a/sys/net/gnrc/tx_sync/Makefile
+++ b/sys/net/gnrc/tx_sync/Makefile
@@ -1,0 +1,3 @@
+MODULE := gnrc_tx_sync
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/tx_sync/gnrc_tx_sync.c
+++ b/sys/net/gnrc/tx_sync/gnrc_tx_sync.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief   Implementation of the TX synchronization helpers
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @}
+ */
+
+#include <assert.h>
+
+#include "net/gnrc/tx_sync.h"
+
+gnrc_pktsnip_t * gnrc_tx_sync_split(gnrc_pktsnip_t *pkt)
+{
+    if (!pkt) {
+        return NULL;
+    }
+    gnrc_pktsnip_t *next;
+
+    while ((next = pkt->next) != NULL) {
+        if (next->type == GNRC_NETTYPE_TX_SYNC) {
+            pkt->next = NULL;
+            /* TX sync snip must be last snip in packet */
+            assert(next->next == NULL);
+            return next;
+        }
+        pkt = next;
+    }
+
+    return NULL;
+}

--- a/tests/gnrc_tx_sync/Makefile
+++ b/tests/gnrc_tx_sync/Makefile
@@ -1,0 +1,13 @@
+include ../Makefile.tests_common
+
+USEMODULE += gnrc_tx_sync
+USEMODULE += netdev_test
+USEMODULE += sock_udp
+USEMODULE += xtimer
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6_default
+
+include $(RIOTBASE)/Makefile.include
+
+# This is needed for support of NETDEV_TYPE_TEST
+CFLAGS += -DTEST_SUITES

--- a/tests/gnrc_tx_sync/main.c
+++ b/tests/gnrc_tx_sync/main.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief       Text application for gnrc_tx_sync
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+/* keep include of stdint.h before stdatomic.h for compatibility with broken
+ * toolchains */
+#include <stdint.h>
+#include <stdatomic.h>
+#include <stdio.h>
+
+#include "net/af.h"
+#include "net/gnrc/netif/raw.h"
+#include "net/ipv6/addr.h"
+#include "net/netdev_test.h"
+#include "net/sock/udp.h"
+#include "test_utils/expect.h"
+#include "xtimer.h"
+
+#define NETIF_STACKSIZE     THREAD_STACKSIZE_DEFAULT
+#define NETIF_PRIO          (THREAD_PRIORITY_MAIN - 4)
+#define MAIN_QUEUE_SIZE     (8)
+
+static char netif_stack[NETIF_STACKSIZE];
+static msg_t main_msg_queue[MAIN_QUEUE_SIZE];
+
+static atomic_int send_completed = ATOMIC_VAR_INIT(0);
+static gnrc_netif_t netif;
+static netdev_test_t netdev;
+
+static int netdev_send(netdev_t *dev, const iolist_t *iolist)
+{
+    (void)dev; (void)iolist;
+    xtimer_msleep(100);
+    atomic_store(&send_completed, 1);
+    return 0;
+}
+
+static int netdev_get_device_type(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev; (void)max_len;
+    const uint16_t type = NETDEV_TYPE_TEST;
+    memcpy(value, &type, sizeof(type));
+    return sizeof(type);
+}
+
+int main(void)
+{
+    msg_init_queue(main_msg_queue, MAIN_QUEUE_SIZE);
+    netdev_test_setup(&netdev, NULL);
+    netdev_test_set_send_cb(&netdev, netdev_send);
+    netdev_test_set_get_cb(&netdev, NETOPT_DEVICE_TYPE, netdev_get_device_type);
+    gnrc_netif_raw_create(&netif, netif_stack, sizeof(netif_stack), NETIF_PRIO,
+                          "netdev_test", &netdev.netdev);
+
+    sock_udp_t sock;
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = { .family = AF_INET6 };
+    remote.port = 12345;
+    ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+                                      IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
+    expect(sock_udp_create(&sock, &local, NULL, 0) == 0);
+    expect(sock_udp_send(&sock, "Test", sizeof("Test"), &remote) > 0);
+    expect(atomic_load(&send_completed));
+
+    puts("TEST PASSED");
+
+    return 0;
+}

--- a/tests/gnrc_tx_sync/tests/01-run.py
+++ b/tests/gnrc_tx_sync/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR rewires `gnrc_neterr` to build upon https://github.com/RIOT-OS/RIOT/pull/15694. Citing from https://github.com/RIOT-OS/RIOT/pull/15694 for motivating this change:

> 3. Simpler error reporting without footguns
>     - The current approach of using `core/msg` for passing up error messages is difficult to use if other message come in. Currently, gnrc_sock is busy-waiting and fetching messages from the message queue until the number of expected status reports is received. It will enqueue all non-status-report messages again at the end of the queue. This has multiple issues:
>         - Busy waiting is especially in lower power scenarios with time slotted MAC protocols harmful, as the CPU will remain active and consume power even though the it could sleep until the TX slot is reached
>         - The status reports from the network stack are send to the user thread blocking. If the message queue of the user thread is full, the network stack would block until the user stack can fetch the messages. If another higher priority thread would start sending a message, it would busy wait for its status reports to completely come in. Hence, the first thread doesn't get CPU time to fetch messages and unblock the network stack. As a result, the system would lock up completely.
>     - Just adding the error/status code to the gnrc_tx_sync_t would preallocate and reserve memory for the error reporting. That way gnrc_sock does not need to search through the message queue for status reports and the network stack does not need to block for the user thread fetching it.
> 

### Testing procedure

1. `gnrc_sock` should still work with `gnrc_neterr` used
2. `tests/netdev_test` should still work
3. `examples/gnrc_lorawan` should still work

### Issues/PRs references

Depends on and includes https://github.com/RIOT-OS/RIOT/pull/15694