### PR TITLE
tools/headerguards: also catch messages from stderr

### DIFF
--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -23,8 +23,7 @@ filter() {
 }
 
 _headercheck() {
-    OUT="$(${RIOTTOOLS}/headerguards/headerguards.py ${FILES} | filter)"
-
+    OUT=$(${RIOTTOOLS}/headerguards/headerguards.py ${FILES} 2>&1 | filter)
     if [ -n "$OUT" ]; then
         EXIT_CODE=1
         echo "$OUT"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When the static tests are performed on master the headerguards check print some issues but the returned code is still 0 (no failure). See [this output](https://github.com/RIOT-OS/RIOT/runs/1681033471?check_suite_focus=true#step:5:20896) for example.

It turns out that when no headerguards are found an error message (like `sys/posix/include/fcntl.h: no / broken header guard`) is printed to stderr and not stdout by the `headerguards.py` script. And since it's written to stderr, it is not taken into account by the `check.sh` script. Although it shows valid problems (see below in the Testing procedure).

This PR changes the `check.sh` script to also take into account messages printed to stderr. Now the static tests should fail again on master.

Another solution is simply print to stdout from the `headerguards.py` script (by removing `file=sys.stderr` in the code below):

https://github.com/RIOT-OS/RIOT/blob/f1600af7018099747f4c6f9b5172b8443c9ec342/dist/tools/headerguards/headerguards.py#L78

I can change to that solution if reviewers prefer that solution.

Please don't merge this PR until the reported problems are fixed (see #15742 and #15741)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `./dist/tools/headerguards/check.sh`, check the output and check the returned value:

- master:

```
$ ./dist/tools/headerguards/check.sh
boards/mbed_lpc1768/include/vendor_conf.h: no / broken header guard
boards/seeeduino_arch-pro/include/vendor_conf.h: no / broken header guard
sys/posix/include/fcntl.h: no / broken header guard
$ echo $?
0
```

- this PR:

```
$ ./dist/tools/headerguards/check.sh
boards/mbed_lpc1768/include/vendor_conf.h: no / broken header guard
boards/seeeduino_arch-pro/include/vendor_conf.h: no / broken header guard
sys/posix/include/fcntl.h: no / broken header guard
$ echo $?
1
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Should be merged after #15742 and #15741

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
