### PR TITLE
sys/net/gnrc/sock: cleanup & fix aux handling

### DIFF
--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -158,18 +158,13 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **buf_ctx,
         return -EPROTO;
     }
 #if IS_USED(MODULE_SOCK_AUX_LOCAL)
-    if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_LOCAL)) {
+    if (aux != NULL) {
         aux->flags &= ~(SOCK_AUX_GET_LOCAL);
     }
 #endif
 #if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
-    if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_TIMESTAMP)) {
-        /* check if network interface did provide a timestamp; this depends on
-         * hardware support. A timestamp of zero is used to indicate a missing
-         * timestamp */
-        if (aux->timestamp > 0) {
-            aux->flags &= ~SOCK_AUX_GET_TIMESTAMP;
-        }
+    if ((aux != NULL) && (_aux.flags & GNRC_SOCK_RECV_AUX_FLAG_TIMESTAMP)) {
+        aux->flags &= ~(SOCK_AUX_GET_TIMESTAMP);
     }
 #endif
     *data = pkt->data;

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -258,13 +258,8 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
     }
 #endif
 #if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
-    if ((aux != NULL) && (aux->flags & SOCK_AUX_GET_TIMESTAMP)) {
-        /* check if network interface did provide a timestamp; this depends on
-         * hardware support. A timestamp of zero is used to indicate a missing
-         * timestamp */
-        if (_aux.flags & GNRC_SOCK_RECV_AUX_FLAG_TIMESTAMP) {
-            aux->flags &= ~SOCK_AUX_GET_TIMESTAMP;
-        }
+    if ((aux != NULL) && (_aux.flags & GNRC_SOCK_RECV_AUX_FLAG_TIMESTAMP)) {
+        aux->flags &= ~SOCK_AUX_GET_TIMESTAMP;
     }
 #endif
     *data = pkt->data;

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -7,7 +7,7 @@ ifeq (1, $(AUX_LOCAL))
   USEMODULE += sock_aux_local
 endif
 
-ifeq (1, $(AUX_LOCAL))
+ifeq (1, $(AUX_TIMESTAMP))
   USEMODULE += sock_aux_timestamp
 endif
 

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -7,7 +7,7 @@ ifeq (1, $(AUX_LOCAL))
   USEMODULE += sock_aux_local
 endif
 
-ifeq (1, $(AUX_LOCAL))
+ifeq (1, $(AUX_TIMESTAMP))
   USEMODULE += sock_aux_timestamp
 endif
 


### PR DESCRIPTION
### Contribution description

The logic used to check whether the RX timestamp was provided in the GNRC
implementation of `sock_ip_recv_buf_aux()` is incorrect: It still uses in-band
signalling via a timestamp of zero, but a dedicated flag was added to allow for
timestamps of zero.

Additionally, it is not necessary to check if a bit is set only to clear it -
clearing it unconditionally is faster and smaller.

### Testing procedure

The tests `tests/gnrc_sock_ip` and `tests/gnrc_sock_udp` should still pass.

### Issues/PRs references

None