### PR TITLE
boards/nucleo-f722ze/Makefile.features: Add periph_can into Makefile.features

### DIFF
--- a/boards/nucleo-f722ze/Kconfig
+++ b/boards/nucleo-f722ze/Kconfig
@@ -21,6 +21,7 @@ config BOARD_NUCLEO_F722ZE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_CAN
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT

--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -42,7 +42,7 @@ extern "C" {
 #elif defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
 #define CANDEV_STM32_CHAN_NUMOF 2
 #elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
-      defined(CPU_FAM_STM32L4) || DOXYGEN
+      defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7) || DOXYGEN
 /** Number of channels in the device (up to 3) */
 #define CANDEV_STM32_CHAN_NUMOF 1
 #else


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
stm32f722ze MCU contains CAN 2.0B interface. Makefile.features for board nucleo-f722ze is missing this periph_can.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Have not done tests due to lack of the board.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fix for https://github.com/RIOT-OS/RIOT/issues/15711
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
