### PR TITLE
uri_parser: check if uri is long enough to even contain a ://

### DIFF
--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -55,7 +55,7 @@ static char *_consume_scheme(uri_parser_result_t *result, char *uri,
     result->scheme_len = p - uri;
 
     /* check if authority part exists '://' */
-    if ((p[1] != '\0') && (p[2] != '\0') && (p[1] == '/') && (p[2] == '/')) {
+    if (((uri_end - p) > 2) && (p[1] == '/') && (p[2] == '/')) {
         *has_authority = true;
         /* skip '://' */
         return p + 3;

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -401,6 +401,17 @@ static const validate_t validate_uris[] = {
         "./this:that",
         "",
         0),
+    VEC("pP://",
+        true,
+        "pP",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        0),
 };
 
 static char _failure_msg[VEC_MSG_LEN];


### PR DESCRIPTION
### Contribution description

Before attempting to access the `://` part of the URI it is necessary to check that the URI is long enough to actually contain this string and data following it. Otherwise, a read outside the bounds of the provided buffer is performed if the buffer is too small.

### Testing procedure

Application code:

```C
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>
#include <uri_parser.h>

#define BUFFER_SIZE 5

static char buf[] = { 112, 80, 58, 47, 47, };

int main(void)
{
    size_t len = sizeof(buf);
    uri_parser_result_t result;

    uri_parser_process(&result, buf, len);
    return 0;
}
```

Makefile:

```Makefile
APPLICATION = uri
DEVELHELP = 1

BOARD = native

USEMODULE += uri_parser

RIOTBASE ?= $(CURDIR)/../..
include $(RIOTBASE)/Makefile.include
```

Run:

```
$ make -C examples/uri all-asan
$ make -C examples/uri term
main(): This is RIOT! (Version: 2021.04-devel-440-g4cc04)
=================================================================
==24892==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5664f105 at pc 0x56645e58 bp 0x56654718 sp 0x5665470c
READ of size 1 at 0x5664f105 thread T0
    #0 0x56645e57 in _consume_authority /root/RIOT/sys/uri_parser/uri_parser.c:132
    #1 0x5664661a in _parse_absolute /root/RIOT/sys/uri_parser/uri_parser.c:224
    #2 0x56646ae9 in uri_parser_process /root/RIOT/sys/uri_parser/uri_parser.c:282
    #3 0x5663cbcb in main /root/RIOT/examples/uri/main.c:15
    #4 0x5663d0ff in main_trampoline /root/RIOT/core/init.c:58
    #5 0xf773853a in makecontext (/lib/i386-linux-gnu/libc.so.6+0x4153a)

0x5664f105 is located 0 bytes to the right of global variable 'buf' defined in '/root/RIOT/examples/uri/main.c:8:13' (0x5664f100) of size 5
SUMMARY: AddressSanitizer: global-buffer-overflow /root/RIOT/sys/uri_parser/uri_parser.c:132 in _consume_authority
Shadow bytes around the buggy address:
  0x2acc9dd0: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x2acc9de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x2acc9df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x2acc9e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x2acc9e10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x2acc9e20:[05]f9 f9 f9 f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9
  0x2acc9e30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x2acc9e40: f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 f9
  0x2acc9e50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x2acc9e60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x2acc9e70: 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==24892==ABORTING
make: *** [/root/RIOT/examples/uri/../../Makefile.include:725: term] Error 1
make: Leaving directory '/root/RIOT/examples/uri'
```

### Issues/PRs references

This is similar to #15927 but not addressed in #15929.

* #15927
* #15928
* #15929