### PR TITLE
makefiles/kconfig.mk: generate config file from RIOT_CONFIG_% environment variables

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -334,6 +334,20 @@ check_no_pkg_source_local() {
         | error_with_message "Don't push PKG_SOURCE_LOCAL definitions upstream"
 }
 
+check_no_riot_config() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e 'RIOT_CONFIG_.*')
+
+    pathspec+=('Makefile*')
+    pathspec+=('**/Makefile*')
+    pathspec+=('**/*.mk')
+    pathspec+=(':!makefiles/kconfig.mk')
+    git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message "Don't push RIOT_CONFIG_* definitions upstream. Rather define configuration via Kconfig"
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -353,6 +367,7 @@ all_checks() {
     check_no_pseudomodules_in_makefile_dep
     check_no_usemodules_in_makefile_include
     check_no_pkg_source_local
+    check_no_riot_config
 }
 
 main() {

--- a/doc/doxygen/src/kconfig/kconfig.md
+++ b/doc/doxygen/src/kconfig/kconfig.md
@@ -86,6 +86,23 @@ be placed in the application's folder. For an example of this you can check
 the [tests/kconfig](https://github.com/RIOT-OS/RIOT/tree/master/tests/kconfig)
 application.
 
+## Configuration via environment variables                {#env-config-kconfig}
+For easy debugging of configuration or testing new modules by compiling them
+into existing applications, one can also use environment variables prefixed by
+`RIOT_CONFIG_`. To achieve the same configuration exemplified in
+@ref configure-using-files, e.g., you could also use
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.sh}
+RIOT_CONFIG_KCONFIG_MODULE_SOCK_UTIL=1 \
+RIOT_CONFIG_SOCK_UTIL_SCHEME_MAXLEN=24 \
+    make
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All the checks that apply for `.config` files also are done with this approach.
+
+Mind that this is only meant to be used during development. In production,
+please set the configuration via `.config` files.
+
 ## A note on the usage of CFLAGS
 When a certain module is being configured via Kconfig the configuration macro
 will not longer be overridable by means of CFLAGS (e.g. set on the

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -42,6 +42,11 @@ endif
 # Default and user overwritten configurations
 KCONFIG_USER_CONFIG = $(APPDIR)/user.config
 
+# This file will contain configuration using the `RIOT_CONFIG_<CONFIG>`
+# environment variables. Used to enforce a rerun of GENCONFIG when environment
+# changes.
+KCONFIG_GENERATED_ENV_CONFIG = $(GENERATED_DIR)/env.config
+
 # This is the output of the generated configuration. It always mirrors the
 # content of KCONFIG_GENERATED_AUTOCONF_HEADER_C, and it is used to load
 # configuration symbols to the build system.
@@ -63,6 +68,7 @@ KCONFIG_OUT_DEP = $(KCONFIG_OUT_CONFIG).d
 MERGE_SOURCES += $(KCONFIG_ADD_CONFIG)
 MERGE_SOURCES += $(wildcard $(KCONFIG_APP_CONFIG))
 MERGE_SOURCES += $(wildcard $(KCONFIG_USER_CONFIG))
+MERGE_SOURCES += $(KCONFIG_GENERATED_ENV_CONFIG)
 
 # Create directory to place generated files
 $(GENERATED_DIR): $(if $(MAKE_RESTARTS),,$(CLEAN))
@@ -141,6 +147,14 @@ $(KCONFIG_GENERATED_DEPENDENCIES): FORCE | $(GENERATED_DIR)
 	$(Q)printf "%s " $(USEMODULE_W_PREFIX) $(USEPKG_W_PREFIX) \
 	  | awk 'BEGIN {RS=" "}{ gsub("-", "_", $$0); \
 	      printf "config %s\n\tbool\n\tdefault y\n", toupper($$0)}' \
+	  | $(LAZYSPONGE) $(LAZYSPONGE_FLAGS) $@
+
+KCONFIG_ENV_CONFIG = $(patsubst RIOT_%,%,$(foreach v,$(filter RIOT_CONFIG_%,$(.VARIABLES)),$(v)=$($(v))))
+
+# Build an intermediate file based on the `RIOT_CONFIG_<CONFIG>` environment
+# variables
+$(KCONFIG_GENERATED_ENV_CONFIG): FORCE | $(GENERATED_DIR)
+	$(Q)printf "%s\n" $(KCONFIG_ENV_CONFIG) \
 	  | $(LAZYSPONGE) $(LAZYSPONGE_FLAGS) $@
 
 # All directories in EXTERNAL_MODULES_PATHS which have a Kconfig file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
If there is one thing I will miss when we go full Kconfig, is setting configuration and module selection via the environment variables without having to touch random files. This drafts out how to do that regardless with Kconfig by using the `RIOT_CONFIG_` prefix for environement variables. At least for the generated output config this seems to be working as I was able to include modules into my build with that, but this is still lacking some functionality:

TODOs:
- [x] Figure out how to include the selection from the environment into `make menuconfig` reliably (sometimes it does already)
- [x] User should get an error when trying to set an invalid value
- [x] Add a check (to `dist/tools/buildsystem_sanity_check`?) to make sure the `RIOT_CONFIG_` environment variables are not used in production code. This is after all only be meant to be used as fluff for devs, Kconfig files should still take precedence.
- [x] Find way to auto-clean config when symbol is removed from environment
- [x] Document this somewhere.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I used a random app of those that already support building with Kconfig:

```
$ TEST_KCONFIG=1 make -C tests/driver_dht/ info-modules
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
=== [ATTENTION] Testing Kconfig dependency modelling ===
=== [ATTENTION] Testing Kconfig dependency modelling ===
=== [ATTENTION] Testing Kconfig dependency modelling ===
make: Nothing to be done for 'clean'.
auto_init
auto_init_xtimer
board
core
core_init
core_msg
core_panic
cortexm_common
cortexm_common_periph
cpu
dht
div
fmt
malloc_thread_safe
newlib
newlib_nano
newlib_syscalls_default
periph
periph_common
periph_gpio
periph_init
periph_init_gpio
periph_init_pm
periph_init_timer
periph_init_uart
periph_pm
periph_timer
periph_uart
pm_layered
sam0_common_periph
samd21_vectors
stdio_uart
sys
xtimer
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
$ TEST_KCONFIG=1 RIOT_CONFIG_MODULE_ZTIMER=y make -C tests/driver_dht/ info-modules
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
=== [ATTENTION] Testing Kconfig dependency modelling ===
=== [ATTENTION] Testing Kconfig dependency modelling ===
=== [ATTENTION] Testing Kconfig dependency modelling ===
make: Nothing to be done for 'clean'.
auto_init
auto_init_xtimer
auto_init_ztimer
board
core
core_init
core_msg
core_panic
cortexm_common
cortexm_common_periph
cpu
dht
div
fmt
frac
malloc_thread_safe
newlib
newlib_nano
newlib_syscalls_default
periph
periph_common
periph_gpio
periph_init
periph_init_gpio
periph_init_pm
periph_init_timer
periph_init_uart
periph_pm
periph_timer
periph_uart
pm_layered
sam0_common_periph
samd21_vectors
stdio_uart
sys
xtimer
ztimer
ztimer_auto_init
ztimer_convert
ztimer_convert_frac
ztimer_convert_shift
ztimer_core
ztimer_extend
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
```

~~`clean` is used to reset the generated output config, I think? Without it the module list sometimes remains unchanged.~~

Invalid values are pointed out as such:

```
$ RIOT_CI_BUILD=1 TEST_KCONFIG=1 RIOT_CONFIG_MODULE_ZTIMER="foobar" make -C tests/driver_dht/ -j
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
=== [ATTENTION] Testing Kconfig dependency modelling ===
[genconfig.py]:ERROR-Treating Kconfig warnings as errors:
[genconfig.py]:ERROR-=> warning: the value 'foobar' is invalid for MODULE_ZTIMER (defined at /home/mlenders/Repositories/RIOT-OS/RIOT/sys/ztimer/Kconfig:8), which has type bool -- assignment ignored
make: *** No rule to make target '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht/bin/samr21-xpro/generated/out.config', needed by 'check-kconfig-errors'.  Stop.
make: *** Waiting for unfinished jobs....
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
$ RIOT_CI_BUILD=1 TEST_KCONFIG=1 RIOT_CONFIG_MODULE_AT=y make -C tests/driver_dht/ -j
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
=== [ATTENTION] Testing Kconfig dependency modelling ===
[genconfig.py]:ERROR-=> The module MODULE_AT could not be set to y.
[genconfig.py]:ERROR-   Check the following unmet dependencies: MODULE_ISRPIPE (=n), MODULE_ISRPIPE_READ_TIMEOUT (=n)

make: *** No rule to make target '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht/bin/samr21-xpro/generated/out.config', needed by 'check-kconfig-errors'.  Stop.
make: *** Waiting for unfinished jobs....
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/tests/driver_dht'
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
