### PR TITLE
examples/gnrc_networking_mac: whitelist ATmega256RFR2 based boards

### DIFF
--- a/examples/gnrc_networking_mac/Makefile
+++ b/examples/gnrc_networking_mac/Makefile
@@ -4,12 +4,13 @@ APPLICATION = gnrc_networking_mac
 # If no BOARD is found in the environment, use this default:
 BOARD ?= samr21-xpro
 
-# Currently, GoMacH has only been tested and evaluated through on samr21-xpro and iotlab-m3.
+# Currently, GoMacH has only been tested and evaluated through on samr21-xpro, iotlab-m3 and
+# derfmega256 (at86rf2xx based radios).
 # Once GoMacH has also been tested through on other boards, the whitelist should be
 # then accordingly extended.
 # Notably, for LWMAC, we have only evaluated it on samr21-xpro nodes. To this end, if
 # you are going to include LWMAC for testing, you should only run the example on samr21-xpro.
-BOARD_WHITELIST := samr21-xpro iotlab-m3
+BOARD_WHITELIST := samr21-xpro iotlab-m3 avr-rss2 atmega256rfr2-xpro derfmega256
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The example now works successfully on these AVR based boards.



### Testing procedure

`avr-rss2` can ping `samr21-xpro`

```
2021-02-20 00:41:33,491 # ping fe80::204:2519:1801:c905
2021-02-20 00:41:33,656 # 12 bytes from fe80::204:2519:1801:c905%7: icmp_seq=0 ttl=64 rssi=-33 dBm time=156.032 ms
2021-02-20 00:41:35,162 # 12 bytes from fe80::204:2519:1801:c905%7: icmp_seq=1 ttl=64 rssi=-38 dBm time=661.936 ms
2021-02-20 00:41:35,887 # 12 bytes from fe80::204:2519:1801:c905%7: icmp_seq=2 ttl=64 rssi=-37 dBm time=388.336 ms
2021-02-20 00:41:35,887 # 
2021-02-20 00:41:35,893 # --- fe80::204:2519:1801:c905 PING statistics ---
2021-02-20 00:41:35,898 # 3 packets transmitted, 3 packets received, 0% packet loss
```


### Issues/PRs references

#16038
