### PR TITLE
uncrustify: use unified diff to generate GH annotation

### DIFF
--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -57,7 +57,8 @@ exec_uncrustify () {
                 if echo "$line" | grep -q '^--- .\+$'; then
                     _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
                     DIFF="$line"
-                    DIFFFILE=$(echo "$line" | sed 's/^--- \(.\+\)$/\1/g')
+                    DIFFFILE=$(echo "$line" |
+                        sed 's#^--- \([ab]/\)\?\(.\+\)$#\2#g')
                     DIFFLINE=""
                 # we are in a diff currently
                 elif [ -n "$DIFF" ]; then


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`git diff` creates diffs where the file name starts with `a/` or `b/` respectively. These are obviously not in path, so the Github annotations point to nowhere when the path is used without accounting for this.

This fixes the GH annotation parsing to account for that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I will provide a test commit to generate annotations. The annotations should now show up in the 'Files' tab as well.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #15748.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
