### PR TITLE
net/ieee802154_security: remove radio hal dependency and cleanup

### DIFF
--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -733,64 +733,6 @@ struct ieee802154_radio_ops {
 };
 
 /**
- * @brief Forward declaration of the radio cipher ops structure
- */
-typedef struct ieee802154_radio_cipher_ops ieee802154_radio_cipher_ops_t;
-
-/**
- * @brief Forward declaration of the IEEE802.15.4 security device descriptor
- */
-typedef struct ieee802154_sec_dev ieee802154_sec_dev_t;
-
-/**
- * @brief IEEE802.15.4 security device descriptor
- */
-struct ieee802154_sec_dev {
-    /**
-     * @brief Pointer to the operations of the device
-     */
-    const struct ieee802154_radio_cipher_ops *cipher_ops;
-    /**
-     * @brief pointer to the context of the device
-     */
-    void *ctx;
-};
-
-struct ieee802154_radio_cipher_ops {
-    /**
-     * @brief   Function to set the encryption key for the
-     *          next cipher operation
-     *
-     * @param[in]       dev         Security device descriptor
-     * @param[in]       key         Key to be used for the next cipher operation
-     * @param[in]       key_size    key size in bytes
-     */
-    void (*set_key)(ieee802154_sec_dev_t *dev,
-                    const uint8_t *key, uint8_t key_size);
-    /**
-     * @brief   Function to perform ECB encryption
-     *
-     * @param[in]       dev         Security device descriptor
-     * @param[out]      cipher      Output cipher blocks
-     * @param[in]       plain       Input plain blocks
-     * @param[in]       nblocks     Number of blocks
-     */
-    void (*ecb)(const ieee802154_sec_dev_t *dev, uint8_t *cipher,
-                const uint8_t *plain, uint8_t nblocks);
-    /**
-     * @brief   Function to compute CBC-MAC
-     *
-     * @param[in]       dev         Security device descriptor
-     * @param[in]       cipher      Output cipher blocks
-     * @param[in, out]  iv          in: IV; out: computed MIC
-     * @param[in]       plain       Input plain blocks
-     * @param[in]       nblocks     Number of blocks
-     */
-    void (*cbc)(const ieee802154_sec_dev_t *dev, uint8_t *cipher,
-                uint8_t *iv, const uint8_t *plain, uint8_t nblocks);
-};
-
-/**
  * @brief Shortcut to @ref ieee802154_radio_ops::write
  *
  * @param[in] dev IEEE802.15.4 device descriptor
@@ -1227,48 +1169,6 @@ static inline int ieee802154_radio_set_rx_mode(ieee802154_dev_t *dev,
                                                ieee802154_rx_mode_t mode)
 {
     return dev->driver->set_rx_mode(dev, mode);
-}
-
-/**
- * @brief Shortcut to ieee802154_sec_dev_t::ieee802154_radio_cipher_ops_t::set_key
- *
- * @param[in] dev IEEE802.15.4 security device descriptor
- * @param[in] key Encryption key
- * @param[in] key_size Size of the key in bytes
- */
-static inline void ieee802154_radio_cipher_set_key(ieee802154_sec_dev_t *dev,
-                                                   const uint8_t *key, uint8_t key_size)
-{
-    dev->cipher_ops->set_key(dev->ctx, key, key_size);
-}
-
-/**
- * @brief Shortcut to ieee802154_sec_dev_t::ieee802154_radio_cipher_ops_t::ecb
- *
- * @param[in] dev IEEE802.15.4 security device descriptor
- * @param[out] cipher Output cipher blocks
- * @param[in] plain Input plain blocks
- * @param[in] nblocks Number of blocks
- */
-static inline void ieee802154_radio_cipher_ecb(const ieee802154_sec_dev_t *dev, uint8_t *cipher,
-                                               const uint8_t *plain, uint8_t nblocks)
-{
-    dev->cipher_ops->ecb(dev->ctx, cipher, plain, nblocks);
-}
-
-/**
- * @brief Shortcut to ieee802154_sec_dev_t::ieee802154_radio_cipher_ops_t::cbc
- *
- * @param[in] dev IEEE802.15.4 security device descriptor
- * @param[out] cipher Output cipher blocks
- * @param[in] iv Initial vector to be XOR´ed to the first plain block
- * @param[in] plain Input plain blocks
- * @param[in] nblocks Number of blocks
- */
-static inline void ieee802154_radio_cipher_cbc(const ieee802154_sec_dev_t *dev, uint8_t *cipher,
-                                               uint8_t *iv, const uint8_t *plain, uint8_t nblocks)
-{
-    dev->cipher_ops->cbc(dev->ctx, cipher, iv, plain, nblocks);
 }
 
 #ifdef __cplusplus

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -40,6 +40,12 @@ typedef struct ieee802154_sec_dev ieee802154_sec_dev_t;
 
 /**
  * @brief   Struct of security operations
+ *
+ * @note    A device can indicate that the fallback implementations should be
+ *          used by setting the corresponding member to `NULL`, or pointing to
+ *          @ref ieee802154_radio_cipher_ops, which does the same. Note that
+ *          @ref ieee802154_radio_cipher_ops is the default security operations
+ *          driver assigned when @ref ieee802154_sec_init is called.
  */
 typedef struct ieee802154_radio_cipher_ops {
     /**
@@ -402,7 +408,7 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
  *
  * @param[in]       ctx                     IEEE 802.15.4 security context
  * @param[in]       frame_size              Size of received frame
- * @param[in]       header                  Poinzter to header, which is also the frame
+ * @param[in]       header                  Pointer to header, which is also the frame
  * @param[in, out]  header_size             in: Header size; out: Size of header and auxiliary header
  * @param[out]      payload                 Will point to the beginning of the payload
  * @param[out]      payload_size            Pointer to store the payload size
@@ -423,57 +429,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
                                  const uint8_t *src_address);
 
 /**
- * @brief   Set the encryption key to be used for the next cipher operation
- *
- * This function should be the default callback operation to set the encryption key,
- * if a radio does not provide special hardware security features.
- *
- * @param[in] dev       Security device
- * @param[in] key       Key to be use for the next cipher operation
- * @param[in] key_size  Key size
- */
-void ieee802154_sec_set_key(ieee802154_sec_dev_t *dev,
-                            const uint8_t *key, uint8_t key_size);
-
-/**
- * @brief   Perform ECB block cipher for IEEE802154 security layer
- *
- * This function should be the default callback operation to perform ECB,
- * if a radio does not provide special hardware security features.
- *
- * @param[in] dev       Security device
- * @param[out] cipher   Output cipher blocks
- * @param[in] plain     Input plain blocks
- * @param[in] nblocks   Number of blocks
- */
-void ieee802154_sec_ecb(const ieee802154_sec_dev_t *dev,
-                        uint8_t *cipher,
-                        const uint8_t *plain,
-                        uint8_t nblocks);
-
-/**
- * @brief   Perform CBC block cipher for IEEE802154 security layer
- *          MIC computation
- *
- * This function should be the default callback operation to perform CBC,
- * if a radio does not provide special hardware security features.
- *
- * @param[in] dev       Security device
- * @param[out] cipher   Output cipher blocks
- * @param[in] iv        Initial vector
- * @param[in] plain     Input plain blocks
- * @param[in] nblocks   Number of blocks
- */
-void ieee802154_sec_cbc(const ieee802154_sec_dev_t *dev,
-                        uint8_t *cipher,
-                        uint8_t *iv,
-                        const uint8_t *plain,
-                        uint8_t nblocks);
-
-/**
- * @brief Implements @ref ieee802154_sec_set_key,
- *                   @ref ieee802154_sec_ecb,
- *                   @ref ieee802154_sec_cbc
+ * @brief Default descriptor that will fallback to default implementations
  */
 extern const ieee802154_radio_cipher_ops_t ieee802154_radio_cipher_ops;
 

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -33,9 +33,6 @@
 extern "C" {
 #endif
 
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-#include "net/ieee802154/radio.h"
-#else
 /**
  * @brief   Forward declaration of an IEEE802.15.4 abstract security device
  */
@@ -97,7 +94,6 @@ struct ieee802154_sec_dev {
      */
     void *ctx;
 };
-#endif
 
 #if !defined(IEEE802154_DEFAULT_KEY) || defined(DOXYGEN)
 /**


### PR DESCRIPTION
### Contribution description
This PR does two things:
1. **Removes duplicated definitions that were added to the radio HAL, which are already defined in `ieee802154_security.h`**
The shortcut functions are removed from the radio HAL. After a discussion with @jia200x, a `ieee802154_sec_context_t` will likely find a place on the newly introduced submac later on. For now, as radios that use the radio HAL are still accessed via the `netdev_ieee802154_submac`, the current status will still work. This allows to remove an avoidable dependency and reduce code duplication.

2. **Makes the default implementations of the cipher operations of ieee802154_security private**
This makes the API of the module simpler, as the fallback implementations are kept private. Now the default cipher operations driver holds `NULL` pointers, which indicates to use the fallback implementation. Documentation on this has been added.
ROM usage seems not to be negatively impacted by the change. In fact, while compiling `examples/gnrc_networking` using `ieee802154_security` for `samr21-xpro`, the `text` section is reduced by 4 bytes.

### Testing procedure
Same procedure as for #15150:
> You can test the implementation with examples/gnrc_networking, if you add USEMODULE += ieee802154_security and try ping6. It is supposed to work with any 802.15.4 radio. If you have an at86rf2xx with SPI, you can additionally add USEMODULE += at86rf2xx_aes_spi, if you want to utilize the transceiver´s hardware crypto module.
I tested the implementation on two nucleo-f767zi with an at86rf233.

### Issues/PRs references
#15150