### PR TITLE
cpu/fe310: Use ecall instruction for thread yield

### DIFF
--- a/cpu/fe310/irq_arch.c
+++ b/cpu/fe310/irq_arch.c
@@ -108,14 +108,28 @@ void handle_trap(uint32_t mcause)
         }
     }
     else {
+        switch (mcause) {
+        case CAUSE_USER_ECALL:    /* ECALL from user mode */
+        case CAUSE_MACHINE_ECALL: /* ECALL from machine mode */
+        {
+            /* TODO: get the ecall arguments */
+            sched_context_switch_request = 1;
+            /* Increment the return program counter past the ecall
+             * instruction */
+            uint32_t return_pc = read_csr(mepc);
+            write_csr(mepc, return_pc + 4);
+            break;
+        }
+        default:
 #ifdef DEVELHELP
-        printf("Unhandled trap:\n");
-        printf("  mcause: 0x%"PRIx32"\n", mcause);
-        printf("  mepc:   0x%"PRIx32"\n", read_csr(mepc));
-        printf("  mtval:  0x%"PRIx32"\n", read_csr(mtval));
+            printf("Unhandled trap:\n");
+            printf("  mcause: 0x%"PRIx32"\n", mcause);
+            printf("  mepc:   0x%"PRIx32"\n", read_csr(mepc));
+            printf("  mtval:  0x%"PRIx32"\n", read_csr(mtval));
 #endif
-        /* Unknown trap */
-        core_panic(PANIC_GENERAL_ERROR, "Unhandled trap");
+            /* Unknown trap */
+            core_panic(PANIC_GENERAL_ERROR, "Unhandled trap");
+        }
     }
     /* ISR done - no more changes to thread states */
     fe310_in_isr = 0;

--- a/cpu/fe310/irq_arch.c
+++ b/cpu/fe310/irq_arch.c
@@ -61,8 +61,7 @@ void irq_init(void)
         plic_init();
     }
 
-    /* Enable SW and external interrupts */
-    set_csr(mie, MIP_MSIP);
+    /* Enable external interrupts */
     set_csr(mie, MIP_MEIP);
 
     /*  Set default state of mstatus */
@@ -82,12 +81,6 @@ void handle_trap(uint32_t mcause)
     if ((mcause & MCAUSE_INT) == MCAUSE_INT) {
         /* Cause is an interrupt - determine type */
         switch (mcause & MCAUSE_CAUSE) {
-            case IRQ_M_SOFT:
-                /* Handle software interrupt - flag for context switch */
-                sched_context_switch_request = 1;
-                CLINT_REG(0) = 0;
-                break;
-
 #ifdef MODULE_PERIPH_TIMER
             case IRQ_M_TIMER:
                 /* Handle timer interrupt */


### PR DESCRIPTION
### Contribution description

This switches the thread yield on the ~~fe310~~ RISC-V CPU to use the ECALL instruction to trap the core. Currently the software interrupt is used for this, but this is supposed to be used for inter-core interrupts according to the manual.

I've kept the option open on the interface to add a number and some context to the ecall and have this passed to the trap handler. This still has to be hooked up to the trap handler itself in the future.

### Testing procedure

This is only tested on Qemu as I currently don't have hardware to test this.

Thread switching on an fe310-based board, e.g. `tests/bench_mutex_pingpong`

I'm also curious about actual numbers, this improves performance for me on Qemu, but no clue if that's also the case on real hardware.

### Issues/PRs references

Alternative to #15277 