### PR TITLE
ci/check-labels: fail for PR blocked by feature freeze label

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: RIOT-OS/check-labels-action@v1.0.0
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
-        unset_labels: 'CI: needs squashing,State: waiting for other PR'
+        unset_labels: 'CI: needs squashing,State: waiting for other PR,Process: blocked by feature freeze'
         cond_labels: '(Process: needs >1 ACK,review.approvals>1),(Area: RDM,review.approvals>2)'
   check-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `State: blocked by feature freeze` label was added and can be used to block a (preferably high impact) PR from being merged during the feature freeze.

This PR is adding a check in the corresponding github action to fail it's set, so the PR cannot be merged.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Set the label and verify that the corresponding check is failing

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
