### PR TITLE
cpu/fe310: Mark registers as clobbered and allow using immediates for values

### DIFF
--- a/cpu/fe310/include/thread_arch.h
+++ b/cpu/fe310/include/thread_arch.h
@@ -38,7 +38,7 @@ static inline void _ecall_dispatch(uint32_t num, void *ctx)
         "ECALL\n"
         : /* No outputs */
         : [num] "r" (num), [ctx] "r" (ctx)
-        : "memory"
+        : "memory", "a0", "a1"
         );
 }
 

--- a/cpu/fe310/include/thread_arch.h
+++ b/cpu/fe310/include/thread_arch.h
@@ -33,8 +33,8 @@ static inline void _ecall_dispatch(uint32_t num, void *ctx)
 {
     /* function arguments are in a0 and a1 as per ABI */
     __asm__ volatile (
-        "mv a0, %[num] \n"
-        "mv a1, %[ctx] \n"
+        "add a0, x0, %[num] \n"
+        "add a1, x0, %[ctx] \n"
         "ECALL\n"
         : /* No outputs */
         : [num] "r" (num), [ctx] "r" (ctx)


### PR DESCRIPTION
### Contribution description

The `mv` instruction (which is usually implemented as `add rd, x0, r1`) is
changed to `add rd, x0, %[input]`. This can either be used as a load
immediate or as an move.

The code size grows by two bytes. This because GCC does not compress the
`li` instruction to the compressed version (even though this is possible). This could be an missed optimization from GCC.

### Testing procedure

With tests/bench_thread_yield_pingpong on the hifive1b:

#### Before:

```
  11108     128    3640   14876    3a1c /home/koen/dev/RIOT-review/tests/bench_thread_yield_pingpong/bin/hifive1b/tests_bench_thread_yield_pingpong.elf
```
```
{ "result" : 694087, "ticks" : 461 }
```

#### After:

```
  11110     128    3640   14878    3a1e /home/koen/dev/RIOT-review/tests/bench_thread_yield_pingpong/bin/hifive1b/tests_bench_thread_yield_pingpong.elf
```
```
{ "result" : 694085, "ticks" : 461 }
```

### Issues/PRs references

Follow up to #15736 