### PR TITLE
sys/sema: add sema_get_value()

### DIFF
--- a/sys/include/sema.h
+++ b/sys/include/sema.h
@@ -98,6 +98,18 @@ void sema_create(sema_t *sema, unsigned int value);
 void sema_destroy(sema_t *sema);
 
 /**
+ * @brief   Get a semaphore's current value
+ *
+ * @param[in]  sema       A semaphore.
+ *
+ * @return  the current value of the semaphore
+ */
+static inline unsigned sema_get_value(const sema_t *sema)
+{
+    return sema->value;
+}
+
+/**
  * @brief Wait for a semaphore, blocking or non-blocking.
  *
  * @details For commit purposes you should probably use sema_wait(),

--- a/sys/posix/include/semaphore.h
+++ b/sys/posix/include/semaphore.h
@@ -283,7 +283,7 @@ static inline int sem_trywait(sem_t *sem)
 static inline int sem_getvalue(sem_t *sem, int *sval)
 {
     if (sem != NULL) {
-        *sval = (int)sem->value;
+        *sval = (int)sema_get_value((sema_t *)sem);
         return 0;
     }
     errno = EINVAL;


### PR DESCRIPTION
### Contribution description
I'd like to optimize the NimBLE port by moving its mapping from the rather large `posix_semaphore` to use RIOTs native semaphore implementation (`sys/sema`). Everyhting is quite straight forward, expect the missing `get_value()` function. So this PR adds this function to the `sys/sema` module.

### Testing procedure
Build test should do.

### Issues/PRs references
none