### PR TITLE
cpu/esp32: fix typo in timer documentation

### DIFF
--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -498,7 +498,7 @@ typedef struct {
 
 
 /**
- * @name   Timer configuration depend on which implementation is used
+ * @name   Timer configuration depending on which implementation is used
  *
  * Timers are MCU built-in feature and not board-specific. They are therefore
  * configured here.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the ESP32 timer documentation as reported by @gschorcht in https://github.com/RIOT-OS/RIOT/pull/15723#discussion_r553866456

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Wrong fix provided in #15723 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
