### PR TITLE
cpu/kinetis: fix compile issue in LPTMR timer

### DIFF
--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -88,7 +88,6 @@ static const clock_config_t clock_config = {
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
 #define PIT_ISR_0               isr_pit1
 #define PIT_ISR_1               isr_pit3
-#define LPTMR_ISR_0             isr_lptmr0
 /** @} */
 
 /**

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -52,6 +52,10 @@
 #error TIMER_NUMOF should be the total of PIT and LPTMR timers in the system
 #endif
 
+#if defined(KINETIS_HAVE_LPTMR) && LPTMR_NUMOF > 0
+#define KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
+#endif
+
 /**
  * @brief  The number of ticks that will be lost when setting a new target in the LPTMR
  *
@@ -67,7 +71,7 @@ typedef struct {
     uint32_t ldval;
 } pit_t;
 
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
 /* LPTMR state */
 typedef struct {
     timer_isr_ctx_t isr_ctx;
@@ -78,12 +82,12 @@ typedef struct {
 #endif
 
 static const pit_conf_t pit_config[PIT_NUMOF] = PIT_CONFIG;
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
 static const lptmr_conf_t lptmr_config[LPTMR_NUMOF] = LPTMR_CONFIG;
 #endif
 
 static pit_t pit[PIT_NUMOF];
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
 static lptmr_t lptmr[LPTMR_NUMOF];
 #endif
 
@@ -92,7 +96,7 @@ static lptmr_t lptmr[LPTMR_NUMOF];
  */
 static inline unsigned int _timer_variant(tim_t dev)
 {
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
     if ((unsigned int) dev >= PIT_NUMOF) {
         return TIMER_LPTMR;
     }
@@ -120,7 +124,7 @@ static inline tim_t _pit_tim_t(uint8_t dev)
     return (tim_t)(((unsigned int)TIMER_DEV(0)) + dev);
 }
 
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
 /**
  * @brief  Find device index in the lptmr_config array
  */
@@ -138,7 +142,7 @@ static inline tim_t _lptmr_tim_t(uint8_t dev)
     return (tim_t)(((unsigned int)TIMER_DEV(0)) + PIT_NUMOF + dev);
 }
 #endif /* defined(LPTMR_ISR_0) || defined(LPTMR_ISR_1) */
-#endif /* KINETIS_HAVE_LPTMR */
+#endif /* KINETIS_BOARD_HAVE_CONFIGURED_LPTMR */
 
 /* ****** PIT module functions ****** */
 
@@ -309,7 +313,7 @@ static inline void pit_irq_handler(tim_t dev)
     cortexm_isr_end();
 }
 
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
 /* ****** LPTMR module functions ****** */
 
 /* Forward declarations */
@@ -617,7 +621,7 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
             return pit_init(_pit_index(dev), freq, cb, arg);
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             return lptmr_init(_lptmr_index(dev), freq, cb, arg);
 #endif
@@ -640,7 +644,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
             return pit_set(_pit_index(dev), timeout);
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             return lptmr_set(_lptmr_index(dev), timeout);
 #endif
@@ -663,7 +667,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int target)
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
             return pit_set_absolute(_pit_index(dev), target);
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             return lptmr_set_absolute(_lptmr_index(dev), target);
 #endif
@@ -688,7 +692,7 @@ int timer_clear(tim_t dev, int channel)
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
             return pit_clear(_pit_index(dev));
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             return lptmr_clear(_lptmr_index(dev));
 #endif
@@ -709,7 +713,7 @@ unsigned int timer_read(tim_t dev)
     switch (_timer_variant(dev)) {
         case TIMER_PIT:
             return pit_read(_pit_index(dev));
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             return lptmr_read(_lptmr_index(dev));
 #endif
@@ -729,7 +733,7 @@ void timer_start(tim_t dev)
         case TIMER_PIT:
             pit_start(_pit_index(dev));
             return;
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             lptmr_start(_lptmr_index(dev));
             return;
@@ -750,7 +754,7 @@ void timer_stop(tim_t dev)
         case TIMER_PIT:
             pit_stop(_pit_index(dev));
             return;
-#ifdef KINETIS_HAVE_LPTMR
+#ifdef KINETIS_BOARD_HAVE_CONFIGURED_LPTMR
         case TIMER_LPTMR:
             lptmr_stop(_lptmr_index(dev));
             return;


### PR DESCRIPTION
### Contribution description
When trying to build the default example for the `pba-d-01-kw2x` using `arm-none-eabi-gcc (Arch Repository) 10.2.0`, it catches the following issue:

```
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c: In function 'isr_lptmr0':
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c:596:10: error: array subscript 0 is outside array bounds of 'lptmr_t[0]' [-Werror=array-bounds]
  596 |     lptmr[dev].running = 0;
      |     ~~~~~^~~~~
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c:87:16: note: while referencing 'lptmr'
   87 | static lptmr_t lptmr[LPTMR_NUMOF];
      |                ^~~~~
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c:602:14: error: array subscript 0 is outside array bounds of 'lptmr_t[0]' [-Werror=array-bounds]
  602 |     if (lptmr[dev].isr_ctx.cb != NULL) {
      |         ~~~~~^~~~~
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c:87:16: note: while referencing 'lptmr'
   87 | static lptmr_t lptmr[LPTMR_NUMOF];
      |                ^~~~~
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c:603:36: error: array subscript 0 is outside array bounds of 'lptmr_t[0]' [-Werror=array-bounds]
  603 |         lptmr[dev].isr_ctx.cb(lptmr[dev].isr_ctx.arg, 0);
      |                               ~~~~~^~~~~
/home/leandro/Work/RIOT/cpu/kinetis/periph/timer.c:87:16: note: while referencing 'lptmr'
   87 | static lptmr_t lptmr[LPTMR_NUMOF];
      |                ^~~~~
cc1: all warnings being treated as errors
make[3]: *** [/home/leandro/Work/RIOT/Makefile.base:107: /home/leandro/Work/RIOT/examples/default/bin/pba-d-01-kw2x/periph/timer.o] Error 1
make[2]: *** [/home/leandro/Work/RIOT/Makefile.base:30: ALL--/home/leandro/Work/RIOT/cpu/kinetis/periph] Error 2
make[1]: *** [/home/leandro/Work/RIOT/Makefile.base:30: ALL--/home/leandro/Work/RIOT/cpu/kinetis] Error 2
make: *** [/home/leandro/Work/RIOT/examples/default/../../Makefile.include:619: application_default.module] Error 2
```

Indeed the board defines `0` LPTMR timers on its configuration. The check to decide if the platform has or not support for that peripheral does not take this into account. This does not seem to be a problem when building in Docker by the way.

This PR changes that and also removes the define for the interrupt vector macro, as it should not be needed.

### Testing procedure
- Green CI
- Timer tests should succeed
- Other kinetis boards that have LPTMR should still use it

### Issues/PRs references
None