### PR TITLE
tests/gnrc_ndp: don't guess size of `gnrc_pktsnip_t` in `pktbuf`

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -21,6 +21,10 @@ ifneq (,$(filter gnrc_pktbuf,$(USEMODULE)))
   include $(RIOTBASE)/sys/net/gnrc/pktbuf/Makefile.include
 endif
 
+ifneq (,$(filter gnrc_pktbuf_static,$(USEMODULE)))
+  include $(RIOTBASE)/sys/net/gnrc/pktbuf_static/Makefile.include
+endif
+
 ifneq (,$(filter malloc_thread_safe,$(USEMODULE)))
   include $(RIOTBASE)/sys/malloc_thread_safe/Makefile.include
 endif

--- a/sys/net/gnrc/pktbuf_static/Makefile.include
+++ b/sys/net/gnrc/pktbuf_static/Makefile.include
@@ -1,0 +1,2 @@
+USEMODULE_INCLUDES_gnrc_pktbuf_static := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_gnrc_pktbuf_static)

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -31,16 +31,10 @@
 #include "net/gnrc/pkt.h"
 
 #include "pktbuf_internal.h"
+#include "pktbuf_static.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
-
-#define _ALIGNMENT_MASK    (sizeof(_unused_t) - 1)
-
-typedef struct _unused {
-    struct _unused *next;
-    unsigned int size;
-} _unused_t;
 
 /* The static buffer needs to be aligned to word size, so that its start
  * address can be casted to `_unused_t *` safely. Just allocating an array of
@@ -58,12 +52,6 @@ static uint16_t max_byte_count = 0;
 static gnrc_pktsnip_t *_create_snip(gnrc_pktsnip_t *next, const void *data, size_t size,
                                     gnrc_nettype_t type);
 static void *_pktbuf_alloc(size_t size);
-
-/* fits size to byte alignment */
-static inline size_t _align(size_t size)
-{
-    return (size + _ALIGNMENT_MASK) & ~(_ALIGNMENT_MASK);
-}
 
 static inline void _set_pktsnip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *next,
                                 void *data, size_t size, gnrc_nettype_t type)

--- a/sys/net/gnrc/pktbuf_static/include/pktbuf_static.h
+++ b/sys/net/gnrc/pktbuf_static/include/pktbuf_static.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-2015 Martine S. Lenders <m.lenders@fu-berlin.de>
+ * Copyright (C) 2014-2021 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup net_gnrc_pktbuf
+ * @brief   Internal definitions of the static implementation of
+ *          @ref net_gnrc_pktbuf
+ * @{
+ *
+ * @file
+ * @brief   Definitions of types and their alignment for usage in tests
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef PKTBUF_STATIC_H
+#define PKTBUF_STATIC_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mask to align packet buffer allocations with size of @ref _unused_t
+ */
+#define GNRC_PKTBUF_STATIC_ALIGN_MASK   (sizeof(_unused_t) - 1)
+
+/**
+ * @brief   Marks an unused section of the packet buffer arena array
+ */
+typedef struct _unused {
+    struct _unused *next;   /**< the next unused section */
+    unsigned int size;      /**< the size of the unused section */
+} _unused_t;
+
+/**
+ * @brief   Calculates the required space of a number of bytes including
+ *          alignment to the size of @ref _unused_t
+ */
+static inline size_t _align(size_t size)
+{
+    return (size + GNRC_PKTBUF_STATIC_ALIGN_MASK) &
+          ~(GNRC_PKTBUF_STATIC_ALIGN_MASK);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PKTBUF_STATIC_H */
+/** @} */

--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -11,6 +11,8 @@ USEMODULE += netdev_test
 CFLAGS += -DGNRC_NETTYPE_NDP=GNRC_NETTYPE_TEST
 CFLAGS += -DTEST_SUITES
 
+INCLUDES += -I$(RIOTBASE)/sys/net/gnrc/pktbuf_static/include
+
 include $(RIOTBASE)/Makefile.include
 
 # Set GNRC_PKTBUF_SIZE via CFLAGS if not being set via Kconfig.

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -38,6 +38,8 @@
 #include "sched.h"
 #include "test_utils/expect.h"
 
+#include "pktbuf_static.h"
+
 #include "net/gnrc/ndp.h"
 
 #define TEST_CUR_HL             (194U)
@@ -81,9 +83,8 @@ static void set_up(void)
 static void fill_pktbuf(void)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL,
-                                          /* 24 = sizeof(gnrc_pktsnip_t) +
-                                           * potential alignment */
-                                          CONFIG_GNRC_PKTBUF_SIZE - 24U,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          _align(sizeof(gnrc_pktsnip_t)),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT(gnrc_pktbuf_is_sane());
@@ -496,9 +497,10 @@ static void test_nbr_sol_send__src_NOT_NULL(void)
 static void test_nbr_sol_send__pktbuf_full1(void)
 {
     /* don't be able to fit any more data into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - 24,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          _align(sizeof(gnrc_pktsnip_t)),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_nbr_sol_send(&test_tgt, test_netif, &test_src, &test_dst, NULL);
@@ -510,10 +512,11 @@ static void test_nbr_sol_send__pktbuf_full1(void)
 static void test_nbr_sol_send__pktbuf_full2(void)
 {
     /* just be able to fit the SLLAO into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (2 * _align(sizeof(gnrc_pktsnip_t))) - 16,
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_nbr_sol_send(&test_tgt, test_netif, &test_src, &test_dst, NULL);
@@ -525,10 +528,11 @@ static void test_nbr_sol_send__pktbuf_full2(void)
 static void test_nbr_sol_send__pktbuf_full3(void)
 {
     /* just be able to fit the SLLAO and NS into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (3 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_nbr_sol_t),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
@@ -541,10 +545,11 @@ static void test_nbr_sol_send__pktbuf_full3(void)
 static void test_nbr_sol_send__pktbuf_full4(void)
 {
     /* just be able to fit the SLLAO, NS, and IPv6 header into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (4 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_nbr_sol_t) -
                                           sizeof(ipv6_hdr_t),
                                           GNRC_NETTYPE_UNDEF);
@@ -707,9 +712,10 @@ static void test_nbr_adv_send__src_tgt_specified_dst_supply_tl2a_ext_opts(void)
 static void test_nbr_adv_send__pktbuf_full1(void)
 {
     /* don't be able to fit any more data into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - 24,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          _align(sizeof(gnrc_pktsnip_t)),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_nbr_adv_send(&test_src, test_netif, &test_dst, true, NULL);
@@ -721,10 +727,11 @@ static void test_nbr_adv_send__pktbuf_full1(void)
 static void test_nbr_adv_send__pktbuf_full2(void)
 {
     /* just be able to fit the TLLAO into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of TLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (2 * _align(sizeof(gnrc_pktsnip_t))) - 16,
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_nbr_adv_send(&test_src, test_netif, &test_dst, true, NULL);
@@ -736,10 +743,11 @@ static void test_nbr_adv_send__pktbuf_full2(void)
 static void test_nbr_adv_send__pktbuf_full3(void)
 {
     /* just be able to fit the TLLAO and NA into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of TLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (3 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_nbr_adv_t),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
@@ -752,10 +760,11 @@ static void test_nbr_adv_send__pktbuf_full3(void)
 static void test_nbr_adv_send__pktbuf_full4(void)
 {
     /* just be able to fit the TLLAO, NA, and IPv6 header into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of TLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (4 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_nbr_adv_t) -
                                           sizeof(ipv6_hdr_t),
                                           GNRC_NETTYPE_UNDEF);
@@ -830,9 +839,10 @@ static void test_rtr_sol_send__dst_global(void)
 static void test_rtr_sol_send__pktbuf_full1(void)
 {
     /* don't be able to fit any more data into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - 24,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          _align(sizeof(gnrc_pktsnip_t)),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_rtr_sol_send(test_netif, &test_dst);
@@ -844,10 +854,11 @@ static void test_rtr_sol_send__pktbuf_full1(void)
 static void test_rtr_sol_send__pktbuf_full2(void)
 {
     /* just be able to fit the SLLAO into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (2 * _align(sizeof(gnrc_pktsnip_t))) - 16,
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_rtr_sol_send(test_netif, &test_dst);
@@ -859,10 +870,11 @@ static void test_rtr_sol_send__pktbuf_full2(void)
 static void test_rtr_sol_send__pktbuf_full3(void)
 {
     /* just be able to fit the SLLAO and RS into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (3 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_rtr_sol_t),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
@@ -875,10 +887,11 @@ static void test_rtr_sol_send__pktbuf_full3(void)
 static void test_rtr_sol_send__pktbuf_full4(void)
 {
     /* just be able to fit the SLLAO, RS, and IPv6 header into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (4 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_rtr_sol_t) -
                                           sizeof(ipv6_hdr_t),
                                           GNRC_NETTYPE_UNDEF);
@@ -1029,9 +1042,10 @@ static void test_rtr_adv_send__src_dst_fin_ext_opts(void)
 static void test_rtr_adv_send__pktbuf_full1(void)
 {
     /* don't be able to fit any more data into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - 24,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          _align(sizeof(gnrc_pktsnip_t)),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_rtr_adv_send(test_netif, &test_src, &test_dst, false, NULL);
@@ -1043,10 +1057,11 @@ static void test_rtr_adv_send__pktbuf_full1(void)
 static void test_rtr_adv_send__pktbuf_full2(void)
 {
     /* just be able to fit the SLLAO into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (2 * 24) - 16,
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (2 * _align(sizeof(gnrc_pktsnip_t))) - 16,
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
     gnrc_ndp_rtr_adv_send(test_netif, &test_src, &test_dst, false, NULL);
@@ -1058,10 +1073,11 @@ static void test_rtr_adv_send__pktbuf_full2(void)
 static void test_rtr_adv_send__pktbuf_full3(void)
 {
     /* just be able to fit the SLLAO and RA into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (3 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (3 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_rtr_adv_t),
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(tmp);
@@ -1074,10 +1090,11 @@ static void test_rtr_adv_send__pktbuf_full3(void)
 static void test_rtr_adv_send__pktbuf_full4(void)
 {
     /* just be able to fit the SLLAO, RA, and IPv6 header into packet buffer
-     * - 24 == sizeof(gnrc_pktsnip_t) + pktbuf internal padding
+     * - sizeof(gnrc_pktsnip_t) + pktbuf internal padding
      * - 16 == size of SLLAO for IEEE 802.15.4 */
     gnrc_pktsnip_t *tmp = gnrc_pktbuf_add(NULL, NULL,
-                                          CONFIG_GNRC_PKTBUF_SIZE - (4 * 24) - 16 -
+                                          CONFIG_GNRC_PKTBUF_SIZE -
+                                          (4 * _align(sizeof(gnrc_pktsnip_t))) - 16 -
                                           sizeof(ndp_rtr_adv_t) -
                                           sizeof(ipv6_hdr_t),
                                           GNRC_NETTYPE_UNDEF);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
From https://github.com/RIOT-OS/RIOT/issues/12651

> &#x2610; tests/gnrc_ndp: no idea of the problems

The problem is that the tests makes some assumptions that do not hold true for every platform: For testing the "packet buffer is full" error case, it fills the packet buffer with just enough data to be able to progress the function under test to a certain point and then fail. For this it assumes the size of a `gnrc_pktsnip_t` to be 24 bytes. However, 24 bytes is only the right size for `gnrc_pktsnip_t` on 32-bit systems (and only if the struct does not change), on AVR e.g. it 9 bytes. By using the internal alignment function of `pktbuf` we are able to precisely tell the internal size of `gnrc_pktsnip_t` using the `sizeof` operator.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run

```sh
make -C tests/gnrc_ndp -j flash test
```

on an 8-bit platform (that fits it) and it should succeed now. Also try to run the test on several other platforms to make sure it does not introduce a regression.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Should fix https://github.com/RIOT-OS/RIOT/issues/12651 for good.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
