### PR TITLE
drivers/periph_spi: let spi_acquire return void

### DIFF
--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -24,10 +24,10 @@
  *
  * @}
  */
+#include <assert.h>
 
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 
 /**
@@ -78,10 +78,11 @@ void spi_init_pins(spi_t bus)
 #endif
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)bus;
     (void)cs;
+    assert(bus == SPI_DEV(0));
 
     /* lock the bus and power on the SPI peripheral */
     mutex_lock(&lock);
@@ -94,8 +95,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     /* clear interrupt flag by reading SPSR and data register by reading SPDR */
     (void)SPSR;
     (void)SPDR;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/atxmega/periph/spi.c
+++ b/cpu/atxmega/periph/spi.c
@@ -87,7 +87,7 @@ void spi_init_pins(spi_t bus)
     gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)cs;
     (void)clk;
@@ -106,8 +106,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     (void)dev(bus)->STATUS;
     (void)dev(bus)->DATA;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -21,12 +21,13 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "vendor/hw_memmap.h"
 #include "vendor/hw_ssi.h"
 
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 
 #define ENABLE_DEBUG 0
@@ -93,10 +94,10 @@ void spi_init_pins(spi_t bus)
     gpio_init_mux(spi_config[bus].miso_pin, OVERRIDE_DISABLE, GPIO_MUX_NONE, rxd);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     DEBUG("%s: bus=%u\n", __FUNCTION__, bus);
-    (void) cs;
+    (void)cs;
     /* lock the bus */
     mutex_lock(&locks[bus]);
     /* power on device */
@@ -107,8 +108,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->CR0 = ((spi_clk_config[clk].scr << 8) | mode | SSI_CR0_DSS(8));
     /* enable SSI device */
     dev(bus)->CR1 = SSI_CR1_SSE;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)
@@ -132,6 +131,7 @@ static uint8_t _trx(cc2538_ssi_t *dev, uint8_t in)
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                         const void *out, void *in, size_t len)
 {
+    assert((unsigned)bus < SPI_NUMOF);
     DEBUG("%s: bus=%u, len=%u\n", __FUNCTION__, bus, (unsigned)len);
 
     const uint8_t *out_buf = out;

--- a/cpu/efm32/periph/spi.c
+++ b/cpu/efm32/periph/spi.c
@@ -56,9 +56,10 @@ void spi_init_pins(spi_t bus)
     gpio_init(spi_config[bus].miso_pin, GPIO_IN_PD);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
 
     mutex_lock(&spi_lock[bus]);
 
@@ -68,8 +69,8 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     USART_InitSync_TypeDef init = USART_INITSYNC_DEFAULT;
 
-    init.baudrate = (uint32_t) clk;
-    init.clockMode = (USART_ClockMode_TypeDef) mode;
+    init.baudrate = (uint32_t)clk;
+    init.clockMode = (USART_ClockMode_TypeDef)mode;
     init.msbf = true;
 
     USART_InitSync(spi_config[bus].dev, &init);
@@ -86,8 +87,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
                                      USART_ROUTEPEN_TXPEN |
                                      USART_ROUTEPEN_CLKPEN);
 #endif
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/esp_common/periph/spi.c
+++ b/cpu/esp_common/periph/spi.c
@@ -289,7 +289,7 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
     return SPI_OK;
 }
 
-int IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     DEBUG("%s bus=%u cs=%u mode=%u clk=%u\n", __func__, bus, cs, mode, clk);
 
@@ -308,7 +308,7 @@ int IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk
         LOG_TAG_ERROR("spi",
                       "SPI_DEV(%d) CS signal could not be initialized\n",
                       bus);
-        return SPI_NOCS;
+        assert(0);
     }
 
     /* lock the bus */
@@ -375,8 +375,6 @@ int IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk
 
     DEBUG("%s bus %d: SPI_CLOCK_REG=%08x\n",
           __func__, bus, _spi[bus].regs->clock.val);
-
-    return SPI_OK;
 }
 
 void IRAM_ATTR spi_release(spi_t bus)

--- a/cpu/fe310/periph/spi.c
+++ b/cpu/fe310/periph/spi.c
@@ -22,9 +22,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 
 #include "vendor/spi.h"
@@ -102,7 +103,7 @@ int spi_init_cs(spi_t dev, spi_cs_t cs)
     return SPI_OK;
 }
 
-int spi_acquire(spi_t dev, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t dev, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)cs;
     assert(dev < SPI_NUMOF);
@@ -111,8 +112,6 @@ int spi_acquire(spi_t dev, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     _REG32(spi_config[dev].addr, SPI_REG_SCKDIV) = _spi_clks_config[clk];
     _REG32(spi_config[dev].addr, SPI_REG_SCKMODE) = mode;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t dev)

--- a/cpu/kinetis/periph/spi.c
+++ b/cpu/kinetis/periph/spi.c
@@ -26,9 +26,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 
 #define ENABLE_DEBUG        0
@@ -144,9 +145,10 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
     return SPI_OK;
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    (void) cs;
+    (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
     /* lock and power on the bus */
     mutex_lock(&locks[bus]);
     poweron(bus);
@@ -156,8 +158,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     /* configure clock and mode */
     dev(bus)->CTAR[0] = (mode | SPI_CTAR_FMSZ(7) | spi_clk_config[clk]);
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/lm4f120/periph/spi.c
+++ b/cpu/lm4f120/periph/spi.c
@@ -67,9 +67,10 @@ void spi_init_pins(spi_t bus)
     ROM_GPIOPinTypeSSI(spi_confs[bus].gpio_port, spi_confs[bus].pins.mask);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    (void) cs;
+    (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
     /* lock bus */
     mutex_lock(&locks[bus]);
     /* enable clock for SSI */
@@ -83,8 +84,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
                            8);
 
     ROM_SSIEnable(spi_confs[bus].ssi_base);
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/lpc23xx/periph/spi.c
+++ b/cpu/lpc23xx/periph/spi.c
@@ -95,19 +95,16 @@ void spi_init_pins(spi_t bus)
     *(&PINSEL0 + cfg->pinsel_clk) |= cfg->pinsel_msk_clk;
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    (void) cs;
+    (void)cs; (void)mode;
+    assert((unsigned)bus < SPI_NUMOF);
+    assert(mode == SPI_MODE_0);
 
     uint32_t pclksel;
     uint32_t cpsr;
 
     lpc23xx_spi_t *dev = get_dev(bus);
-
-    /* only support for mode 0 at the moment */
-    if (mode != SPI_MODE_0) {
-        return SPI_NOMODE;
-    }
 
     /* lock bus */
     mutex_lock(&lock[bus]);
@@ -141,8 +138,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     while (dev->SR & SSPSR_RNE) {       /* while RNE (Receive FIFO Not Empty)...*/
         dev->DR;                        /* read data*/
     }
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/msp430fxyz/periph/spi.c
+++ b/cpu/msp430fxyz/periph/spi.c
@@ -23,9 +23,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 
 /**
@@ -36,7 +37,7 @@ static mutex_t spi_lock = MUTEX_INIT;
 
 void spi_init(spi_t bus)
 {
-    assert(bus <= SPI_NUMOF);
+    assert((unsigned)bus < SPI_NUMOF);
 
 /* we need to differentiate between the legacy SPI device and USCI */
 #ifndef SPI_USE_USCI
@@ -66,14 +67,12 @@ void spi_init_pins(spi_t bus)
     gpio_periph_mode(SPI_PIN_CLK, true);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)bus;
     (void)cs;
-
-    if (clk == SPI_CLK_10MHZ) {
-        return SPI_NOCLK;
-    }
+    assert((unsigned)bus < SPI_NUMOF);
+    assert(clk != SPI_CLK_10MHZ);
 
     /* lock the bus */
     mutex_lock(&spi_lock);
@@ -100,8 +99,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     /* release from software reset */
     SPI_BASE->CTL1 &= ~(USCI_SPI_CTL1_SWRST);
 #endif
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -21,9 +21,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
 
@@ -59,9 +60,10 @@ void spi_init_pins(spi_t bus)
     SPI_MISOSEL = spi_config[bus].miso;
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    (void) cs;
+    (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
 
     mutex_lock(&locks[bus]);
     /* power on the bus (NRF51 only) */
@@ -71,8 +73,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->FREQUENCY = clk;
     /* enable the bus */
     dev(bus)->ENABLE = 1;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/nrf52/periph/spi.c
+++ b/cpu/nrf52/periph/spi.c
@@ -24,9 +24,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
 #include "periph_cpu.h"
@@ -147,9 +148,10 @@ void spi_init_pins(spi_t bus)
     spi_twi_irq_register_spi(dev(bus), spi_isr_handler, (void *)bus);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
 
     mutex_lock(&locks[bus]);
     /* configure bus */
@@ -157,8 +159,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->FREQUENCY = clk;
     /* enable the bus */
     dev(bus)->ENABLE = SPIM_ENABLE_ENABLE_Enabled;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -26,9 +26,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/spi.h"
 #include "pm_layered.h"
 
@@ -374,9 +375,10 @@ void spi_deinit_pins(spi_t bus)
     gpio_disable_mux(spi_config[bus].mosi_pin);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
     (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
 
     /* get exclusive access to the device */
     mutex_lock(&locks[bus]);
@@ -392,8 +394,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     /* mux clk_pin to SPI peripheral */
     gpio_init_mux(spi_config[bus].clk_pin, spi_config[bus].clk_mux);
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -23,9 +23,10 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
 
@@ -62,9 +63,11 @@ void spi_init_pins(spi_t bus)
     gpio_init_mux(spi_config[bus].miso, spi_config[bus].mux);
 }
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    (void) cs;
+    (void)cs;
+    assert((unsigned)bus < SPI_NUMOF);
+
     /* lock bus */
     mutex_lock(&locks[bus]);
     /* enable SPI device clock */
@@ -73,8 +76,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->SPI_CSR[0] = (SPI_CSR_SCBR(CLOCK_CORECLOCK / clk) | mode);
     dev(bus)->SPI_MR = (SPI_MR_MSTR | SPI_MR_MODFDIS);
     dev(bus)->SPI_CR = SPI_CR_SPIEN;
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -26,6 +26,8 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "bitarithm.h"
 #include "cpu.h"
 #include "mutex.h"
@@ -219,8 +221,9 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode)
 }
 #endif
 
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
+    assert((unsigned)bus < SPI_NUMOF);
 
     /* lock bus */
     mutex_lock(&locks[bus]);
@@ -279,8 +282,6 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     if (cr2_extra_settings) {
         dev(bus)->CR2 = (SPI_CR2_SETTINGS | cr2_extra_settings);
     }
-
-    return SPI_OK;
 }
 
 void spi_release(spi_t bus)

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -48,9 +48,9 @@
 #define AT225XXXX_SET_BUF_SIZE      (64)
 #endif
 
-static inline int getbus(const at25xxx_t *dev)
+static inline void getbus(const at25xxx_t *dev)
 {
-    return spi_acquire(dev->params.spi, dev->params.cs_pin, SPI_MODE_0, dev->params.spi_clk);
+    spi_acquire(dev->params.spi, dev->params.cs_pin, SPI_MODE_0, dev->params.spi_clk);
 }
 
 static inline uint32_t _pos(uint8_t cmd, uint32_t pos)
@@ -254,10 +254,11 @@ int at25xxx_init(at25xxx_t *dev, const at25xxx_params_t *params)
         gpio_set(dev->params.hold_pin);
     }
 
-    /* check if the SPI configuration is valid */
-    if (getbus(dev) != SPI_OK) {
-        return -1;
+    if (!IS_ACTIVE(NDEBUG)) {
+        /* if assertions are on, trigger an assert on incorrect SPI settings
+         * right on initialization to ease debugging */
+        getbus(dev);
+        spi_release(dev->params.spi);
     }
-    spi_release(dev->params.spi);
     return 0;
 }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -89,14 +89,11 @@ static int _init(netdev_t *netdev)
     gpio_set(dev->params.reset_pin);
     gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
 
-    /* Intentionally check if bus can be acquired,
-       since getbus() drops the return value */
-    if (spi_acquire(dev->params.spi, dev->params.cs_pin, SPI_MODE_0,
-                                                dev->params.spi_clk) < 0) {
-        DEBUG("[at86rf2xx] error: unable to acquire SPI bus\n");
-        return -EIO;
+    /* Intentionally check if bus can be acquired, if assertions are on */
+    if (!IS_ACTIVE(NDEBUG)) {
+        spi_acquire(dev->params.spi, dev->params.cs_pin, SPI_MODE_0, dev->params.spi_clk);
+        spi_release(dev->params.spi);
     }
-    spi_release(dev->params.spi);
 #endif
 
     /* reset hardware into a defined state */

--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -156,9 +156,7 @@ static void _irq_handler(void *arg)
 
 static void _getbus(const ata8520e_t *dev)
 {
-    if (spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk) < 0) {
-        DEBUG("[ata8520e] ERROR: Cannot acquire SPI bus!\n");
-    }
+    spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk);
 }
 
 static void _spi_transfer_byte(const ata8520e_t *dev, bool cont, uint8_t out)

--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -50,9 +50,7 @@
 #ifdef BMX280_USE_SPI /* using SPI mode */
 static inline int _acquire(const bmx280_t *dev)
 {
-    if (spi_acquire(BUS, CS, MODE, CLK) != SPI_OK) {
-        return BMX280_ERR_BUS;
-    }
+    spi_acquire(BUS, CS, MODE, CLK);
     return BMX280_OK;
 }
 

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -57,9 +57,7 @@ int cc110x_apply_config(cc110x_t *dev, const cc110x_config_t *conf,
         return -ERANGE;
     }
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     gpio_irq_disable(dev->params.gdo0);
     gpio_irq_disable(dev->params.gdo2);
@@ -107,9 +105,7 @@ int cc110x_set_tx_power(cc110x_t *dev, cc110x_tx_power_t power)
         return -ERANGE;
     }
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     switch (dev->state) {
         case CC110X_STATE_IDLE:
@@ -134,9 +130,7 @@ int cc110x_set_channel(cc110x_t *dev, uint8_t channel)
         return -EINVAL;
     }
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     if ((channel >= CC110X_MAX_CHANNELS) || (dev->channels->map[channel] == 0xff)) {
         /* Channel out of range or not supported in current channel map */

--- a/drivers/cc110x/cc110x_calibration.c
+++ b/drivers/cc110x/cc110x_calibration.c
@@ -67,9 +67,7 @@ int cc110x_recalibrate(cc110x_t *dev)
         /* Re-acquire SPI interface in order to check if calibration
          * succeeded
          */
-        if (cc110x_acquire(dev) != SPI_OK) {
-            return -EIO;
-        }
+        cc110x_acquire(dev);
     } while (cc110x_state_from_status(cc110x_status(dev)) != CC110X_STATE_IDLE);
 
     get_calibration_data(dev);
@@ -84,9 +82,7 @@ int cc110x_full_calibration(cc110x_t *dev)
         return -EINVAL;
     }
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     switch (dev->state) {
         case CC110X_STATE_IDLE:

--- a/drivers/cc110x/cc110x_communication.c
+++ b/drivers/cc110x/cc110x_communication.c
@@ -39,9 +39,7 @@ int cc110x_power_on_and_acquire(cc110x_t *dev)
     gpio_set(cs);
     spi_init_cs(dev->params.spi, dev->params.cs);
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     while (cc110x_state_from_status(cc110x_status(dev)) != CC110X_STATE_IDLE) {
         cc110x_cmd(dev, CC110X_STROBE_IDLE);

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -354,11 +354,7 @@ static int cc110x_recv(netdev_t *netdev, void *buf, size_t len, void *info)
     /* Call to cc110x_enter_rx_mode() will clear dev->buf.len, so back up it first */
     int size = dev->buf.len;
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        DEBUG("[cc110x] netdev_driver_t::recv(): cc110x_acquire() "
-              "failed\n");
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     /* Copy RX info on last frame (if requested) */
     if (info != NULL) {
@@ -396,10 +392,7 @@ static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
     /* assert that cc110x_send was called with valid parameters */
     assert(netdev && iolist && (iolist->iol_len == sizeof(cc1xxx_l2hdr_t)));
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        DEBUG("[cc110x] netdev_driver_t::send(): cc110x_acquire() failed\n");
-        return -1;
-    }
+    cc110x_acquire(dev);
 
     switch (dev->state) {
     case CC110X_STATE_FSTXON:
@@ -503,9 +496,7 @@ static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
  */
 static int cc110x_get_promiscuous_mode(cc110x_t *dev, netopt_enable_t *dest)
 {
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     uint8_t pktctrl1;
     cc110x_read(dev, CC110X_REG_PKTCTRL1, &pktctrl1);
@@ -598,9 +589,7 @@ static int cc110x_get(netdev_t *netdev, netopt_t opt,
  */
 static int cc110x_set_addr(cc110x_t *dev, uint8_t addr)
 {
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     dev->addr = addr;
     cc110x_write(dev, CC110X_REG_ADDR, addr);
@@ -618,9 +607,7 @@ static int cc110x_set_addr(cc110x_t *dev, uint8_t addr)
  */
 static int cc110x_set_promiscuous_mode(cc110x_t *dev, netopt_enable_t enable)
 {
-    if (cc110x_acquire(dev) != SPI_OK) {
-        return -EIO;
-    }
+    cc110x_acquire(dev);
 
     uint8_t pktctrl1 = CC110X_PKTCTRL1_VALUE;
     if (enable == NETOPT_ENABLE) {

--- a/drivers/cc110x/cc110x_rx_tx.c
+++ b/drivers/cc110x/cc110x_rx_tx.c
@@ -280,10 +280,7 @@ void cc110x_isr(netdev_t *netdev)
      */
     netdev_event_t post_isr_event = NETDEV_NO_EVENT;
 
-    if (cc110x_acquire(dev) != SPI_OK) {
-        DEBUG("[cc110x] ISR: CRITICAL ERROR: Couldn't acquire device\n");
-        return;
-    }
+    cc110x_acquire(dev);
 
     /* Disable IRQs in a coarse manner, instead of doing so any time the
      * IOCFGx configuration registers are changed. (This should be less

--- a/drivers/cc110x/include/cc110x_communication.h
+++ b/drivers/cc110x/include/cc110x_communication.h
@@ -29,20 +29,15 @@ extern "C" {
 #endif
 
 /**
- * @brief   Acquire the SPI interface of the transceiver and configure it
- *
- * @retval  SPI_OK      Success
- * @retval  SPI_NOMODE  SPI mode 0 not supported by MCU
- * @retval  SPI_NOCLK   SPI clock given in @ref cc110x_params_t is not supported
+ * @brief   Acquire the SPI interface of the transceiver
  *
  * @pre     When first acquiring the device either after boot or after having put
  *          the device to sleep mode, use @ref cc110x_power_on_and_acquire
  *          instead. Subsequently, this function should be used (it is faster).
  */
-static inline int cc110x_acquire(cc110x_t *dev)
+static inline void cc110x_acquire(cc110x_t *dev)
 {
-    return spi_acquire(dev->params.spi, dev->params.cs, SPI_MODE_0,
-                       dev->params.spi_clk);
+    spi_acquire(dev->params.spi, dev->params.cs, SPI_MODE_0, dev->params.spi_clk);
 }
 
 /**

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -340,22 +340,16 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode);
  * is active when this function is called, this function will block until the
  * other transaction is complete (spi_relase was called).
  *
- * @note    This function expects the @p bus and the @p cs parameters to be
- *          valid (they are checked in spi_init and spi_init_cs before)
- *
  * @param[in]   bus     SPI device to access
  * @param[in]   cs      chip select pin/line to use, set to SPI_CS_UNDEF if chip
  *                      select should not be handled by the SPI driver
  * @param[in]   mode    mode to use for the new transaction
  * @param[in]   clk     bus clock speed to use for the transaction
  *
- * @retval  0           success
- * @retval  -EINVAL     Invalid mode in @p mode
- * @retval  -EINVAL     Invalid clock in @p clock
- * @retval  -ENOTSUP    Unsupported but valid mode in @p mode
- * @retval  -ENOTSUP    Unsupported but valid clock in @p clock
+ * @pre     All parameters are valid and supported, otherwise an assertion blows
+ *          up (if assertions are enabled).
  */
-int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk);
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk);
 
 /**
  * @brief   Finish an ongoing SPI transaction by releasing the given SPI bus

--- a/drivers/include/soft_spi.h
+++ b/drivers/include/soft_spi.h
@@ -185,16 +185,12 @@ int soft_spi_init_cs(soft_spi_t bus, soft_spi_cs_t cs);
  * @note    This function expects the @p bus and the @p cs parameters to be
  *          valid (they are checked in soft_spi_init and soft_spi_init_cs before)
  *
- * @param[in] bus       SPI device to access
- * @param[in] cs        chip select pin/line to use
- * @param[in] mode      mode to use for the new transaction
- * @param[in] clk       bus clock speed to use for the transaction
- *
- * @return              SOFT_SPI_OK on success
- * @return              SOFT_SPI_NOMODE if given mode is not supported
- * @return              SOFT_SPI_NOCLK if given clock speed is not supported
+ * @param[in]   bus     SPI device to access
+ * @param[in]   cs      chip select pin/line to use
+ * @param[in]   mode    mode to use for the new transaction
+ * @param[in]   clk     bus clock speed to use for the transaction
  */
-int soft_spi_acquire(soft_spi_t bus, soft_spi_cs_t cs, soft_spi_mode_t mode, soft_spi_clk_t clk);
+void soft_spi_acquire(soft_spi_t bus, soft_spi_cs_t cs, soft_spi_mode_t mode, soft_spi_clk_t clk);
 
 /**
  * @brief   Finish an ongoing SPI transaction by releasing the given SPI bus

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -74,21 +74,11 @@ int kw2xrf_spi_init(kw2xrf_t *dev)
                   (unsigned)SPIDEV, res);
         return 1;
     }
-    /* verify SPI params */
-    res = spi_acquire(SPIDEV, CSPIN, SPIMODE, SPICLK);
-    if (res == SPI_NOMODE) {
-        LOG_ERROR("[kw2xrf_spi] given SPI mode is not supported");
-        return 1;
+    /* verify SPI params, if assertions are on */
+    if (!IS_ACTIVE(NDEBUG)) {
+        spi_acquire(SPIDEV, CSPIN, SPIMODE, SPICLK);
+        spi_release(SPIDEV);
     }
-    else if (res == SPI_NOCLK) {
-        LOG_ERROR("[kw2xrf_spi] targeted clock speed is not supported");
-        return 1;
-    }
-    else if (res != SPI_OK) {
-        LOG_ERROR("[kw2xrf_spi] unable to acquire bus with given parameters");
-        return 1;
-    }
-    spi_release(SPIDEV);
 
     DEBUG("[kw2xrf_spi] SPI_DEV(%u) initialized: mode: %u, clk: %u, cs_pin: %u\n",
           (unsigned)SPIDEV, (unsigned)SPIMODE, (unsigned)SPICLK, (unsigned)CSPIN);

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -58,7 +58,8 @@ static int _init_bus(const lis2dh12_t *dev)
 
 static int _acquire(const lis2dh12_t *dev)
 {
-    return spi_acquire(BUS, BUS_CS, BUS_MODE, BUS_CLK);
+    spi_acquire(BUS, BUS_CS, BUS_MODE, BUS_CLK);
+    return BUS_OK;
 }
 
 static void _release(const lis2dh12_t *dev)

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -83,12 +83,11 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
     /* Init IRQ pin */
     gpio_init_int(dev->irq, GPIO_IN_PU, GPIO_FALLING, nrf24l01p_rx_cb, dev);
 
-    /* Test the SPI connection */
-    if (spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK) != SPI_OK) {
-        DEBUG("error: unable to acquire SPI bus with given params\n");
-        return -1;
+    /* Test the SPI connection, if assertions are on */
+    if (!IS_ACTIVE(NDEBUG)) {
+        spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
+        spi_release(dev->spi);
     }
-    spi_release(dev->spi);
 
     xtimer_spin(DELAY_AFTER_FUNC_TICKS);
 

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_communication.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_communication.h
@@ -105,17 +105,13 @@ extern "C" {
  * @brief   Acquire the SPI bus of the transceiver
  *
  * @param[in] dev       NRF24L01+ device handle
- *
- * @return              @see spi_acquire
  */
-int nrf24l01p_ng_acquire(nrf24l01p_ng_t *dev);
+void nrf24l01p_ng_acquire(nrf24l01p_ng_t *dev);
 
 /**
  * @brief   Release the SPI bus of the transceiver
  *
  * @param[in] dev       NRF24L01+ device handle
- *
- * @return               @see spi_release
  */
 void nrf24l01p_ng_release(nrf24l01p_ng_t *dev);
 

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_communication.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_communication.c
@@ -74,10 +74,9 @@ static void _nrf24l01p_ng_copy_and_swap_bytes(uint8_t* dst, const uint8_t* src, 
     }
 }
 
-int nrf24l01p_ng_acquire(nrf24l01p_ng_t *dev)
+void nrf24l01p_ng_acquire(nrf24l01p_ng_t *dev)
 {
-    return spi_acquire(dev->params.spi, dev->params.pin_cs, SPI_MODE_0,
-                       dev->params.spi_clk);
+    spi_acquire(dev->params.spi, dev->params.pin_cs, SPI_MODE_0, dev->params.spi_clk);
 }
 
 void nrf24l01p_ng_release(nrf24l01p_ng_t *dev)

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -177,10 +177,7 @@ static int _init(netdev_t *netdev)
         return -EIO;
     }
     gpio_clear(dev->params.pin_ce);
-    if (nrf24l01p_ng_acquire(dev) < 0) {
-        DEBUG_PUTS("[nrf24l01p_ng] _init(): nrf24l01p_ng_acquire() failed");
-        return -EIO;
-    }
+    nrf24l01p_ng_acquire(dev);
     if (dev->state != NRF24L01P_NG_STATE_POWER_DOWN) {
         nrf24l01p_ng_transition_to_power_down(dev);
     }

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -101,18 +101,24 @@ int soft_spi_init_cs(soft_spi_t bus, soft_spi_cs_t cs)
     return SOFT_SPI_OK;
 }
 
-int soft_spi_acquire(soft_spi_t bus, soft_spi_cs_t cs, soft_spi_mode_t mode, soft_spi_clk_t clk)
+static inline int soft_spi_mode_is_valid(soft_spi_mode_t mode)
 {
-    (void) cs;
+    if ((mode != SOFT_SPI_MODE_0) && (mode != SOFT_SPI_MODE_1) &&
+        (mode != SOFT_SPI_MODE_2) && (mode != SOFT_SPI_MODE_3)) {
+        return 0;
+    }
+    return 1;
+}
+
+void soft_spi_acquire(soft_spi_t bus, soft_spi_cs_t cs, soft_spi_mode_t mode, soft_spi_clk_t clk)
+{
+    (void)cs;
     assert(soft_spi_bus_is_valid(bus));
+    assert(soft_spi_mode_is_valid(mode));
 
     /* lock bus */
     mutex_lock(&locks[bus]);
 
-    if ((mode != SOFT_SPI_MODE_0) && (mode != SOFT_SPI_MODE_1) &&
-        (mode != SOFT_SPI_MODE_2) && (mode != SOFT_SPI_MODE_3)) {
-        return SOFT_SPI_NOMODE;
-    }
     soft_spi_config[bus].soft_spi_mode = mode;
     switch (mode) {
         case SOFT_SPI_MODE_0:
@@ -127,7 +133,6 @@ int soft_spi_acquire(soft_spi_t bus, soft_spi_cs_t cs, soft_spi_mode_t mode, sof
             break;
     }
     soft_spi_config[bus].soft_spi_clk = clk;
-    return SOFT_SPI_OK;
 }
 
 void soft_spi_release(soft_spi_t bus)

--- a/sys/arduino/SPI.cpp
+++ b/sys/arduino/SPI.cpp
@@ -78,13 +78,7 @@ void SPIClass::beginTransaction(SPISettings settings)
 {
     rmutex_lock(&mut);
     /* Call spi_acquire first to prevent data races */
-    int retval = spi_acquire(spi_dev, SPI_CS_UNDEF,
-                             settings.mode, settings.clock);
-    /* No support for exceptions (at least on AVR), resort to assert() */
-    assert(retval == SPI_OK);
-    if (retval != SPI_OK) {
-        return;
-    }
+    spi_acquire(spi_dev, SPI_CS_UNDEF, settings.mode, settings.clock);
     is_transaction = true;
 }
 
@@ -100,13 +94,7 @@ void SPIClass::transfer(void *buf, size_t count)
     rmutex_lock(&mut);
 
     if (!is_transaction) {
-        int retval = spi_acquire(spi_dev, SPI_CS_UNDEF,
-                                 settings.mode, settings.clock);
-        /* No support for exceptions (at least on AVR), resort to assert() */
-        assert(retval == SPI_OK);
-        if (retval != SPI_OK) {
-            return;
-        }
+        spi_acquire(spi_dev, SPI_CS_UNDEF, settings.mode, settings.clock);
     }
     spi_transfer_bytes(spi_dev, SPI_CS_UNDEF, false, buf, buf, count);
     if (!is_transaction) {

--- a/tests/driver_cc110x/sc_cc110x.c
+++ b/tests/driver_cc110x/sc_cc110x.c
@@ -104,10 +104,7 @@ static void print_state(cc110x_t *dev)
     uint8_t virtual_channel;
 
     /* Get all required data and release device */
-    if (cc110x_acquire(dev) != SPI_OK) {
-        puts("Failed to acquire CC1100/CC1101 transceiver");
-        return;
-    }
+    cc110x_acquire(dev);
 
     if (dev->state == CC110X_STATE_OFF) {
         cc110x_release(dev);


### PR DESCRIPTION
### Contribution description

- Changed signature from `int spi_acquire(...)` to `void spi_acquire(...)`
    - Most SPI implementations and 99.9% of all users treat it like this anyway
    - By adding `assert()`s to verify parameters, this actually increases error checking compared to before, where both SPI implementations and user mostly didn't care about errors
- Updated `soft_spi` to match the `periph_spi` API
- Updated implementations
- Updated the few users, which actually checked the return value
    - Most checked the return value only during `<foo>_init()`, but afterwards never again
    - This is updated to add a pair of `spi_acquire()` and `spi_release()` if and only if `NDEBUG` is not defined.
    - The reasoning is: If `assert()`ions are disabled anyway, we won't trigger them no matter how hard we try :-)

### Testing procedure

This should be mostly unscary. However, without `assert()`ions enabled, timing behavior changes a bit during initilization, as a useless pair of `spi_acquire()` and `spi_release()` is simply dropped.

### Issues/PRs references

Depends on and includes:
- [x] https://github.com/RIOT-OS/RIOT/pull/15896
- [x] https://github.com/RIOT-OS/RIOT/pull/15910