### PR TITLE
riotboot/flashwrite: Remove last dependencies on flashpage size

### DIFF
--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -84,6 +84,27 @@ extern "C" {
 #ifdef DOXYGEN
 #define FLASHPAGE_WRITE_BLOCK_ALIGNMENT
 #endif
+
+/**
+ * @def     PERIPH_FLASHPAGE_CUSTOM_PAGESIZES
+ *
+ * @brief   Defined to signal that the peripheral has non-uniform flash page
+ *          sizes. These devices do not define FLASHPAGE_SIZE and do not
+ *          implement the pagewise api.
+ */
+#ifdef DOXYGEN
+#define PERIPH_FLASHPAGE_CUSTOM_PAGESIZES
+#endif
+
+/**
+ * @brief   Return values used in this interface
+ */
+enum {
+    FLASHPAGE_OK      =  0,     /**< everything succeeded */
+    FLASHPAGE_NOMATCH = -1      /**< page differs from target data */
+};
+
+#if !defined(PERIPH_FLASHPAGE_CUSTOM_PAGESIZES) || defined(DOXYGEN)
 /**
  * @def FLASHPAGE_SIZE
  *
@@ -97,12 +118,17 @@ extern "C" {
 #endif
 
 /**
- * @brief   Return values used in this interface
+ * @brief   Get the page size of the given page number
+ *
+ * @param[in] page      page number to get the size for
+ *
+ * @return              Page size of the given page
  */
-enum {
-    FLASHPAGE_OK      =  0,     /**< everything succeeded */
-    FLASHPAGE_NOMATCH = -1      /**< page differs from target data */
-};
+static inline size_t flashpage_size(unsigned page)
+{
+    (void)page;
+    return FLASHPAGE_SIZE;
+}
 
 /**
  * @brief   Translate the given page number into the page's starting address
@@ -134,6 +160,15 @@ static inline unsigned flashpage_page(void *addr)
 {
     return (((intptr_t)addr - CPU_FLASH_BASE) / FLASHPAGE_SIZE);
 }
+
+#else
+
+/* Bare prototypes for the above functions. See above for the documentation */
+size_t flashpage_size(unsigned page);
+void *flashpage_addr(unsigned page);
+unsigned flashpage_page(void *addr);
+
+#endif
 
 /**
  * @brief   Erase the given page

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -37,7 +37,7 @@ void flashpage_read(unsigned page, void *data)
     assert(page < (FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 
-    memcpy(data, flashpage_addr(page), FLASHPAGE_SIZE);
+    memcpy(data, flashpage_addr(page), flashpage_size(page));
 }
 
 int flashpage_verify(unsigned page, const void *data)
@@ -48,7 +48,7 @@ int flashpage_verify(unsigned page, const void *data)
     assert(page < (int)(FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 
-    if (memcmp(flashpage_addr(page), data, FLASHPAGE_SIZE) == 0) {
+    if (memcmp(flashpage_addr(page), data, flashpage_size(page)) == 0) {
         return FLASHPAGE_OK;
     }
     else {


### PR DESCRIPTION

### Contribution description

As the title says, this removes the last references to `FLASHPAGE_SIZE` from the riotboot code.

### Testing procedure

Use either the `tests/riotboot_flashwrite` test or the `examples/suit_update` application to test this.

### Issues/PRs references

required for #15420