### PR TITLE
sys/saul: add saul_reg_find_type_and_name

### DIFF
--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -90,7 +90,7 @@ int saul_reg_add(saul_reg_t *dev);
 int saul_reg_rm(saul_reg_t *dev);
 
 /**
- * @brief   Find a device by it's position in the registry
+ * @brief   Find a device by its position in the registry
  *
  * @param[in] pos       position to look up
  *
@@ -100,9 +100,9 @@ int saul_reg_rm(saul_reg_t *dev);
 saul_reg_t *saul_reg_find_nth(int pos);
 
 /**
- * @brief   Find the first device of the given type in the registry
+ * @brief   Find the first device by its type in the registry
  *
- * @param[in] type      device type to look for
+ * @param[in] type      the device type to look for
  *
  * @return      pointer to the first device matching the given type
  * @return      NULL if no device of that type could be found
@@ -110,7 +110,7 @@ saul_reg_t *saul_reg_find_nth(int pos);
 saul_reg_t *saul_reg_find_type(uint8_t type);
 
 /**
- * @brief   Find a device by its name
+ * @brief   Find the first device by its name in the registry
  *
  * @param[in] name      the name to look for
  *
@@ -118,6 +118,17 @@ saul_reg_t *saul_reg_find_type(uint8_t type);
  * @return      NULL if no device with that name could be found
  */
 saul_reg_t *saul_reg_find_name(const char *name);
+
+/**
+ * @brief   Find the first device by its type and name in the registry
+ *
+ * @param[in] type      the device type to look for
+ * @param[in] name      the name to look for
+ *
+ * @return      pointer to the first device matching the given type and name
+ * @return      NULL if no device with that type and name could be found
+ */
+saul_reg_t *saul_reg_find_type_and_name(uint8_t type, const char *name);
 
 /**
  * @brief   Read data from the given device

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -113,6 +113,19 @@ saul_reg_t *saul_reg_find_name(const char *name)
     return NULL;
 }
 
+saul_reg_t *saul_reg_find_type_and_name(uint8_t type, const char *name)
+{
+    saul_reg_t *tmp = saul_reg;
+
+    while (tmp) {
+        if (tmp->driver->type == type && strcmp(tmp->name, name) == 0) {
+            return tmp;
+        }
+        tmp = tmp->next;
+    }
+    return NULL;
+}
+
 int saul_reg_read(saul_reg_t *dev, phydat_t *res)
 {
     if (dev == NULL) {


### PR DESCRIPTION
### Contribution description
This PR adds `saul_reg_find_type_and_name(type, name)`.

The existing `saul_reg_find_type(type)` and `saul_reg_find_name(name)` will only return the first registration found. Given that there can be multiple sensors/actuators of the same type and sensors/actuators register with the same name, the existing methods are not useful to find (for instance) a specific sensor or actuator.

The user could write its own method to find a registration, since `saul_reg` is exported as a global, but I think having this method as well won't hurt.

### Testing procedure
Unit tests have been provided.

### Issues/PRs references
None
