### PR TITLE
sys/oneway-malloc: only allocate word-aligned chunks

### DIFF
--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -20,15 +20,23 @@
 
 #include <string.h>
 
+#include "architecture.h"
 #include "malloc.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#define ARCHITECTURE_WORD_MASK (ARCHITECTURE_WORD_BYTES - 1)
+
 extern void *sbrk(int incr);
 
 void __attribute__((weak)) *malloc(size_t size)
 {
+    /* ensure we always allocate word-aligned blocks */
+    if (size & ARCHITECTURE_WORD_MASK) {
+        size += ARCHITECTURE_WORD_BYTES - (size & ARCHITECTURE_WORD_MASK);
+    }
+
     if (size != 0) {
         void *ptr = sbrk(size);
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If an unevenly sized allocation is requested, the next buffer handed out would start at an unaligned address.

Fix this by rounding up to the next word-sized allocation size.


### Testing procedure

Compile `tests/malloc` with

```
USEMODULE += oneway_malloc picolibc
CFLAGS += -DCHUNK_SIZE=129
```

(`oneway-malloc` is not compatible with newlib).

On `master` this will crash after the first allocation.
With this patch, allocations are performed as expected (and no deallocations) 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
