### PR TITLE
congure_test: make shell commands shorter

### DIFF
--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -350,6 +350,14 @@ const shell_command_t _shell_command_list[] = {
       congure_test_call_init },
     { "cong_imi", "Calls inter_message_interval method of the CongURE state object",
       congure_test_call_inter_msg_interval },
+    { "cong_add_msg",
+      "Adds a message to the list of messages to be reported with "
+      "report_msgs_lost or report_msgs_timeout",
+      congure_test_add_msg },
+    { "cong_msgs_reset",
+      "Resets the list of messages to be reported with report_msgs_lost or "
+      "report_msgs_timeout",
+      congure_test_msgs_reset },
     { "cong_report", "Calls a report_* method of the CongURE state object",
       congure_test_call_report },
 #endif

--- a/tests/congure_test/main.c
+++ b/tests/congure_test/main.c
@@ -240,6 +240,9 @@ static void _print_report_msgs_lost_state(void)
 
 static void _print_report_msg_acked_state(void)
 {
+    clist_node_t msgs = {
+        .next = &_congure_state.report_msg_acked_args.msg->super,
+    };
     print_str("\"report_msg_acked\":{");
 
     print_str("\"calls\":");
@@ -252,13 +255,12 @@ static void _print_report_msg_acked_state(void)
     print_u32_hex((intptr_t)_congure_state.report_msg_acked_args.c);
     print_str("\",");
 
-    assert((_congure_state.report_msg_acked_args.msg == NULL) ||
-           (_congure_state.report_msg_acked_args.msg->super.next == NULL));
+    /* Check sanity of `congure_test` internal message list: `cong_msg_add`
+     * should have been only called at most once by the test script */
+    assert(clist_count(&msgs) < 2);
     print_str("\"msg\":");
     if (_congure_state.report_msg_acked_args.msg) {
-        _print_congure_snd_msg(
-            (clist_node_t *)_congure_state.report_msg_acked_args.msg, NULL
-        );
+        _print_congure_snd_msg(msgs.next, NULL);
     }
     else {
         print_str("null,");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The current version of `congure_tests` uses quite a lot of arguments which can be problematic, if e.g. the UART-USB-converter on a board does not support such long inputs. This splits up of those commands, by filling a central argument list. Since this framework is meant to be used with a test script only anyways, I don't think this extra step would make a problem.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```console
$ make -C tests/congure_test -j flash test
```

should still succeed for any board.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/15953#issuecomment-786857059

Required for #15952 and #15953.

![PR dependency graph](https://page.mi.fu-berlin.de/mlenders/congure.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
