### PR TITLE
sys/net/gnrc/netif: only register netif after init was successful

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -74,7 +74,6 @@ int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
 #endif
     rmutex_init(&netif->mutex);
     netif->ops = ops;
-    netif_register((netif_t*) netif);
     assert(netif->dev == NULL);
     netif->dev = netdev;
     res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
@@ -1610,14 +1609,9 @@ static void *_gnrc_netif_thread(void *args)
     res = dev->driver->init(dev);
     if (res < 0) {
         LOG_ERROR("gnrc_netif: netdev init failed: %d\n", res);
-        /* unregister this netif instance */
-        netif->ops = NULL;
-        netif->pid = KERNEL_PID_UNDEF;
-        netif->dev = NULL;
-        dev->event_callback = NULL;
-        dev->context = NULL;
         return NULL;
     }
+    netif_register(&netif->netif);
     _configure_netdev(dev);
     netif->ops->init(netif);
 #if DEVELHELP

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "errno.h"
+#include "irq.h"
 #include "net/netif.h"
 #include "utlist.h"
 
@@ -24,11 +25,14 @@ static list_node_t netif_list;
 
 int netif_register(netif_t *netif)
 {
-    if(netif == NULL) {
+    if (netif == NULL) {
         return -EINVAL;
     }
 
+    unsigned state = irq_disable();
     list_add(&netif_list, &netif->node);
+    irq_restore(state);
+
     return 0;
 }
 
@@ -59,9 +63,9 @@ netif_t *netif_get_by_name(const char *name)
 
     char tmp[CONFIG_NETIF_NAMELENMAX];
 
-    while(node) {
+    while (node) {
        netif_get_name((netif_t *)node, tmp);
-       if(strncmp(name, tmp, CONFIG_NETIF_NAMELENMAX) == 0) {
+       if (strncmp(name, tmp, CONFIG_NETIF_NAMELENMAX) == 0) {
            return (netif_t *)node;
        }
        node = node->next;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If we call `netif_register()` before we can be sure that the interface can be configured, a 'zombie' interface remains in the list, causing all kinds of trouble down the line.

Only call `netif_register()` if `init()` was successful.


### Testing procedure

Build `examples/gnrc_networking` with e.g `USEMODULE += at86rf215` for a board that does not have a `at86rf215` radio. (Any other network driver will do, as long as the board doesn't have the hardware.)

If you call `ifconfig` an assert will trigger, if you remove the `assert()`, you'll get something like

```
2021-02-01 19:03:16,720 # Iface  6  HWaddr: FC:C2:3D:0D:2D:1F 
2021-02-01 19:03:16,726 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2021-02-01 19:03:16,729 #           Link type: wired
2021-02-01 19:03:16,732 #           inet6 group: ff02::1
2021-02-01 19:03:16,732 #           
2021-02-01 19:03:16,733 # Iface  0 
2021-02-01 19:03:16,734 #           
2021-02-01 19:03:16,737 #           Link type: wireless
2021-02-01 19:03:16,738 #           
2021-02-01 19:03:16,739 # Iface  0 
2021-02-01 19:03:16,740 #           
2021-02-01 19:03:16,742 #           Link type: wireless
2021-02-01 19:03:16,743 #     
```
(`same54-xpro`) There are two 'zombie' interfaces in the list.

With this patch, you only see the interfaces that are actually available.

```
2021-02-01 19:12:20,671 # Iface  6  HWaddr: FC:C2:3D:0D:2D:1F 
2021-02-01 19:12:20,677 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2021-02-01 19:12:20,679 #           Link type: wired
2021-02-01 19:12:20,682 #           inet6 group: ff02::1
```

When connecting the REB215-XPRO extension board and rebooting, the additional interfaces are correctly initialized too.

```
2021-02-01 19:12:25,135 # Iface  8  HWaddr: FC:C2:3D:0D:2D:1F 
2021-02-01 19:12:25,141 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2021-02-01 19:12:25,144 #           Link type: wired
2021-02-01 19:12:25,146 #           inet6 group: ff02::1
2021-02-01 19:12:25,147 #           
2021-02-01 19:12:25,154 # Iface  7  HWaddr: 6A:E4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2021-02-01 19:12:25,155 #           
2021-02-01 19:12:25,159 #           Long HWaddr: E6:EA:AF:F8:AF:5D:EA:E4 
2021-02-01 19:12:25,165 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2021-02-01 19:12:25,172 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  6LO  
2021-02-01 19:12:25,173 #           IPHC  
2021-02-01 19:12:25,176 #           Source address length: 8
2021-02-01 19:12:25,179 #           Link type: wireless
2021-02-01 19:12:25,185 #           inet6 addr: fe80::e4ea:aff8:af5d:eae4  scope: link  VAL
2021-02-01 19:12:25,187 #           inet6 group: ff02::1
2021-02-01 19:12:25,188 #           
2021-02-01 19:12:25,195 # Iface  6  HWaddr: 6A:E5  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK 
2021-02-01 19:12:25,196 #           
2021-02-01 19:12:25,200 #           Long HWaddr: E6:EA:AF:F8:AF:5D:EA:E5 
2021-02-01 19:12:25,206 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2021-02-01 19:12:25,213 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  6LO  
2021-02-01 19:12:25,214 #           IPHC  
2021-02-01 19:12:25,217 #           Source address length: 8
2021-02-01 19:12:25,220 #           Link type: wireless
2021-02-01 19:12:25,226 #           inet6 addr: fe80::e4ea:aff8:af5d:eae5  scope: link  VAL
2021-02-01 19:12:25,228 #           inet6 group: ff02::1
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
