### PR TITLE
 tests/cpp11_condition_variable: reduce thread number

### DIFF
--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -6,7 +6,7 @@ CXXEXFLAGS += -std=c++11
 
 # nucleo-f303k8 doesn't have enough RAM to run the test so we reduce the stack
 # size for every thread
-ifneq (,$(filter nucleo-f303k8,$(BOARD)))
+ifneq (,$(filter nucleo-f303k8 nucleo-f334r8,$(BOARD)))
   CFLAGS += -DTHREAD_STACKSIZE_DEFAULT=512
 endif
 

--- a/tests/cpp11_condition_variable/main.cpp
+++ b/tests/cpp11_condition_variable/main.cpp
@@ -79,7 +79,6 @@ int main() {
     thread t1(waits);
     thread t2(waits);
     thread t3(waits);
-    thread t4(waits);
     thread([&m, &cv] {
              unique_lock<mutex> lk(m);
              cv.notify_all();
@@ -87,7 +86,6 @@ int main() {
     t1.join();
     t2.join();
     t3.join();
-    t4.join();
   }
   puts("Done\n");
 


### PR DESCRIPTION
### Contribution description

On small platforms the test is hard-faulting because of RAM, using one less thread makes it fit on more platforms and IMO does not impact the test coverage.

Otherwise I can add the `BOARD` (`nucleo-f334r8`) to `Makefile.ci`

### Testing procedure

Test now passes

`BOARD=nucleo-f334r8 make -C tests/cpp11_condition_variable/ flash test -j3`

```
main(): This is RIOT! (Version: 2021.04-devel-67-g6d9af0b-pr_cpp11_condition_variable_test)

************ C++ condition_variable test ***********
Wait with predicate and notify one ...
Done

Wait and notify all ...
Done

Wait for ...
Done

Wait until ...
Done

Bye, bye.
******************************************************
```
