### PR TITLE
arch/riscv: use natural align data type

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -37,6 +37,9 @@ ifeq ($(TOOLCHAIN),llvm)
   TARGET_ARCH_LLVM := riscv32-none-elf
 else
   CFLAGS_CPU += -mcmodel=medlow -msmall-data-limit=8
+  ifneq (,$(shell $(TARGET_ARCH)-gcc --help=target | grep '\-malign-data='))
+    CFLAGS_CPU += -malign-data=natural
+  endif
 endif
 CFLAGS_LINK  = -ffunction-sections -fdata-sections
 CFLAGS_DBG  ?= -g3


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a CFLAGS option to riscv compiler to use a natural alignment of data instead of xlen (the default). This change fixes the sys_architecture test application on riscv but needs a version of gcc >= 8.3 and the version in riot/riotbuild is 8.2.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<details><summary>`tests/sys_architecture` now works on hifive1b:</summary>

```
$ make BOARD=hifive1b -C tests/sys_architecture/ flash test
make: Entering directory '/work/riot/RIOT/tests/sys_architecture'
Building application "tests_sys_architecture" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/cpu/riscv_common
"make" -C /work/riot/RIOT/cpu/riscv_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
^[[A   text	   data	    bss	    dec	    hex	filename
   9180	    128	   2316	  11624	   2d68	/work/riot/RIOT/tests/sys_architecture/bin/hifive1b/tests_sys_architecture.elf
/work/riot/RIOT/dist/tools/jlink/jlink.sh flash /work/riot/RIOT/tests/sys_architecture/bin/hifive1b/tests_sys_architecture.bin
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001342
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/tests/sys_architecture/bin/hifive1b/tests_sys_architecture.bin]...
Comparing flash   [100%] Done.
Erasing flash     [100%] Done.
Programming flash [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: 1 range affected (65536 bytes)
J-Link: Flash download: Total: 0.812s (Prepare: 0.048s, Compare: 0.318s, Erase: 0.177s, Program & Verify: 0.252s, Restore: 0.015s)
J-Link: Flash download: Program & Verify speed: 254 KB/s
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.

r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Bench Clock Reset Complete

ATE0-->ATE0
OK
AT+BLEINIT=0-->OK
AT+CWMODE=0-->OK

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-464-gca20d-pr/toolchains/riscv_malign_data)
One word is 32 bits or 4 bytes in size
Verifying test works: OK
Verifying WORD_ALIGNED works: OK
TEST SUCCEEDED

make: Leaving directory '/work/riot/RIOT/tests/sys_architecture'

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes one of the issues reported in #13086 (see https://github.com/RIOT-OS/RIOT/issues/13086#issuecomment-774999082)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
