### PR TITLE
sys/net/{lwmac,gomach}: add missing const qualifier

### DIFF
--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -366,7 +366,7 @@ extern "C" {
  * @return  negative number on error
  */
 int gnrc_netif_gomach_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                             char priority, char *name, netdev_t *dev);
+                             char priority, const char *name, netdev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -344,7 +344,7 @@ extern "C" {
  * @return  negative number on error
  */
 int gnrc_netif_lwmac_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                            char priority, char *name, netdev_t *dev);
+                            char priority, const char *name, netdev_t *dev);
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -71,7 +71,7 @@ static const gnrc_netif_ops_t gomach_ops = {
 };
 
 int gnrc_netif_gomach_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                             char priority, char *name, netdev_t *dev)
+                             char priority, const char *name, netdev_t *dev)
 {
     return gnrc_netif_create(netif, stack, stacksize, priority, name, dev,
                              &gomach_ops);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -78,7 +78,7 @@ static const gnrc_netif_ops_t lwmac_ops = {
 };
 
 int gnrc_netif_lwmac_create(gnrc_netif_t *netif, char *stack, int stacksize,
-                            char priority, char *name, netdev_t *dev)
+                            char priority, const char *name, netdev_t *dev)
 {
     return gnrc_netif_create(netif, stack, stacksize, priority, name, dev,
                              &lwmac_ops);


### PR DESCRIPTION
### Contribution description

The name of the thread running the MAC can be stored in ROM. Hence, add the missing `const` qualifier.

With it, `examples/gnrc_networking_mac` should compile with the `at86rf215` driver.

### Testing procedure

Code review should be sufficient IMO.

### Issues/PRs references

None