### PR TITLE
static_tests: move diff annotations by offset.

### DIFF
--- a/dist/tools/coccinelle/check.sh
+++ b/dist/tools/coccinelle/check.sh
@@ -85,6 +85,16 @@ coccinelle_checkone() {
                                    DIFF="--- $DIFFFILE\n+++ $DIFFFILE"
                                fi
                                DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
+                               # Parse
+                               # @@ -<DIFFLINE>,<DIFFOFFSET> ...
+                               DIFFOFFSET="$(echo "$line" |
+                                   sed 's/@@ -[0-9]\+\(,\([0-9]\)\+\)\?.*$/\2/')"
+                               if [ -n "$DIFFOFFSET" ]; then
+                                   # if there is a DIFFOFFSET, add it to
+                                   # DIFFLINE. DIFFLINE starts at 1, so we
+                                   # need to subtract 1 to not overshoot.
+                                   DIFFLINE=$(( DIFFLINE + DIFFOFFSET - 1 ))
+                               fi
                             fi
                             DIFF="$DIFF\n${line//\\/\\\\}"
                         fi

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -72,6 +72,16 @@ _headercheck() {
                                DIFF="--- $DIFFFILE\n+++ $DIFFFILE"
                            fi
                            DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
+                           # Parse
+                           # @@ -<DIFFLINE>,<DIFFOFFSET> ...
+                           DIFFOFFSET="$(echo "$line" |
+                               sed 's/@@ -[0-9]\+\(,\([0-9]\)\+\)\?.*$/\2/')"
+                           if [ -n "$DIFFOFFSET" ]; then
+                               # if there is a DIFFOFFSET, add it to
+                               # DIFFLINE. DIFFLINE starts at 1, so we
+                               # need to subtract 1 to not overshoot.
+                               DIFFLINE=$(( DIFFLINE + DIFFOFFSET - 1 ))
+                           fi
                         fi
                         DIFF="$DIFF\n$(echo "${line}"| sed 's/\\/\\\\/g' )"
                     fi

--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -75,6 +75,16 @@ exec_uncrustify () {
                            DIFF="--- $DIFFFILE\n+++ $DIFFFILE"
                        fi
                        DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
+                       # Parse
+                       # @@ -<DIFFLINE>,<DIFFOFFSET> ...
+                       DIFFOFFSET="$(echo "$line" |
+                           sed 's/@@ -[0-9]\+\(,\([0-9]\+\)\)\?.*$/\2/')"
+                       if [ -n "$DIFFOFFSET" ]; then
+                           # if there is a DIFFOFFSET, add it to
+                           # DIFFLINE. DIFFLINE starts at 1, so we
+                           # need to subtract 1 to not overshoot.
+                           DIFFLINE=$(( DIFFLINE + DIFFOFFSET - 1 ))
+                       fi
                     fi
                     DIFF="$DIFF\n${line//\\/\\\\}"
                 fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I am always a bit irritated when the diffs are _above_ the lines they are commenting on. This should fix that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided changes to trigger annotations. See Files tab.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #15795
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
