### PR TITLE
pkg/lwip: Set netif link state properly when supported

### DIFF
--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -56,6 +56,12 @@ extern "C" {
 #define LWIP_ETHERNET           0
 #endif /* MODULE_LWIP_ETHERNET */
 
+#ifdef MODULE_LWIP_NETIF
+#define LWIP_NETIF_API          1
+#else  /* MODULE_LWIP_NETIF */
+#define LWIP_NETIF_API          0
+#endif /* MODULE_LWIP_NETIF */
+
 #ifdef MODULE_LWIP_IGMP
 #define LWIP_IGMP               1
 #else  /* MODULE_LWIP_IGMP */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Set link state correctly in lwIP for interfaces that support
the `NETOPT_LINK` option. Interfaces that do not support it
(like tap for native arch) remain up all the time.

Netdevs that support `NETOPT_LINK` but do not send `NETDEV_EVENT_LINK_UP`/`DOWN`
events will end up with a mismatched link state - but DHCP would
already not start for them either.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

tests/lwip still passes on native board

Flash a board with an app using lwIP and try plugging/unplugging ethernet cable and verify link state with ifconfig shell command, and that DHCP still gets an address when starting with cable unplugged (if using IPv4).

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
