### PR TITLE
pyterm: read space after prompt into prompt

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -688,13 +688,17 @@ class SerCmd(cmd.Cmd):
         output = ""
         crreceived = False
         nlreceived = False
+        c_already_read = False
         while (1):
-            try:
-                c = self._read_char()
-            # try to re-open it with a timeout of 1s otherwise
-            except (serial.SerialException, ValueError):
-                self._handle_serial_exception()
-                continue
+            # one of the if branches might have read c already
+            if not c_already_read:
+                try:
+                    c = self._read_char()
+                # try to re-open it with a timeout of 1s otherwise
+                except (serial.SerialException, ValueError):
+                    self._handle_serial_exception()
+                    continue
+            c_already_read = False
             if c == '\r':
                 if (self.newline == "LFCR" and nlreceived) or (self.newline == "CR"):
                     self.handle_line(output)
@@ -706,6 +710,21 @@ class SerCmd(cmd.Cmd):
             elif c == self.serprompt and output == "":
                 sys.stdout.write('%c ' % self.serprompt)
                 sys.stdout.flush()
+                # self.serprompt was read, but a space (that we also printed
+                # above) may follow. As such, read the next character, but keep
+                # it for the next iteration in case it is not a space.
+                # If we don't do this, the space from the prompt will be
+                # prepended to the next output, causing the next prompt on empty
+                # output potentially to be ignored, since `output` will be " "
+                try:
+                    c = self._read_char()
+                # try to re-open it with a timeout of 1s otherwise
+                except (serial.SerialException, ValueError):
+                    self._handle_serial_exception()
+                    continue
+                if c != ' ':            # not a space?
+                    # then use `c` in the next iteration
+                    c_already_read = True
             else:
                 output += c
 

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -662,6 +662,26 @@ class SerCmd(cmd.Cmd):
         if self.set_dtr == 1 or self.set_dtr == 0:
             self.ser.setDTR(self.set_dtr)
 
+    def _read_char(self):
+        # check if serial port can be accessed.
+        sr = codecs.getreader("UTF-8")(self.ser,
+                                       errors='replace')
+        return sr.read(1)
+
+    def _handle_serial_exception(self):
+        self.logger.warning("Serial port disconnected, waiting to "
+                            "get reconnected...")
+        self.ser.close()
+        time.sleep(1)
+        if os.path.exists(self.port):
+            self.logger.warning("Try to reconnect to %s again..."
+                                % (self.port))
+            try:
+                self.serial_connect()
+                self.logger.info("Reconnected to serial port %s" % self.port)
+            except serial.SerialException:
+                pass
+
     def reader(self):
         """Serial or TCP reader.
         """
@@ -669,25 +689,11 @@ class SerCmd(cmd.Cmd):
         crreceived = False
         nlreceived = False
         while (1):
-            # check if serial port can be accessed.
             try:
-                sr = codecs.getreader("UTF-8")(self.ser,
-                                               errors='replace')
-                c = sr.read(1)
+                c = self._read_char()
             # try to re-open it with a timeout of 1s otherwise
             except (serial.SerialException, ValueError):
-                self.logger.warning("Serial port disconnected, waiting to "
-                                    "get reconnected...")
-                self.ser.close()
-                time.sleep(1)
-                if os.path.exists(self.port):
-                    self.logger.warning("Try to reconnect to %s again..."
-                                        % (self.port))
-                    try:
-                        self.serial_connect()
-                        self.logger.info("Reconnected to serial port %s" % self.port)
-                    except serial.SerialException:
-                        pass
+                self._handle_serial_exception()
                 continue
             if c == '\r':
                 if (self.newline == "LFCR" and nlreceived) or (self.newline == "CR"):

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -87,11 +87,19 @@ static int print_shell_bufsize(int argc, char **argv)
     return 0;
 }
 
+static int print_empty(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
     { "bufsize", "Get the shell's buffer size", print_shell_bufsize },
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
     { "echo", "prints the input command", print_echo },
+    { "empty", "print nothing on command", print_empty },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently, when the prompt is read in `pyterm` the space after it is ignored for the prompt and the output command just adds its own prompt. This leads to the next output always having a leading space, see e.g. this output from `tests/shell` using `RIOT_TERMINAL=pyterm`:

```
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT2/tests/shell'
/home/mlenders/Repositories/RIOT-OS/RIOT2/dist/tools/pyterm/pyterm -p "/dev/ttyUSB1" -b "500000"
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-09 14:47:15,071 # Connect to serial port /dev/ttyUSB1
Welcome to pyterm!
Type '/exit' to exit.
bufsize
2021-02-09 14:47:19,712 # bufsize
2021-02-09 14:47:19,712 # 128
> bufsize
2021-02-09 14:47:21,535 #  bufsize
2021-02-09 14:47:21,536 # 128
>
```

While this isn't necessarily a problem in most cases, it becomes a problem when the prompt is expected and the output of a command is empty. In that case, the space is added to the empty output, making it " ", so the prompt output command is never triggered and the prompt is added to the next command in the log output. To demonstrate I added a command `empty` to `tests/shell` that just does nothing and deactivated the command echoing using `CFLAGS=-DCONFIG_SHELL_NO_ECHO=1`:

```
empty
> empty
empty
bufsize
2021-02-09 14:54:33,753 #  > > 128
>
```

This fixes that problem by also reading the assumed space (we already assume the prompt, so I don't see no harm in that) and if it is not a space to skip the reading of the next char in the next iteration of the reader loop.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Using the provided `empty` command in `tests/shell` now yields the expected output:

<details>

```console
$ BOARD=iotlab-m3 RIOT_TERMINAL=pyterm CFLAGS=-DCONFIG_SHELL_NO_ECHO=1 RIOT_CI_BUILD=1 make -j --no-print-directory flash term
Building application "tests_shell" for "iotlab-m3" with MCU "stm32".

   text	   data	    bss	    dec	    hex	filename
  12388	    132	   2368	  14888	   3a28	/home/mlenders/Repositories/RIOT-OS/RIOT/tests/shell/bin/iotlab-m3/tests_shell.elf
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/openocd/openocd.sh flash /home/mlenders/Repositories/RIOT-OS/RIOT/tests/shell/bin/iotlab-m3/tests_shell.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01089-g3bfe49266 (2020-02-26-14:18)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
jtag
Warn : Interface already configured, ignoring
trst_and_srst separate srst_nogate trst_push_pull srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : JTAG tap: stm32f1x.cpu tap/device found: 0x3ba00477 (mfg: 0x23b (ARM Ltd.), part: 0xba00, ver: 0x3)
Info : JTAG tap: stm32f1x.bs tap/device found: 0x06414041 (mfg: 0x020 (STMicroelectronics), part: 0x6414, ver: 0x0)
Info : stm32f1x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : stm32f1x.cpu: external reset detected
Info : Listening on port 34845 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f1x.cpu       cortex_m   little stm32f1x.cpu       reset

Info : JTAG tap: stm32f1x.cpu tap/device found: 0x3ba00477 (mfg: 0x23b (ARM Ltd.), part: 0xba00, ver: 0x3)
Info : JTAG tap: stm32f1x.bs tap/device found: 0x06414041 (mfg: 0x020 (STMicroelectronics), part: 0x6414, ver: 0x0)
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080007d0 msp: 0x20000200
Info : device id = 0x10016414
Info : flash size = 512kbytes
auto erase enabled
wrote 14336 bytes from file /home/mlenders/Repositories/RIOT-OS/RIOT/tests/shell/bin/iotlab-m3/tests_shell.elf in 0.641664s (21.818 KiB/s)

verified 12520 bytes in 0.210252s (58.152 KiB/s)

Info : JTAG tap: stm32f1x.cpu tap/device found: 0x3ba00477 (mfg: 0x23b (ARM Ltd.), part: 0xba00, ver: 0x3)
Info : JTAG tap: stm32f1x.bs tap/device found: 0x06414041 (mfg: 0x020 (STMicroelectronics), part: 0x6414, ver: 0x0)
shutdown command invoked
Done flashing
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB1" -b "500000"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-09 15:08:12,883 # Connect to serial port /dev/ttyUSB1
Welcome to pyterm!
Type '/exit' to exit.
empty
> empty
> empty
> bufsize
2021-02-09 15:08:25,954 # 128
```

</details>

Naturally, `tests/shell` should still pass, when run as test

```
make -j -C tests/shell flash test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found in #15951, where a command with empty output lead to problems in the output parsing.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
