### PR TITLE
boards/stm32f030f4-demo: use picolibc to save ROM

### DIFF
--- a/boards/stm32f030f4-demo/Makefile.dep
+++ b/boards/stm32f030f4-demo/Makefile.dep
@@ -1,0 +1,3 @@
+# Use Picolibc to reduce ROM usage
+FEATURES_REQUIRED += picolibc
+USEMODULE += picolibc


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

STM32F030R4 only has 16k Flash, so use picolibc as done on other 16k flash boards to save some ROM.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
