### PR TITLE
riscv_common: make thread_yield_higher IRQ compatible

### DIFF
--- a/cpu/riscv_common/include/thread_arch.h
+++ b/cpu/riscv_common/include/thread_arch.h
@@ -21,6 +21,8 @@
 #ifndef THREAD_ARCH_H
 #define THREAD_ARCH_H
 
+#include "irq.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,7 +46,12 @@ static inline void _ecall_dispatch(uint32_t num, void *ctx)
 
 static inline __attribute__((always_inline)) void thread_yield_higher(void)
 {
-    _ecall_dispatch(0, NULL);
+    if (irq_is_in()) {
+        sched_context_switch_request = 1;
+    }
+    else {
+        _ecall_dispatch(0, NULL);
+    }
 }
 
 #endif /* DOXYGEN */


### PR DESCRIPTION
### Contribution description

This should resolve the issues mentioned [here](https://github.com/RIOT-OS/RIOT/pull/15718#issuecomment-774248134). The thread_yield_higher function now checks if it is executed from interrupt context and just set the `sched_context_switch_request` flag if it is in interrupt context.

### Testing procedure

These tests should work again:

- tests/event_wait_timeout
- tests/thread_flags 
- tests/thread_flags_xtimer.

### Issues/PRs references

Fixes regressions mentioned [here](https://github.com/RIOT-OS/RIOT/pull/15718#issuecomment-774248134)