### PR TITLE
gh/workflows/release-tests: add LoRaWAN secrets env variables

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -122,6 +122,10 @@ jobs:
           GITHUB_REPOSITORY=${GITHUB_REPOSITORY} \
           GITHUB_RUN_ID=${GITHUB_RUN_ID} \
           GITHUB_SERVER_URL=${GITHUB_SERVER_URL} \
+          LORAWAN_APP_KEY="${{ secrets.CI_TTN_APPKEY  }}" \
+          LORAWAN_NWK_SKEY="${{ secrets.CI_TTN_NWKSKEY_ABP  }}" \
+          LORAWAN_APP_SKEY="${{ secrets.CI_TTN_APPSKEY_ABP  }}" \
+          LORAWAN_DL_KEY="${{ secrets.CI_TTN_APPID_KEY  }}" \
           RIOTBASE=${RIOTBASE} \
           $(which tox) -- ${TOX_ARGS} -m "${{ matrix.pytest_mark }}"
     - name: junit2html and XML deploy


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This commit injects some LoRaWAN secrets into `tox` in order to avoid
exposing LoRaWAN keys when running RIOT-OS/Release-Specs#201

The secrets are already loaded.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I will try to run RIOT-OS/Release-Specs#201 pointing to this commit
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
RIOT-OS/Release-Specs#201
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
