### PR TITLE
tools/jlink.sh: fix version check and allow to skip it

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -156,21 +156,23 @@ test_term() {
 }
 
 test_version() {
-    JLINK_MINIMUM_VERSION="6.74"
-    # Adding '-nogui 1' will simply return 'Unknown command line option -nogui'
-    # on older versions, JLINK_VERSION will still be parsed correctly.
-    JLINK_VERSION=$(echo q | "${JLINK}" "${JLINK_SERIAL}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oE "[0-9]+\.[0-9]+")
+    if [ -z "${JLINK_SKIP_VERSION}" ]; then
+        JLINK_MINIMUM_VERSION="6.74"
+        # Adding '-nogui 1' will simply return 'Unknown command line option -nogui'
+        # on older versions, JLINK_VERSION will still be parsed correctly.
+        JLINK_VERSION=$(echo q | "${JLINK}" "${JLINK_SERIAL}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oE "[0-9]+\.[0-9]+")
 
-    if [ $? -ne 0 ]; then
-        echo "Error: J-Link appears not to be installed on your PATH"
-        exit 1
-    fi
+        if [ $? -ne 0 ]; then
+            echo "Error: J-Link appears not to be installed on your PATH"
+            exit 1
+        fi
 
-    "$RIOTTOOLS"/has_minimal_version/has_minimal_version.sh "$JLINK_VERSION" "$JLINK_MINIMUM_VERSION" 2> /dev/null
+        "$RIOTTOOLS"/has_minimal_version/has_minimal_version.sh "$JLINK_VERSION" "$JLINK_MINIMUM_VERSION" 2> /dev/null
 
-    if [ $? -ne 0 ]; then
-        echo "Error: J-Link V$JLINK_MINIMUM_VERSION is required, but V${JLINK_VERSION} is installed"
-        exit 1
+        if [ $? -ne 0 ]; then
+            echo "Error: J-Link V$JLINK_MINIMUM_VERSION is required, but V${JLINK_VERSION} is installed"
+            exit 1
+        fi
     fi
 }
 

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -159,7 +159,7 @@ test_version() {
     JLINK_MINIMUM_VERSION="6.74"
     # Adding '-nogui 1' will simply return 'Unknown command line option -nogui'
     # on older versions, JLINK_VERSION will still be parsed correctly.
-    JLINK_VERSION=$(echo q | "${JLINK}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oE "[0-9]+\.[0-9]+")
+    JLINK_VERSION=$(echo q | "${JLINK}" "${JLINK_SERIAL}" -nogui 1 2> /dev/null | grep "^DLL version*" | grep -oE "[0-9]+\.[0-9]+")
 
     if [ $? -ne 0 ]; then
         echo "Error: J-Link appears not to be installed on your PATH"
@@ -180,8 +180,8 @@ test_version() {
 do_flash() {
     BINFILE=$1
     test_config
-    test_version
     test_serial
+    test_version
     test_binfile
     # clear any existing contents in burn file
     /bin/echo -n "" > ${BINDIR}/burn.seg
@@ -210,8 +210,8 @@ do_flash() {
 do_debug() {
     ELFFILE=$1
     test_config
-    test_version
     test_serial
+    test_version
     test_elffile
     test_ports
     test_tui
@@ -234,9 +234,9 @@ do_debug() {
 
 do_debugserver() {
     test_config
+    test_serial
     test_version
     test_ports
-    test_serial
     # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
                            -nogui \
@@ -249,8 +249,8 @@ do_debugserver() {
 
 do_reset() {
     test_config
-    test_version
     test_serial
+    test_version
     # reset the board
     sh -c "${JLINK} ${JLINK_SERIAL} \
                     -nogui 1 \
@@ -264,8 +264,8 @@ do_reset() {
 
 do_term() {
     test_config
-    test_version
     test_serial
+    test_version
     test_term
 
     # temporary file that save the J-Link Commander pid


### PR DESCRIPTION
### Contribution description
This PR fixes two annyoing issues with the `jlink.sh` script:

A)
 if a specific JLINK_SERIAL is specified, it is ignored by the version check. In case more than one JLink programmer is connected to the host (e.g. multiple nrf5xdk boards), this leads to an ugly UI popup window prompting for a Serial on each flash operation. The selection itself does not matter, its only used for the version check. This PR fixes this by passing the selected JLINK_SERIAL to the JLINK command, like done for flashing and debugging.

B) 
the version check takes quite a long time. Skipping it speeds up flashing by quite a bit. So this PR allows to skip the version check by setting the env var `JLINK_SKIP_VERSION` to `1`. 

Speed gains when flashing `hello-world` on a `nrf52dk`:
```
time JLINK_SERIAL=xxxabc make flash-only
real    0m3,628s
user    0m0,142s
sys     0m0,070s

time JLINK_SKIP_VERSION=1 JLINK_SERIAL=xxxabc make flash-only
real    0m0,624s
user    0m0,115s
sys     0m0,089s
```

I would even tend to throw out the version check altogether, as I don't really see the purpose of it in the first place. But maybe someone can elaborate on why would should have this in?!


### Testing procedure
Programm any board of your choosing using 1 or more JLINK programmers. Once more than one is connected to the host you will see the annoying popup disappear once specifying a JLINK_SERIAL with this PR :-)

### Issues/PRs references
none