### PR TITLE
tools/compile_and_test_for_board: fix lint [backport 2021.01]

### DIFF
--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -475,7 +475,7 @@ class RIOTApplication():
         if output is not None:
             if self.testcase:
                 self.testcase.stdout += output + '\n'
-            return output
+            return
 
         # Run setup-tasks, output is only kept in case of error
         for taskname, taskargs in setuptasks.items():
@@ -494,7 +494,6 @@ class RIOTApplication():
             if self.testcase:
                 self.testcase.stdout += output + '\n'
             self._write_resultfile(name, 'success', output)
-            return output
         except subprocess.CalledProcessError as err:
             self._make_handle_error(name, err)
 


### PR DESCRIPTION
# Backport of #16058

It seems this needs to be backported, in order to continue backporting other PRs to the latest release (see https://github.com/RIOT-OS/RIOT/pull/16120#issuecomment-788789395).
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A [new version of Pylint was released today](https://pypi.org/project/pylint/#history) and [this breaks the tools-test github action](https://github.com/RIOT-OS/RIOT/runs/1947401308?check_suite_focus=true) because of a small inconsistency in the compile_and_test_for_board script.

The raised issue is perfectly valid and this PR is fixing it by cleaning up a bit the `make_with_outfile` function. The return value of this function is never used so a bare return or no return is ok.

https://github.com/RIOT-OS/RIOT/blob/e0211f4574d08f2dac978a91a34a5842a7378491/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py#L410

https://github.com/RIOT-OS/RIOT/blob/e0211f4574d08f2dac978a91a34a5842a7378491/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py#L418-L419

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

compile_and_test_for_board.py works as expected:

<details>

```
$ ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications="tests/shell"
INFO:native:Saving toolchain
INFO:native.tests/shell:Board supported: True
INFO:native.tests/shell:Board has enough memory: True
INFO:native.tests/shell:Application has test: True
INFO:native.tests/shell:Run compilation
INFO:native.tests/shell:Run test
INFO:native.tests/shell:Run test.flash
INFO:native.tests/shell:Success
INFO:native:Tests successful
$ cat results/native/tests/shell/test.success 


/work/riot/RIOT/tests/shell/bin/native/tests_shell.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
test_shell.
> 
> 
> bufsize
bufsize
128
> ________________________________________________________________________________________________________________________________verylong
________________________________________________________________________________________________________________________________verylong
shell: maximum line length exceeded
> garbage1234
garbage1234
> 
> echo____________________________________________________________________________________________________________________________verylong
_________echo                                                                                                                           
"echo"
> 
shell exited
> 
> start_test
start_test
[TEST_START]
> 


> 
> echo a string
echo a string
"echo""a""string"
> echo   multiple   spaces   between   argv
echo   multiple   spaces   between   argv
"echo""multiple""spaces""between""argv"
> echo 	 tabs		 processed 		like	 		spaces
echo 	 tabs		 processed 		like	 		spaces
"echo""tabs""processed""like""spaces"
> unknown_command
unknown_command
shell: command not found: unknown_command
>      echo leading spaces
     echo leading spaces
"echo""leading""spaces"
> 					echo leading tabs
					echo leading tabs
"echo""leading""tabs"
> echo trailing spaces     
echo trailing spaces     
"echo""trailing""spaces"
> echo trailing tabs					
echo trailing tabs					
"echo""trailing""tabs"
> hello-world
hello-world
shell: command not found: hello-world
echo
echo
"echo"
> echo \'
echo \'
"echo""'"
> echo \"
echo \"
"echo""""
> echo escaped\ space
echo escaped\ space
"echo""escaped space"
> echo escape within '\s\i\n\g\l\e\q\u\o\t\e'
echo escape within '\s\i\n\g\l\e\q\u\o\t\e'
"echo""escape""within""singlequote"
> echo escape within "\d\o\u\b\l\e\q\u\o\t\e"
echo escape within "\d\o\u\b\l\e\q\u\o\t\e"
"echo""escape""within""doublequote"
> echo "t\e st" "\"" '\'' a\ b
echo "t\e st" "\"" '\'' a\ b
"echo""te st"""""'""a b"
> echo "hello"world
echo "hello"world
"echo""helloworld"
> echo hel"lowo"rld
echo hel"lowo"rld
"echo""helloworld"
> echo hello"world"
echo hello"world"
"echo""helloworld"
> echo quoted space " "
echo quoted space " "
"echo""quoted""space"" "
> echo abc"def'ghijk"lmn
echo abc"def'ghijk"lmn
"echo""abcdef'ghijklmn"
> echo abc'def"ghijk'lmn
echo abc'def"ghijk'lmn
"echo""abcdef"ghijklmn"
> echo "'" '"'
echo "'" '"'
"echo""'""""
> echo a\
echo a\
shell: incorrect quoting
> echo "
echo "
shell: incorrect quoting
> echo '
echo '
shell: incorrect quoting
> echo abcdef"ghijklmn
echo abcdef"ghijklmn
shell: incorrect quoting
> echo abcdef'ghijklmn
echo abcdef'ghijklmn
shell: incorrect quoting
> ps
ps
	pid | state    Q | pri 
	  1 | pending  Q |  15
	  2 | running  Q |   7
> help
help
Command              Description
---------------------------------------
bufsize              Get the shell's buffer size
start_test           starts a test
end_test             ends a test
echo                 prints the input command
empty                print nothing on command
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
app_metadata         Returns application metadata
> reboot
reboot


		!! REBOOT !!

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
test_shell.
> end_test
end_test
[TEST_END]
> 
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

The CI is failing on several PRs because of this problem.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
