### PR TITLE
boards: remove AVRDUDE_PORT and PORT_BSL

### DIFF
--- a/boards/arduino-leonardo/Makefile.include
+++ b/boards/arduino-leonardo/Makefile.include
@@ -1,9 +1,3 @@
-# For backward compatibility
-ifneq (,$(AVRDUDE_PORT))
-  $(warning Warning! AVRDUDE_PORT is deprecated use PROG_DEV)
-  PROG_DEV ?= $(AVRDUDE_PORT)
-endif
-
 PORT_LINUX      ?= /dev/ttyUSB0
 PROG_DEV        ?= /dev/ttyACM0
 PORT_DARWIN     ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/common/cc2538/Makefile.include
+++ b/boards/common/cc2538/Makefile.include
@@ -1,12 +1,6 @@
 # define the default flash-tool
 PROGRAMMER ?= cc2538-bsl
 
-# For backward compatibility
-ifneq (,$(PORT_BSL))
-  $(warning Warning! PORT_BSL is deprecated use PROG_DEV)
-  PROG_DEV ?= $(PORT_BSL)
-endif
-
 ifeq ($(PROGRAMMER),cc2538-bsl)
   PROG_BAUD ?= 460800
 else ifeq ($(PROGRAMMER),jlink)

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -2,12 +2,6 @@
 # https://www.microchip.com/DevelopmentTools/ProductDetails/atmega1284p-xpld
 ATMEGA_BOOTLOADER_SIZE ?= 4K
 
-# For backward compatibility
-ifneq (,$(AVRDUDE_PORT))
-  $(warning Warning! AVRDUDE_PORT is deprecated use PROG_DEV)
-  PROG_DEV ?= $(AVRDUDE_PORT)
-endif
-
 # Avrdude programmer defaults to the external flasher Bus Pirate ISP.
 AVRDUDE_PROGRAMMER  ?= buspirate
 # set serial port for avrdude with buspirate


### PR DESCRIPTION
### Contribution description

This was scheduled for removal a while ago:

```
- makefiles/vars.inc.mk: PORT_BSL & AVRDUDE_PORT will be removed after release
    2020.04
```

### Testing procedure

```
→ git grep AVRDUDE_PORT
release-notes.txt:- makefiles/vars.inc.mk: PORT_BSL & AVRDUDE_PORT will be removed after release
```

```
→ git it grep PORT_BSL
release-notes.txt:- makefiles/vars.inc.mk: PORT_BSL & AVRDUDE_PORT will be removed after release
```