### PR TITLE
Cpu/nrf52/saul vddh

### DIFF
--- a/boards/nrf52840dongle/Makefile.dep
+++ b/boards/nrf52840dongle/Makefile.dep
@@ -1,6 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += saul_pwm
+  USEMODULE += saul_nrf_vddh
 endif
 
 include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -17,5 +17,9 @@ ifneq (,$(filter nrf52832xxaa,$(CPU_MODEL)))
   endif
 endif
 
+ifneq (,$(filter saul_nrf_vddh,$(CPU_MODEL)))
+  FEATURES_REQUIRED += periph_adc
+endif
+
 include $(RIOTCPU)/nrf5x_common/Makefile.dep
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/drivers/saul/init_devs/auto_init_saul_nrf_vddh.c
+++ b/drivers/saul/init_devs/auto_init_saul_nrf_vddh.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of internal voltage sensor directly mapped to SAUL reg
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "saul/periph.h"
+#include "periph/adc.h"
+
+/* ADC uses ¼ Vdd for Vref amplified by 4 */
+#define VDD_REF_mV  (3300)
+
+static int _read_voltage(const void *dev, phydat_t *res)
+{
+    (void)dev;
+
+    int raw = adc_sample(NRF52_VDDHDIV5, ADC_RES_12BIT) * 5 * VDD_REF_mV;
+    res->val[0] = raw >> 12;
+    res->unit = UNIT_V;
+    res->scale = -3;
+
+    return 1;
+}
+
+static saul_driver_t nrf_vddh_saul_driver = {
+    .read = _read_voltage,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_VOLTAGE,
+};
+
+void auto_init_nrf_vddh(void)
+{
+    static saul_reg_t saul_reg_entry = {
+        .dev = NULL,
+        .name = "NRF_VDDH",
+        .driver = &nrf_vddh_saul_driver,
+    };
+
+    adc_init(NRF52_VDDHDIV5);
+
+    /* add to registry */
+    saul_reg_add(&(saul_reg_entry));
+}

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -43,6 +43,10 @@ void saul_init_devs(void)
         extern void auto_init_nrf_temperature(void);
         auto_init_nrf_temperature();
     }
+    if (IS_USED(MODULE_SAUL_NRF_VDDH)) {
+        extern void auto_init_nrf_vddh(void);
+        auto_init_nrf_vddh();
+    }
     if (IS_USED(MODULE_AD7746)) {
         extern void auto_init_ad7746(void);
         auto_init_ad7746();

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -119,6 +119,7 @@ PSEUDOMODULES += saul_adc
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio
 PSEUDOMODULES += saul_nrf_temperature
+PSEUDOMODULES += saul_nrf_vddh
 PSEUDOMODULES += saul_pwm
 PSEUDOMODULES += scanf_float
 PSEUDOMODULES += sched_cb


### PR DESCRIPTION
### Contribution description

nRF52 parts that can be powered by high voltage (up to 5.5V) can sense the high supply voltage (VDDH) via ADC.
This adds a SAUL fronted to conveniently query the supply voltage.


### Testing procedure

`nrf52840dongle` is the only board powered directly by VDDH, so the SAUL module is only enabled here.

It's possible to see the difference between plugging in the power supply on the USB hub the dongle is connected to:

#### USB hub power supply disconnected

```
2021-02-13 23:42:43,705 # saul
2021-02-13 23:42:43,706 # ID	Class		Name
2021-02-13 23:42:43,707 # #0	SENSE_BTN	SW 1
2021-02-13 23:42:43,707 # #1	ACT_DIMMER	LD 1
2021-02-13 23:42:43,708 # #2	ACT_LED_RGB	LD 2
2021-02-13 23:42:43,708 # #3	SENSE_TEMP	NRF_TEMP
2021-02-13 23:42:43,708 # #4	SENSE_VOLTAGE	NRF_VDDH

> 2021-02-13 23:39:04,589 # saul read 4
2021-02-13 23:39:04,590 # Reading from #4 (NRF_VDDH|SENSE_VOLTAGE)
2021-02-13 23:39:04,591 # Data:	           4842 mV
```

#### USB hub power supply connected

```
> 2021-02-13 23:39:11,645 # saul read 4
2021-02-13 23:39:11,646 # Reading from #4 (NRF_VDDH|SENSE_VOLTAGE)
2021-02-13 23:39:11,647 # Data:	           4946 mV
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
