### PR TITLE
ieee802154: add SFD and length of PHR for MR-FSK.

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -121,6 +121,21 @@ extern "C" {
 #define IEEE802154_RADIO_RSSI_OFFSET        (-174)
 
 #define IEEE802154_PHY_MR_FSK_PHR_LEN      (2)  /**< MR-FSK PHY header length */
+#define IEEE802154_PHY_MR_FSK_2FSK_SFD_LEN (2)  /**< MR-FSK SFD length on Filtered 2-FSK */
+
+/**
+ * For the MR-FSK PHY, the SFD value when PHR + PSDU are coded/uncoded and with
+ * phyMRFSKSFD = 0 or 1 respectively
+ *
+ * 802.15.4g, Table 131 (p. 51)
+ *
+ *  @{
+ */
+#define IEEE802154_PHY_MR_FSK_2FSK_CODED_SFD_0      (0x6F4E)
+#define IEEE802154_PHY_MR_FSK_2FSK_CODED_SFD_1      (0x632D)
+#define IEEE802154_PHY_MR_FSK_2FSK_UNCODED_SFD_0    (0x90E4)
+#define IEEE802154_PHY_MR_FSK_2FSK_UNCODED_SFD_1    (0x7A0E)
+/** @} */
 
 /**
  * For the SUN PHYs, the value is 1 ms expressed in symbol periods, rounded

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -120,6 +120,8 @@ extern "C" {
  */
 #define IEEE802154_RADIO_RSSI_OFFSET        (-174)
 
+#define IEEE802154_PHY_MR_FSK_PHR_LEN      (2)  /**< MR-FSK PHY header length */
+
 /**
  * For the SUN PHYs, the value is 1 ms expressed in symbol periods, rounded
  * up to the next integer number of symbol periods using the ceiling() function.


### PR DESCRIPTION
### Contribution description
Specifies the SFD for MR-FSK on uncoded PHR + PSDU mode.

![Screenshot from 2021-01-26 21-29-36](https://user-images.githubusercontent.com/5952531/105901438-a98f7000-601d-11eb-9085-b9dde5e4a4fd.png)

Also specifies the MR-FSK phy header (PHR) length in bytes. This is _will_ be used on #13295 .

### Testing procedure

- N/A

### Issues/PRs references

- Cherry-picked from #13295 , to not mix things up on that PR which is quite large.
