### PR TITLE
drivers/nrf24l01p_ng: auto retransmission delay conversion bugfix

### DIFF
--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_types.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_types.h
@@ -232,7 +232,10 @@ nrf24l01p_ng_ard_t nrf24l01p_ng_valtoe_ard(uint16_t retr_delay)
     if (retr_delay >= 4000) {
         return NRF24L01P_NG_ARD_4000US;
     }
-    return (nrf24l01p_ng_ard_t)(retr_delay / 250);
+    if (retr_delay < 250) {
+        return NRF24L01P_NG_ARD_250US;
+    }
+    return (nrf24l01p_ng_ard_t)((retr_delay / 250) - 1);
 }
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Bugfix of conversion between `nrf24l01p_ng_etoval_ard()` and  `nrf24l01p_ng_valtoe_ard()`.

### Testing procedure
```C
for (uint16_t ard = 250; ard <= 4000; ard += 250) {
    assert(ard == nrf24l01p_ng_etoval_ard(nrf24l01p_ng_valtoe_ard(ard)));
}
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
fixes: #16027 