### PR TITLE
Fix EXTERNAL_MODULE_DIRS handling

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -10,7 +10,9 @@
 
 # include external modules dependencies
 # processed before RIOT ones to be evaluated before the 'default' rules.
--include $(EXTERNAL_MODULE_DIRS:%=%/Makefile.dep)
+-include $(foreach d,$(EXTERNAL_MODULE_DIRS), \
+			$(if $(filter $(shell sed -E 's/MODULE\s*=\s*(.*)/\1/' $(d)/Makefile), $(USEMODULE)), $(d)/Makefile.dep,\
+				$(if $(filter $(notdir $(d)), $(USEMODULE)), $(d)/Makefile.dep)))
 
 # pull dependencies from sys and drivers
 include $(RIOTBASE)/sys/Makefile.dep

--- a/Makefile.include
+++ b/Makefile.include
@@ -590,7 +590,9 @@ endif
 # We assume $(LINK) to be gcc-like. Use `LINKFLAGPREFIX :=` for ld-like linker options.
 LINKFLAGPREFIX ?= -Wl,
 
-DIRS += $(EXTERNAL_MODULE_DIRS)
+DIRS += $(foreach d,$(EXTERNAL_MODULE_DIRS), \
+			$(if $(filter $(shell sed -E 's/MODULE\s*=\s*(.*)/\1/' $(d)/Makefile), $(USEMODULE)), $(d), \
+				$(if $(filter $(notdir $(d)), $(USEMODULE)), $(d))))
 
 # Define dependencies required for building (headers, downloading source files,)
 BUILDDEPS += $(RIOTBUILD_CONFIG_HEADER_C)


### PR DESCRIPTION
### Contribution description

All paths in EXTERNAL_MODULE_DIRS are added to DIRS, making them built even if they are not activated with USEMODULE.
Worst, their dependencies are parsed and activated too, leading to build non related modules to the original application.
To reproduce, comment "USEMODULE += external_module" in $(RIOTBASE)/tests/external_module_dirs/Makefile: the application build and it should not.
To fix this, filter EXTERNAL_MODULE_DIRS with USEMODULE variable.
To handle cases where module name is different from its folder name, use sed to extract module name from Makefile and try to find the module in USEMODULE.

I set this PR to draft in case someone could have a better solution.

### Testing procedure

```
gdo@gdo-desktop:~/Developpement/Informatique/Personnel/cogip/RIOT$ make -C tests/external_module_dirs/
make : on entre dans le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs »
Building application "tests_external_module_dirs" for "native" with MCU "native".

"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/native/drivers
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/core
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native/periph
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native/stdio_native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/drivers
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/drivers/periph_common
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/auto_init
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/luid
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/random
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs/external_module
   text	   data	    bss	    dec	    hex	filename
  29353	    628	  47820	  77801	  12fe9	/home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs/bin/native/tests_external_module_dirs.elf
make : on quitte le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs »

gdo@gdo-desktop:~/Developpement/Informatique/Personnel/cogip/RIOT$ sed -i "s/^USEMODULE/#USEMODULE/" tests/external_module_dirs/Makefile 

gdo@gdo-desktop:~/Developpement/Informatique/Personnel/cogip/RIOT$ make -C tests/external_module_dirs/
make : on entre dans le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs »
Building application "tests_external_module_dirs" for "native" with MCU "native".

/home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs/main.c:30:2: error: #error "Dependency not included"
   30 | #error "Dependency not included"
      |  ^~~~~
make[1]: *** [/home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/Makefile.base:107 : /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs/bin/native/application_tests_external_module_dirs/main.o] Erreur 1
make: *** [/home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs/../../Makefile.include:636 : application_tests_external_module_dirs.module] Erreur 2
make : on quitte le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/external_module_dirs »
```

### Issues/PRs references

I did not create an issue for that as I already have a fix, but I could.