### PR TITLE
sys/net/gnrc: add gnrc_tx_sync for gnrc_sixlowpan_frag_sfr

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -229,10 +229,6 @@ ifneq (,$(filter gnrc_sixlowpan_frag_sfr,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_frag_rb
   USEMODULE += evtimer
   USEMODULE += xtimer
-  ifneq (,$(filter gnrc_tx_sync,$(USEMODULE)))
-    # TODO: Implement gnrc_tx_sync for gnrc_sixlowpand_frag_sfr
-    $(error module gnrc_tx_sync conflicts with gnrc_sixlowpand_frag_sfr)
-  endif
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_frag_sfr_stats,$(USEMODULE)))

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
@@ -31,6 +31,7 @@
 #include "net/gnrc/sixlowpan/frag/fb.h"
 #include "net/gnrc/sixlowpan/frag/rb.h"
 #include "net/gnrc/sixlowpan/frag/vrb.h"
+#include "net/gnrc/tx_sync.h"
 #include "net/sixlowpan/sfr.h"
 #include "thread.h"
 #include "unaligned.h"
@@ -143,12 +144,15 @@ static void _clean_up_fbuf(gnrc_sixlowpan_frag_fb_t *fbuf, int error);
  * @param[in] netif         Network interface to send fragment over
  * @param[in] fbuf          Fragmentation buffer for the datagram to fragment
  * @param[in] page          Current 6Lo dispatch parsing page.
+ * @param[in,out] tx_sync   Packet snip used to synchronize with transmission, if gnrc_tx_sync is
+ *                          used
  *
  * @return  Size of the fragment
  */
 static uint16_t _send_1st_fragment(gnrc_netif_t *netif,
                                    gnrc_sixlowpan_frag_fb_t *fbuf,
-                                   unsigned page);
+                                   unsigned page,
+                                   gnrc_pktsnip_t **tx_sync);
 
 /**
  * @brief   Send subsequent fragment.
@@ -156,12 +160,15 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *netif,
  * @param[in] netif         Network interface to send fragment over
  * @param[in] fbuf          Fragmentation buffer for the datagram to fragment
  * @param[in] page          Current 6Lo dispatch parsing page.
+ * @param[in,out] tx_sync   Packet snip used to synchronize with transmission, if gnrc_tx_sync is
+ *                          used
  *
  * @return  Size of the fragment
  */
 static uint16_t _send_nth_fragment(gnrc_netif_t *netif,
                                    gnrc_sixlowpan_frag_fb_t *fbuf,
-                                   unsigned page);
+                                   unsigned page,
+                                   gnrc_pktsnip_t **tx_sync);
 
 /**
  * @brief   Send a abort pseudo fragment for datagram identified by @p tag
@@ -305,6 +312,7 @@ void gnrc_sixlowpan_frag_sfr_send(gnrc_pktsnip_t *pkt, void *ctx,
     gnrc_sixlowpan_frag_fb_t *fbuf = ctx;
     gnrc_netif_t *netif;
     int error_no = GNRC_NETERR_SUCCESS;
+    gnrc_pktsnip_t *tx_sync = NULL;
     uint16_t res;
 
     assert((fbuf != NULL) && ((fbuf->pkt == pkt) || (pkt == NULL)));
@@ -314,9 +322,13 @@ void gnrc_sixlowpan_frag_sfr_send(gnrc_pktsnip_t *pkt, void *ctx,
     netif = gnrc_netif_hdr_get_netif(pkt->data);
     assert(netif != NULL);
 
+    if (IS_USED(MODULE_GNRC_TX_SYNC)) {
+        tx_sync = gnrc_tx_sync_split(pkt);
+    }
+
     if (fbuf->offset == 0) {
         DEBUG("6lo sfr: sending first fragment\n");
-        res = _send_1st_fragment(netif, fbuf, page);
+        res = _send_1st_fragment(netif, fbuf, page, &tx_sync);
         if (res == 0) {
             DEBUG("6lo sfr: error sending first fragment\n");
             /* _send_1st_fragment only returns 0 if there is a memory problem */
@@ -330,7 +342,7 @@ void gnrc_sixlowpan_frag_sfr_send(gnrc_pktsnip_t *pkt, void *ctx,
     }
     else if (fbuf->offset < fbuf->datagram_size) {
         DEBUG("6lo sfr: sending subsequent fragment\n");
-        res = _send_nth_fragment(netif, fbuf, page);
+        res = _send_nth_fragment(netif, fbuf, page, &tx_sync);
         if (res == 0) {
             DEBUG("6lo sfr: error sending subsequent fragment (offset = %u)\n",
                   fbuf->offset);
@@ -370,6 +382,12 @@ void gnrc_sixlowpan_frag_sfr_send(gnrc_pktsnip_t *pkt, void *ctx,
         }
         _sched_arq_timeout(fbuf, fbuf->sfr.arq_timeout);
     }
+
+    if (IS_USED(MODULE_GNRC_TX_SYNC) && tx_sync) {
+        /* re-attach tx_sync to allow releasing it at end
+         * of transmission, or transmission failure */
+        gnrc_pkt_append(pkt, tx_sync);
+    }
     thread_yield();
     return;
 error:
@@ -382,6 +400,9 @@ error:
     }
     else {
         _clean_up_fbuf(fbuf, error_no);
+    }
+    if (IS_USED(MODULE_GNRC_TX_SYNC) && tx_sync) {
+        gnrc_pktbuf_release(tx_sync);
     }
 }
 
@@ -1249,7 +1270,7 @@ static void _clean_up_fbuf(gnrc_sixlowpan_frag_fb_t *fbuf, int error)
 
 static uint16_t _send_1st_fragment(gnrc_netif_t *netif,
                                    gnrc_sixlowpan_frag_fb_t *fbuf,
-                                   unsigned page)
+                                   unsigned page, gnrc_pktsnip_t **tx_sync)
 {
     gnrc_pktsnip_t *frag, *pkt = fbuf->pkt;
     sixlowpan_sfr_rfrag_t *hdr;
@@ -1291,6 +1312,10 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *netif,
     sixlowpan_sfr_rfrag_set_offset(hdr, fbuf->datagram_size);
     /* don't copy netif header of pkt => pkt->next */
     frag_size = _copy_pkt_to_frag(data, pkt->next, frag_size, 0);
+    if (IS_USED(MODULE_GNRC_TX_SYNC) && *tx_sync && (frag_size >= fbuf->datagram_size)) {
+        gnrc_pkt_append(frag, *tx_sync);
+        *tx_sync = NULL;
+    }
 
     DEBUG("6lo sfr: send first fragment (tag: %u, X: %i, seq: %u, "
           "frag_size: %u, datagram_size: %u)\n",
@@ -1306,7 +1331,8 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *netif,
 
 static uint16_t _send_nth_fragment(gnrc_netif_t *netif,
                                    gnrc_sixlowpan_frag_fb_t *fbuf,
-                                   unsigned page)
+                                   unsigned page,
+                                   gnrc_pktsnip_t **tx_sync)
 {
     gnrc_pktsnip_t *frag, *pkt = fbuf->pkt;
     sixlowpan_sfr_rfrag_t *hdr;
@@ -1336,6 +1362,10 @@ static uint16_t _send_nth_fragment(gnrc_netif_t *netif,
                                               fbuf->offset);
     /* copy remaining packet snips */
     local_offset = _copy_pkt_to_frag(data, pkt, frag_size, local_offset);
+    if (IS_USED(MODULE_GNRC_TX_SYNC) && *tx_sync && (local_offset >= fbuf->datagram_size)) {
+        gnrc_pkt_append(frag, *tx_sync);
+        *tx_sync = NULL;
+    }
     DEBUG("6lo sfr: send subsequent fragment (tag: %u, X: %i, seq: %u, "
           "frag_size: %u, offset: %u)\n",
           hdr->base.tag, sixlowpan_sfr_rfrag_ack_req(hdr),

--- a/tests/gnrc_tx_sync/Makefile
+++ b/tests/gnrc_tx_sync/Makefile
@@ -1,10 +1,14 @@
 include ../Makefile.tests_common
 
 TEST_6LO ?= 1
+TEST_FRAG_SFR ?= 1
 
 ifeq (1,$(TEST_6LO))
   USEMODULE += gnrc_sixlowpan_default
   USEMODULE += netdev_ieee802154
+  ifeq (1,$(TEST_FRAG_SFR))
+    USEMODULE += gnrc_sixlowpan_frag_sfr
+  endif
 else
   USEMODULE += gnrc_ipv6_default
   USEMODULE += netdev_eth

--- a/tests/gnrc_tx_sync/Makefile.ci
+++ b/tests/gnrc_tx_sync/Makefile.ci
@@ -5,21 +5,33 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega1281 \
+    atmega1284p \
     atmega328p \
     atmega328p-xplained-mini \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
+    derfmega128 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
+    mega-xplained \
+    microduino-corerf \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f070rb \
+    nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    saml10-xpro \
+    saml11-xpro \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \
@@ -29,4 +41,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     z1 \
+    zigduino \
     #


### PR DESCRIPTION
### Contribution description

Implement TX synchronization for `gnrc_sixlowpan_frag_sfr` and also extend the corresponding test.

### Testing procedure

`tests/gnrc_tx_sync` should pass

### Issues/PRs references

None