### PR TITLE
static_tests: fix diff output

### DIFF
--- a/dist/tools/coccinelle/check.sh
+++ b/dist/tools/coccinelle/check.sh
@@ -31,9 +31,9 @@ _annotate_diff() {
     if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
         MSG="Coccinelle proposes the following patch:\n\n$3"
         if [ $COCCINELLE_WARNONLY -eq 0 ]; then
-            github_annotate_error "$1" "$2" "${MSG}"
+            IFS="${OLD_IFS}" github_annotate_error "$1" "$2" "${MSG}"
         else
-            github_annotate_warning "$1" "$2" "${MSG}"
+            IFS="${OLD_IFS}" github_annotate_warning "$1" "$2" "${MSG}"
         fi
     fi
 }
@@ -59,7 +59,9 @@ coccinelle_checkone() {
                 echo "$OUT" | {
                     # see https://stackoverflow.com/a/30064493/11921757 for why we
                     # use a sub shell here
-                    while read line; do
+                    OLD_IFS="${IFS}"    # store old separator to later restore it
+                    IFS=''  # keep leading and trailing spaces
+                    while read -r line; do
                         # parse beginning of new diff
                         if echo "$line" | grep -q '^--- .\+$'; then
                             _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
@@ -84,7 +86,7 @@ coccinelle_checkone() {
                                fi
                                DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
                             fi
-                            DIFF="$DIFF\n$line"
+                            DIFF="$DIFF\n${line//\\/\\\\}"
                         fi
                     done
                     _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -25,7 +25,7 @@ filter() {
 
 _annotate_diff() {
     if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
-        github_annotate_error "$1" "$2" "Wrong header guard format:\n\n$3"
+        IFS="${OLD_IFS}" github_annotate_error "$1" "$2" "Wrong header guard format:\n\n$3"
     fi
 }
 
@@ -40,7 +40,9 @@ _headercheck() {
             echo "$OUT" | {
                 # see https://stackoverflow.com/a/30064493/11921757 for why we
                 # use a sub shell here
-                while read line; do
+                OLD_IFS="$IFS"      # store old separator to later restore it
+                IFS=''  # keep leading and trailing spaces
+                while read -r line; do
                     # file has no or broken header guard
                     if echo "$line" | grep -q '^.*: no / broken header guard$'; then
                         # this output comes outside of a diff, so reset diff parser
@@ -71,7 +73,7 @@ _headercheck() {
                            fi
                            DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
                         fi
-                        DIFF="$DIFF\n$line"
+                        DIFF="$DIFF\n$(echo "${line}"| sed 's/\\/\\\\/g' )"
                     fi
                 done
                 _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"

--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -32,7 +32,7 @@ check () {
 _annotate_diff() {
     if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
         MSG="Uncrustify proposes the following patch:\n\n$3"
-        github_annotate_error "$1" "$2" "${MSG}"
+        IFS="${OLD_IFS}" github_annotate_error "$1" "$2" "${MSG}"
     fi
 }
 
@@ -52,7 +52,9 @@ exec_uncrustify () {
         git diff HEAD | {
             # see https://stackoverflow.com/a/30064493/11921757 for why we
             # use a sub shell here
-            while read line; do
+            OLD_IFS="$IFS"      # store old separator to later restore it
+            IFS=''  # keep leading and trailing spaces
+            while read -r line; do
                 # parse beginning of new diff
                 if echo "$line" | grep -q '^--- .\+$'; then
                     _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
@@ -74,7 +76,7 @@ exec_uncrustify () {
                        fi
                        DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
                     fi
-                    DIFF="$DIFF\n$line"
+                    DIFF="$DIFF\n${line//\\/\\\\}"
                 fi
             done
             _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In https://github.com/RIOT-OS/RIOT/pull/15739 I noticed, that the annotated diffs are a bit broken in their format.

![image](https://user-images.githubusercontent.com/675644/105032607-46b73b00-5a57-11eb-8b0d-6e2ce8e0b775.png)

This should fix that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided a test commit. The annotated patches should now be correct.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but discovered in #15739

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
