### PR TITLE
make: print spinning icon while flashing/resetting

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -709,10 +709,13 @@ distclean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i distclean ; done
 	-@rm -rf $(BINDIRBASE)
 
+# Include PROGRAMMER_FLASH/PROGRAMMER_RESET variables
+include $(RIOTMAKE)/tools/programmer.inc.mk
+
 # Define flash-recipe with a default value
 define default-flash-recipe
   $(call check_cmd,$(FLASHER),Flash program)
-  $(FLASHER) $(FFLAGS)
+  $(PROGRAMMER_FLASH)
 endef
 flash-recipe ?= $(default-flash-recipe)
 
@@ -774,7 +777,7 @@ endif
 
 reset:
 	$(call check_cmd,$(RESET),Reset program)
-	$(RESET) $(RESET_FLAGS)
+	$(PROGRAMMER_RESET)
 
 # tests related targets and variables
 include $(RIOTMAKE)/tests/tests.inc.mk

--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -172,17 +172,14 @@ info-iotlab-node:
 
 # Configure FLASHER, RESET, TERMPROG depending on BOARD and if on frontend
 
-# Command to check if 'stdin' is 0. Cannot use 'cmp - <(echo 0)' without bash shell
-_STDIN_EQ_0 = grep 0
-
 ifneq (iotlab-a8-m3,$(BOARD))
 
   # M3 nodes
   FLASHER     = iotlab-node
   RESET       = iotlab-node
-  _NODE_FMT   = --jmespath='keys(@)[0]' --format='int'
-  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) $(_NODES_FLASH_OPTION) $(FLASHFILE) | $(_STDIN_EQ_0)
-  RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) --reset | $(_STDIN_EQ_0)
+  _NODE_FMT   = --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'
+  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) $(_NODES_FLASH_OPTION) $(FLASHFILE)
+  RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) --reset
 
   ifeq (,$(_IOTLAB_ON_FRONTEND))
     TERMPROG  = ssh
@@ -198,8 +195,8 @@ else
   FLASHER     = iotlab-ssh
   RESET       = iotlab-ssh
   _NODE_FMT   = --jmespath='keys(values(@)[0])[0]' --fmt='int'
-  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) flash-m3 $(_IOTLAB_NODELIST) $(FLASHFILE) | $(_STDIN_EQ_0)
-  RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) reset-m3 $(_IOTLAB_NODELIST) | $(_STDIN_EQ_0)
+  FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) flash-m3 $(_IOTLAB_NODELIST) $(FLASHFILE)
+  RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) reset-m3 $(_IOTLAB_NODELIST)
 
   TERMPROG  = ssh
   ifeq (,$(_IOTLAB_ON_FRONTEND))

--- a/dist/tools/programmer/programmer.py
+++ b/dist/tools/programmer/programmer.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import time
+import shlex
+import subprocess
+import argparse
+
+from contextlib import contextmanager
+
+
+SUCCESS = "\033[32;1m✓\033[0m"
+FAILED = "\033[31;1m×\033[0m"
+SPIN = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+
+class Programmer:
+
+    @contextmanager
+    def spawn_process(self):
+        """Yield a subprocess running in background."""
+        kwargs = {} if self.verbose else {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT
+        }
+        yield subprocess.Popen(shlex.split(self.cmd), **kwargs)
+
+    def spin(self, process):
+        """Print a spinning icon while programmer process is running."""
+        while process.poll() is None:
+            for index in range(len(SPIN)):
+                sys.stdout.write(
+                    "\r \033[36;1m{}\033[0m {} in progress "
+                    "(programmer: '{}')"
+                    .format(SPIN[index], self.action, self.programmer)
+                )
+                sys.stdout.flush()
+                time.sleep(0.1)
+
+    def print_status(self, process, elapsed):
+        """Print status of background programmer process."""
+        print(
+            "\r \u001b[2K{} {} {} (programmer: '{}' - duration: {:0.2f}s)"
+            .format(
+                FAILED if process.returncode != 0 else SUCCESS,
+                self.action,
+                "failed!" if process.returncode != 0 else "done!",
+                self.programmer,
+                elapsed
+            )
+        )
+        # Print content of stdout (which also contain stderr) when the
+        # subprocess failed
+        if process.returncode != 0:
+            print(process.stdout.read().decode())
+        else:
+            print(
+                "(for full programmer output add PROGRAMMER_QUIET=0 or "
+                "QUIET=0 to the make command line)"
+            )
+
+    def run(self):
+        """Run the programmer in a background process."""
+        if not self.cmd.strip():
+            # Do nothing if programmer command is empty
+            return 0
+
+        if self.verbose:
+            print(self.cmd)
+        start = time.time()
+        with self.spawn_process() as proc:
+            try:
+                if self.verbose:
+                    proc.communicate()
+                else:
+                    self.spin(proc)
+            except KeyboardInterrupt:
+                proc.terminate()
+                proc.kill()
+        elapsed = time.time() - start
+        if not self.verbose:
+            # When using the spinning icon, print the programmer status
+            self.print_status(proc, elapsed)
+
+        return proc.returncode
+
+
+def main(parser):
+    """Main function."""
+    programmer = Programmer()
+    parser.parse_args(namespace=programmer)
+    # Return with same return code as subprocess
+    sys.exit(programmer.run())
+
+
+def parser():
+    """Return an argument parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--action", help="Programmer action")
+    parser.add_argument("--cmd", help="Programmer command")
+    parser.add_argument("--programmer", help="Programmer")
+    parser.add_argument(
+        "--verbose", action='store_true', default=False, help="Verbose output"
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    main(parser())

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -81,7 +81,7 @@ riotboot/bootloader/%: $(BUILDDEPS)
 		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
 		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID) \
-		PROGRAMMER=$(PROGRAMMER) \
+		PROGRAMMER=$(PROGRAMMER) PROGRAMMER_QUIET=$(PROGRAMMER_QUIET) \
 			$(MAKE) --no-print-directory -C $(RIOTBOOT_DIR) $*
 
 # Generate a binary file from the bootloader which fills all the

--- a/makefiles/tools/programmer.inc.mk
+++ b/makefiles/tools/programmer.inc.mk
@@ -1,0 +1,26 @@
+# Configure the programmer related variables
+
+PROGRAMMER_QUIET ?= $(QUIET)
+ifeq (0,$(PROGRAMMER_QUIET))
+  PROGRAMMER_VERBOSE_OPT ?= --verbose
+endif
+
+# Don't use the programmer wrapper for the CI (where speed and verbose output
+# are important)
+ifneq (1,$(RIOT_CI_BUILD))
+  USE_PROGRAMMER_WRAPPER_SCRIPT ?= 1
+else
+  USE_PROGRAMMER_WRAPPER_SCRIPT ?= 0
+endif
+
+ifeq (1,$(USE_PROGRAMMER_WRAPPER_SCRIPT))
+  PROGRAMMER_FLASH ?= @$(RIOTTOOLS)/programmer/programmer.py \
+    --action Flashing --cmd "$(FLASHER) $(FFLAGS)" \
+    --programmer "$(PROGRAMMER)" $(PROGRAMMER_VERBOSE_OPT)
+  PROGRAMMER_RESET ?= @$(RIOTTOOLS)/programmer/programmer.py \
+  --action Resetting --cmd "$(RESET) $(RESET_FLAGS)" \
+  --programmer "$(PROGRAMMER)" $(PROGRAMMER_VERBOSE_OPT)
+else
+  PROGRAMMER_FLASH ?= $(FLASHER) $(FFLAGS)
+  PROGRAMMER_RESET ?= $(RESET) $(RESET_FLAGS)
+endif

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -107,6 +107,10 @@ export HEXFILE               # The 'intel hex' stripped result of the compilatio
 # RESET_FLAGS                # The parameters to supply to RESET.
 # PROGRAMMER                 # The programmer to use when flashing, resetting or debugging
 # PROGRAMMERS_SUPPORTED      # The list of programmers supported by a board
+# PROGRAMMER_QUIET           # Change verbosity of programmer output (only used with flash and reset targets).
+                             # Default is 1, not verbose. Use 0 to get normal programmer output.
+# USE_PROGRAMMER_WRAPPER_SCRIPT     # Use the programmer wrapper Python script. Default is 1 (0 if RIOT_CI_BUILD is set).
+
 
 export DLCACHE               # directory used to cache http downloads
 export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL)` to download `$(URL)` to `$(DESTINATION)`.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is an RFC PR that introduces 2 variables to control the output of the flasher. Most of the time it's just noise, especially when pasting them as test output in a PR. The build system also provides the QUIET variable to silent the compiler output and replace it with a nice output. The idea of this PR is to something similar for the flasher and by default, only display the flasher command.

FLASHERLOG and FLASHER_OUTPUT variables are introduced to give a way to control the flasher output.

The proposed behavior is as follows:
- by default, when QUIET=1, nothing is printed to stdout and all output goes to a log file defined by FLASHERLOG
- if FLASHERLOG is empty, the output goes to stdout
- if QUIET=0 and FLASHERLOG is defined, the output goes to stdout and to the log file.
- by default, FLASHERLOG is defined as a file inside the application build directory: `$(BINDIR)/$(PROGRAMMER).log`

Maybe there's a better way to handle this but the proposed solution in this PR is quite simple. The other possibility that I see is to add a wrapper tool that runs the flasher in background with a nice activity printed during flash (dots or progress bar or whatever).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- By default, no flasher output is printed on stdout and the output is available in log file:

<details>

```
$ make BOARD=hifive1b -C examples/hello-world/ flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/jlink/jlink.sh flash /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin > /work/riot/RIOT/examples/hello-world/bin/hifive1b/jlink.log
$ cat /work/riot/RIOT/examples/hello-world/bin/hifive1b/jlink.log
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin]...
Comparing flash   [100%] Done.
Erasing flash     [100%] Done.
Programming flash [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: 1 range affected (65536 bytes)
J-Link: Flash download: Total: 0.398s (Prepare: 0.049s, Compare: 0.038s, Erase: 0.171s, Program & Verify: 0.119s, Restore: 0.019s)
J-Link: Flash download: Program & Verify speed: 537 KB/s
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.

```

</details>

- When QUIET=0, all output is printed both on stdout and in a log file:

<details>

```
QUIET=0 make BOARD=hifive1b -C examples/hello-world/ flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/jlink/jlink.sh flash /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin | tee /work/riot/RIOT/examples/hello-world/bin/hifive1b/jlink.log
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin]...
Comparing flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.


$ cat /work/riot/RIOT/examples/hello-world/bin/hifive1b/jlink.log
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin]...
Comparing flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.

```

</details>

- if FLASHERLOG (or FLASHER_OUTPUT) is empty, output is always printed to stdout:

<details>

```
$ FLASHERLOG= make BOARD=hifive1b -C examples/hello-world/ flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/jlink/jlink.sh flash /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin 
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin]...
Comparing flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.

$ FLASHERLOG= QUIET=0 make BOARD=hifive1b -C examples/hello-world/ flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/jlink/jlink.sh flash /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin 
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin]...
Comparing flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on ~#16046~, ~#16047~, ~#16050~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
