### PR TITLE
gnrc_pktbuf: always use _free function with gnrc_pktbuf_malloc

### DIFF
--- a/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
+++ b/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
@@ -71,7 +71,6 @@ static inline bool gnrc_pktbuf_contains(void *ptr)
 #endif
 }
 
-#if IS_USED(MODULE_GNRC_PKTBUF_STATIC) || DOXYGEN
 /**
  * @brief   Release an internal buffer
  *
@@ -82,13 +81,6 @@ static inline bool gnrc_pktbuf_contains(void *ptr)
  * @param   size    size of @p data in bytes
  */
 void gnrc_pktbuf_free_internal(void *data, size_t size);
-#else
-static inline void gnrc_pktbuf_free_internal(void *data, size_t size)
-{
-    (void)size;
-    free(data);
-}
-#endif
 
 /* for testing */
 #ifdef TEST_SUITES

--- a/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
+++ b/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
@@ -282,4 +282,10 @@ static gnrc_pktsnip_t *_create_snip(gnrc_pktsnip_t *next, const void *data, size
     return pkt;
 }
 
+void gnrc_pktbuf_free_internal(void *data, size_t size)
+{
+    (void)size;
+    _free(data);
+}
+
 /** @} */


### PR DESCRIPTION
Otherwise the local mallocs variable is not decremented correctly (if `TEST_SUITES` is defined) and the fuzzing setup (i.e. when `MODULE_FUZZING` is defined) does not terminate. This regression was introduced in 3970b667aade062ab9dc4e2afe7914f7cd081f80.

See:

https://github.com/RIOT-OS/RIOT/blob/3970b667aade062ab9dc4e2afe7914f7cd081f80/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c#L54-L69

CC: @maribu