### PR TITLE
[RFC, WIP] drivers/periph_spi: improve API of spi_acquire

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -349,6 +349,16 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode);
 spi_clk_t spi_get_clk(uint32_t freq);
 
 /**
+ * @brief   Get the actual frequency Hertz corresponding to the given clock config
+ * @param[in]   clk     The clock configuration to get the corresponding frequency from
+ * @return  The exact frequency in Hertz matching the clock configuration
+ *
+ * @note    In most cases `spi_get_freq(spi_get_clk(x)) != x` will be true, since `spi_get_clk()`
+ *          will return only the closest match, which will rarely be an exact match.
+ */
+uint32_t spi_get_freq(spi_clk_t clk);
+
+/**
  * @brief   Start a new SPI transaction
  *
  * Starting a new SPI transaction will get exclusive access to the SPI bus

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -372,15 +372,13 @@ uint32_t spi_get_freq(spi_clk_t clk);
  * @param[in]   mode    mode to use for the new transaction
  * @param[in]   clk     opaque clock configuration obtain from @ref spi_get_clk
  *
- * @return  The actually used clock frequency in Hz
- *
  * @pre     All parameters are valid and supported, otherwise an assertion blows
  *          up (if assertions are enabled).
  *
  * @post    Exclusive access to the SPI bus is guaranteed until @ref spi_release
  *          is called.
  */
-uint32_t spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk);
+void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk);
 
 /**
  * @brief   Finish an ongoing SPI transaction by releasing the given SPI bus


### PR DESCRIPTION
### Contribution description

Note: only the last commit belongs to this PR, the rest are dependencies.

For specifying the SPI clock rather use a numeric value than a set of predetermined `enum` values. This has the following advantages:

- Code portability
    - If currently an unsupported SPI clock is requested, the API mandates `spi_acquire()` to fail. For sharing code between two MCU types with a different set of supported SPI cocks, this code would have to specify a clock supported by both MCUs
- Better matching hardware requirements
    - Real SPI attached devices usually support arbitrary slow SPI clocks and only have an upper limit. The new API matches this behavior better and allows specifying the maximum SPI clock without worrying what the used  MCU actually supports
- Future proofing the API
    - Many MCUs supported by RIOT support SPI clocks way faster than 10 MHz, but the API doesn't expose this. Adding more enum values would fix this, but would require touching *all* implementations. The new API allows the implementations provide as many and as high clock frequencies as they like, without worrying about other implementations
- Increasing performance
    - Let's say your network devices can work with SPI clocks up to 7 MHz and your MCU supports SPI clocks of 1.5 MHz, 3 MHz, 6MHz and 12 MHz. With the old API, the network device would have to ask for 5 MHz clock and the MCU could only run at 3 MHz when 5 MHz is requested (to remain compatible with devices requesting 5 MHz which run stable at 5 MHz but not with 6 MHz). With the new API, the selected SPI clock would be twice as high in this case.

Returning the actually used frequency can aid in a number of use cases:
- Bit-Banging
    - The SPI COPI pin can be abused for bit-banging protocols like the `ws281x` LEDs are using. This allows using the DMA for bit-banging, which can greatly improve responsiveness of the system
- Better estimations of I/O time
    - A real time system with two external devices connected via the same SPI bus might needs to limit the time a low priority device has access to the bus to fulfill real time requirements. By having good estimations of how long it needs to transfer a byte, the maximum amount of data that can be exchanged with the low priority devices within a single transacting marked by `spi_acquire()` and `spi_release()` can be easily computed.

### Testing procedure

Read the API. Once this API is agreed upon and all dependencies are merged, I can update the implementations. Once this is done, there something to test :-)

### Issues/PRs references

~~Depends on and includes https://github.com/RIOT-OS/RIOT/pull/15902~~