### PR TITLE
sys/shell: fix missing suit shell command in examples/suit_update

### DIFF
--- a/examples/suit_update/tests/01-run.py
+++ b/examples/suit_update/tests/01-run.py
@@ -184,11 +184,19 @@ def _test_successful_update(child, client, app_ver):
         client = get_reachable_addr(child)
 
 
+def _test_suit_command_is_there(child):
+    child.sendline('suit')
+    child.expect_exact("Usage: suit <manifest url>")
+
+
 def testfunc(child):
     # Get current app_ver
     current_app_ver = app_version(child)
     # Verify client is reachable and get address
     client = get_reachable_addr(child)
+
+    # Verify the suit shell command is there
+    _test_suit_command_is_there(child)
 
     def run(func):
         if child.logfile == sys.stdout:

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -114,7 +114,7 @@ ifneq (,$(filter nimble_statconn,$(USEMODULE)))
   SRC += sc_nimble_statconn.c
 endif
 
-ifneq (,$(filter suit_coap,$(USEMODULE)))
+ifneq (,$(filter suit_transport_coap,$(USEMODULE)))
   SRC += sc_suit.c
 endif
 

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -180,7 +180,7 @@ extern int _nimble_netif_handler(int argc, char **argv);
 extern int _nimble_statconn_handler(int argc, char **argv);
 #endif
 
-#ifdef MODULE_SUIT_COAP
+#ifdef MODULE_SUIT_TRANSPORT_COAP
 extern int _suit_handler(int argc, char **argv);
 #endif
 
@@ -316,7 +316,7 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_NIMBLE_STATCONN
     { "statconn", "NimBLE netif statconn", _nimble_statconn_handler},
 #endif
-#ifdef MODULE_SUIT_COAP
+#ifdef MODULE_SUIT_TRANSPORT_COAP
     { "suit", "Trigger a SUIT firmware update", _suit_handler },
 #endif
 #ifdef MODULE_CRYPTOAUTHLIB


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In #13486, the `suit_transport_coap` (sub)module was introduced in replacement of the `suit_coap` module but the inclusion of shell command `suit` into the build was forgotten in that change.

This PR fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Flash the `examples/suit_update` application on a compatible board (tested on iotlab-m3).

<details><summary>master: the suit shell command is not there</summary>

```
RIOT SUIT update example application
Running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x5fecc0fa
Image start address: 0x08001400
Header chksum: 0xb12ada88

suit_coap: started.
Starting the shell
> help
help
Command              Description
---------------------------------------
current-slot         Print current slot number
riotboot-hdr         Print current slot header
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ping6                Ping via ICMPv6
ping                 Alias for ping6
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
> suit
suit
shell: command not found: suit
```

</details> 

<details><summary>this PR: the suit shell command is there as before</summary>

```
RIOT SUIT update example application
Running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x5fecc18e
Image start address: 0x08001400
Header chksum: 0xb37adb1c

suit_coap: started.
Starting the shell
> help
help
Command              Description
---------------------------------------
current-slot         Print current slot number
riotboot-hdr         Print current slot header
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ping6                Ping via ICMPv6
ping                 Alias for ping6
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
suit                 Trigger a SUIT firmware update
> suit
suit
Usage: suit <manifest url>
```

</details> 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fix a regression introduced in #13486

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
