### PR TITLE
cpu/fe310: set back newlib as default libc

### DIFF
--- a/cpu/fe310/Makefile.dep
+++ b/cpu/fe310/Makefile.dep
@@ -1,5 +1,5 @@
 
-FEATURES_REQUIRED_ANY += picolibc|newlib
+FEATURES_REQUIRED_ANY += newlib|picolibc
 ifneq (,$(filter newlib,$(USEMODULE)))
   USEMODULE += newlib_nano
   USEMODULE += newlib_syscalls_default


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a regression introduced by the combination of #15859 and #15957. Initially newlib was used as default libc on fe310 and the regression forces the use of picolibc.

For users with local toolchains providing newlib by default, this regression is a breaking change. Note that in recent Ubuntu versions, riscv64-unknown-elf is available in the package manager but it doesn't come with newlib and the package manager only provides picolibc. So it's not possible to use the riscv toolchain in the package manager of Ubuntu unless FEATURES_REQUIRED=picolibc is added to the build command. So this is not optimal but there's no good solution for all setup at the moment (until we have a way to automatically detect and use the available libc).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock (Murdock provides both newlib and picolibc)
- Use a prebuilt toolchain from https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack with picolibc installed and build a firmware for hifive1b:

<details><summary>this PR</summary>

```
$ make BOARD=hifive1b -C examples/hello-world --no-print-directory 
Building application "hello-world" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/cpu/riscv_common
"make" -C /work/riot/RIOT/cpu/riscv_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   7790	    108	   2248	  10146	   27a2	/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
```

</details>

<details><summary>master</summary>

```
$ make BOARD=hifive1b -C examples/hello-world --no-print-directory 
Building application "hello-world" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/cpu/riscv_common
"make" -C /work/riot/RIOT/cpu/riscv_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/picolibc_syscalls_default
/work/riot/RIOT/sys/picolibc_syscalls_default/syscalls.c:236:5: error: implicit declaration of function 'FDEV_SETUP_STREAM' [-Werror=implicit-function-declaration]
  236 |     FDEV_SETUP_STREAM(picolibc_put, picolibc_get, picolibc_flush, _FDEV_SETUP_RW);
      |     ^~~~~~~~~~~~~~~~~
/work/riot/RIOT/sys/picolibc_syscalls_default/syscalls.c:236:67: error: '_FDEV_SETUP_RW' undeclared here (not in a function)
  236 |     FDEV_SETUP_STREAM(picolibc_put, picolibc_get, picolibc_flush, _FDEV_SETUP_RW);
      |                                                                   ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[3]: *** [/work/riot/RIOT/Makefile.base:107: /work/riot/RIOT/examples/hello-world/bin/hifive1b/picolibc_syscalls_default/syscalls.o] Error 1
make[2]: *** [/work/riot/RIOT/Makefile.base:30: ALL--/work/riot/RIOT/sys/picolibc_syscalls_default] Error 2
make[1]: *** [/work/riot/RIOT/Makefile.base:30: ALL--/work/riot/RIOT/sys] Error 2
make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:618: application_hello-world.module] Error 2
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#15859 and #15957

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
