### PR TITLE
ztimer: fix required_pm_mode initialization

### DIFF
--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -160,10 +160,15 @@ void ztimer_init(void)
                              ZTIMER_MSEC_CONVERT_LOWER,
                              FREQ_1KHZ, ZTIMER_MSEC_CONVERT_LOWER_FREQ);
 #  endif
-#  ifdef CONFIG_ZTIMER_MSEC_ADJUST
-    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust value to %i\n",
+#  ifdef CONFIG_ZTIMER_MSEC_ADJUST_SET
+    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust_set value to %i\n",
               CONFIG_ZTIMER_MSEC_ADJUST);
-    ZTIMER_MSEC->adjust = CONFIG_ZTIMER_MSEC_ADJUST;
+    ZTIMER_MSEC->adjust_set = CONFIG_ZTIMER_MSEC_ADJUST;
+#  endif
+#  ifdef CONFIG_ZTIMER_MSEC_ADJUST_SLEEP
+    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust_sleep value to %i\n",
+              CONFIG_ZTIMER_USEC_ADJUST_SLEEP );
+    ZTIMER_MSEC->adjust_sleep = CONFIG_ZTIMER_MSEC_ADJUST_SLEEP;
 #  endif
 #endif
 }

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -111,6 +111,11 @@ void ztimer_init(void)
                              CONFIG_ZTIMER_USEC_BASE_FREQ,
                              WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
 #  endif
+#  ifdef MODULE_PM_LAYERED
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting required_pm_mode to %i\n",
+              CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE);
+    ZTIMER_USEC_BASE->required_pm_mode = CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE;
+#  endif
 #  if CONFIG_ZTIMER_USEC_BASE_FREQ != FREQ_1MHZ
 #    if CONFIG_ZTIMER_USEC_BASE_FREQ == FREQ_250KHZ
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %lu to 1000000\n",
@@ -135,11 +140,6 @@ void ztimer_init(void)
               CONFIG_ZTIMER_USEC_ADJUST_SLEEP );
     ZTIMER_USEC->adjust_sleep = CONFIG_ZTIMER_USEC_ADJUST_SLEEP;
 #  endif
-#  ifdef MODULE_PM_LAYERED
-    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting required_pm_mode to %i\n",
-              CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE);
-    ZTIMER_USEC->required_pm_mode = CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE;
-#  endif
 #endif
 
 #ifdef ZTIMER_RTT_INIT
@@ -148,6 +148,11 @@ void ztimer_init(void)
 #endif
 
 #if MODULE_ZTIMER_MSEC
+#  ifdef MODULE_PM_LAYERED
+    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting required_pm_mode to %i\n",
+              CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE);
+    ZTIMER_MSEC_BASE->required_pm_mode = CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE;
+#  endif
 #  if ZTIMER_MSEC_CONVERT_LOWER_FREQ
     LOG_DEBUG("ztimer_init(): ZTIMER_MSEC convert_frac from %lu to 1000\n",
               (long unsigned)ZTIMER_MSEC_CONVERT_LOWER_FREQ);
@@ -159,11 +164,6 @@ void ztimer_init(void)
     LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust value to %i\n",
               CONFIG_ZTIMER_MSEC_ADJUST);
     ZTIMER_MSEC->adjust = CONFIG_ZTIMER_MSEC_ADJUST;
-#  endif
-#  ifdef MODULE_PM_LAYERED
-    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting required_pm_mode to %i\n",
-              CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE);
-    ZTIMER_MSEC->required_pm_mode = CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE;
 #  endif
 #endif
 }

--- a/sys/ztimer/convert.c
+++ b/sys/ztimer/convert.c
@@ -46,6 +46,9 @@ void ztimer_convert_init(ztimer_convert_t *ztimer_convert,
             .arg = ztimer_convert,
         },
         .super.max_value = max_value,
+#ifdef MODULE_PM_LAYERED
+        .super.required_pm_mode = ZTIMER_CLOCK_NO_REQUIRED_PM_MODE,
+#endif
     };
 
     *ztimer_convert = tmp;

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -93,7 +93,12 @@ void ztimer_convert_frac_init(ztimer_convert_frac_t *self,
           (void *)self, (void *)lower, freq_self, freq_lower);
 
     *self = (ztimer_convert_frac_t) {
-        .super.super = { .ops = &ztimer_convert_frac_ops, },
+        .super.super = {
+            .ops = &ztimer_convert_frac_ops,
+#ifdef MODULE_PM_LAYERED
+            .required_pm_mode = ZTIMER_CLOCK_NO_REQUIRED_PM_MODE,
+#endif
+        },
         .super.lower = lower,
         .super.lower_entry =
         { .callback = (void (*)(void *))ztimer_handler, .arg = &self->super, },


### PR DESCRIPTION

### Contribution description

This might be flawed, but from my understanding:
-  the `required_pm_mode` should be applied to the 'base' clock (i.e. the periph_timer or periph_rtt clock)
-  'convert' clocks do not have pm requirement

This PR sets `required_pm_mode` on `ZTIMER_USEC_BASE` and `ZTIMER_MSEC_BASE`. Setting this field is also moved before those clocks are used as they can be used in `ztimer_convert_frac_init()`.
I also changed 'convert' clocks init so they set their internal `required_pm_mode` to `ZTIMER_CLOCK_NO_REQUIRED_PM_MODE` instead of nothing (which makes it 0, thus blocking a power mode by error).

As a last minor change, I fixed the initialization of 'adjust' parameter for the `ZTIMER_MSEC` clock as the field was renamed.


### Testing procedure

I tested with our main application and checked that pm was behaving as expected. Before this change, it could never go to sleep.


