### PR TITLE
core/xfa: typeof() -> __typeof__()

### DIFF
--- a/core/include/xfa.h
+++ b/core/include/xfa.h
@@ -158,6 +158,12 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  *
  * Pointers will end up sorted by prio.
  *
+ * @note This implementation uses the __typeof__() C extension.
+ *       It is available both in GCC and LLVM, and both don't complain with
+ *       plain "-std=c11". If deemed necessary, use of __typeof__ can be removed
+ *       and the type can be added as parameter, at the cost of much less
+ *       convenience.
+ *
  * @param[in]   xfa_name    name of the xfa
  * @param[in]   prio        priority within the xfa
  * @param[in]   name        symbol name
@@ -165,7 +171,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  */
 #define XFA_ADD_PTR(xfa_name, prio, name, entry) \
     _XFA_CONST(xfa_name, 5_ ## prio) \
-    const typeof(entry) xfa_name ## _ ## prio ## _ ## name = entry
+    const __typeof__(entry) xfa_name ## _ ## prio ## _ ## name = entry
 
 /**
  * @brief Calculate number of entries in cross-file array


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

xfa previously used `typeof`, which arm-none-eabi-gcc (at least 10.2) doesn't accept in c11 mode.
This changes `typeof` to `__typeof__`, which both gcc and llvm are ok with.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

No user, so nothing to see. Take a good look at the reasoning.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Split from #16061.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
