### PR TITLE
pkg/tinydtls: catch problem "peer not found" when netif is 0

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -313,7 +313,7 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
     if (!sock->udp_sock || (sock_udp_get_local(sock->udp_sock, &local) < 0)) {
         return -EADDRNOTAVAIL;
     }
-    if (ep->port == 0) {
+    if (ep->port == 0 || ep->netif == 0) {
         return -EINVAL;
     }
     switch (ep->family) {
@@ -377,6 +377,13 @@ ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
     assert(sock);
     assert(remote);
     assert(data);
+
+    /* tinydtls stores peers in a hashmap (endpoint parameters are hashed).
+     * Peer will not be re-found when a msg is received from that peer since
+     * it does not come from interface 0 */
+    if (remote->dtls_session.ifindex == 0) {
+        return -EINVAL;
+    }
 
     /* check if session exists, if not create session first then send */
     if (!dtls_get_peer(sock->dtls_ctx, &remote->dtls_session)) {

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -650,6 +650,8 @@ sock_udp_t *sock_dtls_get_udp_sock(sock_dtls_t *sock);
  * @return -EADDRNOTAVAIL, if the local endpoint of @p sock is not set.
  * @return -EINVAL, if @p remote is invalid or @p sock is not properly
  *         initialized (or closed while sock_udp_recv() blocks).
+ *
+ * @note For tinydtls the netif of @p ep cannot be @ref SOCK_ADDR_ANY_NETIF.
  */
 int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
                            sock_dtls_session_t *remote);
@@ -915,6 +917,9 @@ ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
  *                 The send function blocks until the handshake completes or the
  *                 timeout expires. If the handshake was successful the data has
  *                 been sent.
+ *
+ * @note    For tinydtls the netif of the underlying endpoint in @p remote cannot
+ *          be @ref SOCK_ADDR_ANY_NETIF.
  *
  * @return The number of bytes sent on success
  * @return  -ENOTCONN, if `timeout == 0` and no existing session exists with


### PR DESCRIPTION
### Contribution description
I ran into a nasty problem last week and I want to save other people from this fate with this PR.

tinydtls stores its peers in a hash map internally. It hashes the session parameters for that (address, port, interface index/netif). When you start a handshake with `sock_dtls_session_init()` or `sock_dtls_send()` tinydtls allocates a new peer.  If the netif of the udp endpoint for a remote peer is set to `SOCK_ADDR_ANY_NETIF` (equals 0), tinydtls hashes the session parameters with a netif set to 0 and stores the peer with this hash.

When the next handshake message of the remote peer is received, tinydtls hashes the session parameters of the incoming connection ... and does not find the peer, because the netif is != 0 (the message is obviously not received on iface 0). tinydtls then cancels the handshake.

I currently don't see another way to prevent this except catching it for tinydtls. 

The issue can be reproduced with the testing procedure and the provided test-patch to trigger it. (Of course without applying this PR). tinydtls prints `dtls_handle_message: PEER NOT FOUND` when the problem happens. 

### Testing procedure
Can be reproduced and tested with [this example](https://github.com/RIOT-OS/RIOT/tree/master/examples/dtls-sock), together with this patch:

<details>

```
diff --git a/examples/dtls-sock/dtls-client.c b/examples/dtls-sock/dtls-client.c
index c5cb43a894..03f945ef5f 100644
--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -88,10 +88,10 @@ static int client_send(char *addr_str, char *data, size_t datalen)
             puts("Invalid network interface");
             return -1;
         }
-        remote.netif = pid;
+        //remote.netif = pid;
     } else if (gnrc_netif_numof() == 1) {
         /* assign the single interface found in gnrc_netif_numof() */
-        remote.netif = gnrc_netif_iter(NULL)->pid;
+        //remote.netif = gnrc_netif_iter(NULL)->pid;
     } else {
         /* no interface is given, or given interface is invalid */
         /* FIXME This probably is not valid with multiple interfaces */
@@ -123,8 +123,10 @@ static int client_send(char *addr_str, char *data, size_t datalen)
         return -1;
     }
 
+    printf("Remote netif: %d\n", remote.netif);
     res = sock_dtls_session_init(&dtls_sock, &remote, &session);
     if (res <= 0) {
+        printf("sock_dtls_session_init returned %d\n", res);
         return res;
     }

```
 </details>

Important: `CONFIG_DTLS_DEBUG=1` is necessary to see tinydtls debug messages.

* Flash on two devices (e.g. native) `make flash term BOARD=native PORT=tap0 DEVELHELP=1 CONFIG_DTLS_DEBUG=1`
* Add global addresses `ifconfig 5 add 2001:affe::32:1` (for other node other IP)
* Start DTLS server on one of the nodes `dtlss start`
* Send DTLS message from other node `dtlsc {ip} {data}`


### Issues/PRs references
