### PR TITLE
gnrc_lorawan : Add ADR support

### DIFF
--- a/examples/gnrc_lorawan/Makefile
+++ b/examples/gnrc_lorawan/Makefile
@@ -76,11 +76,14 @@ ifndef CONFIG_KCONFIG_USEMODULE_LORAWAN
   # Note this value is also used for the OTAA.
   # CFLAGS += -DCONFIG_LORAMAC_DEFAULT_DR_5
 
-  # # Set default messages to unconfirmable
+  # Set default messages to unconfirmable
   CFLAGS += -DCONFIG_LORAMAC_DEFAULT_TX_MODE_UNCNF
 
   # Set region
   CFLAGS += -DCONFIG_LORAMAC_REGION_EU_868
+
+  # Enable ADR
+  # CFLAGS += -DCONFIG_LORAMAC_DEFAULT_ADR
 endif
 
 # We can reduce the size of the packet buffer for LoRaWAN, since there's no IP

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -70,6 +70,7 @@ typedef enum {
     MIB_ACTIVATION_METHOD,      /**< type is activation method */
     MIB_DEV_ADDR,               /**< type is dev addr */
     MIB_RX2_DR,                 /**< type is rx2 DR */
+    MIB_ADR,                    /**< type is ADR */
 } mlme_mib_type_t;
 
 /**
@@ -101,6 +102,7 @@ typedef struct {
         mlme_activation_t activation;   /**< holds activation mechanism */
         void *dev_addr;                 /**< pointer to the dev_addr */
         uint8_t rx2_dr;                 /** datarate of second rx window */
+        bool adr;                       /** Adaptive data rate (ADR) */
     };
 } mlme_mib_t;
 

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -24,6 +24,7 @@
 #define NET_GNRC_LORAWAN_H
 
 #include "gnrc_lorawan_internal.h"
+#include "assert.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -319,6 +320,21 @@ void gnrc_lorawan_set_timer(gnrc_lorawan_t *mac, uint32_t us);
  * @param[in] mac pointer to the MAC descriptor
  */
 void gnrc_lorawan_remove_timer(gnrc_lorawan_t *mac);
+
+/**
+ * @brief Set unconfirmed uplink redundancy
+ *
+ * @pre   @p redundancy <= 14
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] redundancy number of unconfirmed uplink retransmissions
+ */
+static inline void gnrc_lorawan_set_uncnf_redundancy(gnrc_lorawan_t *mac,
+                                                     uint8_t redundancy)
+{
+    assert(redundancy <= (0xF - 1));
+    mac->mcps.redundancy = redundancy;
+}
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/lorawan/region.h
+++ b/sys/include/net/gnrc/lorawan/region.h
@@ -71,6 +71,16 @@ uint8_t gnrc_lorawan_rx1_get_dr_offset(uint8_t dr_up, uint8_t dr_offset);
  */
 bool gnrc_lorawan_validate_dr(uint8_t dr);
 
+/**
+ * @brief Check if a TX power is valid in the current region
+ *
+ * @param[in] tx_power the TX power to be checked
+ *
+ * @retval true if TX power is valid
+ * @retval false otherwise
+ */
+bool gnrc_lorawan_validate_tx_power(uint8_t tx_power);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -535,7 +535,7 @@ extern "C" {
 #define LORAMAC_PORT_MIN                        (1U)
 
 /**
- * @brief   Maximmu port value
+ * @brief   Maximum port value
  */
 #define LORAMAC_PORT_MAX                        (223U)
 

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -285,6 +285,21 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default redundancy for unconfirmed uplink
+ *
+ * This corresponds to the number of unconfirmed uplink retransmissions when
+ * using ADR. This configuration does not affect confirmed uplinks.  By
+ * default, uplinks are sent without retransmissions (this means, the device
+ * sends only one uplink packet)
+ *
+ * @note This value MUST NOT be greater than 14, since the LinkADRCommand it's
+ *       already limited by a 4 bit value (therefore, 15 uplink transmissions)
+ */
+#ifndef CONFIG_LORAMAC_DEFAULT_REDUNDANCY
+#define CONFIG_LORAMAC_DEFAULT_REDUNDANCY       (0U)
+#endif
+
+/**
  * @brief   Enable/disable adaptive datarate state
  *
  * If enabled the end node will inform the network server about the status of

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -476,15 +476,14 @@ extern "C" {
 #ifndef CONFIG_LORAMAC_DEFAULT_MIN_RX_SYMBOLS
 #define CONFIG_LORAMAC_DEFAULT_MIN_RX_SYMBOLS   (12)
 #endif
-/** @} */
 
 /**
  * @brief   Default adaptive datarate ACK limit (in s)
  *
  * @note This feature is not yet supported.
  */
-#ifndef LORAMAC_DEFAULT_ADR_ACK_LIMIT
-#define LORAMAC_DEFAULT_ADR_ACK_LIMIT           (64U)
+#ifndef CONFIG_LORAMAC_DEFAULT_ADR_ACK_LIMIT
+#define CONFIG_LORAMAC_DEFAULT_ADR_ACK_LIMIT    (64U)
 #endif
 
 /**
@@ -495,6 +494,8 @@ extern "C" {
 #ifndef CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY
 #define CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY    (32)
 #endif
+
+/** @} */
 
 /**
  * @brief   Default adaptive datarate timeout

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -478,18 +478,21 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default adaptive datarate ACK limit (in s)
+ * @brief   Default adaptive datarate ACK limit
  *
- * @note This feature is not yet supported.
+ * Defines the ADR ACK counter limit (`ADR_ACK_CNT`).
+ *
  */
 #ifndef CONFIG_LORAMAC_DEFAULT_ADR_ACK_LIMIT
 #define CONFIG_LORAMAC_DEFAULT_ADR_ACK_LIMIT    (64U)
 #endif
 
 /**
- * @brief   Default adaptive datarate ACK delay (in s)
+ * @brief   Default adaptive datarate ACK delay
  *
- * @note This feature is not yet supported.
+ * ACK delay is the window ,in terms of number of uplink frames, within which
+ * Network Server is expected to send a downlink after `ADRACKReq` bit has
+ * been set by the node.
  */
 #ifndef CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY
 #define CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY    (32)

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -492,8 +492,8 @@ extern "C" {
  *
  * @note This feature is not yet supported.
  */
-#ifndef LORAMAC_DEFAULT_ADR_ACK_DELAY
-#define LORAMAC_DEFAULT_ADR_ACK_DELAY           (32U)
+#ifndef CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY
+#define CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY    (32)
 #endif
 
 /**

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -58,6 +58,7 @@ static inline void gnrc_lorawan_mcps_reset(gnrc_lorawan_t *mac)
     mac->mcps.waiting_for_ack = false;
     mac->mcps.fcnt = 0;
     mac->mcps.fcnt_down = 0;
+    gnrc_lorawan_set_uncnf_redundancy(mac, CONFIG_LORAMAC_DEFAULT_REDUNDANCY);
 }
 
 void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)
@@ -164,8 +165,11 @@ void gnrc_lorawan_timeout_cb(gnrc_lorawan_t *mac)
         case LORAWAN_STATE_JOIN:
             gnrc_lorawan_trigger_join(mac);
             break;
+        case LORAWAN_STATE_IDLE:
+            gnrc_lorawan_event_retrans_timeout(mac);
+            break;
         default:
-            gnrc_lorawan_event_ack_timeout(mac);
+            assert(false);
             break;
     }
 }

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -43,6 +43,9 @@ static inline void gnrc_lorawan_mlme_reset(gnrc_lorawan_t *mac)
     mac->mlme.pending_mlme_opts = 0;
     mac->rx_delay = (CONFIG_LORAMAC_DEFAULT_RX1_DELAY / MS_PER_SEC);
     mac->mlme.nid = CONFIG_LORAMAC_DEFAULT_NETID;
+    mac->mlme.adr = IS_ACTIVE(CONFIG_LORAMAC_DEFAULT_ADR);
+    mac->mlme.adr_ack_cnt = 0;
+    mac->mlme.adr_req_cnt = 0;
 }
 
 static inline void gnrc_lorawan_mlme_backoff_init(gnrc_lorawan_t *mac)
@@ -66,6 +69,17 @@ void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr)
     mac->dl_settings &= ~GNRC_LORAWAN_DL_RX2_DR_MASK;
     mac->dl_settings |= (rx2_dr << GNRC_LORAWAN_DL_RX2_DR_POS) &
                         GNRC_LORAWAN_DL_RX2_DR_MASK;
+}
+
+int gnrc_lorawan_set_adr(gnrc_lorawan_t *mac, bool adr)
+{
+    if (adr == mac->mlme.adr) {
+        return -EALREADY;
+    }
+
+    mac->mlme.adr_ack_cnt = 0;
+    mac->mlme.adr = adr;
+    return GNRC_LORAWAN_REQ_STATUS_SUCCESS;
 }
 
 static void _sleep_radio(gnrc_lorawan_t *mac)
@@ -102,6 +116,7 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
 
     dev->driver->set(dev, NETOPT_RX_TIMEOUT, &rx_timeout, sizeof(rx_timeout));
 
+    mac->last_dr = CONFIG_LORAMAC_DEFAULT_DR;
     gnrc_lorawan_set_rx2_dr(mac, CONFIG_LORAMAC_DEFAULT_RX2_DR);
 
     mac->toa = 0;

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -331,16 +331,33 @@ static void _transmit_pkt(gnrc_lorawan_t *mac)
     last_snip->iol_next = NULL;
 }
 
-void gnrc_lorawan_event_ack_timeout(gnrc_lorawan_t *mac)
+void gnrc_lorawan_event_retrans_timeout(gnrc_lorawan_t *mac)
 {
     _transmit_pkt(mac);
 }
 
 static void _handle_retransmissions(gnrc_lorawan_t *mac)
 {
+    /* Check if retransmission should be handled.
+     *
+     * If there was a confirmed uplink, follow the standard retransmission
+     * procedure.
+     * If it was an unconfirmed uplink, perform retransmissions only if
+     * there's redundancy > 0 */
     if (mac->mcps.nb_trials-- == 0) {
-        _end_of_tx(mac, MCPS_CONFIRMED, -ETIMEDOUT);
-    } else {
+        if (mac->mcps.waiting_for_ack) {
+            /* If we are here, the node ran out of confirmed uplink retransmissions.
+             * This means, the transmission was not successful. */
+            _end_of_tx(mac, MCPS_CONFIRMED, -ETIMEDOUT);
+        }
+        else {
+            /* In this case, we finished sending one or more unconfirmed
+             * (depending on the redundancy) */
+            _end_of_tx(mac, MCPS_UNCONFIRMED, GNRC_LORAWAN_REQ_STATUS_SUCCESS);
+        }
+    }
+    else {
+        /* Schedule a retransmission */
         gnrc_lorawan_set_timer(mac, 1000000 + random_uint32_range(0, 2000000));
     }
 }
@@ -358,14 +375,7 @@ void gnrc_lorawan_event_no_rx(gnrc_lorawan_t *mac)
         return;
     }
 
-    /* Otherwise check if retransmission should be handled */
-
-    if (mac->mcps.waiting_for_ack) {
-        _handle_retransmissions(mac);
-    }
-    else {
-        _end_of_tx(mac, MCPS_UNCONFIRMED, GNRC_LORAWAN_REQ_STATUS_SUCCESS);
-    }
+    _handle_retransmissions(mac);
 }
 
 void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
@@ -416,7 +426,7 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
     mac->mcps.waiting_for_ack = waiting_for_ack;
     mac->mcps.ack_requested = false;
 
-    mac->mcps.nb_trials = CONFIG_LORAMAC_DEFAULT_RETX;
+    mac->mcps.nb_trials = waiting_for_ack ? CONFIG_LORAMAC_DEFAULT_RETX : mac->mcps.redundancy;
 
     mac->mcps.msdu = pkt;
     mac->last_dr = mcps_request->data.dr;

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -25,6 +25,7 @@
 #include "net/lorawan/hdr.h"
 
 #include "random.h"
+#include "kernel_defines.h"
 
 #define ENABLE_DEBUG      0
 #include "debug.h"
@@ -154,6 +155,10 @@ void gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, uint8_t *psdu,
         return;
     }
 
+    /* ADR_ACK_CNT and ADR_REQ_CNT reset after downlink */
+    mac->mlme.adr_ack_cnt = 0;
+    mac->mlme.adr_req_cnt = 0;
+
     iolist_t *fopts = NULL;
 
     if (_pkt.fopts.iol_base) {
@@ -251,6 +256,13 @@ size_t gnrc_lorawan_build_uplink(gnrc_lorawan_t *mac, iolist_t *payload,
     lw_hdr->addr = mac->dev_addr;
     lw_hdr->fctrl = 0;
 
+    lorawan_hdr_set_adr(lw_hdr,mac->mlme.adr);
+
+    /* Set `ADRACKReq` bit */
+    if (gnrc_lorawan_should_set_ack_req(mac->mlme.adr_ack_cnt, mac->last_dr)) {
+        lorawan_hdr_set_adr_ack_req(lw_hdr, true);
+    }
+
     lorawan_hdr_set_ack(lw_hdr, mac->mcps.ack_requested);
 
     lw_hdr->fcnt = byteorder_htols(mac->mcps.fcnt);
@@ -287,6 +299,10 @@ static void _end_of_tx(gnrc_lorawan_t *mac, int type, int status)
     mac->mcps.waiting_for_ack = false;
 
     mac->mcps.fcnt++;
+
+    if (mac->mlme.adr) {
+        mac->mlme.adr_ack_cnt++;
+    }
 
     gnrc_lorawan_mac_release(mac);
 
@@ -375,6 +391,15 @@ void gnrc_lorawan_event_no_rx(gnrc_lorawan_t *mac)
         return;
     }
 
+    if (mac->mlme.adr) {
+        int d = mac->mlme.adr_ack_cnt - CONFIG_LORAMAC_DEFAULT_ADR_ACK_LIMIT;
+        if ((d >= CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY) && \
+             ((d % CONFIG_LORAMAC_DEFAULT_ADR_ACK_DELAY) == 0) && mac->last_dr) {
+            DEBUG("gnrc_lorawan_mcps: ADRACKReq: Decrement DR\n");
+            mac->last_dr--;
+        }
+    }
+
     _handle_retransmissions(mac);
 }
 
@@ -423,13 +448,19 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
     gnrc_lorawan_build_uplink(mac, pkt, waiting_for_ack,
                               mcps_request->data.port);
 
+    if (mac->mlme.pending_mlme_opts & GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS) {
+        mac->mlme.pending_mlme_opts &= ~GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS;
+    }
+
     mac->mcps.waiting_for_ack = waiting_for_ack;
     mac->mcps.ack_requested = false;
-
     mac->mcps.nb_trials = waiting_for_ack ? CONFIG_LORAMAC_DEFAULT_RETX : mac->mcps.redundancy;
-
     mac->mcps.msdu = pkt;
-    mac->last_dr = mcps_request->data.dr;
+
+    if(!mac->mlme.adr){
+        mac->last_dr = mcps_request->data.dr;
+    }
+
     _transmit_pkt(mac);
     mcps_confirm->status = GNRC_LORAWAN_REQ_STATUS_DEFERRED;
 out:

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -209,6 +209,9 @@ static void _mlme_set(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
             gnrc_lorawan_set_rx2_dr(mac, mlme_request->mib.rx2_dr);
             break;
+        case MIB_ADR:
+            mlme_confirm->status = gnrc_lorawan_set_adr(mac, mlme_request->mib.adr);
+            break;
         default:
             break;
     }
@@ -225,6 +228,10 @@ static void _mlme_get(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
         case MIB_DEV_ADDR:
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
             mlme_confirm->mib.dev_addr = &mac->dev_addr;
+            break;
+        case MIB_ADR:
+            mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
+            mlme_confirm->mib.adr = &mac->mlme.adr;
             break;
         default:
             mlme_confirm->status = -EINVAL;
@@ -287,18 +294,131 @@ int _fopts_mlme_link_check_req(lorawan_buffer_t *buf)
     return GNRC_LORAWAN_CID_SIZE;
 }
 
-static void _mlme_link_check_ans(gnrc_lorawan_t *mac, uint8_t *p)
+static int _mlme_link_check_ans(gnrc_lorawan_t *mac, const uint8_t *p, size_t len, uint8_t index)
 {
+    (void) len;
     mlme_confirm_t mlme_confirm;
 
-    mlme_confirm.link_req.margin = p[1];
-    mlme_confirm.link_req.num_gateways = p[2];
+    assert(p[index] == GNRC_LORAWAN_CID_LINK_CHECK_ANS);
+
+    if (!(mac->mlme.pending_mlme_opts & GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ)) {
+        return 0;
+    }
+
+    mlme_confirm.link_req.margin = p[index + 1];
+    mlme_confirm.link_req.num_gateways = p[index + 2];
+
+    DEBUG("gnrc_lorawan_mlme: LinkCheckAns Margin : %u \n",
+          mlme_confirm.link_req.margin);
+    DEBUG("gnrc_lorawan_mlme: LinkCheckAns GwCnt : %u \n",
+          mlme_confirm.link_req.num_gateways);
 
     mlme_confirm.type = MLME_LINK_CHECK;
     mlme_confirm.status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
     gnrc_lorawan_mlme_confirm(mac, &mlme_confirm);
 
     mac->mlme.pending_mlme_opts &= ~GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ;
+
+    return GNRC_LORAWAN_FOPT_LINK_CHECK_ANS_SIZE;
+}
+
+static int _mlme_link_adr_req(gnrc_lorawan_t *mac, const uint8_t *p, size_t len, uint8_t index)
+{
+    int consumed_bytes = 0;
+    assert(p[index] == GNRC_LORAWAN_CID_LINK_ADR_REQ);
+
+    /* Check whether this is the first block. */
+    if (mac->mlme.adr_flags & 0x8) {
+        /* Indicate error */
+        return 0;
+    }
+
+    /* Mark the first contiguous block */
+    mac->mlme.adr_flags |= 0x8;
+    uint8_t c = index;
+    while (c < len) {
+        if (p[c] == GNRC_LORAWAN_CID_LINK_ADR_REQ) {
+            if ((len - c) >= GNRC_LORAWAN_FOPT_LINK_ADR_REQ_SIZE) {
+                /* There's a LinkADRReq */
+                mac->mlme.adr_req_cnt++;
+                consumed_bytes += GNRC_LORAWAN_FOPT_LINK_ADR_REQ_SIZE;
+            }
+            else {
+                /* The current entry overflow */
+                return 0;
+            }
+        }
+        else {
+            break;
+        }
+        /* Update cursor */
+        c = index + consumed_bytes;
+    }
+
+    int req_index = index + consumed_bytes - GNRC_LORAWAN_FOPT_LINK_ADR_REQ_SIZE;
+
+    uint8_t dr = p[req_index + 1] >> 4;
+    uint16_t tx_power = p[req_index + 1] & 0xF;
+    uint16_t channel_mask = (p[req_index + 3] << 8 ) | p[req_index + 2];
+    uint8_t chmask_ctrl = (p[req_index + 4] & 0x70) >> 4;
+    uint8_t nbtrans = p[req_index + 4] & 0xF;
+
+    int status = 0;
+    gnrc_lorawan_set_uncnf_redundancy(mac, ((nbtrans != 0) ? (uint8_t)(nbtrans - 1) \
+                                             : CONFIG_LORAMAC_DEFAULT_REDUNDANCY));
+
+    if (gnrc_lorawan_set_tx_power(mac, tx_power) >= 0) {
+        status |= 0x4;
+    }
+
+    if (gnrc_lorawan_validate_dr(dr) == true) {
+        mac->last_dr = dr;
+        status |= 0x2;
+    }
+
+    if (chmask_ctrl == 6) {
+        channel_mask = 0;
+        for (unsigned i = 0; i < GNRC_LORAWAN_MAX_CHANNELS; i++) {
+            if (mac->channel[i]) {
+                channel_mask |= 1;
+            }
+            channel_mask = channel_mask << 1;
+        }
+        int res = gnrc_lorawan_phy_set_channel_mask(mac, channel_mask);
+        (void) res;
+        assert(res >= 0);
+        status |= 0x1;
+    }
+    else if (chmask_ctrl == 0) {
+        /* Try to apply channel mask */
+        if (gnrc_lorawan_phy_set_channel_mask(mac, channel_mask) >= 0) {
+            status |= 0x1;
+        }
+    }
+
+    /* Use the last 3 bits for the status */
+    mac->mlme.adr_flags |= status;
+
+    /* Set `LinkADRAns` for next uplink */
+    mac->mlme.pending_mlme_opts |=  GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS;
+
+    DEBUG("gnrc_lorawan_mlme: LinkADRReq DataRate_TXPower : DR%u TX%u\n", dr, tx_power);
+    DEBUG("gnrc_lorawan_mlme: LinkADRReq ChMaskCntrl : %u and Channel mask : \
+           %u\n", chmask_ctrl, channel_mask);
+    DEBUG("gnrc_lorawan_mlme: LinkADRReq Redundancy : %u\n", nbtrans);
+
+    return consumed_bytes;
+}
+
+int _fopts_mlme_link_adr_ans(gnrc_lorawan_t *mac, lorawan_buffer_t *buf)
+{
+    for (uint8_t _count = mac->mlme.adr_req_cnt; buf && _count; _count--) {
+        assert(buf->index + GNRC_LORAWAN_CID_LINK_ADR_ANS_SIZE <= buf->size);
+        buf->data[buf->index++] = GNRC_LORAWAN_CID_LINK_ADR_ANS;
+        buf->data[buf->index++] = mac->mlme.adr_flags;
+    }
+
+    return mac->mlme.adr_req_cnt * GNRC_LORAWAN_CID_LINK_ADR_ANS_SIZE;
 }
 
 void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts,
@@ -310,32 +430,38 @@ void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts,
 
     uint8_t ret = 0;
 
-    void (*cb)(gnrc_lorawan_t *, uint8_t *p) = NULL;
+    int (*cb)(gnrc_lorawan_t *, const uint8_t *p, size_t size, uint8_t index) = NULL;
 
     for (uint8_t pos = 0; pos < size; pos += ret) {
+
         switch (fopts[pos]) {
             case GNRC_LORAWAN_CID_LINK_CHECK_ANS:
-                ret += GNRC_LORAWAN_FOPT_LINK_CHECK_ANS_SIZE;
                 cb = _mlme_link_check_ans;
+                break;
+            case GNRC_LORAWAN_CID_LINK_ADR_REQ:
+                cb = _mlme_link_adr_req;
                 break;
             default:
                 return;
         }
 
-        if (pos + ret > size) {
+        ret = cb(mac, fopts, size, pos);
+
+        if (!ret || (pos + ret > size)) {
             return;
         }
-
-        cb(mac, &fopts[pos]);
     }
 }
 
 uint8_t gnrc_lorawan_build_options(gnrc_lorawan_t *mac, lorawan_buffer_t *buf)
 {
     size_t size = 0;
-
     if (mac->mlme.pending_mlme_opts & GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ) {
         size += _fopts_mlme_link_check_req(buf);
+    }
+
+    if (mac->mlme.pending_mlme_opts & GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS) {
+        size += _fopts_mlme_link_adr_ans(mac, buf);
     }
 
     return size;

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -21,7 +21,18 @@
 #include "debug.h"
 
 #define GNRC_LORAWAN_DATARATES_NUMOF        (6U)
+
+#if (IS_ACTIVE(CONFIG_LORAMAC_REGION_EU_868))
 #define GNRC_LORAWAN_TX_POWER_INDEX_MAX     (7U)
+#elif (IS_ACTIVE(CONFIG_LORAMAC_REGION_IN_865))
+#define GNRC_LORAWAN_TX_POWER_INDEX_MAX     (10U)
+#endif
+
+#if (IS_ACTIVE(CONFIG_LORAMAC_REGION_EU_868))
+#define GNRC_LORAWAN_TX_POWER_MAX           (16)
+#elif (IS_ACTIVE(CONFIG_LORAMAC_REGION_IN_865))
+#define GNRC_LORAWAN_TX_POWER_MAX           (30)
+#endif
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -47,6 +58,19 @@ int gnrc_lorawan_set_dr(gnrc_lorawan_t *mac, uint8_t datarate)
     dev->driver->set(dev, NETOPT_SPREADING_FACTOR, &sf, sizeof(sf));
 
     return 0;
+}
+
+int gnrc_lorawan_set_tx_power(gnrc_lorawan_t *mac, uint8_t tx_pwr)
+{
+    netdev_t *dev = gnrc_lorawan_get_netdev(mac);
+
+    if (!gnrc_lorawan_validate_tx_power(tx_pwr)) {
+        return -EINVAL;
+    }
+    DEBUG("gnrc_lorawan_region: TX Power index: %u \n",tx_pwr);
+
+    int tx_pwr_db = GNRC_LORAWAN_TX_POWER_MAX - (tx_pwr * 2);
+    return dev->driver->set(dev, NETOPT_TX_POWER, &tx_pwr_db, sizeof(tx_pwr_db));
 }
 
 #if (IS_ACTIVE(CONFIG_LORAMAC_REGION_EU_868))

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -20,7 +20,8 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#define GNRC_LORAWAN_DATARATES_NUMOF (6U)
+#define GNRC_LORAWAN_DATARATES_NUMOF        (6U)
+#define GNRC_LORAWAN_TX_POWER_INDEX_MAX     (7U)
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -142,6 +143,15 @@ bool gnrc_lorawan_validate_dr(uint8_t dr)
         return true;
     }
     DEBUG("gnrc_lorawan_region: Invalid DR.\n");
+    return false;
+}
+
+bool gnrc_lorawan_validate_tx_power(uint8_t tx_power)
+{
+    if (tx_power <= GNRC_LORAWAN_TX_POWER_INDEX_MAX) {
+        return true;
+    }
+    DEBUG("gnrc_lorawan_region: Invalid TX Power index\n");
     return false;
 }
 

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -153,6 +153,7 @@ typedef struct {
     int nb_trials;                      /**< holds the remaining number of retransmissions */
     int ack_requested;                  /**< whether the network server requested an ACK */
     int waiting_for_ack;                /**< true if the MAC layer is waiting for an ACK */
+    uint8_t redundancy;                 /**< unconfirmed uplink redundancy */
     char mhdr_mic[MHDR_MIC_BUF_SIZE];   /**< internal retransmissions buffer */
 } gnrc_lorawan_mcps_t;
 
@@ -393,11 +394,11 @@ void gnrc_lorawan_mlme_no_rx(gnrc_lorawan_t *mac);
 void gnrc_lorawan_event_no_rx(gnrc_lorawan_t *mac);
 
 /**
- * @brief Mac callback for ACK timeout event
+ * @brief Mac callback for retransmission timeout event
  *
  * @param[in] mac pointer to the MAC descriptor
  */
-void gnrc_lorawan_event_ack_timeout(gnrc_lorawan_t *mac);
+void gnrc_lorawan_event_retrans_timeout(gnrc_lorawan_t *mac);
 
 /**
  * @brief Get the maximum MAC payload (M value) for a given datarate.

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -246,6 +246,18 @@ void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce,
 int gnrc_lorawan_set_dr(gnrc_lorawan_t *mac, uint8_t datarate);
 
 /**
+ * @brief Set TX power (PHY parameter) for the next transmission
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] tx_pwr desired TX power index
+ *
+ * @return 0 on success
+ * @return -EINVAL if TX power is not available in the current region
+ * @return negative number on error
+ */
+int gnrc_lorawan_set_tx_power(gnrc_lorawan_t *mac, uint8_t tx_pwr);
+
+/**
  * @brief build uplink frame
  *
  * @param[in] mac pointer to MAC descriptor

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -69,14 +69,14 @@ extern "C" {
 #define GNRC_LORAWAN_BACKOFF_BUDGET_3   (8700000LL)     /**< budget of time on air every 24 hours */
 
 #define GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ  (1 << 0) /**< Internal Link Check request flag */
-#define GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS    (1 << 1)
+#define GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS    (1 << 1) /**< Internal Link ADR Answer flag */
 
 #define GNRC_LORAWAN_CID_SIZE (1U)                      /**< size of Command ID in FOps */
 #define GNRC_LORAWAN_CID_LINK_ADR_ANS_SIZE (2U)         /**< size of Link ADR Answer CID in FOps */
 
 #define GNRC_LORAWAN_CID_LINK_CHECK_ANS (0x02)          /**< Link Check CID */
-#define GNRC_LORAWAN_CID_LINK_ADR_REQ   (0x03)
-#define GNRC_LORAWAN_CID_LINK_ADR_ANS   (0x03)
+#define GNRC_LORAWAN_CID_LINK_ADR_REQ   (0x03)          /**< Link ADR Request CID */
+#define GNRC_LORAWAN_CID_LINK_ADR_ANS   (0x03)          /**< Link ADR Answer CID */
 
 #define GNRC_LORAWAN_FOPT_LINK_CHECK_ANS_SIZE (3U)      /**< size of Link check answer */
 #define GNRC_LORAWAN_FOPT_LINK_ADR_REQ_SIZE   (5U)      /**< size of Link ADR Request (LinkADRReq) */
@@ -245,7 +245,7 @@ void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce,
                                         uint8_t *appskey);
 
 /**
- * @brief Set SF and BW for the next transmission
+ * @brief Set PHY parameters from DR for the next transmission
  *
  * @param[in] mac pointer to the MAC descriptor
  * @param[in] datarate desired datarate

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -69,11 +69,17 @@ extern "C" {
 #define GNRC_LORAWAN_BACKOFF_BUDGET_3   (8700000LL)     /**< budget of time on air every 24 hours */
 
 #define GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ  (1 << 0) /**< Internal Link Check request flag */
+#define GNRC_LORAWAN_MLME_OPTS_LINK_ADR_ANS    (1 << 1)
 
 #define GNRC_LORAWAN_CID_SIZE (1U)                      /**< size of Command ID in FOps */
+#define GNRC_LORAWAN_CID_LINK_ADR_ANS_SIZE (2U)         /**< size of Link ADR Answer CID in FOps */
+
 #define GNRC_LORAWAN_CID_LINK_CHECK_ANS (0x02)          /**< Link Check CID */
+#define GNRC_LORAWAN_CID_LINK_ADR_REQ   (0x03)
+#define GNRC_LORAWAN_CID_LINK_ADR_ANS   (0x03)
 
 #define GNRC_LORAWAN_FOPT_LINK_CHECK_ANS_SIZE (3U)      /**< size of Link check answer */
+#define GNRC_LORAWAN_FOPT_LINK_ADR_REQ_SIZE   (5U)      /**< size of Link ADR Request (LinkADRReq) */
 
 #define GNRC_LORAWAN_JOIN_DELAY_U32_MASK (0x1FFFFF)     /**< mask for detecting overflow in frame counter */
 
@@ -113,7 +119,7 @@ extern "C" {
 typedef struct {
     uint8_t *data;  /**< pointer to the beginning of the buffer holding data */
     uint8_t size;   /**< size of the buffer */
-    uint8_t index;  /**< current inxed in the buffer */
+    uint8_t index;  /**< current index in the buffer */
 } lorawan_buffer_t;
 
 /**
@@ -162,11 +168,15 @@ typedef struct {
  */
 typedef struct {
     uint8_t activation;     /**< Activation mechanism of the MAC layer */
+    bool adr;               /**< Whether adr is enabled or not */
     int pending_mlme_opts;  /**< holds pending mlme opts */
     uint32_t nid;           /**< current Network ID */
     int32_t backoff_budget; /**< remaining Time On Air budget */
     uint8_t dev_nonce[2];   /**< Device Nonce */
     uint8_t backoff_state;  /**< state in the backoff state machine */
+    uint16_t adr_ack_cnt;   /**< ADR ACK counter */
+    uint8_t adr_req_cnt;    /**< LINK ADR REQ counter */
+    uint8_t adr_flags;      /**< Flags to denote the status of ADR_REQ */
 } gnrc_lorawan_mlme_t;
 
 /**
@@ -235,7 +245,7 @@ void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce,
                                         uint8_t *appskey);
 
 /**
- * @brief Set datarate for the next transmission
+ * @brief Set SF and BW for the next transmission
  *
  * @param[in] mac pointer to the MAC descriptor
  * @param[in] datarate desired datarate
@@ -487,12 +497,34 @@ static inline void gnrc_lorawan_mac_release(gnrc_lorawan_t *mac)
 }
 
 /**
+ * @brief Check if ADRACKReq should be set
+ *
+ * @param[in] adr_ack_cnt ADR ACK counter
+ * @param[in] dr datarate
+ */
+static inline bool gnrc_lorawan_should_set_ack_req(uint16_t adr_ack_cnt, uint8_t dr)
+{
+    return adr_ack_cnt >= CONFIG_LORAMAC_DEFAULT_ADR_ACK_LIMIT && dr;
+}
+
+/**
  * @brief Set the datarate of the second reception window
  *
  * @param[in] mac pointer to the MAC descriptor
  * @param[in] rx2_dr datarate of RX2
  */
 void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr);
+
+/**
+ * @brief Set the datarate of the second reception window
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param[in] adr set ADR status
+`
+ * @retval -EALREADY if current state is same as the requested state.
+ * @retval GNRC_LORAWAN_REQ_STATUS_SUCCESS if success
+ */
+int gnrc_lorawan_set_adr(gnrc_lorawan_t *mac, bool adr);
 
 /**
  * @brief Trigger the transmission of the Join Request packet.

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -414,6 +414,14 @@ static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
             memcpy(opt->data, &tmp, sizeof(uint32_t));
             res = sizeof(uint32_t);
             break;
+        case NETOPT_LORAWAN_ADR:
+            mlme_request.type = MLME_GET;
+            mlme_request.mib.type = MIB_ADR;
+            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                      &mlme_confirm);
+            *((bool *)opt->data) = mlme_confirm.mib.adr;
+            res = sizeof(bool);
+            break;
         default:
             res = netif->dev->driver->get(netif->dev, opt->opt, opt->data,
                                           opt->data_len);
@@ -430,6 +438,14 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
 
     gnrc_netif_acquire(netif);
     switch (opt->opt) {
+        case NETOPT_LORAWAN_ADR:
+            assert(opt->data_len == sizeof(bool));
+            mlme_request.type = MLME_SET;
+            mlme_request.mib.type = MIB_ADR;
+            mlme_request.mib.adr = *((bool *)opt->data);
+            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                      &mlme_confirm);
+            break;
         case NETOPT_LORAWAN_DR:
             assert(opt->data_len == sizeof(uint8_t));
             if (!gnrc_lorawan_validate_dr(*((uint8_t *)opt->data))) {

--- a/sys/net/link_layer/Kconfig.lorawan
+++ b/sys/net/link_layer/Kconfig.lorawan
@@ -524,4 +524,16 @@ config LORAMAC_DEFAULT_MIN_RX_SYMBOLS
         system timer. Refer SX1276_settings_for_LoRaWAN_v2p2.pdf
         (AN1200.24) from Semtech for more information.
 
+config LORAMAC_DEFAULT_REDUNDANCY
+    int "Default redundancy for unconfirmed uplinks"
+    depends on USEMODULE_GNRC_LORAWAN
+    default 0
+    range 0 14
+    help
+         This corresponds to the number of unconfirmed
+         uplink retransmissions when using ADR. This
+         configuration does not affect confirmed uplinks.
+         By default, uplinks are sent without retransmissions
+         (this means, the device sends only one uplink packet)
+
 endif # KCONFIG_USEMODULE_LORAWAN

--- a/sys/net/link_layer/Kconfig.lorawan
+++ b/sys/net/link_layer/Kconfig.lorawan
@@ -374,7 +374,6 @@ config LORAMAC_DEFAULT_RETX
 
 config LORAMAC_DEFAULT_ADR
     bool "Enable ADR" if LORAMAC_ADVANCED_OPTIONS
-    depends on USEPKG_SEMTECH_LORAMAC || USEMODULE_RN2XX3
     help
         Enable or disable Adaptive Data Rate (ADR). If enabled the end node will
         inform the network server about the status of ADR using the ADR field in
@@ -535,5 +534,21 @@ config LORAMAC_DEFAULT_REDUNDANCY
          configuration does not affect confirmed uplinks.
          By default, uplinks are sent without retransmissions
          (this means, the device sends only one uplink packet)
+
+config LORAMAC_DEFAULT_ADR_ACK_LIMIT
+    int "ACK limit (ADR)" if LORAMAC_ADVANCED_OPTIONS
+    depends on USEMODULE_GNRC_LORAWAN
+    default 64
+    help
+        Defines the ADR ACK counter limit (`ADR_ACK_CNT`).
+
+config LORAMAC_DEFAULT_ADR_ACK_DELAY
+    int "ACK delay (ADR)" if LORAMAC_ADVANCED_OPTIONS
+    depends on USEMODULE_GNRC_LORAWAN
+    default 32
+    help
+        Configure the window ,in terms of number of uplink frames, within which
+        Network Server is expected to send a downlink after `ADRACKReq` bit has
+        been set by the node.
 
 endif # KCONFIG_USEMODULE_LORAWAN

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -79,6 +79,7 @@ static const struct {
     { "checksum", NETOPT_CHECKSUM },
     { "otaa", NETOPT_OTAA },
     { "link_check", NETOPT_LINK_CHECK },
+    { "adr", NETOPT_LORAWAN_ADR },
 };
 
 /* utility functions */
@@ -452,6 +453,10 @@ static void _print_netopt(netopt_t opt)
 
         case NETOPT_LORAWAN_RX2_DR:
             printf("RX2 datarate");
+            break;
+
+        case NETOPT_LORAWAN_ADR:
+            printf("ADR");
             break;
 
         default:


### PR DESCRIPTION
The PR adds ADR feature to gnrc_lorawan stack.

More information on the implementation of ADR and ADRACKReq can be found [here](https://hackmd.io/@aeefs2Y8TMms-cjTDX4cfw/Hycae-4Z_)

### Contribution description

- Allow ADR feature to set/reset Datarate.
- Enable ADRACKReq to be served so as to rollback node in the event transmission fails.

Pending:
- ~TX power~
- ~Channel Mask~
- ~Redundancy~ 

Pending ones shall be updated once #15943 ,  #15946 gets merged.

### Testing procedure

- Compiles binaries for b-l072z-lrwan1. Build works fine.
- Tested ADR application using Chirpstack NS in EU868 band.

### Issues/PRs references

 See also ~#15943~ ,  #15946

