### PR TITLE
README: Add merge-chance badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License][license-badge]][license-link]
 [![API docs][api-badge]][api-link]
 [![Wiki][wiki-badge]][wiki-link]
+[![Merge chance][merge-chance-badge]][merge-chance-link]
 [![Stack Overflow questions][stackoverflow-badge]][stackoverflow-link]
 [![Twitter][twitter-badge]][twitter-link]
 [![IRC][irc-badge]][irc-link]
@@ -128,6 +129,8 @@ https://www.riot-os.org
 [master-ci-link]: https://ci.riot-os.org/nightlies.html#master
 [matrix-badge]: https://img.shields.io/badge/chat-Matrix-brightgreen.svg
 [matrix-link]: https://matrix.to/#/#riot-os:matrix.org
+[merge-chance-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fmerge-chance.info%2Fbadge%3Frepo%3DRIOT-OS/RIOT&color=informational
+[merge-chance-link]: https://merge-chance.info/target?repo=RIOT-OS/RIOT
 [release-badge]: https://img.shields.io/github/release/RIOT-OS/RIOT.svg
 [release-link]: https://github.com/RIOT-OS/RIOT/releases/latest
 [stackoverflow-badge]: https://img.shields.io/badge/stackoverflow-%5Briot--os%5D-yellow


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds a new badge to the README, which shows the chance of a PR of a non-member being merged and the number of days that takes. The information is taken from [this website](https://merge-chance.info/target?repo=RIOT-OS/RIOT) which was discovered by @benpicco. I personally find the numbers surprising, given that one of our problems we often discussed in the past was the perceived eternity it tags to merge PRs by new contributors. But maybe the good numbers come from our guilt. To quote @maribu from an offline discussion about this badge:

> Maybe the believe that we are slow on foreign PRs is motivating our fast response time. It would be interesting to see if the lack of guilt results in slower response time once we have this badge in the readme
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Have a look at the rendered README. There should be the new badge now.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
