### PR TITLE
cpu/nrf5x_common: make GPIO_PIN macro model independent

### DIFF
--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -58,6 +58,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   nRF51 only has one GPIO block
+ */
+#define GPIO_COUNT              (1U)
+
+/**
  * @brief   Due to RAM restrictions, we need to limit the default GNRC packet
  *          buffer size on these CPUs
  * @{

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -46,7 +46,7 @@ extern "C" {
  *
  * The port definition is used (and zeroed) to suppress compiler warnings
  */
-#if !defined(CPU_MODEL_NRF52832XXAA) && !defined(CPU_FAM_NRF51)
+#if GPIO_COUNT > 1
 #define GPIO_PIN(x,y)       ((x << 5) | y)
 #else
 #define GPIO_PIN(x,y)       ((x & 0) | y)

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -86,7 +86,7 @@ static inline NRF_GPIO_Type *port(gpio_t pin)
  */
 static inline int pin_num(gpio_t pin)
 {
-#if !defined(CPU_MODEL_NRF52832XXAA) && !defined(CPU_FAM_NRF51)
+#if GPIO_COUNT > 1
     return (pin & PIN_MASK);
 #else
     return (int)pin;
@@ -184,7 +184,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* configure the GPIOTE channel: set even mode, pin and active flank */
     NRF_GPIOTE->CONFIG[_pin_index] = (GPIOTE_CONFIG_MODE_Event |
                              (pin_num(pin) << GPIOTE_CONFIG_PSEL_Pos) |
-#if !defined(CPU_MODEL_NRF52832XXAA) && !defined(CPU_FAM_NRF51)
+#if GPIO_COUNT > 1
                              ((pin & PORT_BIT) << 8) |
 #endif
                              (flank << GPIOTE_CONFIG_POLARITY_Pos));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like you to make sure that your modifications are compliant with the RIOT coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

We can use the `GPIO_COUNT` vendor macro to check if there is more than one GPIO port on nRF52.
This is the case for nRF52840 and nRF52833.

### Testing procedure

Pins on the second GPIO block should still work, no additional code should be generated on MCUs without that block.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
