### PR TITLE
tests/periph_spi: compact help messages a bit to shave off some bytes

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -599,8 +599,7 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    puts("Manual SPI peripheral driver test");
-    puts("Refer to the README.md file for more information.\n");
+    puts("Manual SPI peripheral driver test (see README.md)");
 
     printf("There are %i SPI devices configured for your platform.\n",
            (int)SPI_NUMOF);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

https://github.com/RIOT-OS/RIOT/pull/16061 exposed that on 16kb flash ARM boards (e.g., samd10-xmini), `tests/periph_spi_dma` is borderline not fitting, with maybe 50b left.

This PR just compacts the bootup message slightly:

PR:
```
   text    data     bss     dec     hex filename
  16244      44    3860   20148    4eb4 /data/riotbuild/riotbase/tests/periph_spi_dma/bin/samd10-xmini/tests_periph_spi_dma.elf
```

master:
```
   text    data     bss     dec     hex filename
  16284      44    3860   20188    4edc /data/riotbuild/riotbase/tests/periph_spi_dma/bin/samd10-xmini/tests_periph_spi_dma.elf
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should be fine.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
