### PR TITLE
tests/periph_rtc: test sub-second precision

### DIFF
--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -172,8 +172,15 @@ int main(void)
         /* capture time before printf */
         uint32_t now_usecs = xtimer_now_usec();
         if (++cnt < REPEAT) {
-            struct tm time;
+            struct tm alarm = time;
             rtc_get_time(&time);
+
+            if (alarm.tm_sec != time.tm_sec) {
+                puts("alarm time mismatch");
+                print_time("expected: ", &alarm);
+                print_time("now:      ", &time);
+            }
+
             time.tm_sec += PERIOD;
             rtc_set_alarm(&time, cb, &rtc_mtx);
         }

--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -10,9 +10,10 @@ import os
 import sys
 from testrunner import run
 
-
 BOARD = os.getenv('BOARD', 'native')
 DATE_PATTERN = r'\d{4}\-\d{2}\-\d{2} \d{2}\:\d{2}\:\d{2}'
+
+max_offset_us = 250000  # 250 ms
 
 
 def testfunc(child):
@@ -38,7 +39,11 @@ def testfunc(child):
 
     child.expect(r"  Setting alarm to   ({})".format(DATE_PATTERN))
     for _ in range(alarm_count):
-        child.expect_exact('Alarm!')
+        child.expect(r'\[[0-9]+\] Alarm! after [0-9]+ µs \(error'
+                     r' (\-)*([0-9]+) µs\)')
+        eus = int(child.match.group(2))
+        assert abs(eus) <= max_offset_us, \
+            "Error ({}us) out of range, alarm_count={}".format(eus, _)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

Adapted from @MrKevinWeiss PR #13483.
Add mircosecond precision test to RTC.
Adapt automated python test to match test API changes.
Assert max of 100 ms  error.

This is needed to test that an RTC alarm fires at the desired time and not with an arbitrary offset up to +/-1 second.
It also tests that `rtc_set_time()` behaves equivalently correctly, which is what I needed to test when I wrote this.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

    BOARD=<board_to_test> make flash test -C tests/periph_rtc

on `same54-xpro` this gives

```
2021-02-08 18:39:11,422 # This test will display 'Alarm!' every 2 seconds for 4 times
2021-02-08 18:39:11,429 #   Setting clock to   2020-02-28 23:59:57
2021-02-08 18:39:11,435 # Clock value is now   2020-02-28 23:59:57
2021-02-08 18:39:11,438 #   Setting alarm to   2020-02-28 23:59:59
2021-02-08 18:39:11,445 #    Alarm is set to   2020-02-28 23:59:59
2021-02-08 18:39:11,448 #   Alarm cleared at   2020-02-28 23:59:57
2021-02-08 18:39:13,452 #        No alarm at   2020-02-28 23:59:59
2021-02-08 18:39:14,985 #   Setting alarm to   2020-02-29 00:00:02
2021-02-08 18:39:14,985 # 
2021-02-08 18:39:14,989 # [5153465] First alarm expected at 7146843 µs
2021-02-08 18:39:16,986 # [7146838] Alarm! after 1999995 µs (error -5 µs)
2021-02-08 18:39:18,986 # [9146834] Alarm! after 3999991 µs (error -4 µs)
2021-02-08 18:39:20,986 # [11146828] Alarm! after 5999985 µs (error -6 µs)
2021-02-08 18:39:22,983 # [13146823] Alarm! after 7999980 µs (error -5 µs)
```

### Issues/PRs references

Taken over from #13483