### PR TITLE
tests/driver_at86rf2xx_aes: blacklist native

### DIFF
--- a/tests/driver_at86rf2xx_aes/Makefile
+++ b/tests/driver_at86rf2xx_aes/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init_at86rf2xx
+BOARD_BLACKLIST := native
 
 # define the driver to be used for selected boards
 ifneq (,$(filter samr21-xpro,$(BOARD)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This commit prevents `tests/driver_at86rf2xx_aes` running on native. Although
this might be in theory possible (e.g using Linux SPI), this test fails
when called from `compile_and_test_for_board.py`.

I hope we find a better mechanism in the long run.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`BOARD=native make -C tests/driver_at86rf2xx_aes` should indicate the BOARD is blacklisted.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Appeared while running `compile_and_test_for_board.py` in https://github.com/RIOT-OS/Release-Specs/issues/202
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
