### PR TITLE
drivers/{t, v, u, w}*: add modules to Kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -22,9 +22,9 @@ tests/driver_mag3110 tests/driver_mhz19 tests/driver_mma7660
 tests/driver_motor_driver tests/driver_mpl3115a2 tests/driver_mpu9x50
 tests/driver_mq3 tests/driver_my9221 tests/driver_nvram_spi tests/mtd_flashpage
 tests/mtd_mapper tests/driver_o* tests/driver_p* tests/driver_q*
-tests/driver_r*"}
+tests/driver_r* tests/driver_t* tests/driver_u* tests/driver_v*"}
 : ${TEST_KCONFIG_native:="examples/hello-world tests/periph_*
-tests/xtimer_* tests/ztimer_*"}
+tests/xtimer_* tests/ztimer_* tests/driver_ws281x"}
 
 export RIOT_CI_BUILD=1
 export CC_NOCOLOR=1

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -108,6 +108,7 @@ rsource "sps30/Kconfig"
 rsource "tcs37727/Kconfig"
 rsource "tmp00x/Kconfig"
 rsource "tsl2561/Kconfig"
+rsource "tsl4531x/Kconfig"
 endmenu # Sensor Device Drivers
 
 menu "Storage Device Drivers"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -25,6 +25,7 @@ rsource "disp_dev/Kconfig"
 rsource "dsp0401/Kconfig"
 rsource "hd44780/Kconfig"
 rsource "ili9341/Kconfig"
+rsource "touch_dev/Kconfig"
 endmenu # Display Device Drivers
 
 menu "Miscellaneous Device Drivers"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -111,6 +111,7 @@ rsource "tmp00x/Kconfig"
 rsource "tsl2561/Kconfig"
 rsource "tsl4531x/Kconfig"
 rsource "vcnl40x0/Kconfig"
+rsource "veml6070/Kconfig"
 endmenu # Sensor Device Drivers
 
 menu "Storage Device Drivers"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -38,6 +38,7 @@ rsource "edbg_eui/Kconfig"
 rsource "io1_xplained/Kconfig"
 rsource "tps6274x/Kconfig"
 rsource "uart_half_duplex/Kconfig"
+rsource "usbdev_mock/Kconfig"
 endmenu # Miscellaneous Device Drivers
 
 rsource "Kconfig.net"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -110,6 +110,7 @@ rsource "tcs37727/Kconfig"
 rsource "tmp00x/Kconfig"
 rsource "tsl2561/Kconfig"
 rsource "tsl4531x/Kconfig"
+rsource "vcnl40x0/Kconfig"
 endmenu # Sensor Device Drivers
 
 menu "Storage Device Drivers"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -36,6 +36,7 @@ rsource "ds3231/Kconfig"
 rsource "ds3234/Kconfig"
 rsource "edbg_eui/Kconfig"
 rsource "io1_xplained/Kconfig"
+rsource "tps6274x/Kconfig"
 rsource "uart_half_duplex/Kconfig"
 endmenu # Miscellaneous Device Drivers
 

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -107,6 +107,7 @@ rsource "qmc5883l/Kconfig"
 rsource "sps30/Kconfig"
 rsource "tcs37727/Kconfig"
 rsource "tmp00x/Kconfig"
+rsource "tsl2561/Kconfig"
 endmenu # Sensor Device Drivers
 
 menu "Storage Device Drivers"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -18,6 +18,7 @@ rsource "grove_ledbar/Kconfig"
 rsource "motor_driver/Kconfig"
 rsource "my9221/Kconfig"
 rsource "rgbled/Kconfig"
+rsource "ws281x/Kconfig"
 endmenu # Actuator Device Drivers
 
 menu "Display Device Drivers"

--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -16,5 +16,6 @@ rsource "ncv7356/Kconfig"
 rsource "pn532/Kconfig"
 rsource "rn2xx3/Kconfig"
 rsource "slipdev/Kconfig"
+rsource "tja1042/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers

--- a/drivers/tcs37727/Kconfig
+++ b/drivers/tcs37727/Kconfig
@@ -1,9 +1,17 @@
 # Copyright (c) 2020 Freie Universitaet Berlin
+#               2021 HAW Hamburg
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
+
+config MODULE_TCS37727
+    bool "TCS37727 RGB Light Sensor"
+    depends on HAS_PERIPH_I2C
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH_I2C
+
 menuconfig KCONFIG_USEMODULE_TCS37727
     bool "Configure TCS37727 driver"
     depends on USEMODULE_TCS37727

--- a/drivers/tja1042/Kconfig
+++ b/drivers/tja1042/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_TJA1042
+    bool "TJA1042 High Speed CAN transceiver"
+    depends on HAS_PERIPH_GPIO
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH_GPIO
+    select MODULE_CAN_TRX

--- a/drivers/tmp00x/Kconfig
+++ b/drivers/tmp00x/Kconfig
@@ -1,9 +1,36 @@
 # Copyright (c) 2020 Freie Universitaet Berlin
+#               2021 HAW Hamburg
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
+
+if TEST_KCONFIG
+
+choice
+    bool "TMP006/TMP007 Infrared Thermopile sensors"
+    optional
+    depends on HAS_PERIPH_I2C
+
+config MODULE_TMP006
+    bool "TMP006"
+    select MODULE_TMP00X
+
+config MODULE_TMP007
+    bool "TMP007"
+    select MODULE_TMP00X
+
+endchoice
+
+config MODULE_TMP00X
+    bool
+    depends on HAS_PERIPH_I2C
+    select MODULE_PERIPH_I2C
+    select MODULE_XTIMER
+
+endif # TEST_KCONFIG
+
 menuconfig KCONFIG_USEMODULE_TMP00X
     bool "Configure TMP00X driver"
     depends on USEMODULE_TMP00X

--- a/drivers/touch_dev/Kconfig
+++ b/drivers/touch_dev/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_TOUCH_DEV
+    bool "Touch device generic API"
+    depends on TEST_KCONFIG
+    help
+        This API is experimental and in an early state - expect changes!

--- a/drivers/tps6274x/Kconfig
+++ b/drivers/tps6274x/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_TPS6274X
+    bool "TPS6274x DC-DC converter"
+    depends on HAS_PERIPH_GPIO
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH_GPIO

--- a/drivers/tsl2561/Kconfig
+++ b/drivers/tsl2561/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_TSL2561
+    bool "TSL2561 illuminance sensor"
+    depends on HAS_PERIPH_I2C
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH_I2C
+    select MODULE_XTIMER

--- a/drivers/tsl4531x/Kconfig
+++ b/drivers/tsl4531x/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_TSL4531X
+    bool "TSL4531x Illuminance sensor"
+    depends on HAS_PERIPH_I2C
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH_I2C
+    select MODULE_XTIMER

--- a/drivers/usbdev_mock/Kconfig
+++ b/drivers/usbdev_mock/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_USBDEV_MOCK
+    bool "USBdev mockup device (for testing)"
+    depends on TEST_KCONFIG

--- a/drivers/vcnl40x0/Kconfig
+++ b/drivers/vcnl40x0/Kconfig
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if TEST_KCONFIG
+
+choice
+    bool "VCNL4010/VCNL4020/VCNL4040 Proximity and Ambient Light sensors"
+    optional
+    depends on HAS_PERIPH_I2C
+
+config MODULE_VCNL4010
+    bool "VCNL4010"
+    select MODULE_VCNL40X0
+
+config MODULE_VCNL4020
+    bool "VCNL4020"
+    select MODULE_VCNL40X0
+
+config MODULE_VCNL4040
+    bool "VCNL4040"
+    select MODULE_VCNL40X0
+
+endchoice
+
+config MODULE_VCNL40X0
+    bool
+    depends on HAS_PERIPH_I2C
+    select MODULE_PERIPH_I2C
+
+endif # TEST_KCONFIG

--- a/drivers/veml6070/Kconfig
+++ b/drivers/veml6070/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_VEML6070
+    bool "VEML6070 UV sensor"
+    depends on HAS_PERIPH_I2C
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH_I2C

--- a/drivers/ws281x/Kconfig
+++ b/drivers/ws281x/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_WS281X
+    bool "WS2812/SK6812 RGB LED (NeoPixel)"
+    depends on HAS_ARCH_AVR8 || HAS_ARCH_ESP32 || HAS_ARCH_NATIVE
+    depends on TEST_KCONFIG
+    select MODULE_XTIMER
+    select MODULE_WS281X_ATMEGA if HAS_ARCH_AVR8
+    select MODULE_WS281X_VT100 if HAS_ARCH_NATIVE
+    select MODULE_WS281X_ESP32 if HAS_ARCH_ESP32
+
+config MODULE_WS281X_ATMEGA
+    bool
+    depends on HAS_ARCH_AVR8
+
+config MODULE_WS281X_VT100
+    bool
+    depends on HAS_ARCH_NATIVE
+
+config MODULE_WS281X_ESP32
+    bool
+    depends on HAS_ARCH_ESP32

--- a/tests/driver_tcs37727/app.config.test
+++ b/tests/driver_tcs37727/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TCS37727=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_tmp00x/app.config.test
+++ b/tests/driver_tmp00x/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TMP006=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_tps6274x/app.config.test
+++ b/tests/driver_tps6274x/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TPS6274X=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_tsl2561/app.config.test
+++ b/tests/driver_tsl2561/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TSL2561=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_tsl4531x/app.config.test
+++ b/tests/driver_tsl4531x/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TSL4531X=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_vcnl40x0/app.config.test
+++ b/tests/driver_vcnl40x0/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_VCNL4010=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_veml6070/app.config.test
+++ b/tests/driver_veml6070/app.config.test
@@ -1,0 +1,4 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_VEML6070=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/driver_ws281x/app.config.test
+++ b/tests/driver_ws281x/app.config.test
@@ -1,0 +1,3 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_WS281X=y


### PR DESCRIPTION
### Contribution description
This models more driver modules as Kconfig symbols and adds the configurations for their applications. The following drivers are included:

- ws281x
- veml6070
- vcnl40x0
- usbdev_mock
- tsl4531x
- tsl2561
- tps6274x
- touch_dev
- tmp00x
- tja1042
- tcs37727

### Testing procedure
- Check that the dependencies are correctly modelled
- Check that the new symbols are only visible and usable when `TEST_KCONFIG=1`
- Check that the correspondent applications for the modelled drivers were added to the CI's checks
- Green CI

### Issues/PRs references
None