### PR TITLE
makefiles/tools/programmer: do not use wrapper with pyocd

### DIFF
--- a/makefiles/tools/programmer.inc.mk
+++ b/makefiles/tools/programmer.inc.mk
@@ -5,10 +5,21 @@ ifeq (0,$(PROGRAMMER_QUIET))
   PROGRAMMER_VERBOSE_OPT ?= --verbose
 endif
 
+# When multiple debuggers are connected then pyocd shows an interactive
+# UI to select the user interface to flash, with the python wrapper this
+# is lost and will also cause the wrapper to hang waiting for user input.
+# As long as a similar functionality is not provided by the wrapper
+# then disable it for pyocd.
+PROGRAMMER_WRAPPER_BLACKLIST ?= pyocd
+
 # Don't use the programmer wrapper for the CI (where speed and verbose output
 # are important)
 ifneq (1,$(RIOT_CI_BUILD))
-  USE_PROGRAMMER_WRAPPER_SCRIPT ?= 1
+  ifneq (,$(filter $(PROGRAMMER),$(PROGRAMMER_WRAPPER_BLACKLIST)))
+    USE_PROGRAMMER_WRAPPER_SCRIPT ?= 0
+  else
+    USE_PROGRAMMER_WRAPPER_SCRIPT ?= 1
+  endif
 else
   USE_PROGRAMMER_WRAPPER_SCRIPT ?= 0
 endif


### PR DESCRIPTION
### Contribution description

As reported in https://github.com/RIOT-OS/RIOT/pull/15970#issuecomment-787498973, #15970 introduces a regression for the very specific case where pyocd is used with multiple debuggers. Since pyocd output is not verbose, the Python wrapper is
disabled with pyocd.

Similar functionality could be added to the wrapper script later on and this change reverted.

### Testing procedure

```
BOARD=nrf52840-mdk make -C examples/hello-world/ flash-only
/home/francisco/workspace/RIOT2/dist/tools/pyocd/pyocd.sh flash /home/francisco/workspace/RIOT2/examples/hello-world/bin/nrf52840-mdk/hello-world.hex
### Flashing Target ###
[====================] 100%
0002854:INFO:loader:Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 12288 bytes (3 pages) at 8.39 kB/s
Done flashing
```

### Issues/PRs references

