### PR TITLE
pkg/nimble/statconn: allow random connection interval

### DIFF
--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -59,6 +59,7 @@ ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
 endif
 
 ifneq (,$(filter nimble_statconn,$(USEMODULE)))
+  USEMODULE += random
   USEMODULE += nimble_netif
   USEMODULE += nimble_addr
 endif

--- a/pkg/nimble/statconn/include/nimble_statconn.h
+++ b/pkg/nimble/statconn/include/nimble_statconn.h
@@ -80,10 +80,22 @@ extern "C" {
 #endif
 
 /**
- * @brief   Connection interval used when opening a new connection [in ms]
+ * @brief   Minimum connection interval used when opening a new connection. The
+ *          actual used connection interval will be a random value ranging from
+ *          @ref NIMBLE_STATCONN_CONN_ITVL_MIN_MS to
+ *          @ref NIMBLE_STATCONN_CONN_ITVL_MAX_MS. Set both variables to the same
+ *          value to use a fixed connection interval. [in ms]
  */
-#ifndef NIMBLE_STATCONN_CONN_ITVL_MS
-#define NIMBLE_STATCONN_CONN_ITVL_MS        (75U)
+#ifndef NIMBLE_STATCONN_CONN_ITVL_MIN_MS
+#define NIMBLE_STATCONN_CONN_ITVL_MIN_MS    (75U)
+#endif
+
+/**
+ * @brief   Maximum connection interval to use. See
+ *          @ref NIMBLE_STATCONN_CONN_ITVL_MIN_MS for more information. [in ms]
+ */
+#ifndef NIMBLE_STATCONN_CONN_ITVL_MAX_MS
+#define NIMBLE_STATCONN_CONN_ITVL_MAX_MS    (75U)
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description
When keeping multiple connections in parallel on a node, it has proven to be beneficial when each connection uses a slightly differing connection interval, as this prevents the connections losses due to connection event shadowing caused by clock drift.

This PR adds the possibility to configure the `nimble_statconn` module to use a random connection interval for each new connection from a defined range. Simply configure `NIMBLE_STATCONN_CONN_ITVL_MIN_MS` and `NIMBLE_STATCONN_CONN_ITVL_MAX_MS` to different values.

This PR changes the modules API slightly, but as it is marked as ` @experimental` this should be ok.

### Testing procedure
- build `tests/nimble_statconn_gnrc` with e.g. `CFLAGS=-DNIMBLE_STATCONN_CONN_ITVL_MAX_MS=100` for an `nrf52(840)dk` or similar
- flash it to 2 boards in radio range
- connect the two nodes: node A: `statconn addm HW_ADDR_OF_NODE_B`, node B: `statconn adds HW_ADDR_OF_NODE_A`. Use `ifconfig` or `ble_info` to get the hardware addresses.
- use `ble info` to see the used connection interval for the BLE connection
- close the connection `ble close 0` 
-> the connection will automatically be reopened and you should see a different connection interval every time you do this.

Example, the connection intervals here are 95ms, 91ms, and 86ms:
```
2021-02-04 10:04:48,571 # main(): This is RIOT! (Version: 2021.04-devel-437-gfaf7a-opt_nimble_statconn_randconnitvl)
2021-02-04 10:04:48,576 # IPv6-over-BLE with statconn BLE connection manager
2021-02-04 10:04:48,578 # All up, running the shell now
statconn adds EA:AB:DA:71:79:46
2021-02-04 10:04:55,178 #  statconn adds EA:AB:DA:71:79:46
2021-02-04 10:04:55,181 # success: connecting to peer as master
> 2021-02-04 10:04:55,298 #  [ble] CONNECTED master (0|EA:AB:DA:71:79:46)
ble info
2021-02-04 10:05:00,285 # ble info
2021-02-04 10:05:00,290 # Own Address: C9:88:95:BA:EC:98 -> [FE80::C988:95FF:FEBA:EC98]
2021-02-04 10:05:00,292 #  Free slots: 2/3
2021-02-04 10:05:00,293 # Advertising: no
2021-02-04 10:05:00,295 # Connections: 1
2021-02-04 10:05:00,301 # [ 0] EA:AB:DA:71:79:46 [FE80::EAAB:DAFF:FE71:7946] (M,95ms,2500ms,0)
2021-02-04 10:05:00,305 #      (role, conn itvl, superv. timeout, slave latency)
2021-02-04 10:05:00,306 # Slots:
2021-02-04 10:05:00,310 # [ 0] state: 0x0011 - GAP-master L2CAP-client
2021-02-04 10:05:00,313 # [ 1] state: 0x8000 - unused
2021-02-04 10:05:00,315 # [ 2] state: 0x8000 - unused
2021-02-04 10:05:00,315 # 
> ble close 0
2021-02-04 10:05:03,589 #  ble close 0
2021-02-04 10:05:03,593 # success: connection tear down initiated
> 2021-02-04 10:05:03,657 #  [ble] CLOSED master (0|EA:AB:DA:71:79:46)
2021-02-04 10:05:03,761 # [ble] CONNECTED master (0|EA:AB:DA:71:79:46)
ble info
2021-02-04 10:05:05,028 # ble info
2021-02-04 10:05:05,034 # Own Address: C9:88:95:BA:EC:98 -> [FE80::C988:95FF:FEBA:EC98]
2021-02-04 10:05:05,035 #  Free slots: 2/3
2021-02-04 10:05:05,036 # Advertising: no
2021-02-04 10:05:05,038 # Connections: 1
2021-02-04 10:05:05,044 # [ 0] EA:AB:DA:71:79:46 [FE80::EAAB:DAFF:FE71:7946] (M,91ms,2500ms,0)
2021-02-04 10:05:05,049 #      (role, conn itvl, superv. timeout, slave latency)
2021-02-04 10:05:05,049 # Slots:
2021-02-04 10:05:05,053 # [ 0] state: 0x0011 - GAP-master L2CAP-client
2021-02-04 10:05:05,056 # [ 1] state: 0x8000 - unused
2021-02-04 10:05:05,058 # [ 2] state: 0x8000 - unused
2021-02-04 10:05:05,058 # 
> ble close 0
2021-02-04 10:05:07,112 #  ble close 0
2021-02-04 10:05:07,115 # success: connection tear down initiated
> 2021-02-04 10:05:07,137 #  [ble] CLOSED master (0|EA:AB:DA:71:79:46)
2021-02-04 10:05:07,235 # [ble] CONNECTED master (0|EA:AB:DA:71:79:46)
ble info
2021-02-04 10:05:08,776 # ble info
2021-02-04 10:05:08,782 # Own Address: C9:88:95:BA:EC:98 -> [FE80::C988:95FF:FEBA:EC98]
2021-02-04 10:05:08,783 #  Free slots: 2/3
2021-02-04 10:05:08,785 # Advertising: no
2021-02-04 10:05:08,786 # Connections: 1
2021-02-04 10:05:08,792 # [ 0] EA:AB:DA:71:79:46 [FE80::EAAB:DAFF:FE71:7946] (M,86ms,2500ms,0)
2021-02-04 10:05:08,797 #      (role, conn itvl, superv. timeout, slave latency)
2021-02-04 10:05:08,798 # Slots:
2021-02-04 10:05:08,802 # [ 0] state: 0x0011 - GAP-master L2CAP-client
2021-02-04 10:05:08,804 # [ 1] state: 0x8000 - unused
2021-02-04 10:05:08,807 # [ 2] state: 0x8000 - unused
2021-02-04 10:05:08,807 
```

### Issues/PRs references
none