### PR TITLE
tests/posix_sleep: fix for invalid RTT configurations 

### DIFF
--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -274,6 +274,7 @@ static const i2c_conf_t i2c_config[] = {
 #ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
 #endif
+#define RTT_MIN_OFFSET      (10U)
 /** @} */
 
 /**

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -135,7 +135,7 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 #ifndef RTT_FREQUENCY
-#define RTT_FREQUENCY       (1)             /* in Hz */
+#define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)     /* in Hz */
 #endif
 /** @} */
 

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -117,7 +117,7 @@ static const spi_conf_t spi_config[] = {
  * @{
  */
 #ifndef RTT_FREQUENCY
-#define RTT_FREQUENCY       (1)             /* in Hz */
+#define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)     /* in Hz */
 #endif
 /** @} */
 

--- a/tests/posix_sleep/Makefile
+++ b/tests/posix_sleep/Makefile
@@ -2,8 +2,12 @@ include ../Makefile.tests_common
 
 USEMODULE += posix_sleep
 
-# Pull-in periph-rtt on board that provides this feature to switch to the RTT
-# backend of ztimer
-FEATURES_OPTIONAL += periph_rtt
+# These CPU families have a non configurable RTT of 1Hz, not enough for
+# ztimer_msec to run on periph_rtt
+ifeq (,$(filter efm32 kinetis,$(CPU)))
+  # Pull-in periph-rtt on boards that provide this feature to switch to
+  # the RTT backend of ztimer
+  FEATURES_OPTIONAL += periph_rtt
+endif
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

While testing https://github.com/RIOT-OS/Release-Specs/issues/202 I found that `posix_sleep` was failing because of invalid RTT configurations. The proper fix is different than the one proposed here, I think it would mean adding a feature, but for a realease backport this is IMO the smallest change.

### Testing procedure

Test on `iotab-m3` now passes same for any `kinetis` or `efm32` `BOARD`.
