### PR TITLE
boards: add zigduino 

### DIFF
--- a/boards/zigduino/Kconfig
+++ b/boards/zigduino/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 Benjamin Valentin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+
+config BOARD
+    default "zigduino" if BOARD_ZIGDUINO
+
+config BOARD_ZIGDUINO
+    bool
+    default y
+    select CPU_MODEL_ATMEGA128RFA1
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/zigduino/Makefile
+++ b/boards/zigduino/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/zigduino/Makefile.dep
+++ b/boards/zigduino/Makefile.dep
@@ -1,0 +1,6 @@
+USEMODULE += boards_common_atmega
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_adc
+  USEMODULE += saul_gpio
+endif

--- a/boards/zigduino/Makefile.features
+++ b/boards/zigduino/Makefile.features
@@ -1,0 +1,14 @@
+CPU = atmega128rfa1
+
+# This board is based on an atmega CPU, thus import the features from it
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Put defined MCU peripherals here (in alphabetical order)
+# Peripherals are defined in common/arduino-atmega/Makefile.features
+# Add only additional Peripherals

--- a/boards/zigduino/Makefile.include
+++ b/boards/zigduino/Makefile.include
@@ -1,0 +1,8 @@
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+BAUD        ?= 57600
+
+ZIGDUINO_BOOTLOADER ?= atmegaboot
+
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/zigduino/doc.txt
+++ b/boards/zigduino/doc.txt
@@ -1,0 +1,80 @@
+/**
+ * @defgroup    boards_zigduino Zigduino
+ * @ingroup     boards
+ * @brief       Support for the Zigduino board
+
+# Hardware
+## Pinout
+
+![Zigduino](https://www.iot-lab.info/assets/images/docs/boards/zigduino/zigduino.png)
+[Pinout](https://static1.squarespace.com/static/511f4f0de4b09463c7605f13/t/5275c46be4b07e72f74c7438/1383449707749/zigduino-r2-pinout.pdf)
+
+@warning    Unlike on other ATmega MCUs, the GPIOs are not 5V tolerant.
+
+@note       The 5V pin cannot be used to power the board, as the board is not
+            equipped with an voltage regulator. The pin is therefore not
+            connected. But it can be used to pass 5V to shields, if connected
+            to a 5V supply voltage.
+
+## Board
+The Zigduino board is an Arduino-compatible microcontroller platform that integrates
+a SOC with a 8-Bit AVR MCU and a IEEE 802.15.4 radio chip (ATmega128RFA1).
+
+## MCU Details
+| MCU                           | ATmega128RFA1                     |
+|:------------------------------|:----------------------------------|
+| Family                        | ATmega                            |
+| Vendor                        | Atmel                             |
+| Package                       | QFN/MLF                           |
+| SRAM                          | 16KiB                             |
+| Flash                         | 128KiB                            |
+| EEPROM                        | 4KiB                              |
+| Core Frequency                | 8MHz (16MHz no power save mode)   |
+| Oscillators                   | 32.768 kHz & 16 MHz               |
+| Timer                         | 6 ( 2x8bit & 4x16bit )            |
+| Analog Comparator             | 1                                 |
+| ADCs                          | 1x 15 channel 6 to 12-bit         |
+| USARTs                        | 2                                 |
+| SPIs                          | 3 (1 SPI & 2 USART SPI)           |
+| I2Cs                          | 1 (called TWI)                    |
+| Vcc                           | 1.8V - 3.6V                       |
+| Datasheet / Reference Manual  | [Datasheet and Reference Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8266-MCU_Wireless-ATmega128RFA1_Datasheet.pdf) |
+| Board Manual                  | [Product Page](http://www.logos-electro.com/store/zigduino-r2) |
+
+The MCU comes with a 2.4 GHz IEEE 802.15.4 radio that is compatible with the
+Atmel AT86RF23x line of transceivers with the only difference being that it is
+not being accessed over an SPI bus, but instead the radio registers are directly
+mapped into memory.
+
+# Flashing RIOT
+Flashing RIOT on the Zigduino is done using the on-board USB-TTL adapter.
+The ATmega bootloader is present on the MCU.
+Simply use
+
+`make flash BOARD=zigduino`
+
+# Use on IoT Lab
+
+Most of the Zigduino nodes are deployed in the Strasbourg site with sensors.
+Some of these nodes are also combined with a LoRa modem in order to offer a dual radio stack IEEE 802.15.4/LoRaWAN.
+
+There are two available configurations:
+
+## Zigduino (atmega128rfa1)
+
+A basic Zigduino nodes with embedded sensors:
+
+ - [Grove Temperature Humidity sensor](https://wiki.seeedstudio.com/Grove-Temperature_and_Humidity_Sensor_Pro/) (pin 14, A0)
+ - [Grove Light sensor](https://wiki.seeedstudio.com/Sensor_light/) (pin 15, A1)
+ - [Grove Loudness sensor](https://wiki.seeedstudio.com/Grove-Loudness_Sensor/) (pin 16, A2)
+ - [Grove PIR Motion sensor](https://wiki.seeedstudio.com/Grove-PIR_Motion_Sensor/) (pin 4, D4)
+
+## Zigduino (atmega128rfa1_rn2483)
+This is an extension of the previous Zigduino (atmega128rfa1)
+
+  - Secondary serial port (LoRa modem): 57600 bauds
+  - [RN2483](https://ww1.microchip.com/downloads/en/DeviceDoc/RN2483-LoRa-Technology-Module-Command-Reference-User-Guide-DS40001784G.pdf) modem with 1.0.3 firmware (LoRaWAN Class A only)
+    - TX (pin 1, TXD1)
+    - RX (pin 0, RXD1)
+
+ */

--- a/boards/zigduino/include/adc_params.h
+++ b/boards/zigduino/include/adc_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_zigduino
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped ADC
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "temp",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_10BIT,
+    },
+    {
+        .name = "light",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_10BIT,
+    },
+    {
+        .name = "loud",
+        .line = ADC_LINE(2),
+        .res  = ADC_RES_10BIT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/zigduino/include/board.h
+++ b/boards/zigduino/include/board.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_zigduino
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Zigduino board.
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    baudrate for STDIO terminal
+ *
+ * @{
+ */
+#ifndef STDIO_UART_BAUDRATE
+#define STDIO_UART_BAUDRATE (57600U)      /**< Sets Baudrate for e.g. Shell */
+#endif
+/** @} */
+
+/**
+ * @name    xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           (250000UL)
+#define XTIMER_BACKOFF      (40)
+/** @} */
+
+/**
+ * @name    Grove PIR Motion sensor
+ */
+#define PIR_MOTION_PIN      GPIO_PIN(PORT_D, 4)
+#define PIR_MOTION_MODE     GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and stdio
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/zigduino/include/gpio_params.h
+++ b/boards/zigduino/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_zigduino
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "motion",
+        .pin  = PIR_MOTION_PIN,
+        .mode = PIR_MOTION_MODE,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/zigduino/include/periph_conf.h
+++ b/boards/zigduino/include/periph_conf.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_zigduino
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Zigduino board
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_conf_atmega_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -79,6 +79,7 @@ IOTLAB_ARCHI_nrf52840-mdk   = nrf52840mdk:multi
 IOTLAB_ARCHI_pba-d-01-kw2x  = phynode:kw2xrf
 IOTLAB_ARCHI_samr21-xpro    = samr21:at86rf233
 IOTLAB_ARCHI_samr30-xpro    = samr30:at86rf212b
+IOTLAB_ARCHI_zigduino       = zigduino:atmega128rfa1
 IOTLAB_ARCHI := $(IOTLAB_ARCHI_$(BOARD))
 
 # There are several deprecated and incompatible features used here that were
@@ -93,7 +94,7 @@ else
   _NODES_DEPLOYED = $(shell iotlab-experiment --jmespath='"0"' --format='" ".join' get $(_IOTLAB_EXP_ID) --deployment)
   _NODES_LIST_OPTION = --nodes
   _NODES_FLASH_OPTION = --flash
-  ifneq (firefly,$(BOARD))
+  ifeq (,$(filter firefly zigduino,$(BOARD)))
     # All boards in IoT-LAB except firefly can be flashed using $(BINFILE).
     # On IoT-LAB, firefly only accepts $(ELFFILE) and WSN320 boards on accept $(HEXFILE).
     # Using $(BINFILE) speeds up the firmware upload since the file is much

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -43,4 +43,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -33,4 +33,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -30,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -34,4 +34,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -40,7 +40,7 @@ BOARD_PROVIDES_NETIF := acd52832 adafruit-clue airfy-beacon atmega256rfr2-xpro \
         microduino-corerf native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf52840dongle nrf6310 \
         nucleo-f207zg nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa \
         remote-reva ruuvitag same54-xpro samr21-xpro samr30-xpro spark-core telosb thingy52 yunjia-nrf51822 z1 \
-        frdm-kw41z phynode-kw41z usb-kw41z openlabs-kw41z-mini openlabs-kw41z-mini-256kib
+        frdm-kw41z phynode-kw41z usb-kw41z openlabs-kw41z-mini openlabs-kw41z-mini-256kib zigduino
 
 ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
   # Use modules for networking

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -36,4 +36,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -30,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -61,4 +61,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     weio \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -45,4 +45,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -27,4 +27,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -29,4 +29,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     weio \
     z1 \
+    zigduino \
     #

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -38,4 +38,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/tests/disp_dev/Makefile.ci
+++ b/tests/disp_dev/Makefile.ci
@@ -14,4 +14,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/driver_adt7310/Makefile.ci
+++ b/tests/driver_adt7310/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     microduino-corerf \
     stm32f030f4-demo \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/driver_at86rf215/Makefile.ci
+++ b/tests/driver_at86rf215/Makefile.ci
@@ -28,4 +28,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -40,4 +40,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     wsn430-v1_3b \
     wsn430-v1_4 \
     z1 \
+    zigduino \
     #

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -29,4 +29,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/driver_nrf24l01p_ng/Makefile.ci
+++ b/tests/driver_nrf24l01p_ng/Makefile.ci
@@ -25,4 +25,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -56,4 +56,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -37,4 +37,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -61,4 +61,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -38,4 +38,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     thingy52 \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -41,4 +41,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_opt/Makefile.ci
@@ -30,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_dns/Makefile.ci
@@ -29,4 +29,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -62,4 +62,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -38,4 +38,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     thingy52 \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -37,4 +37,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -41,4 +41,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -32,4 +32,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     thingy52 \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -37,4 +37,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -49,4 +49,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     waspmote-pro \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #

--- a/tests/nanocoap_cli/Makefile.ci
+++ b/tests/nanocoap_cli/Makefile.ci
@@ -30,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     wsn430-v1_3b \
     wsn430-v1_4 \
     z1 \
+    zigduino \
     #

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -24,4 +24,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml10-xpro \
     saml11-xpro \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/pkg_emlearn/Makefile.ci
+++ b/tests/pkg_emlearn/Makefile.ci
@@ -30,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32l0538-disco \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/pkg_libb2/Makefile.ci
+++ b/tests/pkg_libb2/Makefile.ci
@@ -22,4 +22,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/pkg_microcoap/Makefile.ci
+++ b/tests/pkg_microcoap/Makefile.ci
@@ -29,4 +29,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     wsn430-v1_3b \
     wsn430-v1_4 \
     z1 \
+    zigduino \
     #

--- a/tests/pkg_tweetnacl/Makefile.ci
+++ b/tests/pkg_tweetnacl/Makefile.ci
@@ -16,4 +16,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
+    zigduino \
     #

--- a/tests/pthread_cooperation/Makefile.ci
+++ b/tests/pthread_cooperation/Makefile.ci
@@ -18,4 +18,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l011k4 \
     stm32l0538-disco \
     waspmote-pro \
+    zigduino \
     #

--- a/tests/sntp/Makefile.ci
+++ b/tests/sntp/Makefile.ci
@@ -28,4 +28,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/sock_udp_aux/Makefile.ci
+++ b/tests/sock_udp_aux/Makefile.ci
@@ -33,4 +33,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -46,13 +46,13 @@ BOARD_INSUFFICIENT_MEMORY := \
     lobaro-lorabox \
     lsn50 \
     maple-mini \
-    mega-xplained \
     mcb2388 \
+    mega-xplained \
     microbit \
     microduino-corerf \
-    msba2 \
     msb-430 \
     msb-430h \
+    msba2 \
     nrf51dk \
     nrf51dongle \
     nrf6310 \
@@ -117,4 +117,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     yarm \
     yunjia-nrf51822 \
     z1 \
+    zigduino \
     #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description


![image](https://user-images.githubusercontent.com/1301112/106274065-f8165780-6233-11eb-8bf1-93f2f2698e9a.png)


This adds support for the ATmega128RFA1 based [Zigduino](http://www.logos-electro.com/store/zigduino-r2).
The [board](https://www.iot-lab.info/docs/boards/zigduino/) is available on the Strasbourg site of the IoT lab for testing.


### Testing procedure

Create an experiment on the [IoT Lab](https://www.iot-lab.info/testbed/dashboard) and select a Zigduino (`atmega128rfa1`) from the Strasbourg site.

To connect, ssh into `strasbourg.iot-lab.info` and run `nc zigduino-XX 20000` where `XX` is the id of your Zigduino.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
