### PR TITLE
build system: fix FEATURES_REQUIRED_ANY [backport 2021.01]

### DIFF
--- a/makefiles/features_check.inc.mk
+++ b/makefiles/features_check.inc.mk
@@ -32,10 +32,9 @@ FEATURES_USABLE := $(filter-out $(FEATURES_BLACKLIST),$(FEATURES_PROVIDED))
 FEATURES_REQUIRED_ONE_OUT_OF := $(foreach item,\
                                   $(FEATURES_REQUIRED_ANY),\
                                   $(word 1,\
-                                    $(filter $(subst |, ,$(item)),\
-                                              $(FEATURES_USED_SO_FAR) \
-                                              $(FEATURES_USABLE)) \
-                                              $(item)))
+                                    $(filter $(FEATURES_USED_SO_FAR) $(FEATURES_USABLE),\
+                                             $(subst |, ,$(item)))\
+                                    $(item)))
 
 # Features that are required by the application but not provided by the BSP
 # Having features missing may case the build to fail.


### PR DESCRIPTION
# Backport of #15957

### Contribution description

Previously, FEATURES_REQUIRED_ANY didn't honor the order of the alternatives
provided, if none of the features were already in used and multiple options
are provided. This fixes this.

### Testing procedure

See https://github.com/RIOT-OS/RIOT/pull/15855#issuecomment-773471032

### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/pull/15855