### PR TITLE
pkg/openwsn/sock: fix sock_udp_close handling

### DIFF
--- a/pkg/openwsn/sock/openwsn_sock_udp.c
+++ b/pkg/openwsn/sock/openwsn_sock_udp.c
@@ -25,6 +25,7 @@
 #ifdef MODULE_ZTIMER_USEC
 #include "ztimer.h"
 #endif
+#include "mutex.h"
 #include "utlist.h"
 #include "log.h"
 
@@ -43,7 +44,10 @@
 #define _TIMEOUT_MSG_TYPE  (0x8474)
 #endif /* MODULE_ZTIMER_USEC */
 
+/* sock linked list */
 static sock_udp_t *_udp_socket_list;
+/* linked list lock */
+static mutex_t _sock_list_lock;
 
 #ifdef MODULE_ZTIMER_USEC
 static void _timeout_cb(void *arg)
@@ -127,6 +131,7 @@ static uint16_t _get_dyn_port(void)
 void sock_udp_init(void)
 {
     _udp_socket_list = NULL;
+    mutex_init(&_sock_list_lock);
 }
 
 int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
@@ -199,7 +204,9 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
         sock->async_cb = NULL;
 #endif
         /* update socket list */
+        mutex_lock(&_sock_list_lock);
         LL_PREPEND(_udp_socket_list, sock);
+        mutex_unlock(&_sock_list_lock);
     }
 
     /* set flags */
@@ -316,7 +323,10 @@ void sock_udp_close(sock_udp_t *sock)
         return;
     }
     if (sock) {
+        /* remove sock from list */
+        mutex_lock(&_sock_list_lock);
         LL_DELETE(_udp_socket_list, sock);
+        mutex_unlock(&_sock_list_lock);
         sock->next = NULL;
     }
 }
@@ -495,7 +505,10 @@ void sock_receive_internal(void)
         LOG_ERROR("%s: not pkt in queue\n", __FUNCTION__);
         return;
     }
+
+    mutex_lock(&_sock_list_lock);
     current = _udp_socket_list;
+
     while (current != NULL) {
         if (current->gen_sock.local.port == pkt->l4_destination_port &&
             idmanager_isMyAddress(&pkt->l3_destinationAdd)) {
@@ -508,6 +521,8 @@ void sock_receive_internal(void)
                     "openwsn_sock: dropped message to %p (was full)\n",
                     (void *)&current->mbox);
             }
+            /* unlock mutex before callback execution */
+            mutex_unlock(&_sock_list_lock);
 #ifdef SOCK_HAS_ASYNC
             if (current->async_cb != NULL) {
                 current->async_cb(current, SOCK_ASYNC_MSG_RECV, NULL);
@@ -520,6 +535,8 @@ void sock_receive_internal(void)
     }
 
     if (current == NULL) {
+        /* unlock mutex if no associated sock was found */
+        mutex_unlock(&_sock_list_lock);
         openqueue_freePacketBuffer(pkt);
         LOG_ERROR("%s: no associated socket found\n", __FUNCTION__);
     }
@@ -540,16 +557,23 @@ void sock_senddone_internal(OpenQueueEntry_t *msg, owerror_t error)
         return;
     }
 
+    mutex_lock(&_sock_list_lock);
     current = _udp_socket_list;
-
     while (current != NULL) {
         if (current->gen_sock.local.port == pkt->l4_sourcePortORicmpv6Type &&
             current->async_cb != NULL) {
+            /* unlock mutex before callback execution */
+            mutex_unlock(&_sock_list_lock);
             current->async_cb(current, SOCK_ASYNC_MSG_SENT, &error);
             break;
         }
 
         current = current->next;
+    }
+
+    if (current == NULL) {
+        /* unlock mutex if no associated sock was found */
+        mutex_unlock(&_sock_list_lock);
     }
 #else /* SOCK_HAS_ASYNC */
     (void)error;


### PR DESCRIPTION
### Contribution description

There where two problems related to the implementation of `sock_udp_close`:

1. messages where not removed from the mailbox and therefore not removed from `openqueue` after closing a `sock`
2. possible race conditions if a `sock` was closed while iterating through its linked 

Added a unittest for 1 and add check to make sure the mbox is empty before closing.

Addressed 2 by wrapping linked list access with a mutex. I'm unsure if there is still a race condition if `sock_udp_close()` is called in an ISR or by a thread with higher priority just before the asynchronous callback happens.

### Testing procedure

- `make -C tests/pkg_openwsn_sock_udp/ flash test -j3`

- take a close look at the possible race condition