### PR TITLE
drivers/at86rfr2xx: usage of module at86rf2xx_aes_spi fixed

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -111,7 +111,7 @@ static const ieee802154_radio_cipher_ops_t _at86rf2xx_cipher_ops = {
     .ecb = _at86rf2xx_ecb,
     .cbc = _at86rf2xx_cbc
 };
-#endif /* IS_USED(MODULE_AT86RF2XX_COMMON_AES_SPI) && \
+#endif /* IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
           IS_USED(MODULE_IEEE802154_SECURITY) */
 
 void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t index)

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -667,7 +667,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
 #endif /* MODULE_NETDEV_IEEE802154_OQPSK */
 
-#if IS_USED(MODULE_AT86RF2XX_COMMON_AES_SPI) && \
+#if IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
     IS_USED(MODULE_IEEE802154_SECURITY)
         case NETOPT_ENCRYPTION_KEY:
             assert(len >= IEEE802154_SEC_KEY_LENGTH);


### PR DESCRIPTION
### Contribution description

There was mispring in module name MODULE_AT86RF2XX_AES_SPI

### Testing procedure

There are no tests that checks AES encryption key settings by NETOPT_ENCRYPTION_KEY.
