### PR TITLE
pkg/emlearn: bump version to 0.11.6

### DIFF
--- a/pkg/emlearn/Makefile
+++ b/pkg/emlearn/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=emlearn
 PKG_URL=https://github.com/emlearn/emlearn
-PKG_VERSION=1e33ca44ec08ba6545684107240de4e3e9ea5fe0  # 0.10.1
+PKG_VERSION=e9e9d645fc64b1f764d8a8ece6d6427a5297c098 # 0.11.6
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/pkg_emlearn` still works on `same54-xpro` and `native`. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
