### PR TITLE
Kconfig: source EXTERNAL_MODULES configurations

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -33,6 +33,10 @@ rsource "drivers/Kconfig"
 rsource "sys/Kconfig"
 rsource "pkg/Kconfig"
 
+menu "External Modules"
+osource "$(KCONFIG_EXTERNAL_CONFIGS)"
+endmenu # External Modules
+
 comment "RIOT is in a migration phase."
 comment "Some configuration options may not be here. Use CFLAGS instead."
 

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -26,6 +26,9 @@ export KCONFIG_AUTOHEADER_HEADER
 # This file will contain the calculated dependencies formated in Kconfig
 export KCONFIG_GENERATED_DEPENDENCIES = $(GENERATED_DIR)/Kconfig.dep
 
+# This file will contain external module configurations
+export KCONFIG_EXTERNAL_CONFIGS = $(GENERATED_DIR)/Kconfig.external_modules
+
 # This file will contain application default configurations
 KCONFIG_APP_CONFIG = $(APPDIR)/app.config
 
@@ -140,6 +143,23 @@ $(KCONFIG_GENERATED_DEPENDENCIES): FORCE | $(GENERATED_DIR)
 	      printf "config %s\n\tbool\n\tdefault y\n", toupper($$0)}' \
 	  | $(LAZYSPONGE) $(LAZYSPONGE_FLAGS) $@
 
+# All directories in EXTERNAL_MODULES_DIR which have a Kconfig file
+EXTERNAL_MODULE_KCONFIGS ?= $(sort $(foreach dir,$(EXTERNAL_MODULE_DIRS),\
+                              $(wildcard $(dir)/Kconfig)))
+# Build a Kconfig file that source all external modules configuration
+# files. Every EXTERNAL_MODULE_DIRS with a Kconfig file is written to
+# KCONFIG_EXTERNAL_CONFIGS as 'osource dir/Kconfig'
+$(KCONFIG_EXTERNAL_CONFIGS): FORCE | $(GENERATED_DIR)
+	$(Q)\
+	if [ -n "$(EXTERNAL_MODULE_KCONFIGS)" ] ; then  \
+		printf "%s\n" $(EXTERNAL_MODULE_KCONFIGS) \
+		| awk '{ printf "osource \"%s\"\n", $$0 }' \
+		| $(LAZYSPONGE) $(LAZYSPONGE_FLAGS) $@ ; \
+	else \
+		printf "# no external modules" \
+		| $(LAZYSPONGE) $(LAZYSPONGE_FLAGS) $@ ; \
+	fi
+
 # When the 'clean' target is called, the files inside GENERATED_DIR should be
 # regenerated. For that, we conditionally change GENERATED_DIR from an 'order
 # only' requisite to a normal one.
@@ -156,6 +176,7 @@ GENERATED_DIR_DEP := $(if $(CLEAN),,|) $(GENERATED_DIR)
 # Generates a .config file by merging multiple sources specified in
 # MERGE_SOURCES. This will also generate KCONFIG_OUT_DEP with the list of used
 # Kconfig files.
+$(KCONFIG_OUT_CONFIG): $(KCONFIG_EXTERNAL_CONFIGS)
 $(KCONFIG_OUT_CONFIG): $(GENERATED_DEPENDENCIES_DEP) $(GENCONFIG) $(MERGE_SOURCES) $(GENERATED_DIR_DEP)
 	$(Q) $(GENCONFIG) \
 	  --config-out=$(KCONFIG_OUT_CONFIG) \

--- a/tests/kconfig/Makefile
+++ b/tests/kconfig/Makefile
@@ -1,2 +1,8 @@
 include ../Makefile.tests_common
+
+USEMODULE += external_module_1
+USEMODULE += external_module_2
+EXTERNAL_MODULE_DIRS += $(CURDIR)/external_module_1
+EXTERNAL_MODULE_DIRS += $(CURDIR)/external_module_2
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/kconfig/app.config
+++ b/tests/kconfig/app.config
@@ -5,3 +5,7 @@ CONFIG_APP_MSG_1_TEXT="Message 1 defined in app.config file"
 
 # enable printing message 2
 CONFIG_APP_MSG_2=y
+
+# enable configuration of external modules via kconfig
+CONFIG_KCONFIG_EXTERNAL_MODULE_1=y
+CONFIG_KCONFIG_EXTERNAL_MODULE_2=y

--- a/tests/kconfig/external_module_1/Kconfig
+++ b/tests/kconfig/external_module_1/Kconfig
@@ -1,0 +1,13 @@
+menuconfig KCONFIG_EXTERNAL_MODULE_1
+    bool "Configure external module message 1"
+    default y
+    help
+        This will enable configuring the external module message
+
+if KCONFIG_EXTERNAL_MODULE_1
+
+config EXTERNAL_MODULE_1_MESSAGE
+    string "External module 1 text"
+    default "External Message 1 defined in Kconfig file"
+
+endif # KCONFIG_EXTERNAL_MODULE_1

--- a/tests/kconfig/external_module_1/Makefile
+++ b/tests/kconfig/external_module_1/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/kconfig/external_module_1/Makefile.include
+++ b/tests/kconfig/external_module_1/Makefile.include
@@ -1,0 +1,3 @@
+# Use an immediate variable to evaluate `MAKEFILE_LIST` now
+USEMODULE_INCLUDES_external_module_1 := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_external_module_1)

--- a/tests/kconfig/external_module_1/include/external_module_1.h
+++ b/tests/kconfig/external_module_1/include/external_module_1.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup
+ * @ingroup
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef EXTERNAL_MODULE_1_H
+#define EXTERNAL_MODULE_1_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef CONFIG_EXTERNAL_MODULE_1_MESSAGE
+#define CONFIG_EXTERNAL_MODULE_1_MESSAGE    "this should not show"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* EXTERNAL_MODULE_1_H */

--- a/tests/kconfig/external_module_2/Kconfig
+++ b/tests/kconfig/external_module_2/Kconfig
@@ -1,0 +1,13 @@
+menuconfig KCONFIG_EXTERNAL_MODULE_2
+    bool "Configure external module message 2"
+    default y
+    help
+        This will enable configuring the external module message
+
+if KCONFIG_EXTERNAL_MODULE_2
+
+config EXTERNAL_MODULE_2_MESSAGE
+    string "External module 2 text"
+    default "External Message 2 defined in Kconfig file"
+
+endif # KCONFIG_EXTERNAL_MODULE_2

--- a/tests/kconfig/external_module_2/Makefile
+++ b/tests/kconfig/external_module_2/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/kconfig/external_module_2/Makefile.include
+++ b/tests/kconfig/external_module_2/Makefile.include
@@ -1,0 +1,3 @@
+# Use an immediate variable to evaluate `MAKEFILE_LIST` now
+USEMODULE_INCLUDES_external_module_2 := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_external_module_2)

--- a/tests/kconfig/external_module_2/include/external_module_2.h
+++ b/tests/kconfig/external_module_2/include/external_module_2.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup
+ * @ingroup
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef EXTERNAL_MODULE_2_H
+#define EXTERNAL_MODULE_2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef CONFIG_EXTERNAL_MODULE_2_MESSAGE
+#define CONFIG_EXTERNAL_MODULE_2_MESSAGE    "this should not show either"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* EXTERNAL_MODULE_2_H */

--- a/tests/kconfig/main.c
+++ b/tests/kconfig/main.c
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include "app.h"
 #include "kernel_defines.h"
+#include "external_module_1.h"
+#include "external_module_2.h"
 
 int main(void)
 {
@@ -30,5 +32,9 @@ int main(void)
     if (IS_ACTIVE(CONFIG_APP_MSG_2)) {
         puts("MSG_2 is active");
     }
+
+    puts(CONFIG_EXTERNAL_MODULE_1_MESSAGE);
+    puts(CONFIG_EXTERNAL_MODULE_2_MESSAGE);
+
     return 0;
 }

--- a/tests/kconfig/tests/01-run.py
+++ b/tests/kconfig/tests/01-run.py
@@ -13,6 +13,8 @@ from testrunner import run
 def testfunc(child):
     child.expect_exact("Message 1 defined in app.config file")
     child.expect_exact("MSG_2 is active")
+    child.expect_exact("External Message 1 defined in Kconfig file")
+    child.expect_exact("External Message 2 defined in Kconfig file")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

This PR enables handling external module configurations via Kconfig. They are all included under the same `external modules` menu.

To be able to source them easily as a blob all EXTERNAL_MODULE_DIRS that hold a configuration file are written as `osource <dir_path>/Kconfig` to a Kconfig.external_modules file.

### Testing procedure

- Test cases added to extend `tests/kconfig`.

