### PR TITLE
cpu/stm32/rtc: add unlock/lock to rtc_clear_alarm [backport 2021.01]

### DIFF
--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -304,10 +304,10 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     /* normalize input */
     rtc_tm_normalize(time);
 
-    rtc_unlock();
-
     /* disable existing alarm (if enabled) */
     rtc_clear_alarm();
+
+    rtc_unlock();
 
     /* save callback and argument */
     isr_ctx.cb = cb;
@@ -345,11 +345,15 @@ int rtc_get_alarm(struct tm *time)
 
 void rtc_clear_alarm(void)
 {
+    rtc_unlock();
+
     RTC->CR &= ~(RTC_CR_ALRAE | RTC_CR_ALRAIE);
     while (!(RTC_REG_ISR & RTC_ISR_ALRAWF)) {}
 
     isr_ctx.cb = NULL;
     isr_ctx.arg = NULL;
+
+    rtc_lock();
 }
 
 void rtc_poweron(void)


### PR DESCRIPTION
# Backport of #15796

### Contribution description

#15628 (because a `rtc_clear_alarm` call was added to the test) exposed a bug on `stm32/rtc` where the RTC was not `locked`/`unlocked` when calling `rtc_clear_alarm`. This caused `tests/periph_rtc` to hang at least on `nucleo-f207zg`.

### Testing procedure

`BOARD=nucleo-f207zg make -C tests/periph_rtc flash test -j3`

```
main(): This is RIOT! (Version: 2021.04-devel-66-g7c12e-pr_rtc_lock_unlock)

RIOT RTC low-level driver test
This test will display 'Alarm!' every 2 seconds for 4 times
  Setting clock to   2020-02-28 23:59:57
Clock value is now   2020-02-28 23:59:57
  Setting alarm to   2020-02-28 23:59:59
   Alarm is set to   2020-02-28 23:59:59
  Alarm cleared at   2020-02-28 23:59:57
       No alarm at   2020-02-28 23:59:59
  Setting alarm to   2020-02-29 00:00:01

Alarm!
Alarm!
Alarm!
Alarm!
```
