### PR TITLE
pkg/libfixmath: blacklist TOOLCHAIN=gnu for arm since division is off

### DIFF
--- a/pkg/libfixmath/Makefile.dep
+++ b/pkg/libfixmath/Makefile.dep
@@ -6,3 +6,9 @@ ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
   # The round function is not provided by the msp430 toolchain
   FEATURES_BLACKLIST += arch_msp430
 endif
+
+ifneq (,$(filter gnu gcc,$(TOOLCHAIN)))
+  # On recent arm-none-eabi-gcc toolchains division testcases fail
+  # see https://github.com/RIOT-OS/RIOT/issues/14568
+  FEATURES_BLACKLIST += arch_arm
+endif


### PR DESCRIPTION
### Contribution description

Blacklists `gnu` for arm See #14568.

### Testing procedure

Run on `ci/test-on-iotlab`.

### Issues/PRs references
