### PR TITLE
stm32: Resolve RAM size to bytes

### DIFF
--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -10,18 +10,19 @@ include $(RIOTCPU)/stm32/stm32_riotboot.mk
 include $(RIOTCPU)/stm32/stm32_mem_lengths.mk
 KB := 1024
 ROM_LEN_K := $(shell echo $(ROM_LEN) | sed 's/K//')
+RAM_LEN_K := $(shell echo $(RAM_LEN) | sed 's/K//')
 
 ifeq (stm32wb55rg,$(CPU_MODEL))
   # adjust RAM_LEN and ROM_LEN according to CPU2 RAM_LEN and ROM_LEN
-  RAM_LEN_K := $(shell echo $(RAM_LEN) | sed 's/K//')
   CPU2_RAM_LEN_K := $(shell echo $(CPU2_RAM_LEN) | sed 's/K//')
-  RAM_LEN := $(shell echo $$(( ($(RAM_LEN_K) - $(CPU2_RAM_LEN_K) ) ))K)
+  RAM_LEN := $(shell echo $$(( ($(RAM_LEN_K) - $(CPU2_RAM_LEN_K) ) * $(KB) )))
 
   CPU2_ROM_LEN_K := $(shell echo $(CPU2_ROM_LEN) | sed 's/K//')
   FLASHSIZE := $(shell echo $$(( ($(ROM_LEN_K) - $(CPU2_ROM_LEN_K) )* $(KB) )) )
   ROM_LEN := $(shell echo $$(( ($(ROM_LEN_K) - $(CPU2_ROM_LEN_K) ) ))K)
 else
   FLASHSIZE := $(shell echo $$(( $(ROM_LEN_K) * $(KB) )) )
+  RAM_LEN := $(shell echo $$(( $(RAM_LEN_K) * $(KB) )) )
 endif
 
 # Get CPU_LINE_ variable
@@ -37,7 +38,8 @@ info-stm32:
 	@$(COLOR_ECHO) "\tLine: $(CPU_LINE)"
 	@$(COLOR_ECHO) "\tPin count:\t$(STM32_PINS)"
 	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN) ($(FLASHSIZE) Bytes)"
-	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN)"
+	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN_K)KiB"
+
 
 ifneq (,$(CCMRAM_LEN))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ccmram_length=$(CCMRAM_LEN)


### PR DESCRIPTION
### Contribution description

The ram size is exposed as macro value (`CPU_RAM_SIZE`) and available for use in code.
For the stm32 it has a value in kilobytes suffixed with 'k'. This is
less than optimal for usage in arithmetic. This commit modifies the
value to bytes so that it can be used in preprocessor magic

`CPU_RAM_SIZE` is only used by `sys/include/riotboot/usb_dfu.h` so far.

### Testing procedure

This should not affect the current builds.

### Issues/PRs references

Remotely required for #15420