### PR TITLE
boards/yarm: add missing comment ending in doc.txt

### DIFF
--- a/boards/yarm/doc.txt
+++ b/boards/yarm/doc.txt
@@ -106,3 +106,4 @@ sudo service udev restart
 Recommended toolchain for SAML21 is [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded).
 On Debian Buster, the default [gcc-arm-none-eabi](https://packages.debian.org/buster/gcc-arm-none-eabi)
 package works well.
+*/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While reviewing https://github.com/RIOT-OS/riot-os.org/pull/39 I noticed there that the Doxygen link for YARM didn't work.
It turns out there was a missing comment ending in `doc.txt`.
This PR fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Without this PR, there's no "Acmesystems YARM board" under boards. With this PR, you should see it under Boards
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/riot-os.org/pull/39
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
