### PR TITLE
cpu/kinetis: enable floating point support

### DIFF
--- a/cpu/kinetis/Kconfig
+++ b/cpu/kinetis/Kconfig
@@ -44,8 +44,7 @@ config CPU_MODEL_MK20DX256VLH7
 
 config CPU_MODEL_MK22FN512VLH12
     bool
-# This is actually M4F; TODO: Add floating point support
-    select CPU_CORE_CORTEX_M4
+    select CPU_CORE_CORTEX_M4F
     select CPU_FAM_K
     select HAS_PERIPH_HWRNG
 
@@ -77,8 +76,7 @@ config CPU_MODEL_MK60DN512VLL10
 
 config CPU_MODEL_MK64FN1M0VLL12
     bool
-# This is actually M4F; TODO: Add floating point support
-    select CPU_CORE_CORTEX_M4
+    select CPU_CORE_CORTEX_M4F
     select CPU_FAM_K
     select HAS_PERIPH_HWRNG
 

--- a/cpu/kinetis/kinetis-info.mk
+++ b/cpu/kinetis/kinetis-info.mk
@@ -37,8 +37,7 @@ else ifeq ($(KINETIS_CORE), D)
   CPU_CORE = cortex-m4
 else ifeq ($(KINETIS_CORE), F)
   # Cortex-M4F or Cortex-M7
-  # TODO: Add floating point support
-  CPU_CORE = cortex-m4
+  CPU_CORE = cortex-m4f
 endif
 
 # For the rest of the build system we expose the series as family


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I think this CPU was added before RIOT had support for the FPU on Cortex-M4F, this should now have been long fixed.

Advertise the FPU on these CPUs.


### Testing procedure

I don't have a board with this CPU to test.

`tests/thread_float` should still work on affected boards (`frdm-k22f`).


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
