### PR TITLE
sock/dtls: add function to retrieve epoch of session

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -296,6 +296,19 @@ int sock_dtls_create(sock_dtls_t *sock, sock_udp_t *udp_sock,
     return 0;
 }
 
+int16_t sock_dtls_session_get_epoch(sock_dtls_t *sock, sock_dtls_session_t *session)
+{
+    assert(sock);
+    assert(session);
+
+    dtls_peer_t *peer = dtls_get_peer(sock->dtls_ctx, &session->dtls_session);
+    if (!peer) {
+        return -ENOTCONN;
+    }
+    dtls_security_parameters_t *security = dtls_security_params(peer);
+    return security->epoch;
+}
+
 sock_udp_t *sock_dtls_get_udp_sock(sock_dtls_t *sock)
 {
     assert(sock);

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -665,6 +665,19 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
 void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote);
 
 /**
+ * @brief   Get the current epoch of a session.
+ *
+ * @pre `(sock != NULL) && (ep != NULL)`
+ *
+ * @param[in]  sock     @ref sock_dtls_t, which the session is created on
+ * @param[in]  session  @ref sock_dtls_session_t, from which the epoch is to be
+ *                      extracted
+ *
+ * @return  The epoch on success
+ * @return  -ENOTCONN, if the session is not established
+ */
+int16_t sock_dtls_session_get_epoch(sock_dtls_t *sock, sock_dtls_session_t *session);
+/**
  * @brief Get the remote UDP endpoint from a session.
  *
  * @pre `(session != NULL) && (ep != NULL)`


### PR DESCRIPTION
### Contribution description
This PR adds a new function to the DTLS sock API: `sock_dtls_session_get_epoch()`. This function retrieves the current epoch of a session. The epoch is used for example in coap to match request and response for DTLS secured coap messaging. The epoch must be the same for request and response in that case (see [RFC 7252](https://tools.ietf.org/html/rfc7252#section-9.1.1)). This function should provide a generic way to access it.

### Testing procedure
Implementation in tinyDTLS can be tested with the test [pkg_tinydtls_sock_async](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_tinydtls_sock_async) together with this patch:
<details>

```
diff --git a/tests/pkg_tinydtls_sock_async/dtls-client.c b/tests/pkg_tinydtls_sock_async/dtls-client.c
index 78d2fefa19..ccbfa862e0 100644
--- a/tests/pkg_tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-client.c
@@ -163,6 +163,7 @@ static void _dtls_handler(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
             printf("Received %d bytes: \"%.*s\"\n", (int)res, (int)res,
                    (char *)_recv_buf);
         }
+        printf("Epoch of the session is %d\n", sock_dtls_session_get_epoch(sock, &session));
         puts("Terminating session");
         sock_dtls_session_destroy(sock, &session);
         _close_sock(sock);
diff --git a/tests/pkg_tinydtls_sock_async/dtls-server.c b/tests/pkg_tinydtls_sock_async/dtls-server.c
index 060a6f10b7..7a5b637578 100644
--- a/tests/pkg_tinydtls_sock_async/dtls-server.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-server.c
@@ -160,6 +160,7 @@ static void _dtls_handler(sock_dtls_t *sock, sock_async_flags_t type, void *arg)
                 printf("Error resending DTLS message: %d\n", (int)res);
             }
         }
+        printf("Epoch of the session is %d\n", sock_dtls_session_get_epoch(sock, &session));
     }
 }
 
```
</details>

To run it: 
* Flash and run on two devices (e.g. native)
* Execute `dtlss` on one of the devices
* Execute `dtlsc {ip} {some data}` on the other device

The epoch should be printed for the received message. The epoch can also be sniffed with wireshark and must be the same.
Printed epoch is the epoch of the packets with `Application data` in the info field. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
