### PR TITLE
tests/periph_flashpage: print config page address

### DIFF
--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -542,9 +542,9 @@ static int cmd_dump_config(int argc, char **argv)
     (void) argv;
 
 #ifdef FLASH_USER_PAGE_SIZE
-    od_hex_dump((void*)NVMCTRL_USER, FLASH_USER_PAGE_SIZE, 0);
+    od_hex_dump_ext((void*)NVMCTRL_USER, FLASH_USER_PAGE_SIZE, 0, NVMCTRL_USER);
 #else
-    od_hex_dump((void*)NVMCTRL_USER, AUX_PAGE_SIZE * AUX_NB_OF_PAGES, 0);
+    od_hex_dump_ext((void*)NVMCTRL_USER, AUX_PAGE_SIZE * AUX_NB_OF_PAGES, 0, NVMCTRL_USER);
 #endif
 
     return 0;


### PR DESCRIPTION
### Contribution description

Add the address to the config page dump. This makes it clear that the dump contains the entire config page and not just the unused bytes exposed to store user configuration.

### Testing procedure

`dump_config_page` now prints the proper address together with the config page.

```
2021-01-12 08:43:03,096 #  dump_config_page
2021-01-12 08:43:03,103 # 00804000  FF  C7  E0  D8  5D  FC  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2021-01-12 08:43:03,109 # 00804010  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2021-01-12 08:43:03,116 # 00804020  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2021-01-12 08:43:03,122 # 00804030  FF  FF  FF  FF  FF  FF  FF  FF  FF  AA  BB  CC  DD  EE  34  12
```

on **master** this will print

```
2021-01-12 08:48:32,027 #  dump_config_page
2021-01-12 08:48:32,033 # 00000000  FF  C7  E0  D8  5D  FC  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2021-01-12 08:48:32,040 # 00000010  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2021-01-12 08:48:32,046 # 00000020  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF  FF
2021-01-12 08:48:32,053 # 00000030  FF  FF  FF  FF  FF  FF  FF  FF  FF  AA  BB  CC  DD  EE  34  12
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
