### PR TITLE
ble/skald: switch from xtimer to ZTIMER_MSEC

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -916,9 +916,13 @@ endif
 
 ifneq (,$(filter skald,$(USEMODULE)))
   FEATURES_REQUIRED += radio_nrfble
+  FEATURES_OPTIONAL += periph_rtt
   USEMODULE += nrfble
-  USEMODULE += xtimer
   USEMODULE += random
+  USEMODULE += ztimer_msec
+   ifneq (,$(filter periph_rtt,$(USEMODULE)))
+    USEMODULE += ztimer_periph_rtt
+  endif
 endif
 
 ifneq (,$(filter bluetil_addr,$(USEMODULE)))

--- a/sys/include/net/skald.h
+++ b/sys/include/net/skald.h
@@ -46,7 +46,7 @@
 
 #include <stdint.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "net/ble.h"
 #include "net/netdev/ble.h"
 
@@ -62,8 +62,8 @@ extern "C" {
 /**
  * @brief   Advertising interval in microseconds
  */
-#ifndef CONFIG_SKALD_INTERVAL
-#define CONFIG_SKALD_INTERVAL          (1 * US_PER_SEC)
+#ifndef CONFIG_SKALD_INTERVAL_MS
+#define CONFIG_SKALD_INTERVAL_MS        (1000U)
 #endif
 
 /**
@@ -143,8 +143,8 @@ typedef struct {
  */
 typedef struct {
     netdev_ble_pkt_t pkt;   /**< packet holding the advertisement (GAP) data */
-    xtimer_t timer;         /**< timer for scheduling advertising events */
-    uint32_t last;          /**< last timer trigger (for offset compensation) */
+    ztimer_t timer;         /**< timer for scheduling advertising events */
+    ztimer_now_t last;      /**< last timer trigger (for offset compensation) */
     uint8_t cur_chan;       /**< keep track of advertising channels */
 } skald_ctx_t;
 

--- a/sys/net/ble/skald/Kconfig
+++ b/sys/net/ble/skald/Kconfig
@@ -12,12 +12,12 @@ menuconfig KCONFIG_USEMODULE_SKALD
 
 if KCONFIG_USEMODULE_SKALD
 
-config SKALD_INTERVAL
+config SKALD_INTERVAL_MS
     int "Advertising interval in microseconds"
-    default 1000000
+    default 1000
     help
-        Configure advertising interval in microseconds. Default value is 1
-        second which is 1000000 microseconds.
+        Configure advertising interval in milliseconds. Default value is 1
+        second which is 1000 milliseconds.
 
 config ADV_CH_37_DISABLE
     bool "Disable advertising on channel 37"


### PR DESCRIPTION
### Contribution description
So far `skald` is using `xtimer` as timer backend, pulling in the `periph_timer` and with this preventing the lower sleep modes on the nordic platforms. So this PR switches the timer backend for `skald` to `ZTIMER_MSEC`. It also includes the `ztimer_periph_rtt` module, this is save as all nrf boards do provide this feature...

Having this change merged allows together with the nrf HF clock source optimization (see #15804) for substantial power savings when running `skald`!

### Testing procedure
Simply flash `examples/skald_ibeacon` or `examples/skald_eddystone` to any nordic board of your choosing and verify with a BLE scanner (e.g. your smartphone and the Nordic connect App) that the node is sending its BLE advertising packets as it did before.

### Issues/PRs references
part of energy optimization of Nordic nodes, together with #15804
