### PR TITLE
mtd: rename mtd_write_page() -> mtd_write_page_raw(), add high-level mtd_write_page()

### DIFF
--- a/boards/same54-xpro/Makefile.dep
+++ b/boards/same54-xpro/Makefile.dep
@@ -9,6 +9,7 @@ endif
 ifneq (,$(filter mtd,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi_on_qspi
   USEMODULE += mtd_spi_nor
+  USEMODULE += mtd_at24cxxx at24mac
 endif
 
 # enables sam0_eth as default network device

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -49,8 +49,19 @@ static mtd_spi_nor_t same54_nor_dev = {
     },
     .params = &_same54_nor_params,
 };
-
 mtd_dev_t *mtd0 = (mtd_dev_t *)&same54_nor_dev;
+
+#include "mtd_at24cxxx.h"
+#include "at24cxxx_params.h"
+static at24cxxx_t at24cxxx_dev;
+static mtd_at24cxxx_t at24mac_dev = {
+    .base = {
+        .driver = &mtd_at24cxxx_driver,
+    },
+    .at24cxxx_eeprom = &at24cxxx_dev,
+    .params = at24cxxx_params,
+};
+mtd_dev_t *mtd1 = (mtd_dev_t *)&at24mac_dev;
 #endif /* MODULE_MTD */
 
 void board_init(void)

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -34,6 +34,7 @@ extern "C" {
 #define AT24MAC_PARAM_I2C_DEV   I2C_DEV(1)
 #define AT24MAC_PARAM_I2C_ADDR  (0x5E)
 #define AT24MAC_PARAM_TYPE      AT24MAC4XX
+#define AT24CXXX_PARAM_I2C      I2C_DEV(1)
 #define AT24CXXX_PARAM_ADDR     (0x56)
 /** @} */
 
@@ -71,8 +72,10 @@ extern "C" {
  * @name MTD configuration
  * @{
  */
-extern mtd_dev_t *mtd0;
-#define MTD_0 mtd0
+extern mtd_dev_t *mtd0, *mtd1;
+#define MTD_0       mtd0
+#define MTD_1       mtd1
+#define MTD_NUMOF   2
 /** @} */
 
 /**

--- a/drivers/at24cxxx/mtd/mtd.c
+++ b/drivers/at24cxxx/mtd/mtd.c
@@ -80,5 +80,6 @@ const mtd_desc_t mtd_at24cxxx_driver = {
     .write = _mtd_at24cxxx_write,
     .write_page = mtd_at24cxxx_write_page,
     .erase = _mtd_at24cxxx_erase,
-    .power = _mtd_at24cxxx_power
+    .power = _mtd_at24cxxx_power,
+    .flags = MTD_DRIVER_FLAG_DIRECT_WRITE,
 };

--- a/drivers/at25xxx/mtd/mtd.c
+++ b/drivers/at25xxx/mtd/mtd.c
@@ -90,4 +90,5 @@ const mtd_desc_t mtd_at25xxx_driver = {
     .write_page = mtd_at25xxx_write_page,
     .erase = mtd_at25xxx_erase,
     .power = mtd_at25xxx_power,
+    .flags = MTD_DRIVER_FLAG_DIRECT_WRITE,
 };

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -60,7 +60,15 @@ typedef struct {
     uint32_t sector_count;     /**< Number of sector in the MTD */
     uint32_t pages_per_sector; /**< Number of pages by sector in the MTD */
     uint32_t page_size;        /**< Size of the pages in the MTD */
+#if defined(MODULE_MTD_WRITE_PAGE) || DOXYGEN
+    void *work_area;           /**< sector-sized buffer */
+#endif
 } mtd_dev_t;
+
+/**
+ * @brief   MTD driver can write any data to the storage without erasing it first.
+ */
+#define MTD_DRIVER_FLAG_DIRECT_WRITE    (1 << 0)
 
 /**
  * @brief   MTD driver interface
@@ -203,6 +211,11 @@ struct mtd_desc {
      * @return < 0 value on error
      */
     int (*power)(mtd_dev_t *dev, enum mtd_power_state power);
+
+    /**
+     * @brief   Properties of the MTD driver
+     */
+    uint8_t flags;
 };
 
 /**
@@ -305,6 +318,36 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
  */
 int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page,
                        uint32_t offset, uint32_t size);
+
+/**
+ * @brief   Write data to a MTD device with pagewise addressing
+ *
+ * The MTD layer will take care of splitting up the transaction into multiple
+ * writes if it is required by the underlying storage media.
+ *
+ * If the underlying sector needs to be erased before it can be written, the MTD
+ * layer will take care of the read-modify-write operation.
+ *
+ * @p offset must be smaller than the page size
+ *
+ * @note this requires the `mtd_write_page` module
+ *
+ * @param      mtd      the device to write to
+ * @param[in]  src      the buffer to write
+ * @param[in]  page     Page number to start writing to
+ * @param[in]  offset   byte offset from the start of the page
+ * @param[in]  size     the number of bytes to write
+ *
+ * @return 0 on success
+ * @return < 0 if an error occurred
+ * @return -ENODEV if @p mtd is not a valid device
+ * @return -ENOTSUP if operation is not supported on @p mtd
+ * @return -EOVERFLOW if @p addr or @p count are not valid, i.e. outside memory,
+ * @return -EIO if I/O error occurred
+ * @return -EINVAL if parameters are invalid
+ */
+int mtd_write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
+                   uint32_t offset, uint32_t size);
 
 /**
  * @brief   Erase sectors of a MTD device

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -285,8 +285,9 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
  * The MTD layer will take care of splitting up the transaction into multiple
  * writes if it is required by the underlying storage media.
  *
- * @p offset must be smaller than the page size
+ * This performs a raw write, no automatic read-modify-write cycle is performed.
  *
+ * @p offset must be smaller than the page size
  *
  * @param      mtd      the device to write to
  * @param[in]  src      the buffer to write
@@ -302,7 +303,8 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
  * @return -EIO if I/O error occurred
  * @return -EINVAL if parameters are invalid
  */
-int mtd_write_page(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset, uint32_t size);
+int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page,
+                       uint32_t offset, uint32_t size);
 
 /**
  * @brief   Erase sectors of a MTD device

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -122,11 +122,11 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
     const uint32_t page_shift = bitarithm_msb(mtd->page_size);
     const uint32_t page_mask = mtd->page_size - 1;
 
-    return mtd_write_page(mtd, src, addr >> page_shift, addr & page_mask, count);
+    return mtd_write_page_raw(mtd, src, addr >> page_shift, addr & page_mask, count);
 }
 
-int mtd_write_page(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset,
-                   uint32_t count)
+int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset,
+                       uint32_t count)
 {
     if (!mtd || !mtd->driver) {
         return -ENODEV;

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -22,6 +22,8 @@
 #include <errno.h>
 #include <limits.h>
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "bitarithm.h"
 #include "mtd.h"
@@ -32,12 +34,22 @@ int mtd_init(mtd_dev_t *mtd)
         return -ENODEV;
     }
 
+    int res = -ENOTSUP;
+
     if (mtd->driver->init) {
-        return mtd->driver->init(mtd);
+        res = mtd->driver->init(mtd);
     }
-    else {
-        return -ENOTSUP;
+
+#ifdef MODULE_MTD_WRITE_PAGE
+    if ((mtd->driver->flags & MTD_DRIVER_FLAG_DIRECT_WRITE) == 0) {
+        mtd->work_area = malloc(mtd->pages_per_sector * mtd->page_size);
+        if (mtd->work_area == NULL) {
+            res = -ENOMEM;
+        }
     }
+#endif
+
+    return res;
 }
 
 int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count)
@@ -124,6 +136,44 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
 
     return mtd_write_page_raw(mtd, src, addr >> page_shift, addr & page_mask, count);
 }
+
+#ifdef MODULE_MTD_WRITE_PAGE
+int mtd_write_page(mtd_dev_t *mtd, const void *data, uint32_t page,
+                   uint32_t offset, uint32_t len)
+{
+    if (!mtd || !mtd->driver) {
+        return -ENODEV;
+    }
+
+    if (mtd->work_area == NULL) {
+        return mtd_write_page_raw(mtd, data, page, offset, len);
+    }
+
+    int res;
+    uint8_t *work = mtd->work_area;
+    const uint32_t sector = page / mtd->pages_per_sector;
+    const uint32_t sector_page = sector * mtd->pages_per_sector;
+    const uint32_t sector_size = mtd->pages_per_sector * mtd->page_size;
+
+    /* copy sector to RAM */
+    res = mtd_read_page(mtd, work, sector_page, 0, sector_size);
+    if (res < 0) {
+        return res;
+    }
+
+    /* erase sector */
+    res = mtd_erase_sector(mtd, sector, 1);
+    if (res < 0) {
+        return res;
+    }
+
+    /* modify sector in RAM */
+    memcpy(work + (page - sector_page) * mtd->page_size + offset, data, len);
+
+    /* write back modified sector copy */
+    return mtd_write_page_raw(mtd, work, sector_page, 0, sector_size);
+}
+#endif
 
 int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset,
                        uint32_t count)

--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -112,9 +112,9 @@ static int _write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
     mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
 
     _lock(region);
-    int res = mtd_write_page(region->parent->mtd, src,
-                             page + _page_offset(region),
-                             offset, count);
+    int res = mtd_write_page_raw(region->parent->mtd, src,
+                                 page + _page_offset(region),
+                                 offset, count);
     _unlock(region);
     return res;
 }

--- a/drivers/mtd_mci/mtd_mci.c
+++ b/drivers/mtd_mci/mtd_mci.c
@@ -143,4 +143,5 @@ const mtd_desc_t mtd_mci_driver = {
     .write_page     = mtd_mci_write_page,
     .erase_sector   = mtd_mci_erase_sector,
     .power          = mtd_mci_power,
+    .flags          = MTD_DRIVER_FLAG_DIRECT_WRITE,
 };

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -158,4 +158,5 @@ const mtd_desc_t mtd_sdcard_driver = {
     .write_page = mtd_sdcard_write_page,
     .erase = mtd_sdcard_erase,
     .power = mtd_sdcard_power,
+    .flags = MTD_DRIVER_FLAG_DIRECT_WRITE,
 };

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -81,6 +81,7 @@ PSEUDOMODULES += log_color
 PSEUDOMODULES += lora
 PSEUDOMODULES += mpu_stack_guard
 PSEUDOMODULES += mpu_noexec_ram
+PSEUDOMODULES += mtd_write_page
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += netdev_default
 PSEUDOMODULES += netdev_ieee802154_%

--- a/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
@@ -135,8 +135,8 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
     uint32_t sector_size = fatfs_mtd_devs[pdrv]->page_size
                          * fatfs_mtd_devs[pdrv]->pages_per_sector;
 
-    res = mtd_write_page(fatfs_mtd_devs[pdrv], buff,
-                         sector, 0, count * sector_size);
+    res = mtd_write_page_raw(fatfs_mtd_devs[pdrv], buff,
+                             sector, 0, count * sector_size);
 
     if (res != 0) {
         return RES_ERROR;

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -85,8 +85,8 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_write_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                          off, size);
+    return mtd_write_page_raw(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
+                              off, size);
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -85,8 +85,8 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_write_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                          off, size);
+    return mtd_write_page_raw(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
+                              off, size);
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)

--- a/tests/mtd_raw/Makefile
+++ b/tests/mtd_raw/Makefile
@@ -5,5 +5,6 @@ USEMODULE += shell_commands
 
 USEMODULE += od
 USEMODULE += mtd
+USEMODULE += mtd_write_page
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -291,7 +291,7 @@ static void _print_size(uint64_t size)
         unit = "byte";
     }
 
-    printf("total: %lu %s\n", len, unit);
+    printf("%lu %s", len, unit);
 }
 
 static void _print_info(mtd_dev_t *dev)
@@ -299,7 +299,9 @@ static void _print_info(mtd_dev_t *dev)
     printf("sectors: %"PRIu32"\n", dev->sector_count);
     printf("pages per sector: %"PRIu32"\n", dev->pages_per_sector);
     printf("page size: %"PRIu32"\n", dev->page_size);
+    printf("total: ");
     _print_size(_get_size(dev));
+    puts("");
 }
 
 static int cmd_info(int argc, char **argv)
@@ -479,7 +481,9 @@ int main(void)
             continue;
         }
 
-        printf("OK (%lu kiB)\n", (unsigned long)(_get_size(dev) / 1024));
+        printf("OK (");
+        _print_size(_get_size(dev));
+        puts(")");
         mtd_power(dev, MTD_POWER_UP);
     }
 

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -187,7 +187,7 @@ static int cmd_write_page(int argc, char **argv)
     offset = atoi(argv[3]);
     len    = strlen(argv[4]);
 
-    int res = mtd_write_page(dev, argv[4], page, offset, len);
+    int res = mtd_write_page_raw(dev, argv[4], page, offset, len);
 
     if (res) {
         printf("error: %i\n", res);
@@ -376,8 +376,8 @@ static int cmd_test(int argc, char **argv)
 
     /* write dummy data to sectors */
     memset(buffer, 0x23, dev->page_size);
-    assert(mtd_write_page(dev, buffer, page_0, 0, page_size) == 0);
-    assert(mtd_write_page(dev, buffer, page_1, 0, page_size) == 0);
+    assert(mtd_write_page_raw(dev, buffer, page_0, 0, page_size) == 0);
+    assert(mtd_write_page_raw(dev, buffer, page_1, 0, page_size) == 0);
 
     /* erase two sectors and check if they have been erase */
     assert(mtd_erase_sector(dev, sector, 2) == 0);
@@ -389,20 +389,20 @@ static int cmd_test(int argc, char **argv)
     /* write test data & read it back */
     const char test_str[] = "0123456789";
     uint32_t offset = 5;
-    assert(mtd_write_page(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
     assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     /* write across page boundary */
     offset = page_size - sizeof(test_str) / 2;
-    assert(mtd_write_page(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
     assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     /* write across sector boundary */
     offset = page_size - sizeof(test_str) / 2
            + (dev->pages_per_sector - 1) * page_size;
-    assert(mtd_write_page(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
     assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -406,6 +406,13 @@ static int cmd_test(int argc, char **argv)
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
     assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
+    /* overwrite first test string, rely on MTD for read-modify-write */
+    const char test_str_2[] = "Hello World!";
+    offset = 5;
+    assert(mtd_write_page_hl(dev, test_str_2, page_0, offset, sizeof(test_str_2)) == 0);
+    assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str_2)) == 0);
+    assert(memcmp(test_str_2, buffer, sizeof(test_str_2)) == 0);
+
     puts("[SUCCESS]");
 
     free(buffer);

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -404,12 +404,12 @@ static int cmd_test(int argc, char **argv)
     assert(mtd_write_page_raw(dev, buffer, page_0, 0, page_size) == 0);
     assert(mtd_write_page_raw(dev, buffer, page_1, 0, page_size) == 0);
 
-    /* erase two sectors and check if they have been erase */
+    /* erase two sectors and check if they have been erased */
     assert(mtd_erase_sector(dev, sector, 2) == 0);
     assert(mtd_read_page(dev, buffer, page_0, 0, page_size) == 0);
-    assert(mem_is_all_set(buffer, 0xFF, page_size));
+    assert(mem_is_all_set(buffer, 0xFF, page_size) || mem_is_all_set(buffer, 0x00, page_size));
     assert(mtd_read_page(dev, buffer, page_1, 0, page_size) == 0);
-    assert(mem_is_all_set(buffer, 0xFF, page_size));
+    assert(mem_is_all_set(buffer, 0xFF, page_size) || mem_is_all_set(buffer, 0x00, page_size));
 
     /* write test data & read it back */
     const char test_str[] = "0123456789";


### PR DESCRIPTION
### Contribution description

The `mtd_write_page()` function will do a 'raw write' to the underlying memory device.
That means for flash based  storage, it will only do 1 -> 0 bit writes while 0 -> 1 writes are ignored.
This is the behavior that e.g. SPIFFS expects (used there for 'blind writes').

For some applications a more high level view is required where any bit write pattern should result in the requested data being written to the storage device.

For flash based storage, this means a read - modify - write cycle is necessary where a whole flash sector is copied to RAM, modified, erased and re-written.

This PR introduces a `mtd_write_page()` function that will do just that (or fall back to `mtd_write_page_raw()` if the storage supports direct writes, e.g. in the case of EEPROM).

The work area is allocated dynamically once on start-up. This is done because the sector size may not be known at compile-time (see #15617).
To not waste memory when this functionality is not needed, the new function is hidden behind the `mtd_hl_write` pseudo-module.

To properly test this, this also hooks up the AT24MAC EEPROM found on the `same54-xpro` as a second MTD device and fixes some bugs with the `tests/mtd_raw` test that this brought to surface.

### Testing procedure

`tests/mtd_raw` has been extended with a `write_page_hl` command. The new command has also been integrated into the automated `test` command:

```
> test 0 # SPI NOR
2021-01-24 01:14:08,361 #  test 0
2021-01-24 01:14:08,362 # [START]
2021-01-24 01:14:09,122 # [SUCCESS]
> test 1 # AT24MAC EEPROM
2021-01-24 01:14:10,881 #  test 1
2021-01-24 01:14:10,882 # [START]
2021-01-24 01:14:10,929 # [SUCCESS]
```

### Issues/PRs references

`mtd_write_page_hl()` is a terrible name.
I'd much rather rename `mtd_write_page()` ->  `mtd_write_page_raw()`.
But this would be an API change. 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
