### PR TITLE
cpu/stm32/flashpage: reset PER after erase

### DIFF
--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -164,10 +164,11 @@ static void _erase_page(void *page_addr)
     }
 #endif
 
-#ifdef FLASH_CR_PNB
-    /* reset PER bit (if the register settings exist) */
     DEBUG("[flashpage] erase: resetting the page erase bit\n");
-    CNTRL_REG &= ~(FLASH_CR_PER | FLASH_CR_PNB);
+    CNTRL_REG &= ~(FLASH_CR_PER);
+#ifdef FLASH_CR_PNB
+    /* reset PNB bit (if the register settings exist) */
+    CNTRL_REG &= ~(FLASH_CR_PNB);
 #endif
 
     /* lock the flash module again */


### PR DESCRIPTION
### Contribution description

#15420 removes the setting where the PER bit is reset (switched to programming) after an erase, this puts it back in for CPU's with no PNB.

### Testing procedure

- ` BOARD=iotlab-m3 make -C examples/suit_update/ flash test-with-config -j3`

passes again.

