### PR TITLE
sys/net/app/cord: Update to RD draft -27

### DIFF
--- a/examples/cord_ep/README.md
+++ b/examples/cord_ep/README.md
@@ -4,7 +4,7 @@ CoRE Resource Directory: Endpoint Example
 This example application demonstrates the usage of RIOT's Resource Directory
 (RD) endpoint module, called `cord_ep`. This module supports the registration,
 update, and removal procedures as defined in
-[draft-ietf-core-resource-directory-15](https://tools.ietf.org/html/draft-ietf-core-resource-directory-15).
+[draft-ietf-core-resource-directory-27](https://tools.ietf.org/html/draft-ietf-core-resource-directory-27).
 
 Usage
 =====

--- a/examples/cord_epsim/Makefile
+++ b/examples/cord_epsim/Makefile
@@ -32,8 +32,8 @@ CFLAGS += -DRD_ADDR=$(RD_ADDR)
 
 include $(RIOTBASE)/Makefile.include
 
-# For debugging and demonstration purposes, we limit the lifetime to the minimal
-# allowed value of 60s (see draft-ietf-core-resource-directory-11, Table 2)
+# For debugging and demonstration purposes, we limit the lifetime to just one
+# minute
 RD_LT ?= 60
 
 # Set CONFIG_CORD_LT only if not being set via Kconfig

--- a/examples/cord_epsim/README.md
+++ b/examples/cord_epsim/README.md
@@ -3,7 +3,7 @@ CoRE Resource Directory: Simple Endpoint Example
 
 This example shows how a node can register with a CoRE resource directory using
 the simple registration procedure as described in
-draft-ietf-core-resource-directory-15, section 5.3.1.
+draft-ietf-core-resource-directory-27, section 5.1.
 
 When running this example, you **must** define the RD server's IPv6 address
 statically, using the `RD_ADDR` environment variable:

--- a/examples/cord_lc/README.md
+++ b/examples/cord_lc/README.md
@@ -4,7 +4,7 @@ CoRE Resource Directory: Lookup Example
 This example application demonstrates the usage of RIOT's Resource Directory
 (RD) lookup module, called `cord_lc`. This module supports the lookup of
 resources and endpoints as defined in
-[draft-ietf-core-resource-directory-20](https://tools.ietf.org/html/draft-ietf-core-resource-directory-23).
+[draft-ietf-core-resource-directory-27](https://tools.ietf.org/html/draft-ietf-core-resource-directory-27).
 The lookup can be done in two modes: a) raw: result of the lookup is returned
 as is. b) pre-parsed: result of the lookup is parsed and only one link is
 returned for each call.

--- a/sys/include/net/cord/ep.h
+++ b/sys/include/net/cord/ep.h
@@ -14,8 +14,8 @@
  * This module implements a CoRE Resource Directory endpoint library, that
  * allows RIOT nodes to register themselves with resource directories.
  * It implements the standard endpoint functionality as defined in
- * draft-ietf-core-resource-directory-15.
- * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-15
+ * draft-ietf-core-resource-directory-27.
+ * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-27
  *
  * # Design Decisions
  * - all operations provided by this module are fully synchronous, meaning that

--- a/sys/include/net/cord/lc.h
+++ b/sys/include/net/cord/lc.h
@@ -15,8 +15,8 @@
  * allows RIOT nodes to lookup resources, endpoints and groups with resource
  * directories.
  * It implements the standard lookup functionality as defined in
- * draft-ietf-core-resource-directory-23.
- * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-23
+ * draft-ietf-core-resource-directory-27.
+ * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-27
  *
  * ## Lookup modes
  *

--- a/sys/net/application_layer/cord/doc.txt
+++ b/sys/net/application_layer/cord/doc.txt
@@ -15,11 +15,11 @@
  * # About
  * The `cord` ([Co]RE [R]esource [D]irectory) module provides endpoint and
  * lookup client functionality for interacting with CoRE Resource Directories
- * (RDs) as defined in `draft-ietf-core-resource-directory-15`.
+ * (RDs) as defined in `draft-ietf-core-resource-directory-27`.
  *
- * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-15
+ * @see https://tools.ietf.org/html/draft-ietf-core-resource-directory-27
  *
- * `draft-ietf-core-resource-directory-15` defines two types different roles for
+ * `draft-ietf-core-resource-directory-27` defines two types different roles for
  * nodes when interacting with a RD:
  * - `endpoint`: registers and manages entries at the RD
  * - `client`: performs different kind of lookups
@@ -39,7 +39,7 @@
  *   | EP |----      |                 |
  *   +----+
  * ```
- * Figure copied form `draft-ietf-core-resource-directory-15`.
+ * Figure copied form `draft-ietf-core-resource-directory-27`.
  *
  * @note In the context of this module, we refer to these roles as `endpoint
  *       (ep)` and `lookup client (lc)`. This should hopefully prevent some
@@ -49,7 +49,7 @@
  * # Structure
  *
  * This module is structured in a number of submodules with goal to reflect the
- * different roles described in `draft-ietf-core-resource-directory-15`:
+ * different roles described in `draft-ietf-core-resource-directory-27`:
  *
  * - `cord_ep`:     standard endpoint implementation following the rules as
  *                  defined i.a. in sections 5.2, 5.3, A.1, and A.2

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -55,7 +55,7 @@ int cord_epsim_register(const sock_udp_ep_t *rd_ep)
 
     /* build the initial CON packet */
     if (gcoap_req_init(&pkt, buf, sizeof(buf), COAP_METHOD_POST,
-                             "/.well-known/core") < 0) {
+                             "/.well-known/rd") < 0) {
         return CORD_EPSIM_ERROR;
     }
     /* make packet confirmable */


### PR DESCRIPTION
### Contribution description

This enacts the one actual change since this was written (which is, simple registrations go to /.well-known/rd rather than /.well-known/core).

The remaining changes are just updating the references to -27 (updating sections and comments as needed). Unless the RFC editor changes anything about sections, the updated numbers can stay.

### Testing procedure

* [Install latest aiocoap from git](https://aiocoap.readthedocs.io/en/latest/installation.html)
* Run `./aiocoap-rd`
* Run the `examples/cord_epsim` example
* Watch aiocoap-rd's output: It does not warn about a client registering with the old .well-known/core name any more.

(but the code change is really minimal, so looking at the code change might be good enough.)