### PR TITLE
cpu/nrf5x: enhance external HF clock source handling to allow for substantial energy savings

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -27,6 +27,7 @@
 
 #include "cpu.h"
 #include "mutex.h"
+#include "nrf_clock.h"
 
 #include "net/ieee802154.h"
 #include "periph/timer.h"
@@ -246,6 +247,11 @@ static int _init(netdev_t *dev)
     rxbuf[0] = 0;
     txbuf[0] = 0;
     _state = 0;
+
+    /* the radio need the external HF clock source to be enabled */
+    /* @todo    add proper handling to release the clock whenever the radio is
+     *          idle */
+    clock_hfxo_request();
 
     /* power on peripheral */
     NRF_RADIO->POWER = 1;

--- a/cpu/nrf5x_common/include/nrf_clock.h
+++ b/cpu/nrf5x_common/include/nrf_clock.h
@@ -24,10 +24,31 @@ extern "C" {
 #endif
 
 /**
+ * @brief   The high frequency clock (HFCLK) uses the internal oscillator per
+ *          default. Setting this define to 1 will enable the HFXO clock source
+ *          on boot so it will always be active.
+ */
+#ifndef CLOCK_HFXO_ONBOOT
+#define CLOCK_HFXO_ONBOOT       0
+#endif
+
+/**
  * @brief   Initialize the high frequency clock (HFCLK) as configured in the
  *          board's periph_conf.h
  */
 void clock_init_hf(void);
+
+/**
+ * @brief   Request the external high frequency crystal (HFXO) as HF clock
+ *          source. If this is the first request, the HFXO will be enabled.
+ */
+void clock_hfxo_request(void);
+
+/**
+ * @brief   Release the use of the HFXO. If this was the last active request,
+ *          the HFXO will be disabled
+ */
+void clock_hfxo_release(void);
 
 /**
  * @brief   Start the low frequency clock (LFCLK) as configured in the board's

--- a/cpu/nrf5x_common/radio/nrfble/nrfble.c
+++ b/cpu/nrf5x_common/radio/nrfble/nrfble.c
@@ -25,6 +25,7 @@
 
 #include "cpu.h"
 #include "assert.h"
+#include "nrf_clock.h"
 
 #include "nrfble.h"
 #include "net/netdev/ble.h"
@@ -237,6 +238,11 @@ static int _nrfble_init(netdev_t *dev)
 {
     (void)dev;
     assert(_nrfble_dev.driver && _nrfble_dev.event_callback);
+
+    /* the radio need the external HF clock source to be enabled */
+    /* @todo    add proper handling to release the clock whenever the radio is
+     *          idle */
+    clock_hfxo_request();
 
     /* power on the NRFs radio */
     NRF_RADIO->POWER = 1;

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -24,6 +24,7 @@
 #include "cpu.h"
 #include "mutex.h"
 #include "assert.h"
+#include "nrf_clock.h"
 
 #include "periph_conf.h"
 #include "periph/cpuid.h"
@@ -400,6 +401,11 @@ static int nrfmin_init(netdev_t *dev)
     for (unsigned i = 0; i < CPUID_LEN; i++) {
         my_addr ^= cpuid[i] << (8 * (i & 0x01));
     }
+
+    /* the radio need the external HF clock source to be enabled */
+    /* @todo    add proper handling to release the clock whenever the radio is
+     *          idle */
+    clock_hfxo_request();
 
     /* power on the NRFs radio */
     NRF_RADIO->POWER = 1;


### PR DESCRIPTION
### Contribution description
Currently, we enable the external high frequency crystal (`HFXO`) as clock source for the nRFs high frequency clock (`HFCLK`) during CPU initialization per default. With the `HFXO` constantly enabled the CPU is however prevented to to into proper power saving states when idle. Further this external clock source is only needed for some selected peripherals (e.g. `radio`) or some specific peripheral configurations (e.g. `UART` with baudrate >> 500kbps). So the better solution is to not enable this clock source by default, but let the peripherals/drivers request that clock source on demand.

This PR introduces 2 changes:
- add two functions to request/release the `HFXO`
- disable the `HFXO` by default, however, keeping the option to enable it during boot setting the `CLOCK_HFXO_ONBOOT` define to `1`
- call the `clock_hfxo_request()` function from the 3 existing nrf radio drivers, as the radio depends on that clock source

The potential energy savings are drastic:
`examples/minimal` with `USEMODULE=stdio_null` @ `nrf52dk`, average current drawn:
master: 411µA
**with this PR: 3,6µA** -> saving factor > 100!!!

### Testing procedure
With this PR all existing application on any nordic platform should still work as expected.

Most important to verify:
- some xtimer/ztimer tests
- `gnrc_networking` using `USEMODULE=nrfmin`
- `gnrc_networking` using `USEMODULE=nrf802154` @ `nrf52840dk` or similar platform with a `nrf52840` cpu

### Issues/PRs references
none