### PR TITLE
ci/test-on-iotlab: exclude applications that require riotboot

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -75,7 +75,11 @@ jobs:
       # files generation
       DOCKER_ENVIRONMENT_CMDLINE: -e BUILD_FILES=\$$\(BINFILE\)
       COMPILE_AND_TEST_FOR_BOARD: ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
-      COMPILE_AND_TEST_ARGS: --with-test-only --jobs=2
+      COMPILE_AND_TEST_ARGS: --with-test-only --jobs=2 --report-xml
+      # Exclude applications that require the riotboot feature and providing a test
+      # because flashing at a specific offset is not (yet) supported on IoT-LAB
+      # so they will always fail because of that limitation
+      APPLICATIONS_EXCLUDE: examples/suit_update tests/riotboot
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -112,8 +116,9 @@ jobs:
           echo "IOTLAB_EXP_ID=${IOTLAB_EXP_ID}" >> $GITHUB_ENV
       - name: Run compile_and_test_for_board.py on ${{ matrix.boards.riot }}
         run: |
-          ${COMPILE_AND_TEST_FOR_BOARD} --report-xml . ${{ matrix.boards.riot }} \
-            results-${{ matrix.boards.riot }} ${COMPILE_AND_TEST_ARGS}
+          ${COMPILE_AND_TEST_FOR_BOARD} . ${{ matrix.boards.riot }} \
+            results-${{ matrix.boards.riot }} ${COMPILE_AND_TEST_ARGS} \
+            --applications-exclude="${APPLICATIONS_EXCLUDE}"
       - name: Stop IoT-LAB experiment
         if: always()
         run: iotlab-experiment stop -i ${IOTLAB_EXP_ID}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR excludes from the test-on-iotlab action the applications that require the riotboot feature and which provide a test. These applications cannot work yet on iot-lab (yet) because flashing on iot-lab at a given offset is not supported by the cli-tools.
As a temporary solution until this is fixed in the cli-tools, the examples/suit_update and tests/riotboot are excluded.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check that the application are skipped on a manually triggered job, see [this run with samr21-xpro on my local fork](https://github.com/aabadie/RIOT/runs/1696975477?check_suite_focus=true#step:10:3053)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
