### PR TITLE
make/esptool: fix FFLAGS inclusion order for qemu

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -79,9 +79,3 @@ endif
 ifneq (,$(filter cpp,$(FEATURES_USED)))
   ARCHIVES += -lstdc++
 endif
-
-# additional flasher configuration for ESP32 QEMU
-ifneq (,$(filter esp_qemu,$(USEMODULE)))
-  FFLAGS += cp $(RIOTCPU)/$(CPU)/bin/rom_0x3ff90000_0x00010000.bin $(BINDIR)/rom1.bin &&
-  FFLAGS += cp $(RIOTCPU)/$(CPU)/bin/rom_0x40000000_0x000c2000.bin $(BINDIR)/rom.bin
-endif

--- a/makefiles/tools/esptool.inc.mk
+++ b/makefiles/tools/esptool.inc.mk
@@ -40,6 +40,10 @@ ifneq (,$(filter esp_qemu,$(USEMODULE)))
   FFLAGS += head -c $$((0x10000)) |
   FFLAGS += cat - $(FLASHFILE).bin tmp.bin |
   FFLAGS += head -c $(FLASH_SIZE)MB > $(BINDIR)/$(CPU)flash.bin && rm tmp.bin;
+  ifeq (esp32,$(CPU_FAM))
+    FFLAGS += cp $(RIOTCPU)/$(CPU)/bin/rom_0x3ff90000_0x00010000.bin $(BINDIR)/rom1.bin &&
+    FFLAGS += cp $(RIOTCPU)/$(CPU)/bin/rom_0x40000000_0x000c2000.bin $(BINDIR)/rom.bin
+  endif
 else
   PROGRAMMER_SPEED ?= 460800
   FLASHER = $(ESPTOOL)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the inclusion order of FFLAGS with the esptool when using the `esp_qemu` module. In master, this is currently broken (probably because of #15475).

The fix proposed by this PR is to move the logic from esp32 to esptool.inc.mk, which is now included after the cpu Makefile.include is included.

This PR is a quick fix and IMHO a more proper fix is to reuse the EMULATE=1 variable and integrate the esp emulator into the qemu.inc.mk mechanism, instead of relying on the module mechanism. I leave this as a follow-up.

Another cleanup that is worth is to get rid of all this commands configured in the FFLAGS variable, this is an abuse of this variable that should only contain parameters of the flasher tool (configured in FLASHER). I'm also leaving this as a follow-up.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Try to flash an application while using USEMODULE=esp_qemu: in master this fails, with this PR it works:

<details><summary>this PR:</summary>

```
$ USEMODULE=esp_qemu make BOARD=esp32-wroom-32 -C examples/hello-world flash-only --no-print-directory 
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
/work/riot/RIOT/dist/tools/esptool/esptool.py --chip esp32 elf2image --flash_mode dout --flash_size 4MB --flash_freq 40m     -o /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf; printf "\n" > /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "nvs, data, nvs, 0x9000, 0x6000\n" >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "phy_init, data, phy, 0xf000, 0x1000\n" >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "factory, app, factory, 0x10000, " >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; ls -l /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin | awk '{ print $5 }' >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; python3 /work/riot/RIOT/dist/tools/esptool/gen_esp32part.py --verify /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.bin
esptool.py v2.4.0
Parsing CSV input...
dd if=/dev/zero bs=1M count=4 | tr "\\000" "\\377" > tmp.bin && cat tmp.bin | head -c $((0x1000)) | cat - /work/riot/RIOT/cpu/esp32/bin/bootloader.bin tmp.bin | head -c $((0x8000)) | cat - /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.bin tmp.bin | head -c $((0x10000)) | cat - /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin tmp.bin | head -c 4MB > /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/esp32flash.bin && rm tmp.bin; cp /work/riot/RIOT/cpu/esp32/bin/rom_0x3ff90000_0x00010000.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/rom1.bin && cp /work/riot/RIOT/cpu/esp32/bin/rom_0x40000000_0x000c2000.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/rom.bin
4+0 records in
4+0 records out
4194304 bytes (4,2 MB, 4,0 MiB) copied, 0,0091344 s, 459 MB/s
```

</details>

<details><summary>master:</summary>

```
$ USEMODULE=esp_qemu make BOARD=esp32-wroom-32 -C examples/hello-world flash-only --no-print-directory 
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
/work/riot/RIOT/dist/tools/esptool/esptool.py --chip esp32 elf2image --flash_mode dout --flash_size 4MB --flash_freq 40m     -o /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf; printf "\n" > /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "nvs, data, nvs, 0x9000, 0x6000\n" >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "phy_init, data, phy, 0xf000, 0x1000\n" >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; printf "factory, app, factory, 0x10000, " >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; ls -l /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin | awk '{ print $5 }' >> /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv; python3 /work/riot/RIOT/dist/tools/esptool/gen_esp32part.py --verify /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.csv /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.bin
esptool.py v2.4.0
Parsing CSV input...
dd cp /work/riot/RIOT/cpu/esp32/bin/rom_0x3ff90000_0x00010000.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/rom1.bin && cp /work/riot/RIOT/cpu/esp32/bin/rom_0x40000000_0x000c2000.bin /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/rom.bin if=/dev/zero bs=1M count=4 | tr "\\000" "\\377" > tmp.bin && cat tmp.bin | head -c $((0x1000)) | cat - /work/riot/RIOT/cpu/esp32/bin/bootloader.bin tmp.bin | head -c $((0x8000)) | cat - /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/partitions.bin tmp.bin | head -c $((0x10000)) | cat - /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/hello-world.elf.bin tmp.bin | head -c 4MB > /work/riot/RIOT/examples/hello-world/bin/esp32-wroom-32/esp32flash.bin && rm tmp.bin;
dd: unrecognized operand ‘cp’
Try 'dd --help' for more information.
make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:714: flash-only] Error 1
```

=> one can see that the `cp` commands related to qemu are called before the other commands configured in the FFLAGS, so, right after `dd`, which is the flasher in this case. This is why it fails badly.

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that problem while working on #15970 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
