### PR TITLE
cpu/nrf5x: only enable DCDC for REG0 if REG0 exists

### DIFF
--- a/cpu/nrf5x_common/include/nrfx.h
+++ b/cpu/nrf5x_common/include/nrfx.h
@@ -46,7 +46,7 @@ static inline void nrfx_dcdc_init(void)
     /* on CPUs that support high voltage power supply via VDDH and thus use a
      * two stage regulator, we also enable the DC/DC converter for the first
      * state. */
-#ifdef POWER_MAINREGSTATUS_MAINREGSTATUS_High
+#ifdef POWER_DCDCEN0_DCDCEN_Msk
     if (NRF_POWER->MAINREGSTATUS == POWER_MAINREGSTATUS_MAINREGSTATUS_High) {
         NRF_POWER->DCDCEN0 = 1;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

nRF52833 has `POWER_MAINREGSTATUS_MAINREGSTATUS_High`, but no `POWER->DCDCEN0` register.

This breaks all builds on this MCU.

Check for the proper define in the `#ifdef` to fix the build.

### Testing procedure

Murdock should stop failing on `microbit-v2`


### Issues/PRs references

#15991  and #15955 where build independent from each other on CI.
Now that both are merged, the error becomes apparent. 
