### PR TITLE
stm32/periph/uart: set flow control bits before enabling uart

### DIFF
--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -215,6 +215,15 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
      * sent. */
     uart_init_pins(uart, rx_cb);
 
+#ifdef MODULE_PERIPH_UART_HW_FC
+    if (uart_config[uart].cts_pin != GPIO_UNDEF) {
+        dev(uart)->CR3 |= USART_CR3_CTSE;
+    }
+    if (uart_config[uart].rts_pin != GPIO_UNDEF) {
+        dev(uart)->CR3 |= USART_CR3_RTSE;
+    }
+#endif
+
     /* enable RX interrupt if applicable */
     if (rx_cb) {
         NVIC_EnableIRQ(uart_config[uart].irqn);
@@ -226,15 +235,6 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     NVIC_EnableIRQ(uart_config[uart].irqn);
-#endif
-
-#ifdef MODULE_PERIPH_UART_HW_FC
-    if (uart_config[uart].cts_pin != GPIO_UNDEF) {
-        dev(uart)->CR3 |= USART_CR3_CTSE;
-    }
-    if (uart_config[uart].rts_pin != GPIO_UNDEF) {
-        dev(uart)->CR3 |= USART_CR3_RTSE;
-    }
 #endif
 
     return UART_OK;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The STM32 datasheets specify that in order to enable hardware flow control, the `CTSE` and `RTSE` bits should be set. It also states that these have to be set _before_ the `UE` bit is set.
In RIOT, the `CTSE` and `RTSE` bits were set _after_ the `UE` bit was already set. Because of this, the state of `RTSE` and `CTSE` were never actually changed. By moving the bit of code that sets `CTSE` and `RTSE` to a point before `UE` is set, hardware flow control is being enabled correctly. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The bug was found and tested using a custom board developed internally. This board uses a modem which requires hardware flow control.

We noticed no data was being transmitted when using RIOT's hardware flow control. When manually controlling the flow control pins using the gpio functions, data was flowing but with some bytes randomly disappearing.
After this change, data was flowing and there was no more loss of data.

When running the current code using a debugger, it can be seen that `RTSE` and `CTSE` stay low even after RIOT sets them. With this change, `RTSE` and `CTSE` are set after `uart_init()` has been executed.



<!--

### Issues/PRs references
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
