### PR TITLE
sys/net/app/cord: Support the addition of extra registration arguments

### DIFF
--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -91,6 +91,22 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   Extra query parameters added during registration
+ *
+ * Must be suitable for constructing a static array out of them.
+ *
+ * Example:
+ *
+ * ```
+ * CFLAGS += '-DCONFIG_CORD_EXTRAARGS="proxy=on","et=tag:riot-os.org,2020:board"'
+ * ```
+ */
+#ifdef DOXYGEN
+#define CONFIG_CORD_EXTRAARGS
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/application_layer/cord/common/cord_common.c
+++ b/sys/net/application_layer/cord/common/cord_common.c
@@ -79,5 +79,15 @@ int cord_common_add_qstring(coap_pkt_t *pkt)
     }
 #endif
 
+#ifdef CONFIG_CORD_EXTRAARGS
+    static const char *extra[] = { CONFIG_CORD_EXTRAARGS };
+    for (unsigned i = 0; i < ARRAY_SIZE(extra); ++i) {
+        res = coap_opt_add_uri_query(pkt, extra[i], NULL);
+        if (res < 0) {
+            return res;
+        }
+    }
+#endif
+
     return 0;
 }


### PR DESCRIPTION
### Contribution description

Registations at a Resouirce Directory can have extra arguments; this is useful for example to ask an RD to reverse-proxy you.

### Testing procedure

With a board that gets a route to the Internet, add the following config to one of `examples/cord_ep` or `examples/cord_epsim`, and run it.

```patch
+CFLAGS += '-DCONFIG_CORD_EXTRAARGS="proxy=on","et=tag:riot-os.org,2020:board"'
+CFLAGS += '-DCONFIG_CORD_EP="myhost"'
```

The `epsim` version also needs

```patch
-RD_ADDR ?= \"[affe::1]\"
+RD_ADDR ?= \"[2a01:4f8:190:3064::5]\"
```

whereas the non-simple version needs the command

```
> cord_ep register [2a01:4f8:190:3064::5]
```

executed.

Then, you should see your device registering with a synthetic proxy URI (courtesy of the `proxy=on` argument) in the public RD indicated by the addresses:

```shell
$ ./aiocoap-client coap://rd.coap.amsuess.com/endpoint-lookup/ --observe
</reg/2/>; ep="myhost"; et="tag:riot-os.org,2020:board"; base="coap://myhost.proxy.rd.coap.amsuess.com"; rt="core.rd-ep"
```

(The endpoint name is added manually because this particular RD refuses proxying for devices with non-lowercase endpoint IDs to avoid the hassle of disambiguating the case insensitive host names).

### Issues/PRs references

<del>This has all the commits of #16112 in it (as the simple version would otherwise register to an outdated address); the latest commit is what counts.</del>

[edit: all dependencies merged, only single commit left over]