### PR TITLE
makefiles/riotboot: ensure BUILDDEPS are built before riotboot targets

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -76,7 +76,7 @@ riotboot: $(SLOT_RIOT_BINS)
 
 # riotboot bootloader compile target
 riotboot/flash-bootloader: riotboot/bootloader/flash
-riotboot/bootloader/%:
+riotboot/bootloader/%: $(BUILDDEPS)
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\


### PR DESCRIPTION
### Contribution description
As reported in #15434, there seems to be a race condition when building applications with riotboot with STM32 targets, because of the cloning of CMSIS. This adds `BUILDDEPS` as a dependency for the `riotboot/bootloader/%` targets, so we ensure that all the needed files are there before start building the riotboot binary. This prevents starting the clone of CMSIS twice at the same time, which seems to be the problem reported in #15434.

### Testing procedure
- Follow the steps described in #15434, in master you should (after some tries) fall into the race condition. This PR should fix this problem.

### Issues/PRs references
Fixes #15434