### PR TITLE
net/gnrc_lorawan: implement channel mask support

### DIFF
--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -284,6 +284,18 @@ void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm);
  */
 netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac);
 
+/**
+ * @brief Set the channel mask in order to enable or disable LoRaWAN channels
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] channel_mask the channel mask. LSB maps to channel 0
+ *
+ * @return 0 on success
+ * @return -EINVAL if @p channel_mask is zero or if the channel mask tries to
+ *         enable an undefined channel
+ */
+int gnrc_lorawan_phy_set_channel_mask(gnrc_lorawan_t *mac, uint16_t channel_mask);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -144,6 +144,7 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data,
         gnrc_lorawan_process_cflist(mac, out + sizeof(lorawan_join_accept_t) - 1);
     }
 
+    DEBUG("gnrc_lorawan: Channel mask is %04x\n", mac->channel_mask);
     mac->mlme.activation = MLME_ACTIVATION_OTAA;
     status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -64,6 +64,22 @@ uint8_t gnrc_lorawan_rx1_get_dr_offset(uint8_t dr_up, uint8_t dr_offset)
 }
 #endif
 
+int gnrc_lorawan_phy_set_channel_mask(gnrc_lorawan_t *mac, uint16_t channel_mask)
+{
+    if (!channel_mask) {
+        return -EINVAL;
+    }
+
+    for (int n = channel_mask, i = 0; n; n = n >> 1, i++) {
+        if ((n & 0x1) && !mac->channel[i]) {
+           return -EINVAL;
+        }
+    }
+
+    mac->channel_mask = channel_mask;
+    return 0;
+}
+
 void gnrc_lorawan_channels_init(gnrc_lorawan_t *mac)
 {
     /* We set the channel mask for the default channels and populate from the list */

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -91,6 +91,9 @@ static uint32_t _get_nth_channel(gnrc_lorawan_t *mac, size_t n)
 
 void gnrc_lorawan_channels_init(gnrc_lorawan_t *mac)
 {
+    /* We set the channel mask for the default channels and populate from the list */
+    mac->channel_mask = UINT16_MAX >> (16 - GNRC_LORAWAN_DEFAULT_CHANNELS_NUMOF);
+
     for (unsigned i = 0; i < GNRC_LORAWAN_DEFAULT_CHANNELS_NUMOF; i++) {
         mac->channel[i] = gnrc_lorawan_default_channels[i];
         DEBUG("gnrc_lorawan_region: Mac -> Channel %u %" PRIu32 " \n", i, mac->channel[i]);
@@ -122,6 +125,7 @@ void gnrc_lorawan_process_cflist(gnrc_lorawan_t *mac, uint8_t *cflist)
         cl.u32 = 0;
         memcpy(&cl, cflist, GNRC_LORAWAN_CFLIST_ENTRY_SIZE);
         mac->channel[i] = byteorder_ltohl(cl) * 100;
+        mac->channel_mask |= 1 << i;
         cflist += GNRC_LORAWAN_CFLIST_ENTRY_SIZE;
         DEBUG("gnrc_lorawan_region: Mac -> Channel %u %" PRIu32 " \n", i, mac->channel[i]);
     }

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -185,6 +185,7 @@ typedef struct {
     uint8_t *nwkskey;                               /**< pointer to Network SKey buffer */
     uint8_t *appskey;                               /**< pointer to Application SKey buffer */
     uint32_t channel[GNRC_LORAWAN_MAX_CHANNELS];    /**< channel array */
+    uint16_t channel_mask;                          /**< channel mask */
     uint32_t toa;                                   /**< Time on Air of the last transmission */
     int busy;                                       /**< MAC busy  */
     int shutdown_req;                               /**< MAC Shutdown request */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR implements channel mask for GNRC LoRaWAN. The channel mask is used to enable/disable LoRaWAN channels (e.g when the network server sends an ADR-Req command or if requested by the user).

Since there's no support for adding/removing channels yet, I'm not exposing this to the user of the interface.
This is required in order to implement ADR (already handled by @akshaim)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
There's a test commit. Check that GNRC LoRaWAN doesn't assert and that it only transmit in a single channel (868.1 MHz).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
