### PR TITLE
build system: support wrong target triples with LLVM

### DIFF
--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -51,15 +51,16 @@ gcc_include_dirs = $(realpath \
 )
 
 ifneq (,$(TARGET_ARCH))
+  TARGET_ARCH_LLVM ?= $(TARGET_ARCH)
   ifeq (,$(CFLAGS_CPU))
     $(error CFLAGS_CPU must have been defined to use `llvm`.)
   endif
 
   # Tell clang to cross compile
-  CFLAGS     += -target $(TARGET_ARCH)
-  CXXFLAGS   += -target $(TARGET_ARCH)
+  CFLAGS     += -target $(TARGET_ARCH_LLVM)
+  CXXFLAGS   += -target $(TARGET_ARCH_LLVM)
   # We currently don't use LLVM for linking (see comment above).
-  # LINKFLAGS  += -target $(TARGET_ARCH)
+  # LINKFLAGS  += -target $(TARGET_ARCH_LLVM)
 
   # Clang on Linux uses GCC's C and C++ headers and libstdc++ (installed with GCC)
 


### PR DESCRIPTION
### Contribution description

clang/LLVM is a bit more finicky with what target triples it accepts compared
to GCC. However, the GCC target triple is needed to properly locate the C
libraries. In case a locally installed GCC toolchain uses a technically not
fully correct target triple, it might be impossible to build with LLVM.

The solution here is to allow specifying a TARGET_ARCH_LLVM target triple
(which defaults to TARGET_ARCH), which is passed to clang. For locating the
C lib, still TARGET_ARCH is used.

### Testing procedure

Murdock will do.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/15176