### PR TITLE
cpu/stm32: fix wrong max clock for stm32f423xx line

### DIFF
--- a/cpu/stm32/kconfigs/f4/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f4/Kconfig.lines
@@ -94,7 +94,7 @@ config CPU_LINE_STM32F417XX
 config CPU_LINE_STM32F423XX
     bool
     select CPU_FAM_F4
-    select CLOCK_MAX_180MHZ
+    select CLOCK_MAX_100MHZ
 
 config CPU_LINE_STM32F427XX
     bool


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides an obvious fix for the max cpu clock defined in Kconfig for the stm32f423xx cpu line.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

One should check the value with the datasheet or [the ST website](https://www.st.com/en/microcontrollers-microprocessors/stm32f423zh.html#overview): "The STM32F423xH devices are based on the high-performance Arm® Cortex®-M4 32-bit RISC core operating at a frequency of up to 100 MHz"

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Reported offline by @vincent-d who is using one cpu from this line.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
