### PR TITLE
esp_common/esp_now: use netdev_register()

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -449,6 +449,7 @@ esp_now_netdev_t *netdev_esp_now_setup(void)
     DEBUG("%s: multicast node add %s\n", __func__, res ? "success" : "error");
 #endif /* ESP_NOW_UNICAST */
 
+    netdev_register(&dev->netdev, NETDEV_ESP_NOW, 0);
     return dev;
 }
 

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -294,6 +294,7 @@ typedef enum {
     NETDEV_CC110X,
     NETDEV_SX127X,
     NETDEV_SAM0_ETH,
+    NETDEV_ESP_NOW,
     /* add more if needed */
 } netdev_type_t;
 /** @} */


### PR DESCRIPTION
### Contribution description
I added the call to `netdev_register()` in `netdev_esp_now_setup()`.

I hope it's okay to add the `NETDEV_ESP_NOW` to the `netdev.h` in drivers even though it is a CPU-specific driver.

I didn't add the index as in #15537 and others because the interface can exist only once per device I think?

### Issues/PRs references

To benefit from `gnrc_netif_get_by_type()` in #15120