### PR TITLE
boards: add adafruit-itsybitsy-m4

### DIFF
--- a/boards/adafruit-itsybitsy-m4/Kconfig
+++ b/boards/adafruit-itsybitsy-m4/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 ML!PA Consulting GmbH
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "adafruit-itsybitsy-m4" if BOARD_ADAFRUIT_ITSYBITSY_M4
+
+config BOARD_ADAFRUIT_ITSYBITSY_M4
+    bool
+    default y
+    select CPU_MODEL_SAMD51G19A
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/adafruit-itsybitsy-m4/Makefile
+++ b/boards/adafruit-itsybitsy-m4/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/adafruit-itsybitsy-m4/Makefile.dep
+++ b/boards/adafruit-itsybitsy-m4/Makefile.dep
@@ -1,0 +1,11 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi_on_qspi
+  USEMODULE += mtd_spi_nor
+endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/adafruit-itsybitsy-m4/Makefile.features
+++ b/boards/adafruit-itsybitsy-m4/Makefile.features
@@ -1,0 +1,15 @@
+CPU = samd5x
+CPU_MODEL = samd51g19a
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev

--- a/boards/adafruit-itsybitsy-m4/Makefile.include
+++ b/boards/adafruit-itsybitsy-m4/Makefile.include
@@ -1,0 +1,6 @@
+CFLAGS += -DBOOTLOADER_UF2
+
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include
+# Include handling of serial and non-bossa programmers (if selected by user)
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/adafruit-itsybitsy-m4/board.c
+++ b/boards/adafruit-itsybitsy-m4/board.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-m4
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Adafruit ItsyBitsy M4
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+#include "mtd_spi_nor.h"
+#include "timex.h"
+
+#ifdef MODULE_MTD
+/* GD25x16 */
+static const mtd_spi_nor_params_t _samd51_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 15 * US_PER_SEC,
+    .wait_32k_erase = 150 * US_PER_MS,
+    .wait_64k_erase = 250 * US_PER_MS,
+    .wait_sector_erase = 50 * US_PER_MS,
+    .wait_chip_wake_up = 1 * US_PER_MS,
+    .clk  = MHZ(54),
+    .flag = SPI_NOR_F_SECT_4K
+          | SPI_NOR_F_SECT_32K
+          | SPI_NOR_F_SECT_64K,
+    .spi  = SPI_DEV(1),
+    .mode = SPI_MODE_0,
+    .cs   = SAM0_QSPI_PIN_CS,
+    .wp   = SAM0_QSPI_PIN_DATA_2,
+    .hold = SAM0_QSPI_PIN_DATA_3,
+    .addr_width = 3,
+};
+
+static mtd_spi_nor_t samd51_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = 256,
+        .pages_per_sector = 16,
+    },
+    .params = &_samd51_nor_params,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+#endif /* MODULE_MTD */
+
+void board_init(void)
+{
+    /* initialize the on-board LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/adafruit-itsybitsy-m4/doc.txt
+++ b/boards/adafruit-itsybitsy-m4/doc.txt
@@ -1,0 +1,37 @@
+/**
+@defgroup    boards_adafruit-itsybitsy-m4 Adafruit-Itsybitsy-M4
+@ingroup     boards
+@brief       Support for the Adafruit-Itsybitsy-M4
+
+### General information
+
+![Adafruit-Itsybitsy-M4 compared to a quarter dollar](https://cdn-learn.adafruit.com/assets/assets/000/055/465/large1024/adafruit_products_3800_quarter_ORIG_2018_06.jpg?1529192175)
+
+This is a small formfactor (only 1.4" long by 0.7" wide) SAM D51 board made by Adafruit.
+
+The board features one red LED (LD1), one DotStar / APA102 RGB LED, a reset button as well as
+21 configurable external pins(6 of which can be analog in).
+
+### Links
+
+- [Overview](https://learn.adafruit.com/introducing-adafruit-itsybitsy-m4?view=all)
+- [Schematics](https://learn.adafruit.com/assets/55481)
+
+### Flash the board
+
+The board is flashed using its on-board [boot loader](https://github.com/adafruit/uf2-samdx1).
+
+The process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU and enter
+the bootloader.
+If some other firmware is running or RIOT crashed, you need to enter the bootloader
+manually by double tapping the board's reset button.
+
+Readiness of the bootloader is indicated by LD1 pulsing in red.
+
+### Accessing STDIO
+
+The usual way to obtain a console on this board is using an emulated USB serial port.
+
+ */

--- a/boards/adafruit-itsybitsy-m4/include/board.h
+++ b/boards/adafruit-itsybitsy-m4/include/board.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-m4
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Adafruit ItsyBitsy M4
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "mtd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 22)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 22)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+/**
+ * @name APA102 / DotStar configuration
+ * @{
+ */
+#define APA102_PARAM_LED_NUMOF      (1)
+#define APA102_PARAM_DATA_PIN       GPIO_PIN(PB, 3)
+#define APA102_PARAM_CLK_PIN        GPIO_PIN(PB, 2)
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
+/** @} */
+
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (32)
+#define XTIMER_HZ                   (1000000ul)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/adafruit-itsybitsy-m4/include/gpio_params.h
+++ b/boards/adafruit-itsybitsy-m4/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-m4
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/adafruit-itsybitsy-m4/include/periph_conf.h
+++ b/boards/adafruit-itsybitsy-m4/include/periph_conf.h
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-m4
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Adafruit ItsyBitsy M4
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    desired core clock frequency
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+#define CLOCK_CORECLOCK     MHZ(120)
+#endif
+/** @} */
+
+/**
+ * @name    32kHz Oscillator configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                    0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      1
+/** @} */
+
+/**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC0,
+        .irq            = TC0_IRQn,
+        .mclk           = &MCLK->APBAMASK.reg,
+        .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
+        .gclk_id        = TC0_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {   /* Timer 1 */
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
+        .mclk           = &MCLK->APBBMASK.reg,
+        .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
+        .gclk_id        = TC2_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_ISR         isr_tc0
+
+/* Timer 1 configuration */
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_ISR         isr_tc2
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM3->USART,
+        .rx_pin   = GPIO_PIN(PA, 16),
+        .tx_pin   = GPIO_PIN(PA, 17),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom3_2
+#define UART_0_ISR_TX       isr_sercom3_0
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 22), GPIO_MUX_G, 2 },
+};
+#endif
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    { .tim  = TCC_CONFIG(TCC0),
+      .chan = pwm_chan0_config,
+      .chan_numof = ARRAY_SIZE(pwm_chan0_config),
+      .gclk_src = SAM0_GCLK_PERIPH,
+    },
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &(SERCOM1->SPI),
+        .miso_pin = GPIO_PIN(PB, 23),
+        .mosi_pin = GPIO_PIN(PA, 0),
+        .clk_pin  = GPIO_PIN(PA, 1),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM1_DMAC_ID_TX,
+        .rx_trigger = SERCOM1_DMAC_ID_RX,
+#endif
+    },
+#ifdef MODULE_PERIPH_SPI_ON_QSPI
+    {    /* QSPI in SPI mode */
+        .dev      = QSPI,
+        .miso_pin = SAM0_QSPI_PIN_DATA_1,
+        .mosi_pin = SAM0_QSPI_PIN_DATA_0,
+        .clk_pin  = SAM0_QSPI_PIN_CLK,
+        .miso_mux = SAM0_QSPI_MUX,
+        .mosi_mux = SAM0_QSPI_MUX,
+        .clk_mux  = SAM0_QSPI_MUX,
+        .miso_pad = SPI_PAD_MISO_0,         /* unused */
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,   /* unused */
+        .gclk_src = SAM0_GCLK_MAIN,         /* unused */
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = QSPI_DMAC_ID_TX,
+        .rx_trigger = QSPI_DMAC_ID_RX,
+#endif
+    },
+#endif
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 12),
+        .sda_pin  = GPIO_PIN(PA, 13),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_PERIPH,
+        .flags    = I2C_FLAG_NONE
+    },
+};
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_H,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    }
+};
+/** @} */
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLA_PRESCALER_DIV128
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
+#define ADC_DEV                             ADC0
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)},
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN5)},
+    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN2)},
+    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN3)},
+    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN4)},
+    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6)},
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+                            /* Must not exceed 12 MHz */
+#define DAC_CLOCK           SAM0_GCLK_TIMER
+                            /* Use external reference voltage on PA03 */
+                            /* (You have to manually connect PA03 with Vcc) */
+                            /* Internal reference only gives 1V */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VREFPU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/common/samd21-arduino-bootloader/Makefile.include
+++ b/boards/common/samd21-arduino-bootloader/Makefile.include
@@ -12,4 +12,5 @@ ifeq ($(PROGRAMMER),bossa)
     ROM_OFFSET ?= 0x2000
   endif
   BOSSA_ARDUINO_PREFLASH = yes
+  PREFLASH_DELAY ?= 2
 endif

--- a/boards/common/samd21-arduino-bootloader/Makefile.include
+++ b/boards/common/samd21-arduino-bootloader/Makefile.include
@@ -6,6 +6,10 @@ ifeq ($(PROGRAMMER),bossa)
   # by default, we use BOSSA to flash this board and take into account the
   # preinstalled Arduino bootloader. ROM_OFFSET skips the space taken by
   # such bootloader.
-  ROM_OFFSET ?= 0x2000
+  ifeq ($(CPU),samd5x)
+    ROM_OFFSET ?= 0x4000
+  else
+    ROM_OFFSET ?= 0x2000
+  endif
   BOSSA_ARDUINO_PREFLASH = yes
 endif

--- a/boards/same54-xpro/Kconfig
+++ b/boards/same54-xpro/Kconfig
@@ -13,6 +13,7 @@ config BOARD_SAME54_XPRO
     select CPU_MODEL_SAME54P20A
     select HAS_PERIPH_DAC
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT

--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -13,7 +13,6 @@ config CPU_COMMON_SAMD5X
     select HAS_CORTEXM_MPU
     select HAS_CPU_SAMD5X
     select HAS_PERIPH_DMA
-    select HAS_PERIPH_ETH
     select HAS_PERIPH_GPIO_TAMPER_WAKE
     select HAS_PERIPH_HWRNG
     select HAS_PERIPH_SPI_ON_QSPI

--- a/pkg/wolfssl/include/user_settings.h
+++ b/pkg/wolfssl/include/user_settings.h
@@ -315,8 +315,11 @@ int strncasecmp(const char *s1, const char * s2, unsigned int sz);
 
 /* The following defines should prevent declaration of name-colliding "Aes"
  * structure on SAML21, SAME54 platform code
+ *
+ * TODO: avoid pulling in all vendor files through cpu_conf.h
  */
 #define _SAML21_AES_COMPONENT_
+#define _SAMD51_AES_COMPONENT_
 #define _SAME54_AES_COMPONENT_
 #define _SAMR34_AES_COMPONENT_
 


### PR DESCRIPTION
### Contribution description

This adds support for the [Adafruit ItsyBitsy M4 Express](https://learn.adafruit.com/introducing-adafruit-itsybitsy-m4?view=all), a small board based on the SAM D51G19A MCU.

![](https://cdn-learn.adafruit.com/assets/assets/000/055/467/medium640/adafruit_products_pinouts.jpg?1529192312)

It uses Adafruit's UF2 bootloader and comes with a 2 MiB QSPI Flash, a single DotStar (APA102) RGB LED and not much else.

### Testing procedure

I tested all the peripherals:

 - `tests/periph_uart`
 - `tests/periph_i2c`
 - `tests/periph_spi` - this one requires a patch to always enable MOSI mux on `spi_aquire()`, will be provided as a separate PR
 - `tests/periph_adc`
 - `tests/periph_pwm`
 - `tests/mtd_raw`
 - `tests/pkg_littlefs2`
 - `tests/driver_apa102`

### Issues/PRs references

#15846 is needed for SPI to work
