### PR TITLE
pkg/openthread: add support for at86rf215

### DIFF
--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -18,6 +18,7 @@ BOARD_WHITELIST := \
                     remote-reva \
                     remote-revb \
                     omote \
+                    openmote-b \
                     openmote-cc2538 \
                     nrf52840dk \
                     nrf52840-mdk \

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -23,6 +23,11 @@
 #include "thread.h"
 #include "xtimer.h"
 
+#ifdef MODULE_AT86RF215
+#include "at86rf215.h"
+#include "at86rf215_params.h"
+#endif
+
 #ifdef MODULE_AT86RF2XX
 #include "at86rf2xx.h"
 #include "at86rf2xx_params.h"
@@ -55,6 +60,10 @@
 static cc2538_rf_t cc2538_rf_dev;
 #endif
 
+#ifdef MODULE_AT86RF215
+static at86rf215_t at86rf215_dev;
+#endif
+
 #ifdef MODULE_AT86RF2XX
 static at86rf2xx_t at86rf2xx_dev;
 #endif
@@ -77,6 +86,11 @@ void openthread_bootstrap(void)
     ot_random_init();
 
     /* setup netdev modules */
+#ifdef MODULE_AT86RF215
+    /* only use sub-GHz interface */
+    at86rf215_setup(&at86rf215_dev, NULL, &at86rf215_params[0], 0);
+    netdev_t *netdev = (netdev_t *) &at86rf215_dev;
+#endif
 #ifdef MODULE_AT86RF2XX
     at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0], 0);
     netdev_t *netdev = (netdev_t *) &at86rf2xx_dev;


### PR DESCRIPTION
### Contribution description

Since our OpenThread port only supports one interface, enable the sub-GHz interface of the at86rf215 radio.


### Testing procedure

I can ping another node running `examples/openthread`

```
#  ping ff02::1
> 2021-02-06 01:55:19,786 #  16 bytes from fe80:0:0:0:39:c68b:550d:e01b: icmp_seq=1 hlim=64 time=18ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
