### PR TITLE
pkg/umorse: Add kconfig option

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -25,7 +25,8 @@ tests/mtd_mapper tests/driver_o* tests/driver_p* tests/driver_q*
 tests/driver_r* tests/driver_s* tests/driver_t* tests/driver_u*
 tests/driver_v*"}
 : ${TEST_KCONFIG_native:="examples/hello-world tests/periph_* tests/sys_crypto
-tests/prng_* tests/xtimer_* tests/ztimer_* tests/driver_ws281x"}
+tests/prng_* tests/xtimer_* tests/ztimer_* tests/driver_ws281x
+tests/pkg_umorse"}
 
 : ${TEST_WITH_CONFIG_SUPPORTED:="examples/suit_update tests/driver_at86rf2xx_aes"}
 

--- a/pkg/Kconfig
+++ b/pkg/Kconfig
@@ -10,5 +10,6 @@ rsource "driver_bme680/Kconfig"
 rsource "semtech-loramac/Kconfig"
 rsource "tinydtls/Kconfig"
 rsource "wakaama/Kconfig"
+rsource "umorse/Kconfig"
 
 endmenu # Packages

--- a/pkg/umorse/Kconfig
+++ b/pkg/umorse/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+config PACKAGE_UMORSE
+    bool "umorse"
+    select MODULE_POSIX_SLEEP


### PR DESCRIPTION
### Contribution description

Add the umorse pkg to the pkg rsource and expose dependencies.

### Testing procedure

`TEST_KCONFIG=1 make menuconfig -C tests/pkg_umorse/`

### Issues/PRs references

Split from #15950