### PR TITLE
ci: use riot/static-test-tools Docker image with static-tests and doc-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   doc-build:
     docker:
-      - image: riot/riotbuild
+      - image: riot/static-test-tools
     steps:
       - checkout
       - run: make doc

--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -26,8 +26,8 @@ jobs:
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --no-tags
         fi
         git config apply.whitespace nowarn
-    - name: Fetch riot/riotbuild Docker image
-      run: docker pull riot/riotbuild:latest
+    - name: Fetch riot/static-test-tools Docker image
+      run: docker pull riot/static-test-tools:latest
     - name: Run static-tests
       run: |
         # Note: ${{ github.base_ref }} is empty when not in a PR
@@ -35,5 +35,5 @@ jobs:
           -e CI_BASE_BRANCH=${{ github.base_ref }}  \
           -e GITHUB_RUN_ID=${GITHUB_RUN_ID}         \
           -v $(pwd):/data/riotbuild                 \
-          riot/riotbuild:latest                     \
+          riot/static-test-tools:latest             \
           make static-test


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Following https://github.com/RIOT-OS/riotdocker/pull/127, I manually pushed a [riot/static-test-tools Docker image](https://hub.docker.com/repository/docker/riot/static-test-tools).
This PR is using it in replacement of `riot/riotbuild`. We should see a noticeable speed improvement because the new image, dedicated to static tests is less than 700MB and `riot/riotbuid` is more than 6GB.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Reuse the new Docker image organisation from https://github.com/RIOT-OS/riotdocker/pull/127

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
