### PR TITLE
sys/random: allow seed source selection

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -43,6 +43,27 @@ ifneq (,$(filter random,$(USEMODULE)))
   ifeq (,$(filter prng_%,$(USEMODULE)))
     USEMODULE += prng_tinymt32
   endif
+
+  # select a default seed source for auto initialization if none is selected
+  ifeq (,$(filter random_seed_%,$(USEMODULE)))
+    # by default we select the fixed, if another is possible we disable it
+    DEFAULT_MODULE += random_seed_fixed
+
+    ifneq (,$(filter puf_sram,$(USEMODULE)))
+      USEMODULE += random_seed_puf_sram
+      DISABLE_MODULE += random_seed_fixed
+    else ifneq (,$(filter periph_hwrng,$(FEATURES_USED)))
+      USEMODULE += random_seed_hwrng
+      DISABLE_MODULE += random_seed_fixed
+    else ifneq (,$(filter periph_cpuid,$(FEATURES_USED)))
+      USEMODULE += random_seed_luid
+      DISABLE_MODULE += random_seed_fixed
+    else
+      FEATURES_OPTIONAL += periph_hwrng
+      FEATURES_OPTIONAL += periph_cpuid
+    endif
+
+  endif
 endif
 
 ifneq (,$(filter spiffs,$(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -269,6 +269,12 @@ PSEUDOMODULES += lps25hb
 # add all pseudo random number generator variants as pseudomodules
 PSEUDOMODULES += prng_%
 
+# pseudo random number generator seed sources
+PSEUDOMODULES += random_seed_puf_sram
+PSEUDOMODULES += random_seed_hwrng
+PSEUDOMODULES += random_seed_luid
+PSEUDOMODULES += random_seed_fixed
+
 # STM32 periph pseudomodules
 PSEUDOMODULES += stm32_periph_%
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -793,10 +793,18 @@ ifneq (,$(filter random,$(USEMODULE)))
     FEATURES_REQUIRED += periph_hwrng
   endif
 
-  ifeq (,$(filter puf_sram,$(USEMODULE)))
-    FEATURES_OPTIONAL += periph_hwrng
-  endif
+endif
 
+# random module seed sources
+ifneq (,$(filter random_seed_puf_sram,$(USEMODULE)))
+  USEMODULE += puf_sram
+endif
+
+ifneq (,$(filter random_seed_hwrng,$(USEMODULE)))
+  USEMODULE += periph_hwrng
+endif
+
+ifneq (,$(filter random_seed_luid,$(USEMODULE)))
   USEMODULE += luid
 endif
 

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -11,6 +11,43 @@
  * @defgroup    sys_random Random
  * @ingroup     sys
  * @brief       Pseudo Random Number Generator (PRNG)
+ *
+ * To use add `USEMODULE += random` to the application Makefile.
+ *
+ * ## Auto-initialization ##
+ *
+ * Auto-initialization of the random module is controlled by adding the module
+ * `auto_init_random` (as long as `auto_init` is also used). This module is
+ * enabled by default when `random` is included, to disable it one must
+ * explicitly add it to `DISABLE_MODULE` in the application Makefile. During
+ * auto-initialization `auto_init_random` is called, and the PRNG system
+ * is seeded.
+ *
+ * ## PRNG seed sources ##
+ *
+ * The random module allows different sources to be used for the seed during
+ * the auto-initialization (or if `auto_init_random` is used manually). This
+ * is controlled by selecting from the following modules:
+ *
+ * | Module | Description |
+ * | ------ | ----------- |
+ * | `random_seed_hwrng` | Uses the HWRNG peripheral. |
+ * | `random_seed_puf_sram` | Uses the SRAM based physically unclonable function. |
+ * | `random_seed_luid` | Uses the Locally Unique ID Generator module, which uses the CPUID peripheral if present. |
+ * | `random_seed_fixed` | Uses @ref RANDOM_SEED_DEFAULT as seed. |
+ *
+ ***WARNING:** `random_seed_luid` and `random_seed_fixed` are not recommended as
+ * they provide no real entropy.
+ *
+ * ### Default behaviour ###
+ *
+ * The default behaviour, when there is no selected source, is as follows:
+ *
+ * 1. If the @ref sys_puf_sram module is used `random_seed_puf_sram` is used.
+ * 2. If the platform has a HWRNG peripheral `random_seed_hwrng` is used.
+ * 3. If the platform has a CPUID peripheral `random_seed_luid` is used.
+ * 4. If none of the above applies `random_seed_fixed` is used.
+ *
  * @{
  *
  * @file

--- a/sys/random/Makefile.include
+++ b/sys/random/Makefile.include
@@ -13,3 +13,8 @@ ifneq (1,$(words $(filter-out prng_shaxprng,$(USED_PRNG_IMPLEMENTATIONS))))
   $(info Currently the following prng modules are used: $(USED_PRNG_IMPLEMENTATIONS))
   $(error Only one implementation of PRNG should be used.)
 endif
+
+# Check that one and only one seed source has been selected
+ifneq (1,$(words $(filter-out random_seed_%,$(USEMODULE))))
+  $(error One seed should be selected for the random subsystem. Check the documentation for options.)
+endif

--- a/sys/random/Makefile.include
+++ b/sys/random/Makefile.include
@@ -15,6 +15,6 @@ ifneq (1,$(words $(filter-out prng_shaxprng,$(USED_PRNG_IMPLEMENTATIONS))))
 endif
 
 # Check that one and only one seed source has been selected
-ifneq (1,$(words $(filter-out random_seed_%,$(USEMODULE))))
-  $(error One seed should be selected for the random subsystem. Check the documentation for options.)
+ifneq (1,$(words $(filter random_seed_%,$(USEMODULE))))
+  $(error One seed should be selected for the random subsystem: $(filter random_seed_%,$(PSEUDOMODULES)))
 endif

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -26,13 +26,13 @@
 #include "random.h"
 #include "bitarithm.h"
 
-#ifdef MODULE_PUF_SRAM
+#ifdef MODULE_RANDOM_SEED_PUF_SRAM
 #include "puf_sram.h"
 #endif
-#ifdef MODULE_PERIPH_HWRNG
+#ifdef MODULE_RANDOM_SEED_HWRNG
 #include "periph/hwrng.h"
 #endif
-#ifdef MODULE_PERIPH_CPUID
+#ifdef MODULE_RANDOM_SEED_LUID
 #include "luid.h"
 #endif
 
@@ -42,19 +42,21 @@
 void auto_init_random(void)
 {
     uint32_t seed;
-#ifdef MODULE_PUF_SRAM
+#if IS_USED(MODULE_RANDOM_SEED_PUF_SRAM)
     /* TODO: hand state to application? */
     if (puf_sram_state) {
         LOG_WARNING("random: PUF SEED not fresh\n");
     }
     seed = puf_sram_seed;
-#elif defined (MODULE_PERIPH_HWRNG)
+#elif IS_USED(MODULE_RANDOM_SEED_HWRNG)
     hwrng_read(&seed, 4);
-#elif defined (MODULE_PERIPH_CPUID)
+#elif IS_USED(MODULE_RANDOM_SEED_LUID)
     luid_get(&seed, 4);
-#else
+#elif IS_USED(MODULE_RANDOM_SEED_FIXED)
     LOG_WARNING("random: NO SEED AVAILABLE!\n");
     seed = RANDOM_SEED_DEFAULT;
+#else
+    #error "No seed source selected for the random module"
 #endif
     DEBUG("random: using seed value %u\n", (unsigned)seed);
     random_init(seed);


### PR DESCRIPTION
### Contribution description
Currently the random subsystem is seeded by `auto_init_random`, which is called by auto init. It can be seeded using different sources, but the user has no explicit control over that, it just gets resolved depending on hardware availability and used modules. Moreover, the behaviour is not actually documented.

This PR introduces some pseudomodules to allow the explicit configuration of the seed source for random. It also has a default selection, which follows the current order.

**Note**: this depends on the fix provided in #15835

### Testing procedure
- Read the documentation on the header file
- Try selecting different seed sources

### Issues/PRs references
Depends on #15835
Related to #12166
Triggered by https://github.com/RIOT-OS/RIOT/pull/15817#discussion_r561693933