### PR TITLE
sys/bit: provide CPU_HAS_SRAM_BITBAND [backport 2021.01]

### DIFF
--- a/cpu/cortexm_common/include/atomic_utils_arch.h
+++ b/cpu/cortexm_common/include/atomic_utils_arch.h
@@ -68,7 +68,7 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val)
 
 #endif /* __clang__ */
 
-#if CPU_HAS_BITBAND
+#if CPU_HAS_SRAM_BITBAND
 #define HAS_ATOMIC_BIT
 
 typedef volatile uint32_t *atomic_bit_u8_t;

--- a/cpu/kinetis/include/cpu_conf.h
+++ b/cpu/kinetis/include/cpu_conf.h
@@ -49,7 +49,9 @@ extern "C"
  * @{
  */
 #ifdef BITBAND_REG32
-#define CPU_HAS_BITBAND 1
+#define CPU_HAS_BITBAND         1
+/* SRAM_L is mapped before the bit-banding region, only SRAM_U can be used for bit-banding */
+#define CPU_HAS_SRAM_BITBAND    0
 #endif
 /** @} */
 

--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -31,11 +31,31 @@ extern "C" {
 #if !BITBAND_FUNCTIONS_PROVIDED
 
 #if DOXYGEN
-/** @brief Flag for telling if the CPU has hardware bit band support */
+/**
+ * @brief   Flag to check if the CPU has hardware bit band support
+ */
 #define CPU_HAS_BITBAND 1 || 0 (1 if CPU implements bit-banding, 0 if not)
+/**
+ * @brief   Flag to check if bit-banding is supported for all of SRAM
+ *
+ * @details Bit-banding in SRAM is only supported (if available at all) for a
+ *          1 MiB region in the address space. If not all of SRAM is mapped
+ *          there, it is safest to not use bit-banding at all. Luckily, only
+ *          few vendors decided to implement partially broken bit-banding.
+ *
+ * @retval  1   All of SRAM is bit-banding capable
+ * @retval  0   (At least one part) SRAM is not bit-banding capable
+ */
+#define CPU_HAS_SRAM_BITBAND 1 || 0
 #endif
 
 #if CPU_HAS_BITBAND || DOXYGEN
+/* Most CPUs with bitband have all of SRAM mapped in the bit-banding region.
+ * The few oddballs have to define it to zero in cpu_conf.h */
+#ifndef CPU_HAS_SRAM_BITBAND
+#define CPU_HAS_SRAM_BITBAND    1
+#endif
+
 /* Some MCUs provide a bitband address space for atomically accessing
  * single bits of peripheral registers, and sometimes for RAM as well */
 /**


### PR DESCRIPTION
# Backport of #15809

### Contribution description

- Add `CPU_HAS_SRAM_BITBAND` flag to allow checking whether all of SRAM has proper bit-banding support
- Use this in the Cortex M implementation of `atomic_utils`

### Testing procedure

```
make BOARD=frdm-k64f -C tests/sys_atomic_utils_unittests flash test
```

### Issues/PRs references

Reported by @fjmolinas, fixes https://github.com/RIOT-OS/RIOT/issues/15810