### PR TITLE
cpu/sam0_common: RTC: ensure RTC alarm alignment for SAM D2x

### DIFF
--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -463,6 +463,16 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     /* prevent old alarm from ringing */
     rtc_clear_alarm();
 
+#ifdef CPU_COMMON_SAMD21
+    /* When an alarm match occurs, the Alarm 0 Interrupt flag in the Interrupt
+     * Flag Status and Clear registers (INTFLAG.ALARMn0) is set on the next
+     * 0-to-1 transition of CLK_RTC_CNT. E.g. For a 1Hz clock counter, it means
+     * the Alarm 0 Interrupt flag is set with a delay of 1s after the occurrence
+     * of alarm match.
+     */
+    time->tm_sec--;
+#endif
+
     /* normalize input */
     rtc_tm_normalize(time);
 

--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -122,7 +122,7 @@ int main(void)
 
         if (++cnt < REPEAT) {
             struct tm time;
-            rtc_get_alarm(&time);
+            rtc_get_time(&time);
             inc_secs(&time, PERIOD);
             rtc_set_alarm(&time, cb, &rtc_mtx);
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There is an inconsistency with the behavior of the RTC on the sam0 family.
The RTC alarm on SAM D1x/2x is triggered at the *end* of the alarm second, on SAM D5x/E5x it's triggered at the *start* of the set alarm second.

The later behavior is closer to what one would expect IMHO.

The Datasheet read

> When an alarm match occurs, the Alarm 0 Interrupt flag in the Interrupt Flag Status and Clear registers (INTFLAG.ALARMn0) is set on the next 0-to-1 transition of CLK_RTC_CNT. E.g. For a 1Hz clock counter, it means the Alarm 0 Interrupt flag is set **with a delay of 1s** after the occurrence of alarm match.

for all members, but I could not observe this behavior on `same54-xpro`, but only on `samd10-xmini` and `samr21-xpro`.

I modified `tests/periph_rtc` to take the current RTC time into account when setting the alarm instead of just incrementing the alarm time by 2.
This reveals the inconsistent behavior (interval between alarms is now 3s instead of 2s without the RTC patch).

### Testing procedure

Run `tests/periph_rtc` on all supported familys

 - [x] SAM D1x/D2x
 - [ ] SAM L1x
 - [ ] SAM L2x
 - [x] SAM D5x/E5x

### Issues/PRs references

discovered in #15949
