### PR TITLE
cpu/atmega_common: drop unused module

### DIFF
--- a/cpu/atmega_common/Makefile
+++ b/cpu/atmega_common/Makefile
@@ -4,8 +4,4 @@ MODULE = atmega_common
 # add a list of subdirectories, that should also be build
 DIRS = periph avr_libc_extra
 
-ifneq (,$(filter cpu_atmega_common_cxx,$(USEMODULE)))
-  DIRS += cxx
-endif
-
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

The module `cpu_atmega_common_cxx` seems to be non-existing and not used. It is unclear whether this slipped in by accident or if this was actually useful at some point in time. In any case, the module is not present (anymore) and cannot be used, so let's clean up the Makefile.

### Testing procedure

Murdock should show no regressions.

### Issues/PRs references

Found while reviewing https://github.com/RIOT-OS/RIOT/pull/15712