### PR TITLE
[RFC] periph/pdm: propose API and add nrf52 implementation

### DIFF
--- a/boards/adafruit-clue/Makefile.features
+++ b/boards/adafruit-clue/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pdm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/adafruit-clue/include/periph_conf.h
+++ b/boards/adafruit-clue/include/periph_conf.h
@@ -95,6 +95,16 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name    PDM configuration
+ * @{
+ */
+static const pdm_conf_t pdm_config = {
+    .din_pin = GPIO_PIN(0, 0),
+    .clk_pin = GPIO_PIN(0, 1),
+};
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -257,6 +257,15 @@ void spi_twi_irq_register_spi(NRF_SPIM_Type *bus,
  */
 void spi_twi_irq_register_i2c(NRF_TWIM_Type *bus,
                               spi_twi_irq_cb_t cb, void *arg);
+
+/**
+ * @brief   Structure for PDM configuration data
+ */
+typedef struct {
+    uint8_t din_pin;         /**< DIN pin */
+    uint8_t clk_pin;         /**< CLK pin */
+} pdm_conf_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf52/periph/pdm.c
+++ b/cpu/nrf52/periph/pdm.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_nrf52
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the peripheral PDM interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+
+#include "cpu.h"
+#include "periph/gpio.h"
+#include "periph/pdm.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* The samples buffer is a double buffer */
+int16_t _pdm_buf[PDM_BUF_SIZE * 2] = { 0 };
+static uint8_t _pdm_current_buf = 0;
+static pdm_isr_ctx_t isr_ctx;
+
+int pdm_init(pdm_mode_t mode, pdm_sample_rate_t rate, int8_t gain,
+              pdm_data_cb_t cb, void *arg)
+{
+    if (NRF_CLOCK->EVENTS_HFCLKSTARTED == 0) {
+        NRF_CLOCK->TASKS_HFCLKSTART = 1;
+        while (NRF_CLOCK->EVENTS_HFCLKSTARTED == 0) {}
+    }
+
+    /* Configure sampling rate */
+    switch (rate) {
+        case PDM_SAMPLE_RATE_16KHZ:
+#ifdef CPU_MODEL_NRF52840XXAA
+            NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio80 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+            NRF_PDM->PDMCLKCTRL = PDM_PDMCLKCTRL_FREQ_1280K;
+#else
+            NRF_PDM->PDMCLKCTRL = PDM_PDMCLKCTRL_FREQ_Default; /* 1.033MHz */
+#endif
+            break;
+        case PDM_SAMPLE_RATE_20KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x0A000000; /* CLK= 1.280 MHz (32 MHz / 25) => rate= 20000 Hz */
+            break;
+        case PDM_SAMPLE_RATE_41KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x15000000; /* CLK= 2.667 MHz (32 MHz / 12) => rate= 41667 Hz */
+            break;
+        case PDM_SAMPLE_RATE_50KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x19000000; /* CLK= 3.200 MHz (32 MHz / 10) => rate= 50000 Hz */
+            break;
+        case PDM_SAMPLE_RATE_60KHZ:
+            NRF_PDM->PDMCLKCTRL = 0x20000000; /* CLK= 4.000 MHz (32 MHz / 8) => rate= 60000 Hz */
+            break;
+        default:
+            DEBUG("[pdm] init: sample rate not supported\n");
+            return -ENOTSUP;
+    }
+
+    /* Configure mode (Mono or Stereo) */
+    switch (mode) {
+        case PDM_MODE_MONO:
+            NRF_PDM->MODE = PDM_MODE_OPERATION_Mono;
+            break;
+        case PDM_MODE_STEREO:
+            NRF_PDM->MODE = PDM_MODE_OPERATION_Stereo;
+            break;
+        default:
+            DEBUG("[pdm] init: mode not supported\n");
+            return -ENOTSUP;
+    }
+
+    /* Configure gain */
+    if (gain > PDM_GAIN_MAX) {
+        gain = PDM_GAIN_MAX;
+    }
+
+    if (gain < PDM_GAIN_MIN) {
+        gain = PDM_GAIN_MIN;
+    }
+
+    NRF_PDM->GAINR = (gain << 1) + 40;
+    NRF_PDM->GAINL = (gain << 1) + 40;
+
+    /* Configure CLK and DIN pins */
+    gpio_init(pdm_config.clk_pin, GPIO_OUT);
+    gpio_clear(pdm_config.clk_pin);
+    gpio_init(pdm_config.din_pin, GPIO_IN);
+
+    NRF_PDM->PSEL.CLK = pdm_config.clk_pin;
+    NRF_PDM->PSEL.DIN = pdm_config.din_pin;
+
+    /* clear pending events */
+    NRF_PDM->EVENTS_STARTED = 0;
+    NRF_PDM->EVENTS_STOPPED = 0;
+    NRF_PDM->EVENTS_END = 0;
+
+    /* Enable end/started/stopped events */
+    NRF_PDM->INTENSET = ((PDM_INTEN_END_Enabled << PDM_INTEN_END_Pos) |
+                        (PDM_INTEN_STARTED_Enabled << PDM_INTEN_STARTED_Pos) |
+                        (PDM_INTEN_STOPPED_Enabled << PDM_INTEN_STOPPED_Pos));
+
+    /* Configure internal RAM buffer size, divide by 2 for stereo mode */
+    NRF_PDM->SAMPLE.MAXCNT = (PDM_BUF_SIZE >> mode);
+
+    isr_ctx.cb = cb;
+    isr_ctx.arg = arg;
+
+    /* enable interrupt */
+    NVIC_EnableIRQ(PDM_IRQn);
+
+    /* Enable PDM */
+    NRF_PDM->ENABLE = (PDM_ENABLE_ENABLE_Enabled << PDM_ENABLE_ENABLE_Pos);
+
+    return 0;
+}
+
+void pdm_start(void)
+{
+    NRF_PDM->SAMPLE.PTR = (uint32_t)_pdm_buf;
+    DEBUG("[PDM] MAXCNT: %lu\n", NRF_PDM->SAMPLE.MAXCNT);
+
+    NRF_PDM->TASKS_START = 1;
+}
+
+void pdm_stop(void)
+{
+    NRF_PDM->TASKS_STOP = 1;
+}
+
+void isr_pdm(void)
+{
+    if (NRF_PDM->EVENTS_STARTED == 1) {
+        NRF_PDM->EVENTS_STARTED = 0;
+        uint8_t next_buf_pos = (_pdm_current_buf + 1) & 0x1;
+        NRF_PDM->SAMPLE.PTR = (uint32_t)&_pdm_buf[next_buf_pos * (PDM_BUF_SIZE >> 1)];
+    }
+
+    if (NRF_PDM->EVENTS_STOPPED == 1) {
+        NRF_PDM->EVENTS_STOPPED = 0;
+        _pdm_current_buf = 0;
+    }
+
+    if (NRF_PDM->EVENTS_END == 1) {
+        NRF_PDM->EVENTS_END = 0;
+
+        /* Process received samples frame */
+        isr_ctx.cb(isr_ctx.arg, &_pdm_buf[_pdm_current_buf * (PDM_BUF_SIZE >> 1)]);
+
+        /* Set next buffer */
+        _pdm_current_buf = (_pdm_current_buf + 1) & 0x1;
+    }
+
+    cortexm_isr_end();
+}

--- a/drivers/include/periph/pdm.h
+++ b/drivers/include/periph/pdm.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_pdm Pulse Density Modulation (PDM) driver
+ * @ingroup     drivers_periph
+ * @brief       Low-level Pulse Density Modulation (PDM) driver
+ *
+ * @{
+ * @file
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_PDM_H
+#define PERIPH_PDM_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default PDM mode values
+ * @{
+ */
+#ifndef HAVE_PDM_MODE_T
+typedef enum {
+    PDM_MODE_MONO = 0,      /**< Mono mode */
+    PDM_MODE_STEREO,        /**< Stereo mode */
+} pdm_mode_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default PDM sampling rate values
+ * @{
+ */
+#ifndef HAVE_PDM_SAMPLE_RATE_T
+typedef enum {
+    PDM_SAMPLE_RATE_16KHZ = 0,      /**< 16kHz */
+    PDM_SAMPLE_RATE_20KHZ,          /**< 20kHz */
+    PDM_SAMPLE_RATE_41KHZ,          /**< 41.6kHz */
+    PDM_SAMPLE_RATE_50KHZ,          /**< 50kHz */
+    PDM_SAMPLE_RATE_60KHZ,          /**< 60kHz */
+} pdm_sample_rate_t;
+#endif
+/** @} */
+
+/**
+ * @brief   Default PDM min gain values (in dB)
+ */
+#ifndef PDM_GAIN_MIN
+#define PDM_GAIN_MIN        (-20)
+#endif
+
+/**
+ * @brief   Default PDM max gain values (in dB)
+ */
+#ifndef PDM_GAIN_MAX
+#define PDM_GAIN_MAX        (20)
+#endif
+
+/**
+ * @brief   Default PDM samples frame buffer size
+ */
+#ifndef PDM_BUF_SIZE
+#define PDM_BUF_SIZE        (128U)
+#endif
+
+/**
+ * @brief   Signature for data received interrupt callback
+ *
+ * @param[in] arg           context to the callback (optional)
+ * @param[in] buf           the buffer containing the current samples frame
+ */
+typedef void(*pdm_data_cb_t)(void *arg, int16_t *buf);
+
+/**
+ * @brief   Interrupt context for a PDM device
+ */
+#ifndef HAVE_PDM_ISR_CTX_T
+typedef struct {
+    pdm_data_cb_t cb;       /**< data received interrupt callback */
+    void *arg;              /**< argument to both callback routines */
+} pdm_isr_ctx_t;
+#endif
+
+/**
+ * @brief   Initialize the PDM peripheral
+ *
+ * @param[in] rate      sample rate
+ * @param[in] gain      gain
+ * @param[in] cb        data received callback function
+ * @param[in] arg       context passed to the callback function
+ *
+ * @return  0 on successful initialization
+ * @return <0 on error
+ */
+int pdm_init(pdm_mode_t mode, pdm_sample_rate_t rate, int8_t gain,
+             pdm_data_cb_t cb, void *arg);
+
+/**
+ * @brief   Start the PDM peripheral
+ */
+void pdm_start(void);
+
+/**
+ * @brief   Stop the PDM peripheral
+ */
+void pdm_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_PDM_H */
+/** @} */

--- a/tests/periph_pdm/Makefile
+++ b/tests/periph_pdm/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_pdm
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pdm/main.c
+++ b/tests/periph_pdm/main.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Low-level PDM driver test
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "msg.h"
+#include "thread.h"
+#include "stdio_base.h"
+
+#include "periph/pdm.h"
+
+static kernel_pid_t _main_thread_pid;
+
+#ifndef PDM_DATA_PRINT_BINARY
+#define PDM_DATA_PRINT_BINARY   (0)
+#endif
+
+#ifndef PDM_TEST_MODE
+#define PDM_TEST_MODE           (PDM_MODE_MONO)
+#endif
+
+#ifndef PDM_TEST_SAMPLE_RATE
+#define PDM_TEST_SAMPLE_RATE    (PDM_SAMPLE_RATE_16KHZ)
+#endif
+
+#ifndef PDM_TEST_GAIN
+#define PDM_TEST_GAIN           (-10)
+#endif
+
+static void _pdm_cb(void *arg, int16_t *buf)
+{
+    (void)arg;
+    msg_t msg;
+    msg.content.ptr = buf;
+    msg_send(&msg, _main_thread_pid);
+}
+
+int main(void)
+{
+#if !PDM_DATA_PRINT_BINARY
+    puts("PDM peripheral driver test\n");
+#endif
+
+    if (pdm_init(PDM_TEST_MODE, PDM_TEST_SAMPLE_RATE, PDM_TEST_GAIN, _pdm_cb, NULL) < 0) {
+        puts("Failed to initialize PDM peripheral");
+        return 1;
+    }
+
+    pdm_start();
+
+    _main_thread_pid = thread_getpid();
+
+    while (1) {
+        msg_t msg;
+        msg_receive(&msg);
+        int16_t *buf = (int16_t *)msg.content.ptr;
+#if PDM_DATA_PRINT_BINARY
+        stdio_write((uint8_t *)buf, PDM_BUF_SIZE >> 2);
+#else
+        for (unsigned idx = 0; idx < PDM_BUF_SIZE; ++idx) {
+            printf("%i\n", buf[idx]);
+        }
+#endif
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR proposes an API for the PDM peripheral available at least in nRF52 CPUs. An implementation is proposed for nRF and there's a configuration for the adafruit-clue board.

I could never really convert the "sound" to a hearable signal so I'm wondering if it works correctly. The values printed seems correct though (higher when make noise, lower otherwise) but I have no ground truth.

I'm also wondering if this could fit in the I2S API proposed by @bergzand in #15131, and thus there's no need for PDM API of this PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `tests/periph_pdm` on adafruit-clue.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
