### PR TITLE
makefile/..picolibc: make missing picolibc fail louder

### DIFF
--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -7,7 +7,9 @@ ifneq (,$(filter picolibc,$(USEMODULE)))
         LINKFLAGS += -Wl,--no-wchar-size-warning
     endif
   else
-    $(warning picolib was selected to be build but no picolib.spec could be found)
+    $(warning picolibc was selected to be build but no picolibc.spec could be found)
+    $(warning you might want to install "picolibc" for "$(TARGET_ARCH)")
+    $(warning or add "FEATURES_BLACKLIST += picolibc" to Makefile)
     $(error   check your installation or build configuration.)
   endif
 endif

--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -6,6 +6,9 @@ ifneq (,$(filter picolibc,$(USEMODULE)))
         CFLAGS += -fshort-wchar
         LINKFLAGS += -Wl,--no-wchar-size-warning
     endif
+  else
+    $(warning picolib was selected to be build but no picolib.spec could be found)
+    $(error   check your installation or build configuration.)
   endif
 endif
 


### PR DESCRIPTION
### Contribution description

missing picolibc auto adaptation needs changes in make-system and is therefor on hold this PR make the build fail early and loud and needs basically no modification of unrelated make-system parts.

### Testing procedure

Build something that prefers or requires picolibc on a system that does not have it (installed) (e.g.: current Ubuntu LTS 20.04)
e.g.: RIOT/examples/gnrc_minimal for a cortex-m Board

before u get a failure somthing like:
```
"make" -C <Riot>/sys/picolibc_syscalls_default
<Riot>/sys/picolibc_syscalls_default/syscalls.c:236:5: error: implicit declaration of function 'FDEV_SETUP_STREAM' [-Werror=implicit-function-declaration]
  236 |     FDEV_SETUP_STREAM(picolibc_put, picolibc_get, picolibc_flush, _FDEV_SETUP_RW);
      |     ^~~~~~~~~~~~~~~~~
<Riot>/sys/picolibc_syscalls_default/syscalls.c:236:67: error: '_FDEV_SETUP_RW' undeclared here (not in a function)
  236 |     FDEV_SETUP_STREAM(picolibc_put, picolibc_get, picolibc_flush, _FDEV_SETUP_RW);
      |                                                                   ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

somewhere in the build process

after the patch you get:
```
<Riot>/makefiles/libc/picolibc.mk:10: picolib was selected to be build but no picolib.spec could be found
<Riot>/makefiles/libc/picolibc.mk:11: *** check your installation or build configuration.. Stop.
```
right at the start 

### Issues/PRs references
PR.: to fix the selection process (need make-system reordering): #15993
Issue about failed selection process: #15325
Issue about the criticality of order of inclusion: #9913

@maribu, @fjmolinas  might want to have a look at this
