### PR TITLE
sys/sema: allow to use ztimer and/or xtimer

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -626,10 +626,6 @@ ifneq (,$(filter posix_inet,$(USEMODULE)))
   USEMODULE += posix_headers
 endif
 
-ifneq (,$(filter sema,$(USEMODULE)))
-  USEMODULE += xtimer
-endif
-
 ifneq (,$(filter sema_inv,$(USEMODULE)))
   USEMODULE += atomic_utils
 endif

--- a/tests/sema/Makefile
+++ b/tests/sema/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += sema
+USEMODULE += xtimer
+USEMODULE += ztimer_usec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sema/main.c
+++ b/tests/sema/main.c
@@ -25,7 +25,6 @@
 #include "msg.h"
 #include "sema.h"
 #include "thread.h"
-#include "xtimer.h"
 
 #define TEST_TIME_US 1000
 #define TEST_ITERATIONS 4
@@ -77,6 +76,11 @@ int main(void)
 
     if (sema_wait_timed(&test_sema, TEST_TIME_US) != -ETIMEDOUT) {
         printf("MAIN ERROR: sema_wait_timed()");
+        return 1;
+    }
+    if (sema_wait_timed_ztimer(&test_sema, ZTIMER_USEC, TEST_TIME_US)
+        != -ETIMEDOUT) {
+        printf("MAIN_ERROR: sema_wait_timed_ztimer()");
         return 1;
     }
 


### PR DESCRIPTION
### Contribution description
On the winding road to get NimBLE running without including `xtimer` or `periph_timer` in the build, the `sema` and `event` modules are the last ones that pull in these dependencies currently. So I am desperately looking for way to free these modules of `xtimer` deps.

The code in this PR, still very prototypic, illustrates one possible solution to decouple the `sema` module from `xtimer` and at the same time adding `ztimer` support. However, this might not be the most elegant solution, so I am happy to hear any alternative ideas on this task!

Regarding what IMO should be possible:
- per default, build with an untouched API, so no existing code ever breaks
- allow to enable the `ztimer` API in parallel to the existing API -> allows for mixing legacy code with new ztimer code
- allow to disable the `xtimer` support and use the `ztimer` support only -> allows to throw out `xtimer`


### Testing procedure
not in focus, yet.

### Issues/PRs references
none
