### PR TITLE
pkg/lwip: Use NETIF_FOREACH macro in sock implementation

### DIFF
--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -25,6 +25,7 @@
 #include "lwip/api.h"
 #include "lwip/ip4.h"
 #include "lwip/ip6.h"
+#include "lwip/netif.h"
 #include "lwip/opt.h"
 #include "lwip/sys.h"
 #include "lwip/sock_internal.h"
@@ -79,7 +80,9 @@ static uint16_t _ip4_addr_to_netif(const ip4_addr_p_t *addr)
     assert(addr != NULL);
 
     if (!ip4_addr_isany(addr)) {
-        for (struct netif *netif = netif_list; netif != NULL; netif = netif->next) {
+        struct netif *netif;
+        /* cppcheck-suppress uninitvar ; assigned by macro */
+        NETIF_FOREACH(netif) {
             if (netif_ip4_addr(netif)->addr == addr->addr) {
                 return (int)netif->num + 1;
             }
@@ -97,7 +100,9 @@ static uint16_t _ip6_addr_to_netif(const ip6_addr_p_t *_addr)
     assert(_addr != NULL);
     ip6_addr_copy_from_packed(addr, *_addr);
     if (!ip6_addr_isany_val(addr)) {
-        for (struct netif *netif = netif_list; netif != NULL; netif = netif->next) {
+        struct netif *netif;
+        /* cppcheck-suppress uninitvar ; assigned by macro */
+        NETIF_FOREACH(netif) {
             if (netif_get_ip6_addr_match(netif, &addr) >= 0) {
                 return (int)netif->num + 1;
             }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Use lwIP macro to iterate netifs instead of doing it manually. This reduces
dependency on lwIP internals (for instance it will not break if `LWIP_SINGLE_NETIF` is used)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

All lwip tests still pass.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None