### PR TITLE
tests/usbus_hid: uncrustify and cleanup Makefile

### DIFF
--- a/tests/usbus_hid/Makefile
+++ b/tests/usbus_hid/Makefile
@@ -6,7 +6,7 @@ USEMODULE += usbus_hid
 
 DISABLE_MODULE += auto_init_usbus
 
-USB_VID ?= ${USB_VID_TESTING}
-USB_PID ?= ${USB_PID_TESTING}
+USB_VID ?= $(USB_VID_TESTING)
+USB_PID ?= $(USB_PID_TESTING)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/usbus_hid/main.c
+++ b/tests/usbus_hid/main.c
@@ -24,62 +24,66 @@
 #include "usb/usbus/hid.h"
 
 /*
-this descriptor is used, because the basic usb_hid interface was developed in
-conjunction with FIDO2. Descriptor is taken from CTAP2 specification
-(version 20190130) section 8.1.8.2
-*/
+   this descriptor is used, because the basic usb_hid interface was developed in
+   conjunction with FIDO2. Descriptor is taken from CTAP2 specification
+   (version 20190130) section 8.1.8.2
+ */
 static uint8_t report_desc_ctap[] = {
-  0x06, 0xD0, 0xF1, /* HID_UsagePage ( FIDO_USAGE_PAGE ) */
-  0x09, 0x01,       /* HID_Usage ( FIDO_USAGE_CTAPHID ) */
-  0xA1, 0x01,       /* HID_Collection ( HID_Application ) */
-  0x09, 0x20,       /* HID_Usage ( FIDO_USAGE_DATA_IN ) */
-  0x15, 0x00,       /* HID_LogicalMin ( 0 ) */
-  0x26, 0xFF, 0x00, /* HID_LogicalMaxS ( 0xff ) */
-  0x75, 0x08,       /* HID_ReportSize ( 8 ) */
-  0x95, 0x40,       /* HID_ReportCount ( HID_INPUT_REPORT_BYTES ) */
-  0x81, 0x02,       /* HID_Input ( HID_Data | HID_Absolute | HID_Variable ) */
-  0x09, 0x21,       /* HID_Usage ( FIDO_USAGE_DATA_OUT ) */
-  0x15, 0x00,       /* HID_LogicalMin ( 0 ) */
-  0x26, 0xFF, 0x00, /* HID_LogicalMaxS ( 0xff ) */
-  0x75, 0x08,       /* HID_ReportSize ( 8 ) */
-  0x95, 0x40,       /* HID_ReportCount ( HID_OUTPUT_REPORT_BYTES ) */
-  0x91, 0x02,       /* HID_Output ( HID_Data | HID_Absolute | HID_Variable ) */
-  0xC0,             /* HID_EndCollection */
+    0x06, 0xD0, 0xF1,   /* HID_UsagePage ( FIDO_USAGE_PAGE ) */
+    0x09, 0x01,         /* HID_Usage ( FIDO_USAGE_CTAPHID ) */
+    0xA1, 0x01,         /* HID_Collection ( HID_Application ) */
+    0x09, 0x20,         /* HID_Usage ( FIDO_USAGE_DATA_IN ) */
+    0x15, 0x00,         /* HID_LogicalMin ( 0 ) */
+    0x26, 0xFF, 0x00,   /* HID_LogicalMaxS ( 0xff ) */
+    0x75, 0x08,         /* HID_ReportSize ( 8 ) */
+    0x95, 0x40,         /* HID_ReportCount ( HID_INPUT_REPORT_BYTES ) */
+    0x81, 0x02,         /* HID_Input ( HID_Data | HID_Absolute | HID_Variable ) */
+    0x09, 0x21,         /* HID_Usage ( FIDO_USAGE_DATA_OUT ) */
+    0x15, 0x00,         /* HID_LogicalMin ( 0 ) */
+    0x26, 0xFF, 0x00,   /* HID_LogicalMaxS ( 0xff ) */
+    0x75, 0x08,         /* HID_ReportSize ( 8 ) */
+    0x95, 0x40,         /* HID_ReportCount ( HID_OUTPUT_REPORT_BYTES ) */
+    0x91, 0x02,         /* HID_Output ( HID_Data | HID_Absolute | HID_Variable ) */
+    0xC0,               /* HID_EndCollection */
 };
 
 static usbus_t usbus;
 static char _stack[USBUS_STACKSIZE];
 
-void usb_hid_io_init(usbus_t* usbus, uint8_t* report_desc,
+void usb_hid_io_init(usbus_t *usbus, uint8_t *report_desc,
                      size_t report_desc_size);
-ssize_t usb_hid_io_read(void* buffer, size_t len);
+ssize_t usb_hid_io_read(void *buffer, size_t len);
 
 void init(void)
 {
-  usbdev_t *usbdev = usbdev_get_ctx(0);
-  usbus_init(&usbus, usbdev);
+    usbdev_t *usbdev = usbdev_get_ctx(0);
 
-  usb_hid_io_init(&usbus, report_desc_ctap, sizeof(report_desc_ctap));
+    usbus_init(&usbus, usbdev);
 
-  usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus);
+    usb_hid_io_init(&usbus, report_desc_ctap, sizeof(report_desc_ctap));
+
+    usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus);
 }
 
 int main(void)
 {
-  /* sleep to wait for Pyterm attaching in order to see puts messages */
-  xtimer_sleep(3);
-  init();
-  puts("RIOT USB HID echo test");
-  puts("Write input to the hidraw device under /dev/hidrawX, and see if it gets echoed here");
+    /* sleep to wait for Pyterm attaching in order to see puts messages */
+    xtimer_sleep(3);
+    init();
+    puts("RIOT USB HID echo test");
+    puts(
+        "Write input to the hidraw device under /dev/hidrawX, and see if it gets echoed here");
 
-  uint8_t buffer[CONFIG_USBUS_HID_INTERRUPT_EP_SIZE];
-  for (;;) {
-    ssize_t len = usb_hid_io_read(buffer, CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
+    uint8_t buffer[CONFIG_USBUS_HID_INTERRUPT_EP_SIZE];
 
-    printf("Msg received via USB HID: ");
-    for (int i = 0; i < len; i++)  {
-      putc(buffer[i], stdout);
+    for (;;) {
+        ssize_t len =
+            usb_hid_io_read(buffer, CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
+
+        printf("Msg received via USB HID: ");
+        for (int i = 0; i < len; i++) {
+            putc(buffer[i], stdout);
+        }
+        printf("\n");
     }
-    printf("\n");
-  }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is small cleanup if the `tests/usbus_hid` application:
- main.c is uncrustified: among other things, the indentation is using 2 spaces instead of 4
- in the Makefile, USB variables are accessed using `${var}` instead of `$(var)`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Should not change from a functional point of view so a green CI should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Out of curiosity, I had a look at #14629 and noticed that.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
