### PR TITLE
congure_mock: add capability to provide actual methods

### DIFF
--- a/sys/congure/mock/congure_mock.c
+++ b/sys/congure/mock/congure_mock.c
@@ -37,9 +37,11 @@ static const congure_snd_driver_t _driver = {
     .report_ecn_ce = _snd_report_ecn_ce,
 };
 
-void congure_mock_snd_setup(congure_mock_snd_t *c)
+void congure_mock_snd_setup(congure_mock_snd_t *c,
+                            const congure_snd_driver_t *methods)
 {
     c->super.driver = &_driver;
+    c->methods = methods;
 }
 
 static void _snd_init(congure_snd_t *cong, void *ctx)
@@ -49,6 +51,9 @@ static void _snd_init(congure_snd_t *cong, void *ctx)
     c->init_calls++;
     c->init_args.c = &c->super;
     c->init_args.ctx = ctx;
+    if (c->methods && c->methods->init) {
+        c->methods->init(cong, ctx);
+    }
 }
 
 static int32_t _snd_inter_msg_interval(congure_snd_t *cong, unsigned msg_size)
@@ -58,6 +63,9 @@ static int32_t _snd_inter_msg_interval(congure_snd_t *cong, unsigned msg_size)
     c->inter_msg_interval_calls++;
     c->inter_msg_interval_args.c = &c->super;
     c->inter_msg_interval_args.msg_size = msg_size;
+    if (c->methods && c->methods->inter_msg_interval) {
+        return c->methods->inter_msg_interval(cong, msg_size);
+    }
     return -1;
 }
 
@@ -68,6 +76,9 @@ static void _snd_report_msg_sent(congure_snd_t *cong, unsigned msg_size)
     c->report_msg_sent_calls++;
     c->report_msg_sent_args.c = &c->super;
     c->report_msg_sent_args.msg_size = msg_size;
+    if (c->methods && c->methods->report_msg_sent) {
+        c->methods->report_msg_sent(cong, msg_size);
+    }
 }
 
 static void _snd_report_msg_discarded(congure_snd_t *cong, unsigned msg_size)
@@ -77,6 +88,9 @@ static void _snd_report_msg_discarded(congure_snd_t *cong, unsigned msg_size)
     c->report_msg_discarded_calls++;
     c->report_msg_discarded_args.c = &c->super;
     c->report_msg_discarded_args.msg_size = msg_size;
+    if (c->methods && c->methods->report_msg_discarded) {
+        c->methods->report_msg_discarded(cong, msg_size);
+    }
 }
 
 static void _snd_report_msgs_lost(congure_snd_t *cong, congure_snd_msg_t *msgs)
@@ -86,6 +100,9 @@ static void _snd_report_msgs_lost(congure_snd_t *cong, congure_snd_msg_t *msgs)
     c->report_msgs_lost_calls++;
     c->report_msgs_lost_args.c = &c->super;
     c->report_msgs_lost_args.msgs = msgs;
+    if (c->methods && c->methods->report_msgs_lost) {
+        c->methods->report_msgs_lost(cong, msgs);
+    }
 }
 
 static void _snd_report_msgs_timeout(congure_snd_t *cong,
@@ -96,6 +113,9 @@ static void _snd_report_msgs_timeout(congure_snd_t *cong,
     c->report_msgs_timeout_calls++;
     c->report_msgs_timeout_args.c = &c->super;
     c->report_msgs_timeout_args.msgs = msgs;
+    if (c->methods && c->methods->report_msgs_timeout) {
+        c->methods->report_msgs_timeout(cong, msgs);
+    }
 }
 
 static void _snd_report_msg_acked(congure_snd_t *cong, congure_snd_msg_t *msg,
@@ -107,6 +127,9 @@ static void _snd_report_msg_acked(congure_snd_t *cong, congure_snd_msg_t *msg,
     c->report_msg_acked_args.c = &c->super;
     c->report_msg_acked_args.msg = msg;
     c->report_msg_acked_args.ack = ack;
+    if (c->methods && c->methods->report_msg_acked) {
+        c->methods->report_msg_acked(cong, msg, ack);
+    }
 }
 
 static void _snd_report_ecn_ce(congure_snd_t *cong, ztimer_now_t time)
@@ -116,6 +139,9 @@ static void _snd_report_ecn_ce(congure_snd_t *cong, ztimer_now_t time)
     c->report_ecn_ce_calls++;
     c->report_ecn_ce_args.c = &c->super;
     c->report_ecn_ce_args.time = time;
+    if (c->methods && c->methods->report_ecn_ce) {
+        c->methods->report_ecn_ce(cong, time);
+    }
 }
 
 /** @} */

--- a/sys/include/congure/mock.h
+++ b/sys/include/congure/mock.h
@@ -33,7 +33,12 @@ extern "C" {
  * @extends congure_snd_t
  */
 typedef struct {
-    congure_snd_t super;        /**< see @ref congure_snd_t */
+    congure_snd_t super;            /**< see @ref congure_snd_t */
+    /**
+     * @brief   Optional methods called in addition to the tracking functions
+     *          of the mock driver
+     */
+    const congure_snd_driver_t *methods;
     /**
      * @brief   How often was the congure_snd_driver_t::init() method called?
      */
@@ -152,9 +157,12 @@ typedef struct {
 /**
  * @brief   Sets up the driver for CongURE mock object
  *
- * @param[in] c A CongURE mock object
+ * @param[in] c         A CongURE mock object
+ * @param[in] methods   Methods to call in addition to the tracking of the mock
+ *                      driver. May be NULL.
  */
-void congure_mock_snd_setup(congure_mock_snd_t *c);
+void congure_mock_snd_setup(congure_mock_snd_t *c,
+                            const congure_snd_driver_t *methods);
 
 #ifdef __cplusplus
 }

--- a/tests/congure_test/congure_impl.c
+++ b/tests/congure_test/congure_impl.c
@@ -22,7 +22,7 @@ int congure_test_snd_setup(congure_test_snd_t *c, unsigned id)
     if (id > 0) {
         return -1;
     }
-    congure_mock_snd_setup(c);
+    congure_mock_snd_setup(c, NULL);
     return 0;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This extends the `congure_mock` so that actual `congure` method drivers can be added, in case the test needs some actual functionality.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
No tests are provided for the new functionality (it will be used in a later PR). `tests/congure_test` should still compile and pass.

```console
$ BOARD=iotlab-m3 make -C tests/congure_test/ --no-print-directory -j flash test
Building application "tests_congure_test" for "iotlab-m3" with MCU "stm32".

[…]
   text	   data	    bss	    dec	    hex	filename
  18300	    132	   2536	  20968	   51e8	/home/mlenders/Repositories/RIOT-OS/RIOT/tests/congure_test/bin/iotlab-m3/tests_congure_test.elf
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'openocd' - duration: 2.01s)
......................................
----------------------------------------------------------------------
Ran 38 tests in 18.911s

OK
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but part of the larger congestion control effort.

![PR dependency graph](https://page.mi.fu-berlin.de/mlenders/congure.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
