### PR TITLE
sys/ztimer: add periph_ptp backend

### DIFF
--- a/sys/include/ztimer/periph_ptp.h
+++ b/sys/include/ztimer/periph_ptp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C)    2018 Kaspar Schleiser <kaspar@schleiser.de>
+                    2021 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_ztimer_periph_ptp  ztimer periph/ptp backend
+ * @ingroup     sys_ztimer
+ * @brief       ztimer periph/ptp backend
+ *
+ * This ztimer module implements a ztimer virtual clock on top of periph/ptp.
+ *
+ * @{
+ *
+ * @file
+ * @brief       ztimer periph/ptp backend API
+ *
+ * @author      Jana Eisoldt <jana.eisoldt@ovgu.de>
+ */
+
+#ifndef ZTIMER_PERIPH_PTP_H
+#define ZTIMER_PERIPH_PTP_H
+
+#include "ztimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ztimer_periph_ptp structure definition
+ *
+ * The periph/ptp backend has no private fields, thus this is just a typedef
+ * to ztimer_clock_t.
+ */
+typedef ztimer_clock_t ztimer_periph_ptp_t;
+
+/**
+ * @brief   ztimer periph/ptp backend initialization function
+ *
+ * @param[in, out]  clock   ztimer_periph_ptp object to initialize
+ */
+void ztimer_periph_ptp_init(ztimer_periph_ptp_t *clock);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZTIMER_PERIPH_PTP_H */
+/** @} */

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -28,6 +28,11 @@ config MODULE_ZTIMER_PERIPH_RTT
     select MODULE_PERIPH_RTT
     default y if !MODULE_ZTIMER_PERIPH_TIMER
 
+config MODULE_ZTIMER_PERIPH_PTP
+    bool "PTP peripheral"
+    depends on HAS_PERIPH_PTP_TIMER
+    select MODULE_PERIPH_PTP_TIMER
+
 config MODULE_ZTIMER_PERIPH_TIMER
     bool "Timer peripheral"
     depends on HAS_PERIPH_TIMER

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -70,6 +70,10 @@ ifneq (,$(filter ztimer_periph_rtt,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif
 
+ifneq (,$(filter ztimer_periph_ptp,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_ptp_timer
+endif
+
 ifneq (,$(filter ztimer_convert_frac,$(USEMODULE)))
   USEMODULE += frac
 endif

--- a/sys/ztimer/periph_ptp.c
+++ b/sys/ztimer/periph_ptp.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)    2018 Kaspar Schleiser <kaspar@schleiser.de>
+                    2021 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_ztimer_periph_ptp
+ * @{
+ *
+ * @file
+ * @brief       ztimer periph/ptp implementation
+ *
+ * @author      Jana Eisoldt <jana.eisoldt@ovgu.de>
+ *
+ * @}
+ */
+#include "assert.h"
+
+#include "irq.h"
+#include "periph/ptp.h"
+#include "ztimer/periph_ptp.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static ztimer_clock_t *clock_timer;
+
+void ptp_timer_cb(void)
+{
+    ztimer_handler(clock_timer);
+}
+
+static void _ztimer_periph_ptp_set(ztimer_clock_t *clock, uint32_t val)
+{
+    (void)clock;
+    ptp_timer_set_u64(val);
+}
+
+static uint32_t _ztimer_periph_ptp_now(ztimer_clock_t *clock)
+{
+    (void)clock;
+    return (uint32_t)ptp_clock_read_u64();
+}
+
+static void _ztimer_periph_ptp_cancel(ztimer_clock_t *clock)
+{
+    (void)clock;
+    ptp_timer_clear();
+}
+
+static const ztimer_ops_t _ztimer_periph_ptp_ops = {
+    .set = _ztimer_periph_ptp_set,
+    .now = _ztimer_periph_ptp_now,
+    .cancel = _ztimer_periph_ptp_cancel,
+};
+
+void ztimer_periph_ptp_init(ztimer_periph_ptp_t *clock)
+{
+    clock->ops = &_ztimer_periph_ptp_ops;
+    clock->max_value = UINT32_MAX;
+    clock_timer = clock;
+
+    ztimer_init_extend(clock);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for PTP-Clock in ztimer. 

### Testing procedure

I did some basic tests on `nucleo-f767zi` of clock and timer and compared the time values printed with the shell timestamps. It requires to use `ztimer_usec`.  
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
