### PR TITLE
vera++: increase line length

### DIFF
--- a/dist/tools/vera++/profiles/riot_params.txt
+++ b/dist/tools/vera++/profiles/riot_params.txt
@@ -1,3 +1,2 @@
 max-line-length=100
-max-line-length-warn=80
 max-consecutive-empty-lines=1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The vera++ warning annotation about the 80 character max line length is cluttering the review process on certain files.

This PR is increasing the warning line length to 100 and max line length to 120.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The bogus commit should report annotations about maximum line length.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Should improve the situation in PR like #15718 (see https://github.com/RIOT-OS/RIOT/pull/15718/files#diff-1e6a82d8739f75dd4cddea9ecc25505ed042f3670ee5646dfc0c97dba2881662)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
