### PR TITLE
drivers/periph_ptp: fix clock adjustment API

### DIFF
--- a/cpu/stm32/periph/ptp.c
+++ b/cpu/stm32/periph/ptp.c
@@ -114,11 +114,11 @@ void ptp_init(void)
           ptptsar, ptpssir);
 }
 
-void ptp_clock_adjust_speed(int16_t correction)
+void ptp_clock_adjust_speed(int32_t correction)
 {
     uint64_t offset = ptptsar;
     offset *= correction;
-    offset >>= 16;
+    offset >>= 32;
     uint32_t adjusted_ptptsar = ptptsar + (uint32_t)offset;
     /* Value to add onto the 32 bit accumulator register (which causes the
      * value in ETH->PTPSSIR to be added onto the subsection register on

--- a/drivers/include/periph/ptp.h
+++ b/drivers/include/periph/ptp.h
@@ -216,18 +216,18 @@ void ptp_init(void);
  *
  * 1. A call with @p correction set to `0` restores the nominal clock speed.
  * 2. A call with a positive value for @p correction speeds the clock up
- *    by `correction / (1 << 16)` (so up to ~50% for `INT16_MAX`).
+ *    by `correction / (1 << 32)` (so up to ~50% for `INT32_MAX`).
  * 3. A call with a negative value for @p correction slows the clock down by
- *    `-correction / (1 << 16)` (so up to 50% for `INT16_MIN`).
+ *    `-correction / (1 << 32)` (so up to 50% for `INT32_MIN`).
  *
- * This allows the clock speed to be adjusted in steps ± 0.00153% in relation
+ * This allows the clock speed to be adjusted in steps ± 2.3284E-08 % in relation
  * to its nominal clock speed, thus, allowing to counter systematic clock drift.
  * In addition, this is intended to "smoothly" synchronize the clock over time
  * to avoid jumps in the system time. (Especially calling @ref ptp_clock_adjust
  * with negative values might be something to avoid, when applications are not
  * prepared with clocks going backwards.)
  */
-void ptp_clock_adjust_speed(int16_t correction);
+void ptp_clock_adjust_speed(int32_t correction);
 
 /**
  * @brief   Adjust the PTP clock as given

--- a/tests/periph_ptp_clock/main.c
+++ b/tests/periph_ptp_clock/main.c
@@ -63,11 +63,11 @@ static void speed_adj_cb(void *arg, int chan)
     mutex_unlock(&sync_mutex);
 }
 
-static int test_speed_adjustment(const int16_t speed)
+static int test_speed_adjustment(const int32_t speed)
 {
 
     uint32_t expected_ns = TEST_TIME_US * 1000;
-    expected_ns += ((int64_t)expected_ns * speed) >> 16;
+    expected_ns += ((int64_t)expected_ns * speed) >> 32;
     const uint32_t expected_ns_lower = expected_ns *  9999ULL / 10000ULL;
     const uint32_t expected_ns_upper = expected_ns * 10001ULL / 10000ULL;
 
@@ -77,7 +77,7 @@ static int test_speed_adjustment(const int16_t speed)
     print_str(" (~");
     {
         int64_t tmp = speed * 100000ULL;
-        tmp = (tmp + UINT16_MAX / 2) / UINT16_MAX;
+        tmp /= UINT32_MAX;
         tmp += 100000ULL;
         char output[16];
         print(output, fmt_s32_dfp(output, (int32_t)tmp, -3));
@@ -230,8 +230,9 @@ static int test_clock_adjustment(int32_t offset)
 
 int main(void)
 {
-    static const int16_t speeds[] = {
-        0, INT16_MAX, INT16_MIN, 1337, -1337, 42, -42, 665, -665
+    static const int32_t speeds[] = {
+        /* 0%, +50%, -50%, +1%, -1%, +0.1%, -0.1%, +42/(2^32), -42/(2^32) */
+        0, INT32_MAX, INT32_MIN, 42949673, -42949673, 4294967, -4294967, 42, -42
     };
     static const int32_t offsets[] = {
         0, -1337, +1337, INT32_MAX


### PR DESCRIPTION
### Contribution description

The clock adjustment API only used a 16 bit integer for speed correction. This
is to course grained to allow compensating clock drifts at high accuracy.
Using a 32 bit integer instead would allow to fix for a drift of up to
about 1 nanosecond drift per each 5 seconds.

### Testing procedure

The test application was updated to the new API, the test should still pass.

### Issues/PRs references

none
