### PR TITLE
cpu/nrf52: add VDDHDIV5 as ADC input

### DIFF
--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -60,7 +60,11 @@ extern "C" {
 /**
  * @brief   The nRF52 family of CPUs provides a fixed number of 9 ADC lines
  */
+#ifdef SAADC_CH_PSELP_PSELP_VDDHDIV5
+#define ADC_NUMOF           (10U)
+#else
 #define ADC_NUMOF           (9U)
+#endif
 
 /**
  * @brief   SPI temporary buffer size for storing const data in RAM before
@@ -83,6 +87,9 @@ enum {
     NRF52_AIN6 = 6,         /**< Analog Input 6 */
     NRF52_AIN7 = 7,         /**< Analog Input 7 */
     NRF52_VDD  = 8,         /**< VDD, not useful if VDD is reference... */
+#ifdef SAADC_CH_PSELP_PSELP_VDDHDIV5
+    NRF52_VDDHDIV5 = 9,     /**< VDDH divided by 5 */
+#endif
 };
 
 #ifndef DOXYGEN

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -114,13 +114,23 @@ int32_t adc_sample(adc_t line, adc_res_t res)
         return -1;
     }
 
+#ifdef SAADC_CH_PSELP_PSELP_VDDHDIV5
+    if (line == NRF52_VDDHDIV5) {
+        line = SAADC_CH_PSELP_PSELP_VDDHDIV5;
+    } else {
+        line += 1;
+    }
+#else
+    line += 1;
+#endif
+
     /* prepare device */
     prep();
 
     /* set resolution */
     NRF_SAADC->RESOLUTION = res;
     /* set line to sample */
-    NRF_SAADC->CH[0].PSELP = (line + 1);
+    NRF_SAADC->CH[0].PSELP = line;
 
     /* start the SAADC and wait for the started event */
     NRF_SAADC->EVENTS_STARTED = 0;


### PR DESCRIPTION
### Contribution description
The nrf52840 has the awesome option to be powered by an external voltage source from ~3V to over 5V, making it possible to attach the CPU directly to e.g. an USB bus or an li-ion battery. In that case the supply voltage is connected to the CPUs VDDH input pin. This is done e.g. on the `nrf52840dongle` board.

The ADC module for the nrf52 family of CPUs does allow to select their internal VDDH line as input for the ADC, allowing for example to directly sample the volage of an attached li-ion battery without the need of any external components. This PR enables support for this ADC input.

### Testing procedure
Build test and a good review (easy for this 3 line change :-) ) should do. I did test and verify it on a `nrf52840dongle`.


### Issues/PRs references
none