### PR TITLE
boards/native: set FLASHER as empty

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -10,7 +10,7 @@ else
 endif
 
 RESET ?= $(RIOTBOARD)/native/dist/reset.sh
-FLASHER = true
+FLASHER ?=
 FLASHFILE ?= $(ELFFILE)
 
 TERMPROG ?= $(FLASHFILE)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is split-out from #15970. Native doesn't have a flasher so the FLASHER variable can simply be empty to skip this step transparently.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

make -C examples/hello-world flash term should still work but `true` is not printed by this PR:

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 make -C examples/hello-world flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make     
Building application "hello-world" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
   text	   data	    bss	    dec	    hex	filename
  27160	    592	  47748	  75500	  126ec	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
/work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.04-devel-618-ga11dc-pr/make/native_flasher)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
^C
native: exiting
```

</details>


<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 make -C examples/hello-world flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make     
Building application "hello-world" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
   text	   data	    bss	    dec	    hex	filename
  27140	    592	  47748	  75480	  126d8	/data/riotbuild/riotbase/examples/hello-world/bin/native/hello-world.elf
true 
/work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.04-devel-617-gfbe674)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
^C
native: exiting
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

split-out from #15970

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
