### PR TITLE
fe310: make thread_yield_higher IRQ compatible [backport 2021.01]

### DIFF
--- a/cpu/fe310/thread_arch.c
+++ b/cpu/fe310/thread_arch.c
@@ -193,7 +193,12 @@ static inline void _ecall_dispatch(uint32_t num, void *ctx)
 
 void thread_yield_higher(void)
 {
-    _ecall_dispatch(0, NULL);
+    if (irq_is_in()) {
+        sched_context_switch_request = 1;
+    }
+    else {
+        _ecall_dispatch(0, NULL);
+    }
 }
 
 /**


### PR DESCRIPTION
### Contribution description

This commit is a handcrafted backport for
0b2810a856ee1b23315bdbbb8dc074108c87170a, see #15942

This should resolve the issues mentioned [here](https://github.com/RIOT-OS/RIOT/pull/15718#issuecomment-774248134). The thread_yield_higher function now checks if it is executed from interrupt context and just set the `sched_context_switch_request` flag if it is in interrupt context.

### Testing procedure

These tests should work again:

- tests/event_wait_timeout
- tests/thread_flags 
- tests/thread_flags_xtimer.

### Issues/PRs references

Fixes regressions mentioned [here](https://github.com/RIOT-OS/RIOT/pull/15718#issuecomment-774248134)