### PR TITLE
tests: cleanup cond_order and pbkdf2 test scripts

### DIFF
--- a/tests/cond_order/tests/01-run.py
+++ b/tests/cond_order/tests/01-run.py
@@ -7,8 +7,9 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import os
 import sys
+
+from testrunner import run
 
 NUM_THREADS = 5
 
@@ -43,6 +44,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-    from testrunner import run
     sys.exit(run(testfunc))

--- a/tests/pbkdf2/tests/test_base.py
+++ b/tests/pbkdf2/tests/test_base.py
@@ -6,10 +6,11 @@
 #
 # Author: Juan Carrano <j.carrano@fu-berlin.de>
 
-import os
 import sys
 import base64
 from functools import partial
+
+from testrunner import run
 
 MAX_LINE = 128
 
@@ -40,6 +41,4 @@ def test(vectors, child):
 
 
 def main(vectors):
-    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
-    from testrunner import run
     sys.exit(run(partial(test, vectors)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a cleanup of the `tests/cond_order` and `tests/pbkdf2` test scripts: they are still using the old style import of testrunner run function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The scripts are still working, the CI (Murdock test on native by default) should show that.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while looking at #15720.
Needs #15720 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
