### PR TITLE
drivers/usbdev_mock: add to drivers_misc category

### DIFF
--- a/drivers/include/usbdev_mock.h
+++ b/drivers/include/usbdev_mock.h
@@ -7,7 +7,7 @@
  */
 /**
  * @defgroup    drivers_usbdev_mock USBdev mockup device
- * @ingroup     drivers
+ * @ingroup     drivers_misc
  * @brief       USBdev mockup device for testing
  * @{
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While working on https://github.com/RIOT-OS/riot-os.org/pull/39, I noticed that the usbdev_mock driver documentation was directly linked to the main `drivers` category. As a result it shows up in the driver categories page (at the bottom):

![image](https://user-images.githubusercontent.com/1375137/109845707-b838fa80-7c4d-11eb-92b3-d577834ea894.png)

This PR is fixing that by linking it to the `misc` category.

Related questions:
 - should we maybe also link the radio hardware abstraction layer to the `drivers_netdev` category ?
 - Same question with saul: should it go to the misc category (or maybe move it to sys) ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Look at the documentation preview, the usbdev_mock module should show up in the Miscellaneous category.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
