### PR TITLE
drivers/pn532: use pseudomodules to select i2c or spi

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -106,6 +106,16 @@ ifneq (,$(filter periph_ptp_timer periph_ptp_speed_adjustment,$(FEATURES_USED)))
   FEATURES_REQUIRED += periph_ptp
 endif
 
+ifneq (,$(filter pn532_i2c,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += pn532
+endif
+
+ifneq (,$(filter pn532_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
+  USEMODULE += pn532
+endif
+
 ifneq (,$(filter qmc5883l_%,$(USEMODULE)))
   USEMODULE += qmc5883l
 endif

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -25,14 +25,15 @@
 extern "C" {
 #endif
 
+#include "kernel_defines.h"
 #include "mutex.h"
 #include "periph/i2c.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
 #include <stdint.h>
 
-#if !defined(PN532_SUPPORT_I2C) && !defined(PN532_SUPPORT_SPI)
-#error Please define PN532_SUPPORT_I2C and/or PN532_SUPPORT_SPI to enable \
+#if !IS_USED(MODULE_PN532_I2C) && !IS_USED(MODULE_PN532_SPI)
+#error Please use either pn532_i2c and/or pn532_spi module to enable \
     the functionality on this device
 #endif
 
@@ -41,16 +42,16 @@ extern "C" {
  */
 typedef struct {
     union {
-#if defined(PN532_SUPPORT_I2C) || DOXYGEN
+#if IS_USED(MODULE_PN532_I2C) || DOXYGEN
         i2c_t i2c;              /**< I2C device */
 #endif
-#if defined(PN532_SUPPORT_SPI) || DOXYGEN
+#if IS_USED(MODULE_PN532_SPI) || DOXYGEN
         spi_t spi;              /**< SPI device */
 #endif
     };
     gpio_t reset;               /**< Reset pin */
     gpio_t irq;                 /**< Interrupt pin */
-#if defined(PN532_SUPPORT_SPI) || DOXYGEN
+#if IS_USED(MODULE_PN532_SPI) || DOXYGEN
     gpio_t nss;                 /**< Chip Select pin (only SPI) */
 #endif
 } pn532_params_t;
@@ -185,11 +186,12 @@ void pn532_reset(const pn532_t *dev);
 int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode);
 
 
-#if defined(PN532_SUPPORT_I2C) || DOXYGEN
+#if IS_USED(MODULE_PN532_I2C) || DOXYGEN
 /**
  * @brief   Initialization of PN532 using i2c
  *
  * @see pn532_init for parameter and return value details
+ * @note Use `pn532_i2c` module to use this function.
  */
 static inline int pn532_init_i2c(pn532_t *dev, const pn532_params_t *params)
 {
@@ -197,11 +199,12 @@ static inline int pn532_init_i2c(pn532_t *dev, const pn532_params_t *params)
 }
 #endif
 
-#if defined(PN532_SUPPORT_SPI) || DOXYGEN
+#if IS_USED(MODULE_PN532_SPI) || DOXYGEN
 /**
  * @brief   Initialization of PN532 using spi
  *
  * @see pn532_init for parameter and return value details
+ * @note Use `pn532_spi` module to use this function.
  */
 static inline int pn532_init_spi(pn532_t *dev, const pn532_params_t *params)
 {

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "assert.h"
+#include "kernel_defines.h"
 #include "xtimer.h"
 #include "mutex.h"
 #include "pn532.h"
@@ -121,7 +122,7 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
     gpio_set(dev->conf->reset);
     dev->mode = mode;
     if (mode == PN532_SPI) {
-#ifdef PN532_SUPPORT_SPI
+#if IS_USED(MODULE_PN532_SPI)
         /* we handle the CS line manually... */
         gpio_init(dev->conf->nss, GPIO_OUT);
         gpio_set(dev->conf->nss);
@@ -146,8 +147,8 @@ static uint8_t chksum(uint8_t *b, unsigned len)
     return c;
 }
 
-#ifdef PN532_SUPPORT_SPI
-static void reverse(char *buff, unsigned len)
+#if IS_USED(MODULE_PN532_SPI)
+static void reverse(uint8_t *buff, unsigned len)
 {
     while (len--) {
         buff[len] = (buff[len] & 0xF0) >> 4 | (buff[len] & 0x0F) << 4;
@@ -165,7 +166,7 @@ static int _write(const pn532_t *dev, uint8_t *buff, unsigned len)
     (void)len;
 
     switch (dev->mode) {
-#ifdef PN532_SUPPORT_I2C
+#if IS_USED(MODULE_PN532_I2C)
     case PN532_I2C:
         i2c_acquire(dev->conf->i2c);
         ret = i2c_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len, 0);
@@ -175,7 +176,7 @@ static int _write(const pn532_t *dev, uint8_t *buff, unsigned len)
         i2c_release(dev->conf->i2c);
         break;
 #endif
-#ifdef PN532_SUPPORT_SPI
+#if IS_USED(MODULE_PN532_SPI)
     case PN532_SPI:
         spi_acquire(dev->conf->spi, SPI_CS_UNDEF, SPI_MODE, SPI_CLK);
         gpio_clear(dev->conf->nss);
@@ -204,7 +205,7 @@ static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
     (void)len;
 
     switch (dev->mode) {
-#ifdef PN532_SUPPORT_I2C
+#if IS_USED(MODULE_PN532_I2C)
     case PN532_I2C:
         i2c_acquire(dev->conf->i2c);
         /* len+1 for RDY after read is accepted */
@@ -215,7 +216,7 @@ static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
         i2c_release(dev->conf->i2c);
         break;
 #endif
-#ifdef PN532_SUPPORT_SPI
+#if IS_USED(MODULE_PN532_SPI)
     case PN532_SPI:
         spi_acquire(dev->conf->spi, SPI_CS_UNDEF, SPI_MODE, SPI_CLK);
         gpio_clear(dev->conf->nss);

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -215,6 +215,10 @@ PSEUDOMODULES += ina220
 # include variants of mrf24j40 drivers as pseudo modules
 PSEUDOMODULES += mrf24j40m%
 
+# include variants of the pn532 drivers as pseudo modules
+PSEUDOMODULES += pn532_i2c
+PSEUDOMODULES += pn532_spi
+
 # include variants of sdp3x drivers as pseudo modules
 PSEUDOMODULES += sdp3x_irq
 

--- a/tests/driver_pn532/Makefile
+++ b/tests/driver_pn532/Makefile
@@ -1,9 +1,10 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c periph_gpio
-
 USEMODULE += xtimer
-USEMODULE += pn532
+
+# select if you want to build the SPI or the I2C version of the driver:
+USEMODULE += pn532_i2c
+#USEMODULE += pn532_spi
 
 # set default device parameters in case they are undefined
 TEST_PN532_I2C ?= I2C_DEV\(0\)
@@ -20,16 +21,6 @@ CFLAGS += -DTEST_PN532_RESET=$(TEST_PN532_RESET)
 CFLAGS += -DTEST_PN532_IRQ=$(TEST_PN532_IRQ)
 CFLAGS += -DTEST_PN532_SPI=$(TEST_PN532_SPI)
 CFLAGS += -DTEST_PN532_NSS=$(TEST_PN532_NSS)
-
-# select if you want to build the SPI or the I2C version of the driver:
-# set PN532_MODE to `i2c` or to `spi`
-PN532_MODE ?= i2c
-ifeq ($(PN532_MODE),i2c)
-  CFLAGS += -DPN532_SUPPORT_I2C
-endif
-ifeq ($(PN532_MODE),spi)
-  CFLAGS += -DPN532_SUPPORT_SPI
-endif
 
 CFLAGS += -I$(CURDIR)
 

--- a/tests/driver_pn532/main.c
+++ b/tests/driver_pn532/main.c
@@ -46,13 +46,8 @@ int main(void)
     unsigned len;
     int ret;
 
-#if defined(PN532_SUPPORT_I2C)
-    ret = pn532_init_i2c(&pn532, &pn532_conf[0]);
-#elif defined(PN532_SUPPORT_SPI)
-    ret = pn532_init_spi(&pn532, &pn532_conf[0]);
-#else
-#error None of PN532_SUPPORT_I2C and PN532_SUPPORT_SPI set!
-#endif
+    pn532_mode_t mode = IS_ACTIVE(MODULE_PN532_I2C) ? PN532_I2C : PN532_SPI;
+    ret = pn532_init(&pn532, &pn532_conf[0], mode);
 
     if (ret != 0) {
         LOG_INFO("init error %d\n", ret);

--- a/tests/driver_pn532/pn532_params.h
+++ b/tests/driver_pn532/pn532_params.h
@@ -23,16 +23,19 @@
 extern "C" {
 #endif
 
+#include "kernel_defines.h"
+
 static const pn532_params_t pn532_conf[] = {
     {
-#if defined(PN532_SUPPORT_I2C)
+#if IS_USED(MODULE_PN532_I2C)
         .i2c = TEST_PN532_I2C,
-#elif defined(PN532_SUPPORT_SPI)
+#endif
+#if IS_USED(MODULE_PN532_SPI)
         .spi = TEST_PN532_SPI,
 #endif
         .reset = TEST_PN532_RESET,
         .irq = TEST_PN532_IRQ,
-#if defined(PN532_SUPPORT_SPI)
+#if IS_USED(MODULE_PN532_SPI)
         .nss   = TEST_PN532_NSS
 #endif
     },


### PR DESCRIPTION
### Contribution description
This PR adapts the way to select SPI and/or I2C support in the pn532 driver, now it uses pseudomodules. That allows to include the peripheral dependencies in the dependency resolution step, and is in line with the common practice. Also, this includes a fix on the signature of a private function (`static void reverse(...)`), which caused a compile error when enabling SPI support on the driver.

### Testing procedure
- The binary should not change
- SPI support should compile successfully
- The required features should be pulled-in automatically by selecting the correspondent module (`pn532_i2c`, `pn532_spi`)

### Issues/PRs references
None
