### PR TITLE
tools/jlink.sh: Run JlinkExe with silent when debugging

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -219,6 +219,7 @@ do_debug() {
     # start the J-Link GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
                            -nogui \
+                           -silent \
                            -device '${JLINK_DEVICE}' \
                            -speed '${JLINK_SPEED}' \
                            -if '${JLINK_IF}' \


### PR DESCRIPTION
### Contribution description

The print statements from the Jlink binary offer little additional
benefit while debugging and only clutter the output. Furthermore they
interfere with the TUI layout of GDB when one of the context layouts is
used.

### Testing procedure

run `make debug` with one of the many jlink-based boards.

### Issues/PRs references

None

### Test output

<details><summary>Without silent:</summary>

```
(gdb) break cpu_init 
Read 2 bytes @ address 0x0000092C (Data = 0xB510)
Breakpoint 1 at 0x92c: file /home/koen/dev/RIOT-review/cpu/nrf52/cpu.c, line 44.
(gdb) start
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Reset target CPU...
Temporary breakpoint 2 at 0xdc: file /home/koen/dev/RIOT-review/examples/hello-world/main.c, line 26.
Starting program: /home/koen/dev/RIOT-review/examples/hello-world/bin/nrf52dk/hello-world.elf 
Reset target CPU...
Reading all registers
Read 2 bytes @ address 0x0000092C (Data = 0xB510)
Reading 64 bytes @ address 0x000000C0
Read 2 bytes @ address 0x000000DC (Data = 0xB508)
Setting breakpoint @ address 0x000000DC, Size = 2, BPHandle = 0x0001
Setting breakpoint @ address 0x0000092C, Size = 2, BPHandle = 0x0002
Starting target CPU...
...Breakpoint reached @ address 0x0000092C
Reading all registers
[Switching to Thread 57005]
Removing breakpoint @ address 0x000000DC, Size = 2
Removing breakpoint @ address 0x0000092C, Size = 2

Read 4 bytes @ address 0x0000092C (Data = 0xF7FFB510)
Breakpoint 1, cpu_init () at /home/koen/dev/RIOT-review/cpu/nrf52/cpu.c:44
44          if (ftpan_32()) {
(gdb) n
Setting breakpoint @ address 0x000000DC, Size = 2, BPHandle = 0x0003
Performing single step...
...Breakpoint reached @ address 0x0000092E
Reading all registers
Setting breakpoint @ address 0x0000092C, Size = 2, BPHandle = 0x0004
Performing single step...
...Breakpoint reached @ address 0x000008EC
Reading all registers
Read 4 bytes @ address 0x000008EC (Data = 0x781B4B0C)
Read 4 bytes @ address 0x00000932 (Data = 0x4A15B120)
Read 2 bytes @ address 0x00000932 (Data = 0xB120)
Setting breakpoint @ address 0x00000932, Size = 2, BPHandle = 0x0005
Starting target CPU...
...Breakpoint reached @ address 0x00000932
Reading all registers
Read 4 bytes @ address 0x00000932 (Data = 0x4A15B120)
Removing breakpoint @ address 0x00000932, Size = 2
Performing single step...
...Breakpoint reached @ address 0x0000093E
Reading all registers
Read 4 bytes @ address 0x0000093E (Data = 0xFFD5F7FF)
Removing breakpoint @ address 0x000000DC, Size = 2
Removing breakpoint @ address 0x0000092C, Size = 2
50          if (ftpan_37()) {
(gdb) n
Setting breakpoint @ address 0x000000DC, Size = 2, BPHandle = 0x0006
Setting breakpoint @ address 0x0000092C, Size = 2, BPHandle = 0x0007
Performing single step...
...Breakpoint reached @ address 0x000008EC
Reading all registers
Read 4 bytes @ address 0x000008EC (Data = 0x781B4B0C)
Read 4 bytes @ address 0x00000942 (Data = 0x4B12B110)
Read 2 bytes @ address 0x00000942 (Data = 0xB110)
Setting breakpoint @ address 0x00000942, Size = 2, BPHandle = 0x0008
Starting target CPU...
...Breakpoint reached @ address 0x00000942
Reading all registers
Read 4 bytes @ address 0x00000942 (Data = 0x4B12B110)
Removing breakpoint @ address 0x00000942, Size = 2
Performing single step...
...Breakpoint reached @ address 0x0000094A
Reading all registers
Read 4 bytes @ address 0x0000094A (Data = 0xFFCFF7FF)
Removing breakpoint @ address 0x000000DC, Size = 2
Removing breakpoint @ address 0x0000092C, Size = 2
56          if (ftpan_36()) {
(gdb) n
Setting breakpoint @ address 0x000000DC, Size = 2, BPHandle = 0x0009
Setting breakpoint @ address 0x0000092C, Size = 2, BPHandle = 0x000A
Performing single step...
...Breakpoint reached @ address 0x000008EC
Reading all registers
Read 4 bytes @ address 0x000008EC (Data = 0x781B4B0C)
Read 4 bytes @ address 0x0000094E (Data = 0xF04FB130)
Read 2 bytes @ address 0x0000094E (Data = 0xB130)
Setting breakpoint @ address 0x0000094E, Size = 2, BPHandle = 0x000B
Starting target CPU...
...Breakpoint reached @ address 0x0000094E
Reading all registers
Read 4 bytes @ address 0x0000094E (Data = 0xF04FB130)
Removing breakpoint @ address 0x0000094E, Size = 2
Performing single step...
...Breakpoint reached @ address 0x0000095E
Reading all registers
Read 4 bytes @ address 0x0000095E (Data = 0x4380F04F)
Removing breakpoint @ address 0x000000DC, Size = 2
Removing breakpoint @ address 0x0000092C, Size = 2
61          nrfx_dcdc_init();
```

</details>


<details><summary>With silent</summary>

```
Reading symbols from /home/koen/dev/RIOT-review/examples/hello-world/bin/nrf52dk/hello-world.elf...
Remote debugging using :3333
__enable_irq () at /home/koen/dev/RIOT-review/cpu/cortexm_common/include/vendor/cmsis_gcc.h:131
131       __ASM volatile ("cpsie i" : : : "memory");
(gdb) break cpu_init 
Breakpoint 1 at 0x92c: file /home/koen/dev/RIOT-review/cpu/nrf52/cpu.c, line 44.
(gdb) start
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Temporary breakpoint 2 at 0xdc: file /home/koen/dev/RIOT-review/examples/hello-world/main.c, line 26.
Starting program: /home/koen/dev/RIOT-review/examples/hello-world/bin/nrf52dk/hello-world.elf 
[Switching to Thread 57005]

Breakpoint 1, cpu_init () at /home/koen/dev/RIOT-review/cpu/nrf52/cpu.c:44
44          if (ftpan_32()) {
(gdb) n
50          if (ftpan_37()) {
(gdb) n
56          if (ftpan_36()) {
(gdb) n
61          nrfx_dcdc_init();
```

</details>