### PR TITLE
boards/nucleo-f722ze: Add periph_can

### DIFF
--- a/boards/nucleo-f722ze/Kconfig
+++ b/boards/nucleo-f722ze/Kconfig
@@ -21,6 +21,7 @@ config BOARD_NUCLEO_F722ZE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_CAN
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT

--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/cpu/stm32/include/can_params.h
+++ b/cpu/stm32/include/can_params.h
@@ -43,10 +43,12 @@ static const can_conf_t candev_conf[] = {
         .rcc_mask = RCC_APB1ENR1_CAN1EN,
 #else
         .rcc_mask = RCC_APB1ENR_CAN1EN,
+#if CANDEV_STM32_CHAN_NUMOF > 1
         .can_master = CAN1,
         .master_rcc_mask = RCC_APB1ENR_CAN1EN,
         .first_filter = 0,
         .nb_filters = 14,
+#endif
 #endif
 #if  defined(CPU_FAM_STM32F1)
         .rx_pin = GPIO_PIN(PORT_A, 11),

--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -42,7 +42,7 @@ extern "C" {
 #elif defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
 #define CANDEV_STM32_CHAN_NUMOF 2
 #elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
-      defined(CPU_FAM_STM32L4) || DOXYGEN
+      defined(CPU_FAM_STM32L4) || defined(CPU_LINE_STM32F722xx) || DOXYGEN
 /** Number of channels in the device (up to 3) */
 #define CANDEV_STM32_CHAN_NUMOF 1
 #else
@@ -136,7 +136,6 @@ typedef struct {
 #define CAN_STM32_TX_MAILBOXES 3
 /** The number of receive FIFO */
 #define CAN_STM32_RX_MAILBOXES 2
-
 
 #ifndef CAN_STM32_RX_MAIL_FIFO
 /** This is the maximum number of frame the driver can receive simultaneously */

--- a/cpu/stm32/periph/can.c
+++ b/cpu/stm32/periph/can.c
@@ -805,6 +805,12 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
                         can->BTR |= CAN_BTR_SILM;
                         res += set_mode(can, mode);
                         break;
+                    case CANOPT_STATE_LOOPBACK:
+                        DEBUG("candev_stm32 %p: Loopback\n", (void *)dev);
+                        res = set_mode(can, MODE_INIT);
+                        can->BTR |= CAN_BTR_LBKM;
+                        res += set_mode(can, MODE_NORMAL);
+                        break;
                 }
             }
             break;

--- a/sys/include/can/common.h
+++ b/sys/include/can/common.h
@@ -63,8 +63,8 @@ typedef enum {
     CANOPT_STATE_SLEEP,           /**< sleep mode */
     CANOPT_STATE_LISTEN_ONLY,     /**< listen only mode */
     CANOPT_STATE_ON,              /**< power on, rx / tx mode */
+    CANOPT_STATE_LOOPBACK,        /**< loopback mode */
 } canopt_state_t;
-
 
 /**
  * @brief Structure to pass a CAN option

--- a/tests/candev/main.c
+++ b/tests/candev/main.c
@@ -48,6 +48,11 @@ static candev_mcp2515_t mcp2515_dev;
 /* add includes for other candev drivers here */
 #endif
 
+/* Default is not using loopback test mode */
+#ifndef CONFIG_USE_LOOPBACK_MODE
+#define CONFIG_USE_LOOPBACK_MODE        0
+#endif
+
 #define RX_RINGBUFFER_SIZE 128      /* Needs to be a power of 2! */
 static isrpipe_t rxbuf;
 static uint8_t rx_ringbuf[RX_RINGBUFFER_SIZE];
@@ -221,6 +226,18 @@ int main(void)
     candev->isr_arg = NULL;
 
     candev->driver->init(candev);
+
+if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
+    puts("Switching to loopback mode");
+    /* set to loopback test mode */
+    canopt_state_t mode = CANOPT_STATE_LOOPBACK;
+    candev->driver->set(candev, CANOPT_STATE, &mode, sizeof(mode));
+
+    /* do not care, receive all message id */
+    struct can_filter filter;
+    filter.can_mask = 0;
+    candev->driver->set_filter(candev, &filter);
+}
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);


### PR DESCRIPTION
boards/nucleo-f722ze: Add periph_can support

cpu/stm32: Add CAN support for f722ze board
f722ze board has ONLY 1 CAN interface, fix compiling error which
treats f722xx has more than 1 CAN.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- stm32f722ze MCU contains CAN 2.0B interface. Makefile.features for board nucleo-f722ze is missing this periph_can. (1st commit)
- Fix a bug in cpu/stm32/include/can_params.h which treats f722ze with more than 1 CAN interfaces. (1st commit)
- For test purpose, add loopback. Due to hardware limitation, I have to use loopback mode to test my changes. (2nd commit)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
First, pin CAN_TX(PD1) and CAN_RX(PD0) shall be connected with 120 ohm. For me, i short the pins for loopback test is good enough
Second, compile candev application to test. in RIOT/ folder, run
CFLAGS=-DCAN_LOOPBACK_MODE make BOARD=nucleo-f722ze CAN_DRIVER=PERIPH_CAN -C tests/candev flash term
In pyterm, type send <data> to send bytes, and check data is looping back to receive FIFO with command receive
My test as following i.e.

```
2021-03-04 00:45:18,622 # main(): This is RIOT! (Version: 2021.04-devel-931-gbf93d-nucleo-f722ze_add_CAN)
2021-03-04 00:45:18,624 # candev test application
2021-03-04 00:45:18,625 # 
2021-03-04 00:45:18,627 # Initializing CAN periph device
> send 1 2 3 4
2021-03-04 00:45:22,683 # send 1 2 3 4
> 
2021-03-04 00:45:25,078 # send 1 2 3 4
> receive
2021-03-04 00:45:28,133 # receive
2021-03-04 00:45:28,136 # Reading from Rxbuf...
2021-03-04 00:45:28,137 # id: 1 dlc: hx Data: 
2021-03-04 00:45:28,139 # 0x1 0x2 0x3 0x4 
> 
2021-03-04 00:45:29,963 # receive
2021-03-04 00:45:29,965 # Reading from Rxbuf...
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #15711
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
