### PR TITLE
sys/net/gnrc: fix logic bug in gnrc_tx_sync implementation

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -292,15 +292,15 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
         goto error;
     }
     fbuf->offset += res;
-    if (IS_USED(MODULE_GNRC_TX_SYNC) && tx_sync) {
-        /* re-attach tx_sync to allow releasing it at end
-         * of transmission, or transmission failure */
-        gnrc_pkt_append((pkt) ? pkt : fbuf->pkt, tx_sync);
-    }
     if (!gnrc_sixlowpan_frag_fb_send(fbuf)) {
         DEBUG("6lo frag: message queue full, can't issue next fragment "
               "sending\n");
         goto error;
+    }
+    if (IS_USED(MODULE_GNRC_TX_SYNC) && tx_sync) {
+        /* re-attach tx_sync to allow releasing it at end
+         * of transmission, or transmission failure */
+        gnrc_pkt_append((pkt) ? pkt : fbuf->pkt, tx_sync);
     }
     thread_yield();
     return;


### PR DESCRIPTION
### Contribution description

In case of an error, the tx sync packet snip could previously have been
released twice. This moves re-attaching the tx sync snip down after the
last `goto error` to avoid this.

### Testing procedure

The test in `tests/gnrc_tx_sync` should still pass.

### Issues/PRs references

None