### PR TITLE
ci/test-on-iotlab: update list of excluded applications

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -76,10 +76,11 @@ jobs:
       DOCKER_ENVIRONMENT_CMDLINE: -e BUILD_FILES=\$$\(BINFILE\)
       COMPILE_AND_TEST_FOR_BOARD: ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
       COMPILE_AND_TEST_ARGS: --with-test-only --jobs=2 --report-xml
-      # Exclude applications that require the riotboot feature and providing a test
-      # because flashing at a specific offset is not (yet) supported on IoT-LAB
-      # so they will always fail because of that limitation
-      APPLICATIONS_EXCLUDE: examples/suit_update tests/riotboot
+      # Exclude applications that cannot run on iotlab
+      # - tests/riotboot requires the riotboot feature and provides a test
+      #   but flashing at a specific offset is not (yet) supported on IoT-LAB
+      #   so it will always fail because of that limitation
+      APPLICATIONS_EXCLUDE: tests/riotboot
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -76,11 +76,12 @@ jobs:
       DOCKER_ENVIRONMENT_CMDLINE: -e BUILD_FILES=\$$\(BINFILE\)
       COMPILE_AND_TEST_FOR_BOARD: ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
       COMPILE_AND_TEST_ARGS: --with-test-only --jobs=2 --report-xml
-      # Exclude applications that cannot run on iotlab
+      # Exclude applications that are expected to fail or cannot run on iotlab
+      # - tests/periph_timer_short_relative_set is expected to fail
       # - tests/riotboot requires the riotboot feature and provides a test
       #   but flashing at a specific offset is not (yet) supported on IoT-LAB
       #   so it will always fail because of that limitation
-      APPLICATIONS_EXCLUDE: tests/riotboot
+      APPLICATIONS_EXCLUDE: tests/periph_timer_short_relative_set tests/riotboot
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In https://github.com/RIOT-OS/RIOT/pull/15772#issuecomment-763399356, @fjmolinas pointed that examples/suit_update doesn't need to flash at a given offset, which is true. This PR is removing this application from the list of excluded applications.

This PR is also adding the `tests/periph_timer_short_relative_set` application because this one is expected to fail.

I'm wondering if `tests/pkg_libfixmath-unittests` should be added to this list: it doesn't work on ARM and all IoT-LAB boards used by this check are ARM based.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I can run this action on my fork if needed otherwise, just merge and wait for the scheduled run.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Revert part of #15772 changes after this https://github.com/RIOT-OS/RIOT/pull/15772#issuecomment-763399356

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
