### PR TITLE
makefiles/boot: use same PROGRAMMER to flash riotboot

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -80,7 +80,8 @@ riotboot/bootloader/%: $(BUILDDEPS)
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
-		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID)\
+		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID) \
+		PROGRAMMER=$(PROGRAMMER) \
 			$(MAKE) --no-print-directory -C $(RIOTBOOT_DIR) $*
 
 # Generate a binary file from the bootloader which fills all the


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When working on #15970, I noticed that when setting a custom PROGRAMMER (for example openocd instead of edbg with samr21-xpro), and flashing with `riotboot/flash%` targets, I realized that the riot slot is flashed with the custom programmer (openocd) but riotboot is flashed using the default programmer.

This PR is fixing this small inconsistency by passing the PROGRAMMER variable to the riotboot/flash% targets.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Default `tests/riotboot%` flashing behaviour is still working
- Test the flashing of `tests/riotboot` on samr21-xpro by setting `PROGRAMMER=openocd` and verify that openocd is used to flash both the slots and riotboot:

<details><summary>this PR</summary>

```
$ PROGRAMMER=openocd make BOARD=samr21-xpro -C tests/riotboot all riotboot/flash term
make: Entering directory '/work/riot/RIOT/tests/riotboot'
Building application "tests_riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613655644.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  14064	    132	   2368	  16564	   40b4	/work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613655644.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00001000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800009840
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 44219 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x00000380 msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 14592 bytes from file /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613655644.riot.bin in 1.490635s (9.560 KiB/s)

verified 14452 bytes in 1.209276s (11.671 KiB/s)

shutdown command invoked
Done flashing
Building application "riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
   text	   data	    bss	    dec	    hex	filename
   1644	      0	    592	   2236	    8bc	/work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800009840
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 44447 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       unknown

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x00000380 msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 1792 bytes from file /work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.elf in 0.191268s (9.149 KiB/s)

verified 1644 bytes in 0.226742s (7.081 KiB/s)

shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-18 14:40:56,349 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2021-02-18 14:40:58,464 # help
2021-02-18 14:40:58,467 # Command              Description
2021-02-18 14:40:58,470 # ---------------------------------------
2021-02-18 14:40:58,474 # curslotnr            Print current slot number
2021-02-18 14:40:58,480 # curslothdr           Print current slot header
2021-02-18 14:40:58,483 # getslotaddr          Print address of requested slot
2021-02-18 14:40:58,489 # dumpaddrs            Prints all slot data in header
2021-02-18 14:40:58,491 # reboot               Reboot the node
2021-02-18 14:40:58,496 # version              Prints current RIOT_VERSION
2021-02-18 14:40:58,501 # pm                   interact with layered PM subsystem
> 2021-02-18 14:40:59,298 # Exiting Pyterm
```

</details>

<details><summary>master</summary>

```
$ PROGRAMMER=openocd make BOARD=samr21-xpro -C tests/riotboot all riotboot/flash term
make: Entering directory '/work/riot/RIOT/tests/riotboot'
Building application "tests_riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613655673.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  14008	    132	   2368	  16508	   407c	/work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613655673.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00001000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800009840
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 34893 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x00000380 msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 14592 bytes from file /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613655673.riot.bin in 1.484752s (9.598 KiB/s)

verified 14396 bytes in 1.207713s (11.641 KiB/s)

shutdown command invoked
Done flashing
Building application "riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
   text	   data	    bss	    dec	    hex	filename
   1644	      0	    592	   2236	    8bc	/work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.elf
/work/riot/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification.......... done.
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-18 14:41:31,061 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2021-02-18 14:41:35,055 # help
2021-02-18 14:41:35,058 # Command              Description
2021-02-18 14:41:35,061 # ---------------------------------------
2021-02-18 14:41:35,065 # curslotnr            Print current slot number
2021-02-18 14:41:35,070 # curslothdr           Print current slot header
2021-02-18 14:41:35,074 # getslotaddr          Print address of requested slot
2021-02-18 14:41:35,079 # dumpaddrs            Prints all slot data in header
2021-02-18 14:41:35,083 # reboot               Reboot the node
2021-02-18 14:41:35,087 # version              Prints current RIOT_VERSION
2021-02-18 14:41:35,092 # pm                   interact with layered PM subsystem
> 2021-02-18 14:41:35,708 # Exiting Pyterm
```

=> riotboot is flashed using edbg.

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Split-out from #15970 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
