### PR TITLE
boards/stm32f3discovery: add lsm303dlhc configuration

### DIFF
--- a/boards/stm32f3discovery/Makefile.dep
+++ b/boards/stm32f3discovery/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += lsm303dlhc
 endif

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -90,6 +90,12 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN
 /** @} */
 
+/**
+ * @name LSM303DLHC magnetometer data ready pin
+ * @{
+ */
+#define LSM303DLHC_PARAM_MAG_PIN    GPIO_PIN(PORT_E, 2)
+/** @} */
 
 /**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a default configuration for the lsm303dlhc available on the stm32f3discovery board (see dm00063382).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<details><summary>tests/driver_lslm303dlhc prints data</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=stm32f3discovery -C tests/driver_lsm303dlhc/ flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stm32f3discovery'  -w '/data/riotbuild/riotbase/tests/driver_lsm303dlhc/' 'riot/riotbuild:latest' make 'BOARD=stm32f3discovery'    
Building application "tests_driver_lsm303dlhc" for "stm32f3discovery" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/stm32f3discovery
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12932	    112	   2364	  15408	   3c30	/data/riotbuild/riotbase/tests/driver_lsm303dlhc/bin/stm32f3discovery/tests_driver_lsm303dlhc.elf
 ✓ Flashing done! (programmer: 'openocd' - duration: 2.01s)
(for full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line)
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-03-02 17:32:08,119 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
2021-03-02 17:32:09,123 # 
2021-03-02 17:32:09,125 # Accelerometer x: 180 y: 224 z: 288
2021-03-02 17:32:09,126 # Temperature value: 800 degrees
2021-03-02 17:32:09,127 # Magnetometer x: -126 y: -152 z: -197
2021-03-02 17:32:09,128 # Accelerometer x: 184 y: 232 z: 292
2021-03-02 17:32:09,128 # Temperature value: 800 degrees
2021-03-02 17:32:09,128 # Magnetometer x: -127 y: -153 z: -197
2021-03-02 17:32:09,129 # Accelerometer x: 180 y: 236 z: 292
2021-03-02 17:32:09,129 # Temperature value: 800 degrees
2021-03-02 17:32:09,129 # Magnetometer x: -126 y: -152 z: -194
2021-03-02 17:32:09,130 # Accelerometer x: 184 y: 236 z: 296
2021-03-02 17:32:09,130 # Temperature value: 800 degrees
2021-03-02 17:32:09,131 # Magnetometer x: -126 y: -152 z: -196
2021-03-02 17:32:09,131 # Accelerometer x: 188 y: 232 z: 300
2021-03-02 17:32:09,131 # Temperature value: 800 degrees
2021-03-02 17:32:09,132 # Magnetometer x: -128 y: -153 z: -197
2021-03-02 17:32:09,132 # Accelerometer x: 184 y: 228 z: 296
2021-03-02 17:32:09,132 # Temperature value: 800 degrees
2021-03-02 17:32:09,133 # Magnetometer x: -127 y: -152 z: -196
2021-03-02 17:32:09,133 # Accelerometer x: 188 y: 236 z: 292
2021-03-02 17:32:09,133 # Temperature value: 800 degrees
2021-03-02 17:32:09,134 # Magnetometer x: -127 y: -152 z: -198
2021-03-02 17:32:09,134 # Accelerometer x: 184 y: 228 z: 296
2021-03-02 17:32:09,134 # Temperature value: 800 degrees
2021-03-02 17:32:09,135 # Magnetometer x: -126 y: -154 z: -197
2021-03-02 17:32:09,135 # Accelerometer x: 180 y: 232 z: 296
2021-03-02 17:32:09,135 # Temperature value: 800 degrees
2021-03-02 17:32:09,136 # Magnetometer x: -126 y: -153 z: -196
2021-03-02 17:32:09,160 # Accelerometer x: 188 y: 232 z: 292
2021-03-02 17:32:09,161 # Temperature value: 800 degrees
2021-03-02 17:32:09,162 # Magnetometer x: -127 y: -153 z: -196
2021-03-02 17:32:09,271 # Accelerometer x: 188 y: 232 z: 288
2021-03-02 17:32:09,273 # Temperature value: 800 degrees
2021-03-02 17:32:09,274 # Magnetometer x: -126 y: -154 z: -196
2021-03-02 17:32:09,381 # Accelerometer x: 184 y: 228 z: 300
2021-03-02 17:32:09,382 # Temperature value: 800 degrees
2021-03-02 17:32:09,384 # Magnetometer x: -127 y: -154 z: -196
2021-03-02 17:32:09,492 # Accelerometer x: 180 y: 228 z: 296
2021-03-02 17:32:09,494 # Temperature value: 800 degrees
2021-03-02 17:32:09,495 # Magnetometer x: -127 y: -152 z: -197
2021-03-02 17:32:09,603 # Accelerometer x: 184 y: 236 z: 296
2021-03-02 17:32:09,604 # Temperature value: 800 degrees
2021-03-02 17:32:09,606 # Magnetometer x: -126 y: -153 z: -196
2021-03-02 17:32:09,714 # Accelerometer x: 188 y: 232 z: 296
2021-03-02 17:32:09,715 # Temperature value: 800 degrees
2021-03-02 17:32:09,716 # Magnetometer x: -126 y: -153 z: -197
2021-03-02 17:32:09,746 # Exiting Pyterm
```

</details>

<details><summary>accelerometer values can be fetched via saul</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=stm32f3discovery -C examples/saul/ flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stm32f3discovery'  -w '/data/riotbuild/riotbase/examples/saul/' 'riot/riotbuild:latest' make 'BOARD=stm32f3discovery'    
Building application "saul_example" for "stm32f3discovery" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/stm32f3discovery
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/drivers/saul/init_devs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  20728	    132	   2600	  23460	   5ba4	/data/riotbuild/riotbase/examples/saul/bin/stm32f3discovery/saul_example.elf
 ✓ Flashing done! (programmer: 'openocd' - duration: 2.00s)
(for full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line)
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyUSB0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-03-02 17:32:44,340 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
help
2021-03-02 17:32:48,049 #  help
2021-03-02 17:32:48,092 # Command              Description
2021-03-02 17:32:48,093 # ---------------------------------------
2021-03-02 17:32:48,093 # reboot               Reboot the node
2021-03-02 17:32:48,094 # version              Prints current RIOT_VERSION
2021-03-02 17:32:48,094 # pm                   interact with layered PM subsystem
2021-03-02 17:32:48,095 # ps                   Prints information about running threads.
2021-03-02 17:32:48,096 # saul                 interact with sensors and actuators using SAUL
> saul
2021-03-02 17:32:48,881 # saul
2021-03-02 17:32:48,882 # ID	Class		Name
2021-03-02 17:32:48,884 # #0	ACT_SWITCH	LD3
2021-03-02 17:32:48,885 # #1	ACT_SWITCH	LD4
2021-03-02 17:32:48,887 # #2	ACT_SWITCH	LD5
2021-03-02 17:32:48,888 # #3	ACT_SWITCH	LD6
2021-03-02 17:32:48,889 # #4	ACT_SWITCH	LD7
2021-03-02 17:32:48,889 # #5	ACT_SWITCH	LD8
2021-03-02 17:32:48,890 # #6	ACT_SWITCH	LD9
2021-03-02 17:32:48,890 # #7	ACT_SWITCH	LD10
2021-03-02 17:32:48,891 # #8	SENSE_BTN	BTN USER
2021-03-02 17:32:48,892 # #9	SENSE_ACCEL	lsm303dlhc
2021-03-02 17:32:48,892 # #10	SENSE_MAG	lsm303dlhc
> saul read 9
2021-03-02 17:32:51,327 # saul read 9
2021-03-02 17:32:51,348 # Reading from #9 (lsm303dlhc|SENSE_ACCEL)
2021-03-02 17:32:51,349 # Data:	[0]         368 mg
2021-03-02 17:32:51,349 # 	[1]         464 mg
2021-03-02 17:32:51,350 # 	[2]         584 mg
> saul read 10
2021-03-02 17:32:53,624 # saul read 10
2021-03-02 17:32:53,625 # Reading from #10 (lsm303dlhc|SENSE_MAG)
2021-03-02 17:32:53,626 # Data:	[0]        -280 mGs
2021-03-02 17:32:53,627 # 	[1]        -340 mGs
2021-03-02 17:32:53,628 # 	[2]        -435 mGs
> 
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
