### PR TITLE
net/gnrc_lorawan: implement unconfirmed uplink redundancy

### DIFF
--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -24,6 +24,7 @@
 #define NET_GNRC_LORAWAN_H
 
 #include "gnrc_lorawan_internal.h"
+#include "assert.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -319,6 +320,21 @@ void gnrc_lorawan_set_timer(gnrc_lorawan_t *mac, uint32_t us);
  * @param[in] mac pointer to the MAC descriptor
  */
 void gnrc_lorawan_remove_timer(gnrc_lorawan_t *mac);
+
+/**
+ * @brief Set unconfirmed uplink redundancy
+ *
+ * @pre   @p redundancy <= 14
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] redundancy number of unconfirmed uplink retransmissions
+ */
+static inline void gnrc_lorawan_set_uncnf_redundancy(gnrc_lorawan_t *mac,
+                                                     uint8_t redundancy)
+{
+    assert(redundancy <= (0xF - 1));
+    mac->mcps.redundancy = redundancy;
+}
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -535,7 +535,7 @@ extern "C" {
 #define LORAMAC_PORT_MIN                        (1U)
 
 /**
- * @brief   Maximmu port value
+ * @brief   Maximum port value
  */
 #define LORAMAC_PORT_MAX                        (223U)
 

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -285,6 +285,21 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default redundancy for unconfirmed uplink
+ *
+ * This corresponds to the number of unconfirmed uplink retransmissions when
+ * using ADR. This configuration does not affect confirmed uplinks.  By
+ * default, uplinks are sent without retransmissions (this means, the device
+ * sends only one uplink packet)
+ *
+ * @note This value MUST NOT be greater than 14, since the LinkADRCommand it's
+ *       already limited by a 4 bit value (therefore, 15 uplink transmissions)
+ */
+#ifndef CONFIG_LORAMAC_DEFAULT_REDUNDANCY
+#define CONFIG_LORAMAC_DEFAULT_REDUNDANCY       (0U)
+#endif
+
+/**
  * @brief   Enable/disable adaptive datarate state
  *
  * If enabled the end node will inform the network server about the status of

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -58,6 +58,7 @@ static inline void gnrc_lorawan_mcps_reset(gnrc_lorawan_t *mac)
     mac->mcps.waiting_for_ack = false;
     mac->mcps.fcnt = 0;
     mac->mcps.fcnt_down = 0;
+    gnrc_lorawan_set_uncnf_redundancy(mac, CONFIG_LORAMAC_DEFAULT_REDUNDANCY);
 }
 
 void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)
@@ -164,8 +165,11 @@ void gnrc_lorawan_timeout_cb(gnrc_lorawan_t *mac)
         case LORAWAN_STATE_JOIN:
             gnrc_lorawan_trigger_join(mac);
             break;
+        case LORAWAN_STATE_IDLE:
+            gnrc_lorawan_event_retrans_timeout(mac);
+            break;
         default:
-            gnrc_lorawan_event_ack_timeout(mac);
+            assert(false);
             break;
     }
 }

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -331,16 +331,33 @@ static void _transmit_pkt(gnrc_lorawan_t *mac)
     last_snip->iol_next = NULL;
 }
 
-void gnrc_lorawan_event_ack_timeout(gnrc_lorawan_t *mac)
+void gnrc_lorawan_event_retrans_timeout(gnrc_lorawan_t *mac)
 {
     _transmit_pkt(mac);
 }
 
 static void _handle_retransmissions(gnrc_lorawan_t *mac)
 {
+    /* Check if retransmission should be handled.
+     *
+     * If there was a confirmed uplink, follow the standard retransmission
+     * procedure.
+     * If it was an unconfirmed uplink, perform retransmissions only if
+     * there's redundancy > 0 */
     if (mac->mcps.nb_trials-- == 0) {
-        _end_of_tx(mac, MCPS_CONFIRMED, -ETIMEDOUT);
-    } else {
+        if (mac->mcps.waiting_for_ack) {
+            /* If we are here, the node ran out of confirmed uplink retransmissions.
+             * This means, the transmission was not successful. */
+            _end_of_tx(mac, MCPS_CONFIRMED, -ETIMEDOUT);
+        }
+        else {
+            /* In this case, we finished sending one or more unconfirmed
+             * (depending on the redundancy) */
+            _end_of_tx(mac, MCPS_UNCONFIRMED, GNRC_LORAWAN_REQ_STATUS_SUCCESS);
+        }
+    }
+    else {
+        /* Schedule a retransmission */
         gnrc_lorawan_set_timer(mac, 1000000 + random_uint32_range(0, 2000000));
     }
 }
@@ -358,14 +375,7 @@ void gnrc_lorawan_event_no_rx(gnrc_lorawan_t *mac)
         return;
     }
 
-    /* Otherwise check if retransmission should be handled */
-
-    if (mac->mcps.waiting_for_ack) {
-        _handle_retransmissions(mac);
-    }
-    else {
-        _end_of_tx(mac, MCPS_UNCONFIRMED, GNRC_LORAWAN_REQ_STATUS_SUCCESS);
-    }
+    _handle_retransmissions(mac);
 }
 
 void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
@@ -416,7 +426,7 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
     mac->mcps.waiting_for_ack = waiting_for_ack;
     mac->mcps.ack_requested = false;
 
-    mac->mcps.nb_trials = CONFIG_LORAMAC_DEFAULT_RETX;
+    mac->mcps.nb_trials = waiting_for_ack ? CONFIG_LORAMAC_DEFAULT_RETX : mac->mcps.redundancy;
 
     mac->mcps.msdu = pkt;
     mac->last_dr = mcps_request->data.dr;

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -153,6 +153,7 @@ typedef struct {
     int nb_trials;                      /**< holds the remaining number of retransmissions */
     int ack_requested;                  /**< whether the network server requested an ACK */
     int waiting_for_ack;                /**< true if the MAC layer is waiting for an ACK */
+    uint8_t redundancy;                 /**< unconfirmed uplink redundancy */
     char mhdr_mic[MHDR_MIC_BUF_SIZE];   /**< internal retransmissions buffer */
 } gnrc_lorawan_mcps_t;
 
@@ -393,11 +394,11 @@ void gnrc_lorawan_mlme_no_rx(gnrc_lorawan_t *mac);
 void gnrc_lorawan_event_no_rx(gnrc_lorawan_t *mac);
 
 /**
- * @brief Mac callback for ACK timeout event
+ * @brief Mac callback for retransmission timeout event
  *
  * @param[in] mac pointer to the MAC descriptor
  */
-void gnrc_lorawan_event_ack_timeout(gnrc_lorawan_t *mac);
+void gnrc_lorawan_event_retrans_timeout(gnrc_lorawan_t *mac);
 
 /**
  * @brief Get the maximum MAC payload (M value) for a given datarate.

--- a/sys/net/link_layer/Kconfig.lorawan
+++ b/sys/net/link_layer/Kconfig.lorawan
@@ -524,4 +524,16 @@ config LORAMAC_DEFAULT_MIN_RX_SYMBOLS
         system timer. Refer SX1276_settings_for_LoRaWAN_v2p2.pdf
         (AN1200.24) from Semtech for more information.
 
+config LORAMAC_DEFAULT_REDUNDANCY
+    int "Default redundancy for unconfirmed uplinks"
+    depends on USEMODULE_GNRC_LORAWAN
+    default 0
+    range 0 14
+    help
+         This corresponds to the number of unconfirmed
+         uplink retransmissions when using ADR. This
+         configuration does not affect confirmed uplinks.
+         By default, uplinks are sent without retransmissions
+         (this means, the device sends only one uplink packet)
+
 endif # KCONFIG_USEMODULE_LORAWAN


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR implements uplink redundancy for GNRC LoRaWAN.

Uplink redundancy is used to retransmit unconfirmed uplink frames. The retransmission stops when either a downlink message is received or the number of uplink retransmissions is reached. This functionality doesn't affect confirmed uplinks.

Although this functionality is intended to be used by the upcoming implementation of ADR, this can be also set at compile time by the user.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Configure the LORAMAC_DEFAULT_REDUNDANCY parameter using Kconfig (e.g to 3). Then, please check the following stuff:
- [ ]  Check that the MAC layer sends the configured number of redundancy retransmissions when sending an unconfirmed message
    - [ ] Check that the MAC layer doesn't retransmit if a downlink is received (e.g payload from NS, link check request, etc)
    - [x] ~Check if this features still works with the following patch:~ (see https://github.com/RIOT-OS/RIOT/pull/15946#issuecomment-879416956)
```
diff --git a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
index 963e1197e9..2865b74748 100644
--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -64,7 +64,8 @@ static inline void gnrc_lorawan_mcps_reset(gnrc_lorawan_t *mac)
     mac->mcps.waiting_for_ack = false;
     mac->mcps.fcnt = 0;
     mac->mcps.fcnt_down = 0;
-    mac->mcps.redundancy = CONFIG_LORAMAC_DEFAULT_REDUNDANCY;
+    assert(gnrc_lorawan_set_redundancy(mac, 15) == -EINVAL);
+    assert(gnrc_lorawan_set_redundancy(mac, CONFIG_LORAMAC_DEFAULT_REDUNDANCY) == 0);
 }
 
 void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)

```

- [ ] Check that confirmed uplink messages are not affected by this value. This can be tested using ABP and fake keys (in such case the NS won't reply with an ACK)
- [ ] For both tests, check that the retransmissions are sent in different channels (e.g 868.1, 868.5, etc).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far, but required for implementing ADR
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
