### PR TITLE
boards: Remove per-board definition of board_init

### DIFF
--- a/boards/6lowpan-clicker/include/board.h
+++ b/boards/6lowpan-clicker/include/board.h
@@ -69,11 +69,6 @@ extern "C" {
 #define BTN1_MODE           GPIO_IN
 /** @} */
 
-/**
- * @brief   Board level initialization
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/acd52832/include/board.h
+++ b/boards/acd52832/include/board.h
@@ -50,11 +50,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/adafruit-itsybitsy-m4/include/board.h
+++ b/boards/adafruit-itsybitsy-m4/include/board.h
@@ -65,11 +65,6 @@ extern mtd_dev_t *mtd0;
 #define XTIMER_HZ                   (1000000ul)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/arduino-nano-33-iot/include/board.h
+++ b/boards/arduino-nano-33-iot/include/board.h
@@ -41,11 +41,6 @@ extern "C" {
 #define LED0_NAME           "LED(Yellow)"
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/atmega1284p/include/board.h
+++ b/boards/atmega1284p/include/board.h
@@ -53,11 +53,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/atmega256rfr2-xpro/include/board.h
+++ b/boards/atmega256rfr2-xpro/include/board.h
@@ -62,11 +62,6 @@ extern "C" {
 #define BTN0_MODE    GPIO_IN_PU
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/atmega328p/include/board.h
+++ b/boards/atmega328p/include/board.h
@@ -53,11 +53,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/avr-rss2/include/board.h
+++ b/boards/avr-rss2/include/board.h
@@ -110,11 +110,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -88,11 +88,6 @@ extern "C" {
  */
 #define BTN_B1_PIN          GPIO_PIN(PORT_B, 2)
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -80,11 +80,6 @@ extern "C" {
 #define LSM6DSL_PARAM_ADDR  (0x6A)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/bluepill-stm32f030c8/include/board.h
+++ b/boards/bluepill-stm32f030c8/include/board.h
@@ -48,11 +48,6 @@ extern "C" {
 #define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc1312-launchpad/include/board.h
+++ b/boards/cc1312-launchpad/include/board.h
@@ -65,11 +65,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc1350-launchpad/include/board.h
+++ b/boards/cc1350-launchpad/include/board.h
@@ -61,11 +61,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc1352-launchpad/include/board.h
+++ b/boards/cc1352-launchpad/include/board.h
@@ -65,11 +65,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc1352p-launchpad/include/board.h
+++ b/boards/cc1352p-launchpad/include/board.h
@@ -61,11 +61,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -80,11 +80,6 @@ extern "C" {
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/cc2650-launchpad/include/board.h
+++ b/boards/cc2650-launchpad/include/board.h
@@ -63,11 +63,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc2650stk/include/board.h
+++ b/boards/cc2650stk/include/board.h
@@ -61,11 +61,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs, and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/arduino-atmega/include/board_common.h
+++ b/boards/common/arduino-atmega/include/board_common.h
@@ -127,11 +127,6 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/arduino-due/include/board.h
+++ b/boards/common/arduino-due/include/board.h
@@ -51,11 +51,6 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/arduino-mkr/include/board_common.h
+++ b/boards/common/arduino-mkr/include/board_common.h
@@ -30,11 +30,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/arduino-zero/include/board.h
+++ b/boards/common/arduino-zero/include/board.h
@@ -52,11 +52,6 @@ extern "C" {
 #define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/blxxxpill/include/board_common.h
+++ b/boards/common/blxxxpill/include/board_common.h
@@ -50,11 +50,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
-/**
  * @brief   Use the 2nd UART for STDIO on this board
  */
 #define STDIO_UART_DEV      UART_DEV(1)

--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -98,11 +98,6 @@ extern "C" {
 #define LED2_TOGGLE         (GPIOC->ODR ^=  LED2_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/nrf51/include/board_common.h
+++ b/boards/common/nrf51/include/board_common.h
@@ -50,11 +50,6 @@ extern "C" {
 #define XTIMER_BACKOFF              (40)
 /** @} */
 
-/**
- * @brief   Initialize the platform
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/nrf52/include/board_common.h
+++ b/boards/common/nrf52/include/board_common.h
@@ -26,11 +26,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief   Initialize the platform
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -60,11 +60,6 @@ extern "C" {
  */
 void board_common_nucleo_init(void);
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/remote/include/board_common.h
+++ b/boards/common/remote/include/board_common.h
@@ -84,11 +84,6 @@
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -69,11 +69,6 @@ extern "C" {
 #define XTIMER_BACKOFF      (40)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/slwstk6000b/include/board.h
+++ b/boards/common/slwstk6000b/include/board.h
@@ -121,11 +121,6 @@ extern "C" {
 #define SI70XX_PARAM_I2C_DEV    SI7021_I2C
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/sodaq/include/board_common.h
+++ b/boards/common/sodaq/include/board_common.h
@@ -33,11 +33,6 @@ extern "C" {
 #define XTIMER_CHAN         (0)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/weact-f4x1cx/include/board.h
+++ b/boards/common/weact-f4x1cx/include/board.h
@@ -81,11 +81,6 @@ extern mtd_dev_t *mtd0;
 #define MTD_0 mtd0
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/derfmega128/include/board.h
+++ b/boards/derfmega128/include/board.h
@@ -35,11 +35,6 @@ extern "C" {
 
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/derfmega256/include/board.h
+++ b/boards/derfmega256/include/board.h
@@ -35,11 +35,6 @@ extern "C" {
 
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/e180-zg120b-tb/include/board.h
+++ b/boards/e180-zg120b-tb/include/board.h
@@ -86,11 +86,6 @@ extern "C" {
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -99,11 +99,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Initialize the board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -53,11 +53,6 @@ extern "C" {
 #define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -68,11 +68,6 @@ extern "C" {
 #define SX127X_PARAM_PASELECT           (SX127X_PA_BOOST)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/firefly/include/board.h
+++ b/boards/firefly/include/board.h
@@ -72,11 +72,6 @@ extern "C" {
 #define CC1200_GPD2_GPIO    GPIO_PIN(PORT_B, 0)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -96,11 +96,6 @@ extern "C" {
 #define LED1_TOGGLE         (GPIOB->ODR ^=  LED1_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/frdm-k22f/include/board.h
+++ b/boards/frdm-k22f/include/board.h
@@ -74,11 +74,6 @@ extern "C"
 #define FXOS8700_PARAM_ADDR         0x1C
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -75,11 +75,6 @@ extern "C"
 #define FXOS8700_PARAM_ADDR         0x1E
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/frdm-kl43z/include/board.h
+++ b/boards/frdm-kl43z/include/board.h
@@ -95,11 +95,6 @@ extern "C"
 #define MMA8X5X_PARAM_TYPE      (MMA8X5X_TYPE_MMA8451)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -127,11 +127,6 @@ extern "C" {
  */
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/hifive1/include/board.h
+++ b/boards/hifive1/include/board.h
@@ -56,11 +56,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
-/**
  * @brief   Initialize the board clock to use PLL and faster SPI access.
  */
 void board_init_clock(void);

--- a/boards/hifive1b/include/board.h
+++ b/boards/hifive1b/include/board.h
@@ -57,11 +57,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
-/**
  * @brief   Initialize the board clock to use PLL and faster SPI access.
  */
 void board_init_clock(void);

--- a/boards/i-nucleo-lrwan1/include/board.h
+++ b/boards/i-nucleo-lrwan1/include/board.h
@@ -47,11 +47,6 @@ extern "C" {
 #define SX127X_PARAM_PASELECT               (SX127X_PA_BOOST)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -104,11 +104,6 @@ extern mtd_dev_t *mtd0;
 #define MTD_0 mtd0
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/im880b/include/board.h
+++ b/boards/im880b/include/board.h
@@ -57,11 +57,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -57,11 +57,6 @@ extern "C" {
 #define LIS3MDL_PARAM_ADDR       (0x28)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/lobaro-lorabox/include/board.h
+++ b/boards/lobaro-lorabox/include/board.h
@@ -68,11 +68,6 @@ extern "C" {
 #define SX127X_PARAM_DIO3               GPIO_PIN(PORT_B, 7)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/lsn50/include/board.h
+++ b/boards/lsn50/include/board.h
@@ -51,11 +51,6 @@ extern "C" {
 #define SX127X_PARAM_PASELECT               (SX127X_PA_BOOST)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -59,11 +59,6 @@ extern "C" {
  */
 #define STDIO_UART_DEV      UART_DEV(1)
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -52,11 +52,6 @@ extern "C" {
 #define LED3_TOGGLE         gpio_toggle(LED3_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, include clocks, LEDs and stdio
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/mega-xplained/include/board.h
+++ b/boards/mega-xplained/include/board.h
@@ -125,11 +125,6 @@ extern "C" {
 #define CPU_ATMEGA_CLK_SCALE_INIT    CPU_ATMEGA_CLK_SCALE_DIV1
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/microduino-corerf/include/board.h
+++ b/boards/microduino-corerf/include/board.h
@@ -44,11 +44,6 @@ extern "C" {
 #define XTIMER_BACKOFF      (40)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and stdio
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -78,11 +78,6 @@ extern "C" {
 #define BUTTON1_PIN         GPIO_PIN(PORT_A, 0)     /**< Pin of right button */
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -89,11 +89,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/native/include/board_internal.h
+++ b/boards/native/include/board_internal.h
@@ -13,9 +13,10 @@
 extern "C" {
 #endif
 
+#include "board_generic.h"
+
 extern int _native_null_out_file;
 extern int _native_null_in_pipe[2];
-void board_init(void);
 
 #ifdef __cplusplus
 }

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -52,11 +52,6 @@ extern "C" {
 #define LED2_TOGGLE         (NRF_GPIO->OUT   ^= LED2_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nz32-sc151/include/board.h
+++ b/boards/nz32-sc151/include/board.h
@@ -41,11 +41,6 @@ extern "C" {
 #define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
  /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/olimexino-stm32/include/board.h
+++ b/boards/olimexino-stm32/include/board.h
@@ -65,11 +65,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/omote/include/board.h
+++ b/boards/omote/include/board.h
@@ -89,11 +89,6 @@
 #define INTERNAL_PERIPHERAL_PID         (0x16C8)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -77,11 +77,6 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/openlabs-kw41z-mini/include/board.h
+++ b/boards/openlabs-kw41z-mini/include/board.h
@@ -85,11 +85,6 @@ extern "C"
 #define PTB3_OUTPUT_OSCERCLK        (0)
 #endif
 
-/**
- * @brief Initialize board-specific hardware, including clock, LEDs, and stdio
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -147,11 +147,6 @@
 #define BOOT_PIN    GPIO_PIN(0, CCA_BACKDOOR_PORT_A_PIN) /**< BSL_BOOT Pin */
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -90,11 +90,6 @@
 #define CONFIG_CC2538_RF_OBS_SIG_2_PCX  7   /* PC7 */
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/p-l496g-cell02/include/board.h
+++ b/boards/p-l496g-cell02/include/board.h
@@ -66,11 +66,6 @@ extern "C" {
 #define BTN4_MODE           GPIO_IN_PD              /**< Up button mode     */
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -93,11 +93,6 @@ extern "C"
 #define TMP00X_PARAM_ADDR          (0x41)
 /** @}*/
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -80,11 +80,6 @@ extern "C" {
 #define BTN1_MODE           GPIO_IN
 /** @} */
 
-/**
- * @brief   Board level initialization
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pyboard/include/board.h
+++ b/boards/pyboard/include/board.h
@@ -46,11 +46,6 @@ extern "C" {
  */
 #define BTN_B1_PIN          GPIO_PIN(PORT_B, 3)
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and stdio
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/qn9080dk/include/board.h
+++ b/boards/qn9080dk/include/board.h
@@ -77,11 +77,6 @@ extern mtd_dev_t *mtd0;
 #define MTD_0 mtd0
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/reel/include/board.h
+++ b/boards/reel/include/board.h
@@ -104,11 +104,6 @@ extern "C" {
 #define ADPS9960_PARAM_PIN_INT  GPIO_PIN(0, 23)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/remote-pa/include/board.h
+++ b/boards/remote-pa/include/board.h
@@ -74,11 +74,6 @@
  #define RF_SWITCH_TOGGLE    gpio_toggle(RF_SWITCH_GPIO)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/remote-reva/include/board.h
+++ b/boards/remote-reva/include/board.h
@@ -110,11 +110,6 @@
 #define CC1200_GPD2_GPIO    GPIO_PB0
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -122,11 +122,6 @@
 #define SDCARD_SPI_PARAM_POWER_AH  false
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/ruuvitag/include/board.h
+++ b/boards/ruuvitag/include/board.h
@@ -78,11 +78,6 @@ extern "C" {
 #define LIS2DH12_PARAM_INT_PIN2 GPIO_PIN(0, 6)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samd10-xmini/include/board.h
+++ b/boards/samd10-xmini/include/board.h
@@ -61,11 +61,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samd20-xpro/include/board.h
+++ b/boards/samd20-xpro/include/board.h
@@ -59,11 +59,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samd21-xpro/include/board.h
+++ b/boards/samd21-xpro/include/board.h
@@ -62,11 +62,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -86,11 +86,6 @@ extern mtd_dev_t *mtd0, *mtd1;
 #define XTIMER_HZ                   (1000000ul)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/saml21-xpro/include/board.h
+++ b/boards/saml21-xpro/include/board.h
@@ -50,11 +50,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -106,11 +106,6 @@ enum {
 /** @} */
 
 /**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
-/**
  * @brief   Set antenna switch
  */
 void board_antenna_config(uint8_t antenna);

--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -93,11 +93,6 @@ enum {
 /** @} */
 
 /**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
-/**
  * @brief   Set antenna switch
  */
 void board_antenna_config(uint8_t antenna);

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -78,11 +78,6 @@ extern "C" {
 #define BTN0_MODE                   GPIO_IN_PU
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/seeeduino_arch-pro/include/board.h
+++ b/boards/seeeduino_arch-pro/include/board.h
@@ -53,11 +53,6 @@ extern "C" {
 #define LED3_TOGGLE         gpio_toggle(LED3_PIN)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, include clocks, LEDs and stdio
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -190,11 +190,6 @@ extern mtd_dev_t *mtd0;
 /** @} */
 #endif /* MODULE_MTD_SDCARD || DOXYGEN */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/serpente/include/board.h
+++ b/boards/serpente/include/board.h
@@ -89,11 +89,6 @@ extern mtd_dev_t *mtd0;
 #define INTERNAL_PERIPHERAL_VID         (0x239A)
 #define INTERNAL_PERIPHERAL_PID         (0x0057)
 /** @} */
-
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
 #ifdef __cplusplus
 }
 #endif

--- a/boards/slstk3400a/include/board.h
+++ b/boards/slstk3400a/include/board.h
@@ -113,11 +113,6 @@ extern "C" {
 #define SI70XX_PARAM_I2C_DEV    SI7021_I2C
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/slstk3401a/include/board.h
+++ b/boards/slstk3401a/include/board.h
@@ -120,11 +120,6 @@ extern "C" {
 #define SI70XX_PARAM_I2C_DEV    SI7021_I2C
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -120,11 +120,6 @@ extern "C" {
 #define SI70XX_PARAM_I2C_DEV    SI7021_I2C
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -209,11 +209,6 @@ extern "C" {
 #define SI7210_I2C          I2C_DEV(0)
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/slwstk6220a/include/board.h
+++ b/boards/slwstk6220a/include/board.h
@@ -121,11 +121,6 @@ extern "C" {
 #define SI70XX_PARAM_I2C_DEV    SI7021_I2C
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -90,11 +90,6 @@
 #define EXTFLASH            GPIO_PIN(PORT_B,9)
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/stk3200/include/board.h
+++ b/boards/stk3200/include/board.h
@@ -102,11 +102,6 @@ extern "C" {
 #define DISP_POWER_PIN      GPIO_PIN(PA, 10)
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stk3600/include/board.h
+++ b/boards/stk3600/include/board.h
@@ -96,11 +96,6 @@ extern "C" {
 #define CORETEMP_ADC        ADC_LINE(0)
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stk3700/include/board.h
+++ b/boards/stk3700/include/board.h
@@ -96,11 +96,6 @@ extern "C" {
 #define CORETEMP_ADC        ADC_LINE(0)
 /** @} */
 
-/**
- * @brief   Initialize the board (GPIO, sensors, clocks).
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f030f4-demo/include/board.h
+++ b/boards/stm32f030f4-demo/include/board.h
@@ -48,11 +48,6 @@ extern "C" {
 #define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -54,11 +54,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -91,11 +91,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f429i-disc1/include/board.h
+++ b/boards/stm32f429i-disc1/include/board.h
@@ -54,11 +54,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -81,11 +81,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f723e-disco/include/board.h
+++ b/boards/stm32f723e-disco/include/board.h
@@ -61,11 +61,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32f769i-disco/include/board.h
+++ b/boards/stm32f769i-disco/include/board.h
@@ -71,11 +71,6 @@ extern "C" {
 /** @} */
 
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32l0538-disco/include/board.h
+++ b/boards/stm32l0538-disco/include/board.h
@@ -62,11 +62,6 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32l476g-disco/include/board.h
+++ b/boards/stm32l476g-disco/include/board.h
@@ -68,11 +68,6 @@ extern "C" {
 #define BTN4_MODE           GPIO_IN_PD          /**< Up button mode     */
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/stm32mp157c-dk2/include/board.h
+++ b/boards/stm32mp157c-dk2/include/board.h
@@ -28,11 +28,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/teensy31/include/board.h
+++ b/boards/teensy31/include/board.h
@@ -59,11 +59,6 @@ extern "C" {
 #define LED0_TOGGLE         (LED_PORT->PTOR = (1 << LED0_BIT))
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/thingy52/include/board.h
+++ b/boards/thingy52/include/board.h
@@ -55,11 +55,6 @@ extern "C" {
 #define LPSXXX_PARAM_ADDR   (0x5c)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/ublox-c030-u201/include/board.h
+++ b/boards/ublox-c030-u201/include/board.h
@@ -92,11 +92,6 @@ extern "C" {
 #define GPS_RST_PIN             GPIO_PIN(PORT_C, 10) /* Not connected */
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -180,11 +180,6 @@ extern "C" {
 #define CONFIG_ZTIMER_USEC_WIDTH    (16)
 /** @} */
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/yarm/include/board.h
+++ b/boards/yarm/include/board.h
@@ -27,11 +27,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/zigduino/include/board.h
+++ b/boards/zigduino/include/board.h
@@ -51,11 +51,6 @@ extern "C" {
 #define PIR_MOTION_MODE     GPIO_IN_PU
 /** @} */
 
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and stdio
- */
-void board_init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/avr8_common/startup.c
+++ b/cpu/avr8_common/startup.c
@@ -25,6 +25,8 @@
 #include <avr/interrupt.h>
 #include <avr/io.h>
 
+#include "board_generic.h"
+
 /* For Catchall-Loop */
 #include "board.h"
 #ifdef MODULE_PUF_SRAM
@@ -34,7 +36,6 @@
 /**
  * @brief functions for initializing the board, std-lib and kernel
  */
-extern void board_init(void);
 extern void kernel_init(void);
 extern void __libc_init_array(void);
 

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -29,7 +29,7 @@
 #include "cpu.h"
 #include "periph_cpu.h"
 #include "kernel_init.h"
-#include "board.h"
+#include "board_generic.h"
 #include "mpu.h"
 #include "panic.h"
 #include "sched.h"

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -59,6 +59,7 @@
 #include "xtensa/core-macros.h"
 #include "xtensa/xtensa_api.h"
 
+#include "board_generic.h"
 #include "periph_cpu.h"
 #include "tools.h"
 

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -40,6 +40,8 @@
 #include "rom_functions.h"
 #include "sdk/sdk.h"
 
+#include "board_generic.h"
+
 #if MODULE_ESP_GDBSTUB
 #include "gdbstub.h"
 #endif

--- a/cpu/lpc23xx/cpu.c
+++ b/cpu/lpc23xx/cpu.c
@@ -16,6 +16,7 @@
 #include "irq.h"
 #include "VIC.h"
 
+#include "board_generic.h"
 #include "stdio_base.h"
 #include "periph/init.h"
 
@@ -118,8 +119,6 @@ void arm_reset(void)
  */
 void cpu_init(void)
 {
-    extern void board_init(void);
-
     /* configure CPU clock */
     cpu_init_clks();
 

--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -25,6 +25,7 @@
 #include "cpu.h"
 #include "board.h"
 
+#include "board_generic.h"
 
 void mips_start(void);
 

--- a/cpu/msp430_common/msp430-main.c
+++ b/cpu/msp430_common/msp430-main.c
@@ -140,5 +140,3 @@ splx_(int sr)
     asmv("bis %0, r2" : : "r"(sr));
     asmv("nop");
 }
-
-extern void board_init(void);

--- a/cpu/msp430_common/startup.c
+++ b/cpu/msp430_common/startup.c
@@ -28,7 +28,7 @@
 #include "irq.h"
 #include "log.h"
 
-extern void board_init(void);
+#include "board_generic.h"
 
 __attribute__((constructor)) static void startup(void)
 {

--- a/sys/include/board_generic.h
+++ b/sys/include/board_generic.h
@@ -1,0 +1,6 @@
+// TBD: proper place, proper name
+
+/**
+ * @brief   Board level initialization
+ */
+void board_init(void);


### PR DESCRIPTION
This removes the occurrences that can easily be removed automatically.

Command used:

    sed -i -z 's@\n/[\n* ]*.brief[ a-zA-Z,().-]*[\n*/ ]*\nvoid board_init(void);\n@@' boards/**/*.h

Closes: #16007

Summary of #16007: Not all boards do it, so it's clearly not necessary, and the caller of board_init does an extern on it anyway; moreover, it clutters documentation, which should be "every board defines this to do X", not "we do X" for every board. (Notes about the concrete implementation should go to the implementation anyway).

This is not complete yet in that it only does the "easy" ones that are caught by a single-line regexp. A follow-up in here will go through the rest manually, but first I'd like to see how badly things fail.

### Testing procedure

Builds still complete.
