### PR TITLE
dist/tools/uncrustify: annotate errors in Github Action

### DIFF
--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -115,6 +115,10 @@ run ./dist/tools/flake8/check.sh
 run ./dist/tools/headerguards/check.sh
 run ./dist/tools/buildsystem_sanity_check/check.sh
 run ./dist/tools/codespell/check.sh
-run ./dist/tools/uncrustify/uncrustify.sh --check
+if [ -z "${GITHUB_RUN_ID}" ]; then
+    run ./dist/tools/uncrustify/uncrustify.sh --check
+else
+    run ./dist/tools/uncrustify/uncrustify.sh
+fi
 
 exit $RESULT

--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -7,6 +7,7 @@ WHITELIST=$CURDIR/whitelist.txt
 BLACKLIST=$CURDIR/blacklist.txt
 
 . "$RIOTBASE"/dist/tools/ci/changed_files.sh
+. "$RIOTBASE"/dist/tools/ci/github_annotate.sh
 
 # only consider whitelisted stuff, then filter out blacklist
 # note: this also applies changed_files' default filter
@@ -28,6 +29,13 @@ check () {
     echo "All files are uncrustified!"
 }
 
+_annotate_diff() {
+    if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
+        MSG="Uncrustify proposes the following patch:\n\n$3"
+        github_annotate_error "$1" "$2" "${MSG}"
+    fi
+}
+
 exec_uncrustify () {
     if [ "$(git diff HEAD)" ] ; then
         echo "Please commit all changes before running uncrustify.sh"
@@ -37,10 +45,48 @@ exec_uncrustify () {
     do
         uncrustify -c "$UNCRUSTIFY_CFG" --no-backup "$RIOTBASE/$F"
     done
+    if github_annotate_is_on; then
+        DIFF=""
+        DIFFFILE=""
+        DIFFLINE=""
+        git diff HEAD | {
+            # see https://stackoverflow.com/a/30064493/11921757 for why we
+            # use a sub shell here
+            while read line; do
+                # parse beginning of new diff
+                if echo "$line" | grep -q '^--- .\+$'; then
+                    _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
+                    DIFF="$line"
+                    DIFFFILE=$(echo "$line" | sed 's/^--- \(.\+\)$/\1/g')
+                    DIFFLINE=""
+                # we are in a diff currently
+                elif [ -n "$DIFF" ]; then
+                    # grep first line number of diff including offset to
+                    # comment _under_ diff
+                    if echo "$line" | \
+                       grep -q "@@ -[0-9]\+\(,[0-9]\+\)\? +[0-9]\+\(,[0-9]\+\)\? @@"
+                       then
+                       # treat hunk as new diff so it is at the corresponding line
+                       if [ -n "${DIFFLINE}" ]; then
+                           _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
+                           DIFF="--- $DIFFFILE\n+++ $DIFFFILE"
+                       fi
+                       DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
+                    fi
+                    DIFF="$DIFF\n$line"
+                fi
+            done
+            _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
+        }
+    else
+        echo "$OUT"
+    fi
 }
 
 if [ "$1" == "--check" ] ; then
     check
 else
+    github_annotate_setup
     exec_uncrustify
+    github_annotate_teardown
 fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides Github annotation support for the `uncrustify` check.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided a test commit that will cause some annotations.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but the check-script adaptation is similar to #15746 and #15747 as all generate patches.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
