### PR TITLE
pkg/lwip: Add netifs with netif_add_noaddr

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -175,30 +175,15 @@ extern void stm32_eth_netdev_setup(netdev_t *netdev);
 static nrf802154_t nrf802154_dev;
 #endif
 
-/**
- * @brief   Add interface with IPv4 or dual stack support.
- */
-static struct netif *_netif_add(struct netif *netif, void *state,
-                                netif_init_fn init, netif_input_fn input)
-{
-#if IS_USED(MODULE_LWIP_IPV4)
-    return netif_add(netif, ip_2_ip4(IP4_ADDR_ANY), ip_2_ip4(IP4_ADDR_ANY),
-                     ip_2_ip4(IP4_ADDR_ANY), state, init, input);
-#else /* IS_USED(MODULE_LWIP_IPV4) */
-    return netif_add(netif, state, init, input);
-#endif  /* IS_USED(MODULE_LWIP_IPV4) */
-}
-
 void lwip_bootstrap(void)
 {
-    (void)_netif_add;   /* in case it is not used */
     /* TODO: do for every eligible netdev */
 #ifdef LWIP_NETIF_NUMOF
 #ifdef MODULE_NETDEV_TAP
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i]);
-        if (_netif_add(&netif[i], &netdev_taps[i], lwip_netdev_init,
-                       tcpip_input) == NULL) {
+        if (netif_add_noaddr(&netif[i], &netdev_taps[i], lwip_netdev_init,
+                             tcpip_input) == NULL) {
             DEBUG("Could not add netdev_tap device\n");
             return;
         }
@@ -206,8 +191,8 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_MRF24J40)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
-        if (netif_add(&netif[i], &mrf24j40_devs[i], lwip_netdev_init,
-                      tcpip_6lowpan_input) == NULL) {
+        if (netif_add_noaddr(&netif[i], &mrf24j40_devs[i], lwip_netdev_init,
+                             tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add mrf24j40 device\n");
             return;
         }
@@ -215,8 +200,8 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_AT86RF2XX)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
-        if (netif_add(&netif[i], &at86rf2xx_devs[i], lwip_netdev_init,
-                      tcpip_6lowpan_input) == NULL) {
+        if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i], lwip_netdev_init,
+                             tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add at86rf2xx device\n");
             return;
         }
@@ -224,8 +209,8 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_ATWINC15X0)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
-        if (_netif_add(&netif[0], &atwinc15x0_devs[i], lwip_netdev_init,
-                       tcpip_input) == NULL) {
+        if (netif_add_noaddr(&netif[0], &atwinc15x0_devs[i], lwip_netdev_init,
+                             tcpip_input) == NULL) {
             DEBUG("Could not add atwinc15x0 device\n");
             return;
         }
@@ -233,8 +218,8 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_ENC28J60)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i], i);
-        if (_netif_add(&netif[0], &enc28j60_devs[i], lwip_netdev_init,
-                       tcpip_input) == NULL) {
+        if (netif_add_noaddr(&netif[0], &enc28j60_devs[i], lwip_netdev_init,
+                             tcpip_input) == NULL) {
             DEBUG("Could not add enc28j60 device\n");
             return;
         }
@@ -242,8 +227,8 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_SOCKET_ZEP)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
-        if (netif_add(&netif[i], &socket_zep_devs[i], lwip_netdev_init,
-                      tcpip_6lowpan_input) == NULL) {
+        if (netif_add_noaddr(&netif[i], &socket_zep_devs[i], lwip_netdev_init,
+                             tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add socket_zep device\n");
             return;
         }
@@ -251,44 +236,44 @@ void lwip_bootstrap(void)
 #elif (IS_USED(MODULE_ESP_ETH) || IS_USED(MODULE_ESP_WIFI))
 #if IS_USED(MODULE_ESP_ETH)
     esp_eth_setup(&_esp_eth_dev);
-    if (_netif_add(&netif[0], &_esp_eth_dev, lwip_netdev_init,
-                   tcpip_input) == NULL) {
+    if (netif_add_noaddr(&netif[0], &_esp_eth_dev, lwip_netdev_init,
+                         tcpip_input) == NULL) {
         DEBUG("Could not add esp_eth device\n");
         return;
     }
 #endif
 #if IS_USED(MODULE_ESP_WIFI)
     esp_wifi_setup(&_esp_wifi_dev);
-    if (_netif_add(&netif[ESP_WIFI_INDEX], &_esp_wifi_dev, lwip_netdev_init,
-                   tcpip_input) == NULL) {
+    if (netif_add_noaddr(&netif[ESP_WIFI_INDEX], &_esp_wifi_dev, lwip_netdev_init,
+                         tcpip_input) == NULL) {
         DEBUG("Could not add esp_wifi device\n");
         return;
     }
 #endif
 #elif defined(MODULE_SAM0_ETH)
     sam0_eth_setup(&sam0_eth);
-    if (_netif_add(&netif[0], &sam0_eth, lwip_netdev_init,
-                   tcpip_input) == NULL) {
+    if (netif_add_noaddr(&netif[0], &sam0_eth, lwip_netdev_init,
+                         tcpip_input) == NULL) {
         DEBUG("Could not add sam0_eth device\n");
         return;
     }
 #elif defined(MODULE_STM32_ETH)
     stm32_eth_netdev_setup(&stm32_eth);
-    if (_netif_add(&netif[0], &stm32_eth, lwip_netdev_init,
-                   tcpip_input) == NULL) {
+    if (netif_add_noaddr(&netif[0], &stm32_eth, lwip_netdev_init,
+                         tcpip_input) == NULL) {
         DEBUG("Could not add stm32_eth device\n");
         return;
     }
 #elif defined(MODULE_NRF802154)
     nrf802154_setup(&nrf802154_dev);
-    if (netif_add(&netif[0], (netdev_ieee802154_t *)&nrf802154_dev, lwip_netdev_init,
-                tcpip_6lowpan_input) == NULL) {
+    if (netif_add_noaddr(&netif[0], &nrf802154_dev, lwip_netdev_init,
+                         tcpip_6lowpan_input) == NULL) {
         DEBUG("Could not add nrf802154 device\n");
         return;
     }
 #endif
     if (netif[0].state != NULL) {
-        /* state is set to a netdev_t in the netif_add() functions above */
+        /* state is set to a netdev_t in the netif_add_noaddr() calls above */
         netif_set_default(&netif[0]);
     }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Makes 6lowpan netifs work even if dual stack is enabled,
and one less static method needed.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

 * `tests/lwip` still passes
 * Pinging board still works with `example/paho-mqtt` app which uses lwip

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None