### PR TITLE
pkg/nimble/netif: improve _send_pkt() error return value

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -142,7 +142,7 @@ static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)
 
     if ((res != 0) && (res != BLE_HS_ESTALLED)) {
         os_mbuf_free_chain(sdu);
-        return -ENOBUFS;
+        return -ECANCELED;
     }
 
     return num_bytes;


### PR DESCRIPTION
### Contribution description
Minor fix: the internal _send_pkt() function now returns a distinct return value in the case that an internal NimBLE error occurred while sending. This makes debugging a little bit simpler...

### Testing procedure
Build test should be enough, as the return value is not explicitly used in any upstreamed code...


### Issues/PRs references
none
