### PR TITLE
sys/net/gnrc: implement sock_aux_timestamp for TX

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -93,9 +93,6 @@ static xtimer_t _link_status_timer;
 
 #define MIN(a, b) (((a) <= (b)) ? (a) : (b))
 
-/* Synchronization between IRQ and thread context */
-mutex_t stm32_eth_tx_completed = MUTEX_INIT_LOCKED;
-
 /* Descriptors */
 static edma_desc_t rx_desc[ETH_RX_DESCRIPTOR_COUNT];
 static edma_desc_t tx_desc[ETH_TX_DESCRIPTOR_COUNT];
@@ -505,17 +502,22 @@ static int stm32_eth_send(netdev_t *netdev, const struct iolist *iolist)
 
     /* start TX */
     ETH->DMATPDR = 0;
-    /* await completion */
     if (IS_ACTIVE(ENABLE_DEBUG_VERBOSE)) {
         DEBUG("[stm32_eth] Started to send %u B via DMA\n", bytes_to_send);
     }
-    mutex_lock(&stm32_eth_tx_completed);
-    if (IS_ACTIVE(ENABLE_DEBUG_VERBOSE)) {
-        DEBUG("[stm32_eth] TX completed\n");
-    }
+
+    return 0;
+}
+
+
+static int stm32_eth_confirm_send(netdev_t *netdev, void *info)
+{
+    (void)info;
+    DEBUG("[stm32_eth] TX completed\n");
 
     /* Error check */
     _debug_tx_descriptor_info(__LINE__);
+    int tx_bytes = 0;
     int error = 0;
     while (1) {
         uint32_t status = tx_curr->status;
@@ -540,6 +542,7 @@ static int stm32_eth_send(netdev_t *netdev, const struct iolist *iolist)
             _reset_eth_dma();
         }
         tx_curr = tx_curr->desc_next;
+        tx_bytes += tx_curr->control;
         if (status & TX_DESC_STAT_LS) {
             break;
         }
@@ -549,7 +552,7 @@ static int stm32_eth_send(netdev_t *netdev, const struct iolist *iolist)
     if (error) {
         return error;
     }
-    return (int)bytes_to_send;
+    return tx_bytes;
 }
 
 static int get_rx_frame_size(void)
@@ -716,6 +719,7 @@ static void stm32_eth_isr(netdev_t *netdev)
 
 static const netdev_driver_t netdev_driver_stm32f4eth = {
     .send = stm32_eth_send,
+    .confirm_send = stm32_eth_confirm_send,
     .recv = stm32_eth_recv,
     .init = stm32_eth_init,
     .isr = stm32_eth_isr,

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -79,13 +79,13 @@ void isr_eth(void)
 
     if (IS_USED(MODULE_STM32_ETH)) {
         extern netdev_t *stm32_eth_netdev;
-        extern mutex_t stm32_eth_tx_completed;
         unsigned tmp = ETH->DMASR;
 
         if ((tmp & ETH_DMASR_TS)) {
             ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_TS;
             DEBUG("isr_eth: TX completed\n");
-            mutex_unlock(&stm32_eth_tx_completed);
+            stm32_eth_netdev->event_callback(stm32_eth_netdev,
+                                             NETDEV_EVENT_TX_COMPLETE);
         }
 
         if ((tmp & ETH_DMASR_RS)) {

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -282,6 +282,32 @@ struct netdev_radio_rx_info {
 };
 
 /**
+ * @name    Flags indicating which fields in @ref netdev_tx_info_t
+ *          are present
+ * @{
+ */
+#define NETDEV_TX_INFO_FLAG_TIMESTAMP       (1U << 0)
+/** @} */
+
+/**
+ * @brief   Structure to pass on auxiliary data about a transmission
+ */
+typedef struct {
+#if IS_USED(MODULE_NETDEV_TX_INFO_TIMESTAMP) || DOXYGEN
+    /**
+     * @brief   The time stamp of transmission in nanoseconds since epoch
+     *
+     * If possible, this should precisely record the time when the start of
+     * frame delimiter or the first bit after the preamble is transmitted
+     *
+     * @note    Only available when module `netdev_tx_info_timestamp` is used
+     */
+    uint64_t timestamp;
+#endif
+    uint8_t flags;      /**< Flags indicating populated entries */
+} netdev_tx_info_t;
+
+/**
  * @brief   Forward declaration for netdev struct
  */
 typedef struct netdev netdev_t;

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -43,7 +43,6 @@ PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_bus
-PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_netif_timestamp
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -88,6 +88,7 @@ PSEUDOMODULES += netdev_ieee802154
 PSEUDOMODULES += netdev_eth
 PSEUDOMODULES += netdev_layer
 PSEUDOMODULES += netdev_register
+PSEUDOMODULES += netdev_tx_info_timestamp
 PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_neighbor_etx

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -239,6 +239,7 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += l2util
   USEMODULE += fmt
+  USEMODULE += core_thread_flags
   ifneq (,$(filter netdev_ieee802154_submac,$(USEMODULE)))
     USEMODULE += gnrc_netif_pktq
   endif
@@ -255,11 +256,6 @@ endif
 
 ifneq (,$(filter gnrc_netif_bus,$(USEMODULE)))
   USEMODULE += core_msg_bus
-endif
-
-ifneq (,$(filter gnrc_netif_events,$(USEMODULE)))
-  USEMODULE += core_thread_flags
-  USEMODULE += event
 endif
 
 ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -187,6 +187,8 @@ ifneq (,$(filter gnrc_sock_%,$(USEMODULE)))
   USEMODULE += gnrc_sock
   ifneq (,$(filter sock_aux_timestamp,$(USEMODULE)))
     USEMODULE += gnrc_netif_timestamp
+    USEMODULE += gnrc_tx_sync
+    USEMODULE += netdev_tx_info_timestamp
   endif
 endif
 

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -139,16 +139,6 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS) || defined(DOXYGEN)
-    /**
-     * @brief   Event queue for asynchronous events
-     */
-    event_queue_t evq;
-    /**
-     * @brief   ISR event for the network device
-     */
-    event_t event_isr;
-#endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0) || DOXYGEN
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/include/net/gnrc/tx_sync.h
+++ b/sys/include/net/gnrc/tx_sync.h
@@ -100,6 +100,23 @@ static inline int gnrc_tx_sync_append(gnrc_pktsnip_t *pkt,
 gnrc_pktsnip_t * gnrc_tx_sync_split(gnrc_pktsnip_t *pkt);
 
 /**
+ * @brief   Search the TX sync snip and return the pointer to the
+ *          TX sync structure it holds
+ * @param[in]       pkt     Packet to search in
+ * @return  The TX sync structure found
+ * @retval  NULL            @p pkt contains no TX sync snip
+ * @post    @p pkt remains unmodified
+ */
+static inline gnrc_tx_sync_t * gnrc_tx_sync_search(gnrc_pktsnip_t *pkt)
+{
+    pkt = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_TX_SYNC);
+    if (!pkt) {
+        return NULL;
+    }
+    return pkt->data;
+}
+
+/**
  * @brief   Signal TX completion via the given tx sync packet snip
  *
  * @param[in]       pkt     The tx sync packet snip of the packet that was transmitted

--- a/sys/include/net/gnrc/tx_sync.h
+++ b/sys/include/net/gnrc/tx_sync.h
@@ -26,6 +26,7 @@
 
 #include "mutex.h"
 #include "net/gnrc/pktbuf.h"
+#include "net/netdev.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +35,8 @@ extern "C" {
 /**
  * @brief   TX synchronization data */
 typedef struct {
-    mutex_t signal;     /**< Mutex used for synchronization */
+    mutex_t signal;             /**< Mutex used for synchronization */
+    netdev_tx_info_t tx_info;   /**< auxiliary data about transmission */
 } gnrc_tx_sync_t;
 
 /**
@@ -42,7 +44,7 @@ typedef struct {
  */
 static inline gnrc_tx_sync_t gnrc_tx_sync_init(void)
 {
-    gnrc_tx_sync_t result = { .signal = MUTEX_INIT_LOCKED };
+    gnrc_tx_sync_t result = { .signal = MUTEX_INIT_LOCKED, .tx_info = { .flags = 0 } };
     return result;
 }
 

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -162,7 +162,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #endif
     res = dev->driver->send(dev, &iolist);
 
-    gnrc_pktbuf_release(pkt);
+    if (!dev->driver->confirm_send) {
+        /* only for legacy drivers we need to release pkt here */
+        gnrc_pktbuf_release(pkt);
+    }
 
     return res;
 }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <kernel_defines.h>
 
+#include "bitarithm.h"
 #include "bitfield.h"
 #include "event.h"
 #include "net/ethernet.h"
@@ -50,6 +51,10 @@
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+
+#define THREAD_FLAG_IRQ         BIT0
+#define THREAD_FLAG_RX_DONE     BIT1
+#define THREAD_FLAG_TX_DONE     BIT2
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif);
 static void _configure_netdev(netdev_t *dev);
@@ -1412,28 +1417,32 @@ void gnrc_netif_default_init(gnrc_netif_t *netif)
 #endif
 }
 
-static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);
+static gnrc_pktsnip_t * _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);
 
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
-/**
- * @brief   Call the ISR handler from an event
- *
- * @param[in]   evp     pointer to the event
- */
-static void _event_handler_isr(event_t *evp)
+static gnrc_pktsnip_t * _send_queued_pkt(gnrc_netif_t *netif)
 {
-    gnrc_netif_t *netif = container_of(evp, gnrc_netif_t, event_isr);
-    netif->dev->driver->isr(netif->dev);
-}
-#endif
-
-static inline void _event_post(gnrc_netif_t *netif)
-{
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
-    event_post(&netif->evq, &netif->event_isr);
-#else
     (void)netif;
-#endif
+#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
+    gnrc_pktsnip_t *pkt;
+
+    if ((pkt = gnrc_netif_pktq_get(netif)) != NULL) {
+        gnrc_pktsnip_t *result = _send(netif, pkt, true);
+        gnrc_netif_pktq_sched_get(netif);
+        return result;
+    }
+#endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
+    return NULL;
+}
+
+static void _pass_on_packet(gnrc_pktsnip_t *pkt)
+{
+    /* throw away packet if no one is interested */
+    if (!gnrc_netapi_dispatch_receive(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL,
+                                      pkt)) {
+        DEBUG("gnrc_netif: unable to forward packet of type %i\n", pkt->type);
+        gnrc_pktbuf_release(pkt);
+        return;
+    }
 }
 
 static void _process_receive_stats(gnrc_netif_t *netdev, gnrc_pktsnip_t *pkt)
@@ -1458,149 +1467,35 @@ static void _process_receive_stats(gnrc_netif_t *netdev, gnrc_pktsnip_t *pkt)
 }
 
 /**
- * @brief   Retrieve the netif event queue if enabled
+ * @brief   Handle failed transmission attempt
  *
- * @param[in]   netif   gnrc_netif instance to operate on
- *
- * @return              NULL if MODULE_GNRC_NETIF_EVENTS is not enabled
- * @return              gnrc_netif_t::evq if MODULE_GNRC_NETIF_EVENTS is enabled
+ * @param   netif       Interface which failed to transfer a frame
+ * @param   error_code  Return value of send() or send_confirm() indicating
+ *                      the failure cause
+ * @param   pkt         Frame that couldn't be send
+ * @param   push_back   Where to enqueue the frame (with module gnrc_netif_pktq)
  */
-static inline event_queue_t *_get_evq(gnrc_netif_t *netif)
+static void _tx_failed(gnrc_netif_t *netif, int error_code, gnrc_pktsnip_t *pkt,
+                       bool push_back)
 {
-#ifdef MODULE_GNRC_NETIF_EVENTS
-    return &netif->evq;
-#else
-    (void)netif;
-    return NULL;
-#endif
-}
-
-/**
- * @brief   Process any pending events and wait for IPC messages
- *
- * This function will block until an IPC message is received. Events posted to
- * the event queue will be processed while waiting for messages.
- *
- * @param[in]   netif   gnrc_netif instance to operate on
- * @param[out]  msg     pointer to message buffer to write the first received message
- *
- * @return >0 if msg contains a new message
- */
-static void _process_events_await_msg(gnrc_netif_t *netif, msg_t *msg)
-{
-    if (IS_USED(MODULE_GNRC_NETIF_EVENTS)) {
-        while (1) {
-            /* Using messages for external IPC, and events for internal events */
-
-            /* First drain the queues before blocking the thread */
-            /* Events will be handled before messages */
-            DEBUG("gnrc_netif: handling events\n");
-            event_t *evp;
-            /* We can not use event_loop() or event_wait() because then we would not
-             * wake up when a message arrives */
-            event_queue_t *evq = _get_evq(netif);
-            while ((evp = event_get(evq))) {
-                DEBUG("gnrc_netif: event %p\n", (void *)evp);
-                if (evp->handler) {
-                    evp->handler(evp);
-                }
-            }
-            /* non-blocking msg check */
-            int msg_waiting = msg_try_receive(msg);
-            if (msg_waiting > 0) {
-                return;
-            }
-            DEBUG("gnrc_netif: waiting for events\n");
-            /* Block the thread until something interesting happens */
-            thread_flags_wait_any(THREAD_FLAG_MSG_WAITING | THREAD_FLAG_EVENT);
-        }
-    }
-    else {
-        /* Only messages used for event handling */
-        DEBUG("gnrc_netif: waiting for incoming messages\n");
-        msg_receive(msg);
-    }
-}
-
-static void _send_queued_pkt(gnrc_netif_t *netif)
-{
-    (void)netif;
-#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
-    gnrc_pktsnip_t *pkt;
-
-    if ((pkt = gnrc_netif_pktq_get(netif)) != NULL) {
-        _send(netif, pkt, true);
-        gnrc_netif_pktq_sched_get(netif);
-    }
-#endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-}
-
-static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
-{
-    (void)push_back; /* only used with IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-    int res;
-
-#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
-    /* send queued packets first to keep order */
-    if (!push_back && !gnrc_netif_pktq_empty(netif)) {
-        int put_res;
-
-        put_res = gnrc_netif_pktq_put(netif, pkt);
-        if (put_res == 0) {
-            DEBUG("gnrc_netif: (re-)queued pkt %p\n", (void *)pkt);
-            _send_queued_pkt(netif);
-            return;
-        }
-        else {
-            LOG_WARNING("gnrc_netif: can't queue packet for sending\n");
-            /* try to send anyway */
-        }
-    }
-    /* hold in case device was busy to not having to rewrite *all* the link
-     * layer implementations in case `gnrc_netif_pktq` is included */
-    gnrc_pktbuf_hold(pkt, 1);
-#endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-
-    /* Record send in neighbor statistics if destination is unicast */
+    /* arguments may be unused, depending on used pseudo modules */
+    (void)netif; (void)error_code; (void)pkt; (void)push_back;
+    DEBUG("gnrc_netif: error sending packet %p (code: %i)\n",
+          (void *)pkt, error_code);
     if (IS_USED(MODULE_NETSTATS_NEIGHBOR)) {
-        gnrc_netif_hdr_t *netif_hdr = pkt->data;
-        if (netif_hdr->flags &
-            (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-            DEBUG("l2 stats: Destination is multicast or unicast, NULL recorded\n");
-            netstats_nb_record(&netif->netif, NULL, 0);
+        int8_t retries = -1;
+        netstats_nb_result_t result;
+        if (error_code == -EBUSY) {
+            result = NETSTATS_NB_BUSY;
         } else {
-            DEBUG("l2 stats: recording transmission\n");
-            netstats_nb_record(&netif->netif,
-                               gnrc_netif_hdr_get_dst_addr(netif_hdr),
-                               netif_hdr->dst_l2addr_len);
+            result = NETSTATS_NB_NOACK;
+            netdev_t *dev = netif->dev;
+            dev->driver->get(dev, NETOPT_TX_RETRIES_NEEDED, &retries, sizeof(retries));
         }
+        netstats_nb_update_tx(&netif->netif, result, retries + 1);
     }
-
-    /* Split off the TX sync snip */
-    gnrc_pktsnip_t *tx_sync = IS_USED(MODULE_GNRC_TX_SYNC)
-                            ? gnrc_tx_sync_split(pkt) : NULL;
-    res = netif->ops->send(netif, pkt);
-    if (tx_sync != NULL) {
-        uint32_t err = (res < 0) ? -res : GNRC_NETERR_SUCCESS;
-        gnrc_pktbuf_release_error(tx_sync, err);
-    }
-
-    /* no frame was transmitted */
-    if (res < 0) {
-        DEBUG("gnrc_netif: error sending packet %p (code: %i)\n",
-              (void *)pkt, res);
-
-        if (IS_USED(MODULE_NETSTATS_NEIGHBOR)) {
-            netstats_nb_update_tx(&netif->netif, NETSTATS_NB_BUSY, 0);
-        }
-    }
-#ifdef MODULE_NETSTATS_L2
-    else {
-        netif->stats.tx_bytes += res;
-    }
-#endif
 #if IS_USED(MODULE_GNRC_NETIF_PKTQ)
-    if (res == -EBUSY) {
+    if (error_code == -EBUSY) {
         int put_res;
 
         /* Lower layer was busy.
@@ -1620,19 +1515,199 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
             DEBUG("gnrc_netif: (re-)queued pkt %p\n", (void *)pkt);
             return; /* early return to not release */
         }
-        else {
-            LOG_ERROR("gnrc_netif: can't queue packet for sending\n");
-            /* If we got here, it means the device was busy and the pkt queue
-             * was full. The packet should be dropped here anyway */
-            gnrc_pktbuf_release_error(pkt, ENOMEM);
-        }
-        return;
-    }
-    else {
-        /* remove previously held packet */
-        gnrc_pktbuf_release(pkt);
+
+        LOG_ERROR("gnrc_netif: can't queue packet for sending\n");
+        /* If we got here, it means the device was busy and the pkt queue
+         * was full. The packet should be dropped here anyway */
+        error_code = -ENOMEM;
     }
 #endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
+    /* remove previously held packet */
+    gnrc_pktbuf_release_error(pkt, -error_code);
+#if IS_USED(MODULE_NETSTATS_L2)
+    /* we are the only ones supposed to touch this variable,
+     * so no acquire necessary */
+    netif->stats.tx_failed++;
+#endif /* IS_USED(MODULE_NETSTATS_L2) */
+}
+
+/**
+ * @brief   Handle successful transmission attempt
+ *
+ * @param   netif       Interface which failed to transfer a frame
+ * @param   bytes_send  Number of bytes send
+ *
+ * @return  Outgoing frame that was send from packet queue
+ * @retval  `NULL`      No frame is currently being send
+ */
+static gnrc_pktsnip_t * _tx_succeeded(gnrc_netif_t *netif, uint32_t bytes_send)
+{
+    /* arguments may be unused, depending on used pseudo modules */
+    (void)netif; (void)bytes_send;
+#if IS_USED(MODULE_NETSTATS_L2)
+    /* we are the only ones supposed to touch this variable,
+     * so no acquire necessary */
+    netif->stats.tx_success++;
+    netif->stats.tx_bytes += bytes_send;
+#endif /* IS_USED(MODULE_NETSTATS_L2) */
+    if (IS_USED(MODULE_NETSTATS_NEIGHBOR)) {
+        int8_t retries = -1;
+        netdev_t *dev = netif->dev;
+        dev->driver->get(dev, NETOPT_TX_RETRIES_NEEDED, &retries, sizeof(retries));
+        netstats_nb_update_tx(&netif->netif, NETSTATS_NB_SUCCESS, retries + 1);
+    }
+    /* send packet previously queued within netif due to the lower
+     * layer being busy.
+     * Further packets will be sent on later TX_COMPLETE or
+     * TX_MEDIUM_BUSY */
+    return _send_queued_pkt(netif);
+}
+
+
+/**
+ * @brief   Process any pending events and wait for IPC messages
+ *
+ * This function will block until an IPC message is received. ISR events
+ * will still be processed.
+ *
+ * @param[in]   netif       gnrc_netif instance to operate on
+ * @param[in]   dev         netdev corresponding to @p netif
+ * @param[out]  msg         pointer to message buffer to write the first received
+ *                          message
+ * @param[in]   tx_pkt      frame that is currently being send, or `NULL` if no transmission is
+ *                          currently ongoing
+ *
+ * @return  Frame that is currently being send
+ * @retval  NULL            No frame is currently being send
+ */
+static gnrc_pktsnip_t * _process_events_await_msg(gnrc_netif_t *netif, netdev_t *dev, msg_t *msg,
+                                                  gnrc_pktsnip_t *tx_pkt)
+{
+    DEBUG("gnrc_netif: waiting for incoming events or messages\n");
+    const thread_flags_t flags_mask = THREAD_FLAG_IRQ | THREAD_FLAG_RX_DONE | THREAD_FLAG_TX_DONE
+                                    | THREAD_FLAG_MSG_WAITING;
+    while (msg_try_receive(msg) == -1) {
+        thread_flags_t flags = thread_flags_wait_any(flags_mask);
+        if (flags & THREAD_FLAG_IRQ) {
+            dev->driver->isr(dev);
+        }
+        if (flags & THREAD_FLAG_RX_DONE) {
+            gnrc_pktsnip_t *pkt = netif->ops->recv(netif);
+            /* send packet previously queued within netif due to the lower
+             * layer being busy.
+             * Further packets will be sent on later TX_COMPLETE */
+            if (!tx_pkt) {
+                tx_pkt = _send_queued_pkt(netif);
+            }
+            if (pkt) {
+                _process_receive_stats(netif, pkt);
+                _pass_on_packet(pkt);
+            }
+        }
+        if (flags & THREAD_FLAG_TX_DONE) {
+            if (!tx_pkt) {
+                DEBUG("gnrc_netif: got TX_DONE event while not sending\n");
+            }
+            else {
+                int retval;
+                while (-EAGAIN == (retval = dev->driver->confirm_send(dev, NULL)))
+                {
+                    /* Per API contract, this should never happen, but in
+                     * production code it might be better to busy wait here */
+                    assert(0);
+                }
+                if (retval < 0) {
+                    _tx_failed(netif, retval, tx_pkt, false);
+                    tx_pkt = NULL;
+                }
+                else {
+                    gnrc_pktsnip_t *to_release = tx_pkt;
+                    tx_pkt = _tx_succeeded(netif, retval);
+                    gnrc_pktbuf_release(to_release);
+                }
+            }
+        }
+    }
+
+    return tx_pkt;
+}
+
+/**
+ * @brief   Send a frame
+ *
+ * @param[in]   netif       interface to use for sending
+ * @param[in]   pkt         frame to send
+ * @param[in]   push_back   how to enqueue the packet when using gnrc_netif_pktq
+ *
+ * @return  @p pkt, if the frame is still in transit
+ * @retval  NULL            If sending @p pkt has completed and the buffer has been freed
+ */
+static gnrc_pktsnip_t * _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
+{
+    int res;
+
+#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
+    /* send queued packets first to keep order */
+    if (!push_back && !gnrc_netif_pktq_empty(netif)) {
+        int put_res;
+
+        put_res = gnrc_netif_pktq_put(netif, pkt);
+        if (put_res == 0) {
+            DEBUG("gnrc_netif: (re-)queued pkt %p\n", (void *)pkt);
+            return _send_queued_pkt(netif);
+        }
+        else {
+            LOG_WARNING("gnrc_netif: can't queue packet for sending\n");
+            /* try to send anyway */
+        }
+    }
+    if (!netif->dev->driver->confirm_send) {
+        /* hold in case device was busy to not having to rewrite *all* the link
+         * layer implementations in case `gnrc_netif_pktq` is included */
+        gnrc_pktbuf_hold(pkt, 1);
+    }
+#endif /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
+
+    /* Record send in neighbor statistics if destination is unicast */
+    if (IS_USED(MODULE_NETSTATS_NEIGHBOR)) {
+        gnrc_netif_hdr_t *netif_hdr = pkt->data;
+        if (netif_hdr->flags &
+            (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+            DEBUG("l2 stats: Destination is multicast or unicast, NULL recorded\n");
+            netstats_nb_record(&netif->netif, NULL, 0);
+        } else {
+            DEBUG("l2 stats: recording transmission\n");
+            netstats_nb_record(&netif->netif,
+                               gnrc_netif_hdr_get_dst_addr(netif_hdr),
+                               netif_hdr->dst_l2addr_len);
+        }
+    }
+
+#if IS_USED(MODULE_GNRC_TX_SYNC)
+    /* Don't confuse netdevs with TX sync snip */
+    gnrc_pktsnip_t *tx_sync = gnrc_tx_sync_split(pkt);
+#endif
+    res = netif->ops->send(netif, pkt);
+
+    if (res < 0) {
+#if IS_USED(MODULE_GNRC_TX_SYNC)
+        gnrc_pkt_append(pkt, tx_sync);
+#endif
+        _tx_failed(netif, res, pkt, push_back);
+        return NULL;
+    }
+    if (!netif->dev->driver->confirm_send) {
+        /* success and legacy, blocking netdev API */
+#if IS_USED(MODULE_GNRC_TX_SYNC)
+        gnrc_pktbuf_release(tx_sync);
+#endif
+        return _tx_succeeded(netif, res);
+    }
+    /* modern API, outgoing frame needs still to be released upon TX completion */
+#if IS_USED(MODULE_GNRC_TX_SYNC)
+    gnrc_pkt_append(pkt, tx_sync);
+#endif
+    return pkt;
 }
 
 static void *_gnrc_netif_thread(void *args)
@@ -1649,12 +1724,6 @@ static void *_gnrc_netif_thread(void *args)
     gnrc_netif_acquire(netif);
     dev = netif->dev;
     netif->pid = thread_getpid();
-
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS)
-    netif->event_isr.handler = _event_handler_isr,
-    /* set up the event queue */
-    event_queue_init(&netif->evq);
-#endif /* MODULE_GNRC_NETIF_EVENTS */
 
     /* setup the link-layer's message queue */
     msg_init_queue(msg_queue, GNRC_NETIF_MSG_QUEUE_SIZE);
@@ -1687,28 +1756,37 @@ static void *_gnrc_netif_thread(void *args)
     xtimer_ticks32_t last_wakeup = xtimer_now();
 #endif
 
+    gnrc_pktsnip_t *tx_pkt = NULL;
     while (1) {
         msg_t msg;
         /* msg will be filled by _process_events_await_msg.
          * The function will not return until a message has been received. */
-        _process_events_await_msg(netif, &msg);
+        tx_pkt = _process_events_await_msg(netif, dev, &msg, tx_pkt);
 
         /* dispatch netdev, MAC and gnrc_netapi messages */
         DEBUG("gnrc_netif: message %u\n", (unsigned)msg.type);
         switch (msg.type) {
 #if IS_USED(MODULE_GNRC_NETIF_PKTQ)
             case GNRC_NETIF_PKTQ_DEQUEUE_MSG:
-                DEBUG("gnrc_netif: send from packet send queue\n");
-                _send_queued_pkt(netif);
+                if (tx_pkt) {
+                    DEBUG("gnrc_netif: refusing to dequeue from pktq while TX is ongoing\n");
+                }
+                else {
+                    DEBUG("gnrc_netif: send from packet send queue\n");
+                    tx_pkt = _send_queued_pkt(netif);
+                }
                 break;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-            case NETDEV_MSG_TYPE_EVENT:
-                DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
-                dev->driver->isr(dev);
-                break;
             case GNRC_NETAPI_MSG_TYPE_SND:
                 DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_SND received\n");
-                _send(netif, msg.content.ptr, false);
+                if (tx_pkt) {
+                    DEBUG("gnrc_netif: transmission attempt during TX\n");
+                    /* if gnrc_netif_pktq is active, the outgoing frame will be queued up rather
+                     * than dropped */
+                    _tx_failed(netif, -EBUSY, msg.content.ptr, false);
+                } else {
+                    tx_pkt = _send(netif, msg.content.ptr, false);
+                }
 #if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
                 xtimer_periodic_wakeup(
                         &last_wakeup,
@@ -1766,100 +1844,31 @@ static void *_gnrc_netif_thread(void *args)
     return NULL;
 }
 
-static void _pass_on_packet(gnrc_pktsnip_t *pkt)
-{
-    /* throw away packet if no one is interested */
-    if (!gnrc_netapi_dispatch_receive(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL,
-                                      pkt)) {
-        DEBUG("gnrc_netif: unable to forward packet of type %i\n", pkt->type);
-        gnrc_pktbuf_release(pkt);
-        return;
-    }
-}
-
 static void _event_cb(netdev_t *dev, netdev_event_t event)
 {
-    gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
+    gnrc_netif_t *netif = (gnrc_netif_t *)dev->context;
 
-    if (event == NETDEV_EVENT_ISR) {
-        if (IS_USED(MODULE_GNRC_NETIF_EVENTS)) {
-            _event_post(netif);
-        }
-        else {
-            msg_t msg = { .type = NETDEV_MSG_TYPE_EVENT,
-                          .content = { .ptr = netif } };
-
-            if (msg_send(&msg, netif->pid) <= 0) {
-                puts("gnrc_netif: possibly lost interrupt.");
-            }
-        }
-    }
-    else {
-        DEBUG("gnrc_netif: event triggered -> %i\n", event);
-        gnrc_pktsnip_t *pkt = NULL;
-        switch (event) {
-            case NETDEV_EVENT_RX_COMPLETE:
-                pkt = netif->ops->recv(netif);
-                /* send packet previously queued within netif due to the lower
-                 * layer being busy.
-                 * Further packets will be sent on later TX_COMPLETE */
-                _send_queued_pkt(netif);
-                if (pkt) {
-                    _process_receive_stats(netif, pkt);
-                    _pass_on_packet(pkt);
-                }
-                break;
-#if IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)
-            case NETDEV_EVENT_TX_COMPLETE:
-            case NETDEV_EVENT_TX_COMPLETE_DATA_PENDING:
-                /* send packet previously queued within netif due to the lower
-                 * layer being busy.
-                 * Further packets will be sent on later TX_COMPLETE or
-                 * TX_MEDIUM_BUSY */
-                _send_queued_pkt(netif);
-#if IS_USED(MODULE_NETSTATS_L2)
-                /* we are the only ones supposed to touch this variable,
-                 * so no acquire necessary */
-                netif->stats.tx_success++;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) */
-                if (IS_USED(MODULE_NETSTATS_NEIGHBOR)) {
-                    int8_t retries = -1;
-                    dev->driver->get(dev, NETOPT_TX_RETRIES_NEEDED, &retries, sizeof(retries));
-                    netstats_nb_update_tx(&netif->netif, NETSTATS_NB_SUCCESS, retries + 1);
-                }
-                break;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-#if IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) || \
-    IS_USED(MODULE_NETSTATS_NEIGHBOR)
-            case NETDEV_EVENT_TX_MEDIUM_BUSY:
-            case NETDEV_EVENT_TX_NOACK:
-                /* update neighbor statistics */
-                if (IS_USED(MODULE_NETSTATS_NEIGHBOR)) {
-                    int8_t retries = -1;
-                    netstats_nb_result_t result;
-                    if (event == NETDEV_EVENT_TX_NOACK) {
-                        result = NETSTATS_NB_NOACK;
-                        dev->driver->get(dev, NETOPT_TX_RETRIES_NEEDED, &retries, sizeof(retries));
-                    } else {
-                        result = NETSTATS_NB_BUSY;
-                    }
-                    netstats_nb_update_tx(&netif->netif, result, retries + 1);
-                }
-                /* send packet previously queued within netif due to the lower
-                 * layer being busy.
-                 * Further packets will be sent on later TX_COMPLETE or
-                 * TX_MEDIUM_BUSY */
-                _send_queued_pkt(netif);
-#if IS_USED(MODULE_NETSTATS_L2)
-                /* we are the only ones supposed to touch this variable,
-                 * so no acquire necessary */
-                netif->stats.tx_failed++;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) */
-                break;
-#endif  /* IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ) */
-            default:
-                DEBUG("gnrc_netif: warning: unhandled event %u.\n", event);
-        }
+    DEBUG("gnrc_netif: event triggered -> %i\n", event);
+    thread_t *thread = thread_get(netif->pid);
+    switch (event) {
+    case NETDEV_EVENT_ISR:
+        thread_flags_set(thread, THREAD_FLAG_IRQ);
+        break;
+    case NETDEV_EVENT_RX_COMPLETE:
+        thread_flags_set(thread, THREAD_FLAG_RX_DONE);
+        break;
+    case NETDEV_EVENT_TX_COMPLETE:
+        thread_flags_set(thread, THREAD_FLAG_TX_DONE);
+        break;
+    case NETDEV_EVENT_TX_COMPLETE_DATA_PENDING:
+    case NETDEV_EVENT_TX_MEDIUM_BUSY:
+    case NETDEV_EVENT_TX_NOACK:
+        /* legacy events */
+        DEBUG("gnrc_netif: legacy event %u received.\n", event);
+        thread_flags_set(thread, THREAD_FLAG_TX_DONE);
+        break;
+    default:
+        DEBUG("gnrc_netif: warning: unhandled event %u.\n", event);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1610,7 +1610,14 @@ static gnrc_pktsnip_t * _process_events_await_msg(gnrc_netif_t *netif, netdev_t 
             }
             else {
                 int retval;
-                while (-EAGAIN == (retval = dev->driver->confirm_send(dev, NULL)))
+                void *tx_info = NULL;
+                if (IS_USED(MODULE_GNRC_TX_SYNC)) {
+                    gnrc_tx_sync_t *tx_sync = gnrc_tx_sync_search(tx_pkt);
+                    if (tx_sync) {
+                        tx_info = &tx_sync->tx_info;
+                    }
+                }
+                while (-EAGAIN == (retval = dev->driver->confirm_send(dev, tx_info)))
                 {
                     /* Per API contract, this should never happen, but in
                      * production code it might be better to busy wait here */

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -197,8 +197,10 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
 }
 
 ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
-                       const sock_ip_ep_t *remote, uint8_t nh)
+                       const sock_ip_ep_t *remote, uint8_t nh,
+                       gnrc_sock_send_aux_t *aux)
 {
+    (void)aux; /* usage of aux depends on selected modules */
     gnrc_pktsnip_t *pkt;
     kernel_pid_t iface = KERNEL_PID_UNDEF;
     gnrc_nettype_t type;
@@ -286,6 +288,12 @@ ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
 
 #if IS_USED(MODULE_GNRC_TX_SYNC)
     gnrc_tx_sync(&tx_sync);
+#  if IS_USED(MODULE_NETDEV_TX_INFO_TIMESTAMP) && IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if (aux->timestamp && (tx_sync.tx_info.flags & NETDEV_TX_INFO_FLAG_TIMESTAMP)) {
+        *aux->timestamp = tx_sync.tx_info.timestamp;
+        aux->flags |= GNRC_SOCK_SEND_AUX_FLAG_TIMESTAMP;
+    }
+#  endif
 #endif
 
 #ifdef MODULE_GNRC_NETERR

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -86,6 +86,24 @@ typedef struct {
 #define GNRC_SOCK_RECV_AUX_FLAG_RSSI        0x02    /**< RSSI valid */
 
 /**
+ * @brief   Structure to retrieve auxiliary data from @ref gnrc_sock_send
+ *
+ * @details The members of this function depend on the modules used
+ * @internal
+ */
+typedef struct {
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP) || DOXYGEN
+    uint64_t *timestamp;    /**< timestamp PDU was received at in nanoseconds */
+#endif
+    /**
+     * @brief   Flags
+     */
+    uint8_t flags;
+} gnrc_sock_send_aux_t;
+
+#define GNRC_SOCK_SEND_AUX_FLAG_TIMESTAMP   0x01    /**< Timestamp valid */
+
+/**
  * @brief   Internal helper functions for GNRC
  * @internal
  * @{
@@ -153,7 +171,8 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt, uint32_t time
  * @internal
  */
 ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
-                       const sock_ip_ep_t *remote, uint8_t nh);
+                       const sock_ip_ep_t *remote, uint8_t nh,
+                       gnrc_sock_send_aux_t *aux);
 /**
  * @}
  */

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -192,6 +192,7 @@ ssize_t sock_ip_send_aux(sock_ip_t *sock, const void *data, size_t len,
     gnrc_pktsnip_t *pkt;
     sock_ip_ep_t local;
     sock_ip_ep_t rem;
+    gnrc_sock_send_aux_t _aux = { .flags = 0 };
 
     assert((sock != NULL) || (remote != NULL));
     assert((len == 0) || (data != NULL)); /* (len != 0) => (data != NULL) */
@@ -251,7 +252,13 @@ ssize_t sock_ip_send_aux(sock_ip_t *sock, const void *data, size_t len,
     if (pkt == NULL) {
         return -ENOMEM;
     }
-    res = gnrc_sock_send(pkt, &local, &rem, proto);
+
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if (aux && (aux->flags & SOCK_AUX_GET_TIMESTAMP)) {
+        _aux.timestamp = &aux->timestamp;
+    }
+#endif
+    res = gnrc_sock_send(pkt, &local, &rem, proto, &_aux);
     if (res <= 0) {
         return res;
     }
@@ -261,6 +268,12 @@ ssize_t sock_ip_send_aux(sock_ip_t *sock, const void *data, size_t len,
                               sock->reg.async_cb_arg);
     }
 #endif  /* SOCK_HAS_ASYNC */
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if (aux && (aux->flags & SOCK_AUX_GET_TIMESTAMP)
+        && (_aux.flags &GNRC_SOCK_SEND_AUX_FLAG_TIMESTAMP)) {
+        aux->flags &= ~SOCK_AUX_GET_TIMESTAMP;
+    }
+#endif
     return res;
 }
 

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -288,6 +288,7 @@ ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
     sock_ip_ep_t local;
     sock_udp_ep_t remote_cpy;
     sock_ip_ep_t *rem;
+    gnrc_sock_send_aux_t _aux = { .flags = 0 };
 
     assert((sock != NULL) || (remote != NULL));
     assert((len == 0) || (data != NULL)); /* (len != 0) => (data != NULL) */
@@ -372,7 +373,14 @@ ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
         gnrc_pktbuf_release(payload);
         return -ENOMEM;
     }
-    res = gnrc_sock_send(pkt, &local, rem, PROTNUM_UDP);
+
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if (aux && (aux->flags & SOCK_AUX_GET_TIMESTAMP)) {
+        _aux.timestamp = &aux->timestamp;
+    }
+#endif
+
+    res = gnrc_sock_send(pkt, &local, rem, PROTNUM_UDP, &_aux);
     if (res > 0) {
         res -= sizeof(udp_hdr_t);
     }
@@ -382,6 +390,12 @@ ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
                                sock->reg.async_cb_arg);
     }
 #endif  /* SOCK_HAS_ASYNC */
+#if IS_USED(MODULE_SOCK_AUX_TIMESTAMP)
+    if (aux && (aux->flags & SOCK_AUX_GET_TIMESTAMP)
+        && (_aux.flags &GNRC_SOCK_SEND_AUX_FLAG_TIMESTAMP)) {
+        aux->flags &= ~SOCK_AUX_GET_TIMESTAMP;
+    }
+#endif
     return res;
 }
 

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f070rb \
     nucleo-f072rb \
+    nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
@@ -34,6 +35,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
+    stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
     z1 \


### PR DESCRIPTION
### Contribution description

- includes [gnrc_tx_sync](https://github.com/RIOT-OS/RIOT/pull/15694) to allow waiting for completion of TX (as needed to access TX results)
- includes [PR patching `gnrc_netif` to make use of `netdev_driver_t::confirm_send()`](https://github.com/RIOT-OS/RIOT/pull/15821), which allows passing TX info from netdev to netif
- Introduce type `netdev_tx_info_t`, which contains a timestamp if (pseudo-)module `netdev_tx_info_timestamp` is used
- Extend `gnrc_tx_sync_t` to contain a member `netdev_tx_info_t tx_info`, which can be used to transfer TX info up the stack
- Extend `gnrc_netif` to pass the new `tx_info` member of `gnrc_tx_sync_t` to `netdev_driver_t::confirm_send()` when module `gnrc_tx_sync` is used
- Extend `gnrc_sock` to pass timestamp in `gnrc_tx_sync_t::tx_info` up to `sock_udp_send_aux()` / `sock_ip_send_aux()`, which in turn are extended to pass this on to the user
- Implement PTP timestamping for TX in `stm32_eth`

### Testing procedure

- `make BOARD=nucleo-f767zi -C tests/sock_udp_aux flash term`
- Check the IPv6 address of the Nucleo via `ifconfig`
- Send UDP packets directed at port `12345` of the Nucleo

The output should look like this

```
2021-01-29 09:53:25,054 # main(): This is RIOT! (Version: 2021.04-devel-366-g1932ed-tx_timestamp)
2021-01-29 09:53:25,058 # UDP echo server listening at port 12345
> ifconfig
2021-01-29 09:53:28,013 #  ifconfig
2021-01-29 09:53:28,018 # Iface  4  HWaddr: AA:C8:16:C2:3C:6D  Link: up 
2021-01-29 09:53:28,024 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2021-01-29 09:53:28,027 #           Link type: wired
2021-01-29 09:53:28,032 #           inet6 addr: fe80::a8c8:16ff:fec2:3c6d  scope: link  VAL
2021-01-29 09:53:28,035 #           inet6 group: ff02::1
2021-01-29 09:53:28,038 #           inet6 group: ff02::1:ffc2:3c6d
2021-01-29 09:53:28,039 #           
2021-01-29 09:53:28,042 #           Statistics for Layer 2
2021-01-29 09:53:28,045 #             RX packets 2  bytes 180
2021-01-29 09:53:28,050 #             TX packets 2 (Multicast: 2)  bytes 140
2021-01-29 09:53:28,053 #             TX succeeded 2 errors 0
2021-01-29 09:53:28,056 #           Statistics for IPv6
2021-01-29 09:53:28,059 #             RX packets 2  bytes 152
2021-01-29 09:53:28,063 #             TX packets 2 (Multicast: 2)  bytes 112
2021-01-29 09:53:28,067 #             TX succeeded 2 errors 0
2021-01-29 09:53:28,067 # 
>
2021-01-29 09:53:33,848 # Received a message via: [fe80::a8c8:16ff:fec2:3c6d]:12345
2021-01-29 09:53:33,851 # Received a message at: 8795389140 ns
2021-01-29 09:53:33,854 # Received a message with: No RSSI value
2021-01-29 09:53:33,857 # Sent echo at: 8807312980 ns
2021-01-29 09:53:33,862 # Received a message via: [fe80::a8c8:16ff:fec2:3c6d]:12345
2021-01-29 09:53:33,865 # Received a message at: 8807667580 ns
2021-01-29 09:53:33,869 # Received a message with: No RSSI value
2021-01-29 09:53:33,871 # Sent echo at: 8821608820 ns
2021-01-29 09:53:42,175 # Received a message via: [fe80::a8c8:16ff:fec2:3c6d]:12345
2021-01-29 09:53:42,179 # Received a message at: 17122866530 ns
2021-01-29 09:53:42,182 # Received a message with: No RSSI value
2021-01-29 09:53:42,185 # Sent echo at: 17134910120 ns
2021-01-29 09:53:42,190 # Received a message via: [fe80::a8c8:16ff:fec2:3c6d]:12345
2021-01-29 09:53:42,193 # Received a message at: 17135254480 ns
2021-01-29 09:53:42,196 # Received a message with: No RSSI value
2021-01-29 09:53:42,199 # Sent echo at: 17149379960 ns
2021-01-29 09:53:43,471 # Received a message via: [fe80::a8c8:16ff:fec2:3c6d]:12345
2021-01-29 09:53:43,474 # Received a message at: 18418614030 ns
2021-01-29 09:53:43,478 # Received a message with: No RSSI value
2021-01-29 09:53:43,481 # Sent echo at: 18430627420 ns
2021-01-29 09:53:43,486 # Received a message via: [fe80::a8c8:16ff:fec2:3c6d]:12345
2021-01-29 09:53:43,489 # Received a message at: 18430879180 ns
2021-01-29 09:53:43,492 # Received a message with: No RSSI value
2021-01-29 09:53:43,495 # Sent echo at: 18445097980 ns
```

### Issues/PRs references

Depends on and includes:

- [x] https://github.com/RIOT-OS/RIOT/pull/15694
- [ ] https://github.com/RIOT-OS/RIOT/pull/15821