### PR TITLE
cc2538_rf/radio_hal: fix transmit function

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -93,6 +93,13 @@ static int _request_transmit(ieee802154_dev_t *dev)
 
     if (cc2538_csma_ca_retries < 0) {
         RFCORE_SFR_RFST = ISTXON;
+        /* The CPU Ctrl mask is used here to indicate whether the radio is being
+         * controlled by the CPU or the CSP Strobe Processor.
+         * We set this to 1 in order to indicate that the CSP is not used and
+         * thus, that the @ref ieee802154_radio_ops::confirm_transmit should
+         * return 0 immediately after the TXDONE event
+         */
+        RFCORE_XREG_CSPCTRL |= CC2538_CSP_MCU_CTRL_MASK;
     }
     else {
         cc2538_cca = false;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This commit sets the correct value to the MCU_CTRL bit for the
cc2538_rf. This variable is used to detect when the radio is doing
transmission with CCA. Since this was not set to 1 when sending without
CCA, the `confirm_transmit` function returned -EAGAIN after the TX_DONE
event (which violates the HAL API).

This error was discovered using some Radio HAL riotctrl scripts by @LarsKowoll.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This would probably pop up if one tries to transmit with direct mode using the cc2538_rf
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
