### PR TITLE
dist/tools/avarice/debug.sh: Change gdb check order

### DIFF
--- a/dist/tools/avarice/debug.sh
+++ b/dist/tools/avarice/debug.sh
@@ -3,10 +3,10 @@
 # The setsid command is needed so that Ctrl+C in GDB doesn't kill avarice
 : ${SETSID:=setsid}
 
-if gdb-multiarch -v > /dev/null; then
-    GDB=gdb-multiarch
-elif avr-gdb -v > /dev/null; then
+if avr-gdb -v > /dev/null; then
     GDB=avr-gdb
+elif gdb-multiarch -v > /dev/null; then
+    GDB=gdb-multiarch
 else
     echo "Couldn't find multiarch GDB or AVR GDB. Check \$PATH."
     exit 1


### PR DESCRIPTION
### Contribution description

There are some Linux distributions like DEBIAN 10 that gdb-multiarch doesn't work as expected and debug section not start.  Since AVARICE is dedicated to AVR architecture, let's check first by the default tool then multiarch version.

### Testing procedure

`make BOARD=<board name> all flash debug`

### Issues/PRs references

detected at #15758

CC: @maribu 