### PR TITLE
remove unused parameter spi3w_en to solve issue #15954

### DIFF
--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -195,7 +195,6 @@ typedef struct {
     /* Config Register */
     bmx280_t_sb_t t_sb;                 /**< standby */
     bmx280_filter_t filter;             /**< filter coefficient */
-    uint8_t spi3w_en;                   /**< Enables 3-wire SPI interface */
 
     /* ctrl_meas */
     bmx280_mode_t run_mode;             /**< ctrl_meas mode */


### PR DESCRIPTION
Hi RIOT-OS Team,

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I removed spi3w_en parameter in drivers/include/bmx280.h since it is never used.


### Testing procedure

compile bmx280 tests by including bmx280.h header.


### Issues/PRs references

Fixes #15954 .

Have a nice day,
Memiks.