### PR TITLE
pkg/wolfssl: bump version to 4.7.0

### DIFF
--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=wolfssl
 PKG_URL=https://github.com/wolfssl/wolfssl.git
-PKG_VERSION=0fa5af9929ce2ee99e8789996a3048f41a99830e # v4.5.0
+PKG_VERSION=830de9a9fb99e30f9ac9caa0a7f7bba29c3b4863 # v4.7.0
 PKG_LICENSE=GPLv2
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/wolfssl/Makefile.wolfcrypt
+++ b/pkg/wolfssl/Makefile.wolfcrypt
@@ -1,6 +1,7 @@
 MODULE = wolfcrypt
 
 CFLAGS += -Wno-unused
+CFLAGS += -Wno-pedantic
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-unused-parameter

--- a/pkg/wolfssl/include/user_settings.h
+++ b/pkg/wolfssl/include/user_settings.h
@@ -28,6 +28,8 @@ extern "C" {
 
 /* Single precision math */
 #define WOLFSSL_SP_MATH
+#define WOLFSSL_SP_MATH_ALL
+#define WOLFSSL_SP_INT_NEGATIVE
 #define WOLFSSL_SP_SMALL
 #define SP_WORD_SIZE 32
 #define WOLFSSL_SP

--- a/pkg/wolfssl/patches/0001-test.c-remove-extra.patch
+++ b/pkg/wolfssl/patches/0001-test.c-remove-extra.patch
@@ -1,0 +1,30 @@
+From e1d686956cb139c43351e0c79210e5fe4b82c3db Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benpicco@googlemail.com>
+Date: Mon, 1 Mar 2021 20:45:27 +0100
+Subject: [PATCH] test.c: remove extra ;
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+error: ISO C does not allow extra ‘;’ outside of a function [-Werror=pedantic]
+   93 | _Pragma("GCC diagnostic ignored \"-Wunused-function\"");
+---
+ wolfcrypt/test/test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wolfcrypt/test/test.c b/wolfcrypt/test/test.c
+index 952628830..c2fc06f8e 100644
+--- a/wolfcrypt/test/test.c
++++ b/wolfcrypt/test/test.c
+@@ -90,7 +90,7 @@
+ #endif
+ 
+ #ifdef __GNUC__
+-_Pragma("GCC diagnostic ignored \"-Wunused-function\"");
++_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+ #endif
+ 
+ #ifdef USE_FLAT_TEST_H
+-- 
+2.27.0
+

--- a/tests/pkg_wolfssl/Makefile
+++ b/tests/pkg_wolfssl/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 # This is an optimized stack value based on testing, if you observe
 # a segmentation fault please increase this stack size.
-CFLAGS += -DTHREAD_STACKSIZE_MAIN=2*THREAD_STACKSIZE_LARGE
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=3*THREAD_STACKSIZE_LARGE
 
 USEPKG += wolfssl
 USEMODULE += wolfcrypt wolfcrypt-test wolfcrypt_sha512 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Update to the latest upstream release

https://www.wolfssl.com/docs/wolfssl-changelog/


### Testing procedure

`tests/pkg_wolfssl` should still pass.

#### same54-xpro

```
2021-03-05 18:20:41,946 # wolfSSL Crypto Test!
2021-03-05 18:20:42,953 # ------------------------------------------------------------------------------
2021-03-05 18:20:42,955 #  wolfSSL version 4.7.0
2021-03-05 18:20:42,962 # ------------------------------------------------------------------------------
2021-03-05 18:20:42,966 # error    test passed!
2021-03-05 18:20:42,968 # MEMORY   test passed!
2021-03-05 18:20:42,970 # base64   test passed!
2021-03-05 18:20:42,972 # asn      test passed!
2021-03-05 18:20:42,979 # RANDOM   test passed!
2021-03-05 18:20:43,023 # SHA-256  test passed!
2021-03-05 18:20:43,169 # SHA-384  test passed!
2021-03-05 18:20:43,314 # SHA-512  test passed!
2021-03-05 18:20:43,317 # Hash     test passed!
2021-03-05 18:20:43,319 # HC-128   test passed!
2021-03-05 18:20:43,321 # Chacha   test passed!
2021-03-05 18:20:43,323 # POLY1305 test passed!
2021-03-05 18:20:43,327 # ChaCha20-Poly1305 AEAD test passed!
2021-03-05 18:20:43,329 # AES      test passed!
2021-03-05 18:20:43,331 # AES192   test passed!
2021-03-05 18:20:43,333 # AES256   test passed!
2021-03-05 18:20:51,619 # ECC      test passed!
2021-03-05 18:20:52,485 # ECC buffer test passed!
2021-03-05 18:20:57,201 # CURVE25519 test passed!
2021-03-05 18:21:29,709 # ED25519  test passed!
2021-03-05 18:21:29,711 # logging  test passed!
2021-03-05 18:21:29,713 # mutex    test passed!
2021-03-05 18:21:29,714 # Test complete
2021-03-05 18:21:29,716 # wolfSSL Benchmark!
2021-03-05 18:21:29,722 # ------------------------------------------------------------------------------
2021-03-05 18:21:29,724 #  wolfSSL version 4.7.0
2021-03-05 18:21:29,731 # ------------------------------------------------------------------------------
2021-03-05 18:21:29,736 # wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
2021-03-05 18:21:30,754 # RNG                925 KB took 1.010 seconds,  916.269 KB/s
2021-03-05 18:21:31,762 # AES-128-CBC-enc    825 KB took 1.002 seconds,  823.472 KB/s
2021-03-05 18:21:32,788 # AES-128-CBC-dec    775 KB took 1.021 seconds,  759.267 KB/s
2021-03-05 18:21:33,818 # AES-192-CBC-enc    650 KB took 1.025 seconds,  634.371 KB/s
2021-03-05 18:21:34,834 # AES-192-CBC-dec    600 KB took 1.011 seconds,  593.686 KB/s
2021-03-05 18:21:35,881 # AES-256-CBC-enc    550 KB took 1.041 seconds,  528.260 KB/s
2021-03-05 18:21:36,910 # AES-256-CBC-dec    500 KB took 1.023 seconds,  488.577 KB/s
2021-03-05 18:21:37,919 # CHACHA               3 MB took 1.004 seconds,    3.454 MB/s
2021-03-05 18:21:38,928 # CHA-POLY             2 MB took 1.004 seconds,    2.334 MB/s
2021-03-05 18:21:39,934 # POLY1305            10 MB took 1.000 seconds,    9.838 MB/s
2021-03-05 18:21:40,941 # SHA-256              2 MB took 1.001 seconds,    2.316 MB/s
2021-03-05 18:21:41,978 # SHA-384            725 KB took 1.032 seconds,  702.654 KB/s
2021-03-05 18:21:43,015 # SHA-512            725 KB took 1.032 seconds,  702.679 KB/s
2021-03-05 18:21:44,169 # ECC   [      SECP256R1]   256 key gen         4 ops took 1.145 sec, avg 286.261 ms, 3.493 ops/sec
2021-03-05 18:21:45,895 # ECDHE [      SECP256R1]   256 agree           4 ops took 1.145 sec, avg 286.179 ms, 3.494 ops/sec
2021-03-05 18:21:47,118 # ECDSA [      SECP256R1]   256 sign            4 ops took 1.214 sec, avg 303.458 ms, 3.295 ops/sec
2021-03-05 18:21:48,245 # ECDSA [      SECP256R1]   256 verify          2 ops took 1.118 sec, avg 559.143 ms, 1.788 ops/sec
2021-03-05 18:21:49,542 # CURVE  25519 key gen         3 ops took 1.290 sec, avg 429.968 ms, 2.326 ops/sec
2021-03-05 18:21:52,120 # CURVE  25519 agree           4 ops took 1.711 sec, avg 427.746 ms, 2.338 ops/sec
2021-03-05 18:21:53,436 # ED     25519 key gen         3 ops took 1.308 sec, avg 436.055 ms, 2.293 ops/sec
2021-03-05 18:21:55,658 # ED     25519 sign            4 ops took 1.779 sec, avg 444.628 ms, 2.249 ops/sec
2021-03-05 18:21:57,487 # ED     25519 verify          2 ops took 1.822 sec, avg 910.872 ms, 1.098 ops/sec
2021-03-05 18:21:57,488 # Benchmark complete
```

### Issues/PRs references

upstream PR for the minor fix to `test.c`: https://github.com/wolfSSL/wolfssl/pull/3829
