### PR TITLE
pkg/monocypher: bump to version 3.1.2

### DIFF
--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=monocypher
 PKG_URL=https://github.com/LoupVaillant/Monocypher
-PKG_VERSION=ff334e288a667c5cd8500c04d1e2ebd601b9f215
+PKG_VERSION=baca5d31259c598540e4d1284bc8d8f793abf83a # v3.1.2
 PKG_LICENSE=CC-0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Simple version bump of Monocypher.

### Testing procedure

Run the test :)

### Issues/PRs references

None