### PR TITLE
boards: add cc1350 launchpad

### DIFF
--- a/boards/cc1350-launchpad/Kconfig
+++ b/boards/cc1350-launchpad/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "cc1350-launchpad" if BOARD_CC1350_LAUNCHPAD
+
+config BOARD_CC1350_LAUNCHPAD
+    bool
+    default y
+    select CPU_MODEL_CC13X0F128
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/cc1350-launchpad/Makefile
+++ b/boards/cc1350-launchpad/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/cc1350-launchpad/Makefile.dep
+++ b/boards/cc1350-launchpad/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/cc1350-launchpad/Makefile.features
+++ b/boards/cc1350-launchpad/Makefile.features
@@ -1,0 +1,8 @@
+CPU = cc26x0_cc13x0
+CPU_MODEL = cc13x0f128
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_i2c

--- a/boards/cc1350-launchpad/Makefile.include
+++ b/boards/cc1350-launchpad/Makefile.include
@@ -1,0 +1,4 @@
+XDEBUGGER = XDS110
+
+# configure the flash tool
+PROGRAMMER ?= uniflash

--- a/boards/cc1350-launchpad/board.c
+++ b/boards/cc1350-launchpad/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C)    2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc1350_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific implementations for TI CC1350 LaunchPad
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+/**
+ * @brief           Initialise the board.
+ */
+
+void board_init(void)
+{
+    cpu_init();
+
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+}

--- a/boards/cc1350-launchpad/dist/cc13x0f128_XDS110.ccxml
+++ b/boards/cc1350-launchpad/dist/cc13x0f128_XDS110.ccxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+<configuration XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS110 USB Debug Probe_0" href="connections/TIXDS110_Connection.xml" id="Texas Instruments XDS110 USB Debug Probe_0" xml="TIXDS110_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe_0">
+            <instance XML_version="1.2" href="drivers/tixds510icepick_c.xml" id="drivers" xml="tixds510icepick_c.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cs_dap.xml" id="drivers" xml="tixds510cs_dap.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cortexM.xml" id="drivers" xml="tixds510cortexM.xml" xmlpath="drivers"/>
+            <property Type="choicelist" Value="4" id="SWD Mode Settings">
+                <choice Name="cJTAG (1149.7) 2-pin advanced modes" value="enable">
+                    <property Type="choicelist" Value="1" id="XDS110 Aux Port"/>
+                </choice>
+            </property>
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC1310F128_0" href="devices/cc1310f128.xml" id="CC1310F128_0" xml="cc1310f128.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/boards/cc1350-launchpad/dist/cc13x0f128_XDS110.dat
+++ b/boards/cc1350-launchpad/dist/cc13x0f128_XDS110.dat
@@ -1,0 +1,31 @@
+# config version=3.5
+$ sepk
+  pod_drvr=libjioxds110.so
+  pod_port=0
+$ /
+$ product
+  title="Texas Instruments XDS110 USB"
+  alias=TI_XDS110_USB
+  name=XDS110
+$ /
+$ uscif
+  tdoedge=FALL
+  tclk_program=DEFAULT
+  tclk_frequency=2.5MHz
+  jtag_isolate=enable
+$ /
+$ dot7
+  dts_usage=nothing
+$ /
+$ swd
+  swd_debug=disabled
+  swo_data=aux_uart
+$ /
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=1
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no
+    @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477
+      & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
+        @ cortex_m3_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0
+      & /
+  & /
+# /

--- a/boards/cc1350-launchpad/dist/cc13x0f128_gdb.conf
+++ b/boards/cc1350-launchpad/dist/cc13x0f128_gdb.conf
@@ -1,0 +1,6 @@
+mem 0x00 0x20000 ro 32 nocache
+mem 0x10000000 0x10020000 ro 32 nocache
+mem 0x20000000 0x20005000 rw 32 nocache
+mem 0x40000000 0x400E1028 rw 32 nocache
+mem 0xE000E000 0xE000F000 rw 32 nocache
+target remote localhost:3333

--- a/boards/cc1350-launchpad/dist/openocd.cfg
+++ b/boards/cc1350-launchpad/dist/openocd.cfg
@@ -1,0 +1,43 @@
+# Config for Texas Instruments low power SoC CC13xx family
+
+adapter_khz 100
+
+source [find target/icepick.cfg]
+source [find target/ti-cjtag.cfg]
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME cc26xx
+}
+
+#
+# Main DAP
+#
+if { [info exists DAP_TAPID] } {
+   set _DAP_TAPID $DAP_TAPID
+} else {
+   set _DAP_TAPID 0x4BA00477
+}
+jtag newtap $_CHIPNAME dap -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_DAP_TAPID -disable
+jtag configure $_CHIPNAME.dap -event tap-enable "icepick_c_tapenable $_CHIPNAME.jrc 0"
+
+#
+# ICEpick-C (JTAG route controller)
+#
+if { [info exists JRC_TAPID] } {
+   set _JRC_TAPID $JRC_TAPID
+} else {
+   set _JRC_TAPID 0x1B99A02F
+}
+jtag newtap $_CHIPNAME jrc -irlen 6 -ircapture 0x1 -irmask 0x3f -expected-id $_JRC_TAPID -ignore-version
+# A start sequence is needed to change from cJTAG (Compact JTAG) to
+# 4-pin JTAG before talking via JTAG commands
+jtag configure $_CHIPNAME.jrc -event setup "jtag tapenable $_CHIPNAME.dap"
+jtag configure $_CHIPNAME.jrc -event post-reset "ti_cjtag_to_4pin_jtag $_CHIPNAME.jrc"
+
+#
+# Cortex M3 target
+#
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m -chain-position $_CHIPNAME.dap

--- a/boards/cc1350-launchpad/doc.txt
+++ b/boards/cc1350-launchpad/doc.txt
@@ -1,0 +1,51 @@
+/**
+@defgroup        boards_cc1350_launchpad TI CC1350 LaunchPad XL
+@ingroup         boards
+@brief           Texas Instruments SimpleLink(TM) CC1350 Wireless MCU LaunchPad(TM) Kit
+
+## Overview
+
+The [LAUNCHXL-CC1350](https://www.ti.com/tool/LAUNCHXL-CC1350) is a Texas
+Instrument's development kit for the CC1350 SoC MCU which combines a Cortex-M3
+microcontroller alonside a dedicated Cortex-M0 to control a dual-band radio.
+
+## Hardware
+
+![LAUNCHXL-CC1350](https://www.ti.com/diagrams/launchxl-cc1350_launchxl-cc1350.jpg)
+
+| MCU               | CC1312R1              |
+|:----------------- |:--------------------- |
+| Family            | ARM Cortex-M3         |
+| Vendor            | Texas Instruments     |
+| RAM               | 20KiB                 |
+| Flash             | 128KiB                |
+| Frequency         | 48MHz                 |
+| FPU               | no                    |
+| Timers            | 4                     |
+| ADCs              | 1x 12-bit (channels)  |
+| UARTs             | 2                     |
+| SPIs              | 2                     |
+| I2Cs              | 1                     |
+| Vcc               | 1.8V - 3.8V           |
+| Datasheet         | [Datasheet](https://www.ti.com/lit/ds/swrs183b/swrs183b.pdf) |
+| Reference Manual  | [Reference Manual](https://www.ti.com/lit/ug/swcu117i/swcu117i.pdf) |
+
+## Board pinout
+
+The [CC1350 Quick Start Guide](https://www.ti.com/lit/ug/swru478b/swru478b.pdf)
+provides the default pinout for the board.
+
+## Flashing and Debugging
+
+The LAUNCHXL-CC1350 comes with an XDS110 on-board debug probe that provides,
+programming, flashing and debuggigng capabilities.
+
+It can be either flashed either using Uniflash or OpenOCD, by setting
+`PROGRAMMER=uniflash` (default) or `PROGRAMMER=openocd` respectively.
+
+For example, to use OpenOCD:
+
+```
+make -C examples/hello-world flash PROGRAMMER=openocd
+```
+*/

--- a/boards/cc1350-launchpad/include/board.h
+++ b/boards/cc1350-launchpad/include/board.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)    2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc1350_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific definitions for TI CC1350 LaunchPad
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (25)
+#define XTIMER_ISR_BACKOFF  (20)
+/** @} */
+
+/**
+ * @name    On-board button configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_MODE           GPIO_IN_PU
+
+#define BTN1_PIN            GPIO_PIN(0, 14)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   On-board LED configuration and controlling
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 6)          /**< Red   */
+#define LED1_PIN            GPIO_PIN(0, 7)          /**< Green */
+
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+
+#define LED1_ON             gpio_set(LED1_PIN)
+#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/cc1350-launchpad/include/gpio_params.h
+++ b/boards/cc1350-launchpad/include/gpio_params.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_cc1350_launchpad
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button(BTN-1)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Button(BTN-2)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/cc1350-launchpad/include/periph_conf.h
+++ b/boards/cc1350-launchpad/include/periph_conf.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C)    2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         boards_cc1350_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Peripheral MCU configuration for TI CC1350 LaunchPad
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @name    Clock configuration
+* @{
+*/
+/* the main clock is fixed to 48MHZ */
+#define CLOCK_CORECLOCK     MHZ(48)
+/** @} */
+
+/**
+* @name    Timer configuration
+*
+* General purpose timers (GPT[0-3]) are configured consecutively and in order
+* (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
+*
+* @{
+*/
+static const timer_conf_t timer_config[] = {
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ },
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ }
+};
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+* @name    UART configuration
+*
+* The used CC26x0 CPU only supports a single UART device, so all we need to
+* configure are the RX and TX pins.
+*
+* Optionally we can enable hardware flow control, by using periph_uart_hw_fc
+* module (USEMODULE += periph_uart_hw_fc) and defining pins for cts_pin and
+* rts_pin.
+* @{
+*/
+
+static const uart_conf_t uart_config[] = {
+    {
+        .regs = UART0,
+        .tx_pin = GPIO_PIN(0, 3),
+        .rx_pin = GPIO_PIN(0, 2),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin = GPIO_UNDEF,
+        .cts_pin = GPIO_UNDEF,
+#endif
+        .intn = UART0_IRQN
+    }
+};
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (1)
+#define I2C_SDA_PIN         GPIO_PIN(0, 5)
+#define I2C_SCL_PIN         GPIO_PIN(0, 4)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/cc26xx_cc13xx/include/periph_cpu_common.h
+++ b/cpu/cc26xx_cc13xx/include/periph_cpu_common.h
@@ -65,6 +65,11 @@ typedef enum {
     GPIO_BOTH = IOCFG_EDGEDET_BOTH
 } gpio_flank_t;
 
+/**
+ * @brief   CPU specific GPIO pin generator macro
+ */
+#define GPIO_PIN(x, y)  (((x) & 0) | (y))
+
 /*
  * @brief   Invalid UART mode mask
  *

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     e104-bt5010a-tb \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     derfmega128 \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     e104-bt5010a-tb \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2538dk \
     cc2650-launchpad \
     cc2650stk \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     i-nucleo-lrwan1 \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -20,6 +20,7 @@ LOW_MEMORY_BOARDS += \
   bluepill-128kib \
   calliope-mini \
   cc1312-launchpad \
+  cc1350-launchpad \
   cc1352-launchpad \
   cc2650-launchpad \
   cc2650stk \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     derfmega128 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     derfmega128 \

--- a/tests/pkg_tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg_tinydtls_sock_async/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     e104-bt5010a-tb \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-128kib \
     bluepill-stm32f030c8 \
     calliope-mini \
+    cc1350-launchpad \
     cc2650-launchpad \
     cc2650stk \
     i-nucleo-lrwan1 \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     calliope-mini \
     cc1312-launchpad \
+    cc1350-launchpad \
     cc1352-launchpad \
     cc1352p-launchpad \
     cc2650-launchpad \
@@ -46,13 +47,13 @@ BOARD_INSUFFICIENT_MEMORY := \
     lobaro-lorabox \
     lsn50 \
     maple-mini \
-    mega-xplained \
     mcb2388 \
+    mega-xplained \
     microbit \
     microduino-corerf \
-    msba2 \
     msb-430 \
     msb-430h \
+    msba2 \
     nrf51dk \
     nrf51dongle \
     nrf6310 \


### PR DESCRIPTION
### Contribution description

Adds the definitions for the TI CC1350 LAUNCHXL board, including the SAUL gpio params (verified with `examples/saul` and `tests/saul`).

~~By the way, `add_insufficient_memory_board` is still running so this is expecting a rebase :-)~~. Done

### Testing procedure

- Run `./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` for `cc1350-launchpad`.


### Issues/PRs references

Depends on #15944
