### PR TITLE
[RFC] sys/posix/fcntl: fix headerguard

### DIFF
--- a/sys/posix/include/fcntl.h
+++ b/sys/posix/include/fcntl.h
@@ -15,6 +15,9 @@
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fcntl.h.html
  */
 
+#ifndef FCNTL_H
+#define FCNTL_H
+
 #ifndef DOXYGEN
 #if defined(CPU_NATIVE) || MODULE_NEWLIB || MODULE_PICOLIBC
 /* If building on native or newlib we need to use the system header instead */
@@ -22,8 +25,6 @@
 /* without the GCC pragma above #include_next will trigger a pedantic error */
 #include_next <fcntl.h>
 #else
-#ifndef FCNTL_H_
-#define FCNTL_H_
 
 #include <sys/types.h> /* for mode_t, off_t */
 
@@ -67,9 +68,9 @@ int  posix_fallocate(int, off_t, off_t);
 }
 #endif
 
-#endif /* FCNTL_H_ */
-
 #endif /* CPU_NATIVE */
 
 #endif /* DOXYGEN */
+
+#endif /* FCNTL_H */
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix the "no / broken header guard" message printed by the related CI check script for `sys/posix/include/fcntl.h`.
I mark this PR as RFC because I'm not 100% sure about the fix.

But it seems that the proposed solution builds in most of the cases (tried native, AVR, RISCV, ARM with newlib or picolibc).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fix one of the problems reported in #15740 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
