### PR TITLE
cpu/nrf5x: enable DC/DC also for REG0 if VDDH is used

### DIFF
--- a/cpu/nrf5x_common/include/nrfx.h
+++ b/cpu/nrf5x_common/include/nrfx.h
@@ -42,6 +42,15 @@ static inline void nrfx_dcdc_init(void)
 {
 #ifdef NRF5X_ENABLE_DCDC
     NRF_POWER->DCDCEN = 1;
+
+    /* on CPUs that support high voltage power supply via VDDH and thus use a
+     * two stage regulator, we also enable the DC/DC converter for the first
+     * state. */
+#ifdef POWER_MAINREGSTATUS_MAINREGSTATUS_High
+    if (NRF_POWER->MAINREGSTATUS == POWER_MAINREGSTATUS_MAINREGSTATUS_High) {
+        NRF_POWER->DCDCEN0 = 1;
+    }
+#endif
 #endif
 }
 


### PR DESCRIPTION
### Contribution description
When using VDDH (high level volatge source) as power supply for an `nrf52840` CPU, it internally uses a two stage voltage regulator. So far, we only enabled the DC/DC mode for the second stage. This PR also enables the DC/DC mode for the first stage in case it is in use.

### Testing procedure
To my knowledge the `nrf52840dongle` is the only board that uses the VDDH voltage source per default, powering the CPU directly from the 5V USB voltage. To test this PR, best apply the change from  #15990 and verify that any application of your choosing is still running as expected on that board.


### Issues/PRs references
-  #15990 enables to test this
- either this PR or #15989 will need a rebase though, who ever comes first...
