### PR TITLE
riotctrl_shell.tests: add missing method to MockSpawn [backport 2021.01]

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/tests/common.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/common.py
@@ -15,6 +15,10 @@ class MockSpawn():
         self.before = None
         self.echo = False
 
+    def read_nonblocking(self, size=1, timeout=-1):
+        # do nothing, only used to flush pexpect output
+        pass
+
     def sendline(self, line, *args, **kwargs):
         self.last_command = line
         if self.ctrl.output is None:


### PR DESCRIPTION
# Backport of #16132

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
There was an [update to `riotctrl`](https://github.com/RIOT-OS/riotctrl/commit/c039b21e81cc015139ce7035c59c08688e769579) which introduced the usage of another method of `pexpect`'s `spawn` class: `read_nonblocking` to flush the read output by `pexpect`. The mock we currently use in the tests for `riotctrl_shell` does not support that method which makes the CI action `test-tools` fail. This fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`test-tools` should pass again.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow up on RIOT-OS/riotctrl#21
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
