### PR TITLE
make: add cosy as a build target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -513,7 +513,7 @@ include $(RIOTMAKE)/modules.inc.mk
 
 
 .PHONY: all link clean flash flash-only termdeps term doc debug debug-server reset objdump help info-modules
-.PHONY: print-size elffile binfile hexfile flashfile
+.PHONY: print-size elffile binfile hexfile flashfile cosy
 .PHONY: ..in-docker-container
 
 # Targets that depend on FORCE will always be rebuilt. Contrary to a .PHONY
@@ -539,6 +539,7 @@ endif
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
 BINFILE ?= $(ELFFILE:.elf=.bin)
+MAPFILE ?= $(ELFFILE:.elf=.map)
 
 ifneq (,$(filter suit, $(USEMODULE)))
   include $(RIOTMAKE)/suit.base.inc.mk
@@ -715,6 +716,11 @@ flash-only: $(FLASHDEPS)
 
 preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER_PREFIX)$(PREFLASHER) $(PREFFLAGS)
+
+# graphical memory usage analyzer
+COSY_TOOL ?= $(PKGDIRBASE)/cosy/cosy.py
+cosy: $(ELFFILE) $(COSY_TOOL)
+	$(COSY_TOOL) --riot-base $(RIOTBASE) $(APPDIR) $(BOARD) $(ELFFILE) $(MAPFILE)
 
 ifneq (,$(TERMLOG)$(TERMTEE))
   TERMTEE ?= | tee -a $(TERMLOG)

--- a/dist/tools/cosy/Makefile
+++ b/dist/tools/cosy/Makefile
@@ -1,0 +1,9 @@
+PKG_NAME=cosy
+PKG_URL=https://github.com/haukepetersen/cosy.git
+PKG_VERSION=b6098f2cfc2fc9d96850a28776c82c5b785fff7a
+PKG_LICENSE=GPL-3
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	:

--- a/dist/tools/cosy/patches/0001-cosy.py-set-working-directory-to-location-of-cosy.py.patch
+++ b/dist/tools/cosy/patches/0001-cosy.py-set-working-directory-to-location-of-cosy.py.patch
@@ -1,0 +1,46 @@
+From 77f489ec59d30c89e41bb94e2094b8bbaeeec4fb Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@googlemail.com>
+Date: Tue, 23 Feb 2021 23:57:53 +0100
+Subject: [PATCH 1/2] cosy.py: set working directory to location of cosy.py
+
+When calling `cosy.py` from outside it's directory, one gets
+
+     File "/home/benpicco/dev/cosy/cosy.py", line 364, in <module>
+        with open("root/symbols.json", 'w') as f:
+    IOError: [Errno 2] No such file or directory: 'root/symbols.json'
+
+as all paths used inide the script are relative.
+
+Fix this by changing the working directory to the location of `cosy.py`
+---
+ cosy.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/cosy.py b/cosy.py
+index f48f163..7000125 100755
+--- a/cosy.py
++++ b/cosy.py
+@@ -17,7 +17,7 @@
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ import sys
+-from os import path
++from os import path, chdir
+ import argparse
+ import re
+ import subprocess
+@@ -303,6 +303,11 @@ def check_completeness(symbols):
+ 
+ 
+ if __name__ == "__main__":
++
++    # change to directory of cosy.py
++    dname = path.dirname(path.abspath(__file__))
++    chdir(dname)
++
+     # Define some command line args
+     p = argparse.ArgumentParser()
+     p.add_argument("appdir", default="../RIOT/examples/hello-world", nargs="?", help="Full path to application dir")
+-- 
+2.27.0
+

--- a/dist/tools/cosy/patches/0002-frontend_server.py-make-URL-clickable.patch
+++ b/dist/tools/cosy/patches/0002-frontend_server.py-make-URL-clickable.patch
@@ -1,0 +1,23 @@
+From 71050a3460d918f21d1a0550b3388ca4474b5f9a Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@googlemail.com>
+Date: Wed, 24 Feb 2021 00:14:36 +0100
+Subject: [PATCH 2/2] frontend_server.py: make URL clickable
+
+---
+ frontend_server.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/frontend_server.py b/frontend_server.py
+index c06ea2b..a03362f 100644
+--- a/frontend_server.py
++++ b/frontend_server.py
+@@ -36,5 +36,5 @@ def run( root, port, index ):
+     HTTPHandler.index = index
+     HTTPHandler.root = root
+     httpd = HTTPServer(('', port), HTTPHandler)
+-    print("Started frontend server, connect you browser to localhost:" + str(port))
++    print("Started frontend server, connect you browser to http://localhost:" + str(port))
+     httpd.serve_forever()
+-- 
+2.27.0
+

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -22,6 +22,11 @@ $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py: $(RIOTTOOLS)/cc2538-bsl/Makefile
 	@CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/cc2538-bsl
 	@echo "[INFO] cc2538-bsl.py successfully fetched!"
 
+$(PKGDIRBASE)/cosy/cosy.py: $(RIOTTOOLS)/cosy/Makefile
+	@echo "[INFO] cosy.py not found - fetching it from GitHub now"
+	@CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/cosy
+	@echo "[INFO] cosy.py successfully fetched!"
+
 $(RIOTTOOLS)/edbg/edbg: $(RIOTTOOLS)/edbg/Makefile
 	@echo "[INFO] edbg binary not found - building it from source now"
 	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/edbg


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`cosy` is a graphical memory usage analyzer.
It is a great tool, but pretty hidden.
Add it as a build target so it can be easiely summoned for any application and board.


### Testing procedure

Run e.g. 

    make -C examples/hello-world cosy

and open the link (http://localhost:12345) in your browser.
You should see a graphical break down of every symbol and it's memory usage.

![](https://matrix-client.matrix.org/_matrix/media/r0/download/matrix.org/SPazLpxxGAbfLrgKApidYEet)

You can do this for every app or board.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

upstream PRs:
https://github.com/haukepetersen/cosy/pull/9
https://github.com/haukepetersen/cosy/pull/10