### PR TITLE
tests/driver_hih6130: fix 'absolute-value' error

### DIFF
--- a/tests/driver_hih6130/main.c
+++ b/tests/driver_hih6130/main.c
@@ -65,10 +65,10 @@ int main(void)
         /* Split value into two integer parts for printing. */
         fractional = modff(hum, &integral);
         printf("humidity: %4d.%04u %%",
-            (int)integral, (unsigned int)abs(fractional * 10000.f));
+            (int)integral, (unsigned int)abs((int)(fractional * 10000.f)));
         fractional = modff(temp, &integral);
         printf("  temperature: %4d.%04u C\n",
-            (int)integral, (unsigned int)abs(fractional * 10000.f));
+            (int)integral, (unsigned int)abs((int)(fractional * 10000.f)));
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a minor issues with a couple of calls of `abs` in `tests/driver_hih6130`. This function expect an int as input but a float is given. This leads to an error with gcc 10 (on riscv).
The proposed fix is to cast it to an int. It's untested but now it builds fine.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- If someone has the sensor, it would nice to have this PR tested on it
- The build succeeds on gcc 10 riscv:

<details><summary>this PR:</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=atmega256rfr2-xpro -C tests/driver_hih6130/ --no-print-directory Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT-review:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=atmega256rfr2-xpro'  -w '/data/riotbuild/riotbase/tests/driver_hih6130/' 'riot/riotbuild:latest' make 'BOARD=atmega256rfr2-xpro'    
Building application "tests_driver_hih6130" for "atmega256rfr2-xpro" with MCU "atmega256rfr2".

"make" -C /data/riotbuild/riotbase/boards/atmega256rfr2-xpro
"make" -C /data/riotbuild/riotbase/boards/common/atmega
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/atmega256rfr2
"make" -C /data/riotbuild/riotbase/cpu/atmega_common
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/periph
"make" -C /data/riotbuild/riotbase/cpu/avr8_common
"make" -C /data/riotbuild/riotbase/cpu/avr8_common/avr_libc_extra
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/hih6130
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  11390	    556	    984	  12930	   3282	/data/riotbuild/riotbase/tests/driver_hih6130/bin/atmega256rfr2-xpro/tests_driver_hih6130.elf
```

</details>

<details><summary>master:</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C tests/driver_hih6130/ --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT-review:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/tests/driver_hih6130/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    
Building application "tests_driver_hih6130" for "hifive1b" with MCU "fe310".

/data/riotbuild/riotbase/tests/driver_hih6130/main.c: In function 'main':
/data/riotbuild/riotbase/tests/driver_hih6130/main.c:68:42: error: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Werror=absolute-value]
   68 |             (int)integral, (unsigned int)abs(fractional * 10000.f));
      |                                          ^~~
/data/riotbuild/riotbase/tests/driver_hih6130/main.c:71:42: error: using integer absolute value function 'abs' when argument is of floating-point type 'float' [-Werror=absolute-value]
   71 |             (int)integral, (unsigned int)abs(fractional * 10000.f));
      |                                          ^~~
cc1: all warnings being treated as errors
/data/riotbuild/riotbase/Makefile.base:107: recipe for target '/data/riotbuild/riotbase/tests/driver_hih6130/bin/hifive1b/application_tests_driver_hih6130/main.o' failed
make[1]: *** [/data/riotbuild/riotbase/tests/driver_hih6130/bin/hifive1b/application_tests_driver_hih6130/main.o] Error 1
/data/riotbuild/riotbase/Makefile.include:618: recipe for target 'application_tests_driver_hih6130.module' failed
make: *** [application_tests_driver_hih6130.module] Error 2
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Must be fixed before RIOT-OS/riotdocker#131 is merged and deployed on Murdock workers.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
