### PR TITLE
core/mutex: fix typo in documentation

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -59,7 +59,7 @@
  * 1. If the mutex was unlocked (value of `NULL`), its value is changed to
  *    `MUTEX_LOCKED` and the call to `mutex_lock()` returns right away without
  *    blocking.
- * 2. If the mutex as a vale of `MUTEX_LOCKED`, it will be changed to point to
+ * 2. If the mutex has a value of `MUTEX_LOCKED`, it will be changed to point to
  *    the `thread_t` of the running thread. The single item list is terminated
  *    be setting the `thread_t::rq_entry.next` of the running thread to `NULL`.
  *    The running thread blocks as described below.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes obvious typos in the mutex documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
