### PR TITLE
cpu/efm32: fix i2c transfers

### DIFF
--- a/cpu/efm32/periph/i2c.c
+++ b/cpu/efm32/periph/i2c.c
@@ -101,9 +101,9 @@ void i2c_init(i2c_t dev)
     CMU_ClockEnable(cmuClock_HFPER, true);
     CMU_ClockEnable(i2c_config[dev].cmu, true);
 
-    /* configure the pins */
-    gpio_init(i2c_config[dev].scl_pin, GPIO_OD);
-    gpio_init(i2c_config[dev].sda_pin, GPIO_OD);
+    /* configure the pins with pull-up to not drive the lines low */
+    gpio_init(i2c_config[dev].scl_pin, GPIO_OD_PU);
+    gpio_init(i2c_config[dev].sda_pin, GPIO_OD_PU);
 
     /* ensure slave is in a known state, which it may not be after a reset */
     for (int i = 0; i < 9; i++) {


### PR DESCRIPTION
### Contribution description
This PR fixes the current state of the EFM32 I2C driver.

I was using `i2c_scan` until I noticed that the driver will block forever if no device is attached. The root cause of this is caused by the I2C transfer state 'internally' waiting for an ACK or NACK. Since it this would never happen, no interrupt was triggered and [this](https://github.com/RIOT-OS/RIOT/blob/master/cpu/efm32/periph/i2c.c#L68) would block forever.

Part of this problem is caused by `i2c_init` not initializing the pins correctly. They should be open drain with pull-up, based on a [kit driver](https://siliconlabs.github.io/Gecko_SDK_Doc/efm32g/html/i2cspm_8c_source.html#l00039). 4e7df52 fixes this, which will make the problem above less likely.

Still, a rouge sensor could trigger the problem above without ed88c59. This commit removes the `cortexm_sleep_until_event` so that it will just busy-loop, guaranteeing that this loop will finish. This will be less-efficient, but without something like the [ESP32](https://github.com/RIOT-OS/RIOT/blob/master/cpu/esp32/periph/i2c_hw.c#L727-L728) does, I don't have a proper solution.

### Testing procedure
Without this PR, `USEMODULE=i2c_scan make -C examples/default -j16 flash` for a board without I2C devices on-board (e.g. (STK3200, STK3600). 

Without this PR, it will block:

```
> i2c_scan 0
Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
```

With this PR, the output looks like:

```
> i2c_scan 0
Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 R R R R R R R R R R R R R R - -
0x10 - - - - - - - - - - - - - - - -
0x20 - - - - - - - - - - - - - - - -
0x30 - - - - - - - - - - - - - - - -
0x40 - - - - - - - - - - - - - - - -
0x50 - - - - - - - - - - - - - - - -
0x60 - - - - - - - - - - - - - - - -
0x70 - - - - - - - - R R R R R R R R
```

Without 4e7df52, the output would be:

```
> i2c_scan 0
Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 R R R R R R R R R R R R R R E E
0x10 E E E E E E E E E E E E E E E E
0x20 E E E E E E E E E E E E E E E E
0x30 E E E E E E E E E E E E E E E E
0x40 E E E E E E E E E E E E E E E E
0x50 E E E E E E E E E E E E E E E E
0x60 E E E E E E E E E E E E E E E E
0x70 E E E E E E E E R R R R R R R R
```

A board with sensors will return the following (e.g. SLTB001a):

```
> i2c_scan 0
Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 R R R R R R R R R R R R R R - -
0x10 - - - - - - - - - - - - - - - -
0x20 - - - - - - - - - - - - - - - -
0x30 X - - - - - - - - - - - - - - -
0x40 X - - - - - - - - - - - - - - -
0x50 - - - - - X - - - - X - - - - -
0x60 - - - - - - - - - - - - - - - -
0x70 - - - - - - - X R R R R R R R R
```

### Issues/PRs references
None