### PR TITLE
sys/shell: add XFA support

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -24,6 +24,7 @@
 #include "periph/pm.h"
 
 #include "kernel_defines.h"
+#include "xfa.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -195,6 +196,37 @@ static inline void shell_run(const shell_command_t *commands,
 {
     shell_run_forever(commands, line_buf, len);
 }
+
+/**
+ * @brief   Define shell command
+ *
+ * This macro is a helper for defining a shell command and adding it to the
+ * shell commands XFA (cross file array).
+ *
+ * Shell commands added using this macros will be sorted *after* builtins and
+ * commands passed via parameter to `shell_run_once()`. If a command with the
+ * same name exists in any of those, they will make a command added via this
+ * macro inaccassible.
+ *
+ * Commands added with this macro will be sorted alphanumerically by `name`.
+ *
+ * @experimental This should be considered experimental API, subject to change
+ *               without notice!
+ *
+ * Example:
+ *
+ * ```.c
+ * #include "shell.h"
+ * static int _my_command(int argc, char **argv) {
+ *   // ...
+ * }
+ * SHELL_COMMAND(my_command, "my command help text", _my_command);
+ * ```
+ */
+#define SHELL_COMMAND(name, help, func) \
+    XFA_USE_CONST(shell_command_t*, shell_commands_xfa); \
+    static const shell_command_t _xfa_ ## name ## _cmd = { #name, help, &func }; \
+    XFA_ADD_PTR(shell_commands_xfa, name, name, &_xfa_ ## name ## _cmd)
 
 #ifdef __cplusplus
 }

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -36,8 +36,12 @@
 #include <errno.h>
 
 #include "kernel_defines.h"
+#include "xfa.h"
 #include "shell.h"
 #include "shell_commands.h"
+
+/* define shell command cross file array */
+XFA_INIT_CONST(shell_command_t*, shell_commands_xfa);
 
 #define ETX '\x03'  /** ASCII "End-of-Text", or Ctrl-C */
 #define EOT '\x04'  /** ASCII "End-of-Transmission", or Ctrl-D */
@@ -92,6 +96,19 @@ static shell_command_handler_t search_commands(const shell_command_t *entry,
     return NULL;
 }
 
+static shell_command_handler_t search_commands_xfa(char *command)
+{
+    unsigned n = XFA_LEN(shell_command_t*, shell_commands_xfa);
+
+    for (unsigned i = 0; i < n; i++) {
+        const volatile shell_command_t *entry = shell_commands_xfa[i];
+        if (strcmp(entry->name, command) == 0) {
+            return entry->handler;
+        }
+    }
+    return NULL;
+}
+
 static shell_command_handler_t find_handler(
         const shell_command_t *command_list, char *command)
 {
@@ -104,12 +121,25 @@ static shell_command_handler_t find_handler(
         handler = search_commands(_builtin_cmds, command);
     }
 
+    if (handler == NULL) {
+        handler = search_commands_xfa(command);
+    }
+
     return handler;
 }
 
 static void print_commands(const shell_command_t *entry)
 {
     for (; entry->name != NULL; entry++) {
+        printf("%-20s %s\n", entry->name, entry->desc);
+    }
+}
+
+static void print_commands_xfa(void)
+{
+    unsigned n = XFA_LEN(shell_command_t*, shell_commands_xfa);
+    for (unsigned i = 0; i < n; i++) {
+        const volatile shell_command_t *entry = shell_commands_xfa[i];
         printf("%-20s %s\n", entry->name, entry->desc);
     }
 }
@@ -125,6 +155,8 @@ static void print_help(const shell_command_t *command_list)
     if (_builtin_cmds != NULL) {
         print_commands(_builtin_cmds);
     }
+
+    print_commands_xfa();
 }
 
 /**

--- a/tests/periph_spi_dma/Makefile.ci
+++ b/tests/periph_spi_dma/Makefile.ci
@@ -2,4 +2,5 @@
 # this test.
 include ../periph_spi/Makefile.ci
 BOARD_INSUFFICIENT_MEMORY += \
+    samd10-xmini \
     #

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -103,6 +103,30 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
+static int _xfa_test1(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("[XFA TEST 1 OK]\n");
+
+    return 0;
+}
+
+static int _xfa_test2(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("[XFA TEST 2 OK]\n");
+
+    return 0;
+}
+
+/* Add above commands to the shell commands XFA using helper macro.
+ * Intentionally reversed order to test linker script based alphanumeric
+ * ordering. */
+SHELL_COMMAND(xfa_test2, "xfa test command 2",_xfa_test2);
+SHELL_COMMAND(xfa_test1, "xfa test command 1",_xfa_test1);
+
 int main(void)
 {
     printf("test_shell.\n");

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -52,8 +52,8 @@ void shell_post_command_hook(int ret, int argc, char **argv)
 
 static int print_teststart(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     printf("[TEST_START]\n");
 
     return 0;
@@ -61,8 +61,8 @@ static int print_teststart(int argc, char **argv)
 
 static int print_testend(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     printf("[TEST_END]\n");
 
     return 0;
@@ -80,8 +80,8 @@ static int print_echo(int argc, char **argv)
 
 static int print_shell_bufsize(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     printf("%d\n", SHELL_DEFAULT_BUFSIZE);
 
     return 0;
@@ -89,8 +89,8 @@ static int print_shell_bufsize(int argc, char **argv)
 
 static int print_empty(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     return 0;
 }
 
@@ -105,8 +105,8 @@ static const shell_command_t shell_commands[] = {
 
 static int _xfa_test1(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     printf("[XFA TEST 1 OK]\n");
 
     return 0;
@@ -114,8 +114,8 @@ static int _xfa_test1(int argc, char **argv)
 
 static int _xfa_test2(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
     printf("[XFA TEST 2 OK]\n");
 
     return 0;
@@ -124,8 +124,8 @@ static int _xfa_test2(int argc, char **argv)
 /* Add above commands to the shell commands XFA using helper macro.
  * Intentionally reversed order to test linker script based alphanumeric
  * ordering. */
-SHELL_COMMAND(xfa_test2, "xfa test command 2",_xfa_test2);
-SHELL_COMMAND(xfa_test1, "xfa test command 1",_xfa_test1);
+SHELL_COMMAND(xfa_test2, "xfa test command 2", _xfa_test2);
+SHELL_COMMAND(xfa_test1, "xfa test command 1", _xfa_test1);
 
 int main(void)
 {
@@ -144,9 +144,7 @@ int main(void)
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* or use only system shell commands */
-    /*
-    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
-    */
+    /* shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE); */
 
     return 0;
 }

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -19,7 +19,9 @@ EXPECTED_HELP = (
     'echo                 prints the input command',
     'reboot               Reboot the node',
     'ps                   Prints information about running threads.',
-    'app_metadata         Returns application metadata'
+    'app_metadata         Returns application metadata',
+    'xfa_test1            xfa test command 1',
+    'xfa_test2            xfa test command 2'
 )
 
 EXPECTED_PS = (
@@ -95,6 +97,10 @@ CMDS = (
     # test default commands
     ('ps', EXPECTED_PS),
     ('help', EXPECTED_HELP),
+
+    # test commands added to shell_commands_xfa
+    ('xfa_test1', '[XFA TEST 1 OK]'),
+    ('xfa_test2', '[XFA TEST 2 OK]'),
 
     # test reboot
     ('reboot', 'test_shell.'),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a macro that allows adding shell commands using a cross file array.

It basically allows this to be put in *any* file:

```
#include "shell.h"
static int _my_command(int argc, char **argv) {
 // ...
}

SHELL_COMMAND(my_command, "my command help text", _my_command);
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR extends the tests/shell test scripts. Running this on some more platforms (AVR, RISC-V, ...) would be helpful!
Otherwise, please give feedback on the integration / usage.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

First user of  [XFA](https://github.com/RIOT-OS/RIOT/pull/15002).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
