### PR TITLE
cpu/kinetis: drop BITBAND_FUNCTIONS_PROVIDED

### DIFF
--- a/cpu/kinetis/include/bme.h
+++ b/cpu/kinetis/include/bme.h
@@ -29,11 +29,6 @@ extern "C"
 {
 #endif
 
-/**
- * @brief Tell bit.h that we provide CPU specific bit manipulation functions
- */
-#define BITBAND_FUNCTIONS_PROVIDED 1
-
 #define BME_AND_MASK        (1 << 26) /**< AND decoration bitmask */
 #define BME_OR_MASK         (1 << 27) /**< OR decoration bitmask */
 #define BME_XOR_MASK        (3 << 26) /**< XOR decoration bitmask */

--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -26,10 +26,6 @@
 extern "C" {
 #endif
 
-/* Define BITBAND_FUNCTIONS_PROVIDED 1 if the CPU provides its own
- * implementations for bit manipulation */
-#if !BITBAND_FUNCTIONS_PROVIDED
-
 #if DOXYGEN
 /** @brief Flag for telling if the CPU has hardware bit band support */
 #define CPU_HAS_BITBAND 1 || 0 (1 if CPU implements bit-banding, 0 if not)
@@ -212,8 +208,6 @@ static inline void bit_clear8(volatile uint8_t *ptr, uint8_t bit)
 }
 
 #endif /* CPU_HAS_BITBAND */
-
-#endif /* !BITBAND_FUNCTIONS_PROVIDED */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The CPU already defines `CPU_HAS_BITBAND` already, remove the legacy define that was only used by `kinetis`.

In fact defining `BITBAND_FUNCTIONS_PROVIDED` will *disable* the generic bit-band functions, with no replacement at CPU level.

### Testing procedure

`tests/sys_atomic_utils` should still (again?) work on `kinetis`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
