### PR TITLE
driver/bmx280: increase accuracy of SAUL pressure readings

### DIFF
--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -35,9 +35,11 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 static int read_pressure(const void *dev, phydat_t *res)
 {
-    res->val[0] = bmx280_read_pressure((bmx280_t *)dev) / 100;
     res->unit = UNIT_PA;
-    res->scale = 2;
+    res->scale = 0;
+
+    int32_t val = bmx280_read_pressure((bmx280_t *)dev);
+    phydat_fit(res, &val, 1);
 
     return 1;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The SAUL implementation of the BMx280 currently returns the pressure in hPa.
The sensor, however, actually reads the pressure in Pa, leading to a
significant loss of precision.

Because the operation range of the BME280 and BMP280 is 300 hPa to 1100 hPa,
we can safely increase the precision by a factor of 10 without risk of overflow.
The only downside is that readings are now presented as `e1 Pa` (eg 10206e1 Pa).

### Testing procedure

Run SAUL example with a BME280 sensor. Read value:

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

```
2021-03-03 16:03:18,382 # saul read 2
2021-03-03 16:03:18,385 # Reading from #2 (bme280|SENSE_PRESS)
2021-03-03 16:03:18,387 # Data:	        10206e1 Pa
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None.