### PR TITLE
ci: fix all coccinelle recommendations

### DIFF
--- a/cpu/qn908x/periph/rtc.c
+++ b/cpu/qn908x/periph/rtc.c
@@ -30,7 +30,7 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 

--- a/cpu/qn908x/periph/timer.c
+++ b/cpu/qn908x/periph/timer.c
@@ -32,7 +32,7 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /**

--- a/cpu/qn908x/periph/uart.c
+++ b/cpu/qn908x/periph/uart.c
@@ -33,7 +33,7 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /**

--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -27,7 +27,7 @@
 
 #include "sam0_eth_netdev.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 #include "log.h"
 

--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -30,7 +30,7 @@
 
 #include "sam0_eth_netdev.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 #include "log.h"
 

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -28,7 +28,7 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 void stm32_eth_common_init(void)

--- a/cpu/stm32/periph/ptp.c
+++ b/cpu/stm32/periph/ptp.c
@@ -29,7 +29,7 @@
 #include "periph_cpu.h"
 #include "timex.h"
 
-#define ENABLE_DEBUG        (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /* Workaround for typos in vendor files; drop when fixed upstream */

--- a/drivers/at86rf215/at86rf215_fsk.c
+++ b/drivers/at86rf215/at86rf215_fsk.c
@@ -20,7 +20,7 @@
 #include "at86rf215.h"
 #include "at86rf215_internal.h"
 
-#define ENABLE_DEBUG        (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /* symbol time is always 20 µs for MR-FSK (table 0, pg. 7) */

--- a/examples/asymcute_mqttsn/main.c
+++ b/examples/asymcute_mqttsn/main.c
@@ -89,7 +89,7 @@ static uint16_t _parse_predef_id(const char *name)
 {
     uint16_t id = 0;
     if ((strlen(name) > 4) && (strncmp(name, "pre_", 4) == 0)) {
-        id = (uint16_t)atoi(&name[4]);
+        id = atoi(&name[4]);
     }
     return id;
 }
@@ -438,7 +438,7 @@ static int _cmd_sub(int argc, char **argv)
             puts("error: no free topic memory");
             return 1;
         }
-        if (_topic_init(t, argv[1]) == 0) {
+        if (_topic_init(t, argv[1]) == NULL) {
             puts("error: unable to initialize topic");
             return 1;
         }

--- a/pkg/wakaama/contrib/objects/device.c
+++ b/pkg/wakaama/contrib/objects/device.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "kernel_defines.h"
 #include "liblwm2m.h"
 #include "objects/device.h"
 #include "lwm2m_client_config.h"
@@ -77,7 +78,7 @@ static uint8_t prv_device_discover(uint16_t instance_id, int *num_dataP,
             LWM2M_RES_BINDINGS, LWM2M_RES_TYPE, LWM2M_RES_HW_VERSION,
             LWM2M_RES_SW_VERSION,
         };
-        int len = sizeof(res) / sizeof(uint16_t);
+        int len = ARRAY_SIZE(res);
 
         *data_arrayP = lwm2m_data_new(len);
         if (*data_arrayP == NULL) {
@@ -136,7 +137,7 @@ static uint8_t prv_device_read(uint16_t instance_id, int *num_dataP,
             LWM2M_RES_FW_VER,       LWM2M_RES_HW_VERSION, LWM2M_RES_SW_VERSION,
             LWM2M_RES_BINDINGS,     LWM2M_RES_TYPE,       LWM2M_RES_ERROR_CODE,
         };
-        int cnt = sizeof(resList) / sizeof(uint16_t);
+        int cnt = ARRAY_SIZE(resList);
         *data_arrayP = lwm2m_data_new(cnt);
         if (*data_arrayP == NULL) {
             result = COAP_500_INTERNAL_SERVER_ERROR;

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -441,7 +441,7 @@ int _nimble_netif_handler(int argc, char **argv)
         if (!fmt_is_number(argv[2])) {
             unsigned duration = DEFAULT_SCAN_DURATION;
             if (argc > 3) {
-                duration = (unsigned)atoi(argv[3]);
+                duration = atoi(argv[3]);
             }
             _cmd_connect_name(argv[2], duration * 1000);
             return 0;

--- a/tests/unittests/tests-clif/tests-clif.c
+++ b/tests/unittests/tests-clif/tests-clif.c
@@ -101,7 +101,7 @@ static void test_clif_encode_links(void)
     res = clif_encode_link(&links[0], NULL, 0);
     pos += res;
 
-    for (unsigned i = 1; i < sizeof(links) / sizeof(links[0]); i++) {
+    for (unsigned i = 1; i < ARRAY_SIZE(links); i++) {
         res = clif_add_link_separator(NULL, 0);
         if (res <= 0) {
             break;
@@ -122,7 +122,7 @@ static void test_clif_encode_links(void)
     res = clif_encode_link(&links[0], output, sizeof(output));
     pos += res;
 
-    for (unsigned i = 1; i < sizeof(links) / sizeof(links[0]); i++) {
+    for (unsigned i = 1; i < ARRAY_SIZE(links); i++) {
         res = clif_add_link_separator(&output[pos], sizeof(output) - pos);
         if (res <= 0) {
             break;
@@ -195,8 +195,8 @@ static void test_clif_decode_links(void)
         "http://www.example.com/sensors/t123", "/t", "/riot/board", "/riot/info"
     };
 
-    const unsigned exp_links_numof = sizeof(exp_targets) / sizeof(exp_targets[0]);
-    const unsigned exp_attrs_numof = sizeof(exp_attrs) / sizeof(exp_attrs[0]);
+    const unsigned exp_links_numof = ARRAY_SIZE(exp_targets);
+    const unsigned exp_attrs_numof = ARRAY_SIZE(exp_attrs);
     const size_t input_len = sizeof(input_string) - 1;
 
     clif_t out_link;
@@ -229,7 +229,7 @@ static void test_clif_decode_links(void)
     TEST_ASSERT(exp_links_numof == links_numof);
 
     /* now decode again but saving the attributes */
-    clif_attr_t out_attrs[sizeof(exp_attrs) / sizeof(exp_attrs[0])];
+    clif_attr_t out_attrs[ARRAY_SIZE(exp_attrs)];
     pos = input_string;
     unsigned attrs_numof = 0;
     do {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes all errors reported by the coccinelle static checker on master. All of them are pretty obvious:
- `ENABLE_DEBUG` define should not contain parenthesis
- Use of `ARRAY_SIZE` when possible
- The cast of the atoi result is not needed

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- Maybe verify that the code affected by the `ARRAY_SIZE` and atoi casts changes still works (`examples/wakaama`, `examples/asymcute_mqttsn`, `tests/unittests/tests-clif`)
- Run `docker run --rm -v $(pwd):/data/riotbuild riot/riotbuild ./dist/tools/coccinelle/check.sh`. With this PR, you get an empty output (no errors), on master you get the following:
<details>

```
$ docker run --rm -v $(pwd):/data/riotbuild riot/riotbuild ./dist/tools/coccinelle/check.sh
--- examples/asymcute_mqttsn/main.c
+++ /tmp/cocci-output-19-489fcf-main.c
@@ -438,7 +438,7 @@ static int _cmd_sub(int argc, char **arg
             puts("error: no free topic memory");
             return 1;
         }
-        if (_topic_init(t, argv[1]) == 0) {
+        if (_topic_init(t, argv[1]) == NULL) {
             puts("error: unable to initialize topic");
             return 1;
         }
--- pkg/wakaama/contrib/objects/device.c
+++ /tmp/cocci-output-37-8947b5-device.c
@@ -77,7 +77,7 @@ static uint8_t prv_device_discover(uint1
             LWM2M_RES_BINDINGS, LWM2M_RES_TYPE, LWM2M_RES_HW_VERSION,
             LWM2M_RES_SW_VERSION,
         };
-        int len = sizeof(res) / sizeof(uint16_t);
+        int len = ARRAY_SIZE(res);
 
         *data_arrayP = lwm2m_data_new(len);
         if (*data_arrayP == NULL) {
@@ -136,7 +136,7 @@ static uint8_t prv_device_read(uint16_t
             LWM2M_RES_FW_VER,       LWM2M_RES_HW_VERSION, LWM2M_RES_SW_VERSION,
             LWM2M_RES_BINDINGS,     LWM2M_RES_TYPE,       LWM2M_RES_ERROR_CODE,
         };
-        int cnt = sizeof(resList) / sizeof(uint16_t);
+        int cnt = ARRAY_SIZE(resList);
         *data_arrayP = lwm2m_data_new(cnt);
         if (*data_arrayP == NULL) {
             result = COAP_500_INTERNAL_SERVER_ERROR;
--- tests/unittests/tests-clif/tests-clif.c
+++ /tmp/cocci-output-37-aa0912-tests-clif.c
@@ -101,7 +101,7 @@ static void test_clif_encode_links(void)
     res = clif_encode_link(&links[0], NULL, 0);
     pos += res;
 
-    for (unsigned i = 1; i < sizeof(links) / sizeof(links[0]); i++) {
+    for (unsigned i = 1; i < ARRAY_SIZE(links); i++) {
         res = clif_add_link_separator(NULL, 0);
         if (res <= 0) {
             break;
@@ -122,7 +122,7 @@ static void test_clif_encode_links(void)
     res = clif_encode_link(&links[0], output, sizeof(output));
     pos += res;
 
-    for (unsigned i = 1; i < sizeof(links) / sizeof(links[0]); i++) {
+    for (unsigned i = 1; i < ARRAY_SIZE(links); i++) {
         res = clif_add_link_separator(&output[pos], sizeof(output) - pos);
         if (res <= 0) {
             break;
@@ -195,8 +195,8 @@ static void test_clif_decode_links(void)
         "http://www.example.com/sensors/t123", "/t", "/riot/board", "/riot/info"
     };
 
-    const unsigned exp_links_numof = sizeof(exp_targets) / sizeof(exp_targets[0]);
-    const unsigned exp_attrs_numof = sizeof(exp_attrs) / sizeof(exp_attrs[0]);
+    const unsigned exp_links_numof = ARRAY_SIZE(exp_targets);
+    const unsigned exp_attrs_numof = ARRAY_SIZE(exp_attrs);
     const size_t input_len = sizeof(input_string) - 1;
 
     clif_t out_link;
@@ -229,7 +229,7 @@ static void test_clif_decode_links(void)
     TEST_ASSERT(exp_links_numof == links_numof);
 
     /* now decode again but saving the attributes */
-    clif_attr_t out_attrs[sizeof(exp_attrs) / sizeof(exp_attrs[0])];
+    clif_attr_t out_attrs[ARRAY_SIZE(exp_attrs)];
     pos = input_string;
     unsigned attrs_numof = 0;
     do {
--- cpu/qn908x/periph/rtc.c
+++ /tmp/cocci-output-51-482aa7-rtc.c
@@ -30,7 +30,7 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 
--- cpu/qn908x/periph/timer.c
+++ /tmp/cocci-output-51-e23379-timer.c
@@ -32,7 +32,7 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /**
--- cpu/qn908x/periph/uart.c
+++ /tmp/cocci-output-51-3cff5c-uart.c
@@ -33,7 +33,7 @@
 
 #include "vendor/drivers/fsl_clock.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /**
--- cpu/sam0_common/periph/eth.c
+++ /tmp/cocci-output-51-74146f-eth.c
@@ -27,7 +27,7 @@
 
 #include "sam0_eth_netdev.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 #include "log.h"
 
--- cpu/sam0_common/sam0_eth/eth-netdev.c
+++ /tmp/cocci-output-51-d77d13-eth-netdev.c
@@ -30,7 +30,7 @@
 
 #include "sam0_eth_netdev.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 #include "log.h"
 
--- cpu/stm32/periph/eth_common.c
+++ /tmp/cocci-output-51-34dfec-eth_common.c
@@ -28,7 +28,7 @@
 #include "periph_conf.h"
 #include "periph_cpu.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 void stm32_eth_common_init(void)
--- cpu/stm32/periph/ptp.c
+++ /tmp/cocci-output-51-71888f-ptp.c
@@ -29,7 +29,7 @@
 #include "periph_cpu.h"
 #include "timex.h"
 
-#define ENABLE_DEBUG        (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /* Workaround for typos in vendor files; drop when fixed upstream */
--- drivers/at86rf215/at86rf215_fsk.c
+++ /tmp/cocci-output-51-b5864c-at86rf215_fsk.c
@@ -20,7 +20,7 @@
 #include "at86rf215.h"
 #include "at86rf215_internal.h"
 
-#define ENABLE_DEBUG        (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /* symbol time is always 20 µs for MR-FSK (table 0, pg. 7) */
--- examples/asymcute_mqttsn/main.c
+++ /tmp/cocci-output-1129-2074fd-main.c
@@ -89,7 +89,7 @@ static uint16_t _parse_predef_id(const c
 {
     uint16_t id = 0;
     if ((strlen(name) > 4) && (strncmp(name, "pre_", 4) == 0)) {
-        id = (uint16_t)atoi(&name[4]);
+        id = atoi(&name[4]);
     }
     return id;
 }
--- sys/shell/commands/sc_nimble_netif.c
+++ /tmp/cocci-output-1129-58e016-sc_nimble_netif.c
@@ -441,7 +441,7 @@ int _nimble_netif_handler(int argc, char
         if (!fmt_is_number(argv[2])) {
             unsigned duration = DEFAULT_SCAN_DURATION;
             if (argc > 3) {
-                duration = (unsigned)atoi(argv[3]);
+                duration = atoi(argv[3]);
             }
             _cmd_connect_name(argv[2], duration * 1000);
             return 0;

```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
