### PR TITLE
uncrustify-riot.cfg: update to coding convention

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -14,7 +14,7 @@ indent_ternary_operator     = 2                 # When `:` is a continuation, in
 # line splitting
 #
 
-code_width                  = 80                # Try to limit code width to N columns.
+code_width                  = 100               # Try to limit code width to N columns.
 
 #
 # inter-symbol newlines


### PR DESCRIPTION
### Contribution description

The coding convention was changed to suggest breaking lines with with
more than 100 chars. This brings the uncrustify configuration back in
sync.

### Testing procedure

I don't think this needs testing.

### Issues/PRs references

Change of coding convention was done in https://github.com/RIOT-OS/RIOT/pull/15793