### PR TITLE
sys/ztimer: rename required_pm_mode to block_pm_mode

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -337,7 +337,7 @@ struct ztimer_clock {
     ztimer_now_t checkpoint;        /**< cumulated time at last now() call  */
 #endif
 #if MODULE_PM_LAYERED || DOXYGEN
-    uint8_t required_pm_mode;       /**< min. pm mode required for the clock to run */
+    uint8_t block_pm_mode;          /**< min. pm mode to block for the clock to run */
 #endif
 };
 

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -224,9 +224,9 @@ void ztimer_init(void)
     ztimer_periph_timer_init(&ZTIMER_TIMER, CONFIG_ZTIMER_USEC_DEV,
                              ZTIMER_TIMER_FREQ, WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
 #  ifdef MODULE_PM_LAYERED
-    LOG_DEBUG("ztimer_init(): ZTIMER_TIMER setting required_pm_mode to %i\n",
+    LOG_DEBUG("ztimer_init(): ZTIMER_TIMER setting block_pm_mode to %i\n",
               CONFIG_ZTIMER_TIMER_BLOCK_PM_MODE);
-    ZTIMER_TIMER_CLK.required_pm_mode = CONFIG_ZTIMER_TIMER_BLOCK_PM_MODE;
+    ZTIMER_TIMER_CLK.block_pm_mode = CONFIG_ZTIMER_TIMER_BLOCK_PM_MODE;
 #  endif
 #endif
 
@@ -234,9 +234,9 @@ void ztimer_init(void)
     LOG_DEBUG("ztimer_init(): initializing rtt\n");
     ztimer_periph_rtt_init(&ZTIMER_RTT);
 #  ifdef MODULE_PM_LAYERED
-    LOG_DEBUG("ztimer_init(): ZTIMER_RTT setting required_pm_mode to %i\n",
+    LOG_DEBUG("ztimer_init(): ZTIMER_RTT setting block_pm_mode to %i\n",
               CONFIG_ZTIMER_RTT_BLOCK_PM_MODE);
-    ZTIMER_RTT_CLK.required_pm_mode = CONFIG_ZTIMER_RTT_BLOCK_PM_MODE;
+    ZTIMER_RTT_CLK.block_pm_mode = CONFIG_ZTIMER_RTT_BLOCK_PM_MODE;
 #  endif
 #endif
 
@@ -244,9 +244,9 @@ void ztimer_init(void)
     LOG_DEBUG("ztimer_init(): initializing rtc\n");
     ztimer_periph_rtc_init(&ZTIMER_RTC);
 #  ifdef MODULE_PM_LAYERED
-    LOG_DEBUG("ztimer_init(): ZTIMER_RTC setting required_pm_mode to %i\n",
+    LOG_DEBUG("ztimer_init(): ZTIMER_RTC setting block_pm_mode to %i\n",
               CONFIG_ZTIMER_RTC_BLOCK_PM_MODE);
-    ZTIMER_RTC_CLK.required_pm_mode = CONFIG_ZTIMER_RTC_BLOCK_PM_MODE;
+    ZTIMER_RTC_CLK.block_pm_mode = CONFIG_ZTIMER_RTC_BLOCK_PM_MODE;
 #  endif
 #endif
 

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -125,8 +125,8 @@ static void _add_entry_to_list(ztimer_clock_t *clock, ztimer_base_t *entry)
 #ifdef MODULE_PM_LAYERED
     /* First timer on the clock's linked list */
     if (list->next == NULL &&
-        clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
-        pm_block(clock->required_pm_mode);
+        clock->block_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
+        pm_block(clock->block_pm_mode);
     }
 #endif
 
@@ -260,8 +260,8 @@ static void _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry)
 #ifdef MODULE_PM_LAYERED
     /* The last timer just got removed from the clock's linked list */
     if (clock->list.next == NULL &&
-        clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
-        pm_unblock(clock->required_pm_mode);
+        clock->block_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
+        pm_unblock(clock->block_pm_mode);
     }
 #endif
 }
@@ -276,8 +276,8 @@ static ztimer_t *_now_next(ztimer_clock_t *clock)
             /* The last timer just got removed from the clock's linked list */
             clock->last = NULL;
 #ifdef MODULE_PM_LAYERED
-            if (clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
-                pm_unblock(clock->required_pm_mode);
+            if (clock->block_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
+                pm_unblock(clock->block_pm_mode);
             }
 #endif
         }


### PR DESCRIPTION
### Contribution description

the mode that is stored in required_pm_mode would not keep clock running
but one mode higher therefor the timer needs to block that mode, the logic does it this way.

The define keeps it's name for compatiblity but its use should fade, when #15715 is merged,
and should be deprecated in the release after that.

this PR is backward compatible to previous name waiting for it to be deprecated and removed.

### Testing procedure

build and test things that use pm_layerd and ztimer

### Issues/PRs references
the name was introduced with #13722  maybe  https://github.com/RIOT-OS/RIOT/pull/13722#discussion_r400694298_ creted the name != function mismatch
this is in conflict with an other PR I am writing on: #15715 i will happily rebase either when the other is merged