### PR TITLE
tools/insufficient_memory: add create_makefile.ci.sh and Makefile.ci make target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -201,6 +201,7 @@ GLOBAL_GOALS += buildtest \
                 info-boards-features-missing \
                 info-boards-supported \
                 info-buildsizes info-buildsizes-diff \
+                Makefile.ci \
                 #
 
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))

--- a/dist/tools/insufficient_memory/create_makefile.ci.sh
+++ b/dist/tools/insufficient_memory/create_makefile.ci.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 Benjamin Valentin <benjamin.valentin@ml-pa.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+MAKE_ARGS="-j4"
+APP_DIR=$(pwd)
+
+if tput colors &> /dev/null && [ "$(tput colors)" -ge 8 ]; then
+    COK="\e[1;32m"
+    CBIG="\e[1;34m"
+    CNORMAL="\e[1m"
+    CSKIP="\e[1;36m"
+    CERROR="\e[1;31m"
+    CWARN="\e[1;33m"
+    CRESET="\e[0m"
+else
+    COK=
+    CBIG=
+    CNORMAL=
+    CSKIP=
+    CERROR=
+    CWARN=
+    CRESET=
+fi
+
+if [ "$1" == "--no-docker" ]; then
+    LOCAL_MAKE_ARGS=${MAKE_ARGS}
+    shift 1
+else
+    # Use a standardized build within Docker and with minimal output
+    export DOCKER_MAKE_ARGS=${MAKE_ARGS}
+    export BUILD_IN_DOCKER=1
+fi
+
+export RIOT_CI_BUILD=1
+
+BOARDS=
+
+rm "${APP_DIR}/Makefile.ci" 2>/dev/null
+touch "${APP_DIR}/Makefile.ci"
+
+for BOARD in $(make  --no-print-directory info-boards-supported -C "${APP_DIR}"); do
+    printf "${CNORMAL}%-40s${CRESET}" "${BOARD}"
+    output=$(make BOARD="${BOARD}" ${LOCAL_MAKE_ARGS} clean all -C "${APP_DIR}" 2>&1)
+    if [ "$?" != 0 ]; then
+        if echo "${output}" | grep -e overflowed -e "not within region" > /dev/null; then
+            printf "${CBIG}%s${CRESET}\n" "too big"
+            BOARDS="${BOARDS} ${BOARD}"
+        elif echo "${output}" | grep -e "not whitelisted" -e "unsatisfied feature requirements" > /dev/null; then
+            printf "${CWARN}%s${CRESET}\n" "not supported"
+        else
+            printf "${CERROR}%s${CRESET}\n" "build failed"
+        fi
+    else
+        if echo "${output}" | grep -e "skipping link step" > /dev/null; then
+            printf "${CSKIP}%s${CRESET}\n" "skipped"
+        else
+            printf "${COK}%s${CRESET}\n" "OK"
+        fi
+    fi
+done
+
+rm "${APP_DIR}/Makefile.ci"
+make -f "$(dirname "$0")"/Makefile.for_sh DIR="${APP_DIR}" BOARD="${BOARDS}" Makefile.ci > /dev/null

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -143,6 +143,9 @@ info-boards-features-blacklisted:
 info-boards-features-conflicting:
 	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
 
+Makefile.ci:
+	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh --no-docker
+
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only
 # needed for buildtests.inc.mk
 BOARDDIR := $(BOARDDIR_GLOBAL)

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -5,6 +5,7 @@
         info-debug-variable-% info-toolchains-supported \
         check-toolchain-supported \
         info-programmers-supported \
+        Makefile.ci \
         #
 
 info-objsize:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

For adding a new board we have `add_insufficient_memory_board.sh` to automatically update all `Makefile.ci` lists for tests that do not fit the memory of the CPU.

This adds a similar script for doing the same when adding / modifying a test and generates a `Makefile.ci` by compiling the application for all supported boards.

### Testing procedure

For any test / application run

    rm Makefile.ci
    make Makefile.ci

In the end, a new `Makefile.ci` should be created that is indistinguishable from the original one, if that one was correct.

### Issues/PRs references


