### PR TITLE
sys/shell: rename Kconfig symbol to adhere to convention

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -45,7 +45,7 @@ extern "C" {
  * Instead terminate RIOT, which is also the behavior a user would
  * expect from a CLI application.
  */
-#  if defined(CPU_NATIVE) && !IS_ACTIVE(KCONFIG_MODULE_SHELL)
+#  if defined(CPU_NATIVE) && !IS_ACTIVE(KCONFIG_USEMODULE_SHELL)
 #    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 1
 #  else
 #    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 0

--- a/sys/shell/Kconfig
+++ b/sys/shell/Kconfig
@@ -12,11 +12,11 @@ menuconfig MODULE_SHELL
 
 rsource "commands/Kconfig"
 
-menuconfig KCONFIG_MODULE_SHELL
+menuconfig KCONFIG_USEMODULE_SHELL
     bool "Configure the Shell interpreter"
     depends on USEMODULE_SHELL
 
-if KCONFIG_MODULE_SHELL
+if KCONFIG_USEMODULE_SHELL
 
 config SHELL_SHUTDOWN_ON_EXIT
     bool "Shutdown RIOT on shell exit"
@@ -33,4 +33,4 @@ config SHELL_NO_ECHO
 config SHELL_NO_PROMPT
     bool "Disable prompt"
 
-endif # KCONFIG_MODULE_SHELL
+endif # KCONFIG_USEMODULE_SHELL

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -12,8 +12,6 @@ TIMEOUT_MS ?= 3000
 # Suppress test execution to avoid CI errors
 TEST_ON_CI_BLACKLIST += all
 
-CFLAGS += -DCONFIG_SHELL_NO_ECHO
-
 ifeq (native,$(BOARD))
   TERMFLAGS ?= $(TAP)
 else
@@ -53,4 +51,9 @@ endif
 # via Kconfig
 ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS
   CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS=$(TIMEOUT_MS)
+endif
+
+# Set the shell echo configuration via CFLAGS if not being controlled via Kconfig
+ifndef CONFIG_KCONFIG_USEMODULE_SHELL
+  CFLAGS += -DCONFIG_SHELL_NO_ECHO
 endif

--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -3,9 +3,6 @@ include ../Makefile.tests_common
 
 USEMODULE += shell
 
-# Disable shell echo and prompt to not have them in the way for testing
-CFLAGS += -DCONFIG_SHELL_NO_ECHO=1 -DCONFIG_SHELL_NO_PROMPT=1
-
 # No need for test_utils_interactive_sync in this test since the test
 # synchronizes by itself through `shellping` command.
 DISABLE_MODULE += test_utils_interactive_sync
@@ -14,3 +11,9 @@ DISABLE_MODULE += test_utils_interactive_sync
 USEMODULE += dummy_thread
 
 include $(RIOTBASE)/Makefile.include
+
+# Set the shell echo configuration via CFLAGS if not being controlled via Kconfig
+# Disable shell echo and prompt to not have them in the way for testing
+ifndef CONFIG_KCONFIG_USEMODULE_SHELL
+  CFLAGS += -DCONFIG_SHELL_NO_ECHO -DCONFIG_SHELL_NO_PROMPT
+endif


### PR DESCRIPTION
### Contribution description
This modifies the `menuconfig` symbol of shell to adhere to the naming convention. Also, in tests that use CFLAGS to change shell parameters a check for Kconfig is added.

### Testing procedure
- When using Kconfig and enabling `KCONFIG_USEMODULE_SHELL` CFLAGS in the changed tests should not conflict
- Check that the symbol name now follows [the convention](http://doc.riot-os.org/kconfig-in-riot.html#kconfig-transition-phase) on prefixes.

### Issues/PRs references
#15918 
