### PR TITLE
static_tests: enable shellcheck and annote its output

### DIFF
--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -10,7 +10,7 @@
 # directory for more details.
 #
 
-. $(dirname "$0")/github_annotate.sh
+. "$(dirname "${0}")"/github_annotate.sh
 
 declare -A DEPS
 
@@ -24,7 +24,7 @@ DEPS["./dist/tools/codespell/check.sh"]="codespell"
 DEPS["./dist/tools/uncrustify/uncrustify.sh"]="uncrustify"
 DEPS["./dist/tools/shellcheck/shellcheck.sh"]="shellcheck"
 
-if ! command -v git 2>&1 1>/dev/null; then
+if ! command -v git &>/dev/null; then
     echo -n "Required command 'git' for all static tests not found in PATH "
     print_warning
     set_result 1
@@ -61,7 +61,7 @@ set_result() {
 
 function run {
     for dep in ${DEPS["$1"]}; do
-        if ! command -v ${dep} 2>&1 1>/dev/null; then
+        if ! command -v ${dep} &>/dev/null; then
             echo -n "Required command '${dep}' for '$*' not found in PATH "
             print_warning
             set_result 1

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -22,6 +22,7 @@ DEPS["./dist/tools/coccinelle/check.sh"]="spatch"
 DEPS["./dist/tools/flake8/check.sh"]="python3 flake8"
 DEPS["./dist/tools/codespell/check.sh"]="codespell"
 DEPS["./dist/tools/uncrustify/uncrustify.sh"]="uncrustify"
+DEPS["./dist/tools/shellcheck/shellcheck.sh"]="shellcheck"
 
 if ! command -v git 2>&1 1>/dev/null; then
     echo -n "Required command 'git' for all static tests not found in PATH "
@@ -120,5 +121,6 @@ if [ -z "${GITHUB_RUN_ID}" ]; then
 else
     run ./dist/tools/uncrustify/uncrustify.sh
 fi
+ERROR_EXIT_CODE=0 run ./dist/tools/shellcheck/check.sh
 
 exit $RESULT

--- a/dist/tools/shellcheck/check.sh
+++ b/dist/tools/shellcheck/check.sh
@@ -36,11 +36,17 @@ ${SHELLCHECK_CMD} --version &> /dev/null || {
 
 ERRORS=$("${SHELLCHECK_CMD}" --format=gcc ${FILES})
 
+EXIT_CODE=0
+
 if [ -n "${ERRORS}" ]
 then
     printf "%s There are issues in the following shell scripts %s\n" "${CERROR}" "${CRESET}"
     printf "%s\n" "${ERRORS}"
-    exit 1
-else
-    exit 0
+    if [ -z "${ERROR_EXIT_CODE}" ]; then
+        EXIT_CODE=1
+    else
+        EXIT_CODE="${ERROR_EXIT_CODE}"
+    fi
 fi
+
+exit "${EXIT_CODE}"

--- a/dist/tools/shellcheck/check.sh
+++ b/dist/tools/shellcheck/check.sh
@@ -21,6 +21,7 @@ fi
 
 : "${RIOTTOOLS:=${PWD}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
+. "${RIOTTOOLS}"/ci/github_annotate.sh
 
 FILES=$(FILEREGEX='(.*\.sh$)' changed_files)
 
@@ -34,19 +35,41 @@ ${SHELLCHECK_CMD} --version &> /dev/null || {
     exit 1
 }
 
-ERRORS=$("${SHELLCHECK_CMD}" --format=gcc ${FILES})
+github_annotate_setup
+
+# shellcheck disable=SC2086
+# FILES is supposed to be split, so don't quote it
+ERRORS="$("${SHELLCHECK_CMD}" --format=gcc ${FILES})"
 
 EXIT_CODE=0
 
 if [ -n "${ERRORS}" ]
 then
-    printf "%s There are issues in the following shell scripts %s\n" "${CERROR}" "${CRESET}"
-    printf "%s\n" "${ERRORS}"
+    if github_annotate_is_on; then
+        echo "${ERRORS}" | while read -r error; do
+            FILENAME=$(echo "${error}" | cut -d: -f1)
+            LINENUM=$(echo "${error}" | cut -d: -f2)
+            SEVERITY=$(echo "${error}" | cut -d: -f4)
+            DETAILS=$(echo "${error}" | cut -d: -f5- |
+                      sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+            if echo "${SEVERITY}" | grep -q 'error'; then
+                github_annotate_error "${FILENAME}" "${LINENUM}" "${DETAILS}"
+            else
+                github_annotate_warning "${FILENAME}" "${LINENUM}" "${DETAILS}"
+            fi
+        done
+    else
+        printf "%s There are issues in the following shell scripts %s\n" \
+            "${CERROR}" "${CRESET}"
+        printf "%s\n" "${ERRORS}"
+    fi
     if [ -z "${ERROR_EXIT_CODE}" ]; then
         EXIT_CODE=1
     else
         EXIT_CODE="${ERROR_EXIT_CODE}"
     fi
 fi
+
+github_annotate_teardown
 
 exit "${EXIT_CODE}"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This enables the the `shellcheck` check in the static tests (without it erroring) and enables annotations for it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided a test commit (which reverts the fixes of shellcheck I fixed here) that will cause some annotations.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
