### PR TITLE
tests/driver_bq2429x: fix implicit conversion in helper function

### DIFF
--- a/tests/driver_bq2429x/_util.h
+++ b/tests/driver_bq2429x/_util.h
@@ -186,9 +186,9 @@ static inline const char *_util_chrg_stat_to_str(bq2429x_chrg_stat_t stat)
     return "";
 }
 
-static inline const char *_util_chrg_fault_to_str(bq2429x_chrg_stat_t stat)
+static inline const char *_util_chrg_fault_to_str(bq2429x_chrg_fault_t fault)
 {
-    switch (stat) {
+    switch (fault) {
         case BQ2429x_CHRG_FAULT_NORMAL:
             return "Normal";
         case BQ2429x_CHRG_FAULT_INPUT:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a small enum conversion bug in `tests/driver_bq2429x`. The fix is quite obvious, the parameter of one of the helper function expects a bq2429x_chrg_fault_t but it is declared as bq2429x_chrg_stat_t.
This raises a build failure when building with gcc 10 on risc-v.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock.

The build doesn't fail when building with gcc 10 on risc-v:

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C tests/driver_bq2429x --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT-review:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/tests/driver_bq2429x/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    
Building application "tests_driver_bq2429x" for "hifive1b" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/boards/hifive1b
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/cpu/riscv_common
"make" -C /data/riotbuild/riotbase/cpu/riscv_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/bq2429x
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  18282	    156	   2340	  20778	   512a	/data/riotbuild/riotbase/tests/driver_bq2429x/bin/hifive1b/tests_driver_bq2429x.elf
```

</details>

<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C tests/driver_bq2429x --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT-review:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/tests/driver_bq2429x/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    
Building application "tests_driver_bq2429x" for "hifive1b" with MCU "fe310".

/data/riotbuild/riotbase/tests/driver_bq2429x/main.c: In function '_bq2429x_get_fault_cmd':
/data/riotbuild/riotbase/tests/driver_bq2429x/main.c:138:57: error: implicit conversion from 'bq2429x_chrg_fault_t' to 'bq2429x_chrg_stat_t' [-Werror=enum-conversion]
  138 |     printf("Charge: %s\n", _util_chrg_fault_to_str(fault.chrg));
      |                                                    ~~~~~^~~~~
cc1: all warnings being treated as errors
/data/riotbuild/riotbase/Makefile.base:107: recipe for target '/data/riotbuild/riotbase/tests/driver_bq2429x/bin/hifive1b/application_tests_driver_bq2429x/main.o' failed
make[1]: *** [/data/riotbuild/riotbase/tests/driver_bq2429x/bin/hifive1b/application_tests_driver_bq2429x/main.o] Error 1
/data/riotbuild/riotbase/Makefile.include:618: recipe for target 'application_tests_driver_bq2429x.module' failed
make: *** [application_tests_driver_bq2429x.module] Error 2
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Must be fixed before https://github.com/RIOT-OS/riotdocker/pull/131 is merged and deployed on Murdock workers.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
