### PR TITLE
sam0/adc: work around ADC errata on SAM D5x/E5x

### DIFF
--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -69,7 +69,11 @@ static inline void _wait_syncbusy(void)
 #ifdef ADC_STATUS_SYNCBUSY
     while (ADC_DEV->STATUS.reg & ADC_STATUS_SYNCBUSY) {}
 #else
-    while (ADC_DEV->SYNCBUSY.reg) {}
+    /* Ignore the ADC SYNCBUSY.SWTRIG status
+     * The ADC SYNCBUSY.SWTRIG gets stuck to '1' after wake-up from Standby Sleep mode.
+     * SAMD5x/SAME5x errata: DS80000748 (page 10)
+     */
+    while (ADC_DEV->SYNCBUSY.reg & ~ADC_SYNCBUSY_SWTRIG) {}
 #endif
 }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The ADC SYNCBUSY.SWTRIG gets stuck to '1' after wake-up from Standby Sleep mode.
Ignore the ADC `SYNCBUSY.SWTRIG` status bit, this functionality is not used by the driver anyway.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
