### PR TITLE
gnrc_sixlowpan_frag_sfr_congure: add congure_quic support

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -236,6 +236,11 @@ PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_stats
 ## @{
 ##
 PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_congure
+## @defgroup net_gnrc_sixlowpan_frag_sfr_congure_quic gnrc_sixlowpan_frag_sfr_congure_quic: QUIC CC
+## @brief  Congestion control for SFR using the [congestion control algorithm of QUIC](@ref sys_congure_quic)
+## @{
+PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_congure_quic
+## @}
 ## @defgroup net_gnrc_sixlowpan_frag_sfr_congure_sfr gnrc_sixlowpan_frag_sfr_congure_sfr: Appendix C
 ## @brief  Basic congestion control for 6LoWPAN SFR as proposed in Appendix C of RFC 8931
 ## @see    [RFC 8931, Appendix C](https://tools.ietf.org/html/rfc8931#section-appendix.c)

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
@@ -16,6 +16,7 @@
  * (SFR). The flavor of congestion control can be selected using the following sub-modules:
  *
  * - @ref net_gnrc_sixlowpan_frag_sfr_congure_sfr (the default)
+ * - @ref net_gnrc_sixlowpan_frag_sfr_congure_quic
  * @{
  *
  * @file

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -244,6 +244,10 @@ ifneq (,$(filter gnrc_sixlowpan_frag_sfr_congure_%,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_frag_sfr_congure
 endif
 
+ifneq (,$(filter gnrc_sixlowpan_frag_sfr_congure_quic,$(USEMODULE)))
+  USEMODULE += congure_quic
+endif
+
 ifneq (,$(filter gnrc_sixlowpan_frag_sfr_congure,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_frag_sfr
   ifeq (,$(filter gnrc_sixlowpan_frag_sfr_congure_% congure_mock,$(USEMODULE)))

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/congure_quic.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/congure_quic.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "kernel_defines.h"
+#include "congure/quic.h"
+#include "net/gnrc/sixlowpan/config.h"
+
+#include "net/gnrc/sixlowpan/frag/sfr/congure.h"
+
+static congure_quic_snd_t _sfr_congures_quic[CONFIG_GNRC_SIXLOWPAN_FRAG_FB_SIZE];
+static const congure_quic_snd_consts_t _sfr_congure_quic_consts = {
+    /* cong_event_cb to resend a fragment is not needed since SFR always
+     * resends fragments lost or timed out immediately. In case of a reported
+     * ECN, it will also continue with the remaining fragments */
+    .init_wnd = CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE,
+    .min_wnd = CONFIG_GNRC_SIXLOWPAN_SFR_MIN_WIN_SIZE,
+    /* TODO make those configurable via Kconfig? */
+    .init_rtt = 333U,
+    .max_msg_size = 1,
+    .pc_thresh = 3000,
+    .granularity = 1,
+    .loss_reduction_numerator = 1,
+    .loss_reduction_denominator = 2,
+    .inter_msg_interval_numerator = 5,
+    .inter_msg_interval_denominator = 4,
+};
+
+congure_snd_t *gnrc_sixlowpan_frag_sfr_congure_snd_get(void)
+{
+    for (unsigned i = 0; i < ARRAY_SIZE(_sfr_congures_quic); i++) {
+        if (_sfr_congures_quic[i].super.driver == NULL) {
+            congure_quic_snd_setup(&_sfr_congures_quic[i],
+                                   &_sfr_congure_quic_consts);
+            return &_sfr_congures_quic[i].super;
+        }
+    }
+    return NULL;
+}
+
+/** @} */

--- a/tests/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
+++ b/tests/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
@@ -30,10 +30,15 @@ endif
 
 CONGURE_IMPL ?= congure_sfr
 
+ifeq (congure_quic,$(CONGURE_IMPL))
+  USEMODULE += gnrc_sixlowpan_frag_sfr_congure_quic
+  USEMODULE += ztimer_msec
+else
 ifeq (congure_sfr,$(CONGURE_IMPL))
   USEMODULE += gnrc_sixlowpan_frag_sfr_congure_sfr
 else
   $(error "Unknown CongURE implementation `$(CONGURE_IMPL)`")
+endif
 endif
 
 .PHONY: zep_dispatch


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provisions GNRC's 6LoWPAN SFR implementation with the CongURE implementation of QUIC. It also adds that implementation to the `tests/gnrc_sixlowpan_frag_sfr_congure_impl` test application.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The test `tests/gnrc_sixlowpan_frag_sfr_congure_impl` where extended to support `congure_quic`:
```sh
CONGURE_IMPL=congure_quic make -C tests/gnrc_sixlowpan_frag_sfr_congure_impl
```

Ping some nodes with at least 1 hop separation with large payloads. Exchange between should work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on ~~#15952~~ (merged) and ~~#16158~~ (merged) and their respective dependencies.

![PR dependency graph](https://page.mi.fu-berlin.de/mlenders/congure.svg)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
