### PR TITLE
tools/edbg: add and use wrapper shell script

### DIFF
--- a/dist/tools/edbg/edbg.sh
+++ b/dist/tools/edbg/edbg.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Default edbg command
+: "${EDBG:=edbg}"
+# Edbg command base arguments
+: "${EDBG_ARGS:=}"
+
+test_imagefile() {
+    if [ ! -f "${IMAGE_FILE}" ]; then
+        echo "Error: Unable to locate IMAGE_FILE"
+        echo "       (${IMAGE_FILE})"
+        exit 1
+    fi
+}
+
+do_flash() {
+    IMAGE_FILE=$1
+    test_imagefile
+
+    # Configure edbg flash flags
+    local _fflags="${EDBG_ARGS} --verbose --file ${IMAGE_FILE} --verify"
+
+    # flash device
+    sh -c "${EDBG} ${_fflags} || ${EDBG} ${_fflags} --program" && echo 'Done flashing'
+}
+
+do_reset() {
+    sh -c "${EDBG} ${EDBG_ARGS}"
+}
+
+#
+# parameter dispatching
+#
+ACTION="$1"
+shift # pop $1 from $@
+
+case "${ACTION}" in
+  flash)
+    echo "### Flashing Target ###"
+    do_flash "$@"
+    ;;
+  reset)
+    echo "### Resetting Target ###"
+    do_reset
+    ;;
+  *)
+    echo "Usage: $0 {flash|reset}"
+    echo "          flash <flashfile>"
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As requested in #15970, this PR splits out the changes related to edbg in its own PR.

While working on #15970, I noticed that support for edbg was not consistent with the other flashers, using a custom command with a dual call to edbg.
Similar to openocd/jlink/pyocd, this PR adds an edbg.sh script that wrap the flash and reset calls to edbg. As a result, edbg.inc.mk needs some refactoring as well.

The good thing is that there's no need to define a custom `flash-recipe = $(edbg-flash-recipe)`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Flashing and resetting with edbg still works. Also verify that flashing using DEBUG_ADAPTER_ID still works.

Results on samr21-xpro:

<details><summary>flash</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=samr21-xpro -C examples/hello-world flash --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=samr21-xpro'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=samr21-xpro'    
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /data/riotbuild/riotbase/boards/samr21-xpro
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/samd21
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/sam0_common
"make" -C /data/riotbuild/riotbase/cpu/sam0_common/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9004	    112	   2304	  11420	   2c9c	/data/riotbuild/riotbase/examples/hello-world/bin/samr21-xpro/hello-world.elf
/work/riot/RIOT/dist/tools/edbg/edbg.sh flash /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification....................................... done.
Done flashing
```

</details>

<details><summary>reset</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=samr21-xpro -C examples/hello-world reset --no-print-directory 
/work/riot/RIOT/dist/tools/edbg/edbg.sh reset
### Resetting Target ###
```

</details>

<details><summary>flash with DEBUG_ADAPTER_ID</summary>

```
$ DEBUG_ADAPTER_ID=ATML2127031800009840 make BOARD=samr21-xpro -C examples/hello-world flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/edbg/edbg.sh flash /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification....................................... done.
Done flashing
```

</details>

<details><summary>flash riotboot</summary>

```
$ make BOARD=samr21-xpro -C tests/riotboot riotboot/flash term --no-print-directory 
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
creating /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613728886.riot.bin...
/work/riot/RIOT/dist/tools/edbg/edbg.sh flash /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1613728886.riot.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x1004 expected 0x76, read 0x49
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming............................................................ done.
Verification............................................................ done.
Done flashing
Building application "riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
   text	   data	    bss	    dec	    hex	filename
   1644	      0	    592	   2236	    8bc	/work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.elf
/work/riot/RIOT/dist/tools/edbg/edbg.sh flash /work/riot/RIOT/bootloaders/riotboot/bin/samr21-xpro/riotboot.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x4 expected 0x81, read 0xb1
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming.......... done.
Verification.......... done.
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-02-19 11:01:50,779 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2021-02-19 11:01:54,786 # help
2021-02-19 11:01:54,789 # Command              Description
2021-02-19 11:01:54,792 # ---------------------------------------
2021-02-19 11:01:54,797 # curslotnr            Print current slot number
2021-02-19 11:01:54,801 # curslothdr           Print current slot header
2021-02-19 11:01:54,806 # getslotaddr          Print address of requested slot
2021-02-19 11:01:54,810 # dumpaddrs            Prints all slot data in header
2021-02-19 11:01:54,814 # reboot               Reboot the node
2021-02-19 11:01:54,818 # version              Prints current RIOT_VERSION
2021-02-19 11:01:54,823 # pm                   interact with layered PM subsystem
> 2021-02-19 11:01:55,732 # Exiting Pyterm
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

split-out from #15970

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
