### PR TITLE
pkg/fatfs: bump version to r0.14a

### DIFF
--- a/pkg/fatfs/Makefile
+++ b/pkg/fatfs/Makefile
@@ -2,7 +2,7 @@ PKG_NAME=fatfs
 # upstream server is very unreliable, instead host the extracted
 # .zip file on GitHub and apply only the upstream patches
 PKG_URL=https://github.com/RIOT-OS/FatFS
-PKG_VERSION=d8db1de45234d7bcdb4c61e3a3d8af3c9cfb7819 # R0.14 p2
+PKG_VERSION=fb99d00924fd17c2d9c0789510852c2c286403ab # R0.14a
 PKG_LICENSE=BSD-1-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/fatfs/patches/0001-remove-ffconf.h.patch
+++ b/pkg/fatfs/patches/0001-remove-ffconf.h.patch
@@ -1,7 +1,7 @@
-From fcd845f91417c7da0af266229f9997a2e3f08596 Mon Sep 17 00:00:00 2001
+From af647820a330eae463fdf073908dc6f79014481d Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@googlemail.com>
-Date: Tue, 10 Nov 2020 18:30:07 +0100
-Subject: [PATCH] remove ffconf.h
+Date: Sun, 31 Jan 2021 20:00:17 +0100
+Subject: [PATCH 1/2] remove ffconf.h
 
 ---
  source/ffconf.h | 298 ------------------------------------------------
@@ -10,7 +10,7 @@ Subject: [PATCH] remove ffconf.h
 
 diff --git a/source/ffconf.h b/source/ffconf.h
 deleted file mode 100644
-index 5dbe48b..0000000
+index 632736b..0000000
 --- a/source/ffconf.h
 +++ /dev/null
 @@ -1,298 +0,0 @@
@@ -18,7 +18,7 @@ index 5dbe48b..0000000
 -/  FatFs Functional Configurations
 -/---------------------------------------------------------------------------*/
 -
--#define FFCONF_DEF	86606	/* Revision ID */
+-#define FFCONF_DEF	80196	/* Revision ID */
 -
 -/*---------------------------------------------------------------------------/
 -/ Function Configurations
@@ -221,8 +221,8 @@ index 5dbe48b..0000000
 -/  To enable the 64-bit LBA, also exFAT needs to be enabled. (FF_FS_EXFAT == 1) */
 -
 -
--#define FF_MIN_GPT		0x100000000
--/* Minimum number of sectors to switch GPT format to create partition in f_mkfs and
+-#define FF_MIN_GPT		0x10000000
+-/* Minimum number of sectors to switch GPT as partitioning format in f_mkfs and
 -/  f_fdisk function. 0x100000000 max. This option has no effect when FF_LBA64 == 0. */
 -
 -
@@ -253,7 +253,7 @@ index 5dbe48b..0000000
 -#define FF_FS_NORTC		0
 -#define FF_NORTC_MON	1
 -#define FF_NORTC_MDAY	1
--#define FF_NORTC_YEAR	2019
+-#define FF_NORTC_YEAR	2020
 -/* The option FF_FS_NORTC switches timestamp functiton. If the system does not have
 -/  any RTC function or valid timestamp is not needed, set FF_FS_NORTC = 1 to disable
 -/  the timestamp function. Every object modified by FatFs will have a fixed timestamp
@@ -313,5 +313,5 @@ index 5dbe48b..0000000
 -
 -/*--- End of configuration options ---*/
 -- 
-2.25.1
+2.27.0
 

--- a/pkg/fatfs/patches/0002-remove-diskio.c.patch
+++ b/pkg/fatfs/patches/0002-remove-diskio.c.patch
@@ -1,6 +1,6 @@
-From a80c84666ee68876c583af3e130025f2136455cf Mon Sep 17 00:00:00 2001
+From 8b62c5ed1cc74007497baf3a93920bf9ebabf068 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@googlemail.com>
-Date: Tue, 10 Nov 2020 18:39:58 +0100
+Date: Sun, 31 Jan 2021 20:00:38 +0100
 Subject: [PATCH 2/2] remove diskio.c
 
 ---
@@ -10,12 +10,12 @@ Subject: [PATCH 2/2] remove diskio.c
 
 diff --git a/source/diskio.c b/source/diskio.c
 deleted file mode 100644
-index fffa767..0000000
+index 81aaf59..0000000
 --- a/source/diskio.c
 +++ /dev/null
 @@ -1,229 +0,0 @@
 -/*-----------------------------------------------------------------------*/
--/* Low level disk I/O module skeleton for FatFs     (C)ChaN, 2019        */
+-/* Low level disk I/O module SKELETON for FatFs     (C)ChaN, 2019        */
 -/*-----------------------------------------------------------------------*/
 -/* If a working storage control module is available, it should be        */
 -/* attached to the FatFs via a glue function rather than modifying it.   */
@@ -244,5 +244,5 @@ index fffa767..0000000
 -}
 -
 -- 
-2.25.1
+2.27.0
 

--- a/pkg/fatfs/vendor/include/ffconf.h
+++ b/pkg/fatfs/vendor/include/ffconf.h
@@ -2,7 +2,7 @@
 /  FatFs - Configuration file
 /---------------------------------------------------------------------------*/
 
-#define FFCONF_DEF	86606	/* Revision ID */
+#define FFCONF_DEF	80196	/* Revision ID */
 
 /*---------------------------------------------------------------------------/
 / Function Configurations


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A new version has been [released](http://elm-chan.org/fsw/ff/updates.txt).
Update our pkg accordingly.


### Testing procedure

`tests/pkg_fatfs_vfs` should still pass.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
