### PR TITLE
Kconfig: make app.config and app.config.test mutually exclusive

### DIFF
--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -29,8 +29,15 @@ export KCONFIG_GENERATED_DEPENDENCIES = $(GENERATED_DIR)/Kconfig.dep
 # This file will contain external module configurations
 export KCONFIG_EXTERNAL_CONFIGS = $(GENERATED_DIR)/Kconfig.external_modules
 
-# This file will contain application default configurations
-KCONFIG_APP_CONFIG = $(APPDIR)/app.config
+# Add configurations that only work when running the Kconfig test so far,
+# because they activate modules.
+ifeq (1,$(TEST_KCONFIG))
+  # This file will contain application default configurations
+  KCONFIG_APP_CONFIG = $(APPDIR)/app.config.test
+else
+  # This file will contain application default configurations
+  KCONFIG_APP_CONFIG = $(APPDIR)/app.config
+endif
 
 # Default and user overwritten configurations
 KCONFIG_USER_CONFIG = $(APPDIR)/user.config
@@ -54,13 +61,6 @@ KCONFIG_OUT_DEP = $(KCONFIG_OUT_CONFIG).d
 # and share them among boards or cpus.
 # This file will contain application default configurations used for Kconfig Test
 MERGE_SOURCES += $(KCONFIG_ADD_CONFIG)
-
-# Add configurations that only work when running the Kconfig test so far,
-# because they activate modules.
-ifeq (1,$(TEST_KCONFIG))
-  MERGE_SOURCES += $(wildcard $(APPDIR)/app.config.test)
-endif
-
 MERGE_SOURCES += $(wildcard $(KCONFIG_APP_CONFIG))
 MERGE_SOURCES += $(wildcard $(KCONFIG_USER_CONFIG))
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When an application contains an `app.config` for configuration using Kconfig without dependency resolution and an `app.config.test` for configuration using Kconfig with dependency resolution, the `app.config` file is still loaded, setting legacy symbols, and this is causing errors with Kconfig (see e.g. https://github.com/RIOT-OS/RIOT/pull/15951#issuecomment-785760426). This makes `app.config` and `app.config.test` mutually exclusive and their selection as application base configuration based on the setting of `TEST_KCONFIG=1`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I cherry-picked this PR on top of #15951 and try to build the test there with and without `TEST_KCONFIG=1` (currently causing an easy to solve merge conflict

```console
$ git remote add miri64 git@github.com:miri64/RIOT.git
$ git fetch miri64
$ git checkout miri64/congure/feat/initial
$ git cherry-pick miri64/kconfig/fix/app.config-mutual-exclusive
$ TEST_KCONFIG=1 make -C tests/congure_test -j
$ TEST_KCONFIG=1 make -C tests/congure_test -j clean   # otherwise one get's errors
$ make -C tests/congure_test -j
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
