### PR TITLE
malloc_thread_safe: use recursive mutex

### DIFF
--- a/sys/malloc_thread_safe/malloc_wrappers.c
+++ b/sys/malloc_thread_safe/malloc_wrappers.c
@@ -16,47 +16,47 @@
 
 #include "assert.h"
 #include "irq.h"
-#include "mutex.h"
+#include "rmutex.h"
 
 extern void *__real_malloc(size_t size);
 extern void __real_free(void *ptr);
 extern void *__real_calloc(size_t nmemb, size_t size);
 extern void *__real_realloc(void *ptr, size_t size);
 
-static mutex_t _lock;
+static rmutex_t _lock = RMUTEX_INIT;
 
 void *__wrap_malloc(size_t size)
 {
     assert(!irq_is_in());
-    mutex_lock(&_lock);
+    rmutex_lock(&_lock);
     void *ptr = __real_malloc(size);
-    mutex_unlock(&_lock);
+    rmutex_unlock(&_lock);
     return ptr;
 }
 
 void __wrap_free(void *ptr)
 {
     assert(!irq_is_in());
-    mutex_lock(&_lock);
+    rmutex_lock(&_lock);
     __real_free(ptr);
-    mutex_unlock(&_lock);
+    rmutex_unlock(&_lock);
 }
 
 void *__wrap_calloc(size_t nmemb, size_t size)
 {
     assert(!irq_is_in());
-    mutex_lock(&_lock);
+    rmutex_lock(&_lock);
     void *ptr = __real_calloc(nmemb, size);
-    mutex_unlock(&_lock);
+    rmutex_unlock(&_lock);
     return ptr;
 }
 
 void *__wrap_realloc(void *ptr, size_t size)
 {
     assert(!irq_is_in());
-    mutex_lock(&_lock);
+    rmutex_lock(&_lock);
     void *new = __real_realloc(ptr, size);
-    mutex_unlock(&_lock);
+    rmutex_unlock(&_lock);
     return new;
 }
 


### PR DESCRIPTION
When building with picolibc (using `FEATURES_REQUIRED += picolibc`), `realloc()` hangs.
In picolibc, `realloc(NULL, x)` calls `malloc(x)`, and so the code in `malloc_wrappers.c` ends up trying to `mutex_lock(_lock)` twice.

This PR switches to a recursive mutex instead so that it's OK if libc's realloc() calls malloc().