### PR TITLE
makefiles/docker.inc.mk: add and version_is_greater_or_equal for jobs check

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -109,9 +109,9 @@ ETC_LOCALTIME = $(realpath /etc/localtime)
 # $MAKEFLAGS, only that parallelism is requested. So only -j, even if
 # something like -j3 is specified. This can be unexpected and dangerous
 # in older make so don't enable parallelism if $MAKE_VERSION < 4.2
-MAKE_JOBS_NEEDS = 4.1.999
+MAKE_JOBS_NEEDS = 4.2.0
 MAKE_VERSION_OK = $(call memoized,MAKE_VERSION_OK,$(call \
-    version_is_greater,$(MAKE_VERSION),$(MAKE_JOBS_NEEDS)))
+    version_is_greater_or_equal,$(MAKE_VERSION),$(MAKE_JOBS_NEEDS)))
 DOCKER_MAKE_JOBS = $(if $(MAKE_VERSION_OK),$(filter -j%,$(MAKEFLAGS)),)
 DOCKER_MAKE_ARGS += $(DOCKER_MAKE_JOBS)
 

--- a/makefiles/utils/strings.mk
+++ b/makefiles/utils/strings.mk
@@ -33,3 +33,16 @@ _is_greater = $(if $(filter $1,$(firstword $(sort $1 $2))),,1)
 #   Return 1 if $1 is greater than $2, nothing otherwise
 version_is_greater = $(call _is_greater,$(call _padded_version,$1),\
                         $(call _padded_version,$2))
+
+# Checks if version $1 is equal to version $2
+#   $1,$2: version to check, '.' separated version 'major.minor.patch'
+#   Return 1 if $1 equal to $2, nothing otherwise
+_is_equal = $(if $(and $(findstring $(1),$(2)),$(findstring $(2),$(1))),1,)
+
+# Checks if version $1 is greater or equal than version $2
+#   $1: version to check, '.' separated version 'major.minor.patch'
+#   $2: minimum version, '.' separated version 'major.minor.patch'
+#   Return 1 if $1 is greater or equal than $2, nothing otherwise
+version_is_greater_or_equal = $(or \
+    $(call _is_greater,$(call _padded_version,$1),$(call _padded_version,$2)),\
+    $(call _is_equal,$(call _padded_version,$1),$(call _padded_version,$2)))

--- a/makefiles/utils/test-strings.mk
+++ b/makefiles/utils/test-strings.mk
@@ -18,6 +18,7 @@ TEST_VERSION_1 = 4.1
 TEST_VERSION_2 = 3.10
 TEST_VERSION_3 = 4.2.3
 TEST_VERSION_4 = 4.19.3
+TEST_VERSION_5 = 4.1.0
 
 test-version_is_greater:
 	$(Q)bash -c 'test 1 = "$(call version_is_greater,$(TEST_VERSION_1),$(TEST_VERSION_2))" || { echo ERROR: "$(TEST_VERSION_2)" \< "$(TEST_VERSION_1)"; exit 1; }'
@@ -25,3 +26,12 @@ test-version_is_greater:
 	$(Q)bash -c 'test 1 = "$(call version_is_greater,$(TEST_VERSION_4),$(TEST_VERSION_3))" || { echo ERROR: "$(TEST_VERSION_3)" \< "$(TEST_VERSION_4)"; exit 1; }'
 	$(Q)bash -c 'test "" = "$(call version_is_greater,$(TEST_VERSION_3),$(TEST_VERSION_4))" || { echo ERROR: Test should fail, "$(TEST_VERSION_4)" is not \< "$(TEST_VERSION_3)"; exit 1; }'
 	$(Q)bash -c 'test "" = "$(call version_is_greater,$(TEST_VERSION_1),$(TEST_VERSION_4))" || { echo ERROR: Test should fail, "$(TEST_VERSION_1)" is not \< "$(TEST_VERSION_4)"; exit 1; }'
+
+test-version_is_greater_or_equal:
+	$(Q)bash -c 'test 1 = "$(call version_is_greater_or_equal,$(TEST_VERSION_1),$(TEST_VERSION_5))" || { echo ERROR: "$(TEST_VERSION_5)" == "$(TEST_VERSION_1)"; exit 1; }'
+	$(Q)bash -c 'test 1 = "$(call version_is_greater_or_equal,$(TEST_VERSION_1),$(TEST_VERSION_1))" || { echo ERROR: "$(TEST_VERSION_1)" == "$(TEST_VERSION_1)"; exit 1; }'
+	$(Q)bash -c 'test 1 = "$(call version_is_greater_or_equal,$(TEST_VERSION_3),$(TEST_VERSION_3))" || { echo ERROR: "$(TEST_VERSION_3)" == "$(TEST_VERSION_3)"; exit 1; }'
+	$(Q)bash -c 'test 1 = "$(call version_is_greater_or_equal,$(TEST_VERSION_3),$(TEST_VERSION_1))" || { echo ERROR: "$(TEST_VERSION_1)" \< "$(TEST_VERSION_3)"; exit 1; }'
+	$(Q)bash -c 'test 1 = "$(call version_is_greater_or_equal,$(TEST_VERSION_4),$(TEST_VERSION_3))" || { echo ERROR: "$(TEST_VERSION_3)" \< "$(TEST_VERSION_4)"; exit 1; }'
+	$(Q)bash -c 'test "" = "$(call version_is_greater_or_equal,$(TEST_VERSION_3),$(TEST_VERSION_4))" || { echo ERROR: Test should fail, "$(TEST_VERSION_4)" is not \< "$(TEST_VERSION_3)"; exit 1; }'
+	$(Q)bash -c 'test "" = "$(call version_is_greater_or_equal,$(TEST_VERSION_1),$(TEST_VERSION_4))" || { echo ERROR: Test should fail, "$(TEST_VERSION_1)" is not \< "$(TEST_VERSION_4)"; exit 1; }'

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -23,6 +23,7 @@ COMPILE_TESTS += test-lowercase
 COMPILE_TESTS += test-uppercase
 COMPILE_TESTS += test-uppercase_and_underscore
 COMPILE_TESTS += test-version_is_greater
+COMPILE_TESTS += test-version_is_greater_or_equal
 
 # Tests will be run both in the host machine and in `docker`
 all: build-system-utils-tests
@@ -55,3 +56,6 @@ test-uppercase_and_underscore:
 
 test-version_is_greater:
 	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-version_is_greater)
+
+test-version_is_greater_or_equal:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-strings.mk test-version_is_greater_or_equal)


### PR DESCRIPTION
### Contribution description

Follow up to https://github.com/RIOT-OS/RIOT/pull/15196, add and use a `is_version_equal_or_greater` for improved readability.

### Testing procedure

**Force a version match**

- Equal version: `BUILD_IN_DOCKER=1 make -C examples/hello-world/ all -j4 MAKE_VERSION=4.2`

```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/home/francisco/workspace/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make     -j4 all
```

- Lower version: `BUILD_IN_DOCKER=1 make -C examples/hello-world/ all -j4 MAKE_VERSION=4.1.1`
```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/home/francisco/workspace/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make      all
```

- Higher vesrion: `BUILD_IN_DOCKER=1 make -C examples/hello-world/ all -j4 MAKE_VERSION=4.3`
```
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/home/francisco/workspace/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make     -j4 all
```

### Issues/PRs references

Follow up on https://github.com/RIOT-OS/RIOT/pull/15196