### PR TITLE
makefiles/kconfig: include out.config only when running Kconfig

### DIFF
--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -43,11 +43,6 @@ KCONFIG_OUT_CONFIG = $(GENERATED_DIR)/out.config
 # whenever a change occurs on one of the previously used Kconfig files.
 KCONFIG_OUT_DEP = $(KCONFIG_OUT_CONFIG).d
 
-# Include configuration symbols if available. This allows to check for Kconfig
-# symbols in makefiles. Make tries to 'remake' all included files (see
-# https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html).
--include $(KCONFIG_OUT_CONFIG)
-
 # Add configurations to merge, in ascendent priority (i.e. a file overrides the
 # previous ones).
 #
@@ -100,6 +95,11 @@ endif
 export SHOULD_RUN_KCONFIG
 
 ifneq (,$(SHOULD_RUN_KCONFIG))
+
+# Include configuration symbols if available. This allows to check for Kconfig
+# symbols in makefiles. Make tries to 'remake' all included files (see
+# https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html).
+-include $(KCONFIG_OUT_CONFIG)
 
 # Add configuration header to build dependencies
 BUILDDEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) $(FIXDEP)


### PR DESCRIPTION
### Contribution description
This modifies the Kconfig makefile to only source the `out.config` file into the build system when Kconfig has to run. There is no need to include it otherwise.

### Testing procedure
We need to make sure this change keeps Kconfig working across different workflows. I tested the following:
1. `make menuconfig` > `make all` should load `out.config`
2. `env TEST_KCONFIG=1 make` should load `out.config`, using dependency modelling
3. `make` (on an application without Kconfig files) should not load `out.config`
4. `make menuconfig` > `make clean all` should not load `out.config` (because of the clean)
5. Successive configurations via `.config` files or menuconfig should always load `out.config` until clean is executed

To check if there are Kconfig symbols loaded to the build system, one can add something like the following to an application makefile, and run the workflows described above (and more!) on native:
```diff
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9baf..e7e7583bc1 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -16,3 +16,9 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+ifndef CONFIG_HAS_ARCH_32BIT
+  $(info ->> NOT using Kconfig)
+else
+  $(info ->> using Kconfig)
+endif
```

### Issues/PRs references
Addresses the problem described in https://github.com/RIOT-OS/RIOT/pull/16009#issuecomment-783415826
