### PR TITLE
cpu/nrf/radio/nrfble: request HFXO only on demand

### DIFF
--- a/cpu/nrf5x_common/radio/nrfble/nrfble.c
+++ b/cpu/nrf5x_common/radio/nrfble/nrfble.c
@@ -121,6 +121,16 @@ static const uint8_t _ble_chan_map[40] = {
 };
 
 /**
+ * @brief   Enable the radio
+ */
+static void _enable(void)
+{
+    clock_hfxo_request();
+    NRF_RADIO->EVENTS_DISABLED = 0;
+    NRF_RADIO->INTENSET = INT_EN;
+}
+
+/**
  * @brief   Set radio into idle (DISABLED) state
  */
 static void _go_idle(void)
@@ -131,6 +141,7 @@ static void _go_idle(void)
         NRF_RADIO->EVENTS_DISABLED = 0;
         NRF_RADIO->TASKS_DISABLE = 1;
         while (NRF_RADIO->EVENTS_DISABLED == 0) {}
+        clock_hfxo_release();
         _state = STATE_IDLE;
     }
 }
@@ -239,12 +250,8 @@ static int _nrfble_init(netdev_t *dev)
     (void)dev;
     assert(_nrfble_dev.driver && _nrfble_dev.event_callback);
 
-    /* the radio need the external HF clock source to be enabled */
-    /* @todo    add proper handling to release the clock whenever the radio is
-     *          idle */
-    clock_hfxo_request();
-
-    /* power on the NRFs radio */
+    /* power cycle the radio to reset it */
+    NRF_RADIO->POWER = 0;
     NRF_RADIO->POWER = 1;
     /* configure variable parameters to default values */
     NRF_RADIO->TXPOWER = NRFBLE_TXPOWER_DEFAULT;
@@ -286,8 +293,7 @@ static int _nrfble_send(netdev_t *dev, const iolist_t *data)
     /* in case no trx sequence is active, we start a new one now */
     if (_state == STATE_IDLE) {
         _state = STATE_TX;
-        NRF_RADIO->EVENTS_DISABLED = 0;
-        NRF_RADIO->INTENSET = INT_EN;
+        _enable();
         NRF_RADIO->TASKS_TXEN = 1;
     }
 
@@ -307,8 +313,7 @@ static int _nrfble_recv(netdev_t *dev, void *buf, size_t len, void *info)
     /* in case no trx sequence is active, we start a new one now */
     if (_state == STATE_IDLE) {
         _state = STATE_RX;
-        NRF_RADIO->EVENTS_DISABLED = 0;
-        NRF_RADIO->INTENSET = INT_EN;
+        _enable();
         NRF_RADIO->TASKS_RXEN = 1;
     }
 


### PR DESCRIPTION
### Contribution description
This is a continuation of #15804 and enables the `nrfble` radio driver to request the external high frequency crystal as clock source only on demand, hence allowing for the CPU to save significant power. 

When combined with #15804 and #15805 this PR will reduce the average current drawn by the `examples/skald_ibeacon` application from ~400µA down to 13µA!!! Thus it makes the difference from running ~3 months to running >5 years on a 1000mAh battery :-)

### Testing procedure
Simply run `examples/skald_ibeacon` on any Nordic board and verify that the node is broadcasting
EDIT:
Best build without STDIO (`USEMODULE=stdio_null`), otherwise the UART will prevent the HFXO from being disabled...

### Issues/PRs references
EDIT
~~Depends on/rebased on  #15804~~
