### PR TITLE
ci/test-on-iotlab: fix unsupported set-env command

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -109,7 +109,7 @@ jobs:
             -n "riot-ci-${{ matrix.boards.riot }}" -d 360 \
             -l 1,site=${{ matrix.boards.iotlab.site }}+archi=${{ matrix.boards.iotlab.archi }})
           iotlab-experiment wait -i ${IOTLAB_EXP_ID}
-          echo "::set-env name=IOTLAB_EXP_ID::${IOTLAB_EXP_ID}"
+          echo "IOTLAB_EXP_ID=${IOTLAB_EXP_ID}" >> $GITHUB_ENV
       - name: Run compile_and_test_for_board.py on ${{ matrix.boards.riot }}
         run: |
           ${COMPILE_AND_TEST_FOR_BOARD} --report-xml . ${{ matrix.boards.riot }} \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix the "test-on-iotlab" GH action that is currently broken. See the [output of this job](https://github.com/RIOT-OS/RIOT/actions/runs/476450467)

```
Unable to process command '::set-env name=IOTLAB_EXP_ID::242632' successfully. 

The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ 
```

The proposed fix follows [this document](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable) to replace the deprecated use of `set-env` command.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check if the action runs as expected by performing a manual trigger.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
