### PR TITLE
core: Add fault_exception_recovery

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -21,6 +21,10 @@ include $(RIOTBASE)/drivers/Makefile.dep
 # pull dependencies from packages
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
 
+ifneq (,$(filter thread_crash,$(USEMODULE)))
+  FEATURES_REQUIRED += fault_exception_recovery
+endif
+
 ifneq (,$(filter mpu_stack_guard,$(USEMODULE)))
   FEATURES_REQUIRED += cortexm_mpu
 endif

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -148,6 +148,7 @@ typedef struct _thread thread_t;
  */
 typedef enum {
     STATUS_STOPPED,                 /**< has terminated                           */
+    STATUS_CRASHED,                 /**< thread has crashed with a fault          */
     STATUS_ZOMBIE,                  /**< has terminated & keeps thread's thread_t */
     STATUS_SLEEPING,                /**< sleeping                                 */
     STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex               */

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += cortexm_svc
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += cpu_check_address
 FEATURES_PROVIDED += cpu_core_cortexm
+FEATURES_PROVIDED += fault_exception_recovery
 FEATURES_PROVIDED += libstdcpp
 FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += puf_sram

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -47,6 +47,27 @@
 #endif
 
 /**
+ * @brief   CPU core supports full Thumb instruction set
+ */
+#if defined(CPU_CORE_CORTEX_M0) || defined(CPU_CORE_CORTEX_M0PLUS) || \
+    defined(CPU_CORE_CORTEX_M23)
+#define CPU_CORE_CORTEXM_FULL_THUMB 0
+#else
+#define CPU_CORE_CORTEXM_FULL_THUMB 1
+#endif
+
+/**
+ * @brief   CPU core supports the full set of fault handlers
+ */
+#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
+    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
+    defined(CPU_CORE_CORTEX_M7)
+#define VECTORS_CORTEXM_EXTENDED_FAULT_HANDLERS 1
+#else
+#define VECTORS_CORTEXM_EXTENDED_FAULT_HANDLERS 0
+#endif
+
+/**
  * @brief   Memory markers, defined in the linker script
  * @{
  */
@@ -259,9 +280,8 @@ __attribute__((naked)) void hard_fault_default(void)
         "bx      lr                         \n" /* exit the exception handler    */
         " regular_handler:                  \n"
 #endif
-#if defined(CPU_CORE_CORTEX_M0) || defined(CPU_CORE_CORTEX_M0PLUS) \
-    || defined(CPU_CORE_CORTEX_M23)
         "push {r4-r7}                       \n" /* save r4..r7 to the stack   */
+#if CPU_CORE_CORTEXM_FULL_THUMB
         "mov r3, r8                         \n" /*                            */
         "mov r4, r9                         \n" /*                            */
         "mov r5, r10                        \n" /*                            */
@@ -505,9 +525,7 @@ ISR_VECTOR(0) const cortexm_base_t cortex_vector_base = {
         #endif  /* CORTEXM_VECTOR_RESERVED_0X28 */
 
         /* additional vectors used by M3, M33, M4(F), and M7 */
-#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
-    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
-    defined(CPU_CORE_CORTEX_M7)
+#if VECTORS_CORTEXM_EXTENDED_FAULT_HANDLERS
         /* [-12] memory manage exception */
         [ 3] = mem_manage_default,
         /* [-11] bus fault exception */

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -280,18 +280,29 @@ __attribute__((naked)) void hard_fault_default(void)
         "bx      lr                         \n" /* exit the exception handler    */
         " regular_handler:                  \n"
 #endif
-        "push {r4-r7}                       \n" /* save r4..r7 to the stack   */
 #if CPU_CORE_CORTEXM_FULL_THUMB
+        "push {r4-r11,lr}                   \n" /* save r4..r11+lr to the stack */
+#else
+        "push {r4-r7,lr}                    \n" /* save r4..r7+lr to the stack */
         "mov r3, r8                         \n" /*                            */
         "mov r4, r9                         \n" /*                            */
         "mov r5, r10                        \n" /*                            */
         "mov r6, r11                        \n" /*                            */
         "push {r3-r6}                       \n" /* save r8..r11 to the stack  */
-#else
-        "push {r4-r11}                      \n" /* save r4..r11 to the stack  */
 #endif
         "mov r3, sp                         \n" /* r4_to_r11_stack parameter  */
         "bl hard_fault_handler              \n" /* hard_fault_handler(r0)     */
+#if CPU_CORE_CORTEXM_FULL_THUMB
+        "pop  {r4-r11,pc}                   \n" /* pop r4..r11 back from the stack
+                                                 * and return from the handler */
+#else
+        "pop  {r3-r6}                       \n" /* pop r8..r11 from the stack */
+        "mov  r11, r6                       \n" /* and move them to their registers */
+        "mov  r10, r5                       \n" /*                                  */
+        "mov  r9, r4                        \n" /*                                  */
+        "mov  r8, r3                        \n" /*                                  */
+        "pop  {r4-r7,pc}                    \n" /* Pop r4..r7 and return            */
+#endif
           :
           : [sram]   "r" ((uintptr_t)&_sram + HARDFAULT_HANDLER_REQUIRED_STACK_SPACE),
             [eram]   "r" (&_eram),

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -62,6 +62,12 @@ config HAS_ETHERNET
     help
         Indicates that Ethernet connectivity is present.
 
+config HAS_FAULT_EXCEPTION_RECOVERY
+    bool
+    help
+        Indicates that the platform can recover from hard faults and other
+        exceptions.
+
 config HAS_HIGHLEVEL_STDIO
     bool
     help

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -35,6 +35,9 @@ endif
 # select cortexm_svc pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cortexm_svc, $(FEATURES_USED))
 
+# select cortexm_svc pseudomodule if the corresponding feature is used
+USEMODULE += $(filter fault_exception_recovery, $(FEATURES_USED))
+
 # select core_idle_thread if the feature no_idle_thread is *not* used
 ifeq (, $(filter no_idle_thread, $(FEATURES_USED)))
   USEMODULE += core_idle_thread

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -140,6 +140,7 @@ PSEUDOMODULES += stm32mp1_eng_mode
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
+PSEUDOMODULES += thread_crash
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -26,6 +26,7 @@ PSEUDOMODULES += ecc_%
 PSEUDOMODULES += event_%
 PSEUDOMODULES += evtimer_mbox
 PSEUDOMODULES += evtimer_on_ztimer
+PSEUDOMODULES += fault_exception_recovery
 PSEUDOMODULES += fmt_%
 PSEUDOMODULES += gnrc_dhcpv6_%
 PSEUDOMODULES += gnrc_dhcpv6_client_mud_url

--- a/tests/thread_crash/Makefile
+++ b/tests/thread_crash/Makefile
@@ -1,0 +1,7 @@
+BOARD ?= samr21-xpro
+include ../Makefile.tests_common
+
+USEMODULE += ps
+USEMODULE += thread_crash
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_crash/main.c
+++ b/tests/thread_crash/main.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2021 Inria
+ *               2021 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing the thread_crash module
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "thread.h"
+#include "ps.h"
+
+#ifndef FORBIDDEN_ADDRESS
+/* Many platforms do not allow writes to address 0x00000000 */
+#define FORBIDDEN_ADDRESS (0x00000000)
+#endif /* !defined(FORBIDDEN_ADDRESS) */
+#ifndef INVALID_INSTRUCTION
+/* Random garbage may crash the program as well. */
+#define INVALID_INSTRUCTION __asm__ volatile (".short 0xdead, 0xbeef, 0xcafe, 0xbabe\n")
+#endif /* !defined(INVALID_INSTRUCTION) */
+
+static char _stack[THREAD_STACKSIZE_MAIN];
+
+void *_crashing_thread(void *arg)
+{
+    (void)arg;
+    puts("Crashing this thread now");
+    *((volatile int *) FORBIDDEN_ADDRESS) = 12345;
+    volatile int readback = *((volatile int *) FORBIDDEN_ADDRESS);
+    (void)readback;
+    INVALID_INSTRUCTION;
+    /* Nothing worked, let's just try to fail an assertion */
+    assert(false);
+}
+
+int main(void)
+{
+    puts("THREAD_CONFIG_KILL_ON_CRASH test application");
+    puts("Spawning second thread to crash");
+    thread_create(_stack,
+                  sizeof(_stack),
+                  THREAD_PRIORITY_MAIN - 1,
+                  THREAD_CREATE_STACKTEST | THREAD_CONFIG_KILL_ON_CRASH,
+                  _crashing_thread,
+                  NULL,
+                  "crashing");
+    thread_yield();
+
+    ps();
+
+    return 0;
+}

--- a/tests/thread_crash/tests/01-run.py
+++ b/tests/thread_crash/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
+#               2017 Sebastian Meiling <s@mlng.net>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("Crashing this thread now")
+    child.expect(r"\s+ \d+ | crashing \s+ | crashed")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR adds a way to mark a thread as non-essential and allow it to be marked as crashed when it triggers an fault exception on the MCU. This way non-critical threads can fail gracefully without affecting the rest of the system by triggering a reboot.

`core/thread` is extended with the logic and state to initialize a thread as `THREAD_CONFIG_KILL_ON_CRASH`, where the thread will be put into the `STATUS_CRASHED` state if it triggers an exception. Afterwards the scheduler continues as usual and the system will not panic.

the fault_exception_recovery is added to signal that a CPU implements the necessary logic to catch crashed threads. This PR contains an implementation for the cortex-m platform, covering all current cortex-m CPUs.

This module does not protect against lockups where a thread crashes after locking a mutex or crashes inside a critical section.

### Testing procedure

A test application is supplied to test and demo the functionality.

### Issues/PRs references

None