### PR TITLE
pkg/nimble/autoconn: add missing 'random' dep

### DIFF
--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -48,6 +48,7 @@ ifneq (,$(filter nimble_autoconn_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter nimble_autoconn,$(USEMODULE)))
+  USEMODULE += random
   USEMODULE += nimble_netif
   USEMODULE += nimble_scanner
   USEMODULE += bluetil_ad


### PR DESCRIPTION
### Contribution description
Minor fix: the `nimble_autoconn` module uses the `random` module, but this dependency was missing in `pkg/nimble/Makefile.dep`. Now its fixed :-)

### Testing procedure
Build test should do.

### Issues/PRs references
none
