### PR TITLE
cpu/stm32/kconfig: fix rtt/rtc error symbol [backport 2021.01]

### DIFF
--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -30,10 +30,6 @@ config HAS_BOOTLOADER_STM32
     help
         Indicates that the stm32 bootloader is being used.
 
-config ERROR_MODULES_CONFLICT
-    default "On STM32, the RTC and RTT map to the same hardware peripheral." if MODULE_PERIPH_RTC && MODULE_PERIPH_RTT
-    depends on CPU_STM32
-
 orsource "kconfigs/Kconfig.clk"
 orsource "kconfigs/*/Kconfig"
 orsource "kconfigs/*/Kconfig.lines"

--- a/cpu/stm32/kconfigs/f1/Kconfig
+++ b/cpu/stm32/kconfigs/f1/Kconfig
@@ -17,8 +17,15 @@ config CPU_FAM_F1
     select HAS_BOOTLOADER_STM32
     select CLOCK_HAS_NO_MCO_PRE
 
+if CPU_FAM_F1
+
 config CPU_FAM
-    default "f1" if CPU_FAM_F1
+    default "f1"
+
+config ERROR_MODULES_CONFLICT
+    default "On STM32F1, the RTC and RTT map to the same hardware peripheral." if MODULE_PERIPH_RTC && MODULE_PERIPH_RTT
+
+endif # CPU_FAM_F1
 
 config HAS_CPU_STM32F1
     bool


### PR DESCRIPTION
# Backport of #15834

### Contribution description
As pointed out by @aabadie [here](https://github.com/RIOT-OS/RIOT/pull/15198#discussion_r562056282), the conflict between RTC and RTT only applies to the F1 family of STM32. This changes the dependency of the error symbol to only apply when that family is used.

### Testing procedure
- Check that the conflict only should apply to F1. As yet all the stm32-specific modules are not modelled one can't yet compile using Kconfig to select modules.

### Issues/PRs references
#15198