### PR TITLE
cpu: make pm_layered a DEFAULT_MODULE

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -86,8 +86,11 @@ endif
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 
-# always select power management if available
-FEATURES_OPTIONAL += periph_pm
+# always select power management unless building the bootloader
+# pm is not needed by the bootloader and omitting it saves some ROM
+ifneq (1, $(RIOTBOOT_BUILD))
+  FEATURES_OPTIONAL += periph_pm
+endif
 
 # always select provided architecture features
 FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))

--- a/boards/common/e104-bt50xxa-tb/Makefile.dep
+++ b/boards/common/e104-bt50xxa-tb/Makefile.dep
@@ -5,6 +5,7 @@ endif
 # used for software reset
 ifneq (,$(filter board_software_reset,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_pm
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -16,6 +16,7 @@ CFLAGS += -DRIOTBOOT
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 DISABLE_MODULE += core_init core_msg core_panic
 DISABLE_MODULE += auto_init auto_init_%
+DISABLE_MODULE += pm_layered
 
 # avoid using stdio
 USEMODULE += stdio_null

--- a/cpu/cc2538/Makefile.default
+++ b/cpu/cc2538/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -13,6 +13,4 @@ ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
   USEMODULE += tsrb
 endif
 
-USEMODULE += pm_layered
-
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/efm32/Makefile.default
+++ b/cpu/efm32/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -13,9 +13,6 @@ endif
 # include Gecko SDK package
 USEPKG += gecko_sdk
 
-# include layered power management
-USEMODULE += pm_layered
-
 ifneq (,$(filter efm32_coretemp,$(USEMODULE)))
   FEATURES_REQUIRED += periph_adc
 endif

--- a/cpu/esp32/Makefile.default
+++ b/cpu/esp32/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -5,7 +5,6 @@ include $(RIOTCPU)/esp_common/Makefile.dep
 USEMODULE += esp_idf_driver
 USEMODULE += esp_idf_esp32
 USEMODULE += esp_idf_soc
-USEMODULE += pm_layered
 
 ifneq (,$(filter newlib,$(USEMODULE)))
   USEMODULE += newlib_nano

--- a/cpu/kinetis/Makefile.default
+++ b/cpu/kinetis/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -21,6 +21,5 @@ else ifneq (,$(filter periph_mcg_lite,$(FEATURES_USED)))
 endif
 
 USEMODULE += periph_wdog
-USEMODULE += pm_layered
 
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/lpc1768/Makefile.default
+++ b/cpu/lpc1768/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/lpc1768/Makefile.dep
+++ b/cpu/lpc1768/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += pm_layered
-
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/lpc23xx/Makefile.default
+++ b/cpu/lpc23xx/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/lpc23xx/Makefile.dep
+++ b/cpu/lpc23xx/Makefile.dep
@@ -1,7 +1,6 @@
 USEMODULE += arm7_common
 USEMODULE += bitfield
 USEMODULE += periph
-USEMODULE += pm_layered
 
 ifneq (,$(filter mci,$(USEMODULE)))
   USEMODULE += xtimer

--- a/cpu/sam0_common/Makefile.default
+++ b/cpu/sam0_common/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -6,9 +6,6 @@ ifneq (,$(filter periph_rtc periph_rtt,$(USEMODULE)))
   USEMODULE += periph_rtc_rtt
 endif
 
-# All SAM0 based CPUs provide PM
-USEMODULE += pm_layered
-
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
 

--- a/cpu/samd21/Makefile.default
+++ b/cpu/samd21/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.default

--- a/cpu/samd5x/Makefile.default
+++ b/cpu/samd5x/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.default

--- a/cpu/saml1x/Makefile.default
+++ b/cpu/saml1x/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.default

--- a/cpu/saml21/Makefile.default
+++ b/cpu/saml21/Makefile.default
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/sam0_common/Makefile.default

--- a/cpu/stm32/Makefile.default
+++ b/cpu/stm32/Makefile.default
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += pm_layered

--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -1,5 +1,4 @@
 # All stm32 families provide pm support
-USEMODULE += pm_layered
 
 # include stm32 common periph drivers, clock configurations and vectors
 USEMODULE += periph stm32_clk stm32_vectors

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -99,11 +99,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   We provide our own pm_off() function for all STM32-based CPUs
- */
-#define PROVIDES_PM_LAYERED_OFF
-
-/**
  * @brief   All STM timers have 4 capture-compare channels
  */
 #define TIMER_CHANNEL_NUMOF (4U)

--- a/cpu/stm32/periph/pm.c
+++ b/cpu/stm32/periph/pm.c
@@ -151,9 +151,3 @@ void pm_set(unsigned mode)
 #endif
     }
 }
-
-void pm_off(void)
-{
-    irq_disable();
-    pm_set(0);
-}

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1019,6 +1019,7 @@ ifneq (,$(filter riotboot_usb_dfu, $(USEMODULE)))
   USEMODULE += usbus_dfu
   USEMODULE += riotboot_flashwrite
   FEATURES_REQUIRED += no_idle_thread
+  FEATURES_REQUIRED += periph_pm
 endif
 
 ifneq (,$(filter irq_handler,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -732,6 +732,10 @@ ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter pm_layered,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_pm
+endif
+
 ifneq (,$(filter evtimer_mbox,$(USEMODULE)))
   USEMODULE += evtimer
   USEMODULE += core_mbox

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -62,14 +62,22 @@ typedef union {
  *
  * @param[in]   mode      power mode to block
  */
+#ifdef MODULE_PM_LAYERED
 void pm_block(unsigned mode);
+#else
+static inline void pm_block(unsigned mode) { (void)mode; }
+#endif
 
 /**
  * @brief   Unblock a power mode
  *
  * @param[in]   mode      power mode to unblock
  */
+#ifdef MODULE_PM_LAYERED
 void pm_unblock(unsigned mode);
+#else
+static inline void pm_unblock(unsigned mode) { (void)mode; }
+#endif
 
 /**
  * @brief   Switches the MCU to a new power mode


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This makes `pm_layered` a `DEFAULT_MODULE` so it can be disabled.
This is useful to squeeze down the size of riotboot, which does not need pm functionality.


### Testing procedure

`riotboot` should still work.
In fact, also normal applications should still work. I tested this with `examples/default` and it will operate just normal, albeit consuming more power as it's now busy looping instead of idling when no thread is scheduled.

### Issues/PRs references

split off #15493
