### PR TITLE
boards/atmega: cleanup BOOTLOADER variables definitions

### DIFF
--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -4,6 +4,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 ARDUINO_DUEMILANOVE_BOOTLOADER ?= atmegaboot
-BOOTLOADER ?= $(ARDUINO_DUEMILANOVE_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-leonardo/Makefile.include
+++ b/boards/arduino-leonardo/Makefile.include
@@ -11,6 +11,6 @@ BAUD            ?= 9600
 
 # PROGRAMMER defaults to avr109 which is the internal flasher via USB. Can be
 # overridden for debugging (which requires changes that require to use an ISP)
-BOOTLOADER ?= avr109
+ARDUINO_LEONARDO_BOOTLOADER ?= avr109
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -2,6 +2,5 @@
 BAUD        ?= 9600
 
 ARDUINO_MEGA2560_BOOTLOADER ?= stk500v2
-BOOTLOADER ?= $(ARDUINO_MEGA2560_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-nano/Makefile.include
+++ b/boards/arduino-nano/Makefile.include
@@ -4,6 +4,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 ARDUINO_NANO_BOOTLOADER ?= atmegaboot
-BOOTLOADER ?= $(ARDUINO_NANO_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-nano/doc.txt
+++ b/boards/arduino-nano/doc.txt
@@ -46,7 +46,7 @@ available for RIOT. Refer to the project page for instructions on how to
 build an flash the bootloader. Don't forgot to also update the fuse settings
 to set the bootloader size to 256 words (512 bytes).
 
-Compile and flash with `make BOARD=arduino-nano BOOTLOADER=optiboot flash` or
+Compile and flash with `make BOARD=arduino-nano ATMEGA_BOOTLOADER=optiboot flash` or
 use `export ARDUINO_NANO_BOOTLOADER=optiboot` in order to not have to specify
 the bootloader during compilation and flashing.
 

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -2,6 +2,5 @@
 BAUD        ?= 9600
 
 ARDUINO_UNO_BOOTLOADER ?= optiboot
-BOOTLOADER ?= $(ARDUINO_UNO_BOOTLOADER)
 
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/avr-rss2/Makefile.include
+++ b/boards/avr-rss2/Makefile.include
@@ -4,7 +4,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
 AVR_RSS2_BOOTLOADER ?= stk500v2
-BOOTLOADER  ?= $(AVR_RSS2_BOOTLOADER)
-BOOTLOADER_SIZE ?= 4K # Unlike the Arduino Mega2560, the bootloader size is 4K
+ATMEGA_BOOTLOADER_SIZE ?= 4K # Unlike the Arduino Mega2560, the bootloader size is 4K
 
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/common/atmega/Makefile.include
+++ b/boards/common/atmega/Makefile.include
@@ -3,51 +3,54 @@ INCLUDES += -I$(RIOTBOARD)/common/atmega/include
 # Use avrdude programmer
 PROGRAMMER ?= avrdude
 
+# Use atmega board specific bootloader by default
+ATMEGA_BOOTLOADER ?= $($(call uppercase_and_underscore,$(BOARD))_BOOTLOADER)
+
 # If avrdude specific programmer is not set, set it based on the bootloader used
 ifeq (,$(AVRDUDE_PROGRAMMER))
-  ifeq (atmegaboot,$(BOOTLOADER))
+  ifeq (atmegaboot,$(ATMEGA_BOOTLOADER))
     AVRDUDE_PROGRAMMER = arduino
-    BOOTLOADER_SIZE ?= 2048
-    BOOTLOADER_BAUD ?= 57600
+    ATMEGA_BOOTLOADER_SIZE ?= 2048
+    ATMEGA_BOOTLOADER_BAUD ?= 57600
   endif
 
-  ifeq (optiboot,$(BOOTLOADER))
+  ifeq (optiboot,$(ATMEGA_BOOTLOADER))
     AVRDUDE_PROGRAMMER = arduino
     ifneq (,$(filter $(CPU), atmega128rfa1 atmega256rfr2 atmega1281 atmega1284p atmega2560))
       # The minimum bootloader size on these CPUs is 1 KiB (so 512 Byte are wasted)
-      BOOTLOADER_SIZE ?= 1024
+      ATMEGA_BOOTLOADER_SIZE ?= 1024
     else
-      BOOTLOADER_SIZE ?= 512
+      ATMEGA_BOOTLOADER_SIZE ?= 512
     endif
   endif
 
-  ifeq (stk500v1,$(BOOTLOADER))
+  ifeq (stk500v1,$(ATMEGA_BOOTLOADER))
     AVRDUDE_PROGRAMMER = stk500v1
-    BOOTLOADER_SIZE ?= 8K
+    ATMEGA_BOOTLOADER_SIZE ?= 8K
   endif
 
-  ifeq (stk500v2,$(BOOTLOADER))
+  ifeq (stk500v2,$(ATMEGA_BOOTLOADER))
     AVRDUDE_PROGRAMMER = stk500v2
-    BOOTLOADER_SIZE ?= 8K
+    ATMEGA_BOOTLOADER_SIZE ?= 8K
     # Disable auto erase; erasing the flash is done implicitly by the bootloader
     # and explicit erase is not supported
     FFLAGS_EXTRA += -D
   endif
 
-  ifeq (avr109,$(BOOTLOADER))
+  ifeq (avr109,$(ATMEGA_BOOTLOADER))
     AVRDUDE_PROGRAMMER = avr109
-    BOOTLOADER_SIZE ?= 4K
+    ATMEGA_BOOTLOADER_SIZE ?= 4K
   endif
 
-  ifeq (derfmega,$(BOOTLOADER))
+  ifeq (derfmega,$(ATMEGA_BOOTLOADER))
     AVRDUDE_PROGRAMMER = wiring
-    BOOTLOADER_SIZE ?= 4K
+    ATMEGA_BOOTLOADER_SIZE ?= 4K
   endif
 
-  ifneq (,$(BOOTLOADER_BAUD))
-    FFLAGS_EXTRA += -b $(BOOTLOADER_BAUD)
+  ifneq (,$(ATMEGA_BOOTLOADER_BAUD))
+    FFLAGS_EXTRA += -b $(ATMEGA_BOOTLOADER_BAUD)
   endif
 endif
 
-BOOTLOADER_SIZE ?= 0
-ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+ATMEGA_BOOTLOADER_SIZE ?= 0
+ROM_RESERVED ?= $(ATMEGA_BOOTLOADER_SIZE)

--- a/boards/derfmega128/Makefile.include
+++ b/boards/derfmega128/Makefile.include
@@ -5,6 +5,6 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
-BOOTLOADER  ?= derfmega
+DERFMEGA128_BOOTLOADER  ?= derfmega
 
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/derfmega256/Makefile.include
+++ b/boards/derfmega256/Makefile.include
@@ -5,6 +5,6 @@ PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
-BOOTLOADER  ?= derfmega
+DERFMEGA256_BOOTLOADER  ?= derfmega
 
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -1,6 +1,6 @@
 # Found by checking fuse settings (2048 words so 4KB)
 # https://www.microchip.com/DevelopmentTools/ProductDetails/atmega1284p-xpld
-BOOTLOADER_SIZE ?= 4K
+ATMEGA_BOOTLOADER_SIZE ?= 4K
 
 # For backward compatibility
 ifneq (,$(AVRDUDE_PORT))

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -2,6 +2,5 @@
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 BAUD        ?= 9600
 WASPMOTE_PRO_BOOTLOADER ?= stk500v1
-BOOTLOADER  ?= $(WASPMOTE_PRO_BOOTLOADER)
 
 include $(RIOTBOARD)/common/atmega/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a cleanup of the BOOTLOADER/BOOTLOADER_SIZE/BOOTLOADER_BAUD variable used on some atmega platform.
It remove the IMHO useless pattern:

```mk
BOOTLOADER_<board name> ?= bootloader
BOOTLOADER ?= $(BOOTLOADER_<board name>)
```

And add an `ATMEGA_` to all these atmega specific variables (only used in boards/common/atmega).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try to flash the affected boards (but should be harmless).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that while reviewing #15884 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
