### PR TITLE
tools/suit/manifest-generator: fix dependencies in setup.py

### DIFF
--- a/dist/tools/suit/suit-manifest-generator/setup.py
+++ b/dist/tools/suit/suit-manifest-generator/setup.py
@@ -56,7 +56,6 @@ setuptools.setup (
                 'cbor2>=5.0.0',
             'colorama>=0.4.0',
         'cryptography>=2.8',
-        'pyhsslms>=1.0.0',
     ],
          classifiers = [
             "Programming Language :: Python :: 3",

--- a/dist/tools/suit/suit-manifest-generator/setup.py
+++ b/dist/tools/suit/suit-manifest-generator/setup.py
@@ -53,8 +53,8 @@ setuptools.setup (
         entry_points = entry_points,
             zip_safe = False,
     install_requires = [
-                'cbor2>=5.0.0',
-            'colorama>=0.4.0',
+        'cbor2>=5.0.0',
+        'colorama>=0.4.0',
         'cryptography>=2.8',
     ],
          classifiers = [

--- a/dist/tools/suit/suit-manifest-generator/setup.py
+++ b/dist/tools/suit/suit-manifest-generator/setup.py
@@ -53,7 +53,7 @@ setuptools.setup (
         entry_points = entry_points,
             zip_safe = False,
     install_requires = [
-                'cbor>=1.0.0',
+                'cbor2>=5.0.0',
             'colorama>=0.4.0',
         'cryptography>=2.8',
         'pyhsslms>=1.0.0',

--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -33,7 +33,7 @@ Table of contents:
 
 - Install python dependencies (only Python3.6 and later is supported):
 
-      $ pip3 install --user ed25519 pyasn1 cbor
+      $ pip3 install --user cbor2 cryptography
 
 - Install aiocoap from the source
 

--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -69,7 +69,7 @@ Table of contents:
 ### Ble
 [prerequisites-ble]: #Ble
 
-Make sure you fullfil the "Prerequisites" and "Preparing Linux" section in [README.ipv6-over-ble.md](../../pkg/nimble/README.ipv6-over-ble.md).
+Make sure you fulfill the "Prerequisites" and "Preparing Linux" section in [README.ipv6-over-ble.md](../../pkg/nimble/README.ipv6-over-ble.md).
 
 ## Setup
 [setup]: #Setup


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In #14436, cbor2 was used instead of cbor in the suit manifest generator but the setup.py is still mentioning a dependency to cbor. There's also a dependency to pyhsslms but it's not used by the tool at all.
This is fixing that: use cbor2 instead of cbor and remove pyhsslms in the list of required packages. There's also a small alignment fix.

This PR also contains a commit that is fixing the list of required python packages mentioned in the README of `examples/suit_update`. This list is completely out-of-date and the example doesn't work when strictly following the README with a fresh setup.

I mark this as minor because setup.py is not used in practice by the RIOT build system. The change in the README.md is the most important change of this PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Create a Python virtualenv, install the required Python packages for `examples/suit_update` and try to build:

<details><summary>on master:</summary>

```
$ virtualenv .venv/suit
$ source .venv/suit/bin/activate
$ pip install ed25519 pyasn1 cbor
$ make -C examples/suit_update
make: Entering directory '/work/riot/RIOT/examples/suit_update'
Building application "suit_update" for "samr21-xpro" with MCU "samd21".

suit: generating key in /work/riot/RIOT/keys
Traceback (most recent call last):
  File "/work/riot/RIOT/dist/tools/suit/gen_key.py", line 16, in <module>
    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
ModuleNotFoundError: No module named 'cryptography'
make: *** [/work/riot/RIOT/makefiles/suit.base.inc.mk:30: /work/riot/RIOT/keys/default.pem] Error 1

$ SUIT_COAP_SERVER=[2001:db8::1] make -C examples/suit_update
make: Entering directory '/work/riot/RIOT/examples/suit_update'
Building application "suit_update" for "samr21-xpro" with MCU "samd21".

Traceback (most recent call last):
  File "/work/riot/RIOT/dist/tools/suit/suit-manifest-generator/bin/suit-tool", line 25, in <module>
    from suit_tool import clidriver
  File "/work/riot/RIOT/dist/tools/suit/suit-manifest-generator/bin/../suit_tool/clidriver.py", line 22, in <module>
    from suit_tool.argparser import MainArgumentParser
  File "/work/riot/RIOT/dist/tools/suit/suit-manifest-generator/bin/../suit_tool/argparser.py", line 21, in <module>
    from suit_tool import keygen
  File "/work/riot/RIOT/dist/tools/suit/suit-manifest-generator/bin/../suit_tool/keygen.py", line 19, in <module>
    from cryptography.hazmat.backends import default_backend
ModuleNotFoundError: No module named 'cryptography'
make[1]: Nothing to be done for 'prepare'.
"make" -C /work/riot/RIOT/pkg/c25519
"make" -C /work/riot/RIOT/build/pkg/c25519/src -f /work/riot/RIOT/Makefile.base MODULE=c25519
"make" -C /work/riot/RIOT/pkg/libcose
"make" -C /work/riot/RIOT/build/pkg/libcose/src -f /work/riot/RIOT/Makefile.base MODULE=libcose
"make" -C /work/riot/RIOT/build/pkg/libcose/src/crypt -f /work/riot/RIOT/pkg/libcose/Makefile.libcose_crypt
"make" -C /work/riot/RIOT/pkg/nanocbor
"make" -C /work/riot/RIOT/build/pkg/nanocbor/src -f /work/riot/RIOT/Makefile.base MODULE=nanocbor
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/edbg_eui
"make" -C /work/riot/RIOT/drivers/ethos
"make" -C /work/riot/RIOT/drivers/netdev
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/crypto
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/evtimer
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/hashes
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/application_layer/nanocoap
"make" -C /work/riot/RIOT/sys/net/application_layer/uhcp
"make" -C /work/riot/RIOT/sys/net/crosslayer/inet_csum
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/ethernet
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/icmpv6
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/icmpv6/echo
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6/nib
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ndp
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/sock
"make" -C /work/riot/RIOT/sys/net/gnrc/sock/udp
"make" -C /work/riot/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /work/riot/RIOT/sys/net/gnrc/application_layer/uhcpc
"make" -C /work/riot/RIOT/sys/net/link_layer/eui_provider
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/net/network_layer/icmpv6
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/hdr
"make" -C /work/riot/RIOT/sys/net/sock
"make" -C /work/riot/RIOT/sys/net/transport_layer/udp
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/posix/inet
"make" -C /work/riot/RIOT/sys/progress_bar
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/suit
/work/riot/RIOT/sys/suit/handlers_envelope.c: In function '_auth_handler':
/work/riot/RIOT/sys/suit/handlers_envelope.c:54:34: error: 'public_key' undeclared (first use in this function)
   54 |                       (uint8_t *)public_key, NULL, NULL);
      |                                  ^~~~~~~~~~
/work/riot/RIOT/sys/suit/handlers_envelope.c:54:34: note: each undeclared identifier is reported only once for each function it appears in
make[3]: *** [/work/riot/RIOT/Makefile.base:107: /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit/handlers_envelope.o] Error 1
```

</details>

<details><summary>this PR:</summary>

```
$ virtualenv .venv/suit
$ source .venv/suit/bin/activate
$ pip install cryptography cbor2
$ make -C examples/suit_update
make: Entering directory '/work/riot/RIOT/examples/suit_update'
Building application "suit_update" for "samr21-xpro" with MCU "samd21".

suit: generating key in /work/riot/RIOT/keys
make[1]: Nothing to be done for 'prepare'.
"make" -C /work/riot/RIOT/pkg/c25519
"make" -C /work/riot/RIOT/build/pkg/c25519/src -f /work/riot/RIOT/Makefile.base MODULE=c25519
"make" -C /work/riot/RIOT/pkg/libcose
"make" -C /work/riot/RIOT/build/pkg/libcose/src -f /work/riot/RIOT/Makefile.base MODULE=libcose
"make" -C /work/riot/RIOT/build/pkg/libcose/src/crypt -f /work/riot/RIOT/pkg/libcose/Makefile.libcose_crypt
"make" -C /work/riot/RIOT/pkg/nanocbor
"make" -C /work/riot/RIOT/build/pkg/nanocbor/src -f /work/riot/RIOT/Makefile.base MODULE=nanocbor
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/edbg_eui
"make" -C /work/riot/RIOT/drivers/ethos
"make" -C /work/riot/RIOT/drivers/netdev
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/crypto
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/evtimer
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/hashes
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/application_layer/nanocoap
"make" -C /work/riot/RIOT/sys/net/application_layer/uhcp
"make" -C /work/riot/RIOT/sys/net/crosslayer/inet_csum
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/ethernet
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/icmpv6
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/icmpv6/echo
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6/nib
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ndp
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/sock
"make" -C /work/riot/RIOT/sys/net/gnrc/sock/udp
"make" -C /work/riot/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /work/riot/RIOT/sys/net/gnrc/application_layer/uhcpc
"make" -C /work/riot/RIOT/sys/net/link_layer/eui_provider
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/net/network_layer/icmpv6
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/hdr
"make" -C /work/riot/RIOT/sys/net/sock
"make" -C /work/riot/RIOT/sys/net/transport_layer/udp
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/posix/inet
"make" -C /work/riot/RIOT/sys/progress_bar
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/suit
"make" -C /work/riot/RIOT/sys/suit/storage
"make" -C /work/riot/RIOT/sys/suit/transport
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/uuid
"make" -C /work/riot/RIOT/sys/xtimer
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1609338533.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  80064	    244	  21308	 101616	  18cf0	/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update.elf
$ SUIT_COAP_SERVER=[2001:db8::1] make -C examples/suit_update suit/publish
make: Entering directory '/work/riot/RIOT/examples/suit_update'
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
make[1]: Nothing to be done for 'prepare'.
"make" -C /work/riot/RIOT/pkg/c25519
"make" -C /work/riot/RIOT/build/pkg/c25519/src -f /work/riot/RIOT/Makefile.base MODULE=c25519
"make" -C /work/riot/RIOT/pkg/libcose
"make" -C /work/riot/RIOT/build/pkg/libcose/src -f /work/riot/RIOT/Makefile.base MODULE=libcose
"make" -C /work/riot/RIOT/build/pkg/libcose/src/crypt -f /work/riot/RIOT/pkg/libcose/Makefile.libcose_crypt
"make" -C /work/riot/RIOT/pkg/nanocbor
"make" -C /work/riot/RIOT/build/pkg/nanocbor/src -f /work/riot/RIOT/Makefile.base MODULE=nanocbor
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/edbg_eui
"make" -C /work/riot/RIOT/drivers/ethos
"make" -C /work/riot/RIOT/drivers/netdev
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/crypto
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/evtimer
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/hashes
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/net/application_layer/nanocoap
"make" -C /work/riot/RIOT/sys/net/application_layer/uhcp
"make" -C /work/riot/RIOT/sys/net/crosslayer/inet_csum
"make" -C /work/riot/RIOT/sys/net/gnrc
"make" -C /work/riot/RIOT/sys/net/gnrc/netapi
"make" -C /work/riot/RIOT/sys/net/gnrc/netif
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/ethernet
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /work/riot/RIOT/sys/net/gnrc/netreg
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/icmpv6
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/icmpv6/echo
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6/hdr
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ipv6/nib
"make" -C /work/riot/RIOT/sys/net/gnrc/network_layer/ndp
"make" -C /work/riot/RIOT/sys/net/gnrc/pkt
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf
"make" -C /work/riot/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /work/riot/RIOT/sys/net/gnrc/sock
"make" -C /work/riot/RIOT/sys/net/gnrc/sock/udp
"make" -C /work/riot/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /work/riot/RIOT/sys/net/gnrc/application_layer/uhcpc
"make" -C /work/riot/RIOT/sys/net/link_layer/eui_provider
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/netif
"make" -C /work/riot/RIOT/sys/net/network_layer/icmpv6
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/hdr
"make" -C /work/riot/RIOT/sys/net/sock
"make" -C /work/riot/RIOT/sys/net/transport_layer/udp
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/posix/inet
"make" -C /work/riot/RIOT/sys/progress_bar
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/suit
"make" -C /work/riot/RIOT/sys/suit/storage
"make" -C /work/riot/RIOT/sys/suit/transport
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/uuid
"make" -C /work/riot/RIOT/sys/xtimer
creating /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1609338581.riot.bin...
creating /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1609338581.riot.bin...
/work/riot/RIOT/dist/tools/suit/gen_manifest.py \
  --urlroot coap://[2001:db8::1]/fw/samr21-xpro \
  --seqnr 1609338581 \
  --uuid-vendor "riot-os.org" \
  --uuid-class samr21-xpro \
  -o /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1609338581.bin.tmp \
  /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1609338581.riot.bin:0x1000 \
  /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1609338581.riot.bin:133120
/work/riot/RIOT/dist/tools/suit/suit-manifest-generator/bin/suit-tool create -f suit -i /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1609338581.bin.tmp -o /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1609338581.bin
create done. Serializing
rm -f /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1609338581.bin.tmp
/work/riot/RIOT/dist/tools/suit/suit-manifest-generator/bin/suit-tool sign -k /work/riot/RIOT/keys/default.pem -m /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1609338581.bin -o /work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1609338581.bin
published "/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1609338581.bin"
       as "coap://[2001:db8::1]/fw/samr21-xpro/suit_update-riot.suit.1609338581.bin"
published "/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[2001:db8::1]/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1609338581.bin"
       as "coap://[2001:db8::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1609338581.bin"
published "/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[2001:db8::1]/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1609338581.riot.bin"
       as "coap://[2001:db8::1]/fw/samr21-xpro/suit_update-slot0.1609338581.riot.bin"
published "/work/riot/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1609338581.riot.bin"
       as "coap://[2001:db8::1]/fw/samr21-xpro/suit_update-slot1.1609338581.riot.bin"
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
