### PR TITLE
cpu/stm32: model MCO clock configuration in kconfig

### DIFF
--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -373,7 +373,7 @@ config CLOCK_APB2_DIV
     default 8 if CLOCK_APB2_DIV_8
     default 16 if CLOCK_APB2_DIV_16
 
-if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
+if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4
 config CLOCK_ENABLE_MCO
     bool "Enable MCU Clock Output (MCO) on PA8"
 
@@ -390,6 +390,12 @@ config CLOCK_MCO_USE_HSE
 
 config CLOCK_MCO_USE_HSI
     bool "Use HSI as MCO source"
+
+config CLOCK_MCO_USE_LSE
+    bool "Use LSE as MCO source" if CPU_FAM_G0 || CPU_FAM_G4
+
+config CLOCK_MCO_USE_LSI
+    bool "Use LSI as MCO source" if CPU_FAM_G0 || CPU_FAM_G4
 
 config CLOCK_MCO_USE_SYSCLK
     bool "Use SYSCLK as MCO source"
@@ -417,13 +423,13 @@ config CLOCK_MCO_PRE_16
     bool "Divide MCO by 16"
 
 config CLOCK_MCO_PRE_32
-    bool "Divide MCO by 32"
+    bool "Divide MCO by 32" if !CPU_FAM_G4
 
 config CLOCK_MCO_PRE_64
-    bool "Divide MCO by 64"
+    bool "Divide MCO by 64" if !CPU_FAM_G4
 
 config CLOCK_MCO_PRE_128
-    bool "Divide MCO by 128"
+    bool "Divide MCO by 128" if !CPU_FAM_G4
 
 endchoice
 
@@ -438,7 +444,6 @@ config CLOCK_MCO_PRE
     default 128 if CLOCK_MCO_PRE_128
     default 1
 
-endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
-
+endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4
 
 endmenu

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -373,7 +373,7 @@ config CLOCK_APB2_DIV
     default 8 if CLOCK_APB2_DIV_8
     default 16 if CLOCK_APB2_DIV_16
 
-if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4
+if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
 config CLOCK_ENABLE_MCO
     bool "Enable MCU Clock Output (MCO) on PA8"
 
@@ -392,10 +392,13 @@ config CLOCK_MCO_USE_HSI
     bool "Use HSI as MCO source"
 
 config CLOCK_MCO_USE_LSE
-    bool "Use LSE as MCO source" if CPU_FAM_G0 || CPU_FAM_G4
+    bool "Use LSE as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
 
 config CLOCK_MCO_USE_LSI
-    bool "Use LSI as MCO source" if CPU_FAM_G0 || CPU_FAM_G4
+    bool "Use LSI as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+
+config CLOCK_MCO_USE_MSI
+    bool "Use MSI as MCO source" if CPU_FAM_L0 || CPU_FAM_L1
 
 config CLOCK_MCO_USE_SYSCLK
     bool "Use SYSCLK as MCO source"
@@ -423,13 +426,13 @@ config CLOCK_MCO_PRE_16
     bool "Divide MCO by 16"
 
 config CLOCK_MCO_PRE_32
-    bool "Divide MCO by 32" if !CPU_FAM_G4
+    bool "Divide MCO by 32" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1
 
 config CLOCK_MCO_PRE_64
-    bool "Divide MCO by 64" if !CPU_FAM_G4
+    bool "Divide MCO by 64" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1
 
 config CLOCK_MCO_PRE_128
-    bool "Divide MCO by 128" if !CPU_FAM_G4
+    bool "Divide MCO by 128" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1
 
 endchoice
 
@@ -444,6 +447,6 @@ config CLOCK_MCO_PRE
     default 128 if CLOCK_MCO_PRE_128
     default 1
 
-endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4
+endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
 
 endmenu

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -373,7 +373,7 @@ config CLOCK_APB2_DIV
     default 8 if CLOCK_APB2_DIV_8
     default 16 if CLOCK_APB2_DIV_16
 
-if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 config CLOCK_ENABLE_MCO
     bool "Enable MCU Clock Output (MCO) on PA8"
 
@@ -392,13 +392,13 @@ config CLOCK_MCO_USE_HSI
     bool "Use HSI as MCO source"
 
 config CLOCK_MCO_USE_LSE
-    bool "Use LSE as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+    bool "Use LSE as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 config CLOCK_MCO_USE_LSI
-    bool "Use LSI as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+    bool "Use LSI as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 config CLOCK_MCO_USE_MSI
-    bool "Use MSI as MCO source" if CPU_FAM_L0 || CPU_FAM_L1
+    bool "Use MSI as MCO source" if CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 config CLOCK_MCO_USE_SYSCLK
     bool "Use SYSCLK as MCO source"
@@ -426,13 +426,13 @@ config CLOCK_MCO_PRE_16
     bool "Divide MCO by 16"
 
 config CLOCK_MCO_PRE_32
-    bool "Divide MCO by 32" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1
+    bool "Divide MCO by 32" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
 
 config CLOCK_MCO_PRE_64
-    bool "Divide MCO by 64" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1
+    bool "Divide MCO by 64" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
 
 config CLOCK_MCO_PRE_128
-    bool "Divide MCO by 128" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1
+    bool "Divide MCO by 128" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
 
 endchoice
 
@@ -447,6 +447,6 @@ config CLOCK_MCO_PRE
     default 128 if CLOCK_MCO_PRE_128
     default 1
 
-endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 endmenu

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -5,6 +5,11 @@
 # directory for more details.
 #
 
+config CLOCK_HAS_NO_MCO_PRE
+    bool
+    help
+        Indicates that the CPU has no MCO prescaler
+
 menu "STM32 clock configuration"
     depends on !CPU_FAM_F2 && !CPU_FAM_F4 && !CPU_FAM_F7
 

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -373,4 +373,72 @@ config CLOCK_APB2_DIV
     default 8 if CLOCK_APB2_DIV_8
     default 16 if CLOCK_APB2_DIV_16
 
+if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
+config CLOCK_ENABLE_MCO
+    bool "Enable MCU Clock Output (MCO) on PA8"
+
+choice
+bool "MCO source"
+depends on CLOCK_ENABLE_MCO
+default CLOCK_MCO_USE_PLLCLK
+
+config CLOCK_MCO_USE_PLLCLK
+    bool "Use PLLCLK as MCO source"
+
+config CLOCK_MCO_USE_HSE
+    bool "Use HSE as MCO source"
+
+config CLOCK_MCO_USE_HSI
+    bool "Use HSI as MCO source"
+
+config CLOCK_MCO_USE_SYSCLK
+    bool "Use SYSCLK as MCO source"
+
+endchoice
+
+choice
+bool "MCO prescaler"
+depends on !CLOCK_HAS_NO_MCO_PRE && CLOCK_ENABLE_MCO
+default CLOCK_MCO_PRE_1
+
+config CLOCK_MCO_PRE_1
+    bool "Divide MCO by 1"
+
+config CLOCK_MCO_PRE_2
+    bool "Divide MCO by 2"
+
+config CLOCK_MCO_PRE_4
+    bool "Divide MCO by 4"
+
+config CLOCK_MCO_PRE_8
+    bool "Divide MCO by 8"
+
+config CLOCK_MCO_PRE_16
+    bool "Divide MCO by 16"
+
+config CLOCK_MCO_PRE_32
+    bool "Divide MCO by 32"
+
+config CLOCK_MCO_PRE_64
+    bool "Divide MCO by 64"
+
+config CLOCK_MCO_PRE_128
+    bool "Divide MCO by 128"
+
+endchoice
+
+config CLOCK_MCO_PRE
+    int
+    default 2 if CLOCK_MCO_PRE_2
+    default 4 if CLOCK_MCO_PRE_4
+    default 8 if CLOCK_MCO_PRE_8
+    default 16 if CLOCK_MCO_PRE_16
+    default 32 if CLOCK_MCO_PRE_32
+    default 64 if CLOCK_MCO_PRE_64
+    default 128 if CLOCK_MCO_PRE_128
+    default 1
+
+endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
+
+
 endmenu

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -392,13 +392,16 @@ config CLOCK_MCO_USE_HSI
     bool "Use HSI as MCO source"
 
 config CLOCK_MCO_USE_LSE
-    bool "Use LSE as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+    bool "Use LSE as MCO source"
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 config CLOCK_MCO_USE_LSI
-    bool "Use LSI as MCO source" if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+    bool "Use LSI as MCO source"
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 config CLOCK_MCO_USE_MSI
-    bool "Use MSI as MCO source" if CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+    bool "Use MSI as MCO source"
+    depends on CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
 
 config CLOCK_MCO_USE_SYSCLK
     bool "Use SYSCLK as MCO source"
@@ -426,13 +429,16 @@ config CLOCK_MCO_PRE_16
     bool "Divide MCO by 16"
 
 config CLOCK_MCO_PRE_32
-    bool "Divide MCO by 32" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
+    bool "Divide MCO by 32"
+    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
 
 config CLOCK_MCO_PRE_64
-    bool "Divide MCO by 64" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
+    bool "Divide MCO by 64"
+    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
 
 config CLOCK_MCO_PRE_128
-    bool "Divide MCO by 128" if !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
+    bool "Divide MCO by 128"
+    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
 
 endchoice
 

--- a/cpu/stm32/kconfigs/f0/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f0/Kconfig.lines
@@ -17,6 +17,7 @@ config CPU_LINE_STM32F030X6
 config CPU_LINE_STM32F030X8
     bool
     select CPU_FAM_F0
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F030XC
     bool
@@ -41,10 +42,12 @@ config CPU_LINE_STM32F048XX
 config CPU_LINE_STM32F051X8
     bool
     select CPU_FAM_F0
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F058XX
     bool
     select CPU_FAM_F0
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F070X6
     bool

--- a/cpu/stm32/kconfigs/f1/Kconfig
+++ b/cpu/stm32/kconfigs/f1/Kconfig
@@ -15,6 +15,7 @@ config CPU_FAM_F1
     select HAS_PERIPH_FLASHPAGE_RAW
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_FAM
     default "f1" if CPU_FAM_F1

--- a/cpu/stm32/kconfigs/f3/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f3/Kconfig.lines
@@ -21,6 +21,7 @@ config CPU_LINE_STM32F302X8
 config CPU_LINE_STM32F302XC
     bool
     select CPU_FAM_F3
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F302XE
     bool
@@ -34,6 +35,7 @@ config CPU_LINE_STM32F303XC
     bool
     select CPU_FAM_F3
     select HAS_CORTEXM_MPU
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F303XE
     bool
@@ -55,14 +57,17 @@ config CPU_LINE_STM32F334X8
 config CPU_LINE_STM32F358XX
     bool
     select CPU_FAM_F3
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F373XC
     bool
     select CPU_FAM_F3
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F378XX
     bool
     select CPU_FAM_F3
+    select CLOCK_HAS_NO_MCO_PRE
 
 config CPU_LINE_STM32F398XX
     bool


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a Kconfig configuration for the MCO (MCU Clock Output) of some STM32 families (F0/F1/F3/G0/G4/L0/L1/L4/WB). F2/F4/F7 families are not addressed by this PR because there clock configuration is not yet modeled in Kconfig (see #15632) and they provide 2 MCO outputs.

To support the fact that f1 and some f0 and f3 don't provide an MCO prescaler, the `CLOCK_HAS_NO_MCO_PRE` config is introduced and selected in the affected family (f1) and lines (f0/f3).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `make BOARD=<board> -C examples/hello-world menuconfig` and verify that the `Enable MCU Clock Output` option is displayed in the STM32 clock configuration submenu. Once selected, the MCO prescaler and source can be selected. By default, the presaler is 1 and the source is PLLCLK.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick an item in #14975 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
