### PR TITLE
gh_action: exclude tests/periph_timer_periodic from test-on-iotlab

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -82,6 +82,10 @@ jobs:
       #   but flashing at a specific offset is not (yet) supported on IoT-LAB
       #   so it will always fail because of that limitation
       APPLICATIONS_EXCLUDE: tests/periph_timer_short_relative_set tests/riotboot
+      # Increase tolerance error with `tests/periph_timer_periodic` because
+      # of timing issues with the test script when running in the github
+      # actions environment
+      TEST_PERIPH_TIMER_PERIODIC_PRECISION: 0.30
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/tests/periph_timer_periodic/tests/01-run.py
+++ b/tests/periph_timer_periodic/tests/01-run.py
@@ -6,9 +6,13 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+import os
 import sys
 import time
 from testrunner import run
+
+
+PRECISION = float(os.getenv("TEST_PERIPH_TIMER_PERIODIC_PRECISION", "0"))
 
 
 def testfunc(child):
@@ -17,8 +21,9 @@ def testfunc(child):
     child.expect_exact('TEST SUCCEEDED')
     end = time.time()
     # test should run 10 cycles with 25ms each
-    assert (end - start) > 0.25
-    assert (end - start) < 0.40
+    elapsed = end - start
+    assert elapsed > 0.25 * (1 - PRECISION), "=< 0.25s ({})".format(elapsed)
+    assert elapsed < 0.40 * (1 + PRECISION), "=> 0.40s ({})".format(elapsed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The python test script seems to have timing issues when launched from the github actions environment. Most of the boards are failing reliably([example on nrf52dk](https://github.com/RIOT-OS/RIOT/runs/1948186596?check_suite_focus=true)) every week.

I tried locally, or on IoT-LAB, with compile_and_test_for_board used on my computer and I'm not able to reproduce at all.

My guess is that the github actions are running in a virtualized environment and time measured by Python is very imprecise in this context.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The test application is skipped when launched via the test-on-iotlab action.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
