### PR TITLE
boards/e180-zg120b-tb: board cleanups

### DIFF
--- a/boards/e180-zg120b-tb/Kconfig
+++ b/boards/e180-zg120b-tb/Kconfig
@@ -10,7 +10,6 @@ config BOARD
 config BOARD_E180_ZG120B_TB
     bool
     default y
-    select BOARD_COMMON_SILABS
     select CPU_MODEL_EFR32MG1B232F256GM32
     select HAS_PERIPH_ADC
     select HAS_PERIPH_RTC

--- a/boards/e180-zg120b-tb/Makefile
+++ b/boards/e180-zg120b-tb/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/silabs
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/e180-zg120b-tb/Makefile.dep
+++ b/boards/e180-zg120b-tb/Makefile.dep
@@ -2,9 +2,3 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += efm32_coretemp
   USEMODULE += saul_gpio
 endif
-
-# add board common drivers
-USEMODULE += boards_common_silabs
-
-# include board common dependencies
-include $(RIOTBOARD)/common/silabs/Makefile.dep

--- a/boards/e180-zg120b-tb/Makefile.features
+++ b/boards/e180-zg120b-tb/Makefile.features
@@ -12,5 +12,3 @@ FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += efm32_coretemp
-
-include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/e180-zg120b-tb/Makefile.features
+++ b/boards/e180-zg120b-tb/Makefile.features
@@ -10,5 +10,5 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += efm32_coretemp
+FEATURES_PROVIDED += riotboot

--- a/boards/e180-zg120b-tb/Makefile.include
+++ b/boards/e180-zg120b-tb/Makefile.include
@@ -1,10 +1,4 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
+PROGRAMMER ?= jlink
 JLINK_DEVICE = EFR32MG1BxxxF256
 JLINK_PRE_FLASH = r
-
-# include board common
-include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/e180-zg120b-tb/board.c
+++ b/boards/e180-zg120b-tb/board.c
@@ -20,7 +20,6 @@
  */
 
 #include "board.h"
-#include "board_common.h"
 
 void board_init(void)
 {

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -11,5 +11,5 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_uart_modecfg
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += efm32_coretemp
+FEATURES_PROVIDED += riotboot


### PR DESCRIPTION
### Contribution description
This PR updates the `e180-zg120b-tb` board with small changes:

* Simplify flashing and serial port (#15477).
* Remove silabs_common (this was added by accident).
* Sort features (also for `ikea-tradfri`).

### Testing procedure
There should not be a change. Although `silabs_common` was included, it wasn't used.

J-Link should still be the programmer selected.

### Issues/PRs references
#15477