### PR TITLE
lwip: hook up sam0_eth support

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -61,6 +61,10 @@
 #include "esp-wifi/esp_wifi_netdev.h"
 #endif
 
+#ifdef MODULE_SAM0_ETH
+#include "sam0_eth_netdev.h"
+#endif
+
 #ifdef MODULE_STM32_ETH
 #include "stm32_eth.h"
 #endif
@@ -107,6 +111,10 @@
 #define ESP_WIFI_INDEX          (0)
 #endif
 
+#ifdef MODULE_SAM0_ETH
+#define LWIP_NETIF_NUMOF        (1)
+#endif
+
 #ifdef MODULE_STM32_ETH
 #define LWIP_NETIF_NUMOF        (1)
 #endif
@@ -151,6 +159,11 @@ extern void esp_eth_setup (esp_eth_netdev_t* dev);
 #ifdef MODULE_ESP_WIFI
 extern esp_wifi_netdev_t _esp_wifi_dev;
 extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
+#endif
+
+#ifdef MODULE_SAM0_ETH
+static netdev_t sam0_eth;
+extern void sam0_eth_setup(netdev_t *netdev);
 #endif
 
 #ifdef MODULE_STM32_ETH
@@ -252,6 +265,13 @@ void lwip_bootstrap(void)
         return;
     }
 #endif
+#elif defined(MODULE_SAM0_ETH)
+    sam0_eth_setup(&sam0_eth);
+    if (_netif_add(&netif[0], &sam0_eth, lwip_netdev_init,
+                   tcpip_input) == NULL) {
+        DEBUG("Could not add sam0_eth device\n");
+        return;
+    }
 #elif defined(MODULE_STM32_ETH)
     stm32_eth_netdev_setup(&stm32_eth);
     if (_netif_add(&netif[0], &stm32_eth, lwip_netdev_init,


### PR DESCRIPTION
### Contribution description

`lwip` requires a separate init.
Hook up `sam0_eth` init here so lwip can be used with this driver.


### Testing procedure

flash `examples/paho-mqtt` on `same54-xpro`, `ifconfig` should work:

```
2021-02-26 12:55:37,020 # Iface ET0 HWaddr: fc:c2:3d:0d:2d:1f Link: up State: up
2021-02-26 12:55:37,022 #         Link type: wired
2021-02-26 12:55:37,028 #         inet6 addr: fe80:0:0:0:fec2:3dff:fe0d:2d1f scope: link
2021-02-26 12:55:37,043 #         inet6 addr: 2001:16b8:456e:6900:fec2:3dff:fe0d:2d1f scope: global
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
