### PR TITLE
boards/cc1352(p)-launchpad: add SAUL configuration

### DIFF
--- a/boards/cc1352-launchpad/Makefile.dep
+++ b/boards/cc1352-launchpad/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/cc1352-launchpad/include/board.h
+++ b/boards/cc1352-launchpad/include/board.h
@@ -42,7 +42,7 @@ extern "C" {
  * @name    On-board button configuration
  * @{
  */
-#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_PIN            GPIO_PIN(0, 15)
 #define BTN0_MODE           GPIO_IN_PU
 
 #define BTN1_PIN            GPIO_PIN(0, 14)

--- a/boards/cc1352-launchpad/include/gpio_params.h
+++ b/boards/cc1352-launchpad/include/gpio_params.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_cc1352_launchpad
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button(BTN-1)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Button(BTN-2)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/cc1352p-launchpad/Makefile.dep
+++ b/boards/cc1352p-launchpad/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/cc1352p-launchpad/include/board.h
+++ b/boards/cc1352p-launchpad/include/board.h
@@ -38,7 +38,7 @@ extern "C" {
  * @name    On-board button configuration
  * @{
  */
-#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_PIN            GPIO_PIN(0, 15)
 #define BTN0_MODE           GPIO_IN_PU
 
 #define BTN1_PIN            GPIO_PIN(0, 14)

--- a/boards/cc1352p-launchpad/include/gpio_params.h
+++ b/boards/cc1352p-launchpad/include/gpio_params.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_cc1352p_launchpad
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button(BTN-1)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Button(BTN-2)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

The board has two buttons and two LEDs, so export them via SAUL.
I noticed the definition of the first button was wrong (GPIO13 instead of GPIO15) this caused a hang on boot when configured as input.

### Testing procedure

The `saul` command is available in `examples/default` and can read / write LED & button states


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
