### PR TITLE
uncrustify: Add fe310 cpu files to the whitelist

### DIFF
--- a/dist/tools/uncrustify/whitelist.txt
+++ b/dist/tools/uncrustify/whitelist.txt
@@ -1,5 +1,8 @@
 core/.*\.c
 core/include/.*\.h
+cpu/fe310/.*\.c
+cpu/fe310/include/.*\.h
+cpu/fe310/periph/.*\.c
 sys/ztimer/.*\.c
 sys/ztimer.h
 sys/include/ztimer/.*\.h


### PR DESCRIPTION
### Contribution description

And add the recently uncrustified fe310 CPU files to the uncrustify whitelist.

### Testing procedure

CI should remain all green

### Issues/PRs references

Follow-up to #15777 
