### PR TITLE
boards/nrf52840dongle: enable DCDC converters

### DIFF
--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -71,6 +71,13 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#ifndef NRF5X_ENABLE_DCDC
+#define NRF5X_ENABLE_DCDC   1
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description
Straight forward: this PR enables the DC/DC converters for the `nrf52840dongle` board. In most common use cases, this proves to be the more power efficient mode. If wanted, one can always disable it for ones application... (see #15989)

### Testing procedure
Any test application should still run fine for this board...

### Issues/PRs references
Depends on #15989 to work fully, but the effect should also show without #15989 being merged...
