### PR TITLE
sys/net/gnrc/netif: make use of confirm_send

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -45,7 +45,6 @@ PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_bus
-PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_netif_timestamp
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -246,6 +246,7 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += l2util
   USEMODULE += fmt
+  USEMODULE += core_thread_flags
   ifneq (,$(filter netdev_ieee802154_submac,$(USEMODULE)))
     USEMODULE += gnrc_netif_pktq
   endif
@@ -262,11 +263,6 @@ endif
 
 ifneq (,$(filter gnrc_netif_bus,$(USEMODULE)))
   USEMODULE += core_msg_bus
-endif
-
-ifneq (,$(filter gnrc_netif_events,$(USEMODULE)))
-  USEMODULE += core_thread_flags
-  USEMODULE += event
 endif
 
 ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -139,16 +139,6 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS) || defined(DOXYGEN)
-    /**
-     * @brief   Event queue for asynchronous events
-     */
-    event_queue_t evq;
-    /**
-     * @brief   ISR event for the network device
-     */
-    event_t event_isr;
-#endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0) || DOXYGEN
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1559,7 +1559,6 @@ static gnrc_pktsnip_t * _tx_succeeded(gnrc_netif_t *netif, uint32_t bytes_send)
     return _send_queued_pkt(netif);
 }
 
-
 /**
  * @brief   Process any pending events and wait for IPC messages
  *

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1697,6 +1697,9 @@ static gnrc_pktsnip_t * _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool pus
 #if IS_USED(MODULE_GNRC_TX_SYNC)
         gnrc_pktbuf_release(tx_sync);
 #endif
+#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
+        gnrc_pktbuf_release(pkt);
+#endif
         return _tx_succeeded(netif, res);
     }
     /* modern API, outgoing frame needs still to be released upon TX completion */


### PR DESCRIPTION
### Contribution description

- adapt `gnrc_netif.c` to make use of `netdev_driver_t::confirm_send`, if not `NULL
    - As the new API is explicitly non-blocking, this requires now IRQs to be processed while waiting for TX completion.
    - While TX is in progress, IPC messages (which might contain additional data to send) must not be received. To implement this `core/thread_flags` is used to wait for TX completion and IRQs
    - As a result, IRQs are no longer been lost. Hence, it provides the feature `gnrc_netif_events` provides, but with less ROM. Consequently, `gnrc_netif_events` is dropped
    - As nice side effect, now all events can be reported from IRQ context. This can be beneficial for peripheral radios
    - If `confirm_send()` is provided, the pkgsnip is now released by `gnrc_netif.c`, rather by each adaption layer individually. This is needed, as the driver might still operate on the buffer during TX - e.g. peripheral network interfaces with DMA that supports scatter/gather, no copy of the outgoing frame is needed.
- adapt `gnrc_netif_ethernet.c` to only release the packet buffer if `confirm_send` is not provided
- implement `confirm_send` for the STM32 Ethernet driver

### Testing procedure

- There should be no regressions on drivers not using `confirm_send()`
- There should be no regressions on the STM32 Ethernet driver

### Issues/PRs references

- [x] Depends on and includes https://github.com/RIOT-OS/RIOT/pull/15783