### PR TITLE
board/native: add basic debugging compatible optimization

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -21,7 +21,9 @@ export GPROF ?= gprof
 
 # basic cflags:
 CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG) $(CFLAGS_OPT)
+CFLAGS += -U_FORTIFY_SOURCE
 CFLAGS_DBG ?= -g3
+
 ifneq (,$(filter backtrace,$(USEMODULE)))
   $(warning module backtrace is used, do not omit frame pointers)
   CFLAGS_OPT ?= -Og -fno-omit-frame-pointer

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -20,8 +20,9 @@ export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
 # basic cflags:
-CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG)
+CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG) $(CFLAGS_OPT)
 CFLAGS_DBG ?= -g3
+CFLAGS_OPT ?= -Og
 
 # default std set to gnu11 if not overwritten by user
 ifeq (,$(filter -std=%, $(CFLAGS)))

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -22,7 +22,12 @@ export GPROF ?= gprof
 # basic cflags:
 CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG) $(CFLAGS_OPT)
 CFLAGS_DBG ?= -g3
-CFLAGS_OPT ?= -Og
+ifneq (,$(filter backtrace,$(USEMODULE)))
+  $(warning module backtrace is used, do not omit frame pointers)
+  CFLAGS_OPT ?= -Og -fno-omit-frame-pointer
+else
+  CFLAGS_OPT ?= -Og
+endif
 
 # default std set to gnu11 if not overwritten by user
 ifeq (,$(filter -std=%, $(CFLAGS)))

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -287,7 +287,7 @@ static int _tee(int argc, char **argv)
     }
     fclose(f);
 #else
-    int fd = open(argv[1], O_RDWR | O_CREAT);
+    int fd = open(argv[1], O_RDWR | O_CREAT, 00777);
     if (fd < 0) {
         printf("error while trying to create %s\n", argv[1]);
         return 1;

--- a/pkg/qcbor/Makefile
+++ b/pkg/qcbor/Makefile
@@ -5,5 +5,11 @@ PKG_LICENSE = BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+# some variable seem uninitialized to gcc with -Og but are not
+# https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=may%20be%20used%20uninitialized
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42145
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90710#c1
+CFLAGS += -Wno-maybe-uninitialized
+
 all:
 	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -5,6 +5,12 @@ PKG_LICENSE=EDL-1.0,EPL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+# some variable seem uninitialized to gcc with -Og but are not
+# https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=may%20be%20used%20uninitialized
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42145
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90710#c1
+CFLAGS += -Wno-maybe-uninitialized
+
 all:
 	"$(MAKE)" -C $(PKG_SOURCE_DIR)/core -f $(RIOTBASE)/Makefile.base MODULE=wakaama_core
 	"$(MAKE)" -C $(PKG_SOURCE_DIR)/core/er-coap-13 -f $(RIOTBASE)/Makefile.base MODULE=wakaama_core_coap13

--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -5,6 +5,12 @@ PKG_LICENSE=GPLv2
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+# some variable seem uninitialized to gcc with -Og but are not
+# https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=may%20be%20used%20uninitialized
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42145
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90710#c1
+CFLAGS += -Wno-maybe-uninitialized
+
 .PHONY: wolfcrypt%
 
 all: $(filter wolfcrypt wolfcrypt-test wolfcrypt-benchmark,$(USEMODULE))

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -44,10 +44,10 @@ static void test_ieee802154_set_frame_hdr_flags0_non_beacon_non_ack(void)
     const le_uint16_t src_pan = byteorder_htols(0);
     const le_uint16_t dst_pan = byteorder_htols(0);
     const uint8_t flags = IEEE802154_FCF_TYPE_DATA;
-    uint8_t res;
+    uint8_t res[2];
 
     TEST_ASSERT_EQUAL_INT(0,
-                          ieee802154_set_frame_hdr(&res, NULL, 0,
+                          ieee802154_set_frame_hdr(res, NULL, 0,
                                                    NULL, 0,
                                                    src_pan, dst_pan,
                                                    flags, TEST_UINT8));


### PR DESCRIPTION
### Contribution description

adds `-Og` to board/native `CFLAGS`

There is information out there suggesting that `-Og` is actually better for debugging than `-O0`

it is added in the board include since all `CFLAGS` for native are set there 
(it does not have a makefile/arch it also has no arch but that is an other PR)


### Testing procedure

compile with native and see how basic optimization is working (e.g.: actually inline static inlines or reduce unused (static) code)

### Issues/PRs references

not today
