### PR TITLE
sys/fmt: Add print_s64_dec to header

### DIFF
--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -476,6 +476,15 @@ void print_u64_hex(uint64_t val);
 void print_u64_dec(uint64_t val);
 
 /**
+ * @brief Print int64 value as decimal to stdout
+ *
+ * @note This uses fmt_s64_dec(), which uses ~400b of code.
+ *
+ * @param[in]   val  Value to print
+ */
+void print_s64_dec(uint64_t val);
+
+/**
  * @brief Print float value
  *
  * @note See fmt_float for code size warning!

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -25,6 +25,24 @@
 int main(void)
 {
     print_str("If you can read this:\n");
+    print_u32_dec(0xFFFFFFFF);
+    print_str("\n");
+    print_s32_dec(0x80000000);
+    print_str("\n");
+    print_byte_hex(0xFA);
+    print_str("\n");
+    print_s32_dec(0x80000000);
+    print_str("\n");
+    print_u32_hex(0x12345678);
+    print_str("\n");
+    print_u64_hex(0x123456789ABCDEF0);
+    print_str("\n");
+    print_u64_dec(0xFFFFFFFFFFFFFFFF);
+    print_str("\n");
+    print_s64_dec(0x8000000000000000);
+    print_str("\n");
+    print_float(1.2345, 5);
+    print_str("\n");
     print_str("Test successful.\n");
 
     return 0;

--- a/tests/fmt_print/tests/01-run.py
+++ b/tests/fmt_print/tests/01-run.py
@@ -6,6 +6,15 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact('If you can read this:')
+    child.expect_exact('4294967295')
+    child.expect_exact('-2147483648')
+    child.expect_exact('FA')
+    child.expect_exact('-2147483648')
+    child.expect_exact('12345678')
+    child.expect_exact('123456789ABCDEF0')
+    child.expect_exact('18446744073709551615')
+    child.expect_exact('-9223372036854775808')
+    child.expect_exact('1.23450')
     child.expect_exact('Test successful.')
 
 

--- a/tests/periph_ptp_clock/main.c
+++ b/tests/periph_ptp_clock/main.c
@@ -46,16 +46,6 @@
 static mutex_t sync_mutex = MUTEX_INIT_LOCKED;
 static atomic_uint_least64_t timestamp;
 
-static inline void print_s64_dec(int64_t _num)
-{
-    uint64_t num = _num;
-    if (_num < 0) {
-        print_str("-");
-        num = -_num;
-    }
-    print_u64_dec(num);
-}
-
 static void speed_adj_cb(void *arg, int chan)
 {
     (void)arg;


### PR DESCRIPTION
### Contribution description

It seems that `print_s64_dec` is implemented but not exposed in the header.
This PR exposes it and improves coverage of the `fmt` module. 

### Testing procedure

`make all test -C tests/fmt_print/`

CI should pass too.

### Issues/PRs references
 Split from #15950