### PR TITLE
cpu/sam0_common: flashpage: disable interrupts while writing

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -64,7 +64,7 @@ static inline void wait_nvm_is_ready(void)
 #endif
 }
 
-static void _unlock(void)
+static unsigned _unlock(void)
 {
     /* remove peripheral access lock for the NVMCTRL peripheral */
 #ifdef REG_PAC_WRCTRL
@@ -72,9 +72,11 @@ static void _unlock(void)
 #else
     PAC1->WPCLR.reg = PAC1_WPROT_DEFAULT_VAL;
 #endif
+
+    return irq_disable();
 }
 
-static void _lock(void)
+static void _lock(unsigned state)
 {
     wait_nvm_is_ready();
 
@@ -89,6 +91,8 @@ static void _lock(void)
 #ifdef CMCC
     CMCC->MAINT0.bit.INVALL = 1;
 #endif
+
+    irq_restore(state);
 }
 
 static void _cmd_clear_page_buffer(void)
@@ -225,7 +229,7 @@ static void _write_page(void* dst, const void *data, size_t len, void (*cmd_writ
     /* word align destination address */
     uint32_t *dst32 = (void*)((uintptr_t)dst & ~0x3);
 
-    _unlock();
+    unsigned state = _unlock();
     _cmd_clear_page_buffer();
 
     /* write the first, unaligned bytes */
@@ -252,7 +256,7 @@ static void _write_page(void* dst, const void *data, size_t len, void (*cmd_writ
     }
 
     cmd_write();
-    _lock();
+    _lock(state);
 }
 
 static void _erase_page(void* page, void (*cmd_erase)(void))
@@ -260,7 +264,7 @@ static void _erase_page(void* page, void (*cmd_erase)(void))
     uintptr_t page_addr = (uintptr_t)page;
 
     /* erase given page (the ADDR register uses 16-bit addresses) */
-    _unlock();
+    unsigned state = _unlock();
 
     /* ADDR drives the hardware (16-bit) address to the NVM when a command is executed using CMDEX.
      * 8-bit addresses must be shifted one bit to the right before writing to this register.
@@ -273,7 +277,7 @@ static void _erase_page(void* page, void (*cmd_erase)(void))
     _NVMCTRL->ADDR.reg = page_addr;
 
     cmd_erase();
-    _lock();
+    _lock(state);
 }
 
 static void _write_row(uint8_t *dst, const void *_data, size_t len, size_t chunk_size,


### PR DESCRIPTION
### Contribution description

This disabled interrupts while write operations on the internal flash are ongoing.
@firas-hamdi discovered that firmware updates over 802.15.4 with 1024 byte CoAP block size would sometimes (~10% of all updates) trigger a hard fault caused by an *Imprecise data access* (`IMPRECISERR`) on samd51.

I failed to re-create this on same54-xpro over Ethernet, so I was wondering if the increased interrupt load due to 6lo fragmentation might have something to do with it.


### Testing procedure

I'll try to come up with a setup that triggers this via GPIO interrupts.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
