### PR TITLE
net/ieee802154_security: small bugfix and stricter names

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -233,10 +233,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     IS_USED(MODULE_AT86RF2XX_AES_SPI)
     dev->netdev.sec_ctx.dev.cipher_ops = &_at86rf2xx_cipher_ops;
     dev->netdev.sec_ctx.dev.ctx = dev;
-    /* All configurations of the security module, the SRAM content,
-       and keys are reset during DEEP_SLEEP or RESET state. */
-    at86rf2xx_aes_key_write_encrypt(dev,
-        dev->netdev.sec_ctx.cipher.context.context);
 #endif
 
     /* State to return after receiving or transmitting */

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -629,23 +629,6 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             break;
 
 #endif /* MODULE_NETDEV_IEEE802154_OQPSK */
-
-#if IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
-    IS_USED(MODULE_IEEE802154_SECURITY)
-        case NETOPT_ENCRYPTION_KEY:
-            assert(len >= IEEE802154_SEC_KEY_LENGTH);
-            at86rf2xx_aes_key_write_encrypt(dev, val);
-            if (memcmp(dev->netdev.sec_ctx.cipher.context.context, val, len)) {
-                /* If the key changes, the frame conter can be reset to 0*/
-                dev->netdev.sec_ctx.frame_counter = 0;
-            }
-            memcpy(dev->netdev.sec_ctx.cipher.context.context, val,
-                   IEEE802154_SEC_KEY_LENGTH);
-            res = IEEE802154_SEC_KEY_LENGTH;
-            break;
-#endif /* IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
-          IS_USED(MODULE_IEEE802154_SECURITY) */
-
         default:
             break;
     }

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -119,7 +119,7 @@ typedef struct {
     uint8_t page;                           /**< channel page */
     uint16_t flags;                         /**< flags as defined above */
     int16_t txpower;                        /**< tx power in dBm */
-#if IS_USED(MODULE_IEEE802154_SECURITY) || defined (Doxygen)
+#if IS_USED(MODULE_IEEE802154_SECURITY) || defined(DOXYGEN)
     ieee802154_sec_context_t sec_ctx;       /**< security context */
 #endif
     /** @} */

--- a/drivers/netdev/ieee802154.c
+++ b/drivers/netdev/ieee802154.c
@@ -178,7 +178,7 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
             *((uint16_t *)value) = (_get_ieee802154_pdu(dev)
                                     - IEEE802154_MAX_HDR_LEN)
 #if IS_USED(MODULE_IEEE802154_SECURITY)
-                                    -IEEE802154_MAX_AUX_HDR_LEN
+                                    -IEEE802154_SEC_MAX_AUX_HDR_LEN
 #endif /* IS_USED(MODULE_IEEE802154_SECURITY) */
                                     - IEEE802154_FCS_LEN;
             res = sizeof(uint16_t);

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -101,14 +101,14 @@ struct ieee802154_sec_dev {
     void *ctx;
 };
 
-#if !defined(IEEE802154_DEFAULT_KEY) || defined(DOXYGEN)
+#if !defined(IEEE802154_SEC_DEFAULT_KEY) || defined(DOXYGEN)
 /**
  * @brief   AES key that is used in the test vectors from the specification
  *
  * @note    Predefine it yourself,
  *          if you want another key to be set up on initialization
  */
-#define IEEE802154_DEFAULT_KEY                  { 0xc0, 0xc1, 0xc2, 0xc3,   \
+#define IEEE802154_SEC_DEFAULT_KEY              { 0xc0, 0xc1, 0xc2, 0xc3,   \
                                                   0xc4, 0xc5, 0xc6, 0xc7,   \
                                                   0xc8, 0xc9, 0xca, 0xcb,   \
                                                   0xcc, 0xcd, 0xce, 0xcf }
@@ -127,68 +127,68 @@ struct ieee802154_sec_dev {
 /**
  * @brief   Maximum length of the security auxiliary header in bytes
  */
-#define IEEE802154_MAX_AUX_HDR_LEN              (14U)
+#define IEEE802154_SEC_MAX_AUX_HDR_LEN          (14U)
 
 /**
  * @brief   Maximum Size of IEEE 802.15.4 MAC
  */
-#define IEEE802154_MAC_SIZE                     (16U)
+#define IEEE802154_SEC_MAX_MAC_SIZE             (16U)
 
 /**
  * @brief   Mask to get security level bits
  */
-#define IEEE802154_SCF_SECLEVEL_MASK            (0x07)
+#define IEEE802154_SEC_SCF_SECLEVEL_MASK        (0x07)
 
 /**
  * @brief   Number of shifts to set/get security level bits
  */
-#define IEEE802154_SCF_SECLEVEL_SHIFT           (0)
+#define IEEE802154_SEC_SCF_SECLEVEL_SHIFT       (0)
 
 /**
  * @brief   Mask to get key mode bits
  */
-#define IEEE802154_SCF_KEYMODE_MASK             (0x18)
+#define IEEE802154_SEC_SCF_KEYMODE_MASK         (0x18)
 
 /**
  * @brief   Number of shifts to set/get key mode bits
  */
-#define IEEE802154_SCF_KEYMODE_SHIFT            (3)
+#define IEEE802154_SEC_SCF_KEYMODE_SHIFT        (3)
 
 /**
  * @brief    Security levels
  *
- * <em>IEEE802154_SCF_SECLEVEL_MIC*</em>:
+ * <em>IEEE802154_SEC_SCF_SECLEVEL_MIC*</em>:
  * A message integrity code (MIC), also known as MAC,
  * is used to prove authentication. The MIC covers the whole frame
  * i.e. header, auxiliary header, and frame payload.
  * The MIC is always encrypted, thus it must be decrypted by the receiver,
  * to be checked.
  *
- * <em>IEEE802154_SCF_SECLEVEL_ENC*</em>:
+ * <em>IEEE802154_SEC_SCF_SECLEVEL_ENC*</em>:
  * AES-128 in ECB mode is used to encrypt the payload of a frame to provide
  * confidentiality.
  *
- * <em>IEEE802154_SCF_SECLEVEL_ENC_MIC*</em>:
+ * <em>IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC*</em>:
  * A combination of the two modes above is used to ensure
  * authentication and confidentiality.
  */
 typedef enum {
-    IEEE802154_SCF_SECLEVEL_NONE                = 0x00, /**< no security */
-    IEEE802154_SCF_SECLEVEL_MIC32               = 0x01, /**< 32 bit MIC */
-    IEEE802154_SCF_SECLEVEL_MIC64               = 0x02, /**< 64 bit MIC */
-    IEEE802154_SCF_SECLEVEL_MIC128              = 0x03, /**< 128 bit MIC */
-    IEEE802154_SCF_SECLEVEL_ENC                 = 0x04, /**< encryption */
-    IEEE802154_SCF_SECLEVEL_ENC_MIC32           = 0x05, /**< enc. + 32 bit MIC */
-    IEEE802154_SCF_SECLEVEL_ENC_MIC64           = 0x06, /**< enc. + 64 bit MIC (mandatory) */
-    IEEE802154_SCF_SECLEVEL_ENC_MIC128          = 0x07  /**< enc. + 128 bit MIC */
-} ieee802154_scf_seclevel_t;
+    IEEE802154_SEC_SCF_SECLEVEL_NONE            = 0x00, /**< no security */
+    IEEE802154_SEC_SCF_SECLEVEL_MIC32           = 0x01, /**< 32 bit MIC */
+    IEEE802154_SEC_SCF_SECLEVEL_MIC64           = 0x02, /**< 64 bit MIC */
+    IEEE802154_SEC_SCF_SECLEVEL_MIC128          = 0x03, /**< 128 bit MIC */
+    IEEE802154_SEC_SCF_SECLEVEL_ENC             = 0x04, /**< encryption */
+    IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC32       = 0x05, /**< enc. + 32 bit MIC */
+    IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC64       = 0x06, /**< enc. + 64 bit MIC (mandatory) */
+    IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC128      = 0x07  /**< enc. + 128 bit MIC */
+} ieee802154_sec_scf_seclevel_t;
 
 /**
  * @brief   Key identifier modes
  *
  * The key identifier field in the auxiliary header
  * consists of the key source and the key index fields and is only present
- * if the key identifier mode is not IEEE802154_SCF_KEYMODE_IMPLICIT.
+ * if the key identifier mode is not IEEE802154_SEC_SCF_KEYMODE_IMPLICIT.
  * (see 9.4.3 in the spec.)
  *
  * +----------------+-------------+------------------+------------------------------------+
@@ -213,11 +213,11 @@ typedef enum {
  * +----------------+-------------+------------------+------------------------------------+
  */
 typedef enum {
-    IEEE802154_SCF_KEYMODE_IMPLICIT             = 0x00, /**< Key is determined implicitly */
-    IEEE802154_SCF_KEYMODE_INDEX                = 0x01, /**< Key is determined from key index */
-    IEEE802154_SCF_KEYMODE_SHORT_INDEX          = 0x02, /**< Key is determined from 4 byte key source and key index */
-    IEEE802154_SCF_KEYMODE_HW_INDEX             = 0x03  /**< Key is determined from 8 byte key source and key index */
-} ieee802154_scf_keymode_t;
+    IEEE802154_SEC_SCF_KEYMODE_IMPLICIT         = 0x00, /**< Key is determined implicitly */
+    IEEE802154_SEC_SCF_KEYMODE_INDEX            = 0x01, /**< Key is determined from key index */
+    IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX      = 0x02, /**< Key is determined from 4 byte key source and key index */
+    IEEE802154_SEC_SCF_KEYMODE_HW_INDEX         = 0x03  /**< Key is determined from 8 byte key source and key index */
+} ieee802154_sec_scf_keymode_t;
 
 /**
  * @brief   IEEE 802.15.4 security error codes
@@ -239,11 +239,11 @@ typedef struct ieee802154_sec_context {
      */
     cipher_t cipher;
     /**
-     * @brief   Security level IEEE802154_SCF_SECLEVEL_*
+     * @brief   Security level IEEE802154_SEC_SCF_SECLEVEL_*
      */
     uint8_t security_level;
     /**
-     * @brief   Key mode IEEE802154_SCF_KEYMODE_*
+     * @brief   Key mode IEEE802154_SEC_SCF_KEYMODE_*
      */
     uint8_t key_id_mode;
     /**
@@ -279,9 +279,9 @@ typedef struct __attribute__((packed)) {
      *  +--------+--------+--------+--------+--------+--------+--------+--------+
      *
      * security level:
-     * one of IEEE802154_SCF_SECLEVEL_*
+     * one of IEEE802154_SEC_SCF_SECLEVEL_*
      * key identifier mode:
-     * one of IEEE802154_SCF_KEY_*
+     * one of IEEE802154_SEC_SCF_KEY_*
      * frame counter suppression:
      * basically always zero because we do not support TSCH right now
      * ASN:
@@ -296,20 +296,20 @@ typedef struct __attribute__((packed)) {
      * @brief   key identifier (0 - 9 bytes) according to key id. mode
      */
     uint8_t key_id[];
-} ieee802154_aux_sec_t;
+} ieee802154_sec_aux_t;
 
 /**
- * @brief   Content of key_source if key mode is IEEE802154_SCF_KEYMODE_INDEX
+ * @brief   Content of key_source if key mode is IEEE802154_SEC_SCF_KEYMODE_INDEX
  */
 typedef struct __attribute__((packed)) {
     /**
      * @brief   Key index of key from originator, defined by key source
      */
     uint8_t key_index;
-} ieee802154_aux_sec_key_identifier_1_t;
+} ieee802154_sec_aux_key_identifier_1_t;
 
 /**
- * @brief   Content of key_source if key mode is IEEE802154_SCF_KEYMODE_SHORT_INDEX
+ * @brief   Content of key_source if key mode is IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX
  */
 typedef struct __attribute__((packed)) {
     /**
@@ -320,10 +320,10 @@ typedef struct __attribute__((packed)) {
      * @brief   Key index of key from originator, defined by key source
      */
     uint8_t key_index;
-} ieee802154_aux_sec_key_identifier_5_t;
+} ieee802154_sec_aux_key_identifier_5_t;
 
 /**
- * @brief   Content of key_source if key mode is IEEE802154_SCF_KEYMODE_HW_INDEX
+ * @brief   Content of key_source if key mode is IEEE802154_SEC_SCF_KEYMODE_HW_INDEX
  */
 typedef struct __attribute__((packed)) {
     /**
@@ -334,7 +334,7 @@ typedef struct __attribute__((packed)) {
      * @brief   Key index of key from originator, defined by key source
      */
     uint8_t key_index;
-} ieee802154_aux_sec_key_identifier_9_t;
+} ieee802154_sec_aux_key_identifier_9_t;
 
 /**
  * @brief   Format of 13 byte nonce
@@ -349,10 +349,10 @@ typedef struct __attribute__((packed)) {
      */
     uint32_t frame_counter;
     /**
-     * @brief   One of IEEE802154_SCF_SECLEVEL_*
+     * @brief   One of IEEE802154_SEC_SCF_SECLEVEL_*
      */
     uint8_t security_level;
-} ieee802154_ccm_nonce_t;
+} ieee802154_sec_ccm_nonce_t;
 
 /**
  * @brief   Format of 16 byte input block of CCM
@@ -365,13 +365,13 @@ typedef struct __attribute__((packed)) {
     /**
      * @brief   Nonce (Number that is only used once)
      */
-    ieee802154_ccm_nonce_t nonce;
+    ieee802154_sec_ccm_nonce_t nonce;
     /**
      * @brief   Either the length of the actual message (for CBC-MAC) or
      *          a block counter (for CTR)
      */
     uint16_t counter;
-} ieee802154_ccm_block_t;
+} ieee802154_sec_ccm_block_t;
 
 /**
  * @brief   Initialize IEEE 802.15.4 security context with default values

--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Otto-von-Gericke-Universität Magdeburg
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Forward declaration of an IEEE802.15.4 abstract security device
+ * @brief   Forward declaration of an IEEE 802.15.4 abstract security device
  */
 typedef struct ieee802154_sec_dev ieee802154_sec_dev_t;
 
@@ -88,7 +88,7 @@ typedef struct ieee802154_radio_cipher_ops {
 } ieee802154_radio_cipher_ops_t;
 
 /**
- * @brief IEEE802.15.4 security device descriptor
+ * @brief IEEE 802.15.4 security device descriptor
  */
 struct ieee802154_sec_dev {
     /**
@@ -206,7 +206,7 @@ typedef enum {
  * |                |             |                  | short source address               |
  * |                |             |                  | of the originator of the frame.    |
  * +----------------+-------------+------------------+------------------------------------+
- * | HX_INDEX       | 8 bytes     | 1 byte           | The key can be determined          |
+ * | HW_INDEX       | 8 bytes     | 1 byte           | The key can be determined          |
  * |                |             |                  | from the key index and             |
  * |                |             |                  | the long address of the originator |
  * |                |             |                  | of the frame.                      |
@@ -217,7 +217,7 @@ typedef enum {
     IEEE802154_SCF_KEYMODE_INDEX                = 0x01, /**< Key is determined from key index */
     IEEE802154_SCF_KEYMODE_SHORT_INDEX          = 0x02, /**< Key is determined from 4 byte key source and key index */
     IEEE802154_SCF_KEYMODE_HW_INDEX             = 0x03  /**< Key is determined from 8 byte key source and key index */
-} ieee802154_scr_keymode_t;
+} ieee802154_scf_keymode_t;
 
 /**
  * @brief   IEEE 802.15.4 security error codes
@@ -376,7 +376,7 @@ typedef struct __attribute__((packed)) {
 /**
  * @brief   Initialize IEEE 802.15.4 security context with default values
  *
- * @param[out]      ctx                     security context
+ * @param[out]      ctx                     IEEE 802.15.4 security context
  */
 void ieee802154_sec_init(ieee802154_sec_context_t *ctx);
 

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -245,7 +245,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     size_t src_len, dst_len;
     uint8_t mhr_len;
 #if IS_USED(MODULE_IEEE802154_SECURITY)
-    uint8_t mhr[IEEE802154_MAX_HDR_LEN + IEEE802154_MAX_AUX_HDR_LEN];
+    uint8_t mhr[IEEE802154_MAX_HDR_LEN + IEEE802154_SEC_MAX_AUX_HDR_LEN];
 #else
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
 #endif
@@ -336,7 +336,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
         iolist_header.iol_next = (iolist_t *)pkt->next;
 
-        uint8_t mic[IEEE802154_MAC_SIZE];
+        uint8_t mic[IEEE802154_SEC_MAX_MAC_SIZE];
         uint8_t mic_size = 0;
 
         if (flags & NETDEV_IEEE802154_SECURITY_EN) {

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -221,9 +221,9 @@ static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
  * @brief   Construct the first block A0 for CTR
  */
 static inline void _init_ctr_A0(ieee802154_ccm_block_t *A0,
-                               uint32_t frame_counter,
-                               uint8_t security_level,
-                               const uint8_t *src_address)
+                                uint32_t frame_counter,
+                                uint8_t security_level,
+                                const uint8_t *src_address)
 {
     A0->flags = _ccm_flag(0, 2);
     A0->nonce.frame_counter = htonl(frame_counter);
@@ -244,11 +244,11 @@ static inline void _advance_ctr_Ai(ieee802154_ccm_block_t *Ai)
  * @brief   Construct the first block B0 for CBC-MAC
  */
 static inline void _init_cbc_B0(ieee802154_ccm_block_t *B0,
-                               uint32_t frame_counter,
-                               uint8_t security_level,
-                               uint16_t m_len,
-                               uint8_t mic_size,
-                               const uint8_t *src_address)
+                                uint32_t frame_counter,
+                                uint8_t security_level,
+                                uint16_t m_len,
+                                uint8_t mic_size,
+                                const uint8_t *src_address)
 {
     B0->flags = _ccm_flag(mic_size, 2);
     B0->nonce.frame_counter = htonl(frame_counter),

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -118,27 +118,27 @@ static inline uint8_t _ccm_flag(uint8_t M, uint8_t L)
 
 static inline uint8_t _get_sec_level(uint8_t scf)
 {
-    return (scf & IEEE802154_SCF_SECLEVEL_MASK)
-           >> IEEE802154_SCF_SECLEVEL_SHIFT;
+    return (scf & IEEE802154_SEC_SCF_SECLEVEL_MASK)
+           >> IEEE802154_SEC_SCF_SECLEVEL_SHIFT;
 }
 
 static inline uint8_t _get_key_id_mode(uint8_t scf)
 {
-    return (scf & IEEE802154_SCF_KEYMODE_MASK)
-           >> IEEE802154_SCF_KEYMODE_SHIFT;
+    return (scf & IEEE802154_SEC_SCF_KEYMODE_MASK)
+           >> IEEE802154_SEC_SCF_KEYMODE_SHIFT;
 }
 
 static inline uint8_t _mac_size(uint8_t sec_level)
 {
     switch (sec_level) {
-        case IEEE802154_SCF_SECLEVEL_MIC32:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC32:
+        case IEEE802154_SEC_SCF_SECLEVEL_MIC32:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC32:
             return 4;
-        case IEEE802154_SCF_SECLEVEL_MIC64:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC64:
+        case IEEE802154_SEC_SCF_SECLEVEL_MIC64:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC64:
             return 8;
-        case IEEE802154_SCF_SECLEVEL_MIC128:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC128:
+        case IEEE802154_SEC_SCF_SECLEVEL_MIC128:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC128:
             return 16;
         default:
             return 0;
@@ -149,12 +149,12 @@ static inline uint8_t _mac_size(uint8_t sec_level)
 static inline bool _req_mac(uint8_t sec_level)
 {
     switch (sec_level) {
-        case IEEE802154_SCF_SECLEVEL_MIC32:
-        case IEEE802154_SCF_SECLEVEL_MIC64:
-        case IEEE802154_SCF_SECLEVEL_MIC128:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC32:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC64:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC128:
+        case IEEE802154_SEC_SCF_SECLEVEL_MIC32:
+        case IEEE802154_SEC_SCF_SECLEVEL_MIC64:
+        case IEEE802154_SEC_SCF_SECLEVEL_MIC128:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC32:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC64:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC128:
             return true;
         default:
             return false;
@@ -165,10 +165,10 @@ static inline bool _req_mac(uint8_t sec_level)
 static inline bool _req_encryption(uint8_t sec_level)
 {
     switch (sec_level) {
-        case IEEE802154_SCF_SECLEVEL_ENC:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC32:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC64:
-        case IEEE802154_SCF_SECLEVEL_ENC_MIC128:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC32:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC64:
+        case IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC128:
             return true;
         default:
             return false;
@@ -184,24 +184,24 @@ static inline void _memxor(void *dst, const void* src, size_t size)
 
 static inline uint8_t _scf(uint8_t sec_level, uint8_t key_mode)
 {
-    return (sec_level << IEEE802154_SCF_SECLEVEL_SHIFT) |
-           (key_mode << IEEE802154_SCF_KEYMODE_SHIFT);
+    return (sec_level << IEEE802154_SEC_SCF_SECLEVEL_SHIFT) |
+           (key_mode << IEEE802154_SEC_SCF_KEYMODE_SHIFT);
 }
 
 static inline uint8_t _get_aux_hdr_size(uint8_t security_level,
                                         uint8_t key_mode)
 {
-    if (security_level == IEEE802154_SCF_SECLEVEL_NONE) {
+    if (security_level == IEEE802154_SEC_SCF_SECLEVEL_NONE) {
             return 0;
     }
     switch (key_mode) {
-        case IEEE802154_SCF_KEYMODE_IMPLICIT:
+        case IEEE802154_SEC_SCF_KEYMODE_IMPLICIT:
             return 5;
-        case IEEE802154_SCF_KEYMODE_INDEX:
+        case IEEE802154_SEC_SCF_KEYMODE_INDEX:
             return 6;
-        case IEEE802154_SCF_KEYMODE_SHORT_INDEX:
+        case IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX:
             return 10;
-        case IEEE802154_SCF_KEYMODE_HW_INDEX:
+        case IEEE802154_SEC_SCF_KEYMODE_HW_INDEX:
             return 14;
         default:
             return 0;
@@ -209,7 +209,7 @@ static inline uint8_t _get_aux_hdr_size(uint8_t security_level,
 }
 
 static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
-                            ieee802154_aux_sec_t *ahr)
+                            ieee802154_sec_aux_t *ahr)
 {
     ahr->scf = _scf(ctx->security_level, ctx->key_id_mode);
     /* If you look in the specification: Annex C,
@@ -217,18 +217,18 @@ static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
     ahr->fc = byteorder_htoll(ctx->frame_counter).u32;
     size_t len = 5;
     switch (ctx->key_id_mode) {
-        case IEEE802154_SCF_KEYMODE_IMPLICIT:
+        case IEEE802154_SEC_SCF_KEYMODE_IMPLICIT:
             break;
-        case IEEE802154_SCF_KEYMODE_INDEX:
+        case IEEE802154_SEC_SCF_KEYMODE_INDEX:
             memcpy(ahr->key_id, &ctx->key_index, 1);
             len++;
             break;
-        case IEEE802154_SCF_KEYMODE_SHORT_INDEX:
+        case IEEE802154_SEC_SCF_KEYMODE_SHORT_INDEX:
             memcpy(ahr->key_id, ctx->key_source, 4);
             memcpy(ahr->key_id + 4, &ctx->key_index, 1);
             len += 5;
             break;
-        case IEEE802154_SCF_KEYMODE_HW_INDEX:
+        case IEEE802154_SEC_SCF_KEYMODE_HW_INDEX:
             memcpy(ahr->key_id, ctx->key_source, 8);
             memcpy(ahr->key_id + 8, &ctx->key_index, 1);
             len += 9;
@@ -242,7 +242,7 @@ static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
 /**
  * @brief   Construct the first block A0 for CTR
  */
-static inline void _init_ctr_A0(ieee802154_ccm_block_t *A0,
+static inline void _init_ctr_A0(ieee802154_sec_ccm_block_t *A0,
                                 uint32_t frame_counter,
                                 uint8_t security_level,
                                 const uint8_t *src_address)
@@ -257,7 +257,7 @@ static inline void _init_ctr_A0(ieee802154_ccm_block_t *A0,
 /**
  * @brief   In CTR, the blocks Ai differ in a successive counter
  */
-static inline void _advance_ctr_Ai(ieee802154_ccm_block_t *Ai)
+static inline void _advance_ctr_Ai(ieee802154_sec_ccm_block_t *Ai)
 {
     Ai->counter = htons(ntohs(Ai->counter) + 1);
 }
@@ -265,7 +265,7 @@ static inline void _advance_ctr_Ai(ieee802154_ccm_block_t *Ai)
 /**
  * @brief   Construct the first block B0 for CBC-MAC
  */
-static inline void _init_cbc_B0(ieee802154_ccm_block_t *B0,
+static inline void _init_cbc_B0(ieee802154_sec_ccm_block_t *B0,
                                 uint32_t frame_counter,
                                 uint8_t security_level,
                                 uint16_t m_len,
@@ -281,7 +281,7 @@ static inline void _init_cbc_B0(ieee802154_ccm_block_t *B0,
 
 static const uint8_t *_get_encryption_key(const ieee802154_sec_context_t *ctx,
                                           const uint8_t *mhr, uint8_t mhr_len,
-                                          const ieee802154_aux_sec_t *ahr)
+                                          const ieee802154_sec_aux_t *ahr)
 {
     (void)mhr;
     (void)mhr_len;
@@ -293,7 +293,7 @@ static const uint8_t *_get_encryption_key(const ieee802154_sec_context_t *ctx,
 
 static const uint8_t *_get_decryption_key(const ieee802154_sec_context_t *ctx,
                                           const uint8_t *mhr, uint8_t mhr_len,
-                                          const ieee802154_aux_sec_t *ahr)
+                                          const ieee802154_sec_aux_t *ahr)
 {
     (void)mhr;
     (void)mhr_len;
@@ -344,14 +344,14 @@ static uint8_t _cbc_next(ieee802154_sec_context_t *ctx,
 }
 
 static void _comp_mic(ieee802154_sec_context_t *ctx,
-                      uint8_t mic[IEEE802154_MAC_SIZE],
-                      ieee802154_ccm_block_t *B0,
+                      uint8_t mic[IEEE802154_SEC_MAX_MAC_SIZE],
+                      ieee802154_sec_ccm_block_t *B0,
                       const void *a, uint16_t a_len,
                       const void *m, uint16_t m_len)
 {
     uint8_t tmp[IEEE802154_SEC_BLOCK_SIZE] = { 0 };
     uint16_t off;
-    memset(mic, 0, IEEE802154_MAC_SIZE);
+    memset(mic, 0, IEEE802154_SEC_MAX_MAC_SIZE);
     _cbc_next(ctx, mic, tmp, (uint8_t *)B0, sizeof(*B0));
     byteorder_htobebufs(tmp, a_len);
     off = _min(sizeof(tmp) - sizeof(uint16_t), a_len);
@@ -366,7 +366,7 @@ static void _comp_mic(ieee802154_sec_context_t *ctx,
 }
 
 static void _ctr(ieee802154_sec_context_t *ctx,
-                 ieee802154_ccm_block_t *A0,
+                 ieee802154_sec_ccm_block_t *A0,
                  const void *m, uint16_t m_len)
 {
     uint8_t tmp1[IEEE802154_SEC_BLOCK_SIZE] = { 0 };
@@ -380,7 +380,7 @@ static void _ctr(ieee802154_sec_context_t *ctx,
 }
 
 static void _ctr_mic(ieee802154_sec_context_t *ctx,
-                     ieee802154_ccm_block_t *A0,
+                     ieee802154_sec_ccm_block_t *A0,
                      void *mic, uint8_t mic_size)
 {
     uint8_t tmp1[IEEE802154_SEC_BLOCK_SIZE] = { 0 };
@@ -396,13 +396,12 @@ void ieee802154_sec_init(ieee802154_sec_context_t *ctx)
     /* device driver can override this */
     ctx->dev.ctx = ctx;
     /* MIC64 is the only mandatory security mode */
-    ctx->security_level = IEEE802154_SCF_SECLEVEL_ENC_MIC64;
-    ctx->key_id_mode = IEEE802154_SCF_KEYMODE_IMPLICIT;
+    ctx->security_level = IEEE802154_SEC_SCF_SECLEVEL_ENC_MIC64;
+    ctx->key_id_mode = IEEE802154_SEC_SCF_KEYMODE_IMPLICIT;
     memset(ctx->key_source, 0, sizeof(ctx->key_source));
     ctx->key_index = 0;
     ctx->frame_counter = 0;
-    uint8_t key[] = IEEE802154_DEFAULT_KEY;
-
+    uint8_t key[] = IEEE802154_SEC_DEFAULT_KEY;
     assert(CIPHER_MAX_CONTEXT_SIZE >= IEEE802154_SEC_KEY_LENGTH);
     cipher_init(&ctx->cipher, CIPHER_AES_128, key, IEEE802154_SEC_KEY_LENGTH);
 }
@@ -417,7 +416,7 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
        ACKs are not encrypted. */
     assert((*((uint8_t *)header)) & IEEE802154_FCF_TYPE_DATA);
 
-    if (ctx->security_level == IEEE802154_SCF_SECLEVEL_NONE) {
+    if (ctx->security_level == IEEE802154_SEC_SCF_SECLEVEL_NONE) {
         *mic_size = 0;
         return IEEE802154_SEC_OK;
     }
@@ -428,7 +427,7 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
     }
 
     /* write the auxiliary header */
-    ieee802154_aux_sec_t *aux = (ieee802154_aux_sec_t *)(header + *header_size);
+    ieee802154_sec_aux_t *aux = (ieee802154_sec_aux_t *)(header + *header_size);
     uint8_t aux_size = _get_aux_hdr_size(ctx->security_level, ctx->key_id_mode);
     _set_aux_hdr(ctx, aux);
 
@@ -444,7 +443,7 @@ int ieee802154_sec_encrypt_frame(ieee802154_sec_context_t *ctx,
     uint8_t *m = payload;
     uint16_t a_len = *header_size + aux_size;
     uint16_t m_len = payload_size;
-    ieee802154_ccm_block_t ccm; /* Ai or Bi */
+    ieee802154_sec_ccm_block_t ccm; /* Ai or Bi */
 
     /* compute MIC */
     if (_req_mac(ctx->security_level)) {
@@ -477,7 +476,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     assert(*header & IEEE802154_FCF_TYPE_DATA);
 
     /* read the fields of the auxiliary header */
-    ieee802154_aux_sec_t *aux = (ieee802154_aux_sec_t *)(header + *header_size);
+    ieee802154_sec_aux_t *aux = (ieee802154_sec_aux_t *)(header + *header_size);
     uint8_t security_level = _get_sec_level(aux->scf);
     uint8_t key_mode = _get_key_id_mode(aux->scf);
     uint8_t aux_size = _get_aux_hdr_size(security_level, key_mode);
@@ -485,7 +484,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     /* remember that the frame counter was stored in little endian */
     uint32_t frame_counter = byteorder_ltohl((le_uint32_t){aux->fc});
 
-    if (security_level == IEEE802154_SCF_SECLEVEL_NONE) {
+    if (security_level == IEEE802154_SEC_SCF_SECLEVEL_NONE) {
         *payload = header + *header_size;
         *payload_size = frame_size - *header_size;
         *mic = NULL;
@@ -510,7 +509,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     uint16_t a_len = *header_size + aux_size;
     uint16_t c_len = *payload_size;
     uint8_t *mac = *mic;
-    ieee802154_ccm_block_t ccm; /* Ai or Bi */
+    ieee802154_sec_ccm_block_t ccm; /* Ai or Bi */
 
     /* TODO:
        A better implementation would check if the received frame counter is
@@ -531,7 +530,7 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
     }
     /* check MIC */
     if (_req_mac(security_level)) {
-        uint8_t tmp_mic[IEEE802154_MAC_SIZE];
+        uint8_t tmp_mic[IEEE802154_SEC_MAX_MAC_SIZE];
         _init_cbc_B0(&ccm, frame_counter, security_level, c_len, mac_size, src_address);
         _comp_mic(ctx, tmp_mic, &ccm, a, a_len, c, c_len);
         if (memcmp(tmp_mic, *mic, mac_size)) {

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -178,7 +178,7 @@ static inline bool _req_encryption(uint8_t sec_level)
 static inline void _memxor(void *dst, const void* src, size_t size)
 {
     while (size--) {
-        ((uint8_t *)dst)[size] ^= ((uint8_t *)src)[size];
+        ((uint8_t *)dst)[size] ^= ((const uint8_t *)src)[size];
     }
 }
 

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -208,7 +208,7 @@ static uint8_t _set_aux_hdr(const ieee802154_sec_context_t *ctx,
             break;
         case IEEE802154_SCF_KEYMODE_HW_INDEX:
             memcpy(ahr->key_id, ctx->key_source, 8);
-            memcpy(ahr->key_id + 4, &ctx->key_index, 1);
+            memcpy(ahr->key_id + 8, &ctx->key_index, 1);
             len += 9;
             break;
         default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While working on replay protection I found 3 things that I want to fix. 
This PR does three things:
1. Remove `NETOPT_ENCRYPTION_KEY` from the `at86rf2xx` driver.
It was redundant because the IEEE 802.15.4 `netdev` driver also sets the key and
the IEEE 802.15.4 security implementation transfers the key to the hardware if required. 

2.  Fix a small copy paste bug.
Luckily the code segment was not executed because we only use the implicit key mode so far.

3. Stricter prefixing of types and constants with `ieee802154_sec_`

No change of functionality.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
works as before
```
2021-02-28 10:23:12,699 # ifconfig 6 set key 00112233445566778899aabbccddeeff
2021-02-28 10:23:12,699 # 
2021-02-28 10:23:12,705 # Notice: setting 128 bit key.success: set encryption key on interface 6 to 
2021-02-28 10:23:12,708 # 00112233445566778899001122334455
```
```
2021-02-28 10:22:55,358 # ifconfig 6 set key 00112233445566778899aabbccddeeff
2021-02-28 10:22:55,359 # 
2021-02-28 10:22:55,365 # Notice: setting 128 bit key.success: set encryption key on interface 6 to 
2021-02-28 10:22:55,368 # 00112233445566778899001122334455
ping6 fe80::fc0f:9087:caff:ef38
2021-02-28 10:23:18,738 # ping6 fe80::fc0f:9087:caff:ef38
2021-02-28 10:23:18,759 # 12 bytes from fe80::fc0f:9087:caff:ef38%6: icmp_seq=0 ttl=64 rssi=-58 dBm time=13.317 ms
2021-02-28 10:23:19,751 # 12 bytes from fe80::fc0f:9087:caff:ef38%6: icmp_seq=1 ttl=64 rssi=-58 dBm time=12.026 ms
2021-02-28 10:23:20,745 # 12 bytes from fe80::fc0f:9087:caff:ef38%6: icmp_seq=2 ttl=64 rssi=-58 dBm time=15.237 ms
2021-02-28 10:23:20,746 # 
2021-02-28 10:23:20,750 # --- fe80::fc0f:9087:caff:ef38 PING statistics ---
2021-02-28 10:23:20,755 # 3 packets transmitted, 3 packets received, 0% packet loss
2021-02-28 10:23:20,759 # round-trip min/avg/max = 12.026/13.526/15.237 ms

```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
