### PR TITLE
drivers/bmx280: add missing _release

### DIFF
--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -255,6 +255,7 @@ int bmx280_init(bmx280_t *dev, const bmx280_params_t *params)
     /* test the connection to the device by reading and verifying its chip ID */
     if (_read_reg(dev, BMX280_CHIP_ID_REG, &reg) != BMX280_OK) {
         DEBUG("[bmx280] error: unable to read chip ID from device\n");
+        _release(dev);
         return BMX280_ERR_NODEV;
     }
     if (reg != BMX280_CHIP_ID_VAL) {


### PR DESCRIPTION
### Contribution description
This PR fixes a bug where the BMx280 driver would not release the mutex on initialization.

### Testing procedure
I noticed this when `i2c_scan` blocked on acquiring the I2C mutex, on a board with `bmx280_i2c`, but without the sensor attached. Nonetheless, the fix is quite obvious.

### Issues/PRs references
None