### PR TITLE
makefiles/tests: add unit test for info-boards-supported

### DIFF
--- a/dist/tools/boards_supported/check.sh
+++ b/dist/tools/boards_supported/check.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+make --silent -C "$(dirname "$0")"/../../../makefiles/tests/boards_supported

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -123,6 +123,7 @@ run ./dist/tools/flake8/check.sh
 run ./dist/tools/headerguards/check.sh
 run ./dist/tools/buildsystem_sanity_check/check.sh
 run ./dist/tools/feature_resolution/check.sh
+run ./dist/tools/boards_supported/check.sh
 run ./dist/tools/codespell/check.sh
 if [ -z "${GITHUB_RUN_ID}" ]; then
     run ./dist/tools/uncrustify/uncrustify.sh --check

--- a/makefiles/tests/boards_supported/Makefile
+++ b/makefiles/tests/boards_supported/Makefile
@@ -1,0 +1,28 @@
+# In order to be able to include info-global.inc.mk, we need to provide some variables
+RIOTBASE            ?= $(abspath $(CURDIR)/../../..)
+RIOTBOARD           ?= $(RIOTBASE)/boards
+RIOTMAKE            ?= $(RIOTBASE)/makefiles
+RIOTCPU             ?= $(RIOTBASE)/cpu
+RIOTTOOLS           ?= $(RIOTBASE)/dist/tools
+LAST_MAKEFILEDIR    = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+# Folders to search: First the external boards, than the official
+BOARDSDIRS := $(EXTERNAL_BOARD_DIRS) $(RIOTBOARD)
+
+# Take the first folder in $(BOARDSDIRS) that contains a folder named $(BOARD)
+BOARDDIR := $(word 1,$(foreach dir,$(BOARDSDIRS),$(wildcard $(dir)/$(BOARD)/.)))
+# Sanitize folder
+BOARDDIR := $(abspath $(BOARDDIR))
+
+include $(RIOTMAKE)/utils/strings.mk
+include $(RIOTMAKE)/boards.inc.mk
+include $(RIOTMAKE)/info-global.inc.mk
+
+ifneq (,$(BOARDS_WITH_MISSING_FEATURES))
+  $(info BOARDS_FEATURES_MISSING=$(BOARDS_FEATURES_MISSING))
+  $(error The CI will never build for the following boards: $(BOARDS_WITH_MISSING_FEATURES))
+endif
+
+.PHONY: all
+all:
+	@echo "Success"

--- a/makefiles/tests/boards_supported/README.md
+++ b/makefiles/tests/boards_supported/README.md
@@ -1,0 +1,15 @@
+Simple Unit Tests for `make info-boards-supported`
+==================================================
+
+This folder contains a Makefile that runs a set of unit tests for the logic that figures out which
+boards are supported. In the past there have been some issues with this despite the feature
+resolution for a single board worked fine, so it is worth testing this functionality. This is
+especially true since this list is used by the CI to check which boards to build for.
+
+Right now, only a single test case is added: It will run the logic behind
+`make info-boards-supported` without any modules used other than the default modules and subtracts
+the result from the list of all available boards. The resulting difference is the set of boards
+which will never be build by the CI - not even for `examples/hello-world`. If this result is empty,
+the test succeeds. Otherwise the list of never build boards will be printed and the test fails.
+
+It is intended that some more advanced unit tests will be added later on.


### PR DESCRIPTION
### Contribution description

This adds a unit test for `make info-boards-supported` to `make static-tests` which will enforce that at least applications that do not use any modules (other than the default modules) are build for *all* boards supported by RIOT. It can detect some issues of the following class:

- Something with `make info-boards-supported` is broken and too few boards are printed
- The set of default modules gets extended to render boards unusable
- Boards are added to RIOT that are missing some mandatory features, so that not even `examples/hello-world` can be build on them

### Testing procedure

This should expose an issue with current `master` within the static tests that should look like this:

```
Running "./dist/tools/boards_supported/check.sh" x
Command output:

BOARDS_FEATURES_MISSING="yarm highlevel_stdio"
Makefile:23: *** The CI will never build for the following boards: yarm.  Stop.
```

### Issues/PRs references

None