### PR TITLE
Makefile.include: avoid recursive expansion of USEMODULE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -387,6 +387,9 @@ else
   # handle removal of default modules
   USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 
+  # avoid recursive expansion
+  USEMODULE := $(sort $(USEMODULE))
+
   # process dependencies
   include $(RIOTMAKE)/dependency_resolution.inc.mk
 endif

--- a/boards/common/e104-bt50xxa-tb/Makefile.default
+++ b/boards/common/e104-bt50xxa-tb/Makefile.default
@@ -1,0 +1,2 @@
+# Default modules for e104-bt50xxa-tb boards
+DEFAULT_MODULE += board_software_reset

--- a/boards/common/e104-bt50xxa-tb/Makefile.dep
+++ b/boards/common/e104-bt50xxa-tb/Makefile.dep
@@ -7,6 +7,4 @@ ifneq (,$(filter board_software_reset,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio_irq
 endif
 
-DEFAULT_MODULE += board_software_reset
-
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/e104-bt5010a-tb/Makefile.default
+++ b/boards/e104-bt5010a-tb/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/e104-bt50xxa-tb/Makefile.default

--- a/boards/e104-bt5011a-tb/Makefile.default
+++ b/boards/e104-bt5011a-tb/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/e104-bt50xxa-tb/Makefile.default

--- a/cpu/msp430_common/Makefile.default
+++ b/cpu/msp430_common/Makefile.default
@@ -1,0 +1,2 @@
+# msp430 uses newlib by default
+DEFAULT_MODULE += newlib

--- a/cpu/msp430_common/Makefile.dep
+++ b/cpu/msp430_common/Makefile.dep
@@ -1,8 +1,5 @@
 USEMODULE += msp430_common msp430_common_periph
 
-# msp430 uses newlib by default
-DEFAULT_MODULE += newlib
-
 ifneq (,$(filter newlib,$(USEMODULE)))
   USEMODULE += newlib_nano
 endif

--- a/cpu/msp430fxyz/Makefile.default
+++ b/cpu/msp430fxyz/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/msp430_common/Makefile.default

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -4,3 +4,9 @@ DEFAULT_MODULE += auto_init
 
 # Initialize all used peripherals by default
 DEFAULT_MODULE += periph_init
+
+# Include potentially added default modules by the board
+-include $(BOARDDIR)/Makefile.default
+
+# Include potentially added default modules by the CPU
+-include $(RIOTCPU)/$(CPU)/Makefile.default

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -723,6 +723,7 @@ endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_saul
+  DEFAULT_MODULE += saul_init_devs
   USEMODULE += saul
   USEMODULE += saul_reg
 endif


### PR DESCRIPTION
### Contribution description
The desired behaviour of `DEFAULT_MODULES` during the dependency resolution is to be evaluated once before the dependency resolution occurs and once after that.

Currently `USEMODULE` is appended using `+=` which makes it recursively expanded. [1] That means that it keeps a reference to `DEFAULT_MODULES`, during the first iteration of the process. This breaks the intended behaviour. For example, if some dependency adds a module to `DEFAULT_MODULES` during the first iteration, on a following check `USEMODULE` is updated with that module instantly.

This can be fixed by making `USEMODULE` simply expanded before the dependency resolution starts.

**edit**
[1]: According to the [GNU make documentation](https://www.gnu.org/software/make/manual/make.html):
>For the append operator ‘+=’, the right-hand side is considered immediate if the variable was previously set as a simple variable (‘:=’ or ‘::=’), and deferred otherwise.

In the particular case of `USEMODULE` it turns it into a deferred assignment. 

### Testing procedure
- Green CI
- Although this is the correct behaviour, we should watch out for dependencies that may have been working because of this error

### Issues/PRs references
None