### PR TITLE
make/emulate: fix bugs when using flash target

### DIFF
--- a/makefiles/tools/cc2538-bsl.inc.mk
+++ b/makefiles/tools/cc2538-bsl.inc.mk
@@ -1,10 +1,13 @@
 FLASHFILE ?= $(BINFILE)
-FLASHER ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
+CC2538_BSL ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
 FFLAGS_OPTS ?=
 PROG_BAUD ?= 500000	# default value in cc2538-bsl
 
-FFLAGS  = $(if $(IMAGE_OFFSET), -a $(shell printf "0x%08x" $$(($(IMAGE_OFFSET) + $(ROM_START_ADDR)))))
-FFLAGS += -p "$(PROG_DEV)" $(FFLAGS_OPTS) --write-erase -v -b $(PROG_BAUD) $(FLASHFILE)
+CC2538_BSL_FLAGS  = $(if $(IMAGE_OFFSET), -a $(shell printf "0x%08x" $$(($(IMAGE_OFFSET) + $(ROM_START_ADDR)))))
+CC2538_BSL_FLAGS += -p "$(PROG_DEV)" $(FFLAGS_OPTS) --write-erase -v -b $(PROG_BAUD) $(FLASHFILE)
+
+FLASHER ?= $(CC2538_BSL)
+FFLAGS ?= $(CC2538_BSL_FLAGS)
 
 RESET ?= $(FLASHER) -p "$(PROG_DEV)" $(FFLAGS_OPTS) -b $(PROG_BAUD)
 

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -1,4 +1,4 @@
-FLASHER = $(RIOTTOOLS)/jlink/jlink.sh
+FLASHER ?= $(RIOTTOOLS)/jlink/jlink.sh
 DEBUGGER ?= $(RIOTTOOLS)/jlink/jlink.sh
 DEBUGSERVER ?= $(RIOTTOOLS)/jlink/jlink.sh
 RESET ?= $(RIOTTOOLS)/jlink/jlink.sh


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a couple of bugs in the build system when using EMULATE=1 and flash in the same command and the emulated boards are using jlink or cc2538-bsl as default programmer.
In the first case, hifive1b are affected and the command just fails. In the second case, cc2538dk and firefly are affected and a weird error message is printed, but the emulation can start still.

The problem comes from the fact that when using EMULATE=1, the FLASHER and FFLAGS variables are set to an empty value by the emulator logic:

https://github.com/RIOT-OS/RIOT/blob/b25c63757e22bde35056e3c83ecc8d70a42fbbff/makefiles/tools/renode.inc.mk#L60-L62

But in jlink.inc.mk, FLASHER is set regardless if it was already set before:

https://github.com/RIOT-OS/RIOT/blob/b25c63757e22bde35056e3c83ecc8d70a42fbbff/makefiles/tools/jlink.inc.mk#L1

And in cc2538-bsl.inc.mk, it's FFLAGS that is set this way:

https://github.com/RIOT-OS/RIOT/blob/b25c63757e22bde35056e3c83ecc8d70a42fbbff/makefiles/tools/cc2538-bsl.inc.mk#L6-L7

This PR is fixing both cases.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try to emulate the hifive1b and cc2538dk using this command `EMULATE=1 make BOARD=<board> -C examples/saul flash term`

- This PR:

<details><summary>hifive1b</summary>

```
$ EMULATE=1 make BOARD=hifive1b -C examples/saul flash term
make: Entering directory '/work/riot/RIOT/examples/saul'
Building application "saul_example" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/cpu/riscv_common
"make" -C /work/riot/RIOT/cpu/riscv_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  16216	    128	   2316	  18660	   48e4	/work/riot/RIOT/examples/saul/bin/hifive1b/saul_example.elf
/work/riot/RIOT/dist/tools/emulator/term.sh renode hifive1b /work/riot/RIOT/examples/saul /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_saul_example_hifive1b_uart" -b "115200" ' /tmp/riot_saul_example_hifive1b_uart 
Using Renode pid file /tmp/emulator_pid.udZRmQjf99
renode -e "set image_file '/work/riot/RIOT/examples/saul/bin/hifive1b/saul_example.elf'" -e "include @/work/riot/RIOT/boards/hifive1b/dist/board.resc" --pid-file /tmp/emulator_pid.udZRmQjf99 --hide-log -e "logLevel 2  " --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_saul_example_hifive1b_uart\" true" -e "connector Connect sysbus.uart0 term" -e start
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-09 19:09:50,750 # Connect to serial port /tmp/riot_saul_example_hifive1b_uart
Welcome to pyterm!
Type '/exit' to exit.
help
2021-02-09 19:09:53,512 # help
2021-02-09 19:09:53,513 # Command              Description
2021-02-09 19:09:53,514 # ---------------------------------------
2021-02-09 19:09:53,517 # reboot               Reboot the node
2021-02-09 19:09:53,517 # version              Prints current RIOT_VERSION
2021-02-09 19:09:53,518 # pm                   interact with layered PM subsystem
2021-02-09 19:09:53,518 # ps                   Prints information about running threads.
2021-02-09 19:09:53,519 # saul                 interact with sensors and actuators using SAUL
> 2021-02-09 19:09:54,340 # Exiting Pyterm
cleanup /tmp/emulator_pid.udZRmQjf99
```

</details>

<details><summary>cc2538dk</summary>

```
$ EMULATE=1 make BOARD=cc2538dk -C examples/saul flash term
make: Entering directory '/work/riot/RIOT/examples/saul'
Building application "saul_example" for "cc2538dk" with MCU "cc2538".

"make" -C /work/riot/RIOT/boards/cc2538dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  17628	    132	   2364	  20124	   4e9c	/work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.elf
/work/riot/RIOT/dist/tools/emulator/term.sh renode cc2538dk /work/riot/RIOT/examples/saul /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_saul_example_cc2538dk_uart" -b "115200" ' /tmp/riot_saul_example_cc2538dk_uart 
Using Renode pid file /tmp/emulator_pid.LG94NkTu5P
renode -e "set image_file '/work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.elf'" -e "include @/work/riot/RIOT/boards/cc2538dk/dist/board.resc" --pid-file /tmp/emulator_pid.LG94NkTu5P --hide-log -e "logLevel 2  " --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_saul_example_cc2538dk_uart\" true" -e "connector Connect sysbus.uart0 term" -e start
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-09 19:10:15,923 # Connect to serial port /tmp/riot_saul_example_cc2538dk_uart
hWelcome to pyterm!
Type '/exit' to exit.
help
2021-02-09 19:10:17,267 # help
2021-02-09 19:10:17,272 # Command              Description
2021-02-09 19:10:17,274 # ---------------------------------------
2021-02-09 19:10:17,280 # reboot               Reboot the node
2021-02-09 19:10:17,282 # version              Prints current RIOT_VERSION
2021-02-09 19:10:17,284 # pm                   interact with layered PM subsystem
2021-02-09 19:10:17,286 # ps                   Prints information about running threads.
2021-02-09 19:10:17,289 # saul                 interact with sensors and actuators using SAUL
> 2021-02-09 19:10:18,624 # Exiting Pyterm
cleanup /tmp/emulator_pid.LG94NkTu5P
make: Leaving directory '/work/riot/RIOT/examples/saul'
Terminated
```

</details>

- master:

<details><summary>hifive1b</summary>

```
$ BUILD_IN_DOCKER=1 EMULATE=1 make BOARD=hifive1b -C examples/saul flash term
make: Entering directory '/work/riot/RIOT/examples/saul'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/examples/saul/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    
Building application "saul_example" for "hifive1b" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/boards/hifive1b
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/cpu/riscv_common
"make" -C /data/riotbuild/riotbase/cpu/riscv_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/drivers/saul/init_devs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/picolibc_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  11443	     40	   2315	  13798	   35e6	/data/riotbuild/riotbase/examples/saul/bin/hifive1b/saul_example.elf
/work/riot/RIOT/dist/tools/jlink/jlink.sh 
/work/riot/RIOT/dist/tools/jlink/jlink.sh: 307: shift: can't shift that many
make: *** [/work/riot/RIOT/examples/saul/../../Makefile.include:707: flash] Error 2
```

=> I have to build in docker because my local toolchain is broken somehow.

</details>

<details><summary>cc2538dk</summary>

```
$ EMULATE=1 make BOARD=cc2538dk -C examples/saul flash term
make: Entering directory '/work/riot/RIOT/examples/saul'
Building application "saul_example" for "cc2538dk" with MCU "cc2538".

"make" -C /work/riot/RIOT/boards/cc2538dk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/cc2538
"make" -C /work/riot/RIOT/cpu/cc2538/periph
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  17576	    132	   2364	  20072	   4e68	/work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.elf
p "/tmp/riot_saul_example_cc2538dk_uart"  --write-erase -v -b 460800 /work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.bin
/bin/sh: 1: p: not found
make: [/work/riot/RIOT/examples/saul/../../Makefile.include:707: flash] Error 127 (ignored)
/work/riot/RIOT/dist/tools/emulator/term.sh renode cc2538dk /work/riot/RIOT/examples/saul /work/riot/RIOT/dist/tools/pyterm/pyterm '-p "/tmp/riot_saul_example_cc2538dk_uart" -b "115200" ' /tmp/riot_saul_example_cc2538dk_uart 
Using Renode pid file /tmp/emulator_pid.LtsRTRHyK3
renode -e "set image_file '/work/riot/RIOT/examples/saul/bin/cc2538dk/saul_example.elf'" -e "include @/work/riot/RIOT/boards/cc2538dk/dist/board.resc" --pid-file /tmp/emulator_pid.LtsRTRHyK3 --hide-log -e "logLevel 2  " --disable-xwt -e "emulation CreateUartPtyTerminal \"term\" \"/tmp/riot_saul_example_cc2538dk_uart\" true" -e "connector Connect sysbus.uart0 term" -e start
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-09 19:14:20,854 # Connect to serial port /tmp/riot_saul_example_cc2538dk_uart
heWelcome to pyterm!
Type '/exit' to exit.
help
2021-02-09 19:14:22,421 # help
2021-02-09 19:14:22,423 # Command              Description
2021-02-09 19:14:22,424 # ---------------------------------------
2021-02-09 19:14:22,428 # reboot               Reboot the node
2021-02-09 19:14:22,429 # version              Prints current RIOT_VERSION
2021-02-09 19:14:22,431 # pm                   interact with layered PM subsystem
2021-02-09 19:14:22,435 # ps                   Prints information about running threads.
2021-02-09 19:14:22,439 # saul                 interact with sensors and actuators using SAUL
> 2021-02-09 19:14:23,376 # Exiting Pyterm
cleanup /tmp/emulator_pid.LtsRTRHyK3
make: Leaving directory '/work/riot/RIOT/examples/saul'
Terminated
```

=> here you can see in the output the message "/bin/sh: 1: p: not found". This is because of the FFLAGS being redefined and used as a command by the flashing code.

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that problem while working on #15970 (I wanted to verify that EMULATE=1 was not affected)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
