### PR TITLE
drivers/mtd_spi_nor: fix poll on init

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -393,7 +393,7 @@ static int mtd_spi_nor_power(mtd_dev_t *mtd, enum mtd_power_state power)
                 xtimer_usleep(dev->params->wait_chip_wake_up);
                 res = mtd_spi_read_jedec_id(dev, &dev->jedec_id);
                 retries++;
-            } while (res < 0 || retries < MTD_POWER_UP_WAIT_FOR_ID);
+            } while (res < 0 && retries < MTD_POWER_UP_WAIT_FOR_ID);
             if (res < 0) {
                 return -EIO;
             }


### PR DESCRIPTION

The while condition for polling the chip ID is broken, it will always poll for the max amount of retries.

Change the condition from `or` to `and` to fix the logic.


### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A spi nor device is still detected by `tests/mtd_raw`

```
2021-02-11 22:52:00,752 # test 0
2021-02-11 22:52:00,752 # [START]
2021-02-11 22:52:00,980 # [SUCCESS]

2021-02-11 22:52:11,040 # info 0
2021-02-11 22:52:11,040 # sectors: 128
2021-02-11 22:52:11,041 # pages per sector: 16
2021-02-11 22:52:11,041 # page size: 256
2021-02-11 22:52:11,042 # total: 512 kiB
```


### Issues/PRs references

fixes #15894

