### PR TITLE
sys/shell: document configs and add them to Kconfig

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -30,7 +30,14 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup sys_shell_config Shell compile time configurations
+ * @ingroup config
+ * @{
+ */
+/**
  * @brief Shutdown RIOT on shell exit
+ *
+ * @note On native platform this option defaults to 1.
  */
 #ifndef CONFIG_SHELL_SHUTDOWN_ON_EXIT
 /* Some systems (e.g Ubuntu 20.04) close stdin on CTRL-D / EOF
@@ -38,10 +45,46 @@ extern "C" {
  * Instead terminate RIOT, which is also the behavior a user would
  * expect from a CLI application.
  */
-#  ifdef CPU_NATIVE
+#  if defined(CPU_NATIVE) && !IS_ACTIVE(KCONFIG_MODULE_SHELL)
 #    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 1
+#  else
+#    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 0
 #  endif
 #endif
+
+/**
+ * @brief Set to 1 to disable shell's echo
+ */
+#ifndef CONFIG_SHELL_NO_ECHO
+#define CONFIG_SHELL_NO_ECHO 0
+#endif
+
+/**
+ * @brief Set to 1 to disable shell's prompt
+ */
+#ifndef CONFIG_SHELL_NO_PROMPT
+#define CONFIG_SHELL_NO_PROMPT 0
+#endif
+
+/**
+ * @brief Set to 1 to disable shell's echo
+ * @deprecated This has been replaced by @ref CONFIG_SHELL_NO_ECHO and will be
+ *             removed after release 2021.07.
+ */
+#ifndef SHELL_NO_ECHO
+#define SHELL_NO_ECHO CONFIG_SHELL_NO_ECHO
+#endif
+
+/**
+ * @brief Set to 1 to disable shell's prompt
+ * @deprecated This has been replaced by @ref CONFIG_SHELL_NO_PROMPT and will be
+ *             removed after release 2021.07.
+ */
+#ifndef SHELL_NO_PROMPT
+#define SHELL_NO_PROMPT CONFIG_SHELL_NO_PROMPT
+#endif
+
+/** @} */
 
 /**
  * @brief Default shell buffer size (maximum line length shell can handle)

--- a/sys/shell/Kconfig
+++ b/sys/shell/Kconfig
@@ -11,3 +11,26 @@ menuconfig MODULE_SHELL
     depends on TEST_KCONFIG
 
 rsource "commands/Kconfig"
+
+menuconfig KCONFIG_MODULE_SHELL
+    bool "Configure the Shell interpreter"
+    depends on USEMODULE_SHELL
+
+if KCONFIG_MODULE_SHELL
+
+config SHELL_SHUTDOWN_ON_EXIT
+    bool "Shutdown RIOT on shell exit"
+    default y if CPU_NATIVE
+    help
+        Some systems (e.g Ubuntu 20.04) close stdin on CTRL-D / EOF
+        That means we can't just re-start the shell.
+        Instead terminate RIOT, which is also the behavior a user would expect
+        from a CLI application.
+
+config SHELL_NO_ECHO
+    bool "Disable echo"
+
+config SHELL_NO_PROMPT
+    bool "Disable prompt"
+
+endif # KCONFIG_MODULE_SHELL

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include "kernel_defines.h"
 #include "shell.h"
 #include "shell_commands.h"
 
@@ -48,18 +49,6 @@
 #else
     #define flush_if_needed()
 #endif /* MODULE_NEWLIB || MODULE_PICOLIBC */
-
-#ifndef SHELL_NO_ECHO
-    #define ECHO_ON 1
-#else
-    #define ECHO_ON 0
-#endif /* SHELL_NO_ECHO */
-
-#ifndef SHELL_NO_PROMPT
-    #define PROMPT_ON 1
-#else
-    #define PROMPT_ON 0
-#endif /* SHELL_NO_PROMPT */
 
 #ifdef MODULE_SHELL_COMMANDS
     #define _builtin_cmds _shell_command_list
@@ -343,7 +332,7 @@ __attribute__((weak)) void shell_post_command_hook(int ret, int argc,
 
 static inline void print_prompt(void)
 {
-    if (PROMPT_ON) {
+    if (!IS_ACTIVE(CONFIG_SHELL_NO_PROMPT) && !IS_ACTIVE(SHELL_NO_PROMPT)) {
         putchar('>');
         putchar(' ');
     }
@@ -353,14 +342,14 @@ static inline void print_prompt(void)
 
 static inline void echo_char(char c)
 {
-    if (ECHO_ON) {
+    if (!IS_ACTIVE(CONFIG_SHELL_NO_ECHO) && !IS_ACTIVE(SHELL_NO_ECHO)) {
         putchar(c);
     }
 }
 
 static inline void white_tape(void)
 {
-    if (ECHO_ON) {
+    if (!IS_ACTIVE(CONFIG_SHELL_NO_ECHO) && !IS_ACTIVE(SHELL_NO_ECHO)) {
         putchar('\b');
         putchar(' ');
         putchar('\b');
@@ -369,7 +358,7 @@ static inline void white_tape(void)
 
 static inline void new_line(void)
 {
-    if (ECHO_ON) {
+    if (!IS_ACTIVE(CONFIG_SHELL_NO_ECHO) && !IS_ACTIVE(SHELL_NO_ECHO)) {
         putchar('\r');
         putchar('\n');
     }

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -12,7 +12,7 @@ TIMEOUT_MS ?= 3000
 # Suppress test execution to avoid CI errors
 TEST_ON_CI_BLACKLIST += all
 
-CFLAGS += -DSHELL_NO_ECHO
+CFLAGS += -DCONFIG_SHELL_NO_ECHO
 
 ifeq (native,$(BOARD))
   TERMFLAGS ?= $(TAP)

--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 USEMODULE += shell
 
 # Disable shell echo and prompt to not have them in the way for testing
-CFLAGS += -DSHELL_NO_ECHO=1 -DSHELL_NO_PROMPT=1
+CFLAGS += -DCONFIG_SHELL_NO_ECHO=1 -DCONFIG_SHELL_NO_PROMPT=1
 
 # No need for test_utils_interactive_sync in this test since the test
 # synchronizes by itself through `shellping` command.

--- a/tests/test_tools/main.c
+++ b/tests/test_tools/main.c
@@ -18,10 +18,11 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "kernel_defines.h"
 #include "shell_commands.h"
 #include "shell.h"
 
-#if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
+#if !IS_ACTIVE(CONFIG_SHELL_NO_ECHO) || !IS_ACTIVE(CONFIG_SHELL_NO_PROMPT)
 #error This test assumes no shell echo or shell prompt
 #endif
 


### PR DESCRIPTION
### Contribution description
This documents the compile time configurations of the shell interpreter module, and models them in Kconfig. Although the previous macros were not documented I marked them now as deprecated, favoring the `CONFIG_` version of them.

### Testing procedure
- `tests/test_tool`, `tests/shell` should work as usual
- The changed applications should work
- You should be able to configure via menuconfig or `CFLAGS`
- The deprecated macros should still work

### Issues/PRs references
Part of #12888