### PR TITLE
tests/test_tools: set RIOT_TERMINAL to socat

### DIFF
--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -1,6 +1,10 @@
 DEVELHELP = 0
 include ../Makefile.tests_common
 
+# for some reason pyterm sends ANSI characters when used with graphical
+# terminal emulators. Socat doesn't seem to do it.
+RIOT_TERMINAL ?= socat
+
 USEMODULE += shell
 
 # Disable shell echo and prompt to not have them in the way for testing


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
For some reason pyterm sends ANSI escape sequences. The tests fails when
trying to read the clean output from the node.
I believe we should check why pyterm does that, but I propose this fix
in the meantime.

I tested this one on `samr21-xpro` and `iotlab-m3`, but I guess all boards should be affected.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`BOARD=samr21-xpro make -C tests/test_tools flash test` should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found while testing in https://github.com/RIOT-OS/Release-Specs/issues/206
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
