### PR TITLE
nrf802154/hal: fix unwanted emissions at the end of ACK frame

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -93,6 +93,13 @@ static int _request_transmit(ieee802154_dev_t *dev)
 
     if (cc2538_csma_ca_retries < 0) {
         RFCORE_SFR_RFST = ISTXON;
+        /* The CPU Ctrl mask is used here to indicate whether the radio is being
+         * controlled by the CPU or the CSP Strobe Processor.
+         * We set this to 1 in order to indicate that the CSP is not used and
+         * thus, that the @ref ieee802154_radio_ops::confirm_transmit should
+         * return 0 immediately after the TXDONE event
+         */
+        RFCORE_XREG_CSPCTRL |= CC2538_CSP_MCU_CTRL_MASK;
     }
     else {
         cc2538_cca = false;

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -548,6 +548,11 @@ void isr_radio(void)
             break;
         case STATE_ACK:
             _state = STATE_IDLE;
+
+            /* We disable the radio to avoid unwanted emmissions (see ERRATA
+             * ID 204, "Switching between TX and RX causes unwanted emissions")
+             */
+            _disable();
             DEBUG("[nrf52840] TX ACK done.")
             _set_ifs_timer(false);
             break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This commit turns off the transceiver immediately after sending an ACK frame in order to avoid unwanted emissions (see [ERRATA ID 204, page 25](https://infocenter.nordicsemi.com/pdf/nRF52840_Rev_2_Errata_v1.3.pdf)).
When the radio stays in TX_ON without an explicit transition, the radio keeps sending a spurious signal for some milliseconds.


Check the following picture to see how this looks like (using the SDR, Y axis is RF power, X axis is time, first frame is the CC2538 and the second one is the ACK of the nrf802154)
![pic](https://user-images.githubusercontent.com/1260616/104578214-bba30300-565a-11eb-9545-f79a1eea2193.png)

And this is how it looks with this PR:
![img](https://user-images.githubusercontent.com/1260616/104578275-d2495a00-565a-11eb-8fdc-aa4017f62be1.png)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Hard to test without an SDR, but at least make sure that some ping stress tests still work ok.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
