### PR TITLE
boards/yarm: add Highlevel STDIO feature

### DIFF
--- a/boards/yarm/Kconfig
+++ b/boards/yarm/Kconfig
@@ -11,6 +11,7 @@ config BOARD_YARM
     bool
     default y
     select CPU_MODEL_SAML21J18B
+    select HAS_HIGHLEVEL_STDIO
     select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_RTC

--- a/boards/yarm/Makefile.features
+++ b/boards/yarm/Makefile.features
@@ -2,6 +2,7 @@ CPU = saml21
 CPU_MODEL = saml21j18b
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The board uses USB CDC ACM as stdio by default, so select the highlevel_stdio feature.


### Testing procedure

`yarm` should build on CI again.




### Issues/PRs references

discovered by #16034


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
