### PR TITLE
tests/xfa: use BUILDDEPS instead of overriding the all target

### DIFF
--- a/tests/xfa/Makefile
+++ b/tests/xfa/Makefile
@@ -2,7 +2,13 @@ include ../Makefile.tests_common
 
 include $(RIOTBASE)/Makefile.include
 
+# BUILD_IN_DOCKER needs special handling to keep target order
+ifeq ($(BUILD_IN_DOCKER),1)
+all: ..in-docker-container
+else
 all: static-test
+endif
+
 static-test: $(ELFFILE)
 	$(Q)TEST_STARTADDR=$$($(OBJDUMP) -t $< | grep -E '\sxfatest_const$$' | awk '{ printf "0x%s", $$1}'); \
 	TEST_ENDADDR=$$($(OBJDUMP) -t $< | grep -E '\sxfatest_const_end$$' | awk '{ printf "0x%s", $$1}'); \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the `tests/xfa` build when using `BUILD_IN_DOCKER=1` on the command line and a parallel make (using --jobs=x). The proposed fix is to append the `static-test` target to the `BUILDDEPS` variable after Makefile.include is parsed. With the `BUILDDEPS` variable, order is apparently kept with parallel make.

This problem triggers a build failure in the test-on-iotlab action (for example [on nrf52dk](https://github.com/RIOT-OS/RIOT/runs/1948186596?check_suite_focus=true#step:10:2258)), because this action uses `BUILD_IN_DOCKER=1` and `--jobs=2`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try `BUILD_IN_DOCKER=1 make RIOT_CI_BUILD=1 --no-print-directory -C tests/xfa clean al --jobs=2`, with this PR is works, on master it fails:

<details><summary>this PR:</summary>

```
$ BUILD_IN_DOCKER=1 make RIOT_CI_BUILD=1 --no-print-directory -C tests/xfa clean all --jobs=2
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/tests/xfa/' 'riot/riotbuild:latest' make 'RIOT_CI_BUILD=1'    all
Building application "tests_xfa" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  23652	   4694	  47748	  76094	  1293e	/data/riotbuild/riotbase/tests/xfa/bin/native/tests_xfa.elf
$ echo $?
0
$ make --no-print-directory -C tests/xfa test
r
/work/riot/RIOT/tests/xfa/bin/native/tests_xfa.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: buildtest)
Cross file array test
xfatest[2]:
[0] = 1, "xfatest1"
[1] = 2, "xfatest2"
xfatest_const[2]:
[0] = 123, "xfatest_const1"
[1] = 45, "xfatest_const2"
```

</details>

<details><summary>master:</summary>

```
$ BUILD_IN_DOCKER=1 make RIOT_CI_BUILD=1 --no-print-directory -C tests/xfa clean all --jobs=2
/usr/bin/objdump: '/work/riot/RIOT/tests/xfa/bin/native/tests_xfa.elf': No such file
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/tests/xfa/' 'riot/riotbuild:latest' make 'RIOT_CI_BUILD=1'   -j2 all
/usr/bin/objdump: '/work/riot/RIOT/tests/xfa/bin/native/tests_xfa.elf': No such file
Error: Static check of XFA linked const array failed, verify linker flags and try again
make: *** [Makefile:7: static-test] Error 1
make: *** Waiting for unfinished jobs....
Building application "tests_xfa" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  23652	   4694	  47748	  76094	  1293e	/data/riotbuild/riotbase/tests/xfa/bin/native/tests_xfa.elf
$ echo $?
2
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found when working on #16067 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
