### PR TITLE
sys/fmt_table: fix infinite loop

### DIFF
--- a/sys/fmt/table.c
+++ b/sys/fmt/table.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "fmt.h"
+#include "fmt_table.h"
 
 static const char fmt_table_spaces[16] = "                ";
 
@@ -43,6 +44,7 @@ static void print_pattern(const char *pat, size_t pat_size, size_t fill_size)
 {
     while (fill_size > pat_size) {
         print(pat, pat_size);
+        fill_size -= pat_size;
     }
 
     print(pat, fill_size);


### PR DESCRIPTION
### Contribution description

In the loop, the counter variable wasn't decremented :-/ This PR fixes this

### Testing procedure

Apply

```diff
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9baf..5ce0559b9d 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -15,4 +15,6 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+USEMODULE += fmt_table
+
 include $(RIOTBASE)/Makefile.include
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..9d7dc038ba 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -21,12 +21,17 @@
 
 #include <stdio.h>
 
+#include "fmt.h"
+#include "fmt_table.h"
+
 int main(void)
 {
     puts("Hello World!");
 
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
+    print_col_u32_dec(1, 20);
+    print_str("\n");
 
     return 0;
 }
```

With that, `examples/hello-world` should print one additional line consisting of 20 chars, of which are 19 a space, and one being the digit "1".

### Issues/PRs references

None