### PR TITLE
USB CDC: fix typo in definitions

### DIFF
--- a/sys/include/usb/cdc.h
+++ b/sys/include/usb/cdc.h
@@ -219,7 +219,7 @@ typedef struct __attribute__((packed)) {
     uint8_t length;         /**< Size of this descriptor */
     uint8_t type;           /**< Descriptor type (@ref USB_TYPE_DESCRIPTOR_CDC) */
     uint8_t subtype;        /**< Descriptor subtype (@ref USB_CDC_DESCR_SUBTYPE_ACM) */
-    uint8_t capabalities;   /**< Bitmap indicating the capabilities */
+    uint8_t capabilities;   /**< Bitmap indicating the capabilities */
 } usb_desc_acm_t;
 
 /**
@@ -254,7 +254,7 @@ typedef struct __attribute__((packed)) {
     uint8_t length;     /**< Size of this descriptor */
     uint8_t type;       /**< Descriptor type (@ref USB_TYPE_DESCRIPTOR_CDC) */
     uint8_t subtype;    /**< Descriptor subtype (@ref USB_CDC_DESCR_SUBTYPE_CALL_MGMT) */
-    uint8_t capabalities; /**< Supported capabilities */
+    uint8_t capabilities; /**< Supported capabilities */
     uint8_t data_if;      /**< Interface number used for the call management */
 } usb_desc_call_mngt_t;
 

--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -89,7 +89,7 @@ static size_t _gen_mngt_descriptor(usbus_t *usbus, usbus_cdcacm_device_t *cdcacm
     mngt.length = sizeof(usb_desc_call_mngt_t);
     mngt.type = USB_TYPE_DESCRIPTOR_CDC;
     mngt.subtype = USB_CDC_DESCR_SUBTYPE_CALL_MGMT;
-    mngt.capabalities = 0;
+    mngt.capabilities = 0;
     mngt.data_if = cdcacm->iface_data.idx;
     usbus_control_slicer_put_bytes(usbus, (uint8_t*)&mngt, sizeof(mngt));
     return sizeof(usb_desc_call_mngt_t);
@@ -117,7 +117,7 @@ static size_t _gen_acm_descriptor(usbus_t *usbus)
     acm.type = USB_TYPE_DESCRIPTOR_CDC;
     acm.subtype = USB_CDC_DESCR_SUBTYPE_ACM;
     /* Support for Set/Get_Line_coding, Control_State, and Serial_State notif */
-    acm.capabalities = 0x02;
+    acm.capabilities = 0x02;
     usbus_control_slicer_put_bytes(usbus, (uint8_t*)&acm, sizeof(acm));
     return sizeof(usb_desc_acm_t);
 }


### PR DESCRIPTION
Found a small typo when studying USB CDC ACM code: _capabalities_ - renamed as it should.