### PR TITLE
newlib: remove include order dependency by setting `_DEFAULT_SOURCE` flag in Makefiles

### DIFF
--- a/sys/fs/constfs/Makefile
+++ b/sys/fs/constfs/Makefile
@@ -1,2 +1,6 @@
 MODULE=constfs
+
+# Required for strnlen in string.h, when building with -std=c99
+CFLAGS += -D_DEFAULT_SOURCE=1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -18,8 +18,6 @@
  * @}
  */
 
-/* Required for strnlen in string.h, when building with -std=c99 */
-#define _DEFAULT_SOURCE 1
 #include <stddef.h>
 #include <string.h>
 #include <unistd.h>

--- a/sys/fs/devfs/Makefile
+++ b/sys/fs/devfs/Makefile
@@ -1,2 +1,6 @@
 MODULE=devfs
+
+# Required for strnlen in string.h, when building with -std=c99
+CFLAGS += -D_DEFAULT_SOURCE=1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/fs/devfs/devfs.c
+++ b/sys/fs/devfs/devfs.c
@@ -18,8 +18,6 @@
  * @}
  */
 
-/* Required for strnlen in string.h, when building with -std=c99 */
-#define _DEFAULT_SOURCE 1
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -65,7 +65,9 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     SRC += sc_gnrc_rpl.c
 endif
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
-    SRC += sc_gnrc_6ctx.c
+  # Required for strtok_r in string.h, when building with -std=c99
+  CFLAGS += -D_DEFAULT_SOURCE=1
+  SRC += sc_gnrc_6ctx.c
 endif
 ifneq (,$(filter gnrc_sixlowpan_frag_stats,$(USEMODULE)))
   SRC += sc_gnrc_6lo_frag_stats.c

--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -12,8 +12,6 @@
  * @file
  */
 
-/* Required for strtok_r in string.h, when building with -std=c99 */
-#define _DEFAULT_SOURCE 1
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -2,6 +2,9 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 
+# Make some different functions visible between newlib and newlib-nano
+CFLAGS += -D_DEFAULT_SOURCE=1
+
 include $(RIOTBASE)/Makefile.include
 
 # Compile time tests

--- a/tests/libc_newlib/main.c
+++ b/tests/libc_newlib/main.c
@@ -18,11 +18,6 @@
  * @}
  */
 
-/*
- * Make some different functions visible between newlib and newlib-nano
- */
-#define _DEFAULT_SOURCE 1
-
 #include <stdio.h>
 #include "embUnit.h"
 


### PR DESCRIPTION
### Contribution description
The bulid tests for #15931 failed on some platforms due to include order problems for modules that declare the `_DEFAULT_SOURCE` flag before including some newlib headers. Reason is, that #15931 includes a specific header file globally, which also pulls some stdlib functionality on some platforms, and thus disabling the effect of the `_DEFAULT_SOURCE` flag set in subsequent C files.

This PR fixes this issue by pulling the `_DEFAULT_SOURCE` flag definition out of the corresponding C files and putting it inside the Makefile for that specific compilation unit. This mitigates any include order dependencies for good. 

This PR also adds slightly more coherency to RIOT, as now all modules that use this flag do use the same way of setting it (`pkg/minmea` already applied this pattern before...).

### Testing procedure
Build test would show if anything got broken.

### Issues/PRs references
Needed for #15931 to work correctly.
