### PR TITLE
net/skald: Update Kconfig implementation

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -101,6 +101,10 @@ ifneq (,$(filter riotboot,$(FEATURES_USED)))
   include $(RIOTBASE)/sys/riotboot/Makefile.include
 endif
 
+ifneq (,$(filter skald, $(USEMODULE)))
+  include $(RIOTBASE)/sys/net/ble/skald/Makefile.include
+endif
+
 ifneq (,$(filter sock_async_event,$(USEMODULE)))
   include $(RIOTBASE)/sys/net/sock/async/event/Makefile.include
 endif

--- a/sys/include/net/skald.h
+++ b/sys/include/net/skald.h
@@ -65,70 +65,13 @@ extern "C" {
 #ifndef CONFIG_SKALD_INTERVAL_MS
 #define CONFIG_SKALD_INTERVAL_MS        (1000U)
 #endif
-
-/**
- * @brief   Configure advertising channel 37
- *
- * Set CONFIG_ADV_CH_37_DISABLE to disable channel 37
- */
-#ifdef DOXYGEN
-#define CONFIG_ADV_CH_37_DISABLE
-#endif
-
-/**
- * @brief   Configure advertising channel 38
- *
- * Set CONFIG_ADV_CH_38_DISABLE to disable channel 38
- */
-#ifdef DOXYGEN
-#define CONFIG_ADV_CH_38_DISABLE
-#endif
-
-/**
- * @brief   Configure advertising channel 39
- *
- * Set CONFIG_ADV_CH_39_DISABLE to disable channel 39
- */
-#ifdef DOXYGEN
-#define CONFIG_ADV_CH_39_DISABLE
-#endif
 /** @} */
-
-/**
- * @brief   Define advertising channel 37 if @ref CONFIG_ADV_CH_37_DISABLE is
- *          not set
- */
-#if !defined(CONFIG_ADV_CH_37_DISABLE) || defined(DOXYGEN)
-#define ADV_CH_37 37,
-#else
-#define ADV_CH_37
-#endif
-
-/**
- * @brief   Define advertising channel 38 if @ref CONFIG_ADV_CH_38_DISABLE is
- *          not set
- */
-#if !defined(CONFIG_ADV_CH_38_DISABLE) || defined(DOXYGEN)
-#define ADV_CH_38 38,
-#else
-#define ADV_CH_38
-#endif
-
-/**
- * @brief   Define advertising channel 39 if @ref CONFIG_ADV_CH_39_DISABLE is
- *          not set
- */
-#if !defined(CONFIG_ADV_CH_39_DISABLE) || defined(DOXYGEN)
-#define ADV_CH_39 39
-#else
-#define ADV_CH_39
-#endif
 
 /**
  * @brief   List of advertising channels
  */
 #ifndef SKALD_ADV_CHAN
-#define SKALD_ADV_CHAN { ADV_CH_37 ADV_CH_38 ADV_CH_39 }
+#define SKALD_ADV_CHAN                 { 37, 38, 39 }
 #endif
 
 /**

--- a/sys/net/ble/skald/Kconfig
+++ b/sys/net/ble/skald/Kconfig
@@ -19,13 +19,11 @@ config SKALD_INTERVAL_MS
         Configure advertising interval in milliseconds. Default value is 1
         second which is 1000 milliseconds.
 
-config ADV_CH_37_DISABLE
-    bool "Disable advertising on channel 37"
-
-config ADV_CH_38_DISABLE
-    bool "Disable advertising on channel 38"
-
-config ADV_CH_39_DISABLE
-    bool "Disable advertising on channel 39"
+config SKALD_ADV_CHANNELS
+    string "Advertising channels"
+    default "37, 38, 39"
+    help
+        Configure advertising channels. Default advertising channels are 37, 38
+        and 39 which can be customised to upto 40 (0-39) channels.
 
 endif # KCONFIG_USEMODULE_SKALD

--- a/sys/net/ble/skald/Makefile.include
+++ b/sys/net/ble/skald/Makefile.include
@@ -1,0 +1,5 @@
+# Parse kconfig symbol `CONFIG_SKALD_ADV_CHANNELS` to an ordered list
+ifdef CONFIG_SKALD_ADV_CHANNELS
+  SKALD_ADV_CHAN := { $(shell echo $(CONFIG_SKALD_ADV_CHANNELS)) }
+  CFLAGS += -DSKALD_ADV_CHAN="$(SKALD_ADV_CHAN)"
+endif


### PR DESCRIPTION
### Contribution description

This PR fixes issue #15776 

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Build successful. Tested this [example](https://github.com/akshaim/RIOT/commit/1d13658430c0ad77de08429e174c292a2e16dc85). Results below

      Compiled binaries for nrf52dk

#### Default State:

##### Firmware Output

```
main(): This is RIOT! (Version: 2021.04-devel-177-ga9da09-Kconfig_skald_update)
CONFIG_SKALD_INTERVAL=(1 * (1000000LU))
3
37
38
39
```

#### Usage with menuconfig :


`make menuconfig`

#### Default values

```
main(): This is RIOT! (Version: 2021.04-devel-177-ga9da09-Kconfig_skald_update)
CONFIG_SKALD_INTERVAL=1000000
3
37
38
39
```
##### Macros Configured output

```
main(): This is RIOT! (Version: 2021.04-devel-177-ga9da09-Kconfig_skald_update)
CONFIG_SKALD_INTERVAL=1000000
5
37
10
11
38
39
```


**MACROS were successfully configured.**

### Issues/PRs references

#12888 
#14824
Fixes #15776