### PR TITLE
cpu/nrf5x: enhance enabling of internal DC/DC converter

### DIFF
--- a/boards/acd52832/include/periph_conf.h
+++ b/boards/acd52832/include/periph_conf.h
@@ -81,11 +81,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/nrf52xxxdk/Kconfig
+++ b/boards/common/nrf52xxxdk/Kconfig
@@ -11,5 +11,6 @@ config BOARD_COMMON_NRF52XXXDK
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/common/nrf52xxxdk/Makefile.features
+++ b/boards/common/nrf52xxxdk/Makefile.features
@@ -3,5 +3,6 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -68,11 +68,6 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -14,5 +14,6 @@ config BOARD_COMMON_PARTICLE_MESH
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_HIGHLEVEL_STDIO
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 # Various other features (if any)
 

--- a/boards/dwm1001/Kconfig
+++ b/boards/dwm1001/Kconfig
@@ -15,5 +15,6 @@ config BOARD_DWM1001
     select HAS_PERIPH_I2C
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/dwm1001/Makefile.features
+++ b/boards/dwm1001/Makefile.features
@@ -4,5 +4,6 @@ CPU_MODEL = nrf52832xxaa
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/dwm1001/include/periph_conf.h
+++ b/boards/dwm1001/include/periph_conf.h
@@ -77,11 +77,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/microbit-v2/Kconfig
+++ b/boards/microbit-v2/Kconfig
@@ -16,5 +16,6 @@ config BOARD_MICROBIT_V2
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/microbit-v2/Makefile.features
+++ b/boards/microbit-v2/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 # include common nrf52 based boards features
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/microbit-v2/include/periph_conf.h
+++ b/boards/microbit-v2/include/periph_conf.h
@@ -30,11 +30,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
-/**
  * @name    UART configuration
  * @{
  */

--- a/boards/nrf51dk/Kconfig
+++ b/boards/nrf51dk/Kconfig
@@ -16,5 +16,6 @@ config BOARD_NRF51DK
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_HW_FC
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/nrf51dk/Makefile.features
+++ b/boards/nrf51dk/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_uart_hw_fc
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 # include common nrf51 based boards features
 include $(RIOTBOARD)/common/nrf51/Makefile.features

--- a/boards/nrf51dk/include/periph_conf.h
+++ b/boards/nrf51dk/include/periph_conf.h
@@ -73,11 +73,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf52832-mdk/Kconfig
+++ b/boards/nrf52832-mdk/Kconfig
@@ -14,5 +14,6 @@ config BOARD_NRF52832_MDK
     select CPU_MODEL_NRF52832XXAA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_UART
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52832-mdk/Makefile.features
+++ b/boards/nrf52832-mdk/Makefile.features
@@ -3,5 +3,6 @@ CPU_MODEL = nrf52832xxaa
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52832-mdk/include/periph_conf.h
+++ b/boards/nrf52832-mdk/include/periph_conf.h
@@ -40,11 +40,6 @@ extern "C" {
 #define UART_PIN_TX         GPIO_PIN(0,20)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf52840-mdk/Kconfig
+++ b/boards/nrf52840-mdk/Kconfig
@@ -16,5 +16,6 @@ config BOARD_NRF52840_MDK
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840-mdk/Makefile.features
+++ b/boards/nrf52840-mdk/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 # Various other features (if any)
 

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -53,11 +53,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf52840dk/Kconfig
+++ b/boards/nrf52840dk/Kconfig
@@ -14,5 +14,6 @@ config BOARD_NRF52840DK
     select CPU_MODEL_NRF52840XXAA
     select HAS_PERIPH_PWM
     select HAS_PERIPH_USBDEV
+    select HAS_VDD_LC_FILTER_REG0
 
 source "$(RIOTBOARD)/common/nrf52xxxdk/Kconfig"

--- a/boards/nrf52840dk/Makefile.features
+++ b/boards/nrf52840dk/Makefile.features
@@ -5,3 +5,4 @@ include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features
 # Various other features (if any)
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += vdd_lc_filter_reg0

--- a/boards/nrf52840dongle/Kconfig
+++ b/boards/nrf52840dongle/Kconfig
@@ -16,5 +16,7 @@ config BOARD_NRF52840DONGLE
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_HIGHLEVEL_STDIO
+    select HAS_VDD_LC_FILTER_REG0
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840dongle/Makefile.features
+++ b/boards/nrf52840dongle/Makefile.features
@@ -4,6 +4,8 @@ CPU_MODEL = nrf52840xxaa
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += vdd_lc_filter_reg0
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 # Various other features (if any)
 FEATURES_PROVIDED += highlevel_stdio

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -71,13 +71,6 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#ifndef NRF5X_ENABLE_DCDC
-#define NRF5X_ENABLE_DCDC   1
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/particle-argon/include/periph_conf.h
+++ b/boards/particle-argon/include/periph_conf.h
@@ -60,11 +60,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/particle-boron/include/periph_conf.h
+++ b/boards/particle-boron/include/periph_conf.h
@@ -60,11 +60,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/particle-xenon/include/periph_conf.h
+++ b/boards/particle-xenon/include/periph_conf.h
@@ -60,11 +60,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pinetime/Kconfig
+++ b/boards/pinetime/Kconfig
@@ -14,5 +14,6 @@ config BOARD_PINETIME
     select CPU_MODEL_NRF52832XXAA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_SPI
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/pinetime/Makefile.features
+++ b/boards/pinetime/Makefile.features
@@ -4,5 +4,6 @@ CPU_MODEL = nrf52832xxaa
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 #FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/pinetime/include/periph_conf.h
+++ b/boards/pinetime/include/periph_conf.h
@@ -64,11 +64,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/reel/Kconfig
+++ b/boards/reel/Kconfig
@@ -16,5 +16,6 @@ config BOARD_REEL
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/reel/Makefile.features
+++ b/boards/reel/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 # Various other features (if any)
 

--- a/boards/reel/include/periph_conf.h
+++ b/boards/reel/include/periph_conf.h
@@ -68,11 +68,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/ruuvitag/Kconfig
+++ b/boards/ruuvitag/Kconfig
@@ -14,5 +14,6 @@ config BOARD_RUUVITAG
     select CPU_MODEL_NRF52832XXAA
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -3,5 +3,6 @@ CPU_MODEL = nrf52832xxaa
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/ruuvitag/include/periph_conf.h
+++ b/boards/ruuvitag/include/periph_conf.h
@@ -55,11 +55,6 @@ static const spi_conf_t spi_config[] = {
 #define UART_PIN_TX         GPIO_PIN(0, 5)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/thingy52/Kconfig
+++ b/boards/thingy52/Kconfig
@@ -14,5 +14,6 @@ config BOARD_THINGY52
     select CPU_MODEL_NRF52832XXAA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_UART
+    select HAS_VDD_LC_FILTER_REG1
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -3,5 +3,6 @@ CPU_MODEL = nrf52832xxaa
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += vdd_lc_filter_reg1
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/thingy52/include/periph_conf.h
+++ b/boards/thingy52/include/periph_conf.h
@@ -62,11 +62,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
-/**
- * @brief Enable the internal DC/DC converter
- */
-#define NRF5X_ENABLE_DCDC
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf5x_common/Kconfig
+++ b/cpu/nrf5x_common/Kconfig
@@ -43,4 +43,16 @@ config HAS_RADIO_NRFMIN
         Indicates that a radio compatible with the nRF minimal radio driver is
         present.
 
+config HAS_VDD_LC_FILTER_REG0
+    bool
+    help
+        Indicates that a board is equipped with an external LC filter circuit
+        attached to the CPUs voltage regulator stage 0.
+
+config HAS_VDD_LC_FILTER_REG1
+    bool
+    help
+        Indicates that a board is equipped with an external LC filter circuit
+        attached to the CPUs voltage regulator stage 1.
+
 source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/nrf5x_common/Makefile.dep
+++ b/cpu/nrf5x_common/Makefile.dep
@@ -3,3 +3,10 @@ USEMODULE += nrf5x_common_periph
 
 # link common cpu code
 USEMODULE += cpu_common
+
+# per default, enable DCDC converter if an external LC filter is provided
+# reg1 feature denotes state 1 on two-stage regulator models or the single
+# state in single-regulator models
+FEATURES_OPTIONAL += vdd_lc_filter_reg1
+# reg0 feature denotes stage 0 two-stage regulator models
+FEATURES_OPTIONAL += vdd_lc_filter_reg0

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -57,3 +57,6 @@ endif
 
 # use efm32_coretemp if the feature is used
 USEMODULE += $(filter efm32_coretemp, $(FEATURES_USED))
+
+# if LC filter(s) is attached to the CPUs voltage regulator, use it
+USEMODULE += $(filter vdd_lc_filter_%,$(FEATURES_USED))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -147,6 +147,7 @@ PSEUDOMODULES += stm32mp1_eng_mode
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
+PSEUDOMODULES += vdd_lc_filter_%
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer


### PR DESCRIPTION
### Contribution description
Currently, the use of the DC/DC mode of the NRFs internal voltage regulator is hard coded per board. This PR is optimizing the enabling code by making use of the encouraged  `IS_ACTIVE()` macro and adapting the existing board configs to define the used `NRF5X_ENABLE_DCDC` macro to `1`.

This PR further allows to override this setting by e.g. defining this macro to `0` during compile time, e.g. `CFLAGS=-DNRF5X_ENABLE_DCDC=0 make ...`

### Testing procedure
- obviously the build test should still run through without any trouble :-)
- to verify the effect of the enabling macro, simply build any example application for one of the supported nrf boards (e.g. `nrf52dk`) with DCDC enabled and DCDC disabled. You should see a slight variation in code size.

Example output for `examples/hello-world`:
```
CFLAGS=-DNRF5X_ENABLE_DCDC=0 BOARD=nrf52840dk make all

--> text: 8716
```
vs.
```
CFLAGS=-DNRF5X_ENABLE_DCDC=1 BOARD=nrf52840dk make all

--> text: 8732
```

### Issues/PRs references
none