### PR TITLE
sys/net/netopt: make NETOPT_TX_END_IRQ and friends read-only

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -93,6 +93,9 @@ void at86rf215_reset_and_cfg(at86rf215_t *dev)
     /* default to requesting ACKs, just like at86rf2xx */
     const netopt_enable_t enable = NETOPT_ENABLE;
     netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ, &enable, sizeof(enable));
+
+    /* enable RX start IRQs */
+    at86rf215_reg_or(dev, dev->BBC->RG_IRQM, BB_IRQ_RXAM);
 }
 
 void at86rf215_reset(at86rf215_t *dev)

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -269,14 +269,6 @@ void at86rf215_set_option(at86rf215_t *dev, uint16_t option, bool state)
                          : (dev->flags & ~option);
 
     switch (option) {
-        case AT86RF215_OPT_TELL_RX_START:
-            if (state) {
-                at86rf215_reg_or(dev, dev->BBC->RG_IRQM, BB_IRQ_RXAM);
-            } else {
-                at86rf215_reg_and(dev, dev->BBC->RG_IRQM, ~BB_IRQ_RXAM);
-            }
-
-            break;
         case AT86RF215_OPT_PROMISCUOUS:
             if (state) {
                 at86rf215_reg_or(dev, dev->BBC->RG_AFC0, AFC0_PM_MASK);

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -169,6 +169,7 @@ static void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
 
 void at86rf2xx_reset(at86rf2xx_t *dev)
 {
+    uint8_t tmp;
     netdev_ieee802154_reset(&dev->netdev);
 
     /* Reset state machine to ensure a known state */
@@ -204,7 +205,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 
 #if !defined(MODULE_AT86RFA1) && !defined(MODULE_AT86RFR2)
     /* don't populate masked interrupt flags to IRQ_STATUS register */
-    uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);
+    tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);
     tmp &= ~(AT86RF2XX_TRX_CTRL_1_MASK__IRQ_MASK_MODE);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_1, tmp);
 #endif
@@ -242,6 +243,11 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     dev->idle_state = AT86RF2XX_PHY_STATE_RX;
     /* go into RX state */
     at86rf2xx_set_state(dev, AT86RF2XX_PHY_STATE_RX);
+
+    /* Enable RX start IRQ */
+    tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_MASK);
+    tmp |= AT86RF2XX_IRQ_STATUS_MASK__RX_START;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK, tmp);
 
     DEBUG("at86rf2xx_reset(): reset complete.\n");
 }
@@ -292,8 +298,7 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
     /* trigger sending of pre-loaded frame */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE,
                         AT86RF2XX_TRX_STATE__TX_START);
-    if (netdev->event_callback &&
-        (dev->flags & AT86RF2XX_OPT_TELL_TX_START)) {
+    if (netdev->event_callback) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
     }
 }

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -446,14 +446,6 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
                           : (tmp |  AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK);
             at86rf2xx_reg_write(dev, AT86RF2XX_REG__CSMA_SEED_1, tmp);
             break;
-        case AT86RF2XX_OPT_TELL_RX_START:
-            DEBUG("[at86rf2xx] opt: %s SFD IRQ\n",
-                  (state ? "enable" : "disable"));
-            tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_MASK);
-            tmp = (state) ? (tmp |  AT86RF2XX_IRQ_STATUS_MASK__RX_START)
-                          : (tmp & ~AT86RF2XX_IRQ_STATUS_MASK__RX_START);
-            at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK, tmp);
-            break;
         case AT86RF2XX_OPT_ACK_PENDING:
             DEBUG("[at86rf2xx] opt: enabling pending ACKs\n");
             tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__CSMA_SEED_1);

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -145,7 +145,7 @@ size_t cc2420_tx_prepare(cc2420_t *dev, const iolist_t *iolist)
 void cc2420_tx_exec(cc2420_t *dev)
 {
     /* trigger the transmission */
-    if (dev->options & CC2420_OPT_TELL_TX_START) {
+    if (dev->netdev.netdev.event_callback) {
         dev->netdev.netdev.event_callback(&dev->netdev.netdev,
                                           NETDEV_EVENT_TX_STARTED);
     }

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -199,14 +199,6 @@ int cc2420_set_option(cc2420_t *dev, uint16_t option, bool state)
                 DEBUG("cc2420: set_opt: CC2420_OPT_PRELOADING\n");
                 break;
 
-            case CC2420_OPT_TELL_TX_START:
-            case CC2420_OPT_TELL_TX_END:
-            case CC2420_OPT_TELL_RX_START:
-            case CC2420_OPT_TELL_RX_END:
-                DEBUG("cc2420: set_opt: TX/RX START/END\n");
-                /* TODO */
-                break;
-
             default:
                 return -ENOTSUP;
         }
@@ -240,14 +232,6 @@ int cc2420_set_option(cc2420_t *dev, uint16_t option, bool state)
 
             case CC2420_OPT_PRELOADING:
                 DEBUG("cc2420: clr_opt: CC2420_OPT_PRELOADING\n");
-                break;
-
-            case CC2420_OPT_TELL_TX_START:
-            case CC2420_OPT_TELL_TX_END:
-            case CC2420_OPT_TELL_RX_START:
-            case CC2420_OPT_TELL_RX_END:
-                DEBUG("cc2420: clr_opt: TX/RX START/END\n");
-                /* TODO */
                 break;
 
             default:

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -213,16 +213,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             return opt_state(val, (dev->options & CC2420_OPT_PROMISCUOUS));
 
         case NETOPT_RX_START_IRQ:
-            return opt_state(val, (dev->options & CC2420_OPT_TELL_RX_START));
-
         case NETOPT_RX_END_IRQ:
-            return opt_state(val, (dev->options & CC2420_OPT_TELL_TX_END));
-
         case NETOPT_TX_START_IRQ:
-            return opt_state(val, (dev->options & CC2420_OPT_TELL_RX_START));
-
         case NETOPT_TX_END_IRQ:
-            return opt_state(val, (dev->options & CC2420_OPT_TELL_RX_END));
+            *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            return sizeof(netopt_enable_t);
 
         default:
             return -ENOTSUP;
@@ -279,18 +274,6 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t val_len)
 
         case NETOPT_PROMISCUOUSMODE:
             return cc2420_set_option(dev, CC2420_OPT_PROMISCUOUS, to_bool(val));
-
-        case NETOPT_RX_START_IRQ:
-            return cc2420_set_option(dev, CC2420_OPT_TELL_RX_START, to_bool(val));
-
-        case NETOPT_RX_END_IRQ:
-            return cc2420_set_option(dev, CC2420_OPT_TELL_RX_END, to_bool(val));
-
-        case NETOPT_TX_START_IRQ:
-            return cc2420_set_option(dev, CC2420_OPT_TELL_TX_START, to_bool(val));
-
-        case NETOPT_TX_END_IRQ:
-            return cc2420_set_option(dev, CC2420_OPT_TELL_TX_END, to_bool(val));
 
         default:
             return ext;

--- a/drivers/cc2420/include/cc2420_registers.h
+++ b/drivers/cc2420/include/cc2420_registers.h
@@ -31,17 +31,8 @@ extern "C" {
  */
 #define CC2420_OPT_AUTOACK          (0x0001)    /**< auto ACKs active */
 #define CC2420_OPT_CSMA             (0x0002)    /**< CSMA active */
-#define CC2420_OPT_PROMISCUOUS      (0x0004)    /**< promiscuous mode
-                                                 *   active */
+#define CC2420_OPT_PROMISCUOUS      (0x0004)    /**< promiscuous mode active */
 #define CC2420_OPT_PRELOADING       (0x0008)    /**< preloading enabled */
-#define CC2420_OPT_TELL_TX_START    (0x0010)    /**< notify MAC layer on TX
-                                                 *   start */
-#define CC2420_OPT_TELL_TX_END      (0x0020)    /**< notify MAC layer on TX
-                                                 *   finished */
-#define CC2420_OPT_TELL_RX_START    (0x0040)    /**< notify MAC layer on RX
-                                                 *   start */
-#define CC2420_OPT_TELL_RX_END      (0x0080)    /**< notify MAC layer on RX
-                                                 *   finished */
 /** @} */
 
 /**
@@ -49,11 +40,11 @@ extern "C" {
  * @{
  */
 enum {
-    CC2420_GOTO_PD,       /**< power down */
+    CC2420_GOTO_PD,         /**< power down */
     CC2420_GOTO_IDLE,       /**< idle */
-    CC2420_GOTO_RX,       /**< receive state */
+    CC2420_GOTO_RX,         /**< receive state */
     CC2420_GOTO_TXON,       /**< transmit packet without CCA */
-    CC2420_GOTO_TXONCCA        /**< transmit packet using CCA */
+    CC2420_GOTO_TXONCCA     /**< transmit packet using CCA */
 };
 
 /**

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -303,10 +303,6 @@ typedef enum {
  * @name    Internal device option flags
  * @{
  */
-#define AT86RF215_OPT_TELL_TX_START  (0x0001)       /**< notify MAC layer on TX start */
-#define AT86RF215_OPT_TELL_TX_END    (0x0002)       /**< notify MAC layer on TX finished */
-#define AT86RF215_OPT_TELL_RX_START  (0x0004)       /**< notify MAC layer on RX start */
-#define AT86RF215_OPT_TELL_RX_END    (0x0008)       /**< notify MAC layer on RX finished */
 #define AT86RF215_OPT_CSMA           (0x0010)       /**< CSMA active */
 #define AT86RF215_OPT_PROMISCUOUS    (0x0020)       /**< promiscuous mode active */
 #define AT86RF215_OPT_PRELOADING     (0x0040)       /**< preloading enabled */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -177,21 +177,11 @@ extern "C" {
  * @name    Internal device option flags
  * @{
  */
-#define AT86RF2XX_OPT_TELL_TX_START  (0x0001)       /**< notify MAC layer on TX
-                                                     *   start */
-#define AT86RF2XX_OPT_TELL_TX_END    (0x0002)       /**< notify MAC layer on TX
-                                                     *   finished */
-#define AT86RF2XX_OPT_TELL_RX_START  (0x0004)       /**< notify MAC layer on RX
-                                                     *   start */
-#define AT86RF2XX_OPT_TELL_RX_END    (0x0008)       /**< notify MAC layer on RX
-                                                     *   finished */
 #define AT86RF2XX_OPT_CSMA           (0x0010)       /**< CSMA active */
-#define AT86RF2XX_OPT_PROMISCUOUS    (0x0020)       /**< promiscuous mode
-                                                     *   active */
+#define AT86RF2XX_OPT_PROMISCUOUS    (0x0020)       /**< promiscuous mode active */
 #define AT86RF2XX_OPT_PRELOADING     (0x0040)       /**< preloading enabled */
 #define AT86RF2XX_OPT_AUTOACK        (0x0080)       /**< Auto ACK active */
-#define AT86RF2XX_OPT_ACK_PENDING    (0x0100)       /**< ACK frames with data
-                                                     *   pending */
+#define AT86RF2XX_OPT_ACK_PENDING    (0x0100)       /**< ACK frames with data pending */
 
 /** @} */
 

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -95,14 +95,6 @@ extern "C" {
 #define KW2XRF_OPT_PROMISCUOUS      (0x0200)    /**< promiscuous mode
                                                   *   active */
 #define KW2XRF_OPT_PRELOADING       (0x0400)    /**< preloading enabled */
-#define KW2XRF_OPT_TELL_TX_START    (0x0800)    /**< notify MAC layer on TX
-                                                  *   start */
-#define KW2XRF_OPT_TELL_TX_END      (0x1000)    /**< notify MAC layer on TX
-                                                  *   finished */
-#define KW2XRF_OPT_TELL_RX_START    (0x2000)    /**< notify MAC layer on RX
-                                                  *   start */
-#define KW2XRF_OPT_TELL_RX_END      (0x4000)    /**< notify MAC layer on RX
-                                                  *   finished */
 #define KW2XRF_OPT_AUTOACK          (0x8000)    /**< enable automatically ACK
                                                   *   for incommint packet */
 /** @} */

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -104,8 +104,6 @@ extern "C" {
                                                      *   start */
 #define MRF24J40_OPT_TELL_RX_END        (0x4000)    /**< notify MAC layer on RX
                                                      *   finished */
-#define MRF24J40_OPT_REQ_AUTO_ACK       (0x8000)    /**< notify MAC layer on RX
-                                                     *   finished */
 /** @} */
 
 

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -96,14 +96,6 @@ extern "C" {
 #define MRF24J40_OPT_PROMISCUOUS        (0x0200)    /**< promiscuous mode
                                                      *   active */
 #define MRF24J40_OPT_PRELOADING         (0x0400)    /**< preloading enabled */
-#define MRF24J40_OPT_TELL_TX_START      (0x0800)    /**< notify MAC layer on TX
-                                                     *   start */
-#define MRF24J40_OPT_TELL_TX_END        (0x1000)    /**< notify MAC layer on TX
-                                                     *   finished */
-#define MRF24J40_OPT_TELL_RX_START      (0x2000)    /**< notify MAC layer on RX
-                                                     *   start */
-#define MRF24J40_OPT_TELL_RX_END        (0x4000)    /**< notify MAC layer on RX
-                                                     *   finished */
 /** @} */
 
 

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -66,6 +66,10 @@ void kw2xrf_setup(kw2xrf_t *dev, const kw2xrf_params_t *params)
     dev->pending_tx = 0;
     kw2xrf_spi_init(dev);
     kw2xrf_set_power_mode(dev, KW2XRF_IDLE);
+    DEBUG("[kw2xrf] enabling RX/TX completion and start events");
+    kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2, MKW2XDM_PHY_CTRL2_RX_WMRK_MSK);
+    kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2, MKW2XDM_PHY_CTRL2_RXMSK);
+    kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2, MKW2XDM_PHY_CTRL2_TXMSK);
     DEBUG("[kw2xrf] setup finished\n");
 }
 

--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -398,22 +398,6 @@ void kw2xrf_set_option(kw2xrf_t *dev, uint16_t option, bool state)
                     MKW2XDM_PHY_CTRL1_RXACKRQD);
                 break;
 
-            case KW2XRF_OPT_TELL_RX_START:
-                kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2,
-                    MKW2XDM_PHY_CTRL2_RX_WMRK_MSK);
-                break;
-
-            case KW2XRF_OPT_TELL_RX_END:
-                kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2,
-                    MKW2XDM_PHY_CTRL2_RXMSK);
-                break;
-
-            case KW2XRF_OPT_TELL_TX_END:
-                kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2,
-                    MKW2XDM_PHY_CTRL2_TXMSK);
-                break;
-
-            case KW2XRF_OPT_TELL_TX_START:
             default:
                 /* do nothing */
                 break;
@@ -453,23 +437,6 @@ void kw2xrf_set_option(kw2xrf_t *dev, uint16_t option, bool state)
                     MKW2XDM_PHY_CTRL1_RXACKRQD);
                 break;
 
-            case KW2XRF_OPT_TELL_RX_START:
-                kw2xrf_set_dreg_bit(dev, MKW2XDM_PHY_CTRL2,
-                    MKW2XDM_PHY_CTRL2_RX_WMRK_MSK);
-                break;
-
-            case KW2XRF_OPT_TELL_RX_END:
-                kw2xrf_set_dreg_bit(dev, MKW2XDM_PHY_CTRL2,
-                    MKW2XDM_PHY_CTRL2_RXMSK);
-                break;
-
-            case KW2XRF_OPT_TELL_TX_END:
-                kw2xrf_set_dreg_bit(dev, MKW2XDM_PHY_CTRL2,
-                    MKW2XDM_PHY_CTRL2_TXMSK);
-                break;
-
-
-            case KW2XRF_OPT_TELL_TX_START:
             default:
                 /* do nothing */
                 break;

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -298,23 +298,10 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_START_IRQ:
-            *((netopt_enable_t *)value) =
-                !!(dev->netdev.flags & KW2XRF_OPT_TELL_RX_START);
-            return sizeof(netopt_enable_t);
-
         case NETOPT_RX_END_IRQ:
-            *((netopt_enable_t *)value) =
-                !!(dev->netdev.flags & KW2XRF_OPT_TELL_RX_END);
-            return sizeof(netopt_enable_t);
-
         case NETOPT_TX_START_IRQ:
-            *((netopt_enable_t *)value) =
-                !!(dev->netdev.flags & KW2XRF_OPT_TELL_TX_START);
-            return sizeof(netopt_enable_t);
-
         case NETOPT_TX_END_IRQ:
-            *((netopt_enable_t *)value) =
-                !!(dev->netdev.flags & KW2XRF_OPT_TELL_TX_END);
+            *((netopt_enable_t *)value) = NETOPT_ENABLE;
             return sizeof(netopt_enable_t);
 
         case NETOPT_AUTOCCA:
@@ -479,30 +466,6 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
         case NETOPT_PROMISCUOUSMODE:
             kw2xrf_set_option(dev, KW2XRF_OPT_PROMISCUOUS,
                               ((bool *)value)[0]);
-            res = sizeof(netopt_enable_t);
-            break;
-
-        case NETOPT_RX_START_IRQ:
-            kw2xrf_set_option(dev, KW2XRF_OPT_TELL_RX_START,
-                                 ((bool *)value)[0]);
-            res = sizeof(netopt_enable_t);
-            break;
-
-        case NETOPT_RX_END_IRQ:
-            kw2xrf_set_option(dev, KW2XRF_OPT_TELL_RX_END,
-                                 ((bool *)value)[0]);
-            res = sizeof(netopt_enable_t);
-            break;
-
-        case NETOPT_TX_START_IRQ:
-            kw2xrf_set_option(dev, KW2XRF_OPT_TELL_TX_START,
-                                 ((bool *)value)[0]);
-            res = sizeof(netopt_enable_t);
-            break;
-
-        case NETOPT_TX_END_IRQ:
-            kw2xrf_set_option(dev, KW2XRF_OPT_TELL_TX_END,
-                                 ((bool *)value)[0]);
             res = sizeof(netopt_enable_t);
             break;
 

--- a/drivers/kw41zrf/include/kw41zrf_getset.h
+++ b/drivers/kw41zrf/include/kw41zrf_getset.h
@@ -33,10 +33,6 @@ extern "C" {
 #define KW41ZRF_OPT_CSMA            (0x01u) /**< use CSMA/CA algorithm for sending */
 #define KW41ZRF_OPT_PROMISCUOUS     (0x02u) /**< promiscuous mode active */
 #define KW41ZRF_OPT_PRELOADING      (0x04u) /**< preloading enabled */
-#define KW41ZRF_OPT_TELL_TX_START   (0x08u) /**< notify MAC layer on TX start */
-#define KW41ZRF_OPT_TELL_TX_END     (0x10u) /**< notify MAC layer on TX finished */
-#define KW41ZRF_OPT_TELL_RX_START   (0x20u) /**< notify MAC layer on RX start */
-#define KW41ZRF_OPT_TELL_RX_END     (0x40u) /**< notify MAC layer on RX finished */
 #define KW41ZRF_OPT_AUTOACK         (0x80u) /**< automatic sending of ACKs */
 #define KW41ZRF_OPT_ACK_PENDING     (0x81u) /**< set pending bit on auto ACKs */
 /** @} */

--- a/drivers/kw41zrf/kw41zrf.c
+++ b/drivers/kw41zrf/kw41zrf.c
@@ -96,6 +96,9 @@ int kw41zrf_init(kw41zrf_t *dev, kw41zrf_cb_t cb)
     /* Allow radio interrupts */
     kw41zrf_unmask_irqs();
 
+    DEBUG("[kw41zrf] enabling RX start IRQs\n");
+    bit_clear32(&ZLL->PHY_CTRL, ZLL_PHY_CTRL_RX_WMRK_MSK_SHIFT);
+
     DEBUG("[kw41zrf] init finished\n");
 
     return 0;

--- a/drivers/kw41zrf/kw41zrf_getset.c
+++ b/drivers/kw41zrf/kw41zrf_getset.c
@@ -195,7 +195,6 @@ void kw41zrf_set_option(kw41zrf_t *dev, uint8_t option, uint8_t state)
             case KW41ZRF_OPT_PROMISCUOUS:
             case KW41ZRF_OPT_AUTOACK:
             case KW41ZRF_OPT_ACK_PENDING:
-            case KW41ZRF_OPT_TELL_RX_START:
                 LOG_ERROR("[kw41zrf] Attempt to modify option %04x while radio is sleeping\n",
                           (unsigned) option);
                 assert(0);
@@ -234,22 +233,6 @@ void kw41zrf_set_option(kw41zrf_t *dev, uint8_t option, uint8_t state)
                 bit_set32(&ZLL->SAM_TABLE, ZLL_SAM_TABLE_ACK_FRM_PND_SHIFT);
                 break;
 
-            case KW41ZRF_OPT_TELL_RX_START:
-                DEBUG("[kw41zrf] enable: TELL_RX_START\n");
-                bit_clear32(&ZLL->PHY_CTRL, ZLL_PHY_CTRL_RX_WMRK_MSK_SHIFT);
-                break;
-
-            case KW41ZRF_OPT_TELL_RX_END:
-                DEBUG("[kw41zrf] enable: TELL_RX_END\n");
-                break;
-
-            case KW41ZRF_OPT_TELL_TX_END:
-                DEBUG("[kw41zrf] enable: TELL_TX_END\n");
-                break;
-
-            case KW41ZRF_OPT_TELL_TX_START:
-                DEBUG("[kw41zrf] enable: TELL_TX_START (ignored)\n");
-
             default:
                 /* do nothing */
                 break;
@@ -280,21 +263,6 @@ void kw41zrf_set_option(kw41zrf_t *dev, uint8_t option, uint8_t state)
                 bit_clear32(&ZLL->SAM_TABLE, ZLL_SAM_TABLE_ACK_FRM_PND_SHIFT);
                 break;
 
-            case KW41ZRF_OPT_TELL_RX_START:
-                DEBUG("[kw41zrf] disable: TELL_RX_START\n");
-                bit_set32(&ZLL->PHY_CTRL, ZLL_PHY_CTRL_RX_WMRK_MSK_SHIFT);
-                break;
-
-            case KW41ZRF_OPT_TELL_RX_END:
-                DEBUG("[kw41zrf] disable: TELL_RX_END\n");
-                break;
-
-            case KW41ZRF_OPT_TELL_TX_END:
-                DEBUG("[kw41zrf] disable: TELL_TX_END\n");
-                break;
-
-            case KW41ZRF_OPT_TELL_TX_START:
-                DEBUG("[kw41zrf] disable: TELL_TX_START (ignored)\n");
             default:
                 /* do nothing */
                 break;

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -457,27 +457,11 @@ int kw41zrf_netdev_get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_START_IRQ:
-            assert(len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t *)value) =
-                !!(dev->flags & KW41ZRF_OPT_TELL_RX_START);
-            return sizeof(netopt_enable_t);
-
         case NETOPT_RX_END_IRQ:
-            assert(len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t *)value) =
-                !!(dev->flags & KW41ZRF_OPT_TELL_RX_END);
-            return sizeof(netopt_enable_t);
-
         case NETOPT_TX_START_IRQ:
-            assert(len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t *)value) =
-                !!(dev->flags & KW41ZRF_OPT_TELL_TX_START);
-            return sizeof(netopt_enable_t);
-
         case NETOPT_TX_END_IRQ:
             assert(len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t *)value) =
-                !!(dev->flags & KW41ZRF_OPT_TELL_TX_END);
+            *((netopt_enable_t *)value) = NETOPT_ENABLE;
             return sizeof(netopt_enable_t);
 
         case NETOPT_CSMA:
@@ -661,27 +645,6 @@ static int kw41zrf_netdev_set(netdev_t *netdev, netopt_t opt, const void *value,
             res = sizeof(const netopt_enable_t);
             break;
 
-        case NETOPT_RX_END_IRQ:
-            assert(len <= sizeof(const netopt_enable_t));
-            kw41zrf_set_option(dev, KW41ZRF_OPT_TELL_RX_END,
-                               *((const netopt_enable_t *)value));
-            res = sizeof(const netopt_enable_t);
-            break;
-
-        case NETOPT_TX_START_IRQ:
-            assert(len <= sizeof(const netopt_enable_t));
-            kw41zrf_set_option(dev, KW41ZRF_OPT_TELL_TX_START,
-                               *((const netopt_enable_t *)value));
-            res = sizeof(const netopt_enable_t);
-            break;
-
-        case NETOPT_TX_END_IRQ:
-            assert(len <= sizeof(const netopt_enable_t));
-            kw41zrf_set_option(dev, KW41ZRF_OPT_TELL_TX_END,
-                               *((const netopt_enable_t *)value));
-            res = sizeof(const netopt_enable_t);
-            break;
-
         case NETOPT_CSMA_RETRIES:
             assert(len <= sizeof(uint8_t));
             dev->csma_max_backoffs = *((const uint8_t*)value);
@@ -761,13 +724,6 @@ static int kw41zrf_netdev_set(netdev_t *netdev, netopt_t opt, const void *value,
         case NETOPT_PROMISCUOUSMODE:
             assert(len <= sizeof(const netopt_enable_t));
             kw41zrf_set_option(dev, KW41ZRF_OPT_PROMISCUOUS,
-                               *((const netopt_enable_t *)value));
-            res = sizeof(const netopt_enable_t);
-            break;
-
-        case NETOPT_RX_START_IRQ:
-            assert(len <= sizeof(const netopt_enable_t));
-            kw41zrf_set_option(dev, KW41ZRF_OPT_TELL_RX_START,
                                *((const netopt_enable_t *)value));
             res = sizeof(const netopt_enable_t);
             break;
@@ -931,7 +887,7 @@ static uint32_t _isr_event_seq_t_ccairq(kw41zrf_t *dev, uint32_t irqsts)
             kw41zrf_abort_sequence(dev);
             kw41zrf_set_sequence(dev, dev->idle_seq);
 
-            if (dev->flags & KW41ZRF_OPT_TELL_TX_END) {
+            if (dev->netdev.netdev.event_callback) {
                 dev->netdev.netdev.event_callback(&dev->netdev.netdev, NETDEV_EVENT_TX_MEDIUM_BUSY);
                 LOG_INFO("[kw41zrf] dropping frame after %u backoffs\n",
                           dev->csma_num_backoffs);
@@ -945,7 +901,7 @@ static uint32_t _isr_event_seq_t_ccairq(kw41zrf_t *dev, uint32_t irqsts)
                   ZLL_LQI_AND_RSSI_CCA1_ED_FNL_SHIFT),
                   dev->csma_num_backoffs
             );
-            if (dev->flags & KW41ZRF_OPT_TELL_TX_START) {
+            if (dev->netdev.netdev.event_callback) {
                 /* TX will start automatically after CCA check succeeded */
                 dev->netdev.netdev.event_callback(&dev->netdev.netdev, NETDEV_EVENT_TX_STARTED);
             }
@@ -962,7 +918,7 @@ static uint32_t _isr_event_seq_r(kw41zrf_t *dev, uint32_t irqsts)
     if (irqsts & ZLL_IRQSTS_RXWTRMRKIRQ_MASK) {
         DEBUG("[kw41zrf] RXWTRMRKIRQ (R)\n");
         handled_irqs |= ZLL_IRQSTS_RXWTRMRKIRQ_MASK;
-        if (dev->flags & KW41ZRF_OPT_TELL_RX_START) {
+        if (dev->netdev.netdev.event_callback) {
             dev->netdev.netdev.event_callback(&dev->netdev.netdev, NETDEV_EVENT_RX_STARTED);
         }
     }
@@ -1017,7 +973,7 @@ static uint32_t _isr_event_seq_r(kw41zrf_t *dev, uint32_t irqsts)
             /* Block XCVSEQ_RECEIVE until netdev->recv has been called */
             dev->recv_blocked = 1;
             kw41zrf_set_sequence(dev, dev->idle_seq);
-            if (dev->flags & KW41ZRF_OPT_TELL_RX_END) {
+            if (dev->netdev.netdev.event_callback) {
                 dev->netdev.netdev.event_callback(&dev->netdev.netdev, NETDEV_EVENT_RX_COMPLETE);
             }
             return handled_irqs;
@@ -1045,7 +1001,7 @@ static uint32_t _isr_event_seq_t(kw41zrf_t *dev, uint32_t irqsts)
 
         DEBUG("[kw41zrf] SEQIRQ (T)\n");
         handled_irqs |= ZLL_IRQSTS_SEQIRQ_MASK;
-        if (dev->flags & KW41ZRF_OPT_TELL_TX_END) {
+        if (dev->netdev.netdev.event_callback) {
             dev->netdev.netdev.event_callback(&dev->netdev.netdev, NETDEV_EVENT_TX_COMPLETE);
         }
         KW41ZRF_LED_TX_OFF;
@@ -1126,7 +1082,7 @@ static uint32_t _isr_event_seq_tr(kw41zrf_t *dev, uint32_t irqsts)
         assert(!kw41zrf_is_dsm());
         kw41zrf_set_sequence(dev, dev->idle_seq);
 
-        if (dev->flags & KW41ZRF_OPT_TELL_TX_END) {
+        if (dev->netdev.netdev.event_callback) {
             if (seq_ctrl_sts & ZLL_SEQ_CTRL_STS_TC3_ABORTED_MASK) {
                 LOG_DEBUG("[kw41zrf] RXACK timeout (TR)\n");
                 dev->netdev.netdev.event_callback(&dev->netdev.netdev, NETDEV_EVENT_TX_NOACK);

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -156,7 +156,7 @@ void mrf24j40_tx_exec(mrf24j40_t *dev)
     else {
         mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNTRIG);
     }
-    if (netdev->event_callback && (dev->netdev.flags & MRF24J40_OPT_TELL_TX_START)) {
+    if (netdev->event_callback) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
     }
 }

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -249,37 +249,43 @@ typedef enum {
      */
     NETOPT_RAWMODE,
     /**
-     * @brief   (@ref netopt_enable_t) trigger interrupt at reception start
+     * @brief   (@ref netopt_enable_t) Used to check if the driver generates NETDEV_EVENT_RX_STARTED
+     *          events
      *
      * It is mostly triggered after the preamble is correctly received
      *
-     * @note not all transceivers may support this interrupt
+     * @warning This value is read-only and cannot be configured at run-time
      */
     NETOPT_RX_START_IRQ,
 
     /**
-     * @brief   (@ref netopt_enable_t) trigger interrupt after frame reception
+     * @brief   (@ref netopt_enable_t) Used to check if the driver generates
+     *          NETDEV_EVENT_RX_COMPLETE events
      *
      * This interrupt is triggered after a complete frame is received.
      *
-     * @note in case a transceiver does not support this interrupt, the event
-     *       may be triggered by the driver
+     * @note    In case a transceiver does not support this interrupt, the event
+     *          may be triggered by the driver
+     * @warning This value is read-only and cannot be configured at run-time
      */
     NETOPT_RX_END_IRQ,
 
     /**
-     * @brief   (@ref netopt_enable_t) trigger interrupt at transmission start
+     * @brief   (@ref netopt_enable_t) Used to check if the driver generates NETDEV_EVENT_TX_STARTED
+     *          events
      *
      * This interrupt is triggered when the transceiver starts to send out the
      * frame.
      *
-     * @note in case a transceiver does not support this interrupt, the event
-     *       may be triggered by the driver
+     * @note    In case a transceiver does not support this interrupt, the event
+     *          may be triggered by the driver
+     * @warning This value is read-only and cannot be configured at run-time
      */
     NETOPT_TX_START_IRQ,
 
     /**
-     * @brief   (@ref netopt_enable_t) trigger interrupt after frame transmission
+     * @brief   (@ref netopt_enable_t) Used to check if the driver generates
+     *          NETDEV_EVENT_TX_COMPLETE events
      *
      * This interrupt is triggered when the full frame has been transmitted.
      *

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -149,12 +149,16 @@ static void gomach_reinit_radio(gnrc_netif_t *netif)
                                 sizeof(netif->l2addr));
     }
 
-    /* Enable RX-start and TX-started and TX-END interrupts. */
-    netopt_enable_t enable = NETOPT_ENABLE;
-    netif->dev->driver->set(netif->dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
-    netif->dev->driver->set(netif->dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-    netif->dev->driver->set(netif->dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
-
+    /* Check if RX-start and TX-started and TX-END interrupts are supported */
+    if (IS_ACTIVE(DEVELHELP)) {
+        netopt_enable_t enable;
+        netif->dev->driver->get(netif->dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
+        assert(enable == NETOPT_ENABLE);
+        netif->dev->driver->get(netif->dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
+        assert(enable == NETOPT_ENABLE);
+        netif->dev->driver->get(netif->dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+        assert(enable == NETOPT_ENABLE);
+    }
 }
 
 static void _gomach_rtt_cb(void *arg)

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -107,13 +107,16 @@ static void lwmac_reinit_radio(gnrc_netif_t *netif)
                                 sizeof(netif->l2addr));
     }
 
-   /* Enable RX-start and TX-started and TX-END interrupts. */
-   netopt_enable_t enable = NETOPT_ENABLE;
-   netif->dev->driver->set(netif->dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
-   netif->dev->driver->set(netif->dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-   netif->dev->driver->set(netif->dev, NETOPT_TX_START_IRQ, &enable, sizeof(enable));
-   netif->dev->driver->set(netif->dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
-
+    /* Check if RX-start and TX-started and TX-END interrupts are supported */
+    if (IS_ACTIVE(DEVELHELP)) {
+        netopt_enable_t enable;
+        netif->dev->driver->get(netif->dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
+        assert(enable == NETOPT_ENABLE);
+        netif->dev->driver->get(netif->dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
+        assert(enable == NETOPT_ENABLE);
+        netif->dev->driver->get(netif->dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+        assert(enable == NETOPT_ENABLE);
+    }
 }
 
 static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)

--- a/tests/driver_xbee/Makefile.ci
+++ b/tests/driver_xbee/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
+    arduino-mega2560 \
     arduino-nano \
     arduino-uno \
     atmega328p \


### PR DESCRIPTION
### Contribution description

Update the API contract to make `NETOPT_TX_END_IRQ`, `NETOPT_TX_START_IRQ`, `NETOPT_RX_END_IRQ`, and `NETOPT_RX_START_IRQ` read-only. That is, the corresponding events are not expected to be always send, and the netopts can only be used to test if a netdev supports them.

Additionally, the handful of drivers actually having support for configuring at run time were adapted.

#### Reasoning

- The event on RX completion is already mandatory, as no network stack can operate without it. The event on TX completion recently became mandatory with the new confirm_send API. There is not reason to ever turn them off.
- Configuring the other events at run time increases complexity, ROM size, and maintenance burden
- There really seems to be no use case to configure them at runt time.

### Testing procedure

For of the following list of drivers one should test ideally `examples/gnrc_networking_mac` or at the very least basic network functionality:

- [x] `at86rf215`
- [x] `at86rf2xx`
- [x] `mrf24j40`
- [x] `kw2xrf`
- [x] `kw41zrf`
- [ ] `cc2420`

Additionally, at least once LWMAC should be used instead of GoMacH in `examples/gnrc_networking_mac`.

### Issues/PRs references

None