### PR TITLE
drivers/mcp2515: move dependencies to own Makefile.dep

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -72,11 +72,6 @@ ifneq (,$(filter ltc4150_%,$(USEMODULE)))
   USEMODULE += ltc4150
 endif
 
-ifneq (,$(filter mcp2515,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio periph_spi periph_gpio_irq
-endif
-
 ifneq (,$(filter mhz19_%,$(USEMODULE)))
   USEMODULE += mhz19
 endif

--- a/drivers/mcp2515/Makefile.dep
+++ b/drivers/mcp2515/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio periph_spi periph_gpio_irq


### PR DESCRIPTION

### Contribution description

This PR moves the driver dependies to its own makefile to remove clutter from `driver/Makefile.dep`

### Testing procedure

`make -C tests/candev/ info-modules` remains unchanged.

### Issues/PRs references

Found when looking at #15607