### PR TITLE
pkg/wakaama: fix compilation with 6lowpan-clicker [backport 2021.01]

### DIFF
--- a/pkg/wakaama/include/lwm2m_client.h
+++ b/pkg/wakaama/include/lwm2m_client.h
@@ -26,7 +26,6 @@ extern "C" {
 
 #include <ctype.h>
 #include <errno.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
# Backport of #16042

### Contribution description

Drop included of unused header file that caused conflict with the new toolchain


### Testing procedure

Murdock should turn green again.

### Issues/PRs references

None