### PR TITLE
sys/event: fix possibly uninitialized return warning

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -75,7 +75,7 @@ event_t *event_get(event_queue_t *queue)
 event_t *event_wait_multi(event_queue_t *queues, size_t n_queues)
 {
     assert(queues && n_queues);
-    event_t *result;
+    event_t *result = NULL;
 
     do {
         unsigned state = irq_disable();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes this warning:

```
event.c: In function â€˜event_wait_multiâ€™:
event.c:96:12: error: â€˜resultâ€™ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return result;
            ^~~~~~
cc1: all warnings being treated as errors
```

The warning is valid if `n_queues` is zero, which it shouldn't be and which is checked by assert. alas, asserts are not always compiled in.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found in #16143
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
