### PR TITLE
ci/vera++/rules/L004: remove warning support

### DIFF
--- a/dist/tools/vera++/scripts/rules/L004.tcl
+++ b/dist/tools/vera++/scripts/rules/L004.tcl
@@ -3,17 +3,11 @@
 
 set maxLength [getParameter "max-line-length" 100]
 
-#MOD: We add here a line length thershold for line length
-set maxLengthWarn [getParameter "max-line-length-warn" 80]
-
 foreach f [getSourceFileNames] {
     set lineNumber 1
     foreach line [getAllLines $f] {
         if {[string length $line] > $maxLength} {
             report $f $lineNumber "line is longer than ${maxLength} characters"
-        } elseif {[string length $line] > $maxLengthWarn} {
-            # puts won't make vera++ return error code when invoked with --error
-            puts "$f:$lineNumber: warning: line is longer than $maxLengthWarn characters"
         }
         incr lineNumber
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This reverts commit f3a934a169abd299f593c9e60d6ef53da1d68dfb.
The original patch added a mechanism to avoid 2 consecutive calls to `vera++`, assuming we would be using both warnings and errors for line length.
Since #15793 removed the warning, this patch is required to go back to the vanilla use case of vera++ (only report, no prints).

This should fix the issue described in https://github.com/RIOT-OS/RIOT/pull/15793#issuecomment-762938130
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check `vera++` output with the bogus commit.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/15793
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
