### PR TITLE
boards/b-l072z-lrwan1: add ADC definitions

### DIFF
--- a/boards/b-l072z-lrwan1/Kconfig
+++ b/boards/b-l072z-lrwan1/Kconfig
@@ -14,6 +14,7 @@ config BOARD_B_L072Z_LRWAN1
     select CPU_MODEL_STM32L072CZ
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_RTC

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l072cz
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -147,6 +147,27 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * we just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0},
+    {GPIO_PIN(PORT_A, 0), 0},
+    {GPIO_PIN(PORT_A, 4), 4},
+    {GPIO_PIN(PORT_A, 4), 4},
+    {GPIO_PIN(PORT_B, 9), 1},
+    {GPIO_PIN(PORT_B, 8), 8},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -39,15 +39,15 @@ extern "C" {
  * @{
  */
 static const dma_conf_t dma_config[] = {
-    { .stream = 1  }, /* channel 2 */
-    { .stream = 2  }, /* channel 3 */
-    { .stream = 3  }, /* channel 4 */
-    { .stream = 4  }, /* channel 5 */
-    { .stream = 5  }, /* channel 6 */
+    { .stream = 1  },   /* channel 2 */
+    { .stream = 2  },   /* channel 3 */
+    { .stream = 3  },   /* channel 4 */
+    { .stream = 4  },   /* channel 5 */
+    { .stream = 5  },   /* channel 6 */
 };
 
 #define DMA_SHARED_ISR_0            isr_dma1_channel2_3
-#define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
+#define DMA_SHARED_ISR_0_STREAMS    { 0, 1 }    /* Indexes 0 and 1 of dma_config share the same isr */
 #define DMA_SHARED_ISR_1            isr_dma1_channel4_5_6_7
 #define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
 
@@ -60,35 +60,35 @@ static const dma_conf_t dma_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev        = USART2,
-        .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 3),
-        .tx_pin     = GPIO_PIN(PORT_A, 2),
-        .rx_af      = GPIO_AF4,
-        .tx_af      = GPIO_AF4,
-        .bus        = APB1,
-        .irqn       = USART2_IRQn,
-        .type       = STM32_USART,
-        .clk_src    = 0, /* Use APB clock */
+        .dev = USART2,
+        .rcc_mask = RCC_APB1ENR_USART2EN,
+        .rx_pin = GPIO_PIN(PORT_A, 3),
+        .tx_pin = GPIO_PIN(PORT_A, 2),
+        .rx_af = GPIO_AF4,
+        .tx_af = GPIO_AF4,
+        .bus = APB1,
+        .irqn = USART2_IRQn,
+        .type = STM32_USART,
+        .clk_src = 0,    /* Use APB clock */
 #ifdef MODULE_PERIPH_DMA
-        .dma        = 2,
-        .dma_chan   = 4,
+        .dma = 2,
+        .dma_chan = 4,
 #endif
     },
     {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 10),
-        .tx_pin     = GPIO_PIN(PORT_A, 9),
-        .rx_af      = GPIO_AF4,
-        .tx_af      = GPIO_AF4,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
-        .type       = STM32_USART,
-        .clk_src    = 0, /* Use APB clock */
+        .dev = USART1,
+        .rcc_mask = RCC_APB2ENR_USART1EN,
+        .rx_pin = GPIO_PIN(PORT_A, 10),
+        .tx_pin = GPIO_PIN(PORT_A, 9),
+        .rx_af = GPIO_AF4,
+        .tx_af = GPIO_AF4,
+        .bus = APB2,
+        .irqn = USART1_IRQn,
+        .type = STM32_USART,
+        .clk_src = 0,    /* Use APB clock */
 #ifdef MODULE_PERIPH_DMA
-        .dma        = 0,
-        .dma_chan   = 3,
+        .dma = 0,
+        .dma_chan = 3,
 #endif
     },
 };
@@ -105,40 +105,40 @@ static const uart_conf_t uart_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI2,
+        .dev = SPI2,
         .mosi_pin = GPIO_PIN(PORT_B, 15),
         .miso_pin = GPIO_PIN(PORT_B, 14),
         .sclk_pin = GPIO_PIN(PORT_B, 13),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF0,
-        .miso_af  = GPIO_AF0,
-        .sclk_af  = GPIO_AF0,
-        .cs_af    = GPIO_AF0,
-        .rccmask  = RCC_APB1ENR_SPI2EN,
-        .apbbus   = APB1,
+        .cs_pin = GPIO_UNDEF,
+        .mosi_af = GPIO_AF0,
+        .miso_af = GPIO_AF0,
+        .sclk_af = GPIO_AF0,
+        .cs_af = GPIO_AF0,
+        .rccmask = RCC_APB1ENR_SPI2EN,
+        .apbbus = APB1,
 #ifdef MODULE_PERIPH_DMA
-        .tx_dma   = 3,
+        .tx_dma = 3,
         .tx_dma_chan = 2,
-        .rx_dma   = 2,
+        .rx_dma = 2,
         .rx_dma_chan = 2,
 #endif
     },
     {
-        .dev      = SPI1, /* connected to SX1276 */
+        .dev = SPI1,      /* connected to SX1276 */
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_B, 3),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF0,
-        .miso_af  = GPIO_AF0,
-        .sclk_af  = GPIO_AF0,
-        .cs_af    = GPIO_AF0,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2,
+        .cs_pin = GPIO_UNDEF,
+        .mosi_af = GPIO_AF0,
+        .miso_af = GPIO_AF0,
+        .sclk_af = GPIO_AF0,
+        .cs_af = GPIO_AF0,
+        .rccmask = RCC_APB2ENR_SPI1EN,
+        .apbbus = APB2,
 #ifdef MODULE_PERIPH_DMA
-        .tx_dma   = 1,
+        .tx_dma = 1,
         .tx_dma_chan = 1,
-        .rx_dma   = 0,
+        .rx_dma = 0,
         .rx_dma_chan = 1,
 #endif
     },
@@ -157,20 +157,12 @@ static const spi_conf_t spi_config[] = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    {GPIO_PIN(PORT_A, 0), 0},
-<<<<<<< HEAD
-    {GPIO_PIN(PORT_A, 0), 0},
-    {GPIO_PIN(PORT_A, 4), 4},
-    {GPIO_PIN(PORT_A, 4), 4},
-    {GPIO_PIN(PORT_B, 9), 1},
-    {GPIO_PIN(PORT_B, 8), 8},
-=======
-    {GPIO_PIN(PORT_A, 1), 1},
-    {GPIO_PIN(PORT_A, 4), 4},
-    {GPIO_PIN(PORT_B, 0), 0},
-    {GPIO_PIN(PORT_C, 1), 1},
-    {GPIO_PIN(PORT_C, 0), 0},
->>>>>>> abf148135e285138c4ec02e5f7262243a62bd7f1
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 9), 1 },
+    { GPIO_PIN(PORT_B, 8), 8 },
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)


### PR DESCRIPTION
### Contribution description

Updated the boards/b-l072z-lrwan1/ directory to define the ADC wiring.

### Testing procedure

Simply use the adctest with the A0 or A2 ardiuono connectors.