### PR TITLE
makefiles/info.inc.mk: fix EXTERNAL_BOARD_DIRS in info-build-json

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -146,7 +146,7 @@ info-build-json:
 	@echo '"BOARDDIR": "$(BOARDDIR)",'
 	@echo '"RIOTCPU": "$(RIOTCPU)",'
 	@echo '"RIOTPKG": "$(RIOTPKG)",'
-	@echo '"EXTERNAL_BOARD_DIRS": $(call json_string_or_null $(EXTERNAL_BOARD_DIRS)),'
+	@echo '"EXTERNAL_BOARD_DIRS": $(call json_string_or_null,$(EXTERNAL_BOARD_DIRS)),'
 	@echo '"BINDIR": "$(BINDIR)",'
 	@echo '"ELFFILE": "$(ELFFILE)",'
 	@echo '"HEXFILE": "$(HEXFILE)",'


### PR DESCRIPTION
### Contribution description

Fixes an small typo in the `EXTERNAL_BOARD_DIRS` field in the JSON output that caused it to not show on the JSON output.

### Testing procedure

- `make -C examples/hello-world info-build-json --silent` and check the variable in question.

### Issues/PRs references
