### PR TITLE
makefiles/libc/picolibc.mk: only fail when building

### DIFF
--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -7,12 +7,18 @@ ifneq (,$(filter picolibc,$(USEMODULE)))
         LINKFLAGS += -Wl,--no-wchar-size-warning
     endif
   else
-    $(warning picolibc was selected to be build but no picolibc.spec could be found)
-    $(warning you might want to install "picolibc" for "$(TARGET_ARCH)")
-    $(warning or add "FEATURES_BLACKLIST += picolibc" to Makefile)
-    $(error   check your installation or build configuration.)
+    BUILDDEPS += _missing-picolibc
   endif
 endif
+
+.PHONY: _missing-picolibc
+
+_missing-picolibc:
+	@$(Q)echo "picolibc was selected to be build but no picolibc.spec could be found"
+	@$(Q)echo "you might want to install "picolibc" for "$(TARGET_ARCH)""
+	@$(Q)echo "or add "FEATURES_BLACKLIST += picolibc" to Makefile)"
+	@$(COLOR_ECHO) "$(COLOR_RED)check your installation or build configuration."
+	@$(Q)exit 1
 
 ifeq (1,$(USE_PICOLIBC))
   LINKFLAGS += -specs=picolibc.specs


### PR DESCRIPTION


### Contribution description

With #16008 an error is outputted whenever a build is attempted with missing `picolibc`. Issue is this check runs always and does when querying build_system variables,eg:

```
BOARD=iotlab-m3 RIOT_CI_BUILD=1 make -C examples/gnrc_minimal info-debug-variable-BOARD_INSUFFICIENT_MEMORY 
/home/francisco/workspace/RIOT/makefiles/libc/picolibc.mk:10: picolibc was selected to be build but no picolibc.spec could be found
/home/francisco/workspace/RIOT/makefiles/libc/picolibc.mk:11: you might want to install "picolibc" for "arm-none-eabi"
/home/francisco/workspace/RIOT/makefiles/libc/picolibc.mk:12: or add "FEATURES_BLACKLIST += picolibc" to Makefile
/home/francisco/workspace/RIOT/makefiles/libc/picolibc.mk:13: *** check your installation or build configuration..  Stop.
```

This is not desirable since it interferes with a lot of scripts which will exit early, e.g.: `compile_and_test_for_board` as seen here https://github.com/RIOT-OS/RIOT/actions/runs/608883211.

This PR refactor the error a bit to run only when building and so is added to `BUILDDEPS`

### Testing procedure

- works in docker:

```
BUILD_IN_DOCKER=1 BOARD=samr21-xpro make -C examples/gnrc_minimal/ all
```

- fails when toolchain is not installed

```
BOARD=samr21-xpro make -C examples/gnrc_minimal/
Building application "gnrc_minimal" for "samr21-xpro" with MCU "samd21".

picolibc was selected to be build but no picolibc.spec could be found
you might want to install picolibc for arm-none-eabi
or add FEATURES_BLACKLIST += picolibc to Makefile)
check your installation or build configuration.
make: *** [/home/francisco/workspace/RIOT/makefiles/libc/picolibc.mk:21: _missing-picolibc] Error 1
```

- with `compile_and_test_for_boards` only the indivusal build fails:

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . samr21-xpro --applications="examples/hello_world examples/gnrc_minimal tests/bloom_bytes"
INFO:samr21-xpro:Saving toolchain
INFO:samr21-xpro.examples/gnrc_minimal:Board supported: True
INFO:samr21-xpro.examples/gnrc_minimal:Board has enough memory: True
INFO:samr21-xpro.examples/gnrc_minimal:Application has test: False
INFO:samr21-xpro.examples/gnrc_minimal:Run compilation
WARNING:samr21-xpro.examples/gnrc_minimal:make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C ./examples/gnrc_minimal clean all
Building application "gnrc_minimal" for "samr21-xpro" with MCU "samd21".

picolibc was selected to be build but no picolibc.spec could be found
you might want to install picolibc for arm-none-eabi
or add FEATURES_BLACKLIST += picolibc to Makefile)
check your installation or build configuration.
make: *** [/home/francisco/workspace/RIOT/makefiles/libc/picolibc.mk:21: _missing-picolibc] Error 1

Return value: 2

ERROR:samr21-xpro.examples/gnrc_minimal:Error during compilation, writing to results/samr21-xpro/examples/gnrc_minimal/compilation.failed
ERROR:samr21-xpro.examples/gnrc_minimal:Failed during: compilation
INFO:samr21-xpro.tests/bloom_bytes:Board supported: True
INFO:samr21-xpro.tests/bloom_bytes:Board has enough memory: True
INFO:samr21-xpro.tests/bloom_bytes:Application has test: True
INFO:samr21-xpro.tests/bloom_bytes:Run compilation
INFO:samr21-xpro.tests/bloom_bytes:Run test
INFO:samr21-xpro.tests/bloom_bytes:Run test.flash
WARNING:samr21-xpro.tests/bloom_bytes:make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C ./tests/bloom_bytes flash-only
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /home/francisco/workspace/RIOT/dist/tools/edbg
env -i PATH="/home/francisco/.cargo/bin:/home/francisco/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/francisco/opt/rpi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin:/home/francisco/opt/aiocoap/contrib:/home/francisco/Android/Sdk/tools:/home/francisco/Android/Sdk/platform-tools:/home/francisco/.local/bin:/home/francisco/.local/lib:/home/francisco/workspace/android-studio:/home/francisco/opt/joe:/opt/gcc-arm-none-eabi-10-2020-q2-preview/bin:/home/francisco/opt/msp430-gcc-8.2.0.52_linux64/bin:/home/francisco/opt/esp/esptool-esp8266-rtos-sdk-v3:/home/francisco/opt/esp/xtensa-lx106-elf/bin:/home/francisco/opt/gnu-mcu-eclipse/riscv-none-gcc/8.2.0-2.2-20190521-0004/bin:/opt/mattermost-desktop-4.5.0-linux-x64:/home/francisco/opt/renode_portable:/home/francisco/opt/balena-cli:/home/francisco/.cargo/bin" TERM="xterm-256color" "make" -C "/home/francisco/workspace/RIOT/dist/tools/edbg/bin"
make: Entering directory '/home/francisco/workspace/RIOT/dist/tools/edbg/bin'
gcc -W -Wall -Wextra -O2 -std=gnu11 dap.c edbg.c target.c target_atmel_cm0p.c target_atmel_cm3.c target_atmel_cm4.c target_atmel_cm7.c target_atmel_cm4v2.c target_mchp_cm23.c target_st_stm32g0.c target_gd_gd32f4xx.c  dbg_lin.c -ludev -o edbg
make: Leaving directory '/home/francisco/workspace/RIOT/dist/tools/edbg/bin'
mv /home/francisco/workspace/RIOT/dist/tools/edbg/bin/edbg .
[INFO] edbg binary successfully built!
/home/francisco/workspace/RIOT/dist/tools/edbg/edbg.sh flash /home/francisco/workspace/RIOT/tests/bloom_bytes/bin/samr21-xpro/tests_bloom_bytes.bin
### Flashing Target ###
Error: no debuggers found
Error: no debuggers found
make: *** [/home/francisco/workspace/RIOT/tests/bloom_bytes/../../Makefile.include:729: flash-only] Error 1

Return value: 2

ERROR:samr21-xpro.tests/bloom_bytes:Error during test.flash, writing to results/samr21-xpro/tests/bloom_bytes/test.flash.failed
ERROR:samr21-xpro.tests/bloom_bytes:Failed during: test.flash
ERROR:samr21-xpro:Tests failed: 2
Failures during compilation:
- [examples/gnrc_minimal](examples/gnrc_minimal/compilation.failed)

Failures during test.flash:
- [tests/bloom_bytes](tests/bloom_bytes/test.flash.failed)
```

### Issues/PRs references

Related to #16008 
