### PR TITLE
cpu/esp_common: Add missing includes and ISO-C++ compatibility

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -65,7 +65,7 @@
 static esp_now_netdev_t _esp_now_dev = { 0 };
 static const netdev_driver_t _esp_now_driver;
 
-static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, uint8_t* key)
+static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, const uint8_t* key)
 {
     if (esp_now_is_peer_exist(bssid)) {
         return false;

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -21,6 +21,11 @@
 #define ESP_NOW_NETDEV_H
 
 #include "net/netdev.h"
+#include "mutex.h"
+#include "net/ethernet/hdr.h"
+#ifdef MODULE_GNRC
+#include "net/gnrc/nettype.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -103,10 +103,10 @@
  */
 typedef struct
 {
-    uint8_t* key;         /**< key of type uint8_t [16] or NULL (no encryption) */
-    uint32_t scan_period; /**< Period at which the node scans for other nodes */
-    char*    softap_pass; /**< Passphrase used for the SoftAP interface */
-    uint8_t  channel;     /**< Channel used for ESP-NOW nodes */
+    const uint8_t* key;      /**< key of type uint8_t [16] or NULL (no encryption) */
+    uint32_t scan_period;    /**< Period at which the node scans for other nodes */
+    const char* softap_pass; /**< Passphrase used for the SoftAP interface */
+    uint8_t channel;         /**< Channel used for ESP-NOW nodes */
 
 } esp_now_params_t;
 


### PR DESCRIPTION
### Contribution description
This PR fixes two bugs:
1. Including `esp_now_params.h` was not possible from C++, because ISO-C++ forbids `char* var = "somevalue"` initialization without const. Even in C this is no good practice. The missing const statements were added for `esp_now_params_t`.
2. `esp_now_netdev.h` was not self-contained, because it uses definitions from headers that are not included. I've added these missing includes.

### Testing procedure
There shouldn't be much to test. You can try including the two headers in a C/C++ project before and after the PR and see the failing/fixed build.

CC @maribu 
