### PR TITLE
dist/tools/programmer: always print how to disable programmer wrapper

### DIFF
--- a/dist/tools/programmer/programmer.py
+++ b/dist/tools/programmer/programmer.py
@@ -33,6 +33,10 @@ class Programmer:
 
     def spin(self, process):
         """Print a spinning icon while programmer process is running."""
+        print(
+            "For full programmer output add PROGRAMMER_QUIET=0 or "
+            "QUIET=0 to the make command line."
+        )
         while process.poll() is None:
             for index in range(len(SPIN)):
                 sys.stdout.write(
@@ -59,11 +63,6 @@ class Programmer:
         # subprocess failed
         if process.returncode != 0:
             print(process.stdout.read().decode())
-        else:
-            print(
-                "(for full programmer output add PROGRAMMER_QUIET=0 or "
-                "QUIET=0 to the make command line)"
-            )
 
     def run(self):
         """Run the programmer in a background process."""


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If the help is only printed on failure, if the script does not detect failure
and programming still fails, the user has no idea how to get the full information.

Always print help on how to disable this feature.


### Testing procedure

The help text is now always printed.

```
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'edbg' - duration: 3.01s)
make BOARD=same54-xpro APP_VER=1612217220  -j flash  39,90s user 4,24s system 441% cpu 9,992 total
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
