### PR TITLE
riotboot: Mode selection for boards

### DIFF
--- a/bootloaders/riotboot_dfu/bootloader_selection.h
+++ b/bootloaders/riotboot_dfu/bootloader_selection.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/** @ingroup bootloaders
+ *
+ * @{
+ *
+ * @file
+ * @brief Configuration for the riotboot_dfu bootloader
+ *
+ * @author Christian Amsüss <chrysn@fsfe.org>
+ */
+
+/* Include guards and cplusplus are more of a formality; this header is local
+ * to the riotboot_dfu application that isn't written in C++ and not included
+ * from anywhere else either, but still here for consistency (and because
+ * otherwise the checks complain) */
+#ifndef BOOTLOADER_SELECTION_H
+#define BOOTLOADER_SELECTION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Not including GPIO headers: we're not actually *doing* anything on GPIO, and
+ * if no BTN0_PIN is defined we don't define anything either */
+#include <board.h>
+
+
+/** @brief Button pin for bootloader selection
+ *
+ * This pin (typically connected to a button) is checked by the riotboot_dfu
+ * bootloader to decide whether to enter DFU mode even if a valid image is
+ * present.
+ *
+ * The default value for all boards is BTN0, if one is defined.
+ *
+ * Boards that insist on not using any button even though they have some can
+ * define BTN_BOOTLOADER_NONE in their `board.h`.
+ *
+ * */
+#if (!defined(BTN_BOOTLOADER_PIN) && defined(BTN0_PIN) && !defined(BTN_BOOTLOADER_NONE)) || DOXYGEN
+#define BTN_BOOTLOADER_PIN BTN0_PIN
+#endif
+
+/** @brief Pin mode for @ref BTN_BOOTLOADER_PIN
+ *
+ * Mode into which the riotboot_dfu bootloader will configure @ref
+ * BTN_BOOTLOADER_PIN before reading it.
+ *
+ * */
+#ifndef BTN_BOOTLOADER_MODE
+#define BTN_BOOTLOADER_MODE BTN0_MODE
+#endif
+
+/** @brief Interpretation of @ref BTN_BOOTLOADER_PIN.
+ *
+ * Set to true for active-low buttons (go to DFU if the pin is low), otherwise
+ * to false (go to DFU if the pin is high).
+ *
+ * The default value for all boards is inverted (active-low).
+ *
+ * */
+#ifndef BTN_BOOTLOADER_INVERTED
+#define BTN_BOOTLOADER_INVERTED true
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOOTLOADER_SELECTION_H */
+
+/** @} */

--- a/bootloaders/riotboot_dfu/main.c
+++ b/bootloaders/riotboot_dfu/main.c
@@ -27,6 +27,22 @@
 #include "riotboot/slot.h"
 #include "riotboot/usb_dfu.h"
 
+#include "bootloader_selection.h"
+
+#ifdef BTN_BOOTLOADER_PIN
+#include "periph/gpio.h"
+#endif
+
+static bool _bootloader_alternative_mode(void)
+{
+#ifdef BTN_BOOTLOADER_PIN
+    gpio_init(BTN_BOOTLOADER_PIN, BTN_BOOTLOADER_MODE);
+    return (bool)gpio_read(BTN_BOOTLOADER_PIN) != BTN_BOOTLOADER_INVERTED;
+#else
+    return false;
+#endif
+}
+
 void kernel_init(void)
 {
     uint32_t version = 0;
@@ -50,7 +66,7 @@ void kernel_init(void)
     /* Flash the unused slot if magic word is set */
     riotboot_usb_dfu_init(0);
 
-    if (slot != -1) {
+    if (slot != -1 && !_bootloader_alternative_mode()) {
         riotboot_slot_jump(slot);
     }
 


### PR DESCRIPTION
### Contribution description

For USB bootloaders, it is common to have a way of entering the bootloader even when the application is not cooperating. A typical way is to poll a button on startup. (For example, the bootloaders shipped with nrf52840dongle and the particle xenon boards to that; the latter in a more elaborate fashion that includes blink patterns).

It doesn't help with remote bricking, and it doesn't help against flash writes to the bootloader (both of which might be mitigated by additional means), but solves the common case of "I forgot to give my application the right USEMODULES to get back into DFU" or "crash at board_init". 

### Testing procedure

* Flash the bootloader using `make -C bootloaders/riotboot_dfu BOARD=particle-xenon PROGRAMMER=openocd DEBUG_ADAPTER=stlink all flash`
* Dismantle your programmer. (Well, at least assume that from now on you won't want to use it any more).
* Notice how it comes up in the bootloader by running `dfu-util -l` and seeing "Found DFU" (unless, of course, there happens to be a valid image in there; an openocd `flash erase_sector 0 0 last` before the original programming ensures a cleans state)
* Add `FEATURES_REQUIRED += riotboot` to examples/filesystem/Makefile
* make -C examples/usbus_minimal BOARD=particle-xenon APP_VER=$(date +%s) PROGRAMMER=dfu-util all riotboot/flash-slot0`
* Notice how we forgot to add `USEMODULE += usbus_dfu`, and the board doesn't even come up. (That's probably a different bug, at least an ACM TTY should come up). Add the USEMODULE to filesystem example.
* To get the device usable without connecting a programmer, just keep the user button pressed while briefly pressing the reset button.
* On `dfu-util -l` the device now shows "Found DFU", indicating it's in bootloader mode.
* Run the riotboot/flash-slot0 target again.
* There should now be a ttyACM0, and dfu-util would report having found a Runtime.

### Open questions

* [x] The board's ability to pick an alternate mode is modeled as a FEATURE, which is optionally used by the bootloader. Is that the right choice?
* [x] I'm extracting whether or not the feature is used into a `CFLAGS+=-D...`. That looks uncommon, but creating a complete pseudomodule for it sounds extraneous. What's the best way?
* [x] The way the definition is then used in the code is crude; I hope to get some guidance out of #16007 on whether there should be an extra header file or whether it's really just `extern bool ...` everywhere it's used.
* [ ] Do we want to allow boards to do more fancy indicating? (Might be in one go -- a feature that, if set, provides this function *and* a "switch on whichever LED indicates bootloader mode here").
* [ ] For the DFU bootloader, there's a pretty obvious thing to do with the information. Can other variants (riotboot without DFU) make any use of it? That bootloader isn't much use if it doesn't find an image, but it might be asked to load the other image if still good (yay downgrade attacks -- but is local downgrading allowed?).
