### PR TITLE
makefile: Fix usage error with busybox grep

### DIFF
--- a/makefiles/usb-codes.inc.mk
+++ b/makefiles/usb-codes.inc.mk
@@ -19,7 +19,7 @@ endif
 USB_VID_TESTING = 1209
 USB_PID_TESTING = 7D01
 usb_id_check:
-	@if grep --quiet --ignore-case "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
+	@if grep -q -i "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
 		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
 		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
 	fi


### PR DESCRIPTION
Busybox grep does not support long options. In fact, the utilized long options are not mandated by POSIX.1-2008. Using the short options allows cross compiling RIOT applications on Alpine Linux which utilizes Busybox instead of GNU coreutils by default.

CC: @maribu 