### PR TITLE
drivers: remove unused luid dependencies

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -24,8 +24,7 @@
  * @}
  */
 
-
-#include "luid.h"
+#include "kernel_defines.h"
 #include "byteorder.h"
 #include "net/ieee802154.h"
 #if IS_USED(IEEE802154_SECURITY)

--- a/drivers/atwinc15x0/Makefile.dep
+++ b/drivers/atwinc15x0/Makefile.dep
@@ -1,4 +1,3 @@
-USEMODULE += luid
 USEMODULE += netdev_eth
 USEMODULE += xtimer
 USEPKG += driver_atwinc15x0

--- a/drivers/mrf24j40/Makefile.dep
+++ b/drivers/mrf24j40/Makefile.dep
@@ -1,5 +1,4 @@
 USEMODULE += xtimer
-USEMODULE += luid
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 FEATURES_REQUIRED += periph_gpio


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Those drivers don't rely on luid directly anymore, we can drop the dependency.



### Testing procedure

Everything should still compile.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
