### PR TITLE
tools/codespell: fix new typos found by recent version + add new ignored words

### DIFF
--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -17,7 +17,7 @@ Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
 ### Flash the board
 
 See the **Flashing** section in @ref boards_common_nrf52. The easiest way is to
-use an external Segger J-Link Progammer connected to the [SWD Connector].
+use an external Segger J-Link Programmer connected to the [SWD Connector].
 
 [SWD Connector]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/pinouts#swd-connector-3-12
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -498,7 +498,7 @@ typedef struct {
 
 
 /**
- * @name   Timer configuration depenend on which implementation is used
+ * @name   Timer configuration depend on which implementation is used
  *
  * Timers are MCU built-in feature and not board-specific. They are therefore
  * configured here.

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -106,9 +106,6 @@ dedup
 circularly
 
 # Chang (common name) => Change
-Chang
-
-# chang (common name) => change
 chang
 
 # filp (variable name for file pointer) => flip

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -110,3 +110,6 @@ Chang
 
 # chang (common name) => change
 chang
+
+# filp (variable name for file pointer) => flip
+filp

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -113,3 +113,6 @@ chang
 
 # filp (variable name for file pointer) => flip
 filp
+
+# Ether (Scapy class name and means Ethernet in some parts of the code) => Either
+ether

--- a/dist/tools/nrf52_resetpin_cfg/main.c
+++ b/dist/tools/nrf52_resetpin_cfg/main.c
@@ -97,7 +97,7 @@ int main(void)
         puts("\n\nPress any key (meaning send any char) to continue");
         getchar();
 
-        puts("Progamming the pin now...");
+        puts("Programming the pin now...");
         if ((NRF_UICR->PSELRESET[0] != RESET_VAL) ||
             (NRF_UICR->PSELRESET[1] != RESET_VAL)) {
             /* we can only erase all UICR registers at once, so we need to save

--- a/doc/doxygen/src/kconfig/kconfig.md
+++ b/doc/doxygen/src/kconfig/kconfig.md
@@ -443,7 +443,7 @@ config BOARD_SAMR21_XPRO
 
 ## Summary of reserved Kconfig prefixes
 The following symbol prefixes have been assigned particular semantics and are
-reserved for the cases described bellow:
+reserved for the cases described below:
 
 <!-- Keep the table in alphabetical order -->
 | Prefix | Description |

--- a/drivers/include/pca9685.h
+++ b/drivers/include/pca9685.h
@@ -130,7 +130,7 @@ extern "C"
 #define PCA9685_RESOLUTION      (1 << 12)
 
 /**
- * @brief   Internal PCA9685 oscilator frequency is 25 MHz
+ * @brief   Internal PCA9685 oscillator frequency is 25 MHz
  */
 #define PCA9685_OSC_FREQ        (25000000)
 

--- a/drivers/pca9685/pca9685.c
+++ b/drivers/pca9685/pca9685.c
@@ -212,14 +212,14 @@ void pca9685_pwm_poweron(pca9685_t *dev)
         /* clear the SLEEP bit */
         byte &= ~PCA9685_MODE1_SLEEP;
         EXEC(_write(dev, PCA9685_REG_MODE1, &byte, 1));
-        /* allow 500 us for oscilator to stabilize */
+        /* allow 500 us for oscillator to stabilize */
         xtimer_usleep(500);
         /* clear the RESTART bit to start all PWM channels*/
         EXEC(_update(dev, PCA9685_REG_MODE1, PCA9685_MODE1_RESTART, 1));
     }
     else {
         EXEC(_update(dev, PCA9685_REG_MODE1, PCA9685_MODE1_SLEEP, 0));
-        /* allow 500 us for oscilator to stabilize */
+        /* allow 500 us for oscillator to stabilize */
         xtimer_usleep(500);
         /* clear the RESTART bit to start all PWM channels*/
         EXEC(_update(dev, PCA9685_REG_MODE1, PCA9685_MODE1_RESTART, 1));

--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -75,13 +75,13 @@ void sys_sem_free(sys_sem_t *sem)
 
 void sys_sem_signal(sys_sem_t *sem)
 {
-    LWIP_ASSERT("invalid semaphor", sys_sem_valid(sem));
+    LWIP_ASSERT("invalid semaphore", sys_sem_valid(sem));
     sema_post((sema_t *)sem);
 }
 
 u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t count)
 {
-    LWIP_ASSERT("invalid semaphor", sys_sem_valid(sem));
+    LWIP_ASSERT("invalid semaphore", sys_sem_valid(sem));
     if (count != 0) {
         uint64_t stop, start;
         start = xtimer_now_usec64();

--- a/sys/entropy_source/doc.txt
+++ b/sys/entropy_source/doc.txt
@@ -24,7 +24,7 @@
  * @ref drivers_periph_hwrng and @ref sys_puf_sram. The concepts implemented here are heavily
  * influenced by NIST SP 800-90B. Entropy sources can be used to feed more advanced entropy
  * modules for cryptographic purposes, which typically accumulate multiple sources and safely
- * maintain internal sates. Alternatively, these sources can be used directly or with internal
+ * maintain internal states. Alternatively, these sources can be used directly or with internal
  * conditioning enabled for non-cryptographic tasks like seed generation of general purpose PRNGs,
  * in the absence of a hardware random number generator. The API, however, is not meant to face a user.
  *

--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -175,7 +175,7 @@ int _sht_config_handler(int argc, char **argv)
     int dev_num = 0;
 
     if ((argc == 2) && (strcmp("--help", argv[1]) == 0)) {
-        printf("Usage: \"%s [PARMS]\n"
+        printf("Usage: \"%s [PARAMS]\n"
                "\n"
                "Supported parameters:\n"
                "  -d <NUM>\n"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When a new riotdocker image is built, the latest version of codespell is installed: https://github.com/RIOT-OS/riotdocker/blob/201cb542c1365956b941fa4870ccbd6479392f3d/requirements.txt#L14

And it seems that the latest riotdocker image contains a really new version of codespell with new words added in his dictionary of typos. So when run on master, the static tests are failing because:
- of new false positives (filp and ether)
- new typos

This PR is fixing all of them (luckily, not so much).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Ensure you have the latest release of codespell installed:

```
$ pip install codespell -U
$ codespell --version
2.0.0
```

- Run the codespell check from RIOTBASE: `/dist/tools/codespell/check.sh`. With this PR, you get an empty output, on master a lost of typos are found.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Last check that fails with the static tests performed on master. ([example job](https://github.com/RIOT-OS/RIOT/runs/1664753077)).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
