### PR TITLE
sys/evtimer: fix module dependencies

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1063,7 +1063,11 @@ ifneq (,$(filter ztimer% %ztimer,$(USEMODULE)))
 endif
 
 ifneq (,$(filter evtimer,$(USEMODULE)))
-  USEMODULE += xtimer
+  ifneq (,$(filter evtimer_on_ztimer,$(USEMODULE)))
+    USEMODULE += ztimer_msec
+  else
+    USEMODULE += xtimer
+  endif
 endif
 
 # handle xtimer's deps. Needs to be done *after* ztimer


### PR DESCRIPTION
### Contribution description
#13661 introduced the mapping of `evtimer` to `ztimer`. But the module dependencies were untouched. This PR resolves this by selected the correct timer backend depending on the use of the `evtimer_on_ztimer` module.

### Testing procedure
Run `tests/evtimer_msg` with `USEMODULE="evtimer_on_ztimer ztimer_usec"` or `USEMODULE="evtimer_on_ztimer ztimer_periph_rtt"` -> should run just fine.

EDIT
~~Also: run `make info-modules` when using the module configuration described above. The build should **not** contain `xtimer`~~
Also: run `make info-modules` for `tests/evtimer_mbox` using the module configuration described above. The build should **not** contain `xtimer`.

### Issues/PRs references
continuation of #13661