### PR TITLE
gcoap: remove deprecated gcoap_add_qstring

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -917,26 +917,6 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf);
 ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
                           size_t maxlen, coap_link_encoder_ctx_t *context);
 
-/**
- * @brief   Adds a single Uri-Query option to a CoAP request
- *
- * To add multiple Uri-Query options, simply call this function multiple times.
- * The Uri-Query options will be added in the order those calls.
- *
- * @deprecated  Will not be available after the 2020.10 release. Use
- * coap_opt_add_uri_query() instead.
- *
- * @param[out] pdu      The package that is being build
- * @param[in]  key      Key to add to the query string
- * @param[in]  val      Value to assign to @p key (may be NULL)
- *
- * @pre     ((pdu != NULL) && (key != NULL))
- *
- * @return  overall length of new query string
- * @return  -1 on error
- */
-int gcoap_add_qstring(coap_pkt_t *pdu, const char *key, const char *val);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1067,27 +1067,4 @@ ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
     return exp_size;
 }
 
-int gcoap_add_qstring(coap_pkt_t *pdu, const char *key, const char *val)
-{
-    char qs[CONFIG_NANOCOAP_QS_MAX];
-    size_t len = strlen(key);
-    size_t val_len = (val) ? (strlen(val) + 1) : 0;
-
-    /* test if the query string fits, account for the zero termination */
-    if ((len + val_len + 1) >= CONFIG_NANOCOAP_QS_MAX) {
-        return -1;
-    }
-
-    memcpy(&qs[0], key, len);
-    if (val) {
-        qs[len] = '=';
-        /* the `=` character was already counted in `val_len`, so subtract it here */
-        memcpy(&qs[len + 1], val, (val_len - 1));
-        len += val_len;
-    }
-    qs[len] = '\0';
-
-    return coap_opt_add_string(pdu, COAP_OPT_URI_QUERY, qs, '&');
-}
-
 /** @} */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This feature was marked to be deprecated after the release 2020.10.
Therefore this commit removes that feature.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I think compile tests should be enough.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
