### PR TITLE
cpu/cortexm_common: Do not use SVC for cpu_switch_context_exit

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -283,15 +283,10 @@ void *thread_isr_stack_start(void)
 
 void NORETURN cpu_switch_context_exit(void)
 {
-    /* enable IRQs to make sure the SVC interrupt is reachable */
+    /* enable IRQs to make sure the PENDSV interrupt is reachable */
     irq_enable();
-    /* trigger the SVC interrupt */
-    __asm__ volatile (
-        "svc    #1                            \n"
-        : /* no outputs */
-        : /* no inputs */
-        : /* no clobbers */
-    );
+
+    thread_yield_higher();
 
     UNREACHABLE();
 }

--- a/tests/driver_sdp3x/Makefile.ci
+++ b/tests/driver_sdp3x/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l011k4 \
     samd10-xmini \
+    stk3200 \
     #


### PR DESCRIPTION

### Contribution description

Directly use the pendsv interrupt instead of chaining through the SVC
interrupt

### Testing procedure

run the thread tests on a cortex-m board, mainly `tests/thread_exit`

### Issues/PRs references

None