### PR TITLE
tests/pkg_littlefs:  tests/pkg_spiffs: fix test timeouts on nrf52840dk

### DIFF
--- a/tests/pkg_littlefs/main.c
+++ b/tests/pkg_littlefs/main.c
@@ -23,8 +23,11 @@
 
 #include "embUnit.h"
 
-/* Define MTD_0 in board.h to use the board mtd if any */
-#ifdef MTD_0
+/* Define MTD_0 in board.h to use the board mtd if any and if
+ * CONFIG_USE_HARDWARE_MTD is defined (add CFLAGS=-DCONFIG_USE_HARDWARE_MTD to
+ * the command line to enable it */
+#if defined(MTD_0) && IS_ACTIVE(CONFIG_USE_HARDWARE_MTD)
+#define USE_MTD_0
 #define _dev (MTD_0)
 #else
 /* Test mock object implementing a simple RAM-based mtd */
@@ -404,7 +407,7 @@ static void tests_littlefs_statvfs(void)
 
 Test *tests_littlefs(void)
 {
-#ifndef MTD_0
+#ifndef USE_MTD_0
     memset(dummy_memory, 0xff, sizeof(dummy_memory));
 #endif
 

--- a/tests/pkg_littlefs/tests/01-run.py
+++ b/tests/pkg_littlefs/tests/01-run.py
@@ -10,5 +10,8 @@ import sys
 from testrunner import run_check_unittests
 
 
+TIMEOUT = 180  # takes more than 2 minutes to complete on nrf52840dk
+
+
 if __name__ == "__main__":
-    sys.exit(run_check_unittests())
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_littlefs2/main.c
+++ b/tests/pkg_littlefs2/main.c
@@ -23,8 +23,11 @@
 
 #include "embUnit.h"
 
-/* Define MTD_0 in board.h to use the board mtd if any */
-#ifdef MTD_0
+/* Define MTD_0 in board.h to use the board mtd if any and if
+ * CONFIG_USE_HARDWARE_MTD is defined (add CFLAGS=-DCONFIG_USE_HARDWARE_MTD to
+ * the command line to enable it */
+#if defined(MTD_0) && IS_ACTIVE(CONFIG_USE_HARDWARE_MTD)
+#define USE_MTD_0
 #define _dev (MTD_0)
 #else
 /* Test mock object implementing a simple RAM-based mtd */
@@ -406,7 +409,7 @@ static void tests_littlefs_statvfs(void)
 
 Test *tests_littlefs(void)
 {
-#ifndef MTD_0
+#ifndef USE_MTD_0
     memset(dummy_memory, 0xff, sizeof(dummy_memory));
 #endif
 

--- a/tests/pkg_littlefs2/tests/01-run.py
+++ b/tests/pkg_littlefs2/tests/01-run.py
@@ -10,5 +10,8 @@ import sys
 from testrunner import run_check_unittests
 
 
+TIMEOUT = 180  # takes more than 2 minutes to complete on nrf52840dk
+
+
 if __name__ == "__main__":
-    sys.exit(run_check_unittests())
+    sys.exit(run_check_unittests(timeout=TIMEOUT))

--- a/tests/pkg_spiffs/main.c
+++ b/tests/pkg_spiffs/main.c
@@ -21,9 +21,11 @@
 
 #include "embUnit.h"
 
-
-/* Define MTD_0 in board.h to use the board mtd if any */
-#ifdef MTD_0
+/* Define MTD_0 in board.h to use the board mtd if any and if
+ * CONFIG_USE_HARDWARE_MTD is defined (add CFLAGS=-DCONFIG_USE_HARDWARE_MTD to
+ * the command line to enable it */
+#if defined(MTD_0) && IS_ACTIVE(CONFIG_USE_HARDWARE_MTD)
+#define USE_MTD_0
 #define _dev (MTD_0)
 #else
 /* Test mock object implementing a simple RAM-based mtd */
@@ -436,7 +438,7 @@ static void tests_spiffs_partition(void)
 
 Test *tests_spiffs(void)
 {
-#ifndef MTD_0
+#ifndef USE_MTD_0
     memset(dummy_memory, 0xff, sizeof(dummy_memory));
 #endif
     EMB_UNIT_TESTFIXTURES(fixtures) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes #14579.

The MTD configuration of the nrf52840dk was added in #14052 but it never worked when using the littlefs/spiffs automated tests because of a timeout. Indeed, to complete the littlefs tests take more than 2 minutes and it's even 10 minutes for spiffs.

Those tests [break in the test-on-iotlab github action](https://github.com/RIOT-OS/RIOT/runs/1964404209?check_suite_focus=true) (and are now the only ones there).

So this PR fixes the problem by 2 means:
- set a long enough timeout for the littlefs test, since waiting 2 minutes is reasonable (but maybe not for everyone :) )
- don't test on MTD_0 the spiffs, and just use the mtd in RAM. This is much faster (of course) and the MTD configured for a board is already tested by other tests anyway. If this is not acceptable for the reviewer, we can do it differently of course.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The mentioned tests now work on iot-lab:

<details><summary>tests/pkg_littlefs</summary>

```
$ make BOARD=nrf52840dk -C tests/pkg_littlefs clean flash test IOTLAB_NODE=auto-ssh
make: Entering directory '/work/riot/RIOT/tests/pkg_littlefs'
rm -rf /work/riot/RIOT/tests/pkg_littlefs/bin/nrf52840dk/pkg-build/littlefs
Building application "tests_pkg_littlefs" for "nrf52840dk" with MCU "nrf52".

"make" -C /work/riot/RIOT/pkg/littlefs
"make" -C /work/riot/RIOT/build/pkg/littlefs -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/nrf52840dk
"make" -C /work/riot/RIOT/boards/common/nrf52xxxdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/mtd
"make" -C /work/riot/RIOT/drivers/mtd_spi_nor
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/littlefs/fs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/embunit
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/vfs
   text	   data	    bss	    dec	    hex	filename
  30104	    220	   3956	  34280	   85e8	/work/riot/RIOT/tests/pkg_littlefs/bin/nrf52840dk/tests_pkg_littlefs.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf52840dk,10 --flash /work/riot/RIOT/tests/pkg_littlefs/bin/nrf52840dk/tests_pkg_littlefs.bin | grep 0
0
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52840dk-10.saclay.iot-lab.info:20000' 
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-849-g2e069)
........
OK (8 tests)

make: Leaving directory '/work/riot/RIOT/tests/pkg_littlefs
```

</details>

<details><summary>tests/pkg_littlefs2</summary>

```
$ make BOARD=nrf52840dk -C tests/pkg_littlefs2 clean flash test IOTLAB_NODE=auto-ssh
make: Entering directory '/work/riot/RIOT/tests/pkg_littlefs2'
rm -rf /work/riot/RIOT/tests/pkg_littlefs2/bin/nrf52840dk/pkg-build/littlefs2
Building application "tests_pkg_littlefs2" for "nrf52840dk" with MCU "nrf52".

[INFO] cloning littlefs2
Cloning into '/work/riot/RIOT/build/pkg/littlefs2'...
remote: Enumerating objects: 140, done.
remote: Counting objects: 100% (140/140), done.
remote: Compressing objects: 100% (84/84), done.
remote: Total 3284 (delta 80), reused 87 (delta 47), pack-reused 3144
Receiving objects: 100% (3284/3284), 1.87 MiB | 1.10 MiB/s, done.
Resolving deltas: 100% (2263/2263), done.
HEAD is now at 1863dc7 Merge pull request #519 from littlefs-project/devel
[INFO] updating littlefs2 /work/riot/RIOT/build/pkg/littlefs2/.pkg-state.git-downloaded
echo 1863dc7883d82bd6ca79faa164b65341064d1c16 > /work/riot/RIOT/build/pkg/littlefs2/.pkg-state.git-downloaded
[INFO] patch littlefs2
"make" -C /work/riot/RIOT/pkg/littlefs2
"make" -C /work/riot/RIOT/build/pkg/littlefs2 -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/nrf52840dk
"make" -C /work/riot/RIOT/boards/common/nrf52xxxdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/mtd
"make" -C /work/riot/RIOT/drivers/mtd_spi_nor
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/littlefs2/fs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/embunit
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/vfs
   text	   data	    bss	    dec	    hex	filename
  35676	    220	   4476	  40372	   9db4	/work/riot/RIOT/tests/pkg_littlefs2/bin/nrf52840dk/tests_pkg_littlefs2.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf52840dk,10 --flash /work/riot/RIOT/tests/pkg_littlefs2/bin/nrf52840dk/tests_pkg_littlefs2.bin | grep 0
0
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52840dk-10.saclay.iot-lab.info:20000' 
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-849-g2e069)
........
OK (8 tests)

make: Leaving directory '/work/riot/RIOT/tests/pkg_littlefs2'
```

</details>

<details><summary>tests/pkg_spiffs</summary>

```
$ make BOARD=nrf52840dk -C tests/pkg_spiffs flash test IOTLAB_NODE=auto-ssh
make: Entering directory '/work/riot/RIOT/tests/pkg_spiffs'
Building application "tests_pkg_spiffs" for "nrf52840dk" with MCU "nrf52".

"make" -C /work/riot/RIOT/pkg/spiffs
"make" -C /work/riot/RIOT/build/pkg/spiffs/src -f /work/riot/RIOT/Makefile.base MODULE=spiffs
"make" -C /work/riot/RIOT/boards/nrf52840dk
"make" -C /work/riot/RIOT/boards/common/nrf52xxxdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/mtd
"make" -C /work/riot/RIOT/drivers/mtd_spi_nor
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/spiffs/fs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/embunit
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/vfs
   text	   data	    bss	    dec	    hex	filename
  36292	    196	   8392	  44880	   af50	/work/riot/RIOT/tests/pkg_spiffs/bin/nrf52840dk/tests_pkg_spiffs.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf52840dk,10 --flash /work/riot/RIOT/tests/pkg_spiffs/bin/nrf52840dk/tests_pkg_spiffs.bin | grep 0
0
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52840dk-10.saclay.iot-lab.info:20000' 
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-849-g2e069)
.........
OK (9 tests)

make: Leaving directory '/work/riot/RIOT/tests/pkg_spiffs'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

The tests were failing since #14052. Fixes #14579

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
