### PR TITLE
usbus/msc: add initial support for Mass Storage Class

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -681,6 +681,12 @@ ifneq (,$(filter ut_process,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter usbus_msc,$(USEMODULE)))
+  USEMODULE += usbus
+  USEMODULE += mtd
+  USEMODULE += mtd_write_page
+endif
+
 ifneq (,$(filter uuid,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += random

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -40,6 +40,11 @@ usbus_cdcecm_device_t cdcecm;
 static usbus_dfu_device_t dfu;
 #endif
 
+#ifdef MODULE_USBUS_MSC
+#include "usb/usbus/msc.h"
+usbus_msc_device_t msc;
+#endif
+
 static char _stack[USBUS_STACKSIZE];
 static usbus_t usbus;
 
@@ -66,6 +71,9 @@ void auto_init_usb(void)
     usbus_dfu_init(&usbus, &dfu, USB_DFU_PROTOCOL_RUNTIME_MODE);
 #endif
 
+#ifdef MODULE_USBUS_MSC
+    usbus_msc_init(&usbus, &msc);
+#endif
     /* Finally initialize USBUS thread */
     usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus);
 }

--- a/sys/include/usb/msc.h
+++ b/sys/include/usb/msc.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2019-2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ *
+ *
+ */
+
+/**
+ * @defgroup    usbus_msc USBUS Mass Storage Class functions
+ * @ingroup     usb
+ *
+ * @{
+ *
+ * @file
+ * @brief       USB Mass Storage Class functions definitions
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef USB_MSC_H
+#define USB_MSC_H
+
+#include <stdint.h>
+#include "usb/usbus.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name USB Mass Storage Class subclass definitions
+ *
+ * @see Table 1 — SubClass Codes Mapped to Command Block Specifications
+ * from Universal Serial Bus Mass Storage Class Specification Overview 1.4
+ * @{
+ */
+#define USB_MSC_SUBCLASS_SCSI         0x00 /**< SCSI command set not reported */
+#define USB_MSC_SUBCLASS_RBC          0x01 /**< RBC allocated by USB-IF */
+#define USB_MSC_SUBCLASS_MMC5         0x02 /**< MMC5 allocated by USB-IF */
+#define USB_MSC_SUBCLASS_UFI          0x04 /**< Interface Floppy Disk Drives */
+#define USB_MSC_SUBCLASS_SCSI_TCS     0x06 /**< SCSI transparent command set */
+#define USB_MSC_SUBCLASS_LSDFS        0x07 /**< Early negotiation access */
+#define USB_MSC_SUBCLASS_IEEE1667     0x08 /**< IEEE1677 allocated by USB-IF */
+#define USB_MSC_SUBCLASS_VENDOR       0xFF /**< Vendor Specific */
+/** @} */
+
+/**
+ * @name USB Mass Storage Class protocol definitions
+ *
+ * @see Table 2 — Mass Storage Transport Protocol
+ * from Universal Serial Bus Mass Storage Class Specification Overview 1.4
+ * @{
+ */
+#define USB_MSC_PROTOCOL_CBI_CCI      0x00  /**< CBI transport with command completion interrupt*/
+#define USB_MSC_PROTOCOL_CBI_NO_CCI   0x01  /**< CBI transport without command completion \
+                                                 interrupt */
+#define USB_MSC_PROTOCOL_BBB          0x50  /**< Bulk only (BBB) transport */
+#define USB_MSC_PROTOCOL_UAS          0x62  /**< UAS allocated by USB-IF */
+#define USB_MSC_PROTOCOL_VENDOR       0xFF  /**< Vendor Specific */
+/** @} */
+
+/**
+ * @brief   Command Block Wrapper flags
+ *
+ * @see     Chap 5.1 — Command Block Wrapper (CBW)
+ * from Universal Serial Bus Mass Storage Class Bulk-Only Transport
+ */
+#define USB_MSC_CBW_FLAG_IN             0x80    /**< Indicate Device to Host direction */
+
+/**
+ * @name USB Mass Storage Class request codes
+ *
+ * @see Table 3 — Mass Storage Request Codes
+ * from Universal Serial Bus Mass Storage Class Specification Overview 1.4
+ * @{
+ */
+#define USB_MSC_SETUP_REQ_ADSC      0x01     /**< Accept Device-Specific Command request */
+#define USB_MSC_SETUP_REQ_GET_REQ   0xFC     /**< Get Request */
+#define USB_MSC_SETUP_REQ_PUT_REQ   0xFD     /**< Put Request */
+#define USB_MSC_SETUP_REQ_GML       0xFE     /**< Get Max LUN request */
+#define USB_MSC_SETUP_REQ_BOMSR     0xFF     /**< Bulk-Only Mass Storage Reset request */
+/** @} */
+
+/**
+ * @name USB Mass Storage Class CSW status code
+ *
+ * @see Table 5.3 — Command Block Status Values
+ * from Universal Serial Bus Mass Storage Class Bulk-Only Transport
+ * @{
+ */
+#define USB_MSC_CSW_STATUS_COMMAND_PASSED       0x00     /**< CSW Status command successful */
+#define USB_MSC_CSW_STATUS_COMMAND_FAILED       0x01     /**< CSW Status command failure */
+#define USB_MSC_CSW_STATUS_COMMAND_PHASE_ERROR  0x02     /**< CSW Status command phase error */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_MSC_H */
+/** @} */

--- a/sys/include/usb/usbus/msc.h
+++ b/sys/include/usb/usbus/msc.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019-2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ *
+ *
+ */
+
+/**
+ * @ingroup     usbus_msc
+ *
+ * @{
+ *
+ * @file
+ * @brief       USBUS Mass Storage Class functions definitions
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef USB_USBUS_MSC_H
+#define USB_USBUS_MSC_H
+
+#include <stdint.h>
+#include "usb/usbus.h"
+#include "usb/usbus/msc/scsi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef USBUS_MSC_BUFFER_SIZE
+#define USBUS_MSC_BUFFER_SIZE 512
+#endif /* USBUS_MSC_BUFFER_SIZE */
+
+typedef enum {
+    WAITING,
+    WAIT_FOR_TRANSFER,
+    DATA_TRANSFER_IN,
+    DATA_TRANSFER_OUT,
+    DATA_TRANSFER_LAST,
+    GEN_CSW
+} usbus_msc_state_t;
+
+/**
+ * @brief USBUS MSC device interface context
+ */
+typedef struct usbus_msc_device {
+    usbus_handler_t handler_ctrl;   /**< Control interface handler */
+    usbus_interface_t iface;        /**< MSC interface */
+    usbus_endpoint_t *ep_in;        /**< Data endpoint in */
+    usbus_endpoint_t *ep_out;       /**< Data endpoint out */
+    uint8_t* out_buf;               /**< Pointer to internal out endpoint buffer */
+    uint8_t* in_buf;                /**< Pointer to internal in endpoint buffer */
+    usbus_descr_gen_t msc_descr;    /**< MSC descriptor generator */
+    usbus_t *usbus;                 /**< Pointer to the USBUS context */
+    cbw_info_t cmd;                 /**< Command Block Wrapper information */
+    event_t rx_event;               /**< Transmit ready event */
+    usbus_msc_state_t state;        /**< Internal state machine for msc */
+    uint8_t *buffer;                /**< Pointer to the current data transfer buffer */
+    uint32_t block;                 /**< First block to transfer data from/to */
+    uint16_t block_nb;              /**< Number of block to transfer for READ and
+                                         WRITE operations */
+    uint16_t block_offset;          /**< Internal offset for endpoint size chunk transfer */
+    uint8_t  pages_per_vpage;       /**< Number of pages to fill host expected page size */
+} usbus_msc_device_t;
+
+/**
+ * @brief MSC initialization function
+ *
+ * @param   usbus   USBUS thread to use
+ * @param   handler MSC device struct
+ */
+
+int usbus_msc_init(usbus_t *usbus, usbus_msc_device_t *handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_USBUS_MSC_H */
+/** @} */

--- a/sys/include/usb/usbus/msc/scsi.h
+++ b/sys/include/usb/usbus/msc/scsi.h
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2019-2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     usbus_msc
+ *
+ * @{
+ *
+ * @file
+ * @brief       SCSI protocol definitions for USBUS
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef USB_USBUS_MSC_SCSI_H
+#define USB_USBUS_MSC_SCSI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef USBUS_MSC_VENDOR_ID
+#define USBUS_MSC_VENDOR_ID "RIOT-OS"
+#endif /* USBUS_MSC_VENDOR_ID */
+
+#ifndef USBUS_MSC_PRODUCT_ID
+#define USBUS_MSC_PRODUCT_ID "RIOT_MSC_DISK"
+#endif /* USBUS_MSC_PRODUCT_ID */
+
+#ifndef USBUS_MSC_PRODUCT_REV
+#define USBUS_MSC_PRODUCT_REV " 1.0"
+#endif /* USBUS_MSC_PRODUCT_REV */
+
+/**
+ * @name USB SCSI Commands
+ *
+ * @see Table 9 - Packet Commands Supported by ATAPI Block Devices
+ * from INF-8070i draft published by SFF
+ * @{
+ */
+#define SCSI_TEST_UNIT_READY            0x00    /**< SCSI Test Unit Ready */
+#define SCSI_REQUEST_SENSE              0x03    /**< SCSI Request Sense */
+#define SCSI_FORMAT_UNIT                0x04    /**< SCSI Format Unit */
+#define SCSI_INQUIRY                    0x12    /**< SCSI Inquiry */
+#define SCSI_MODE_SELECT6               0x15    /**< SCSI Mode Select6 */
+#define SCSI_MODE_SENSE6                0x1A    /**< SCSI Mode Sense6 */
+#define SCSI_START_STOP_UNIT            0x1B    /**< SCSI Start Stop Unit */
+#define SCSI_MEDIA_REMOVAL              0x1E    /**< SCSI Media Removal */
+#define SCSI_READ_FORMAT_CAPACITIES     0x23    /**< SCSI Read Format Capacities */
+#define SCSI_READ_CAPACITY              0x25    /**< SCSI Read Capacity */
+#define SCSI_READ10                     0x28    /**< SCSI Read10 */
+#define SCCI_READ12                     0xA8    /**< SCSI Read12 */
+#define SCSI_WRITE10                    0x2A    /**< SCSI Write10 */
+#define SCSI_WRITE12                    0xAA    /**< SCSI Write12 */
+#define SCSI_SEEK                       0x2B    /**< SCSI Seek */
+#define SCSI_WRITE_AND_VERIFY           0x2E    /**< SCSI Write and Verify */
+#define SCSI_VERIFY10                   0x2F    /**< SCSI Verify10 */
+#define SCSI_MODE_SELECT10              0x55    /**< SCSI Mode Select10 */
+#define SCSI_MODE_SENSE10               0x5A    /**< SCSI Mode Sense10 */
+/** @} */
+
+/**
+ * @brief Command Block Wrapper signature
+ */
+#define SCSI_CBW_SIGNATURE              0x43425355
+
+/**
+ * @brief Command Status Wrapper signature
+ */
+#define SCSI_CSW_SIGNATURE              0x53425355
+
+/**
+ * @name USB SCSI Version list
+ * @{
+ */
+#define SCSI_VERSION_NONE               0x0000
+#define SCSI_VERSION_SCSI1              0x0001
+#define SCSI_VERSION_SCSI2              0x0002
+/** @} */
+
+/**
+ * @name USB SCSI Read format capacities descriptor type
+ *
+ * @see ( @ref msc_read_fmt_capa_pkt_t )
+ * @{
+ */
+#define SCSI_READ_FMT_CAPA_TYPE_RESERVED    0x00
+#define SCSI_READ_FMT_CAPA_TYPE_UNFORMATTED 0x01
+#define SCSI_READ_FMT_CAPA_TYPE_FORMATTED   0x02
+#define SCSI_READ_FMT_CAPA_TYPE_NO_MEDIA    0x03
+/** @} */
+
+/**
+ * @brief SCSI Request Sense error type
+ */
+#define SCSI_REQUEST_SENSE_ERROR              0x70
+
+/**
+ * @name USB SCSI Request Sense Sense Key type
+ *
+ * @{
+ */
+#define SCSI_SENSE_KEY_NO_SENSE             0x00
+#define SCSI_SENSE_KEY_RECOVERED_ERROR      0x01
+#define SCSI_SENSE_KEY_NOT_READY            0x02
+#define SCSI_SENSE_KEY_MEDIUM_ERROR         0x03
+#define SCSI_SENSE_KEY_HARDWARE_ERROR       0x04
+#define SCSI_SENSE_KEY_ILLEGAL_REQUEST      0x05
+#define SCSI_SENSE_KEY_UNIT_ATTENTION       0x06
+#define SCSI_SENSE_KEY_DATA_PROTECT         0x07
+#define SCSI_SENSE_KEY_BLANK_CHECK          0x08
+#define SCSI_SENSE_KEY_VENDOR_SPECIFIC      0x09
+#define SCSI_SENSE_KEY_ABORTED_COMMAND      0x0B
+#define SCSI_SENSE_KEY_VOLUME_OVERFLOW      0x0D
+#define SCSI_SENSE_KEY_MISCOMPARE           0x0E
+/** @} */
+
+/**
+ * @brief Packet structure to answer (@ref SCSI_TEST_UNIT_READY) request
+ *
+ * @see Inquiry Command from SCSI Primary Command
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;           /**< type of device */
+    uint8_t logical_unit;   /**< Selected LUN */
+    uint8_t reserved[10];   /**< Reserved */
+} msc_test_unit_pkt_t;
+
+/**
+ * @brief Packet structure to answer (@ref SCSI_MODE_SELECT6) and
+ * (@ref SCSI_MODE_SENSE6) requests
+ *
+ * @see Inquiry Command from SCSI Primary Command
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t mode_data_len;      /**< Size of the whole packet */
+    uint8_t medium_type;        /**< Type of medium */
+    uint8_t flags;              /**< Miscellaneous flags */
+    uint8_t block_desc_len;     /**< Length of block descriptor */
+} msc_mode_parameter_pkt_t;
+
+/**
+ * @brief CBW Packet structure for (@ref SCSI_READ10) and
+ * (@ref SCSI_WRITE10) requests
+ *
+ * @see Read10 or Write10 Command from SCSI Primary Command
+ *
+ * @warning uint16_t and uint32_t will be BIG ENDIAN
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t opcode;         /**< Operation code */
+    uint8_t flags;          /**< Miscellaneous flags */
+    uint32_t blk_addr;      /**< Block address */
+    uint8_t group_number;   /**< Group number */
+    uint16_t xfer_len;      /**< Transfer length in bytes */
+} msc_cbw_rw10_pkt_t;
+
+/**
+ * @brief Packet structure to answer (@ref SCSI_INQUIRY) request
+ *
+ * @see Inquiry Command from SCSI Primary Command
+ *
+ * @note Vendor specific information (Byte 36 and above) and flags from bytes
+ *       5 to 7 are currently unsupported
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;               /**< Byte 0 Peripheral type */
+    uint8_t reserved1:7;        /**< Byte 1 [B6..B0] Reserved */
+    uint8_t removable:1;        /**< Byte 1 [B7] Removable device flag */
+    uint8_t version;            /**< Byte 2 SCSI Version */
+    uint8_t response_format:4;  /**< Byte 3 [B3..B0] Response Data Format */
+    uint8_t reserved3:4;        /**< Byte 3 [B7..B4] Reserved */
+    uint8_t length;             /**< Byte 4 Additional Length (n-4) */
+    uint8_t flags[3];           /**< Byte 7..5 Miscellaneous flags UNUSED BY USBUS ONLY */
+    uint8_t vendor_id[8];       /**< Byte 15..8 Vendor Identification */
+    uint8_t product_id[16];     /**< Byte 31..16 Product Identification */
+    uint8_t product_rev[4];     /**< Byte 35..32 Product Revision */
+} msc_inquiry_pkt_t;
+
+
+/**
+ * @brief Packet structure to answer (@ref SCSI_READ_FORMAT_CAPACITIES) request
+ *
+ * @see   READ FORMAT CAPACITIES from SCSI Multimedia Commands – 2 (MMC-2)
+ *
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t reserved1[3];       /**< Byte 2..0 reserved */
+    uint8_t list_length;        /**< Byte 3 Capacity list length */
+    uint32_t blk_nb;            /**< Byte 7..4 Number of blocks */
+    uint8_t type;               /**< Byte 8 Descriptor type */
+    uint8_t blk_len[3];       /**< Byte 11..9 Block length */
+} msc_read_fmt_capa_pkt_t;
+
+/**
+ * @brief Packet structure to answer (@ref SCSI_REQUEST_SENSE) request
+ *
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t error_code;       /**< Byte 0 Error code */
+    uint8_t reserved1;        /**< Reserved */
+    uint8_t sense_key;        /**< Byte 2 Sense key */
+    uint8_t reserved2[4];     /**< Byte 6..3 Information */
+    uint8_t add_len;          /**< Byte 7 Additional sense length */
+    uint8_t reserved3[4];     /**< Byte 11..8 Vendor specific */
+    uint8_t asc;              /**< Byte 12 Additional Sense Code */
+    uint8_t ascq;             /**< Byte 13 Additional Sense Code Qualifier */
+    uint8_t fruc;             /**< Byte 14 Field Replaceable Unit Code */
+    uint16_t sk_spec;         /**< Byte 16..15 Sense Key Specific */
+} msc_request_sense_pkt_t;
+
+/**
+ * @brief Packet structure to answer (@ref SCSI_READ_CAPACITY) request
+ *
+ * @note Multiply the two values from this struct between them
+ * indicates the total size of your MTD device
+ *
+ * @see Read Capacities from SCSI Primary Command
+ */
+typedef struct __attribute__((packed)) {
+    uint32_t last_blk;  /**< Indicate last block number */
+    uint32_t blk_len;   /**< Total size of a block in bytes */
+} msc_read_capa_pkt_t;
+
+/**
+ * @brief Command Block Wrapper packet structure
+ *
+ * @see Table 5.1 Command Block Wrapper (CBW)
+ * from Universal Serial Bus Mass Storage Class Bulk-Only Transport
+ */
+typedef struct __attribute__((packed)) {
+    uint32_t signature; /**< CBW signature (@ref SCSI_CBW_SIGNATURE) */
+    uint32_t tag;       /**< ID for the current command */
+    uint32_t data_len;  /**< Number of bytes host expects to transfer from/to */
+    uint8_t  flags;     /**< Command block flags */
+    uint8_t  lun;       /**< Target Logical Unit Number */
+    uint8_t  cb_len;    /**< Length of the block in bytes (max: 16 bytes) */
+    uint8_t  cb[16];    /**< Command block buffer */
+} msc_cbw_buf_t;
+
+/**
+ * @brief Command Status Wrapper packet structure
+ *
+ * @see Table 5.2 - Command Status Wrapper
+ * from Universal Serial Bus Mass Storage Class Bulk-Only Transport
+ */
+typedef struct __attribute__((packed)) {
+    uint32_t signature; /**< CSW signature (@ref SCSI_CSW_SIGNATURE) */
+    uint32_t tag;       /**< ID for the answered CBW */
+    uint32_t data_left; /**< Indicate how many bytes from the CBW were not processed */
+    uint8_t  status;    /**< Status of the command */
+} msc_csw_buf_t;
+
+/**
+ * @brief USBUS Command Block Wrapper information
+ *
+ */
+typedef struct {
+    uint32_t tag;   /**< Store tag information from CBW */
+    size_t len;     /**< Remaining bytes to handle */
+    uint8_t status; /**< Status of the current operation */
+} cbw_info_t;
+
+/**
+ * @brief Process incoming Command Block Wrapper buffer
+ *
+ * @param   usbus   USBUS thread to use
+ * @param   handler MSC device struct
+ * @param   ep      Endpoint pointer to read CBW from
+ * @param   len     Size of the received CBW buffer
+ */
+void scsi_process_cmd(usbus_t *usbus, usbus_handler_t *handler, usbdev_ep_t *ep, size_t len);
+
+/**
+ * @brief Generate Command Status Wrapper and send it to the host
+ *
+ * @param   handler   MSC device struct
+ * @param   cmd       struct containing needed information to generate CBW response
+ */
+void scsi_gen_csw(usbus_handler_t *handler, cbw_info_t *cmd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_USBUS_MSC_SCSI_H */
+/** @} */

--- a/sys/usb/usbus/Kconfig
+++ b/sys/usb/usbus/Kconfig
@@ -68,3 +68,6 @@ endif # KCONFIG_USEMODULE_USBUS
 rsource "cdc/Kconfig"
 rsource "dfu/Kconfig"
 rsource "hid/Kconfig"
+rsource "msc/Kconfig"
+
+endif # KCONFIG_USEMODULE_USBUS

--- a/sys/usb/usbus/Makefile
+++ b/sys/usb/usbus/Makefile
@@ -13,4 +13,7 @@ endif
 ifneq (,$(filter usbus_hid,$(USEMODULE)))
     DIRS += hid
 endif
+ifneq (,$(filter usbus_msc,$(USEMODULE)))
+    DIRS += msc
+endif
 include $(RIOTBASE)/Makefile.base

--- a/sys/usb/usbus/msc/Kconfig
+++ b/sys/usb/usbus/msc/Kconfig
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 Mesotic SAS
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_USEMODULE_USBUS_MSC
+    bool "Configure USBUS MSC"
+    depends on USEMODULE_USBUS_MSC
+    help
+        Configure the USBUS MSC module via Kconfig.
+
+if KCONFIG_USEMODULE_USBUS_MSC
+
+USBUS_MSC_BUFFER_SIZE
+
+config USBUS_MSC_BUFFER_SIZE
+    int "Buffer size for storing a flash page"
+    default 512
+
+config USBUS_MSC_VENDOR_ID
+    string "MSC Vendor ID"
+    default "RIOT-OS"
+
+config USBUS_MSC_PRODUCT_ID
+    string "MSC Product ID"
+    default "RIOT_MSC_DISK"
+
+config USBUS_MSC_PRODUCT_REV
+    string "MSC Product Revision"
+    default "1.0"
+
+endif # KCONFIG_USEMODULE_USBUS_MSC

--- a/sys/usb/usbus/msc/Makefile
+++ b/sys/usb/usbus/msc/Makefile
@@ -1,0 +1,3 @@
+MODULE = usbus_msc
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2019-2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup usbus_msc
+ * @{
+ *
+ * @author  Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @}
+ */
+
+#include "usb/descriptor.h"
+#include "usb/usbus.h"
+#include "usb/usbus/control.h"
+
+#include "usb/msc.h"
+#include "usb/usbus/msc.h"
+#include "usb/usbus/msc/scsi.h"
+#include "board.h"
+
+#include <string.h>
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#include "mtd.h"
+
+#ifndef MTD_MSC
+/* TODO: add support for multiple MTD devices */
+#define MTD_MSC MTD_0
+#endif
+
+/* Internal buffer to handle size difference between MTD layer and USB
+   endpoint size as some MTD implementation (like mtd_sdcard) doesn't allow
+   endpoint size transfer */
+static unsigned char _buff[USBUS_MSC_BUFFER_SIZE];
+static unsigned char _ep_out_buf[CONFIG_USBUS_EP0_SIZE];
+static unsigned char _ep_in_buf[CONFIG_USBUS_EP0_SIZE];
+
+/* Internal handler definitions */
+static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,
+                           usbus_event_usb_t event);
+
+static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
+                            usbus_control_request_state_t state,
+                            usb_setup_t *setup);
+
+static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
+                              usbdev_ep_t *ep, usbus_event_transfer_t event);
+
+static void _init(usbus_t *usbus, usbus_handler_t *handler);
+
+static const usbus_handler_driver_t msc_driver = {
+    .init = _init,
+    .event_handler = _event_handler,
+    .control_handler = _control_handler,
+    .transfer_handler = _transfer_handler,
+};
+
+static const usbus_descr_gen_funcs_t _msc_descriptor = {
+    .fmt_post_descriptor = NULL,
+    .fmt_pre_descriptor = NULL,
+    .len = {
+        .fixed_len =  0,
+    },
+    .len_type = USBUS_DESCR_LEN_FIXED,
+};
+
+static void _write_xfer(usbus_msc_device_t *msc)
+{
+    /* Check if we have a block to read and transfer */
+    if (!msc->block_nb) {
+        return;
+    }
+
+    size_t len;
+    /* Retrieve incoming data */
+    usbdev_ep_get(msc->ep_out->ep, USBOPT_EP_AVAILABLE, &len, sizeof(size_t));
+
+    /* Update offset for page buffer */
+    msc->block_offset += len;
+    /* Decrement whole len */
+    msc->cmd.len -= len;
+
+    /* buffer is full, write it and point to new block if any */
+    if (msc->block_offset >= (MTD_MSC->page_size * msc->pages_per_vpage)) {
+        mtd_write_page(MTD_MSC, msc->buffer, msc->block * msc->pages_per_vpage,
+                       0, MTD_MSC->page_size * msc->pages_per_vpage);
+        msc->block_offset = 0;
+        msc->block++;
+        msc->block_nb--;
+    }
+
+    if (msc->cmd.len == 0) {
+        /* All blocks have been transferred, send CSW to host */
+        if (msc->state == DATA_TRANSFER_OUT) {
+            msc->state = GEN_CSW;
+            /* Data was processed, ready next transfer */
+            usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
+            return;
+        }
+    }
+
+    if (len > 0) {
+        /* Directly put data incoming on the endpoint to the flashpage buffer */
+        usbdev_ep_xmit(msc->ep_out->ep, &msc->buffer[msc->block_offset], len);
+    }
+}
+
+static void _xfer_data( usbus_msc_device_t *msc)
+{
+    /* Check if we have a block to read and transfer */
+    if (msc->block_nb) {
+        /* read buffer from mtd device */
+        if (msc->block_offset == 0) {
+            mtd_read_page(MTD_MSC, msc->buffer, msc->block * msc->pages_per_vpage,
+                          0, MTD_MSC->page_size * msc->pages_per_vpage);
+        }
+        /* Data prepared, signal ready to usbus */
+        usbdev_ep_xmit(msc->ep_in->ep, &msc->buffer[msc->block_offset], msc->ep_in->ep->len);
+        /* Update offset for page buffer */
+        msc->block_offset += msc->ep_in->ep->len;
+        /* Decrement whole len */
+        msc->cmd.len -= msc->ep_in->ep->len;
+        /* whole buffer is empty, point to new block if any */
+        if (msc->block_offset >= (MTD_MSC->page_size * msc->pages_per_vpage)) {
+            msc->block_offset = 0;
+            msc->block++;
+            msc->block_nb--;
+        }
+    }
+    else {
+        /* All blocks have been transferred, send CSW to host */
+        if (msc->state == DATA_TRANSFER_IN) {
+            msc->state = GEN_CSW;
+        }
+    }
+}
+
+static void _handle_rx_event(event_t *ev)
+{
+    usbus_msc_device_t *msc = container_of(ev, usbus_msc_device_t, rx_event);
+
+    _xfer_data(msc);
+}
+
+int usbus_msc_init(usbus_t *usbus, usbus_msc_device_t *handler)
+{
+    assert(usbus);
+    assert(handler);
+    memset(handler, 0, sizeof(usbus_msc_device_t));
+    handler->usbus = usbus;
+    handler->handler_ctrl.driver = &msc_driver;
+    usbus_register_event_handler(usbus, (usbus_handler_t *)handler);
+    printf("[MSC]: MTD init...");
+    if (mtd_init(MTD_MSC) != 0) {
+        puts("[FAILED]");
+        return -1;
+    }
+    puts("[OK]");
+    return 0;
+}
+
+static void _init(usbus_t *usbus, usbus_handler_t *handler)
+{
+    DEBUG("MSC: initialization\n");
+    usbus_msc_device_t *msc = (usbus_msc_device_t *)handler;
+
+    msc->msc_descr.next = NULL;
+    msc->msc_descr.funcs = &_msc_descriptor;
+    msc->msc_descr.arg = msc;
+    msc->block_offset = 0;
+    msc->buffer = _buff;
+    msc->block_nb = 0;
+    msc->block = 0;
+    msc->state = WAITING;
+    /* Assign internal endpoint buffers */
+    msc->out_buf = _ep_out_buf;
+    msc->in_buf = _ep_in_buf;
+    /* Add event handlers */
+    msc->rx_event.handler = _handle_rx_event;
+    /* Instantiate interfaces */
+    memset(&msc->iface, 0, sizeof(usbus_interface_t));
+    /* Configure Interface 0 as control interface */
+    msc->iface.class = USB_CLASS_MASS_STORAGE;
+    msc->iface.subclass = USB_MSC_SUBCLASS_SCSI_TCS;
+    msc->iface.protocol = USB_MSC_PROTOCOL_BBB;
+    msc->iface.descr_gen = &(msc->msc_descr);
+    msc->iface.handler = handler;
+
+    /* Create required endpoints */
+    msc->ep_in = usbus_add_endpoint(usbus, &msc->iface, USB_EP_TYPE_BULK,
+                                    USB_EP_DIR_IN, CONFIG_USBUS_EP0_SIZE);
+    msc->ep_in->interval = 0;
+    msc->ep_out = usbus_add_endpoint(usbus, &msc->iface, USB_EP_TYPE_BULK,
+                                     USB_EP_DIR_OUT, CONFIG_USBUS_EP0_SIZE);
+    msc->ep_out->interval = 0;
+
+    /* Add interfaces to the stack */
+    usbus_add_interface(usbus, &msc->iface);
+
+    usbus_enable_endpoint(msc->ep_in);
+    usbus_enable_endpoint(msc->ep_out);
+
+    usbus_handler_set_flag(handler, USBUS_HANDLER_FLAG_RESET);
+
+    /* Prepare to receive first bytes from Host */
+    usbdev_ep_xmit(msc->ep_out->ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
+}
+
+static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
+                            usbus_control_request_state_t state,
+                            usb_setup_t *setup)
+{
+    (void)usbus;
+    (void)state;
+
+    usbus_msc_device_t *msc = (usbus_msc_device_t *)handler;
+    static usbopt_enable_t enable = USBOPT_ENABLE;
+
+    switch (setup->request) {
+    case USB_MSC_SETUP_REQ_GML:
+        /* Stall as we don't support this feature */
+        usbdev_ep_set(msc->ep_in->ep, USBOPT_EP_STALL, &enable,
+                      sizeof(usbopt_enable_t));
+        break;
+    case USB_MSC_SETUP_REQ_BOMSR:
+        DEBUG("TODO: implement reset setup request\n");
+        break;
+    default:
+        DEBUG("default handle setup rqt:0x%x\n", setup->request);
+        return -1;
+    }
+    return 1;
+}
+
+static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
+                              usbdev_ep_t *ep, usbus_event_transfer_t event)
+{
+    (void)usbus;
+    (void)event;
+
+    usbus_msc_device_t *msc = (usbus_msc_device_t *)handler;
+
+    if (ep->dir == USB_EP_DIR_OUT) {
+        size_t len=0;
+        /* Previous transfer is sent, send the next one */
+        if (msc->state == DATA_TRANSFER_OUT) {
+            _write_xfer(msc);
+        }
+        else {
+            /* Retrieve incoming data */
+            usbdev_ep_get(ep, USBOPT_EP_AVAILABLE, &len, sizeof(size_t));
+            if (len > 0) {
+                /* Process incoming endpoint buffer */
+                scsi_process_cmd(usbus, handler, ep, len);
+            }
+            /* Data was processed, ready next transfer */
+            if (msc->state == DATA_TRANSFER_OUT) {
+                /* If the next pkt is supposed to be a WRITE10 transfer,
+                   directly redirect content to appropriate buffer */
+                usbdev_ep_xmit(msc->ep_out->ep, &msc->buffer[msc->block_offset], 64);
+            }
+            else {
+                usbdev_ep_xmit(ep, msc->out_buf, CONFIG_USBUS_EP0_SIZE);
+            }
+        }
+    }
+    else {
+        /* Data Transfer pending */
+        if (msc->state == DATA_TRANSFER_IN) {
+            _xfer_data(msc);
+        }
+        /* CBW answer was sent, prepare CSW */
+        else if (msc->state == WAIT_FOR_TRANSFER) {
+            msc->state = GEN_CSW;
+        }
+    }
+
+    if (msc->cmd.tag && msc->cmd.len == 0 && msc->state == GEN_CSW) {
+        DEBUG_PUTS("[MSC]: Generate CSW");
+        scsi_gen_csw(handler, &(msc->cmd));
+        /* Command has been handled, so clear tag and state machine */
+        msc->cmd.tag = 0;
+        msc->state = WAITING;
+    }
+}
+
+static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,
+                           usbus_event_usb_t event)
+{
+    (void)usbus;
+    (void)handler;
+    switch (event) {
+    case USBUS_EVENT_USB_RESET:
+        DEBUG_PUTS("EVENT RESET");
+        break;
+
+    default:
+        DEBUG("Unhandled event :0x%x\n", event);
+        break;
+    }
+}

--- a/sys/usb/usbus/msc/scsi.c
+++ b/sys/usb/usbus/msc/scsi.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2019-2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup usbus_msc
+ * @{
+ *
+ * @note    Keep in mind that SCSI is a big endian protocol and
+ *          USB transfer data as little endian
+ *
+ * @author  Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @}
+ */
+
+#include "usb/usbus.h"
+#include "usb/msc.h"
+#include "usb/usbus/msc.h"
+#include "usb/usbus/msc/scsi.h"
+#include "board.h"
+#include "byteorder.h"
+
+#include <string.h>
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#define HOST_MINIMAL_PAGE_SIZE  512
+
+static void _rx_ready(usbus_msc_device_t *msc)
+{
+    usbus_event_post(msc->usbus, &msc->rx_event);
+}
+
+void _scsi_test_unit_ready(usbus_handler_t *handler,  msc_cbw_buf_t *cbw)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+
+    if (cbw->data_len != 0) {
+        static const usbopt_enable_t enable = USBOPT_ENABLE;
+
+        if ((cbw->flags & USB_MSC_CBW_FLAG_IN) != 0) {
+            usbdev_ep_set(msc->ep_in->ep, USBOPT_EP_STALL, &enable,
+                          sizeof(usbopt_enable_t));
+        }
+        else {
+            usbdev_ep_set(msc->ep_out->ep, USBOPT_EP_STALL, &enable,
+                          sizeof(usbopt_enable_t));
+        }
+    }
+    msc->state = GEN_CSW;
+}
+
+void _scsi_write10(usbus_handler_t *handler, msc_cbw_buf_t *cbw)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_cbw_rw10_pkt_t *pkt = (msc_cbw_rw10_pkt_t *)cbw->cb;
+
+    /* Convert big endian data from SCSI to little endian */
+    /* Get first block number to read from */
+    msc->block = byteorder_swapl(pkt->blk_addr);
+
+    /* Get number of blocks to transfer */
+    msc->block_nb = byteorder_swaps(pkt->xfer_len);
+    msc->cmd.len = cbw->data_len;
+    msc->state = DATA_TRANSFER_OUT;
+}
+
+void _scsi_read10(usbus_handler_t *handler, msc_cbw_buf_t *cbw)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_cbw_rw10_pkt_t *pkt = (msc_cbw_rw10_pkt_t *)cbw->cb;
+
+    /* Convert big endian data from SCSI to little endian */
+    /* Get first block number to read from */
+    msc->block = byteorder_swapl(pkt->blk_addr);
+
+    /* Get number of blocks to transfer */
+    msc->block_nb = byteorder_swaps(pkt->xfer_len);
+
+    msc->cmd.len = cbw->data_len;
+    msc->state = DATA_TRANSFER_IN;
+
+    if ((cbw->flags & USB_MSC_CBW_FLAG_IN) != 0) {
+            _rx_ready(msc);
+    }
+}
+
+void _scsi_inquiry(usbus_handler_t *handler)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_inquiry_pkt_t *pkt = (msc_inquiry_pkt_t*)msc->in_buf;
+    size_t len = sizeof(msc_inquiry_pkt_t);
+
+    /* Clear the exact amount of bytes needed for this transfer */
+    memset(pkt, 0, len);
+
+    /* prepare pkt response */
+    pkt->type = 0;
+    pkt->removable = 1;
+    pkt->version = 0x01;
+    pkt->length = len - 4;
+    pkt->flags[0] = 0x80;
+
+    memcpy(&pkt->vendor_id, USBUS_MSC_VENDOR_ID, sizeof(pkt->vendor_id));
+    memcpy(&pkt->product_id, USBUS_MSC_PRODUCT_ID, sizeof(pkt->product_id));
+    memcpy(&pkt->product_rev, USBUS_MSC_PRODUCT_REV, sizeof(pkt->product_rev));
+
+    /* copy into ep buffer */
+    usbdev_ep_xmit(msc->ep_in->ep, (uint8_t*)pkt, len);
+    msc->state = WAIT_FOR_TRANSFER;
+    return;
+}
+
+void _scsi_read_format_capacities(usbus_handler_t *handler)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_read_fmt_capa_pkt_t *pkt = (msc_read_fmt_capa_pkt_t*)msc->in_buf;
+    uint32_t blk_nb = (mtd0->sector_count * mtd0->pages_per_sector);
+    size_t len = sizeof(msc_read_fmt_capa_pkt_t);
+
+    /* Clear the exact amount of bytes needed for this transfer */
+    memset(pkt, 0, len);
+
+    /* Only support one list, size of the whole struct minus the 4 first bytes */
+    pkt->list_length = len - 4;
+    pkt->blk_nb = byteorder_swapl(blk_nb);
+    pkt->type = SCSI_READ_FMT_CAPA_TYPE_FORMATTED;
+    
+    /* Manage endianness, bytes 11..9 -> LSB..MSB */
+    pkt->blk_len[0] = (HOST_MINIMAL_PAGE_SIZE >> 16) && 0xFF;
+    pkt->blk_len[1] = (HOST_MINIMAL_PAGE_SIZE >> 8) && 0xFF;
+    pkt->blk_len[2] = HOST_MINIMAL_PAGE_SIZE && 0xFF;
+
+    /* copy into ep buffer */
+    usbdev_ep_xmit(msc->ep_in->ep, (uint8_t*)pkt, sizeof(msc_read_fmt_capa_pkt_t));
+    msc->state = WAIT_FOR_TRANSFER;
+}
+
+void _scsi_read_capacity(usbus_handler_t *handler)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_read_capa_pkt_t *pkt = (msc_read_capa_pkt_t*)msc->in_buf;
+    uint32_t blk_nb = (mtd0->sector_count * mtd0->pages_per_sector);
+    size_t len = sizeof(msc_read_capa_pkt_t);
+
+    /* page size > 512 are unsupported for now */
+    /* TODO: add support for flashpage > 512 bytes */
+    assert(mtd0->page_size <= HOST_MINIMAL_PAGE_SIZE);
+
+    /* Clear the exact amount of bytes needed for this transfer */
+    memset(pkt, 0, len);
+
+
+    pkt->blk_len = byteorder_swapl(HOST_MINIMAL_PAGE_SIZE);
+    /* Check if MTD page size is greater than 512 to apply specific logic */
+    if (mtd0->page_size > HOST_MINIMAL_PAGE_SIZE) {
+        /* Currently unsupported */
+        msc->offset = mtd0->page_size / HOST_MINIMAL_PAGE_SIZE;
+
+        pkt->last_blk = byteorder_swapl((blk_nb / msc->offset)-1);
+    }
+    else {
+        /* Host side expects to have at least 512 bytes per page, otherwise it will reject
+           the setup. Thus add some logic here to be able to use smaller page size mtd device */
+        msc->pages_per_vpage = HOST_MINIMAL_PAGE_SIZE / mtd0->page_size;
+        pkt->last_blk = byteorder_swapl((blk_nb / msc->pages_per_vpage)-1);
+    }
+
+    /* copy into ep buffer */
+    usbdev_ep_xmit(msc->ep_in->ep, (uint8_t*)pkt, len);
+    msc->state = WAIT_FOR_TRANSFER;
+}
+
+void _scsi_request_sense(usbus_handler_t *handler)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_request_sense_pkt_t *pkt = (msc_request_sense_pkt_t*)msc->in_buf;
+    size_t len = sizeof(msc_request_sense_pkt_t);
+
+    /* Clear the exact amount of bytes needed for this transfer */
+    memset(pkt, 0, len);
+
+    pkt->error_code = SCSI_REQUEST_SENSE_ERROR;
+    pkt->sense_key  = SCSI_SENSE_KEY_ILLEGAL_REQUEST;
+    /* Report the size of the struct minus the 7 first bytes */
+    pkt->add_len    = len - 7;
+    pkt->asc        = 0x30;
+    pkt->ascq       = 0x01;
+
+    /* copy into ep buffer */
+    usbdev_ep_xmit(msc->ep_in->ep, (uint8_t*)pkt, len);
+    /* Wait for the current pkt to transfer before sending CSW */
+    msc->state = WAIT_FOR_TRANSFER;
+}
+
+void _scsi_sense6(usbus_handler_t *handler)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_mode_parameter_pkt_t *pkt = (msc_mode_parameter_pkt_t*)msc->in_buf;
+    size_t len = sizeof(msc_mode_parameter_pkt_t);
+
+    /* Clear the exact amount of bytes needed for this transfer */
+    memset(pkt, 0, len);
+    /* Length of the packet minus the first byte */
+    pkt->mode_data_len = len - 1;
+
+    /* copy into ep buffer */
+    usbdev_ep_xmit(msc->ep_in->ep, (uint8_t*)pkt, len);
+    /* Wait for the current pkt to transfer before sending CSW */
+    msc->state = WAIT_FOR_TRANSFER;
+}
+
+void scsi_process_cmd(usbus_t *usbus, usbus_handler_t *handler,
+                      usbdev_ep_t *ep, size_t len)
+{
+    (void)usbus;
+    (void)ep;
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+
+    /* store data into specific struct */
+    msc_cbw_buf_t *cbw = (msc_cbw_buf_t*) msc->out_buf;
+
+    /* Check Command Block signature */
+    if (cbw->signature != SCSI_CBW_SIGNATURE) {
+        DEBUG("Invalid CBW signature:0x%lx, abort\n", cbw->signature);
+        msc->cmd.status = USB_MSC_CSW_STATUS_COMMAND_FAILED;
+        msc->state = GEN_CSW;
+        return;
+    }
+
+    /* Store command for CSW generation */
+    msc->cmd.tag = cbw->tag;
+    msc->cmd.status = 0;
+    msc->cmd.len = 0;
+
+    switch (cbw->cb[0]) {
+        case SCSI_TEST_UNIT_READY:
+            DEBUG("SCSI_TEST_UNIT_READY:%d\n", len);
+            _scsi_test_unit_ready(handler, cbw);
+            break;
+        case SCSI_REQUEST_SENSE:
+            DEBUG_PUTS("SCSI_REQUEST_SENSE");
+            _scsi_request_sense(handler);
+            break;
+        case SCSI_FORMAT_UNIT:
+            DEBUG_PUTS("TODO: SCSI_FORMAT_UNIT");
+            msc->state=GEN_CSW;
+            break;
+        case SCSI_INQUIRY:
+            DEBUG_PUTS("SCSI_INQUIRY");
+            _scsi_inquiry(handler);
+            break;
+        case SCSI_START_STOP_UNIT:
+            DEBUG_PUTS("TODO: SCSI_START_STOP_UNIT");
+            msc->state=GEN_CSW;
+            break;
+        case SCSI_MEDIA_REMOVAL:
+            msc->cmd.status = 1;
+            DEBUG_PUTS("SCSI_MEDIA_REMOVAL");
+            msc->state=GEN_CSW;
+            break;
+        case SCSI_MODE_SELECT6:
+            DEBUG_PUTS("TODO: SCSI_MODE_SELECT6");
+            msc->state=GEN_CSW;
+            break;
+        case SCSI_MODE_SENSE6:
+            DEBUG_PUTS("SCSI_MODE_SENSE6");
+            _scsi_sense6(handler);
+            break;
+        case SCSI_MODE_SELECT10:
+            DEBUG_PUTS("TODO: SCSI_MODE_SELECT10");
+            msc->state=GEN_CSW;
+            break;
+        case SCSI_MODE_SENSE10:
+            DEBUG_PUTS("TODO: SCSI_MODE_SENSE10");
+            msc->state=GEN_CSW;
+            break;
+        case SCSI_READ_FORMAT_CAPACITIES:
+            DEBUG_PUTS("SCSI_READ_FORMAT_CAPACITIES");
+            _scsi_read_format_capacities(handler);
+            break;
+        case SCSI_READ_CAPACITY:
+            DEBUG_PUTS("SCSI_READ_CAPACITY");
+            _scsi_read_capacity(handler);
+            break;
+        case SCSI_READ10:
+            DEBUG("SCSI_READ10:%d\n", len);
+            _scsi_read10(handler, cbw);
+            break;
+        case SCSI_WRITE10:
+            DEBUG("SCSI_WRITE10:%d\n", len);
+            _scsi_write10(handler, cbw);
+            break;
+        case SCSI_VERIFY10:
+            DEBUG_PUTS("TODO: SCSI_VERIFY10");
+            msc->state=GEN_CSW;
+            break;
+        default:
+            DEBUG("Unhandled SCSI command:0x%x", cbw->cb[0]);
+            msc->state=GEN_CSW;
+    }
+}
+
+void scsi_gen_csw(usbus_handler_t *handler, cbw_info_t *cmd)
+{
+    usbus_msc_device_t *msc = (usbus_msc_device_t*)handler;
+    msc_csw_buf_t *csw = (msc_csw_buf_t*)msc->in_buf;
+    memset(csw, 0, sizeof(msc_csw_buf_t));
+    csw->signature = SCSI_CSW_SIGNATURE;
+    csw->tag = cmd->tag;
+    csw->data_left = cmd->len;
+    csw->status = cmd->status;
+    usbdev_ep_xmit(msc->ep_in->ep, (uint8_t*)csw, sizeof(msc_csw_buf_t));
+}

--- a/tests/usbus_msc/Makefile
+++ b/tests/usbus_msc/Makefile
@@ -1,0 +1,25 @@
+
+BOARD ?= same54-xpro
+include ../Makefile.tests_common
+
+ # This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+ # Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+USEMODULE += auto_init_usbus
+USEMODULE += usbus_msc
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+USB_VID ?= $(USB_VID_TESTING)
+USB_PID ?= $(USB_PID_TESTING)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/usbus_msc/main.c
+++ b/tests/usbus_msc/main.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019-2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for demonstrating USBUS MSC implementation
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("RIOT USB MSC test application");
+
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds the initial support for Mass Storage Class in USBUS. This PR relies on the  RIOT MTD implementation to implement the Mass Storage Class support. With the provided test application, a MTD device will be accessible as a normal storage device on your host computer ~~(Linux only for now)~~.
Read and Write operations are allowed.
The MSC relies on SCSI protocol to operate. SCSI is a beast and only a part of it has been implemented.

Currently there are some limitations:
- Supported host : Linux & Windows
- MSC cannot be used if MTD page size > 512
- Only mtd0 is supported.

~~Looks like some additional requests code must be supported to get it running on Windows~~ -> Done.
Regarding the page size, on the host side, Linux expects at least 512 bytes as page size. (512 is standard. 1024/2048 are accepted as some recent SSD make use of these values). This means that some logic was added in case the MTD page size is less than 512 bytes like SPI-NOR devices.
More logic must be added to handle page size superior to 512 bytes (e.g some flashpage implementation) but I think this should belongs to another PR.

Please be aware that performance are not so great. Be patient if you are using a big SD card.
And also, don't use a sd card if you have important data on it :)

Comments, especially on the MTD part, are very welcome !

### Testing procedure

Flash `tests/usbus_msc`, on a board with a MTD device.
Access your memory as a standard memory through /dev/sdX
You can use dd to read/write data  or even format a FS on your memory device so you can access it the same way as a USB stick.


### Issues/PRs references
None