### PR TITLE
net/ieee802154/radio: use bitflags for capabilities

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -400,23 +400,6 @@ static int _off(ieee802154_dev_t *dev)
     return -ENOTSUP;
 }
 
-static bool _get_cap(ieee802154_dev_t *dev, ieee802154_rf_caps_t cap)
-{
-    (void) dev;
-    switch (cap) {
-        case IEEE802154_CAP_24_GHZ:
-        case IEEE802154_CAP_AUTO_CSMA:
-        case IEEE802154_CAP_IRQ_CRC_ERROR:
-        case IEEE802154_CAP_IRQ_TX_DONE:
-        case IEEE802154_CAP_IRQ_CCA_DONE:
-        case IEEE802154_CAP_IRQ_RX_START:
-        case IEEE802154_CAP_IRQ_TX_START:
-            return true;
-        default:
-            return false;
-    }
-}
-
 static int _set_hw_addr_filter(ieee802154_dev_t *dev, const network_uint16_t *short_addr,
                                const eui64_t *ext_addr, const uint16_t *pan_id)
 {
@@ -536,6 +519,14 @@ static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *b
 }
 
 static const ieee802154_radio_ops_t cc2538_rf_ops = {
+    .caps = IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_AUTO_CSMA
+          | IEEE802154_CAP_IRQ_CRC_ERROR
+          | IEEE802154_CAP_IRQ_TX_DONE
+          | IEEE802154_CAP_IRQ_CCA_DONE
+          | IEEE802154_CAP_IRQ_RX_START
+          | IEEE802154_CAP_IRQ_TX_START,
+
     .write = _write,
     .read = _read,
     .request_transmit = _request_transmit,
@@ -548,7 +539,6 @@ static const ieee802154_radio_ops_t cc2538_rf_ops = {
     .confirm_set_trx_state = _confirm_set_trx_state,
     .request_cca = _request_cca,
     .confirm_cca = _confirm_cca,
-    .get_cap = _get_cap,
     .set_cca_threshold = _set_cca_threshold,
     .set_cca_mode = _set_cca_mode,
     .config_phy = _config_phy,

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -661,22 +661,6 @@ static int _off(ieee802154_dev_t *dev)
     return 0;
 }
 
-static bool _get_cap(ieee802154_dev_t *dev, ieee802154_rf_caps_t cap)
-{
-    (void) dev;
-    switch (cap) {
-    case IEEE802154_CAP_24_GHZ:
-    case IEEE802154_CAP_IRQ_CRC_ERROR:
-    case IEEE802154_CAP_IRQ_RX_START:
-    case IEEE802154_CAP_IRQ_TX_START:
-    case IEEE802154_CAP_IRQ_TX_DONE:
-    case IEEE802154_CAP_IRQ_CCA_DONE:
-        return true;
-    default:
-        return false;
-    }
-}
-
 int _len(ieee802154_dev_t *dev)
 {
     (void) dev;
@@ -793,6 +777,13 @@ void nrf802154_setup(nrf802154_t *dev)
 }
 
 static const ieee802154_radio_ops_t nrf802154_ops = {
+    .caps =  IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_IRQ_CRC_ERROR
+          | IEEE802154_CAP_IRQ_RX_START
+          | IEEE802154_CAP_IRQ_TX_START
+          | IEEE802154_CAP_IRQ_TX_DONE
+          | IEEE802154_CAP_IRQ_CCA_DONE,
+
     .write = _write,
     .read = _read,
     .request_transmit = _request_transmit,
@@ -805,7 +796,6 @@ static const ieee802154_radio_ops_t nrf802154_ops = {
     .confirm_set_trx_state = _confirm_set_trx_state,
     .request_cca = _request_cca,
     .confirm_cca = _confirm_cca,
-    .get_cap = _get_cap,
     .set_cca_threshold = set_cca_threshold,
     .set_cca_mode = _set_cca_mode,
     .config_phy = _config_phy,


### PR DESCRIPTION
### Contribution description

Modifies the `ieee802154_radio_ops_t` structure to use an integer to store capabilities instead of a function call. Uses an `uint16_t` for this purpose, in the future, if needed could be extended to an `uint32_t` if more capabilities are needed.

The `caps` field was put on the top of the structure just for aesthetics reasons (to not mix actual operations with the capabilities).

The motivation is to (on another PR) add the PHY capabilities, see https://github.com/RIOT-OS/RIOT/pull/15932#discussion_r570904375 and previous comment on the HAL RDM (https://github.com/RIOT-OS/RIOT/pull/13943#discussion_r414769629).

<details>
<summary>Binary size changes</summary>

Tested with `make -C examples/gnrc_networking BOARD=<....>`

#### PR

**cc2538dk**
```
   text	   data	    bss	    dec	    hex	filename
  91512	    208	  19092	 110812	  1b0dc	/home/jeandudey/Dev/RIOT/examples/gnrc_networking/bin/cc2538dk/gnrc_networking.elf
```

**nrf52840dk**

```
   text	   data	    bss	    dec	    hex	filename
  88796	    200	  19388	 108384	  1a760	/home/jeandudey/Dev/RIOT/examples/gnrc_networking/bin/nrf52840dk/gnrc_networking.elf
```

#### master

**cc2538dk**
```
   text	   data	    bss	    dec	    hex	filename
  91556	    208	  19092	 110856	  1b108	/home/jeandudey/Dev/RIOT/examples/gnrc_networking/bin/cc2538dk/gnrc_networking.elf
```

**nrf52840dk**

```
   text	   data	    bss	    dec	    hex	filename
  88836	    200	  19388	 108424	  1a788	/home/jeandudey/Dev/RIOT/examples/gnrc_networking/bin/nrf52840dk/gnrc_networking.elf
```

The `text`  section was reduced by 44 bytes on `cc2538dk` and 40 bytes on `nrf52840dk`. `data` and `bss` stayed the same.

</details>

### Testing procedure

- `make -C examples/gnrc_networking BOARD=cc2538dk`
- `make -C examples/gnrc_networking BOARD=nrf52840dk`


*Note:* i don't own any of the boards for actual testing, so if something is wrong or doesn't work as expected leave a comment 😉 .

### Issues/PRs references

See #15932 
