### PR TITLE
drivers/mtd_flashpage: fixes for native (and stm32l0, stm32l4)

### DIFF
--- a/cpu/native/periph/flashpage.c
+++ b/cpu/native/periph/flashpage.c
@@ -24,9 +24,10 @@
 #include "cpu.h"
 #include "periph/flashpage.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
+__attribute__((aligned(FLASHPAGE_SIZE * FLASHPAGE_NUMOF)))
 char _native_flash[FLASHPAGE_SIZE * FLASHPAGE_NUMOF];
 
 void flashpage_erase(unsigned page)

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -116,8 +116,7 @@ extern "C" {
 #define FLASHPAGE_SIZE                  (128U)
 #endif
 
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(CPU_FAM_STM32L4)
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
 #define FLASHPAGE_ERASE_STATE           (0x00U)
 #endif
 
@@ -187,7 +186,6 @@ extern "C" {
 #endif
 
 #endif
-
 
 /* The minimum block size which can be written depends on the family.
  * However, the erase block is always FLASHPAGE_SIZE.

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -44,6 +44,12 @@ static int _read(mtd_dev_t *dev, void *buf, uint32_t addr, uint32_t size)
 
     (void)dev;
 
+#ifndef CPU_HAS_UNALIGNED_ACCESS
+    if (addr % sizeof(uword_t)) {
+        return -EINVAL;
+    }
+#endif
+
     uword_t dst_addr = addr;
     memcpy(buf, (void *)dst_addr, size);
 

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <assert.h>
 
+#include "architecture.h"
 #include "cpu_conf.h"
 #include "mtd_flashpage.h"
 #include "periph/flashpage.h"
@@ -42,12 +43,7 @@ static int _read(mtd_dev_t *dev, void *buf, uint32_t addr, uint32_t size)
 
     (void)dev;
 
-#if (__SIZEOF_POINTER__ == 2)
-    uint16_t dst_addr = addr;
-#else
-    uint32_t dst_addr = addr;
-#endif
-
+    uword_t dst_addr = addr;
     memcpy(buf, (void *)dst_addr, size);
 
     return 0;
@@ -67,12 +63,7 @@ static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
         return -EOVERFLOW;
     }
 
-#if (__SIZEOF_POINTER__ == 2)
-    uint16_t dst_addr = addr;
-#else
-    uint32_t dst_addr = addr;
-#endif
-
+    uword_t dst_addr = addr;
     flashpage_write((void *)dst_addr, buf, size);
 
     return 0;
@@ -92,11 +83,7 @@ int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
         return -EOVERFLOW;
     }
 
-#if (__SIZEOF_POINTER__ == 2)
-    uint16_t dst_addr = addr;
-#else
-    uint32_t dst_addr = addr;
-#endif
+    uword_t dst_addr = addr;
 
     for (size_t i = 0; i < size; i += sector_size) {
         flashpage_erase(flashpage_page((void *)(dst_addr + i)));
@@ -104,7 +91,6 @@ int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 
     return 0;
 }
-
 
 const mtd_desc_t mtd_flashpage_driver = {
     .init = _init,

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -24,6 +24,7 @@
 #include <assert.h>
 
 #include "architecture.h"
+#include "cpu.h"
 #include "cpu_conf.h"
 #include "mtd_flashpage.h"
 #include "periph/flashpage.h"
@@ -53,6 +54,11 @@ static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
 {
     (void)dev;
 
+#ifndef CPU_HAS_UNALIGNED_ACCESS
+    if ((uintptr_t)buf % sizeof(uword_t)) {
+        return -EINVAL;
+    }
+#endif
     if (addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) {
         return -EINVAL;
     }

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -42,10 +42,6 @@ static int _read(mtd_dev_t *dev, void *buf, uint32_t addr, uint32_t size)
 
     (void)dev;
 
-    if (addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) {
-        return -EINVAL;
-    }
-
 #if (__SIZEOF_POINTER__ == 2)
     uint16_t dst_addr = addr;
 #else
@@ -62,9 +58,6 @@ static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
     (void)dev;
 
     if (addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) {
-        return -EINVAL;
-    }
-    if ((uintptr_t)buf % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) {
         return -EINVAL;
     }
     if (size % FLASHPAGE_WRITE_BLOCK_SIZE) {

--- a/tests/mtd_flashpage/Makefile
+++ b/tests/mtd_flashpage/Makefile
@@ -3,10 +3,4 @@ include ../Makefile.tests_common
 USEMODULE += mtd_flashpage
 USEMODULE += embunit
 
-# https://github.com/RIOT-OS/RIOT/pull/15859 exposed a bug in the
-# handling of FEATURES_REQUIRED_ANY, so https://github.com/RIOT-OS/RIOT/pull/15935
-# did not run unittests, native is currently failing, so blacklist while this
-# is still the case
-FEATURES_BLACKLIST += arch_native
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/mtd_flashpage/main.c
+++ b/tests/mtd_flashpage/main.c
@@ -88,12 +88,8 @@ static void test_mtd_write_erase(void)
 {
     const char buf[] = "ABCDEFGHIJKLMNO";
 
-    /* stm32l0x and stm32l1x erase its flash with 0's */
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
-    uint8_t buf_empty[] = {0, 0, 0};
-#else
-    uint8_t buf_empty[] = {0xff, 0xff, 0xff};
-#endif
+    uint8_t buf_empty[3];
+    memset(buf_empty, FLASHPAGE_ERASE_STATE, sizeof(buf_empty));
     char buf_read[sizeof(buf) + sizeof(buf_empty)];
     memset(buf_read, 0, sizeof(buf_read));
 
@@ -107,11 +103,7 @@ static void test_mtd_write_erase(void)
     TEST_ASSERT_EQUAL_INT(0, ret);
 
     uint8_t expected[sizeof(buf_read)];
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
-    memset(expected, 0, sizeof(expected));
-#else
-    memset(expected, 0xff, sizeof(expected));
-#endif
+    memset(expected, FLASHPAGE_ERASE_STATE, sizeof(expected));
     ret = mtd_read(dev, buf_read, TEST_ADDRESS1, sizeof(buf_read));
     TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(expected, buf_read, sizeof(buf_read)));
@@ -125,12 +117,8 @@ static void test_mtd_write_read(void)
     const char buf[] __attribute__ ((aligned (FLASHPAGE_WRITE_BLOCK_ALIGNMENT)))
             = "ABCDEFGHIJKLMNO";
 
-    /* stm32l0x and stm32l1x erase its flash with 0's */
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
-    uint8_t buf_empty[] = {0, 0, 0};
-#else
-    uint8_t buf_empty[] = {0xff, 0xff, 0xff};
-#endif
+    uint8_t buf_empty[3];
+    memset(buf_empty, FLASHPAGE_ERASE_STATE, sizeof(buf_empty));
     char buf_read[sizeof(buf) + sizeof(buf_empty)];
     memset(buf_read, 0, sizeof(buf_read));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`native` uses the same 'unusual' flashpage properties as stm32l0, also the flash does not start at address 0 this uncovered some issues:

 - when calculating alignment, we have to do so in regards to the start of the flash, not it's absolute address
 - `FLASHPAGE_WRITE_BLOCK_ALIGNMENT` is a requirement for the *target* block alignment for *writing*, it shouldn't say enforce about the *source* alignment or *read* alignment


### Testing procedure

`tests/mtd_flashpage` now works on `native`.

### Issues/PRs references

fixes issue brought to light by #16026
