### PR TITLE
cpu/cc26xx_cc13xx: add CPU documentation

### DIFF
--- a/boards/cc1312-launchpad/doc.txt
+++ b/boards/cc1312-launchpad/doc.txt
@@ -3,13 +3,20 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1312 Wireless MCU LaunchPad(TM) Kit
 
-## Overview
+## <a name="cc1312_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
+
+1. [Overview](#cc1312_launchpad_overview)
+2. [Hardware](#cc1312_launchpad_hardware)
+3. [Board pinout](#cc1312_launchpad_pinout)
+4. [Flashing the Device](#cc1312_launchpad_flashing)
+
+## <a name="cc1312_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
 
 The [LAUNCHXL-CC1312R1](http://www.ti.com/tool/LAUNCHXL-CC1312R1) is a Texas
 Instrument's development kit for the CC1312R1 SoC MCU which combines a
 Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 
-## Hardware
+## <a name="cc1312_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
 
 ![LAUNCHXL-CC1312R1](http://www.ti.com/diagrams/launchxl-cc1312r1_cc1312r1-top-prof1.jpg)
 
@@ -30,93 +37,34 @@ Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 | Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1312r.pdf) (pdf file) |
 | Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
 
-## Board pinout
+## <a name="cc1312_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
 
-The [CC1312R Quick Start Guide](http://www.ti.com/lit/ml/swru535c/swru535c.pdf)
+The [LAUNXHL-CC1312R Quick Start Guide](http://www.ti.com/lit/ml/swru535c/swru535c.pdf)
 provides the default pinout for the board.
 
-## Flashing and Debugging
+## <a name="cc1312_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1312_launchpad_toc)
 
-The LAUNCHXL-CC1312R1 comes with an XDS110 on-board debug probe that provides
-programming, flashing and debugging capabilities.
-
-### Using TI tools
-
-#### Installing CCS and Uniflash
-
-The TI's Code Composer Studio provides the necessary tools to use the debug
-features of the XDS110; Uniflash provides flashing tools. Both programs can
-be found here:
-
-- [Code Composer Studio (CCS) Integrated Development Environment (IDE)](http://www.ti.com/tool/CCSTUDIO).
-- [Uniflash Standalone Flash Tool for TI Microcontrollers (MCU), Sitara Processors & SimpleLink devices](http://www.ti.com/tool/UNIFLASH).
-
-Before using the XDS110 with the latest CCS/Uniflash versions the firmware for
-it needs to be updated. Texas Instruments has a guide to correctly update it
-[here](http://software-dl.ti.com/ccs/esd/documents/xdsdebugprobes/emu_xds110.html#updating-the-xds110-firmware).
-
-#### Setting up the environment
-
-In order to make use of the programming and debugging capabilities of the XDS110
-some environment variable needs to be set:
+Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
+debug probe that provides programming, flashing and debugging capabilities
+through the USB Micro-USB connector. Once either TI Uniflash or OpenOCD are
+installed just connect the board using the Micro-USB port to your computer and
+type:
 
 ```
-export CCS_PATH=<path to ti install folder>/ti/ccs930
-export UNIFLASH_PATH<path to ti install folder>/ti/uniflash_5.2.0
+make flash BOARD=cc1312-launchpad
 ```
 
-That assumes you have CCS 9.3.0 (for the path name) and Uniflash 5.2.0, adjust
-accordingly.
-
-After that you can flash using the RIOT `make flash` command on your application
-or to debug you first start the debug server:
-
-```
-make debug-server
-```
-
-And then on another terminal you can run:
-
-```
-make debug
-```
-
-It will open GDB and connect to the debug server automatically.
-
-#### Reset
-
-The LAUNCHXL-CC1312R1 provides a reset button but it can also be reset from
-a computer using the `make reset` command.
-
-### Using OpenOCD
-
-To use OpenOCD with the XDS110 you need to use the an special version of
-OpenOCD made by TI (upstream version is not _yet_ compatible). You can
-clone and compile it from source:
-
-```
-# Clone into the openocd-ti folder
-git clone https://git.ti.com/cgit/sdo-emu/openocd openocd-ti
-
-# Change directory to the openocd source code
-cd openocd-ti/openocd
-
-# Configure, build, install
-./configure
-make
-sudo make install
-```
-
-#### Setting up the environment
-
-Now that we have the TI version of OpenOCD we need to export the `PROGRAMMER`
-environment variable, this is to enable OpenOCD instead of Uniflash.
+To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
+variable, this is to enable OpenOCD instead of Uniflash.
 
 ```
 export PROGRAMMER=openocd
 ```
 
-Now we can just do `make debug-server` and then `make debug`, this all using
-OpenOCD.
+Now we can just do `make flash` and `make debug`, this all using OpenOCD.
+
+For detailed information about CC1312 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1312 boards,
+see \ref cc26xx_cc13xx_riot.
 
 */

--- a/boards/cc1350-launchpad/doc.txt
+++ b/boards/cc1350-launchpad/doc.txt
@@ -3,17 +3,24 @@
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1350 Wireless MCU LaunchPad(TM) Kit
 
-## Overview
+## <a name="cc1350_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
+
+1. [Overview](#cc1350_launchpad_overview)
+2. [Hardware](#cc1350_launchpad_hardware)
+3. [Board pinout](#cc1350_launchpad_pinout)
+4. [Flashing the Device](#cc1350_launchpad_flashing)
+
+## <a name="cc1350_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
 
 The [LAUNCHXL-CC1350](https://www.ti.com/tool/LAUNCHXL-CC1350) is a Texas
 Instrument's development kit for the CC1350 SoC MCU which combines a Cortex-M3
 microcontroller alonside a dedicated Cortex-M0 to control a dual-band radio.
 
-## Hardware
+## <a name="cc1350_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
 
 ![LAUNCHXL-CC1350](https://www.ti.com/diagrams/launchxl-cc1350_launchxl-cc1350.jpg)
 
-| MCU               | CC1312R1              |
+| MCU               | CC1350                |
 |:----------------- |:--------------------- |
 | Family            | ARM Cortex-M3         |
 | Vendor            | Texas Instruments     |
@@ -23,29 +30,41 @@ microcontroller alonside a dedicated Cortex-M0 to control a dual-band radio.
 | FPU               | no                    |
 | Timers            | 4                     |
 | ADCs              | 1x 12-bit (channels)  |
-| UARTs             | 2                     |
+| UARTs             | 1                     |
 | SPIs              | 2                     |
 | I2Cs              | 1                     |
 | Vcc               | 1.8V - 3.8V           |
 | Datasheet         | [Datasheet](https://www.ti.com/lit/ds/swrs183b/swrs183b.pdf) |
 | Reference Manual  | [Reference Manual](https://www.ti.com/lit/ug/swcu117i/swcu117i.pdf) |
 
-## Board pinout
+## <a name="cc1350_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
 
 The [CC1350 Quick Start Guide](https://www.ti.com/lit/ug/swru478b/swru478b.pdf)
 provides the default pinout for the board.
 
-## Flashing and Debugging
+## <a name="cc1350_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1350_launchpad_toc)
 
-The LAUNCHXL-CC1350 comes with an XDS110 on-board debug probe that provides,
-programming, flashing and debuggigng capabilities.
-
-It can be either flashed either using Uniflash or OpenOCD, by setting
-`PROGRAMMER=uniflash` (default) or `PROGRAMMER=openocd` respectively.
-
-For example, to use OpenOCD:
+Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
+debug probe that provides programming, flashing and debugging capabilities
+through the USB Micro-USB connector. Once either TI Uniflash or OpenOCD are
+installed just connect the board using the Micro-USB port to your computer and
+type:
 
 ```
-make -C examples/hello-world flash PROGRAMMER=openocd
+make flash BOARD=cc1350-launchpad
 ```
+
+To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
+variable, this is to enable OpenOCD instead of Uniflash.
+
+```
+export PROGRAMMER=openocd
+```
+
+Now we can just do `make flash` and `make debug`, this all using OpenOCD.
+
+For detailed information about CC1312 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1312 boards,
+see \ref cc26xx_cc13xx_riot.
+
 */

--- a/boards/cc1352-launchpad/doc.txt
+++ b/boards/cc1352-launchpad/doc.txt
@@ -1,5 +1,70 @@
 /**
- * @defgroup        boards_cc1352_launchpad TI CC1352 LaunchPad
- * @ingroup         boards
- * @brief           Texas Instruments SimpleLink(TM) CC1352 Wireless MCU LaunchPad(TM) Kit
- */
+@defgroup        boards_cc1352_launchpad TI CC1352 LaunchPad
+@ingroup         boards
+@brief           Texas Instruments SimpleLink(TM) CC1352 Wireless MCU LaunchPad(TM) Kit
+
+## <a name="cc1352_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+
+1. [Overview](#cc1352_launchpad_overview)
+2. [Hardware](#cc1352_launchpad_hardware)
+3. [Board pinout](#cc1352_launcpad_pinout)
+4. [Flashing the Device](#cc1352_launchpad_flashing)
+
+## <a name="cc1352_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+
+The [LAUNCHXL-CC1352R1](https://www.ti.com/tool/LAUNCHXL-CC1352R1) is a Texas
+Instrument's development kit for the CC1352R1 SoC MCU which combines a
+Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
+
+## <a name="cc1352_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+
+![LAUNCHXL-CC1352R1](https://www.ti.com/diagrams/launchxl-cc1352r1_launchxl-cc1352r1-angled.jpg)
+
+| MCU               | CC1352R1              |
+|:----------------- |:--------------------- |
+| Family            | ARM Cortex-M4F        |
+| Vendor            | Texas Instruments     |
+| RAM               | 80KiB                 |
+| Flash             | 352KiB                |
+| Frequency         | 48MHz                 |
+| FPU               | yes                   |
+| Timers            | 4                     |
+| ADCs              | 1x 12-bit (channels)  |
+| UARTs             | 2                     |
+| SPIs              | 2                     |
+| I2Cs              | 1                     |
+| Vcc               | 1.8V - 3.8V           |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352r.pdf) (pdf file) |
+| Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
+
+## <a name="cc1352_launcpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+
+The [LAUNCHXL-CC1352R1 Quick Start Guide](https://www.ti.com/lit/ml/swru525e/swru525e.pdf)
+provides the default pinout for the board.
+
+## <a name="cc1352_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+
+Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
+debug probe that provides programming, flashing and debugging capabilities
+through the USB Micro-USB connector. Once either TI Uniflash or OpenOCD are
+installed just connect the board using the Micro-USB port to your computer and
+type:
+
+```
+make flash BOARD=cc1352-launchpad
+```
+
+To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
+variable, this is to enable OpenOCD instead of Uniflash.
+
+```
+export PROGRAMMER=openocd
+```
+
+Now we can just do `make flash` and `make debug`, this all using OpenOCD.
+
+For detailed information about CC1352R1 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1352R1 boards,
+see \ref cc26xx_cc13xx_riot.
+
+*/

--- a/boards/cc1352p-launchpad/doc.txt
+++ b/boards/cc1352p-launchpad/doc.txt
@@ -2,94 +2,75 @@
 @defgroup        boards_cc1352p_launchpad TI CC1352P LaunchPad
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1352P Wireless MCU LaunchPad(TM) Kit
-*/
 
-## Overview
+## <a name="cc1352p_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
+
+1. [Overview](#cc1352p_launchpad_overview)
+2. [Hardware](#cc1352p_launchpad_hardware)
+3. [Board pinout](#cc1352p_launcpad_pinout)
+4. [Flashing the Device](#cc1352p_launchpad_flashing)
+
+## <a name="cc1352p_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
 
 The [LAUNCHXL-CC1352P](http://www.ti.com/tool/LAUNCHXL-CC1352P) is a Texas
 Instrument's development kit for the CC1352P SoC which combines dual-band wireless MCU
 with integrated power amplifier.
 
-## Hardware
+## <a name="cc1352p_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
 
 ![LAUNCHPAD-CC1352P](http://www.ti.com/diagrams/launchxl-cc1352p_launchxl-cc1352p_mcu041a_cc1352p1.jpg)
+
+| MCU               | CC1352R1              |
+|:----------------- |:--------------------- |
+| Family            | ARM Cortex-M4F        |
+| Vendor            | Texas Instruments     |
+| RAM               | 80KiB                 |
+| Flash             | 352KiB                |
+| Frequency         | 48MHz                 |
+| FPU               | yes                   |
+| Timers            | 4                     |
+| ADCs              | 1x 12-bit (channels)  |
+| UARTs             | 2                     |
+| SPIs              | 2                     |
+| I2Cs              | 1                     |
+| Vcc               | 1.8V - 3.8V           |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352p.pdf) (pdf file) |
+| Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
 
 The board comes in two variants with different RF matching network on the 20 dBm PA output port:
 
 - LAUNCHXL-CC1352P1: 868/915 MHz up to 20 dBm, 2.4 GHz up to 5 dBm
 - LAUNCHXL-CC1352P-2: 868/915 MHz up to 14 dBm, 2.4 GHz up to 20 dBm.
 
-For a more detailed information, please check out the [CC1352P datasheet](http://www.ti.com/lit/ds/swrs192c/swrs192c.pdf) or the [quick start guide](http://www.ti.com/lit/ug/swau108a/swau108a.pdf)
+## <a name="cc1352p_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
 
-## Flashing and Debugging
+The [LAUNCHXL-CC1352P1 Quick Start Guide](https://www.ti.com/lit/ug/swau108a/swau108a.pdf)
+provides the default pinout for the board.
 
-The LAUNCHXL-CC1352P comes with an XDS110 on-board debug probe that provides
-programming, flashing and debugging capabilities.
+## <a name="cc1352p_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc1352p_launchpad_toc)
 
-### TI Code Composer Studio _CCS_
-
-The TI's [Code Composer Studio _CCS_](http://www.ti.com/tool/CCSTUDIO) is an Integrated Development Environment which provides the necessary tools to use the debug features of the XDS110.
-
-### Uniflash
-
-[Uniflash](http://www.ti.com/tool/UNIFLASH) is a standalone flash tool for TI MCUs, Sitara Processors & SimpleLink devices.
-
-#### Setting up the environment
-
-In order to make use of the programming and debugging capabilities of the XDS110 some environment variable needs to be set:
+Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
+debug probe that provides programming, flashing and debugging capabilities
+through the USB Micro-USB connector. Once either TI Uniflash or OpenOCD are
+installed just connect the board using the Micro-USB port to your computer and
+type:
 
 ```
-export CCS_PATH=<path to ti install folder>/ti/ccs930
-export UNIFLASH_PATH<path to ti install folder>/ti/uniflash_5.2.0
+make flash BOARD=cc1352p-launchpad
 ```
 
-That assumes you have CCS 9.3.0 (for the path name) and Uniflash 5.2.0, adjust
-accordingly.
-
-After that you can flash using the RIOT `make flash` command on your application
-or to debug you first start the debug server:
-
-```
-make debug-server
-```
-
-And then on another terminal you can run:
-
-```
-make debug
-```
-
-It will open GDB and connect to the debug server automatically.
-
-### Using OpenOCD
-
-To use OpenOCD with the XDS110 you need to use the an special version of
-OpenOCD made by TI (upstream version is not _yet_ compatible). You can
-clone and compile it from source:
-
-```
-# Clone into the openocd-ti folder
-git clone https://git.ti.com/cgit/sdo-emu/openocd openocd-ti
-
-# Change directory to the openocd source code
-cd openocd-ti/openocd
-
-# Configure, build, install
-./configure
-make
-sudo make install
-```
-
-#### Setting up the environment
-
-Now that we have the TI version of OpenOCD we need to export the `PROGRAMMER`
-environment variable, this is to enable OpenOCD instead of Uniflash.
+To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
+variable, this is to enable OpenOCD instead of Uniflash.
 
 ```
 export PROGRAMMER=openocd
 ```
 
-Now we can just do `make debug-server` and then `make debug`, this all using
-OpenOCD.
+Now we can just do `make flash` and `make debug`, this all using OpenOCD.
+
+For detailed information about CC1312 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1312 boards,
+see \ref cc26xx_cc13xx_riot.
+
 
 */

--- a/boards/cc2650-launchpad/doc.txt
+++ b/boards/cc2650-launchpad/doc.txt
@@ -2,4 +2,69 @@
 @defgroup        boards_cc2650_launchpad TI CC2650 LaunchPad XL
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC2650 Wireless MCU LaunchPad(TM) Kit
- */
+
+## <a name="cc2650_launchpad_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+
+1. [Overview](#cc2650_launchpad_overview)
+2. [Hardware](#cc2650_launchpad_hardware)
+3. [Board pinout](#cc2650_launchpad_pinout)
+4. [Flashing the Device](#cc2650_launchpad_flashing)
+
+## <a name="cc2650_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+
+The [LAUNCHXL-CC2650](https://www.ti.com/tool/LAUNCHXL-CC2650) is a Texas
+Instrument's development kit for the CC2650 SoC MCU which combines a Cortex-M3
+microcontroller alonside a dedicated Cortex-M0 to control the radio.
+
+## <a name="cc2650_launchpad_hardware"> Hardware </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+
+![LAUNCHXL-CC2650](https://www.ti.com/diagrams/launchxl-cc2650_launchxl-cc2650.jpg)
+
+| MCU               | CC2650                |
+|:----------------- |:--------------------- |
+| Family            | ARM Cortex-M3         |
+| Vendor            | Texas Instruments     |
+| RAM               | 20KiB                 |
+| Flash             | 128KiB                |
+| Frequency         | 48MHz                 |
+| FPU               | no                    |
+| Timers            | 4                     |
+| ADCs              | 1x 12-bit (channels)  |
+| UARTs             | 1                     |
+| SPIs              | 2                     |
+| I2Cs              | 1                     |
+| Vcc               | 1.8V - 3.8V           |
+| Datasheet         | [Datasheet](https://www.ti.com/lit/ds/symlink/cc2650.pdf) |
+| Reference Manual  | [Reference Manual](https://www.ti.com/lit/ug/swcu117i/swcu117i.pdf) |
+
+## <a name="cc2650_launchpad_pinout"> Board pinout </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+
+The [CC2650 Quick Start Guide](https://www.ti.com/lit/ml/swru451/swru451.pdf)
+provides the default pinout for the board.
+
+## <a name="cc2650_launchpad_flashing"> Flashing the Device </a> &nbsp;[[TOC]](#cc2650_launchpad_toc)
+
+Flashing RIOT is quite straight forward. The board comes with an XDS110 on-board
+debug probe that provides programming, flashing and debugging capabilities
+through the USB Micro-USB connector. Once either TI Uniflash or OpenOCD are
+installed just connect the board using the Micro-USB port to your computer and
+type:
+
+```
+make flash BOARD=cc2650-launchpad
+```
+
+To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
+variable, this is to enable OpenOCD instead of Uniflash.
+
+```
+export PROGRAMMER=openocd
+```
+
+Now we can just do `make flash` and `make debug`, this all using OpenOCD.
+
+For detailed information about CC1312 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1312 boards,
+see \ref cc26xx_cc13xx_riot.
+
+*/

--- a/cpu/cc26xx_cc13xx/doc.txt
+++ b/cpu/cc26xx_cc13xx/doc.txt
@@ -1,15 +1,162 @@
 /**
- * @defgroup        cpu_cc26xx_cc13xx CC26xx_CC13xx common
- * @ingroup         cpu
- * @brief           Common code for TI cc26xx/cc13xx family
- *
- * This module contains code common to all cc26xx/cc13xx cpus
- * supported by RIOT: @ref cpu_cc26x0_cc13x0, @ref cpu_cc26x2_cc13x2
- *
- */
+@defgroup        cpu_cc26xx_cc13xx CC26xx/CC13xx common
+@ingroup         cpu
+@brief           Common code for TI cc26xx/cc13xx family
+
+This module contains code common to all cc26xx/cc13xx cpus
+supported by RIOT: @ref cpu_cc26x0_cc13x0, @ref cpu_cc26x2_cc13x2
+
+\section cc26xx_cc13xx_riot RIOT-OS on CC26xx/CC13xx boards
+
+## <a name="cc26xx_cc13xx_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+1. [Overview](#cc26xx_cc13xx_overview)
+2. [Flashing the CCFG](#cc26xx_cc13xx_ccfg)
+3. [Debugging](#cc26xx_cc13xx_debugging)
+    1. [Using OpenOCD](#cc26xx_cc13xx_openocd)
+    1. [Using Uniflash](#cc26xx_cc13xx_uniflash)
+
+# <a name="cc26xx_cc13xx_overview"> Overview </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+The CC26xx/C13xx is a family of micro controllers fabricated by Texas Instruments
+for low-power communications, using protocols such as BLE, IEEE 802.15.4g-2012,
+and proprietary radio protocols.
+
+These family of MCUs is divided in two generations, the cc26x0/cc13x0, and the
+cc26x2/cc13x2 family. The difference is that the later provides more ROM and RAM
+and improvements on various peripherals.
+
+ MCU family    | RAM  | Flash
+:--------------|:-----|:------
+ CC26x0/CC13x0 | 20 K | 128 K
+ CC26x2/CC13x2 | 80 K | 352 K
+
+@note The actual flash size is the flash size minus 88 bytes, these 88 bytes are
+reserved for the CCFG, see also [Flashing the CCFG](#cc26xx_cc13xx_ccfg).
+
+# <a name="cc26xx_cc13xx_ccfg"> Flashing the CCFG </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+@warning Setting an incorrect CCFG configuration may lock out yourself
+out of the device.
+
+@note Blank chips from Texas Instruments come without a CCFG flashed, so any
+firmware flashed won't boot until the configuration is flashed. As this might be
+the case for custom boards remember flashing it.
+
+RIOT provides built-in support to flash the Customer Configuration on the
+CC26xx/CC13xx MCUs. It can be done through Kconfig using `make menuconfig`.
+
+For example:
+
+```
+make -C examples/hello-world menuconfig BOARD=cc1350-launchpad
+```
+
+It will open the Kconfig terminal configuration utility, you may see the
+`Update CCFG` option, selecting it will include the default configuration that
+Texas Instruments provides from their own SDK. You may change any further
+options available through Kconfig.
+
+Once configuration is saved you may compile a new binary and flash it onto the
+device.
+
+For example:
+
+```
+make -C examples/hello-world flash BOARD=cc1350-launchpad
+```
+
+@note Once flashed, there's no need to flash it again, unless the configuration
+needs to be changed.
+
+# <a name="cc26xx_cc13xx_debugging"> Debuggging </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+Development kits from Texas Instruments come with an XDS110 on-board debug probe
+that provides programming, flashing and debugging capabilities.
+
+It can either use proprietary Texas Instruments tools for programming, or OpenOCD.
+
+### <a name="cc26xx_cc13xx_openocd"> Using OpenOCD </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+To use OpenOCD with the XDS110 you need to use the an special version of
+OpenOCD made by TI (upstream version is not _yet_ compatible). You can
+clone and compile it from source:
+
+```
+# Clone into the openocd-ti folder
+git clone https://git.ti.com/cgit/sdo-emu/openocd openocd-ti
+
+# Change directory to the openocd source code
+cd openocd-ti/openocd
+
+# Configure, build, install
+./configure
+make
+sudo make install
+```
+
+@note Sometimes OpenOCD may stop working when the firmware on the XDS110
+is updated (when using Uniflash, happens without user intervention). With that
+in mind, it's encouraged to either enable the ROM bootloader backdoor to enable
+serial programming or the installation of TI Uniflash as a fallback. See
+[Using Uniflash](#cc26xx_cc13xx_uniflash)
+
+#### Setting up the environment
+
+To flash a board using OpenOCD you can use do it so by setting the `PROGRAMMER`
+environment variable directly in the make command line or in your shell
+nitialization
+
+### <a name="cc26xx_cc13xx_uniflash"> Using Uniflash </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+The TI's Code Composer Studio provides the necessary tools to use the debug
+features of the XDS110; Uniflash provides flashing tools. Both programs can
+be found here:
+
+- [Code Composer Studio (CCS) Integrated Development Environment (IDE)](http://www.ti.com/tool/CCSTUDIO).
+- [Uniflash Standalone Flash Tool for TI Microcontrollers (MCU), Sitara Processors & SimpleLink devices](http://www.ti.com/tool/UNIFLASH).
+
+Before using the XDS110 with the latest CCS/Uniflash versions the firmware for
+it needs to be updated. Texas Instruments has a guide to correctly update it
+[here](http://software-dl.ti.com/ccs/esd/documents/xdsdebugprobes/emu_xds110.html#updating-the-xds110-firmware).
+
+#### Setting up the environment
+
+In order to make use of the programming and debugging capabilities of the XDS110
+some environment variable needs to be set:
+
+```
+export CCS_PATH=<path to ti install folder>/ti/ccs930
+export UNIFLASH_PATH<path to ti install folder>/ti/uniflash_5.2.0
+```
+
+That assumes you have CCS 9.3.0 (for the path name) and Uniflash 5.2.0, adjust
+accordingly.
+
+After that you can flash using the RIOT `make flash` command on your application
+or to debug you first start the debug server:
+
+```
+make debug-server
+```
+
+And then on another terminal you can run:
+
+```
+make debug
+```
+
+It will open GDB and connect to the debug server automatically.
+
+@note By default LaunchPad boards on RIOT use uniflash as the default
+programmer, if it's not the case for an external board, you can always use
+uniflash by setting this environment variable `PROGRAMMER=uniflash` to change
+the default programmer.
+
+*/
 
 /**
- * @defgroup        cpu_cc26xx_cc13xx_definitions CC26xx_CC13xx common
+ * @defgroup        cpu_cc26xx_cc13xx_definitions CC26xx/CC13xx common
  * @ingroup         cpu
  * @brief           Common definitions for TI cc26xx/cc13xx family
  *


### PR DESCRIPTION
### Contribution description

- Adds documentation for LaunchPad boards.
- Moves the flashing section of existing boards to a central place (on CC26xx/CC13xx common).
- Fixes the number of UARTs for cc1350-launchpad, has only 1 :-(.
- Adds a Table of Contents for each board and CPU, slightly copied from the great esp32 documentation.

### Testing procedure

- `make docs`
- Take a cup of coffee, read it, point out errors 😉 . 

### Issues/PRs references

None