### PR TITLE
gnrc_netif_lorawan: add missing NULL check [backport 2021.01]

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -92,6 +92,10 @@ void gnrc_lorawan_mcps_indication(gnrc_lorawan_t *mac, mcps_indication_t *ind)
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, ind->data.pkt->iol_base,
                                           ind->data.pkt->iol_len,
                                           GNRC_NETTYPE_LORAWAN);
+    if (!pkt) {
+        DEBUG("gnrc_lorawan: mcps_indication: couldn't allocate pktbuf\n");
+        return;
+    }
 
     if (!gnrc_netapi_dispatch_receive(GNRC_NETTYPE_LORAWAN, ind->data.port,
                                       pkt)) {


### PR DESCRIPTION
# Backport of #16110

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a missing NULL check when allocating a `gnrc_pktsnip_t` on reception. If the pktbuf is full, GNRC netif doesn't return immediately.

This PR fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Configure the Network Server to send a downlink to the node and try this patch:
```
diff --git a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
index c30519220f..a6fb79cb72 100644
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -26,7 +26,7 @@
 #include "net/loramac.h"
 #include "net/gnrc/netreg.h"
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 #include "debug.h"
 
 static uint8_t _nwkskey[LORAMAC_NWKSKEY_LEN];
@@ -91,7 +91,7 @@ void gnrc_lorawan_mcps_indication(gnrc_lorawan_t *mac, mcps_indication_t *ind)
 {
     (void)mac;
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, ind->data.pkt->iol_base,
-                                          ind->data.pkt->iol_len,
+                                          1024,
                                           GNRC_NETTYPE_LORAWAN);
     if (!pkt) {
         DEBUG("gnrc_lorawan: mcps_indication: couldn't allocate pktbuf\n");

```

It should print "gnrc_lorawan: mcps_indication: couldn't allocate pktbuf" when a packet is received
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
