### PR TITLE
cpu/cc26xx_cc13xx: add AON_BATMON saul driver 

### DIFF
--- a/boards/cc1312-launchpad/Makefile.dep
+++ b/boards/cc1312-launchpad/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_cc26xx_cc13xx_batmon
 endif

--- a/boards/cc1350-launchpad/Makefile.dep
+++ b/boards/cc1350-launchpad/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_cc26xx_cc13xx_batmon
 endif

--- a/boards/cc1352-launchpad/Makefile.dep
+++ b/boards/cc1352-launchpad/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_cc26xx_cc13xx_batmon
 endif

--- a/boards/cc1352p-launchpad/Makefile.dep
+++ b/boards/cc1352p-launchpad/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_cc26xx_cc13xx_batmon
 endif

--- a/boards/cc2650-launchpad/Makefile.dep
+++ b/boards/cc2650-launchpad/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_cc26xx_cc13xx_batmon
 endif

--- a/boards/cc2650stk/Makefile.dep
+++ b/boards/cc2650stk/Makefile.dep
@@ -1,0 +1,4 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += saul_cc26xx_cc13xx_batmon
+endif

--- a/cpu/cc26x0_cc13x0/vendor/driverlib/aon_batmon.h
+++ b/cpu/cc26x0_cc13x0/vendor/driverlib/aon_batmon.h
@@ -66,6 +66,7 @@ extern "C"
 #include "../inc/hw_memmap.h"
 #include "../inc/hw_aon_batmon.h"
 #include "debug.h"
+#include "cpu.h"
 
 //*****************************************************************************
 //

--- a/cpu/cc26x0_cc13x0/vendor/inc/hw_memmap.h
+++ b/cpu/cc26x0_cc13x0/vendor/inc/hw_memmap.h
@@ -79,7 +79,7 @@
 //#define AON_RTC_BASE            0x40092000 // AON_RTC
 #define AON_EVENT_BASE          0x40093000 // AON_EVENT
 //#define AON_IOC_BASE            0x40094000 // AON_IOC
-#define AON_BATMON_BASE         0x40095000 // AON_BATMON
+//#define AON_BATMON_BASE         0x40095000 // AON_BATMON
 #define AUX_AIODIO0_BASE        0x400C1000 // AUX_AIODIO
 #define AUX_AIODIO1_BASE        0x400C2000 // AUX_AIODIO
 #define AUX_TDC_BASE            0x400C4000 // AUX_TDC

--- a/cpu/cc26xx_cc13xx/Makefile
+++ b/cpu/cc26xx_cc13xx/Makefile
@@ -1,6 +1,9 @@
 MODULE = cc26xx_cc13xx
 
 DIRS = periph
+ifneq (,$(filter saul_cc26xx_cc13xx_batmon,$(USEMODULE)))
+  DIRS += batmon
+endif
 
 # (file triggers compiler bug. see #5775)
 SRC_NOLTO += vectors.c

--- a/cpu/cc26xx_cc13xx/batmon/Makefile
+++ b/cpu/cc26xx_cc13xx/batmon/Makefile
@@ -1,0 +1,3 @@
+MODULE = saul_cc26xx_cc13xx_batmon
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/cc26xx_cc13xx/batmon/batmon.c
+++ b/cpu/cc26xx_cc13xx/batmon/batmon.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     cpu_cc26xx_cc13xx
+ *
+ * @{
+ *
+ * @file
+ * @brief       Battery monitor API
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "saul.h"
+
+/** Bits used to enable measurements/calculations */
+#define BATMON_ENABLE   (AON_BATMON_CTL_CALC_EN | AON_BATMON_CTL_MEAS_EN)
+
+void cc26xx_cc13xx_batmon_init(void)
+{
+    /* Disable events */
+#ifdef CPU_VARIANT_X2
+    AON_BATMON->EVENTMASK &= ~AON_BATMON_EVENTMASK_TEMP_BELOW_LL_MASK;
+    AON_BATMON->EVENTMASK &= ~AON_BATMON_EVENTMASK_TEMP_OVER_UL_MASK;
+#endif /* CPU_VARIANT_X2 */
+
+    /* Enable calculations and measurements */
+    AON_BATMON->CTL |= BATMON_ENABLE;
+}
+
+static int _read_voltage(const void *dev, phydat_t *res)
+{
+    (void)dev;
+
+    uint16_t value = AON_BATMON->BAT >> AON_BATMON_BAT_FRAC_s;
+
+    /* voltage is provided in a 3.8 fixed-point value, convert
+     * it directly to mV */
+    res->val[0] = (value * 125) >> 5;
+    res->unit = UNIT_V;
+    res->scale = -3;
+
+    return 1;
+}
+
+static int _read_temperature(const void *dev, phydat_t *res)
+{
+    (void)dev;
+
+    /* Shift left then right to sign extend the AON_BATMON.TEMP field */
+    int32_t signed_temp = (int32_t)AON_BATMON->TEMP;
+    signed_temp <<= 32 - AON_BATMON_TEMP_INT_w - AON_BATMON_TEMP_INT_s;
+    signed_temp >>= 32 - AON_BATMON_TEMP_INT_w - AON_BATMON_TEMP_INT_s;
+
+    /* Casting voltage_slope to int8_t prior to assignment in order to make
+     * sure sign extension works properly */
+    int32_t voltage_slope = (int8_t)*((reg8_t *)&FCFG->MISC_TRIM);
+    int32_t temp_correction = (int32_t)voltage_slope
+                            * ((int32_t)AON_BATMON->BAT - 0x300) >> 4;
+
+    res->val[0] = ((signed_temp - temp_correction) + 0x80) >> 8;
+
+    res->unit = UNIT_TEMP_C;
+    res->scale = 0;
+
+    return 1;
+}
+
+saul_driver_t cc26xx_cc13xx_voltage_saul_driver = {
+    .read = _read_voltage,
+    .write = NULL,
+    .type = SAUL_SENSE_VOLTAGE,
+};
+
+saul_driver_t cc26xx_cc13xx_temperature_saul_driver = {
+    .read = _read_temperature,
+    .write = NULL,
+    .type = SAUL_SENSE_TEMP,
+};

--- a/cpu/cc26xx_cc13xx/doc.txt
+++ b/cpu/cc26xx_cc13xx/doc.txt
@@ -11,10 +11,11 @@ supported by RIOT: @ref cpu_cc26x0_cc13x0, @ref cpu_cc26x2_cc13x2
 ## <a name="cc26xx_cc13xx_toc"> Table of Contents </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
 
 1. [Overview](#cc26xx_cc13xx_overview)
-2. [Flashing the CCFG](#cc26xx_cc13xx_ccfg)
-3. [Debugging](#cc26xx_cc13xx_debugging)
+3. [Battery Monitor](#cc26xx_cc13xx_batmon)
+4. [Flashing the CCFG](#cc26xx_cc13xx_ccfg)
+5. [Debugging](#cc26xx_cc13xx_debugging)
     1. [Using OpenOCD](#cc26xx_cc13xx_openocd)
-    1. [Using Uniflash](#cc26xx_cc13xx_uniflash)
+    2. [Using Uniflash](#cc26xx_cc13xx_uniflash)
 
 # <a name="cc26xx_cc13xx_overview"> Overview </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
 
@@ -33,6 +34,32 @@ and improvements on various peripherals.
 
 @note The actual flash size is the flash size minus 88 bytes, these 88 bytes are
 reserved for the CCFG, see also [Flashing the CCFG](#cc26xx_cc13xx_ccfg).
+
+# <a name="cc26xx_cc13xx_batmon"> Battery Monitor </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
+
+This CPU family provides the Always-On Battery Monitor peripheral which
+takes measurements of voltage and temperature of the MCU.
+
+The API is provided through SAUL and can be enabled using `saul_default` on
+LaunchPad boards or by adding `saul_cc26xx_cc13xx_batmon` as a dependency.
+This module has SAUL auto initialization capabilities.
+
+After initialization two SAUL sensors will be available:
+
+- `CC26XX_CC13XX_BAT_V` which provides the battery voltage in milli-volts.
+- `CC26XX_CC13XX_BAT_T` which provides the battery/CPU voltage in degrees Celsius.
+
+## Temperature measurement confidence
+
+The measurements of the devices are innaccurate and varies by chip. Texas
+Instruments provides a table with upper and lower bounds that provide 99%
+confidence for the measured temperatures. Values are provided in degrees Celsius.
+
+ Ambient Temperature | -40 | -30 | -20 | -10 | 0  | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100 | 110 | 120
+:--------------------|:----|:----|:----|:----|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:----|:----|:----
+ Upper               | -28 | -20 | -12 | -3  | 7  | 17 | 26 | 36 | 46 | 56 | 65 | 75 | 85 | 95 | 105 | 115 | 125
+ Lower               | -45 | -36 | -26 | -16 | -5 | 4  | 14 | 24 | 35 | 45 | 54 | 65 | 75 | 85 | 94  | 104 | 113
+
 
 # <a name="cc26xx_cc13xx_ccfg"> Flashing the CCFG </a> &nbsp;[[TOC]](#cc26xx_cc13xx_toc)
 

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_aon.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_aon.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_cc26xx_cc13xx_definitions
+ * @{
+ *
+ * @file
+ * @brief           CC26xx/CC13xx MCU I/O register definitions
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef CC26XX_CC13XX_AON_H
+#define CC26XX_CC13XX_AON_H
+
+#include "cc26xx_cc13xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   AON_BATMON registers
+ */
+typedef struct {
+    reg32_t CTL; /**< Internal */
+    reg32_t MEASCFG; /**< Internal */
+    reg32_t TEMPP0; /**< Internal */
+    reg32_t TEMPP1; /**< Internal */
+    reg32_t TEMPP2; /**< Internal */
+    reg32_t BATMONP0; /**< Internal */
+    reg32_t BATMONP1; /**< Internal */
+    reg32_t IOSTRP0; /**< Internal */
+    reg32_t FLASHPUMPP0; /**< Internal */
+    reg32_t BAT; /**< Last Measured Battery Voltage */
+    reg32_t BATUPD; /**< Battery Update */
+    reg32_t TEMP; /**< Temperature */
+    reg32_t TEMPUPD; /**< Temperature Update */
+    reg32_t __reserved1; /**< Reserved */
+    reg32_t __reserved2; /**< Reserved */
+    reg32_t __reserved3; /**< Reserved */
+#ifdef CPU_VARIANT_X2
+    reg32_t EVENTMASK; /**< Event Mask */
+    reg32_t EVENT; /**< Event */
+    reg32_t BATTUL; /**< Battery Upper Limit */
+    reg32_t BATTLL; /**< Battery Lower Limit */
+    reg32_t TEMPUL; /**< Temperature Upper Limit */
+    reg32_t TEMPLL; /**< Temperature Lower Limit */
+#endif
+} aon_batmon_regs_t;
+
+/**
+ * @brief   AON_BATMON register values
+ * @{
+ */
+#define AON_BATMON_CTL_CALC_EN                  0x00000002
+#define AON_BATMON_CTL_MEAS_EN                  0x00000001
+#define AON_BATMON_BAT_FRAC_s                   0
+#define AON_BATMON_TEMP_INT_w                   9
+#define AON_BATMON_TEMP_INT_s                   8
+#define AON_BATMON_EVENTMASK_TEMP_BELOW_LL_MASK 0x00000008
+#define AON_BATMON_EVENTMASK_TEMP_OVER_UL_MASK  0x00000004
+/** @} */
+
+/**
+ * @ingroup cpu_specific_peripheral_memory_map
+ * @{
+ */
+#define AON_BATMON_BASE             (PERIPH_BASE + 0x95000)
+/** @} */
+
+/**
+ * @brief   AON_BATMON register bank
+ */
+#define AON_BATMON                  ((aon_batmon_regs_t *) (AON_BATMON_BASE))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC26XX_CC13XX_AON_H */
+/** @} */

--- a/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
@@ -28,6 +28,7 @@
 #include "cc26xx_cc13xx.h"
 
 #include "cc26xx_cc13xx_adi.h"
+#include "cc26xx_cc13xx_aon.h"
 #include "cc26xx_cc13xx_ccfg.h"
 #include "cc26xx_cc13xx_gpio.h"
 #include "cc26xx_cc13xx_gpt.h"

--- a/drivers/saul/init_devs/auto_init_saul_cc26xx_cc13xx_batmon.c
+++ b/drivers/saul/init_devs/auto_init_saul_cc26xx_cc13xx_batmon.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021 Jean Pierre Dudey
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of internal temperature and battery voltage
+ *              sensor directly mapped to SAUL reg
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "saul/periph.h"
+
+extern void cc26xx_cc13xx_batmon_init(void);
+
+extern saul_driver_t cc26xx_cc13xx_voltage_saul_driver;
+
+extern saul_driver_t cc26xx_cc13xx_temperature_saul_driver;
+
+/**
+ * @brief   Memory for the registry entries
+ */
+static saul_reg_t saul_entries[] = {
+    {
+        .dev = NULL,
+        .name = "CC26XX_CC13XX_BAT_V",
+        .driver = &cc26xx_cc13xx_voltage_saul_driver,
+    },
+    {
+        .dev = NULL,
+        .name = "CC26XX_CC13XX_BAT_T",
+        .driver = &cc26xx_cc13xx_temperature_saul_driver,
+    }
+};
+
+void auto_init_cc26xx_cc13xx_batmon(void)
+{
+    cc26xx_cc13xx_batmon_init();
+
+    /* Add to registry */
+    saul_reg_add(&(saul_entries[0]));
+    saul_reg_add(&(saul_entries[1]));
+}

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -39,6 +39,10 @@ void saul_init_devs(void)
         extern void auto_init_saul_pwm(void);
         auto_init_saul_pwm();
     }
+    if (IS_USED(MODULE_SAUL_CC26XX_CC13XX_BATMON)) {
+        extern void auto_init_cc26xx_cc13xx_batmon(void);
+        auto_init_cc26xx_cc13xx_batmon();
+    }
     if (IS_USED(MODULE_SAUL_NRF_TEMPERATURE)) {
         extern void auto_init_nrf_temperature(void);
         auto_init_nrf_temperature();


### PR DESCRIPTION
### Contribution description

Add `AON_BATMON` saul driver. The CC26xx/CC13xx MCU family provides an Always-On Battery Monitor peripheral which measures the internal chip temperature and the supply voltage. The peripheral also offers events for the upper and lower voltage limits, although I think this can be done when we have something like #14182 .

That said, the battery montior has some inaccuracies on the temperature measurements.

<details>
<summary>make -C examples/saul flash term BOARD=cc1350-launchpad</summary>

```
2021-02-19 23:33:08,999 # Welcome to RIOT!
2021-02-19 23:33:09,000 # 
2021-02-19 23:33:09,005 # Type `help` for help, type `saul` to see all SAUL devices
2021-02-19 23:33:09,005 # 
> saul
2021-02-19 23:33:10,307 # saul
2021-02-19 23:33:10,308 # ID	Class		Name
2021-02-19 23:33:10,311 # #0	ACT_SWITCH	LED(red)
2021-02-19 23:33:10,313 # #1	ACT_SWITCH	LED(green)
2021-02-19 23:33:10,315 # #2	SENSE_BTN	Button(BTN-1)
2021-02-19 23:33:10,318 # #3	SENSE_BTN	Button(BTN-2)
2021-02-19 23:33:10,320 # #4	SENSE_VOLTAGE	CC26XX_CC13XX_BAT_V
2021-02-19 23:33:10,324 # #5	SENSE_TEMP	CC26XX_CC13XX_BAT_T
> saul read 4
2021-02-19 23:33:16,588 # saul read 4
2021-02-19 23:33:16,593 # Reading from #4 (CC26XX_CC13XX_BAT_V|SENSE_VOLTAGE)
2021-02-19 23:33:16,595 # Data:	           1152 mV
> saul read 5
2021-02-19 23:33:18,914 # saul read 5
2021-02-19 23:33:18,919 # Reading from #5 (CC26XX_CC13XX_BAT_T|SENSE_TEMP)
2021-02-19 23:33:18,921 # Data:	            -11 °C
> 
```
</details>

The values both for voltage and temperature seem to be out of range, however launchpads aren't connected to a battery (at least for the voltage), tomorrow I will test with a cc1312 custom board to see any differences. It might also be that the cc13x0 need the `SetupTrimDevice` function implemented as it touches a register related to it.

### Testing procedure

- `make -C examples/saul flash term BOARD=cc1312-launchpad`
- `make -C examples/saul flash term BOARD=cc1350-launchpad`
- `make -C examples/saul flash term BOARD=cc1352-launchpad`
- `make -C examples/saul flash term BOARD=cc1352p-launchpad`

### Issues/PRs references