### PR TITLE
sys/riotboot/flashwrite: when invalidating erase checksum as well 

### DIFF
--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -116,6 +116,11 @@ extern "C" {
 #define FLASHPAGE_SIZE                  (128U)
 #endif
 
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
+    defined(CPU_FAM_STM32L4)
+#define FLASHPAGE_ERASE_STATE           (0x00U)
+#endif
+
 #ifdef FLASHPAGE_SIZE
 #define FLASHPAGE_NUMOF                 (STM32_FLASHSIZE / FLASHPAGE_SIZE)
 #endif

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -86,6 +86,15 @@ extern "C" {
 #endif
 
 /**
+ * @def FLASHPAGE_ERASE_STATE
+ *
+ * @brief   State of an erased byte in memory
+ */
+#if defined(DOXYGEN) || !defined(FLASHPAGE_ERASE_STATE)
+#define FLASHPAGE_ERASE_STATE           (0xFFU)
+#endif
+
+/**
  * @def     PERIPH_FLASHPAGE_CUSTOM_PAGESIZES
  *
  * @brief   Defined to signal that the peripheral has non-uniform flash page


### PR DESCRIPTION
### Contribution description

This PR addresses two issues with `riotboot_flashwrite_invalidate`:

- writing `0XAA` to invalidate will no always work, e.g. for stm32f1:

> In this mode the CPU programs the main Flash memory by performing standard half-word
write operations. The PG bit in the FLASH_CR register must be set. FPEC preliminarily
reads the value at the addressed main Flash memory location and checks that it has been
erased. If not, the program operation is skipped and a warning is issued by the PGERR bit in
FLASH_SR register (the only exception to this is when 0x0000 is programmed. In this case,
the location is correctly programmed to 0x0000 and the PGERR bit is not set). If the
addressed main Flash memory location is write-protected by the FLASH_WRPR register,
the program operation is skipped and a warning is issued by the WRPRTERR bit in the
FLASH_SR register. The end of the program operation is indicated by the EOP bit in the
FLASH_SR register.

Also `FLASHPAGE_WRITE_BLOCK_SIZE`  was not taken into account, so writing to `RIOTBOOT_MAGIC` might not work.

Discussing offline with @bergzand it was mentioned that the checksum should also be erased.

To be able to do this I added a `FLASHPAGE_ERASE_STATE` definition for all `CPU`s supporting `flashpage`.

### Testing procedure

Use #15559 to test, with this PR these test passes, without it fails the invalidation check.

- `BOARD=iotlab-m3 make -C tests/riotboot_flashwrite/ flash test-with-config -j3`

```
```

