### PR TITLE
drivers/dfplayer: fix error handling [backport 2021.01]

### DIFF
--- a/drivers/dfplayer/dfplayer_internal.c
+++ b/drivers/dfplayer/dfplayer_internal.c
@@ -416,13 +416,12 @@ int dfplayer_file_cmd(dfplayer_t *dev, uint8_t cmd, uint8_t p1, uint8_t p2)
          * We just check if the DFPlayer is actually playing
          */
         if (gpio_is_valid(dev->busy_pin)) {
+            retval = 0;
             /* Using BUSY pin to check if device is playing */
             if (gpio_read(dev->busy_pin)) {
                 /* Device not playing, file does not exist */
                 retval = -ENOENT;
             }
-
-            retval = 0;
         }
         else {
             /* BUSY pin not connected, query status instead */


### PR DESCRIPTION
# Backport of #15825

### Contribution description

The error code was previously overwritten :-/ this clearly is not how it is
intended to work.

### Testing procedure

The code change is trivial enough to be only code-reviewed. This info from the datasheet should be helpful:

| No | Pin | Description    | Note                             |
| --:|:--- |:-------------- | :------------------------------- |
| ...| ... | ...            | ...                              |
| 16 |BUSY | Playing Status | Low means playing \High means no |

### Issues/PRs references

None
