### PR TITLE
pkg/nimble/netif: allow to read used channel map

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -241,6 +241,21 @@ int nimble_netif_accept_stop(void);
 int nimble_netif_update(int handle,
                         const struct ble_gap_upd_params *conn_params);
 
+/**
+ * @brief   Get the currently used channel map for the given connection as
+ *          bitmap
+ *
+ * @param[in] handle        connection handle
+ * @param[out] map          used channel map, map[0] denotes channels 0 to 7,
+ *                          map[1] chan 8-15, ..., map[5] channels 33 to 36.
+ *                          **must** be able to hold 5 bytes.
+ *
+ * @return  NIMBLE_NETIF_OK on success
+ * @return  NIMBLE_NETIF_NOTCONN if handle dos not point to a connection
+ * @return  NIMBLE_NETIF_DEVERR if reading the channel map failed otherwise
+ */
+int nimble_netif_used_chanmap(int handle, uint8_t map[5]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -660,3 +660,18 @@ int nimble_netif_update(int handle,
 
     return NIMBLE_NETIF_OK;
 }
+
+int nimble_netif_used_chanmap(int handle, uint8_t map[5])
+{
+    nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+    if (conn == NULL) {
+        return NIMBLE_NETIF_NOTCONN;
+    }
+
+    int res = ble_hs_hci_read_chan_map(conn->gaphandle, map);
+    if (res != 0) {
+        return NIMBLE_NETIF_DEVERR;
+    }
+
+    return NIMBLE_NETIF_OK;
+}

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -380,9 +380,9 @@ int _nimble_netif_handler(int argc, char **argv)
 {
     if ((argc == 1) || _ishelp(argv[1])) {
 #if !IS_USED(MODULE_NIMBLE_AUTOCONN) && !IS_USED(MODULE_NIMBLE_STATCONN)
-        printf("usage: %s [help|info|adv|scan|connect|close|update]\n", argv[0]);
+        printf("usage: %s [help|info|adv|scan|connect|close|update|chanmap]\n", argv[0]);
 #else
-        printf("usage: %s [help|info|close|update]\n", argv[0]);
+        printf("usage: %s [help|info|close|update|chanmap]\n", argv[0]);
 #endif
         return 0;
     }
@@ -474,6 +474,28 @@ int _nimble_netif_handler(int argc, char **argv)
         int timeout = atoi(argv[4]);
         _cmd_update(handle, itvl, timeout);
     }
+    else if ((memcmp(argv[1], "chanmap", 7) == 0)) {
+        int handle = nimble_netif_conn_get_next(NIMBLE_NETIF_CONN_INVALID,
+                                                NIMBLE_NETIF_GAP_CONNECTED);
+        if (handle == NIMBLE_NETIF_CONN_INVALID) {
+            printf("err: no BLE connection(s) found\n");
+            return 0;
+        }
+        puts("Used channels per Slot\n"
+             "Bitmap denotes channels in ascending order: CH36, ..., CH0\n"
+             "e.g. '1f ff ff ff ff' shows that all 37 data channels in use");
+        while (handle != NIMBLE_NETIF_CONN_INVALID) {
+            uint8_t map[5];
+            nimble_netif_used_chanmap(handle, map);
+            printf("[%02i] %02x %02x %02x %02x %02x\n", handle,
+                    (int)map[4], (int)map[3], (int)map[2],
+                    (int)map[1], (int)map[0]);
+            handle = nimble_netif_conn_get_next(handle,
+                                                NIMBLE_NETIF_GAP_CONNECTED);
+        }
+        return 0;
+    }
+
     else {
         printf("unable to parse the command. Use '%s help' for more help\n",
                argv[0]);


### PR DESCRIPTION
### Contribution description
This PR extends the `ble` shell command with the `ble chanmap` subcommand, allowing to list the used channel map for each open connection. This is e.g. useful to check which data channels are currently used in each connection so see if any adaptive channel selection is being used.

### Testing procedure
- flash the `gnrc_networking` with `USEMODULE=nimble_netif` on any two nrf52(840) nodes that are in radio range of each other
- open a BLE connection, e.g. node A: `ble adv foo`, node B: `ble connect foo`
- list the used channel map on each node: `ble chanmap`
-> the output should be `1f ff ff ff ff` on both nodes, as NimBLE is per default always using all 37 data channels.

### Issues/PRs references
none
