### PR TITLE
uncrustify-riot.cfg: align uncrustify config

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -2,100 +2,100 @@
 # indentation
 #
 
-indent_with_tabs        = 0                 # 1=indent to level only, 2=indent with tabs
-input_tab_size          = 4                 # original tab size
-output_tab_size         = 4                 # new tab size
-indent_columns          = output_tab_size   #
-indent_label            = 1                 # pos: absolute col, neg: relative column
-indent_switch_case      = 0                 # number
-indent_ternary_operator = 2                 # When the `:` is a continuation, indent it under `?`
+indent_with_tabs            = 0                 # 1=indent to level only, 2=indent with tabs
+input_tab_size              = 4                 # original tab size
+output_tab_size             = 4                 # new tab size
+indent_columns              = output_tab_size   #
+indent_label                = 1                 # pos: absolute col, neg: relative column
+indent_switch_case          = 0                 # number
+indent_ternary_operator     = 2                 # When `:` is a continuation, indent it under `?`
 
 #
 # line splitting
 #
 
-code_width              = 80      # Try to limit code width to N columns.
+code_width                  = 80                # Try to limit code width to N columns.
 
 #
 # inter-symbol newlines
 #
 
-nl_enum_brace          = remove   # "enum {" vs "enum \n {"
-nl_union_brace         = remove   # "union {" vs "union \n {"
-nl_struct_brace        = remove   # "struct {" vs "struct \n {"
-nl_do_brace            = remove   # "do {" vs "do \n {"
-nl_if_brace            = remove   # "if () {" vs "if () \n {"
-nl_for_brace           = remove   # "for () {" vs "for () \n {"
-nl_else_brace          = remove   # "else {" vs "else \n {"
-nl_while_brace         = remove   # "while () {" vs "while () \n {"
-nl_switch_brace        = remove   # "switch () {" vs "switch () \n {"
-nl_brace_while         = remove   # "} while" vs "} \n while" - cuddle while
-nl_brace_else          = add      # "} \n else" vs "} else"
-nl_func_var_def_blk    = 1        #
-nl_fcall_brace         = remove   # "list_for_each() {" vs "list_for_each()\n{"
-nl_fdef_brace          = add      # "int foo() {" vs "int foo()\n{"
-nl_collapse_empty_body = true     # set while(){\n} to while(){}
-nl_end_of_file         = add      # fix no newline at end of file
-nl_end_of_file_min     = 1        #
+nl_enum_brace               = remove            # "enum {" vs "enum \n {"
+nl_union_brace              = remove            # "union {" vs "union \n {"
+nl_struct_brace             = remove            # "struct {" vs "struct \n {"
+nl_do_brace                 = remove            # "do {" vs "do \n {"
+nl_if_brace                 = remove            # "if () {" vs "if () \n {"
+nl_for_brace                = remove            # "for () {" vs "for () \n {"
+nl_else_brace               = remove            # "else {" vs "else \n {"
+nl_while_brace              = remove            # "while () {" vs "while () \n {"
+nl_switch_brace             = remove            # "switch () {" vs "switch () \n {"
+nl_brace_while              = remove            # "} while" vs "} \n while" - cuddle while
+nl_brace_else               = add               # "} \n else" vs "} else"
+nl_func_var_def_blk         = 1                 #
+nl_fcall_brace              = remove            # "list_for_each() {" vs "list_for_each()\n{"
+nl_fdef_brace               = add               # "int foo() {" vs "int foo()\n{"
+nl_collapse_empty_body      = true              # set while(){\n} to while(){}
+nl_end_of_file              = add               # fix no newline at end of file
+nl_end_of_file_min          = 1                 # one new line at end of file
 
 #
 # Source code modifications
 #
 
-mod_paren_on_return        = ignore   # "return 1;" vs "return (1);"
-mod_full_brace_if          = add      # "if() { } else { }" vs "if() else"
-mod_full_brace_while       = force    # force while(); to while(){ \n ; }
-mod_full_brace_for         = force    # force for(); to for(){ \n ; }
-mod_remove_extra_semicolon = true     # remove superfluous semicolons.
+mod_paren_on_return         = ignore            # "return 1;" vs "return (1);"
+mod_full_brace_if           = add               # "if() { } else { }" vs "if() else"
+mod_full_brace_while        = force             # force while(); to while(){ \n ; }
+mod_full_brace_for          = force             # force for(); to for(){ \n ; }
+mod_remove_extra_semicolon  = true              # remove superfluous semicolons.
 
 #
 # inter-character spacing options
 #
 
-sp_sizeof_paren         = remove   # "sizeof (int)" vs "sizeof(int)"
-sp_before_sparen        = force    # "if (" vs "if("
-sp_after_sparen         = force    # "if () {" vs "if (){"
-sp_inside_braces        = add      # "{ 1 }" vs "{1}"
-sp_inside_braces_struct = add      # "{ 1 }" vs "{1}"
-sp_inside_braces_enum   = add      # "{ 1 }" vs "{1}"
-sp_assign               = add      #
-sp_arith                = add      #
-sp_bool                 = add      #
-sp_compare              = add      #
-sp_assign               = add      #
-sp_after_comma          = add      #
-sp_after_cast           = remove   # "(int) foo vs (int)foo
-sp_func_def_paren       = remove   # "int foo (){" vs "int foo(){"
-sp_func_call_paren      = remove   # "foo (" vs "foo("
-sp_func_proto_paren     = remove   # "int foo ();" vs "int foo();"
-sp_else_brace           = add      # ignore/add/remove/force
-sp_before_ptr_star      = add      # ignore/add/remove/force
-sp_after_ptr_star       = remove   # ignore/add/remove/force
-sp_between_ptr_star     = remove   # ignore/add/remove/force
-sp_inside_paren         = remove   # remove spaces inside parens
-sp_paren_paren          = remove   # remove spaces between nested parens
-sp_inside_sparen        = remove   # remove spaces inside parens for if, while and the like
-sp_inside_braces_empty  = remove   # force while(){ } to while(){}
+sp_sizeof_paren             = remove            # "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen            = force             # "if (" vs "if("
+sp_after_sparen             = force             # "if () {" vs "if (){"
+sp_inside_braces            = add               # "{ 1 }" vs "{1}"
+sp_inside_braces_struct     = add               # "{ 1 }" vs "{1}"
+sp_inside_braces_enum       = add               # "{ 1 }" vs "{1}"
+sp_assign                   = add               #
+sp_arith                    = add               #
+sp_bool                     = add               #
+sp_compare                  = add               #
+sp_assign                   = add               #
+sp_after_comma              = add               #
+sp_after_cast               = remove            # "(int) foo vs (int)foo
+sp_func_def_paren           = remove            # "int foo (){" vs "int foo(){"
+sp_func_call_paren          = remove            # "foo (" vs "foo("
+sp_func_proto_paren         = remove            # "int foo ();" vs "int foo();"
+sp_else_brace               = add               # ignore/add/remove/force
+sp_before_ptr_star          = add               # ignore/add/remove/force
+sp_after_ptr_star           = remove            # ignore/add/remove/force
+sp_between_ptr_star         = remove            # ignore/add/remove/force
+sp_inside_paren             = remove            # remove spaces inside parens
+sp_paren_paren              = remove            # remove spaces between nested parens
+sp_inside_sparen            = remove            # remove spaces inside parens for if, while, ...
+sp_inside_braces_empty      = remove            # force while(){ } to while(){}
 
 #
 # Aligning stuff
 #
 
-align_with_tabs        = FALSE     # use tabs to align
-align_on_tabstop       = TRUE      # align on tabstops
-align_enum_equ_span    = 4         # '=' in enum definition
-align_struct_init_span = 0         # align stuff in a structure init '= { }'
-align_right_cmt_span   = 3         #
+align_with_tabs             = FALSE             # use tabs to align
+align_on_tabstop            = TRUE              # align on tabstops
+align_enum_equ_span         = 4                 # '=' in enum definition
+align_struct_init_span      = 0                 # align stuff in a structure init '= { }'
+align_right_cmt_span        = 3                 #
 
 #
 # Special cases
 #
 
-set PROTO_WRAP ISR   # Wrap ISR macros like functions
+set PROTO_WRAP              ISR                 # Wrap ISR macros like functions
 
 #
 # enable / disable marker config
 #
 
-disable_processing_cmt          = " begin{code-style-ignore}"
-enable_processing_cmt           = " end{code-style-ignore}"
+disable_processing_cmt      = " begin{code-style-ignore}"
+enable_processing_cmt       = " end{code-style-ignore}"


### PR DESCRIPTION
### Contribution description

This doesn't change the config, it only beautifies it. Some comments are
shortened to keep the 100 char limit.

### Testing procedure

Verify that only there are no changes but white-space and comment changes.

### Issues/PRs references

None