### PR TITLE
core/mutex: Check against mutex use outside of threads

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -49,7 +49,9 @@ static inline __attribute__((always_inline)) void _block(mutex_t *mutex,
                                                          unsigned irq_state)
 {
     thread_t *me = thread_get_active();
-
+    /* Fail visibly even if a blocking action is called from somewhere where
+     * it's subtly not allowed, eg. board_init */
+    assert(me != NULL);
     DEBUG("PID[%" PRIkernel_pid "] mutex_lock() Adding node to mutex queue: "
           "prio: %" PRIu32 "\n", thread_getpid(), (uint32_t)me->priority);
     sched_set_status(me, STATUS_MUTEX_BLOCKED);

--- a/doc/doxygen/src/porting-boards.md
+++ b/doc/doxygen/src/porting-boards.md
@@ -60,7 +60,9 @@ somewhere else then they must be added to the include path. In
 
 Board initialization functions are defined in `board.c`. This file must at
 least define a `board_init()` function that is called at startup. This
-function initializes the `CPU` by calling`cpu_init()` among others.
+function initializes the `CPU` by calling`cpu_init()` among others. It is run
+before the scheduler is started, so it must not block (e.g. by performing I2C
+operations).
 
 ```c
 void board_init(void)


### PR DESCRIPTION
### Contribution description

I recently (obligatory "this happened a few weeks ago") got bitten by doing I2C (which is blocking) inside board_init (which happens way before threads are around). In retrospect the error is obvious, but before, it heisenbugged me -- for while I2C is set to debug, the mutices don't block for stdio takes longer, and once you start building without I2C debug, Weird Things happen.

This adds an assert into the mutex locking path that checks whether the about-to-be-used thread struct pointer is actually non-null, ie. whether it's actually being executed from a thread (and not before threads are around).

Some warning words about the board_init implementation are added to catch the mistake before it is made.

### Open questinos

* This triggers only when there are no threads *yet*, not when in an IRQ. Would it make sense to add an `&& !irq_is_in()`?

### Testing procedure

Insert the following around and into `board_init` in `boards/native/board_init.c`:

```c
#include <mutex.h>
```
```c
mutex_t m;
mutex_init(&m);
mutex_lock(&m);
mutex_lock(&m);
```

Without the patch, it segfaults. With the patch, it crashes with an assertion error.

### Impact

As asserts are disabled without DEVHELP, there should be no impact for the tightest build; for everything else, it's a relatively cheap check.