### PR TITLE
sys/net/gnrc: fix in-band signaling of no RSSI

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -163,8 +163,6 @@ static gnrc_pktsnip_t *gnrc_nrfmin_recv(gnrc_netif_t *dev)
     if (nrfmin->dst_addr == NRFMIN_ADDR_BCAST) {
         netif->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
     }
-    netif->lqi = 0;
-    netif->rssi = 0;
     gnrc_netif_hdr_set_netif(netif, dev);
     pkt_snip->type = nrfmin->proto;
 

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -47,6 +47,19 @@ extern "C" {
 #define GNRC_NETIF_HDR_L2ADDR_PRINT_LEN (GNRC_NETIF_HDR_L2ADDR_MAX_LEN * 3)
 
 /**
+ * @brief   Special value to indicate that no RSSI value is present
+ *
+ * See @ref gnrc_netif_hdr_t::rssi
+ */
+#define GNRC_NETIF_HDR_NO_RSSI          (INT16_MIN)
+/**
+ * @brief   Special value to indicate that no LQI value is present
+ *
+ * See @ref gnrc_netif_hdr_t::lqi
+ */
+#define GNRC_NETIF_HDR_NO_LQI           (0)
+
+/**
  * @{
  * @name    Flags for the gnrc_netif_hdr_t
  */
@@ -114,8 +127,14 @@ typedef struct {
     uint8_t dst_l2addr_len;     /**< length of l2 destination address in byte */
     kernel_pid_t if_pid;        /**< PID of network interface */
     uint8_t flags;              /**< flags as defined above */
-    uint8_t lqi;                /**< lqi of received packet (optional) */
-    int16_t rssi;               /**< rssi of received packet in dBm (optional) */
+    /**
+     * @brief   LQI of received packet or @ref GNRC_NETIF_HDR_NO_LQI
+     */
+    uint8_t lqi;
+    /**
+     * @brief   RSSI of received packet or @ref GNRC_NETIF_HDR_NO_RSSI
+     */
+    int16_t rssi;
 #if IS_USED(MODULE_GNRC_NETIF_TIMESTAMP) || defined(DOXYGEN)
     /**
      * @brief   Timestamp of reception in nanoseconds since epoch
@@ -149,8 +168,8 @@ static inline void gnrc_netif_hdr_init(gnrc_netif_hdr_t *hdr, uint8_t src_l2addr
     hdr->src_l2addr_len = src_l2addr_len;
     hdr->dst_l2addr_len = dst_l2addr_len;
     hdr->if_pid = KERNEL_PID_UNDEF;
-    hdr->rssi = 0;
-    hdr->lqi = 0;
+    hdr->rssi = GNRC_NETIF_HDR_NO_RSSI;
+    hdr->lqi = GNRC_NETIF_HDR_NO_LQI;
     hdr->flags = 0;
 }
 

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -346,7 +346,7 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6,
     icmpv6_echo_t *icmpv6_hdr = icmpv6->data;
 
     kernel_pid_t if_pid = netif_hdr ? netif_hdr->if_pid : KERNEL_PID_UNDEF;
-    int16_t rssi = netif_hdr ? netif_hdr->rssi : 0;
+    int16_t rssi = netif_hdr ? netif_hdr->rssi : GNRC_NETIF_HDR_NO_RSSI;
 
     /* discard if too short */
     if (icmpv6->size < (data->datalen + sizeof(icmpv6_echo_t))) {
@@ -397,7 +397,7 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6,
                    from_str, if_pid, recv_seq, hoplimit);
 
         }
-        if (rssi) {
+        if (rssi != GNRC_NETIF_HDR_NO_RSSI) {
             printf(" rssi=%"PRId16" dBm", rssi);
         }
         if (data->datalen >= sizeof(uint32_t)) {


### PR DESCRIPTION
### Contribution description

Previously a value of 0 was used for the RSSI to signal that this value is not
present in `gnrc_netif_hdr_t`. However, an RSSI of 0 dBm is legal and even very
plausible data.

This commit defines `GNRC_NETIF_HDR_NO_RSSI` as `INT16_MIN`, which is below the
noise floor in the vacuum of outer space and hence impossible to receive.
For consistency, also GNRC_NETIF_HDR_NO_LQI is defined.

### Testing procedure

E.g. using `examples/gnrc_networking` the `ping6` command should still print correct RSSI values.

### Issues/PRs references

None