### PR TITLE
dist/tools/headerguards: fix annotation for multiple patches per file

### DIFF
--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -65,6 +65,11 @@ _headercheck() {
                         if echo "$line" | \
                            grep -q "@@ -[0-9]\+\(,[0-9]\+\)\? +[0-9]\+\(,[0-9]\+\)\? @@"
                            then
+                           # treat hunk as new diff so it is at the corresponding line
+                           if [ -n "${DIFFLINE}" ]; then
+                               _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
+                               DIFF="--- $DIFFFILE\n+++ $DIFFFILE"
+                           fi
                            DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
                         fi
                         DIFF="$DIFF\n$line"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes a problem in the annotation generation for the `headerguard` check where multiple patches in a file are only shown as one annotation.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided a test commit that should now generate _two_ annotations instead of one.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #15746.
See https://github.com/RIOT-OS/RIOT/pull/15747#issuecomment-758662022 ff.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
