### PR TITLE
boards/[cc2650, cc1312]-launchpad: add saul_gpio definitions

### DIFF
--- a/boards/cc1312-launchpad/Makefile.dep
+++ b/boards/cc1312-launchpad/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/cc1312-launchpad/include/gpio_params.h
+++ b/boards/cc1312-launchpad/include/gpio_params.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_cc1312_launchpad
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button(BTN-1)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Button(BTN-2)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/cc2650-launchpad/Makefile.dep
+++ b/boards/cc2650-launchpad/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/cc2650-launchpad/include/gpio_params.h
+++ b/boards/cc2650-launchpad/include/gpio_params.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_cc2650_launchpad
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "Button(BTN-1)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Button(BTN-2)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

Adds the `gpio_params.h` and default dependency to `saul_gpio` when `saul_default` is present. These were the only in-tree boards that missed these definitions of this CPU family.

### Testing procedure

- `make -C examples/saul BOARD=cc1312-launchpad`
- `make -C examples/saul BOARD=cc2650-launchpad`

And the buttons/leds defined in the quick start guide for the boards should work as expected:

- [LAUNCHXL-CC2650 Quick Start Guide](https://www.ti.com/lit/ml/swru451/swru451.pdf).
- [LAUNCHXL-CC1312R1 Quick Start Guide](https://www.ti.com/lit/ml/swru535c/swru535c.pdf)

### Issues/PRs references

N/A.