### PR TITLE
doc: Make bootloaders visible in modules

### DIFF
--- a/bootloaders/doc.txt
+++ b/bootloaders/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup bootloaders Bootloaders
+ * @brief Applications that facilitate the startup process in presence of upgradable firmware
+ *
+ */

--- a/bootloaders/riotboot/doc.txt
+++ b/bootloaders/riotboot/doc.txt
@@ -107,7 +107,7 @@ flash` if the `riotboot` feature is used.
 
 ## Testing riotboot
 
-See [tests/riotboot/README.md](https://github.com/RIOT-OS/RIOT/blob/master/tests/riotboot/README.md).
+See <a href="https://github.com/RIOT-OS/RIOT/blob/master/tests/riotboot/README.md">tests/riotboot/README.md</a>.
 
 # Quick riotboot porting guide
 

--- a/bootloaders/riotboot/doc.txt
+++ b/bootloaders/riotboot/doc.txt
@@ -1,3 +1,7 @@
+/**
+@defgroup    bootloader_riotboot riotboot
+@ingroup     bootloaders
+
 # Overview
 This folder contains a simple bootloader called "riotboot".
 A header with metadata of length `RIOTBOOT_HDR_LEN` precedes
@@ -48,7 +52,7 @@ no image will be booted and the bootloader will enter `while(1);` endless loop.
 # Requirements
 Try to compile and run tests/riotboot:
 
-$ BOARD=<board> make -C tests/riotboot flash test
+    $ BOARD=<board> make -C tests/riotboot flash test
 
 If the test succeeds, your board is supported. Else you can try to port
 riotboot to your board (see the below porting guide).
@@ -151,3 +155,5 @@ offset and a defined firmware size. To get an idea look at
 Additional remarks:
 
 - If your are in Big-Endian, you may need to further adapt some part of the code.
+
+*/

--- a/bootloaders/riotboot/main.c
+++ b/bootloaders/riotboot/main.c
@@ -8,7 +8,6 @@
  */
 
 /**
- * @defgroup    bootloaders    RIOT compatible bootloaders
  * @ingroup     bootloaders
  * @{
  *

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -757,6 +757,7 @@ INPUT                  = ../../doc.txt \
                          ../../core \
                          ../../cpu \
                          ../../boards \
+                         ../../bootloaders \
                          ../../drivers \
                          ../../pkg \
                          ../../sys \


### PR DESCRIPTION
### Contribution description

Currently, documentation about the bootloaders is only accessible through the source tree and not through the API documentation.

This adds the `bootloaders/` directory to the list of starting points for doxygen, and moves the riotboot documentation into a place where doxygen can pick it up. Some metadata is added to make it fit nicely.

### Testing procedure

* Open the documentation search for "bootloader".
* Since this change, a section shows up (also in the modules list) that currently contains only riotboot

### Issues/PRs references

* The current form of #16011 adds board defines that influence how the bootloader is used; until this is merged, they are not visibly documented.
* Further work seems indicated to document the DFU based bootloader (currently blank), and to make the riotboot docs more newcomer friendly in general. (They describe how it works, but not why it's done (to enable further modules like SUIT to do the actual uploads, or DFU uploads), or how to use it when one does not already have a progammer attached anyway)