### PR TITLE
ztimer: add ztimer_is_set() to user API

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -350,6 +350,17 @@ void ztimer_handler(ztimer_clock_t *clock);
 void ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val);
 
 /**
+ * @brief   Check if a timer is currently active
+ *
+ * @param[in]   clock       ztimer clock to operate on
+ * @param[in]   timer       timer to check
+ *
+ * @return  > 0 if timer is active
+ * @return 0 if timer is not active
+ */
+unsigned ztimer_is_set(const ztimer_clock_t *clock, const ztimer_t *timer);
+
+/**
  * @brief   Remove a timer from a clock
  *
  * This will place @p timer in the timer targets queue for @p clock.

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -58,6 +58,15 @@ static unsigned _is_set(const ztimer_clock_t *clock, const ztimer_t *t)
     }
 }
 
+unsigned ztimer_is_set(const ztimer_clock_t *clock, const ztimer_t *timer)
+{
+    unsigned state = irq_disable();
+    unsigned res = _is_set(clock, timer);
+
+    irq_restore(state);
+    return res;
+}
+
 void ztimer_remove(ztimer_clock_t *clock, ztimer_t *timer)
 {
     unsigned state = irq_disable();

--- a/tests/ztimer_periodic/main.c
+++ b/tests/ztimer_periodic/main.c
@@ -70,6 +70,11 @@ int main(void)
 
     ztimer_periodic_start(&t);
 
+    if (!ztimer_is_set(ZTIMER_MSEC, &t.timer)) {
+        print_str("Test failed\n");
+        return 1;
+    }
+
     /* wait for periodic to trigger N times */
     mutex_lock(&_mutex);
 


### PR DESCRIPTION
### Contribution description
To improve the low power support I am currently porting NimBLE to use `ztimer` as RIOT timer backend. Mapping the `ztimer` API works mostly flawless, the only thing missing is a `is_set()` function. The current implementation uses an ugly hack by using xtimer internal struct members to do this check -> so for the improved port I'd like to have this less error prone :-)

This PR simply exposes `ztimer`s internal `_is_set()` function by wrapping it into a critical section inside a newly added `ztimer_is_set()` user API function. Should be pretty straight forward.

### Testing procedure
I added a call to the new `ztimer_is_set()` function in `tests/ztimer_periodic`. So simply run `tests/ztimer_periodic` on any platform -> it should succeed as expected.

### Issues/PRs references
none