### PR TITLE
bootloader/dfu: fix USEMODULE=

### DIFF
--- a/bootloaders/riotboot_dfu/Makefile
+++ b/bootloaders/riotboot_dfu/Makefile
@@ -19,12 +19,8 @@ DISABLE_MODULE += auto_init auto_init_%
 
 # avoid using stdio
 USEMODULE += stdio_null
-
-# Include riotboot flash partition functionality
-USEMODULE += riotboot_slot
-
 # Add RIOTBOOT USB DFU integration
-USEMODULE=riotboot_usb_dfu
+USEMODULE += riotboot_usb_dfu
 
 # Use xtimer for scheduled reboot
 USEMODULE += xtimer


### PR DESCRIPTION
### Contribution description

While looking at  #16044 I realized there was an issue with USEMODULE declaration in `bootloader/dfu`. Because of this `stdio_uart` was actually pulled in.

### Testing procedure

- flashing with the bootloader should still work
- stdio_null is now used

```
make -C bootloaders/riotboot_dfu/ info-modules | grep stdio_null
stdio_null
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
