### PR TITLE
release-tests: fix artifact naming and steps cleanup for matrix build

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -100,6 +100,7 @@ jobs:
         fi
         docker pull riot/riotbuild:$DOCKER_VERSION
     - name: Create TAP interfaces
+      if: ${{ matrix.pytest_mark == 'not iotlab_creds' }}
       run: |
         sudo RIOT/dist/tools/tapsetup/tapsetup -c 11
     - name: Run release tests

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -134,11 +134,12 @@ jobs:
         else
           VER=$(git -C $GITHUB_WORKSPACE/RIOT rev-parse --short HEAD)
         fi
+        MARK=$(echo "${{ matrix.pytest_mark }}" | tr '[ _]' '-')
+        REPORT_XML=$GITHUB_WORKSPACE/Release-Specs/test-report.xml
+        REPORT_NAME=test-reports/test-report-$MARK-$VER-$DATE
         mkdir test-reports/
-        junit2html $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
-          test-reports/test-report-native-$VER-$DATE.html
-        cp $GITHUB_WORKSPACE/Release-Specs/test-report.xml \
-          test-reports/test-report-native-$VER-$DATE.xml
+        junit2html ${REPORT_XML} ${REPORT_NAME}.html
+        cp ${REPORT_XML} ${REPORT_NAME}.xml
     - uses: actions/upload-artifact@v2
       if: always()
       with:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Found this while helping @jia200x to trouble should a failed run of the release tests: When I moved the release tests to the matrix-based strategy, I forgot to rename the artifacts, so the generated XML and HTML files now both are named after `native`. This fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I guess one has to run the release tests :-/. But it _should_ also work when you abort them, as artifact uploading is always executed and the new names should at least be seen. 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #15637.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
