### PR TITLE
uri_parser: check result->host_len before incrementing result->host

### DIFF
--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -75,9 +75,11 @@ void _consume_userinfo(uri_parser_result_t *result, char *uri,
     if (userinfo_end) {
         result->userinfo = uri;
         result->userinfo_len = userinfo_end - uri;
-        /* shift host part beyond userinfo and '@' */
-        result->host += result->userinfo_len + 1;
-        result->host_len -= result->userinfo_len + 1;
+        if ((result->userinfo_len + 1) < result->host_len) {
+            /* shift host part beyond userinfo and '@' */
+            result->host += result->userinfo_len + 1;
+            result->host_len -= result->userinfo_len + 1;
+        }
     }
 }
 


### PR DESCRIPTION
This is intended as a hotfix for #15927. Not sure if I would be preferable to return an error in this case instead. Information on testing et cetera is provided in the referenced issue.

Fixes #15927.