### PR TITLE
murdock: break loop when app found and fix error message

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -290,6 +290,7 @@ compile() {
                 kconfig_test_hash=0
                 echo "An error occurred while compiling using Kconfig";
             fi
+            break
         fi
     done
 
@@ -302,7 +303,7 @@ compile() {
 
     if [ ${should_check_kconfig_hash} != 0 ]; then
         if [ ${kconfig_test_hash} != ${test_hash} ]; then
-            echo "Hashes of binaries with and without Kconfig mismatch for ${app}";
+            echo "Hashes of binaries with and without Kconfig mismatch for ${appdir}";
             echo "Please check that all used modules are modelled in Kconfig and enabled";
             RES=1
         fi


### PR DESCRIPTION
### Contribution description
Currently the loop that cycles through the applications to test Kconfig on does not break when t finds it. This adds a break when the application is found. Also, `appdir` is used for the error message instead.

### Testing procedure
- Green CI
- Locally one could force an issue in the Kconfig test (e.g. by adding/removing some module) and running the compile function in the script. For instance: `/bin/bash -c "source .murdock; JOBS=4 compile tests/driver_ad7746 samr21-xpro:gnu"` The error message should return the correct application name.

### Issues/PRs references
None
