### PR TITLE
tests / pkg: fixes for toolchain changes in docker container [backport 2021.01]

### DIFF
--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -7,6 +7,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 # Enable code forcing aligned reads
 CFLAGS += -DCBOR_ALIGN_READS
+CFLAGS += -Wno-return-local-addr
 
 all:
 	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/wakaama/include/lwm2m_client.h
+++ b/pkg/wakaama/include/lwm2m_client.h
@@ -26,7 +26,6 @@ extern "C" {
 
 #include <ctype.h>
 #include <errno.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/driver_hih6130/main.c
+++ b/tests/driver_hih6130/main.c
@@ -65,10 +65,10 @@ int main(void)
         /* Split value into two integer parts for printing. */
         fractional = modff(hum, &integral);
         printf("humidity: %4d.%04u %%",
-            (int)integral, (unsigned int)abs(fractional * 10000.f));
+            (int)integral, (unsigned int)abs((int)(fractional * 10000.f)));
         fractional = modff(temp, &integral);
         printf("  temperature: %4d.%04u C\n",
-            (int)integral, (unsigned int)abs(fractional * 10000.f));
+            (int)integral, (unsigned int)abs((int)(fractional * 10000.f)));
     }
 
     return 0;

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -11,3 +11,7 @@ include $(RIOTBASE)/Makefile.include
 ifneq (,$(shell $(CC) --help=warnings | grep '\-Wstringop-overflow='))
   CFLAGS += -Wstringop-overflow=0
 endif
+
+ifneq (,$(shell $(CC) --help=warnings | grep '\-Warray-bounds='))
+  CFLAGS += -Warray-bounds=0
+endif


### PR DESCRIPTION
# Backport of #15966, #15964, and #16042

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR silences 2 warning raised when building with gcc 10 on riscv:
- upstream code of pkg/cn-cbor raises the return-local-address error. The latest version of the upstream code doesn't provide a fix for this
- `tests/ssp` allocates on purpose a buffer too small but this is catched by the compiler as array-bound warning. Similar to the stringop-overflow warning, the array-bound warning is silenced if it's available in the compiler.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Both applications build with gcc 10 for riscv and works on hifive1b:

<details><summary>tests/pkg_cn-cbor</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C tests/pkg_cn-cbor --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT-review:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/tests/pkg_cn-cbor/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    
Building application "tests_pkg_cn-cbor" for "hifive1b" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/pkg/cn-cbor
"make" -C /data/riotbuild/riotbase/build/pkg/cn-cbor/src -f /data/riotbuild/riotbase/Makefile.base MODULE=cn-cbor
"make" -C /data/riotbuild/riotbase/boards/hifive1b
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/cpu/riscv_common
"make" -C /data/riotbuild/riotbase/cpu/riscv_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/embunit
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/memarray
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  22401	    192	   2677	  25270	   62b6	/data/riotbuild/riotbase/tests/pkg_cn-cbor/bin/hifive1b/tests_pkg_cn-cbor.elf
/work/riot/RIOT-review/dist/tools/jlink/jlink.sh flash /work/riot/RIOT-review/tests/pkg_cn-cbor/bin/hifive1b/tests_pkg_cn-cbor.bin
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT-review/tests/pkg_cn-cbor/bin/hifive1b/tests_pkg_cn-cbor.bin]...
Comparing flash   [100%] Done.
Erasing flash     [100%] Done.
Programming flash [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: 1 range affected (65536 bytes)
J-Link: Flash download: Total: 0.622s (Prepare: 0.048s, Compare: 0.038s, Erase: 0.170s, Program & Verify: 0.345s, Restore: 0.019s)
J-Link: Flash download: Program & Verify speed: 185 KB/s
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.

r
/work/riot/RIOT-review/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Bench Clock Reset Complete

ATE0-->OK
AT+BLEINIT=0-->OK
AT+CWMODE=0-->OK

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-487-g23ea7-pr/make/gcc_10_riscv_failures)
..
OK (2 tests)
```

</details>

<details><summary>tests/ssp</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=hifive1b -C tests/ssp/ --no-print-directory flash test
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT-review:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b'  -w '/data/riotbuild/riotbase/tests/ssp/' 'riot/riotbuild:latest' make 'BOARD=hifive1b'    
Building application "tests_ssp" for "hifive1b" with MCU "fe310".

"make" -C /data/riotbuild/riotbase/boards/hifive1b
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/fe310
"make" -C /data/riotbuild/riotbase/cpu/fe310/periph
"make" -C /data/riotbuild/riotbase/cpu/fe310/vendor
"make" -C /data/riotbuild/riotbase/cpu/riscv_common
"make" -C /data/riotbuild/riotbase/cpu/riscv_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/ssp
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
   9222	    140	   2312	  11674	   2d9a	/data/riotbuild/riotbase/tests/ssp/bin/hifive1b/tests_ssp.elf
/work/riot/RIOT-review/dist/tools/jlink/jlink.sh flash /work/riot/RIOT-review/tests/ssp/bin/hifive1b/tests_ssp.bin
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.94b (Compiled Jan 26 2021 18:05:49)
DLL version V6.94b, compiled Jan 26 2021 18:05:34

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Jan 18 2021 09:05:42
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT-review/tests/ssp/bin/hifive1b/tests_ssp.bin]...
Comparing flash   [100%] Done.
Erasing flash     [100%] Done.
Programming flash [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: 1 range affected (65536 bytes)
J-Link: Flash download: Total: 0.447s (Prepare: 0.048s, Compare: 0.038s, Erase: 0.171s, Program & Verify: 0.170s, Restore: 0.019s)
J-Link: Flash download: Program & Verify speed: 376 KB/s
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.
RISC-V: Performing reset via <ndmreset>



Script processing completed.

r
/work/riot/RIOT-review/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Bench Clock Reset Complete

ATE0-->ATE0
OK
AT+BLEINIT=0-->OK
AT+CWMODE=0-->OK

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-487-g23ea7-pr/make/gcc_10_riscv_failures)
calling stack corruption function
*** RIOT kernel panic:
ssp: stack smashing detected
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Must be fixed before RIOT-OS/riotdocker#131 is merged and deployed on Murdock workers.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
