### PR TITLE
sys/arduino: Bug and style fixes in SPI

### DIFF
--- a/sys/arduino/SPI.cpp
+++ b/sys/arduino/SPI.cpp
@@ -39,19 +39,19 @@ SPISettings::SPISettings(uint32_t clock_hz, uint8_t bitOrder, uint8_t dataMode)
 
     assert(bitOrder == MSBFIRST);
     switch(dataMode) {
-        default:
-        case SPI_MODE0:
-            mode = SPI_MODE_0;
-            break;
-        case SPI_MODE1:
-            mode = SPI_MODE_1;
-            break;
-        case SPI_MODE2:
-            mode = SPI_MODE_2;
-            break;
-        case SPI_MODE3:
-            mode = SPI_MODE_3;
-            break;
+    default:
+    case SPI_MODE0:
+        mode = SPI_MODE_0;
+        break;
+    case SPI_MODE1:
+        mode = SPI_MODE_1;
+        break;
+    case SPI_MODE2:
+        mode = SPI_MODE_2;
+        break;
+    case SPI_MODE3:
+        mode = SPI_MODE_3;
+        break;
     }
 
     for (uint8_t i = 0; i < ARRAY_SIZE(steps); i++) {
@@ -90,8 +90,8 @@ void SPIClass::beginTransaction(SPISettings settings)
 
 void SPIClass::endTransaction()
 {
-    spi_release(spi_dev);
     is_transaction = false;
+    spi_release(spi_dev);
     rmutex_unlock(&mut);
 }
 
@@ -125,19 +125,19 @@ void SPIClass::setBitOrder(uint8_t order)
 void SPIClass::setDataMode(uint8_t dataMode)
 {
     switch(dataMode) {
-        default:
-        case SPI_MODE0:
-            settings.mode = SPI_MODE_0;
-            break;
-        case SPI_MODE1:
-            settings.mode = SPI_MODE_1;
-            break;
-        case SPI_MODE2:
-            settings.mode = SPI_MODE_2;
-            break;
-        case SPI_MODE3:
-            settings.mode = SPI_MODE_3;
-            break;
+    default:
+    case SPI_MODE0:
+        settings.mode = SPI_MODE_0;
+        break;
+    case SPI_MODE1:
+        settings.mode = SPI_MODE_1;
+        break;
+    case SPI_MODE2:
+        settings.mode = SPI_MODE_2;
+        break;
+    case SPI_MODE3:
+        settings.mode = SPI_MODE_3;
+        break;
     }
 }
 


### PR DESCRIPTION
### Contribution description

- set `is_transaction` before releasing the SPI bus (and the mutex) to avoid data races
- adapt switch indent to coding convention

### Testing procedure

This is trivial enough that IMO code review and CI should be sufficient.

### Issues/PRs references

None