### PR TITLE
Add lwIP ifconfig shell command

### DIFF
--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -49,6 +49,9 @@
 #define ETHERNET_IFNAME1 'E'
 #define ETHERNET_IFNAME2 'T'
 
+#define WPAN_IFNAME1 'W'
+#define WPAN_IFNAME2 'P'
+
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 static char _stack[LWIP_NETDEV_STACKSIZE];
 static msg_t _queue[LWIP_NETDEV_QUEUE_LEN];
@@ -135,6 +138,8 @@ err_t lwip_netdev_init(struct netif *netif)
         {
             u16_t val;
             ip6_addr_t *addr;
+            netif->name[0] = WPAN_IFNAME1;
+            netif->name[1] = WPAN_IFNAME2;
             if (netdev->driver->get(netdev, NETOPT_NID, &val,
                                     sizeof(val)) < 0) {
                 return ERR_IF;

--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -58,7 +58,7 @@ extern "C" {
 #define S32_F   PRId32
 #define X32_F   PRIx32
 
-#define SZT_F   "lu"
+#define SZT_F   PRIuPTR
 /** @} */
 
 /**

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -137,6 +137,9 @@ extern "C" {
 #define LWIP_NETCONN            0
 #endif /* MODULE_LWIP_SOCK */
 
+#ifdef MODULE_SHELL_COMMANDS
+#define LWIP_DEBUG              1
+#endif
 
 #ifndef TCP_LISTEN_BACKLOG
 # if defined(MODULE_LWIP_SOCK_TCP)

--- a/pkg/lwip/patches/0002-lowpan6-Use-arch-independent-printf-formatters.patch
+++ b/pkg/lwip/patches/0002-lowpan6-Use-arch-independent-printf-formatters.patch
@@ -1,0 +1,51 @@
+From e02d126b07388c5ff49a6cd25cef14214157b52f Mon Sep 17 00:00:00 2001
+From: Erik Ekman <erik@kryo.se>
+Date: Sat, 13 Feb 2021 21:14:29 +0100
+Subject: [PATCH] lowpan6: Use arch-independent printf formatters
+
+---
+ src/netif/lowpan6_common.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/netif/lowpan6_common.c b/src/netif/lowpan6_common.c
+index 6900eec7..01b62dfd 100644
+--- a/src/netif/lowpan6_common.c
++++ b/src/netif/lowpan6_common.c
+@@ -440,7 +440,7 @@ lowpan6_decompress_hdr(u8_t *lowpan6_buffer, size_t lowpan6_bufsize,
+   if ((lowpan6_buffer[0] & 0x18) == 0x00) {
+     header_temp = ((lowpan6_buffer[lowpan6_offset+1] & 0x0f) << 16) | \
+       (lowpan6_buffer[lowpan6_offset + 2] << 8) | lowpan6_buffer[lowpan6_offset+3];
+-    LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("TF: 00, ECN: 0x%2x, Flowlabel+DSCP: 0x%8X\n", \
++    LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("TF: 00, ECN: 0x%"X8_F", Flowlabel+DSCP: 0x%8"X32_F"\n", \
+       lowpan6_buffer[lowpan6_offset],header_temp));
+     IP6H_VTCFL_SET(ip6hdr, 6, lowpan6_buffer[lowpan6_offset], header_temp);
+     /* increase offset, processed 4 bytes here:
+@@ -448,14 +448,14 @@ lowpan6_decompress_hdr(u8_t *lowpan6_buffer, size_t lowpan6_bufsize,
+     lowpan6_offset += 4;
+   } else if ((lowpan6_buffer[0] & 0x18) == 0x08) {
+     header_temp = ((lowpan6_buffer[lowpan6_offset] & 0x0f) << 16) | (lowpan6_buffer[lowpan6_offset + 1] << 8) | lowpan6_buffer[lowpan6_offset+2];
+-    LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("TF: 01, ECN: 0x%2x, Flowlabel: 0x%2X, DSCP ignored\n", \
++    LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("TF: 01, ECN: 0x%"X8_F", Flowlabel: 0x%2"X32_F", DSCP ignored\n", \
+       lowpan6_buffer[lowpan6_offset] & 0xc0,header_temp));
+     IP6H_VTCFL_SET(ip6hdr, 6, lowpan6_buffer[lowpan6_offset] & 0xc0, header_temp);
+     /* increase offset, processed 3 bytes here:
+      * TF=01:  ECN + 2-bit Pad + Flow Label (3 bytes), DSCP is elided.*/
+     lowpan6_offset += 3;
+   } else if ((lowpan6_buffer[0] & 0x18) == 0x10) {
+-    LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("TF: 10, DCSP+ECN: 0x%2x, Flowlabel ignored\n", lowpan6_buffer[lowpan6_offset]));
++    LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("TF: 10, DCSP+ECN: 0x%"X8_F", Flowlabel ignored\n", lowpan6_buffer[lowpan6_offset]));
+     IP6H_VTCFL_SET(ip6hdr, 6, lowpan6_buffer[lowpan6_offset],0);
+     /* increase offset, processed 1 byte here:
+      * ECN + DSCP (1 byte), Flow Label is elided.*/
+@@ -564,7 +564,7 @@ lowpan6_decompress_hdr(u8_t *lowpan6_buffer, size_t lowpan6_bufsize,
+ #if LWIP_6LOWPAN_NUM_CONTEXTS > 0
+       ip6hdr->src.addr[0] = lowpan6_contexts[i].addr[0];
+       ip6hdr->src.addr[1] = lowpan6_contexts[i].addr[1];
+-      LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("SAM == xx, context compression found @%d: %8X, %8X\n", (int)i, ip6hdr->src.addr[0], ip6hdr->src.addr[1]));
++      LWIP_DEBUGF(LWIP_LOWPAN6_DECOMPRESSION_DEBUG, ("SAM == xx, context compression found @%d: %8"X32_F", %8"X32_F"\n", (int)i, ip6hdr->src.addr[0], ip6hdr->src.addr[1]));
+ #else
+       LWIP_UNUSED_ARG(lowpan6_contexts);
+ #endif
+-- 
+2.29.2
+

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -93,6 +93,10 @@ ifneq (,$(filter openwsn,$(USEPKG)))
   SRC += sc_openwsn.c
 endif
 
+ifneq (,$(filter lwip_netif,$(USEMODULE)))
+  SRC += sc_lwip_netif.c
+endif
+
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   SRC += sc_rtc.c
 endif

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell command for printing lwIP network interface status
+ *
+ * @author      Erik Ekman <eekman@google.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "lwip/netif.h"
+#include "net/netdev.h"
+#include "net/netopt.h"
+
+#ifdef MODULE_LWIP_IPV6
+static void _netif_list_ipv6(struct netif *netif, int addr_index) {
+    printf("        inet6 addr: ");
+    ip_addr_debug_print(LWIP_DBG_ON, netif_ip_addr6(netif, addr_index));
+    printf(" scope: ");
+    if (ip6_addr_isglobal(netif_ip6_addr(netif, addr_index))) {
+        printf("global");
+    } else if (ip6_addr_islinklocal(netif_ip6_addr(netif, addr_index))) {
+        printf("link");
+    } else if (ip6_addr_issitelocal(netif_ip6_addr(netif, addr_index))) {
+        printf("site");
+    } else {
+        printf("unknown");
+    }
+    printf("\n");
+}
+#endif
+
+static void _netif_list(struct netif *netif) {
+    int i;
+    struct netdev *dev = netif->state;
+    printf("Iface %c%c%u ", netif->name[0], netif->name[1], netif->num);
+    printf("HWaddr: ");
+    for (i = 0; i < netif->hwaddr_len; i++) {
+        printf("%02x", netif->hwaddr[i]);
+        if ((i+1) < netif->hwaddr_len) {
+            printf(":");
+        }
+    }
+    printf(" Link: %s State: %s\n",
+        netif_is_link_up(netif) ? "up" : "down",
+        netif_is_up(netif) ? "up" : "down");
+    printf("        Link type: %s\n",
+        (dev->driver->get(dev, NETOPT_IS_WIRED, &i, sizeof(i)) > 0) ?
+            "wired" : "wireless");
+#ifdef MODULE_LWIP_IPV4
+    printf("        inet addr: ");
+    ip_addr_debug_print(LWIP_DBG_ON, netif_ip_addr4(netif));
+    printf(" mask: ");
+    ip_addr_debug_print(LWIP_DBG_ON, netif_ip_netmask4(netif));
+    printf(" gw: ");
+    ip_addr_debug_print(LWIP_DBG_ON, netif_ip_gw4(netif));
+    printf("\n");
+#endif
+
+#ifdef MODULE_LWIP_IPV6
+    for (i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+        if (netif_ip6_addr_state(netif, i) != IP6_ADDR_INVALID) {
+            _netif_list_ipv6(netif, i);
+        }
+    }
+#endif
+}
+
+int _lwip_netif_config(int argc, char **argv)
+{
+    if (argc < 2) {
+        /* List in interface order, which is normally reverse of list order */
+        struct netif *netif;
+        int netifs = 0;
+        int listed = 0;
+        u8_t i;
+        NETIF_FOREACH(netif) netifs++;
+        for (i = 0; listed < netifs; i++) {
+            NETIF_FOREACH(netif) {
+                if (i == netif->num) {
+                    _netif_list(netif);
+                    listed++;
+                }
+            }
+        }
+        return 0;
+    }
+    printf("%s takes no arguments.\n", argv[0]);
+    return 1;
+}

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -108,6 +108,10 @@ extern int _openwsn_ifconfig(int argc, char **argv);
 extern int _openwsn_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_LWIP_NETIF
+extern int _lwip_netif_config(int argc, char **argv);
+#endif
+
 #ifdef MODULE_FIB
 extern int _fib_route_handler(int argc, char **argv);
 #endif
@@ -261,6 +265,9 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_OPENWSN
     {"ifconfig", "Shows assigned IPv6 addresses", _openwsn_ifconfig},
     {"openwsn", "OpenWSN commands", _openwsn_handler},
+#endif
+#ifdef MODULE_LWIP_NETIF
+    {"ifconfig", "List network interfaces", _lwip_netif_config},
 #endif
 #ifdef MODULE_FIB
     {"fibroute", "Manipulate the FIB (info: 'fibroute [add|del]')", _fib_route_handler},

--- a/tests/lwip/main.c
+++ b/tests/lwip/main.c
@@ -32,43 +32,6 @@
 #endif
 #include "shell.h"
 
-#define IFCONFIG_FILLER     "       "
-
-static int ifconfig(int argc, char **argv)
-{
-    (void)argc;
-    (void)argv;
-    for (struct netif *iface = netif_list; iface != NULL; iface = iface->next) {
-        printf("%s_%02u: ", iface->name, iface->num);
-#if IS_USED(MODULE_LWIP_IPV6)
-        char addrstr[IPV6_ADDR_MAX_STR_LEN];
-#elif IS_USED(MODULE_LWIP_IPV4)
-        char addrstr[IPV4_ADDR_MAX_STR_LEN];
-#endif
-#ifdef MODULE_LWIP_IPV6
-        for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
-            if (!ipv6_addr_is_unspecified((ipv6_addr_t *)&iface->ip6_addr[i])) {
-                printf("%s inet6 %s\n", (i == 0) ? "" : IFCONFIG_FILLER,
-                       ipv6_addr_to_str(addrstr,
-                                        (ipv6_addr_t *)&iface->ip6_addr[i],
-                                        sizeof(addrstr)));
-            }
-        }
-#endif
-#ifdef MODULE_LWIP_IPV4
-        if (IS_USED(MODULE_LWIP_IPV6)) {
-            /* insert spaces to be aligned with inet6 */
-            printf(IFCONFIG_FILLER);
-        }
-        printf(" inet %s\n", ipv4_addr_to_str(addrstr,
-                                              (ipv4_addr_t *)&iface->ip_addr,
-                                              sizeof(addrstr)));
-#endif
-        puts("");
-    }
-    return 0;
-}
-
 static const shell_command_t shell_commands[] = {
 #ifdef MODULE_SOCK_IP
     { "ip", "Send IP packets and listen for packets of certain type", ip_cmd },
@@ -79,7 +42,6 @@ static const shell_command_t shell_commands[] = {
 #ifdef MODULE_SOCK_UDP
     { "udp", "Send UDP messages and listen for messages on UDP port", udp_cmd },
 #endif
-    { "ifconfig", "Shows assigned IP addresses", ifconfig },
     { NULL, NULL, NULL }
 };
 

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -15,6 +15,7 @@ import time
 import types
 import pexpect
 import socket
+import ipaddress
 
 DEFAULT_TIMEOUT = 5
 
@@ -190,8 +191,9 @@ class TestStrategy(ApplicationStrategy):
 
 def get_ipv6_address(spawn):
     spawn.sendline(u"ifconfig")
-    spawn.expect(r"[A-Za-z0-9]{2}_[0-9]+:  inet6 (fe80::[0-9a-f:]+)\s")
-    return spawn.match.group(1)
+    spawn.expect(r" inet6 addr: (fe80:[0-9a-f:]+)\s")
+    # pack v6 address to minimal form (lwIP returns fe80:0:0:..)
+    return str(ipaddress.ip_address(spawn.match.group(1)))
 
 
 def test_ipv6_send(board_group, application, env=None):


### PR DESCRIPTION
### Contribution description

This PR adds ifconfig shell command when lwIP is included as IP stack,
plus some minor tweaks (allowing both ESP netifs to be used, and setting
name for 6lowpan netifs).

This is the result when running on an ESP board with wifi & ethernet:
```
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f Link: up State: up
        Link type: wired
        inet addr: 10.4.4.81 mask: 255.255.254.0 gw: 10.4.4.1
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9f scope: link
        inet6 addr: 2001:db8:1000:0:260a:c4ff:fee6:e9f scope: global
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c Link: up State: up
        Link type: wireless
        inet addr: 10.4.4.82 mask: 255.255.254.0 gw: 10.4.4.1
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9c scope: link
        inet6 addr: 2001:db8:1000:0:260a:c4ff:fee6:e9c scope: global
>
```

I have used the lwIP internal methods for printing ip addresses.
This does not seem to be the standard, and I am happy to change it
and understand why it is done like it is now (and if dual stack works with that).

Link state is always up currently since that is how it is configured by the lwip netdev setup code.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run testcase tests/lwip on native board, or

Flash tests/lwip (or other app with lwIP) to a board with ethernet and run ifconfig in the shell

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None.