### PR TITLE
cpu/sam0_common: SPI: MOSI only operation & fix for adafruit-itsybitsy-m4

### DIFF
--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -356,11 +356,9 @@ void spi_init_pins(spi_t bus)
     }
 
     gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
-    gpio_init_mux(spi_config[bus].mosi_pin, spi_config[bus].mosi_mux);
-
     gpio_init(spi_config[bus].clk_pin, GPIO_OUT);
-    /* clk_pin will be muxed during acquire / release */
 
+    /* mosi_pin, clk_pin will be muxed during acquire / release */
     mutex_unlock(&locks[bus]);
 }
 
@@ -371,7 +369,6 @@ void spi_deinit_pins(spi_t bus)
     if (gpio_is_valid(spi_config[bus].miso_pin)) {
         gpio_disable_mux(spi_config[bus].miso_pin);
     }
-    gpio_disable_mux(spi_config[bus].mosi_pin);
 }
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
@@ -391,6 +388,7 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     }
 
     /* mux clk_pin to SPI peripheral */
+    gpio_init_mux(spi_config[bus].mosi_pin, spi_config[bus].mosi_mux);
     gpio_init_mux(spi_config[bus].clk_pin, spi_config[bus].clk_mux);
 
     return SPI_OK;
@@ -398,9 +396,11 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
 void spi_release(spi_t bus)
 {
-    /* Demux clk_pin back to GPIO_OUT function. Otherwise it will get HIGH-Z
-     * and lead to unexpected current draw by SPI salves. */
+    /* Demux clk_pin and mosi_pin back to GPIO_OUT function.
+     * Otherwise it will get HIGH-Z and lead to unexpected current draw by SPI salves.
+     */
     gpio_disable_mux(spi_config[bus].clk_pin);
+    gpio_disable_mux(spi_config[bus].mosi_pin);
 
     if (_is_qspi(bus)) {
         _qspi_release();

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -350,11 +350,15 @@ void spi_init(spi_t bus)
 void spi_init_pins(spi_t bus)
 {
     /* MISO must always have PD/PU, see #5968. This is a ~65uA difference */
-    gpio_init(spi_config[bus].miso_pin, GPIO_IN_PD);
+    if (gpio_is_valid(spi_config[bus].miso_pin)) {
+        gpio_init(spi_config[bus].miso_pin, GPIO_IN_PD);
+        gpio_init_mux(spi_config[bus].miso_pin, spi_config[bus].miso_mux);
+    }
+
     gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
-    gpio_init(spi_config[bus].clk_pin, GPIO_OUT);
-    gpio_init_mux(spi_config[bus].miso_pin, spi_config[bus].miso_mux);
     gpio_init_mux(spi_config[bus].mosi_pin, spi_config[bus].mosi_mux);
+
+    gpio_init(spi_config[bus].clk_pin, GPIO_OUT);
     /* clk_pin will be muxed during acquire / release */
 
     mutex_unlock(&locks[bus]);
@@ -364,7 +368,9 @@ void spi_deinit_pins(spi_t bus)
 {
     mutex_lock(&locks[bus]);
 
-    gpio_disable_mux(spi_config[bus].miso_pin);
+    if (gpio_is_valid(spi_config[bus].miso_pin)) {
+        gpio_disable_mux(spi_config[bus].miso_pin);
+    }
     gpio_disable_mux(spi_config[bus].mosi_pin);
 }
 


### PR DESCRIPTION
### Contribution description

 - If no MISO is configured, don't enable it. This is useful for devices like APA102 LEDs that don't have a back-channel
 - On `adafruit-itsybitsy-m4` I would not get a signal on MOSI unless I also would mux the pin on `acquire`. Without this, MOSI would just go low during the transmission with no output. I can't really explain it, in `tests/periph_spi` with MISO & MOSI connected I would see
     - `init 0 0 0`
     - `send test` -> no reply
     - `spi_gpio 0`
     - `send test` -> got reply

I narrowed this down to the second `gpio_init_mux()` fixing SPI. Turns out a late `gpio_init_mux()` on `spi_aquire()` would also do.

Also, why are MISO and CLK configured as output gpio? Shouldn't this not be necessary if we mux them to SERCOM mode anyway?

### Testing procedure

`tests/periph_spi` should still work.
Pay attention to changes in power draw with SPI devices attached, I didn't see a difference on a quick test on `samr21-xpro` after putting the radio to sleep.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
