### PR TITLE
core/thread: move thread configuration into seperate header

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -124,6 +124,7 @@
 #include "msg.h"
 #include "cpu_conf.h"
 #include "sched.h"
+#include "thread_config.h"
 
 #ifdef MODULE_CORE_THREAD_FLAGS
 #include "thread_flags.h"
@@ -210,113 +211,6 @@ struct _thread {
     thread_arch_t arch;             /**< architecture dependent part    */
 #endif
 };
-
-/**
- * @def THREAD_STACKSIZE_DEFAULT
- * @brief A reasonable default stack size that will suffice most smaller tasks
- *
- * @note This value must be defined by the CPU specific implementation, please
- *       take a look at @c cpu/$CPU/include/cpu_conf.h
- */
-#ifndef THREAD_STACKSIZE_DEFAULT
-#error THREAD_STACKSIZE_DEFAULT must be defined per CPU
-#endif
-#ifdef DOXYGEN
-#define THREAD_STACKSIZE_DEFAULT
-#endif
-
-/**
- * @def THREAD_STACKSIZE_IDLE
- * @brief Size of the idle task's stack in bytes
- *
- * @note This value must be defined by the CPU specific implementation, please
- *       take a look at @c cpu/$CPU/include/cpu_conf.h
- */
-#ifndef THREAD_STACKSIZE_IDLE
-#error THREAD_STACKSIZE_IDLE must be defined per CPU
-#endif
-#ifdef DOXYGEN
-#define THREAD_STACKSIZE_IDLE
-#endif
-
-/**
- * @def THREAD_EXTRA_STACKSIZE_PRINTF
- * @brief Size of the task's printf stack in bytes
- *
- * @note This value must be defined by the CPU specific implementation, please
- *       take a look at @c cpu/$CPU/include/cpu_conf.h
- */
-#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
-#error THREAD_EXTRA_STACKSIZE_PRINTF must be defined per CPU
-#endif
-#ifdef DOXYGEN
-#define THREAD_EXTRA_STACKSIZE_PRINTF
-#endif
-
-/**
- * @def THREAD_STACKSIZE_MAIN
- * @brief Size of the main task's stack in bytes
- */
-#ifndef THREAD_STACKSIZE_MAIN
-#define THREAD_STACKSIZE_MAIN      (THREAD_STACKSIZE_DEFAULT + \
-                                    THREAD_EXTRA_STACKSIZE_PRINTF)
-#endif
-
-/**
- * @brief Large stack size
- */
-#ifndef THREAD_STACKSIZE_LARGE
-#define THREAD_STACKSIZE_LARGE (THREAD_STACKSIZE_MEDIUM * 2)
-#endif
-
-/**
- * @brief Medium stack size
- */
-#ifndef THREAD_STACKSIZE_MEDIUM
-#define THREAD_STACKSIZE_MEDIUM THREAD_STACKSIZE_DEFAULT
-#endif
-
-/**
- * @brief Small stack size
- */
-#ifndef THREAD_STACKSIZE_SMALL
-#define THREAD_STACKSIZE_SMALL (THREAD_STACKSIZE_MEDIUM / 2)
-#endif
-
-/**
- * @brief Tiny stack size
- */
-#ifndef THREAD_STACKSIZE_TINY
-#define THREAD_STACKSIZE_TINY (THREAD_STACKSIZE_MEDIUM / 4)
-#endif
-
-/**
- * @brief Minimum stack size
- */
-#ifndef THREAD_STACKSIZE_MINIMUM
-#define THREAD_STACKSIZE_MINIMUM  (sizeof(thread_t))
-#endif
-
-/**
- * @def THREAD_PRIORITY_MIN
- * @brief Least priority a thread can have
- */
-#define THREAD_PRIORITY_MIN            (SCHED_PRIO_LEVELS - 1)
-
-/**
- * @def THREAD_PRIORITY_IDLE
- * @brief Priority of the idle thread
- */
-#define THREAD_PRIORITY_IDLE           (THREAD_PRIORITY_MIN)
-
-/**
- * @def THREAD_PRIORITY_MAIN
- * @brief Priority of the main thread
- */
-#ifndef THREAD_PRIORITY_MAIN
-#define THREAD_PRIORITY_MAIN           (THREAD_PRIORITY_MIN - \
-                                        (SCHED_PRIO_LEVELS / 2))
-#endif
 
 /**
  * @name Optional flags for controlling a threads initial state

--- a/core/include/thread_config.h
+++ b/core/include/thread_config.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2014-21 Freie Universität Berlin
+ *               2021 Inria
+ *               2021 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_thread
+ *
+ * @{
+ *
+ * @file
+ * @brief       Thread configuration defines
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef THREAD_CONFIG_H
+#define THREAD_CONFIG_H
+
+#include "cpu_conf.h"
+#include "sched.h"      /* for SCHED_PRIO_LEVELS */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @def THREAD_STACKSIZE_DEFAULT
+ * @brief A reasonable default stack size that will suffice most smaller tasks
+ *
+ * @note This value must be defined by the CPU specific implementation, please
+ *       take a look at @c cpu/$CPU/include/cpu_conf.h
+ */
+#ifndef THREAD_STACKSIZE_DEFAULT
+#error THREAD_STACKSIZE_DEFAULT must be defined per CPU
+#endif
+#ifdef DOXYGEN
+#define THREAD_STACKSIZE_DEFAULT
+#endif
+
+/**
+ * @def THREAD_STACKSIZE_IDLE
+ * @brief Size of the idle task's stack in bytes
+ *
+ * @note This value must be defined by the CPU specific implementation, please
+ *       take a look at @c cpu/$CPU/include/cpu_conf.h
+ */
+#ifndef THREAD_STACKSIZE_IDLE
+#error THREAD_STACKSIZE_IDLE must be defined per CPU
+#endif
+#ifdef DOXYGEN
+#define THREAD_STACKSIZE_IDLE
+#endif
+
+/**
+ * @def THREAD_EXTRA_STACKSIZE_PRINTF
+ * @brief Size of the task's printf stack in bytes
+ *
+ * @note This value must be defined by the CPU specific implementation, please
+ *       take a look at @c cpu/$CPU/include/cpu_conf.h
+ */
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#error THREAD_EXTRA_STACKSIZE_PRINTF must be defined per CPU
+#endif
+#ifdef DOXYGEN
+#define THREAD_EXTRA_STACKSIZE_PRINTF
+#endif
+
+/**
+ * @def THREAD_STACKSIZE_MAIN
+ * @brief Size of the main task's stack in bytes
+ */
+#ifndef THREAD_STACKSIZE_MAIN
+#define THREAD_STACKSIZE_MAIN      (THREAD_STACKSIZE_DEFAULT + \
+                                    THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
+
+/**
+ * @brief Large stack size
+ */
+#ifndef THREAD_STACKSIZE_LARGE
+#define THREAD_STACKSIZE_LARGE (THREAD_STACKSIZE_MEDIUM * 2)
+#endif
+
+/**
+ * @brief Medium stack size
+ */
+#ifndef THREAD_STACKSIZE_MEDIUM
+#define THREAD_STACKSIZE_MEDIUM THREAD_STACKSIZE_DEFAULT
+#endif
+
+/**
+ * @brief Small stack size
+ */
+#ifndef THREAD_STACKSIZE_SMALL
+#define THREAD_STACKSIZE_SMALL (THREAD_STACKSIZE_MEDIUM / 2)
+#endif
+
+/**
+ * @brief Tiny stack size
+ */
+#ifndef THREAD_STACKSIZE_TINY
+#define THREAD_STACKSIZE_TINY (THREAD_STACKSIZE_MEDIUM / 4)
+#endif
+
+/**
+ * @brief Minimum stack size
+ */
+#ifndef THREAD_STACKSIZE_MINIMUM
+#define THREAD_STACKSIZE_MINIMUM  (sizeof(thread_t))
+#endif
+
+/**
+ * @def THREAD_PRIORITY_MIN
+ * @brief Least priority a thread can have
+ */
+#define THREAD_PRIORITY_MIN            (SCHED_PRIO_LEVELS - 1)
+
+/**
+ * @def THREAD_PRIORITY_IDLE
+ * @brief Priority of the idle thread
+ */
+#define THREAD_PRIORITY_IDLE           (THREAD_PRIORITY_MIN)
+
+/**
+ * @def THREAD_PRIORITY_MAIN
+ * @brief Priority of the main thread
+ */
+#ifndef THREAD_PRIORITY_MAIN
+#define THREAD_PRIORITY_MAIN           (THREAD_PRIORITY_MIN - \
+                                        (SCHED_PRIO_LEVELS / 2))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* THREAD_CONFIG_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves some thread configuration defines from thread.h into thread_config.h.
As is, this only moves code around, but it is the first step to untangle the thread.h API from cpu specific stuff (see e.g., [here](https://github.com/RIOT-OS/RIOT/pull/15595#issuecomment-762094819)).
It is also a necessary step for providing alternative scheduler / core implementations.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This only moves code around, so a CI success should be fine.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Suggested in #15595.