### PR TITLE
tools/insufficient_memory: add clone_board.sh

### DIFF
--- a/dist/tools/insufficient_memory/clone_board.sh
+++ b/dist/tools/insufficient_memory/clone_board.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ -z $2 ]; then
+    echo "usage: $0 <old_board> <new_board>"
+    echo ""
+    echo "Add a new board with the same MCU as an old board."
+    exit 1
+fi
+
+BOARD_OLD=$1
+BOARD_NEW=$2
+RIOTBASE=$(dirname $0)/../../..
+
+find $RIOTBASE -name Makefile.ci | while read FILE; do
+    if grep $BOARD_OLD $FILE > /dev/null; then
+        make -f $(dirname $0)/Makefile.for_sh DIR=$(dirname $FILE) BOARD=${BOARD_NEW} Makefile.ci > /dev/null
+    fi
+done


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When adding a board that has the same MCU and a similar configuration as an existing board, we can just add it to the same Makefile.ci files without having to build everything.


### Testing procedure

run e.g

    dist/tools/insufficient_memory/clone_board.sh microduino-corerf zigduino


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
