### PR TITLE
riotctrl_ctrl: A reset helper class for `native`

### DIFF
--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -24,10 +24,13 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox
         python -m pip install kconfiglib
+        sudo apt-get install gcc-multilib
     - name: Test backport_pr
       run: cd dist/tools/backport_pr && tox
     - name: Test compile_and_test_for_board
       run: cd dist/tools/compile_and_test_for_board && tox
+    - name: Test riotctrl_ctrl
+      run: cd dist/pythonlibs/riotctrl_ctrl && tox
     - name: Test riotctrl_shell
       run: cd dist/pythonlibs/riotctrl_shell && tox
     - name: Test kconfig script

--- a/dist/pythonlibs/riotctrl_ctrl/native.py
+++ b/dist/pythonlibs/riotctrl_ctrl/native.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2021 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import riotctrl.ctrl
+
+import psutil
+
+
+class NativeRIOTCtrl(riotctrl.ctrl.RIOTCtrl):
+    """RIOTCtrl abstraction for a native node
+
+    This works exactly as a normal RIOTCtrl, with the exception that
+    `DEBUG_ADAPTER_ID` is set in the environment to the PID of the `native`
+    process, whenever a terminal is started. This allows for `reset()` to also
+    work for a the `native` instance.
+    """
+    def _set_debug_adapter_id(self, child):
+        if child.name().endswith('.elf'):
+            self.env['DEBUG_ADAPTER_ID'] = str(child.pid)
+            return True
+        return False
+
+    def start_term(self, *args, **kwargs):
+        super().start_term(*args, **kwargs)
+        for child in psutil.Process(pid=self._term_pid()).children():
+            if self._set_debug_adapter_id(child):
+                break

--- a/dist/pythonlibs/riotctrl_ctrl/requirements.txt
+++ b/dist/pythonlibs/riotctrl_ctrl/requirements.txt
@@ -1,0 +1,2 @@
+psutil
+riotctrl

--- a/dist/pythonlibs/riotctrl_ctrl/tests/test_native.py
+++ b/dist/pythonlibs/riotctrl_ctrl/tests/test_native.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2021 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os.path
+
+import riotctrl.ctrl
+
+import riotctrl_ctrl.native
+
+
+def test_reset():
+    env = {'DEBUG_ADAPTER_ID': '', 'BOARD': 'native'}
+    ctrl = riotctrl_ctrl.native.NativeRIOTCtrl(
+        application_directory=os.path.normpath(os.path.join(
+            os.path.abspath(__file__),
+            '..', '..', '..', '..', '..',
+            'examples', 'hello-world'
+        )),
+        env=env,
+    )
+    print(ctrl.application_directory)
+    assert not ctrl.env['DEBUG_ADAPTER_ID']
+    ctrl.make_run(['flash'])
+    with ctrl.run_term(reset=False):
+        # DEBUG_ADAPTER_ID is now a PID
+        assert int(ctrl.env['DEBUG_ADAPTER_ID'])
+        ctrl.term.expect_exact('Hello World!')
+        ctrl.reset()
+        ctrl.term.expect_exact('!! REBOOT !!')
+        ctrl.term.expect_exact('Hello World!')
+
+
+def test_w_factory():
+    env = {'BOARD': 'native'}
+    factory = riotctrl.ctrl.RIOTCtrlBoardFactory(
+        board_cls={'native': riotctrl_ctrl.native.NativeRIOTCtrl}
+    )
+    assert 'native' in factory.board_cls
+    ctrl = factory.get_ctrl(env=env)
+    # pylint: disable=unidiomatic-typecheck
+    # in this case we want to know the exact type
+    assert type(ctrl) is riotctrl_ctrl.native.NativeRIOTCtrl

--- a/dist/pythonlibs/riotctrl_ctrl/tox.ini
+++ b/dist/pythonlibs/riotctrl_ctrl/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = test,flake8
+skipsdist = True
+
+[testenv]
+commands =
+    test:       {[testenv:test]commands}
+    flake8:     {[testenv:flake8]commands}
+
+[testenv:test]
+deps =
+    pytest
+    -rrequirements.txt
+commands =
+    pytest -v --doctest-modules
+
+[testenv:flake8]
+deps = flake8
+commands =
+    flake8 .


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides two helper classes for tests with `riotctrl`:

1. A `NativeRIOTCtrl` for native specifically, so the nodes can be resetable with the workflow provided in https://github.com/RIOT-OS/RIOT/pull/12517.
2. ~~A factory class `RIOTCtrlFactory` that allows for automatic generation of a RIOTCtrl object. In a first step, the `NativeRIOTCtrl` is selected, when `BOARD` is set to `native` in the environment variables (or a provided `env` dictionary)~~ ([migrated to `riotctrl`](https://github.com/RIOT-OS/riotctrl/pull/18))
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tests are provided and hooked into the `test-tools` Github Action. For manual testing call

```
cd dist/pythonlibs/riotctrl_ctrl
tox
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
