### PR TITLE
Adding ADC declarations for B-L072Z-LORAWAN1 board

### DIFF
--- a/boards/b-l072z-lrwan1/Kconfig
+++ b/boards/b-l072z-lrwan1/Kconfig
@@ -14,6 +14,7 @@ config BOARD_B_L072Z_LRWAN1
     select CPU_MODEL_STM32L072CZ
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC    
     select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_RTC

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l072cz
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -147,6 +147,27 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * we just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0},
+    {GPIO_PIN(PORT_A, 1), 1},
+    {GPIO_PIN(PORT_A, 4), 4},
+    {GPIO_PIN(PORT_B, 0), 0},
+    {GPIO_PIN(PORT_C, 1), 0},
+    {GPIO_PIN(PORT_C, 0), 0},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

Updated the boards/b-l072z-lrwan1/ directory to define the ADC wiring.

### Testing procedure

Simply use the adctest with the A0 or A2 ardiuono connectors.