### PR TITLE
riotboot_dfu: Use allocated USB IDs

### DIFF
--- a/bootloaders/riotboot_dfu/Makefile
+++ b/bootloaders/riotboot_dfu/Makefile
@@ -35,8 +35,10 @@ RIOTBASE ?= $(CURDIR)/../../
 # USB device vendor and product ID
 # pid.codes test VID/PID, not globally unique
 
-USB_VID ?= ${USB_VID_TESTING}
-USB_PID ?= ${USB_PID_TESTING}
+# The VID/PID pair allocated for the RIOT bootloader
+# as allocated on https://pid.codes/1209/7D02/
+USB_VID ?= 1209
+USB_PID ?= 7D02
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
The IDs are not advertised to dfu-util to allow a smooth transition into
having a VID/PID-identifiable riotboot_dfu.

As allocated on https://pid.codes/1209/7D02/. (Don't mind the license stated there, it's a copy-paste error and to be fixed in https://github.com/pidcodes/pidcodes.github.com/pull/619).

---

### Testing procedure

* Flash riotboot_dfu applying test procedure from https://github.com/RIOT-OS/RIOT/pull/16011 up to "Notice how it comes up in the bootloader".
* Observe in `lsusb` that the "Generic USB device" is now shown as 1209:7d02 when the bootloader is entered.
* No warnings of test PIDs show up.

### Usage and long-term next steps

With the allocated code, devices in bootloader mode will be more clearly visible in `lsusb`. This is especially important when bootloader mode can be entered manually (as of #16011) to tell which state the board is in.

Once this has been in for some time (probably after the next release), when using dfu-util on devices known to use the riotboot_usb bootloader, we could tell dfu-util which codes to expect from the bootloader, thus reducing the chance of flashes not matching the expectations.