### PR TITLE
pkg/lwip: Allow initializing different types of netifs

### DIFF
--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -63,6 +63,7 @@ ifneq (,$(filter lwip_%,$(USEMODULE)))
   USEMODULE += lwip_contrib
   USEMODULE += lwip_core
   USEMODULE += lwip_netif
+  USEMODULE += lwip_netif_init_devs
   USEMODULE += netdev
   ifeq (,$(filter lwip_ipv4 lwip_ipv6,$(USEMODULE)))
     USEMODULE += lwip_ipv4

--- a/pkg/lwip/Makefile.include
+++ b/pkg/lwip/Makefile.include
@@ -29,6 +29,9 @@ endif
 ifneq (,$(filter lwip_netdev,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/lwip/contrib/netdev
 endif
+ifneq (,$(filter lwip_netif_init_devs,$(USEMODULE)))
+  DIRS += $(RIOTBASE)/pkg/lwip/init_devs
+endif
 ifneq (,$(filter lwip_sock,$(USEMODULE)))
   ifneq (,$(filter lwip_ipv6,$(USEMODULE)))
     CFLAGS += -DSOCK_HAS_IPV6

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -47,10 +47,6 @@
 #include "socket_zep_params.h"
 #endif
 
-#ifdef MODULE_ESP_ETH
-#include "esp-eth/esp_eth_netdev.h"
-#endif
-
 #ifdef MODULE_ESP_WIFI
 #include "esp-wifi/esp_wifi_netdev.h"
 #endif
@@ -98,12 +94,8 @@
 #endif
 
 /* is mutual exclusive with above ifdef */
-#if IS_USED(MODULE_ESP_ETH) && IS_USED(MODULE_ESP_WIFI)
-#define LWIP_NETIF_NUMOF        (2)
-#define ESP_WIFI_INDEX          (1)
-#elif IS_USED(MODULE_ESP_ETH) || IS_USED(MODULE_ESP_WIFI)
+#if IS_USED(MODULE_ESP_WIFI)
 #define LWIP_NETIF_NUMOF        (1)
-#define ESP_WIFI_INDEX          (0)
 #endif
 
 #ifdef MODULE_SAM0_ETH
@@ -140,11 +132,6 @@ static mrf24j40_t mrf24j40_devs[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_SOCKET_ZEP
 static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_ESP_ETH
-extern esp_eth_netdev_t _esp_eth_dev;
-extern void esp_eth_setup (esp_eth_netdev_t* dev);
 #endif
 
 #ifdef MODULE_ESP_WIFI
@@ -216,23 +203,13 @@ void lwip_bootstrap(void)
             return;
         }
     }
-#elif (IS_USED(MODULE_ESP_ETH) || IS_USED(MODULE_ESP_WIFI))
-#if IS_USED(MODULE_ESP_ETH)
-    esp_eth_setup(&_esp_eth_dev);
-    if (netif_add_noaddr(&netif[0], &_esp_eth_dev.netdev, lwip_netdev_init,
-                         tcpip_input) == NULL) {
-        DEBUG("Could not add esp_eth device\n");
-        return;
-    }
-#endif
-#if IS_USED(MODULE_ESP_WIFI)
+#elif IS_USED(MODULE_ESP_WIFI)
     esp_wifi_setup(&_esp_wifi_dev);
-    if (netif_add_noaddr(&netif[ESP_WIFI_INDEX], &_esp_wifi_dev.netdev, lwip_netdev_init,
+    if (netif_add_noaddr(&netif[0], &_esp_wifi_dev.netdev, lwip_netdev_init,
                          tcpip_input) == NULL) {
         DEBUG("Could not add esp_wifi device\n");
         return;
     }
-#endif
 #elif defined(MODULE_SAM0_ETH)
     sam0_eth_setup(&sam0_eth);
     if (netif_add_noaddr(&netif[0], &sam0_eth, lwip_netdev_init,

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -37,10 +37,6 @@
 #include "socket_zep_params.h"
 #endif
 
-#ifdef MODULE_SAM0_ETH
-#include "sam0_eth_netdev.h"
-#endif
-
 #ifdef MODULE_STM32_ETH
 #include "stm32_eth.h"
 #endif
@@ -72,10 +68,6 @@
 #endif
 
 /* is mutual exclusive with above ifdef */
-#ifdef MODULE_SAM0_ETH
-#define LWIP_NETIF_NUMOF        (1)
-#endif
-
 #ifdef MODULE_STM32_ETH
 #define LWIP_NETIF_NUMOF        (1)
 #endif
@@ -98,11 +90,6 @@ static mrf24j40_t mrf24j40_devs[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_SOCKET_ZEP
 static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_SAM0_ETH
-static netdev_t sam0_eth;
-extern void sam0_eth_setup(netdev_t *netdev);
 #endif
 
 #ifdef MODULE_STM32_ETH
@@ -145,13 +132,6 @@ void lwip_bootstrap(void)
             DEBUG("Could not add socket_zep device\n");
             return;
         }
-    }
-#elif defined(MODULE_SAM0_ETH)
-    sam0_eth_setup(&sam0_eth);
-    if (netif_add_noaddr(&netif[0], &sam0_eth, lwip_netdev_init,
-                         tcpip_input) == NULL) {
-        DEBUG("Could not add sam0_eth device\n");
-        return;
     }
 #elif defined(MODULE_STM32_ETH)
     stm32_eth_netdev_setup(&stm32_eth);

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -27,11 +27,6 @@
 #include "at86rf2xx_params.h"
 #endif
 
-#ifdef MODULE_ATWINC15X0
-#include "atwinc15x0.h"
-#include "atwinc15x0_params.h"
-#endif
-
 #ifdef MODULE_ENC28J60
 #include "enc28j60.h"
 #include "enc28j60_params.h"
@@ -73,10 +68,6 @@
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 #endif
 
-#ifdef MODULE_ATWINC15X0    /* is mutual exclusive with above ifdef */
-#define LWIP_NETIF_NUMOF        ARRAY_SIZE(atwinc15x0_params)
-#endif
-
 #ifdef MODULE_ENC28J60    /* is mutual exclusive with above ifdef */
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(enc28j60_params)
 #endif
@@ -108,10 +99,6 @@ static struct netif netif[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_AT86RF2XX
 static at86rf2xx_t at86rf2xx_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_ATWINC15X0
-static atwinc15x0_t atwinc15x0_devs[LWIP_NETIF_NUMOF];
 #endif
 
 #ifdef MODULE_ENC28J60
@@ -160,15 +147,6 @@ void lwip_bootstrap(void)
         if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i].netdev.netdev, lwip_netdev_init,
                              tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add at86rf2xx device\n");
-            return;
-        }
-    }
-#elif defined(MODULE_ATWINC15X0)
-    for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
-        if (netif_add_noaddr(&netif[0], &atwinc15x0_devs[i].netdev, lwip_netdev_init,
-                             tcpip_input) == NULL) {
-            DEBUG("Could not add atwinc15x0 device\n");
             return;
         }
     }

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -22,45 +22,15 @@
 #include "lwip/netifapi.h"
 #include "netif/lowpan6.h"
 
-#ifdef MODULE_SOCKET_ZEP
-#include "socket_zep.h"
-#include "socket_zep_params.h"
-#endif
-
 #include "lwip.h"
 #include "lwip_init_devs.h"
 
 #define ENABLE_DEBUG    0
 #include "debug.h"
 
-#ifdef MODULE_SOCKET_ZEP
-#define LWIP_NETIF_NUMOF        ARRAY_SIZE(socket_zep_params)
-#endif
-
-#ifdef LWIP_NETIF_NUMOF
-static struct netif netif[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_SOCKET_ZEP
-static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
-#endif
-
 void lwip_bootstrap(void)
 {
     lwip_netif_init_devs();
-    /* TODO: do for every eligible netdev */
-#ifdef LWIP_NETIF_NUMOF
-#if defined(MODULE_SOCKET_ZEP)
-    for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
-        if (netif_add_noaddr(&netif[i], &socket_zep_devs[i].netdev.netdev, lwip_netdev_init,
-                             tcpip_6lowpan_input) == NULL) {
-            DEBUG("Could not add socket_zep device\n");
-            return;
-        }
-    }
-#endif
-#endif
     /* also allow for external interface definition */
     tcpip_init(NULL, NULL);
 #if IS_USED(MODULE_LWIP_DHCP_AUTO)

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -22,11 +22,6 @@
 #include "lwip/netifapi.h"
 #include "netif/lowpan6.h"
 
-#ifdef MODULE_AT86RF2XX
-#include "at86rf2xx.h"
-#include "at86rf2xx_params.h"
-#endif
-
 #ifdef MODULE_SOCKET_ZEP
 #include "socket_zep.h"
 #include "socket_zep_params.h"
@@ -46,11 +41,7 @@
 #define ENABLE_DEBUG    0
 #include "debug.h"
 
-#ifdef MODULE_AT86RF2XX
-#define LWIP_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
-#endif
-
-#ifdef MODULE_SOCKET_ZEP   /* is mutual exclusive with above ifdef */
+#ifdef MODULE_SOCKET_ZEP
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(socket_zep_params)
 #endif
 
@@ -61,10 +52,6 @@
 
 #ifdef LWIP_NETIF_NUMOF
 static struct netif netif[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_AT86RF2XX
-static at86rf2xx_t at86rf2xx_devs[LWIP_NETIF_NUMOF];
 #endif
 
 #ifdef MODULE_SOCKET_ZEP
@@ -80,16 +67,7 @@ void lwip_bootstrap(void)
     lwip_netif_init_devs();
     /* TODO: do for every eligible netdev */
 #ifdef LWIP_NETIF_NUMOF
-#if defined(MODULE_AT86RF2XX)
-    for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
-        if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i].netdev.netdev, lwip_netdev_init,
-                             tcpip_6lowpan_input) == NULL) {
-            DEBUG("Could not add at86rf2xx device\n");
-            return;
-        }
-    }
-#elif defined(MODULE_SOCKET_ZEP)
+#if defined(MODULE_SOCKET_ZEP)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
         if (netif_add_noaddr(&netif[i], &socket_zep_devs[i].netdev.netdev, lwip_netdev_init,

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -27,14 +27,6 @@
 #include "socket_zep_params.h"
 #endif
 
-#ifdef MODULE_NRF802154
-#include "nrf802154.h"
-#endif
-
-#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
-#include "net/netdev/ieee802154_submac.h"
-#endif
-
 #include "lwip.h"
 #include "lwip_init_devs.h"
 
@@ -45,21 +37,12 @@
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(socket_zep_params)
 #endif
 
-/* is mutual exclusive with above ifdef */
-#ifdef MODULE_NRF802154
-#define LWIP_NETIF_NUMOF        (1)
-#endif
-
 #ifdef LWIP_NETIF_NUMOF
 static struct netif netif[LWIP_NETIF_NUMOF];
 #endif
 
 #ifdef MODULE_SOCKET_ZEP
 static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_NRF802154
-static netdev_ieee802154_submac_t nrf802154_netdev;
 #endif
 
 void lwip_bootstrap(void)
@@ -75,17 +58,6 @@ void lwip_bootstrap(void)
             DEBUG("Could not add socket_zep device\n");
             return;
         }
-    }
-#elif defined(MODULE_NRF802154)
-    netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
-    netdev_ieee802154_submac_init(&nrf802154_netdev);
-
-    nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
-    nrf802154_init();
-    if (netif_add_noaddr(&netif[0], &nrf802154_netdev.dev.netdev, lwip_netdev_init,
-                         tcpip_6lowpan_input) == NULL) {
-        DEBUG("Could not add nrf802154 device\n");
-        return;
     }
 #endif
 #endif

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -37,10 +37,6 @@
 #include "socket_zep_params.h"
 #endif
 
-#ifdef MODULE_STM32_ETH
-#include "stm32_eth.h"
-#endif
-
 #ifdef MODULE_NRF802154
 #include "nrf802154.h"
 #endif
@@ -68,10 +64,6 @@
 #endif
 
 /* is mutual exclusive with above ifdef */
-#ifdef MODULE_STM32_ETH
-#define LWIP_NETIF_NUMOF        (1)
-#endif
-
 #ifdef MODULE_NRF802154
 #define LWIP_NETIF_NUMOF        (1)
 #endif
@@ -90,11 +82,6 @@ static mrf24j40_t mrf24j40_devs[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_SOCKET_ZEP
 static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_STM32_ETH
-static netdev_t stm32_eth;
-extern void stm32_eth_netdev_setup(netdev_t *netdev);
 #endif
 
 #ifdef MODULE_NRF802154
@@ -132,13 +119,6 @@ void lwip_bootstrap(void)
             DEBUG("Could not add socket_zep device\n");
             return;
         }
-    }
-#elif defined(MODULE_STM32_ETH)
-    stm32_eth_netdev_setup(&stm32_eth);
-    if (netif_add_noaddr(&netif[0], &stm32_eth, lwip_netdev_init,
-                         tcpip_input) == NULL) {
-        DEBUG("Could not add stm32_eth device\n");
-        return;
     }
 #elif defined(MODULE_NRF802154)
     netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -27,11 +27,6 @@
 #include "at86rf2xx_params.h"
 #endif
 
-#ifdef MODULE_ENC28J60
-#include "enc28j60.h"
-#include "enc28j60_params.h"
-#endif
-
 #ifdef MODULE_MRF24J40
 #include "mrf24j40.h"
 #include "mrf24j40_params.h"
@@ -68,10 +63,6 @@
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 #endif
 
-#ifdef MODULE_ENC28J60    /* is mutual exclusive with above ifdef */
-#define LWIP_NETIF_NUMOF        ARRAY_SIZE(enc28j60_params)
-#endif
-
 #ifdef MODULE_MRF24J40     /* is mutual exclusive with above ifdef */
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(mrf24j40_params)
 #endif
@@ -99,10 +90,6 @@ static struct netif netif[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_AT86RF2XX
 static at86rf2xx_t at86rf2xx_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_ENC28J60
-static enc28j60_t enc28j60_devs[LWIP_NETIF_NUMOF];
 #endif
 
 #ifdef MODULE_MRF24J40
@@ -147,15 +134,6 @@ void lwip_bootstrap(void)
         if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i].netdev.netdev, lwip_netdev_init,
                              tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add at86rf2xx device\n");
-            return;
-        }
-    }
-#elif defined(MODULE_ENC28J60)
-    for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i], i);
-        if (netif_add_noaddr(&netif[0], &enc28j60_devs[i].netdev, lwip_netdev_init,
-                             tcpip_input) == NULL) {
-            DEBUG("Could not add enc28j60 device\n");
             return;
         }
     }

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -47,10 +47,6 @@
 #include "socket_zep_params.h"
 #endif
 
-#ifdef MODULE_ESP_WIFI
-#include "esp-wifi/esp_wifi_netdev.h"
-#endif
-
 #ifdef MODULE_SAM0_ETH
 #include "sam0_eth_netdev.h"
 #endif
@@ -94,10 +90,6 @@
 #endif
 
 /* is mutual exclusive with above ifdef */
-#if IS_USED(MODULE_ESP_WIFI)
-#define LWIP_NETIF_NUMOF        (1)
-#endif
-
 #ifdef MODULE_SAM0_ETH
 #define LWIP_NETIF_NUMOF        (1)
 #endif
@@ -132,11 +124,6 @@ static mrf24j40_t mrf24j40_devs[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_SOCKET_ZEP
 static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
-#endif
-
-#ifdef MODULE_ESP_WIFI
-extern esp_wifi_netdev_t _esp_wifi_dev;
-extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
 #endif
 
 #ifdef MODULE_SAM0_ETH
@@ -202,13 +189,6 @@ void lwip_bootstrap(void)
             DEBUG("Could not add socket_zep device\n");
             return;
         }
-    }
-#elif IS_USED(MODULE_ESP_WIFI)
-    esp_wifi_setup(&_esp_wifi_dev);
-    if (netif_add_noaddr(&netif[0], &_esp_wifi_dev.netdev, lwip_netdev_init,
-                         tcpip_input) == NULL) {
-        DEBUG("Could not add esp_wifi device\n");
-        return;
     }
 #elif defined(MODULE_SAM0_ETH)
     sam0_eth_setup(&sam0_eth);

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -259,10 +259,6 @@ void lwip_bootstrap(void)
         return;
     }
 #endif
-    if (netif[0].state != NULL) {
-        /* state is set to a netdev_t in the netif_add_noaddr() calls above */
-        netif_set_default(&netif[0]);
-    }
 #endif
     /* also allow for external interface definition */
     tcpip_init(NULL, NULL);

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -27,11 +27,6 @@
 #include "at86rf2xx_params.h"
 #endif
 
-#ifdef MODULE_MRF24J40
-#include "mrf24j40.h"
-#include "mrf24j40_params.h"
-#endif
-
 #ifdef MODULE_SOCKET_ZEP
 #include "socket_zep.h"
 #include "socket_zep_params.h"
@@ -55,10 +50,6 @@
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 #endif
 
-#ifdef MODULE_MRF24J40     /* is mutual exclusive with above ifdef */
-#define LWIP_NETIF_NUMOF        ARRAY_SIZE(mrf24j40_params)
-#endif
-
 #ifdef MODULE_SOCKET_ZEP   /* is mutual exclusive with above ifdef */
 #define LWIP_NETIF_NUMOF        ARRAY_SIZE(socket_zep_params)
 #endif
@@ -76,10 +67,6 @@ static struct netif netif[LWIP_NETIF_NUMOF];
 static at86rf2xx_t at86rf2xx_devs[LWIP_NETIF_NUMOF];
 #endif
 
-#ifdef MODULE_MRF24J40
-static mrf24j40_t mrf24j40_devs[LWIP_NETIF_NUMOF];
-#endif
-
 #ifdef MODULE_SOCKET_ZEP
 static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
 #endif
@@ -93,16 +80,7 @@ void lwip_bootstrap(void)
     lwip_netif_init_devs();
     /* TODO: do for every eligible netdev */
 #ifdef LWIP_NETIF_NUMOF
-#ifdef MODULE_MRF24J40
-    for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
-        if (netif_add_noaddr(&netif[i], &mrf24j40_devs[i].netdev.netdev, lwip_netdev_init,
-                             tcpip_6lowpan_input) == NULL) {
-            DEBUG("Could not add mrf24j40 device\n");
-            return;
-        }
-    }
-#elif defined(MODULE_AT86RF2XX)
+#if defined(MODULE_AT86RF2XX)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
         if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i].netdev.netdev, lwip_netdev_init,

--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -40,6 +40,16 @@ void lwip_netif_init_devs(void);
  */
 struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
 
+/**
+ * @brief Adds a 6LoWPAN netif using the supplied netdev.
+ *
+ * @param netif         pointer to the interface to be added
+ * @param state         pointer to the netdev for the interface
+ *
+ * The netif will be set up using the `lwip_netdev_init` helper.
+ */
+struct netif *lwip_add_6lowpan(struct netif *netif, netdev_t *state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ *
+ * @{
+ *
+ * @file
+ * @brief   Helpers for simplified network setup
+ *
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#ifndef LWIP_INIT_DEVS_H
+#define LWIP_INIT_DEVS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lwip/netif.h"
+#include "net/netdev.h"
+
+void lwip_netif_init_devs(void);
+
+/**
+ * @brief Adds an Ethernet netif using the supplied netdev.
+ *
+ * @param netif         pointer to the interface to be added
+ * @param state         pointer to the netdev for the interface
+ *
+ * The netif will be set up using the `lwip_netdev_init` helper.
+ */
+struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWIP_INIT_DEVS_H */
+/** @} */

--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -26,6 +26,7 @@ extern "C" {
 
 #include "lwip/netif.h"
 #include "net/netdev.h"
+#include "xfa.h"
 
 void lwip_netif_init_devs(void);
 
@@ -49,6 +50,22 @@ struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
  * The netif will be set up using the `lwip_netdev_init` helper.
  */
 struct netif *lwip_add_6lowpan(struct netif *netif, netdev_t *state);
+
+typedef void (*lwip_netif_setup_func_t)(void);
+
+/**
+ * @brief Registers initialization function for an Ethernet interface
+ */
+#define LWIP_INIT_ETH_NETIF(func) \
+    XFA_USE_CONST(lwip_netif_setup_func_t, lwip_netif_eth_xfa); \
+    XFA_ADD_PTR(lwip_netif_eth_xfa, func, func, &func)
+
+/**
+ * @brief Registers initialization function for a 6LoWPAN interface
+ */
+#define LWIP_INIT_6LOWPAN_NETIF(func) \
+    XFA_USE_CONST(lwip_netif_setup_func_t, lwip_netif_6lowpan_xfa); \
+    XFA_ADD_PTR(lwip_netif_6lowpan_xfa, func, func, &func)
 
 #ifdef __cplusplus
 }

--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -36,6 +36,7 @@ void lwip_netif_init_devs(void);
  * @param state         pointer to the netdev for the interface
  *
  * The netif will be set up using the `lwip_netdev_init` helper.
+ * The first netif added will be marked as the default route.
  */
 struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
 

--- a/pkg/lwip/init_devs/Makefile
+++ b/pkg/lwip/init_devs/Makefile
@@ -1,0 +1,3 @@
+MODULE = lwip_netif_init_devs
+
+include $(RIOTMAKE)/auto_init.inc.mk

--- a/pkg/lwip/init_devs/auto_init_at86rf2xx.c
+++ b/pkg/lwip/init_devs/auto_init_at86rf2xx.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for at86rf2xx network interfaces
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "at86rf2xx.h"
+#include "at86rf2xx_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_AT86RF2XX_NUMOF        ARRAY_SIZE(at86rf2xx_params)
+
+static struct netif netif[NETIF_AT86RF2XX_NUMOF];
+static at86rf2xx_t at86rf2xx_devs[NETIF_AT86RF2XX_NUMOF];
+
+void auto_init_at86rf2xx(void)
+{
+    for (unsigned i = 0; i < NETIF_AT86RF2XX_NUMOF; i++) {
+        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
+        if (lwip_add_6lowpan(&netif[i], &at86rf2xx_devs[i].netdev.netdev) == NULL) {
+            DEBUG("Could not add at86rf2xx device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_at86rf2xx.c
+++ b/pkg/lwip/init_devs/auto_init_at86rf2xx.c
@@ -30,7 +30,7 @@
 static struct netif netif[NETIF_AT86RF2XX_NUMOF];
 static at86rf2xx_t at86rf2xx_devs[NETIF_AT86RF2XX_NUMOF];
 
-void auto_init_at86rf2xx(void)
+static void auto_init_at86rf2xx(void)
 {
     for (unsigned i = 0; i < NETIF_AT86RF2XX_NUMOF; i++) {
         at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
@@ -40,4 +40,6 @@ void auto_init_at86rf2xx(void)
         }
     }
 }
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_at86rf2xx);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_atwinc15x0.c
+++ b/pkg/lwip/init_devs/auto_init_atwinc15x0.c
@@ -30,7 +30,7 @@
 static struct netif netif[NETIF_ATWINC_NUMOF];
 static atwinc15x0_t atwinc15x0_devs[NETIF_ATWINC_NUMOF];
 
-void auto_init_atwinc15x0(void)
+static void auto_init_atwinc15x0(void)
 {
     for (unsigned i = 0; i < NETIF_ATWINC_NUMOF; i++) {
         atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
@@ -40,4 +40,6 @@ void auto_init_atwinc15x0(void)
         }
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_atwinc15x0);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_atwinc15x0.c
+++ b/pkg/lwip/init_devs/auto_init_atwinc15x0.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for atwinc15x0 network interfaces
+ *
+ * @author  Gunar Schorcht <gunar@schorcht.net>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "atwinc15x0.h"
+#include "atwinc15x0_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_ATWINC_NUMOF ARRAY_SIZE(atwinc15x0_params)
+
+static struct netif netif[NETIF_ATWINC_NUMOF];
+static atwinc15x0_t atwinc15x0_devs[NETIF_ATWINC_NUMOF];
+
+void auto_init_atwinc15x0(void)
+{
+    for (unsigned i = 0; i < NETIF_ATWINC_NUMOF; i++) {
+        atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
+        if (lwip_add_ethernet(&netif[i], &atwinc15x0_devs[i].netdev) == NULL) {
+            DEBUG("Could not add atwinc15x0 device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_enc28j60.c
+++ b/pkg/lwip/init_devs/auto_init_enc28j60.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Giuseppe Tipaldi
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for enc28j60 network interfaces
+ *
+ * @author  Giuseppe Tipaldi <ing.giuseppe.tipaldi@gmail.com>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "enc28j60.h"
+#include "enc28j60_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_ENC28J60_NUMOF        ARRAY_SIZE(enc28j60_params)
+
+static struct netif netif[NETIF_ENC28J60_NUMOF];
+static enc28j60_t enc28j60_devs[NETIF_ENC28J60_NUMOF];
+
+void auto_init_enc28j60(void)
+{
+    for (unsigned i = 0; i < NETIF_ENC28J60_NUMOF; i++) {
+        enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i], i);
+        if (lwip_add_ethernet(&netif[i], &enc28j60_devs[i].netdev) == NULL) {
+            DEBUG("Could not add enc28j60 device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_enc28j60.c
+++ b/pkg/lwip/init_devs/auto_init_enc28j60.c
@@ -30,7 +30,7 @@
 static struct netif netif[NETIF_ENC28J60_NUMOF];
 static enc28j60_t enc28j60_devs[NETIF_ENC28J60_NUMOF];
 
-void auto_init_enc28j60(void)
+static void auto_init_enc28j60(void)
 {
     for (unsigned i = 0; i < NETIF_ENC28J60_NUMOF; i++) {
         enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i], i);
@@ -40,4 +40,6 @@ void auto_init_enc28j60(void)
         }
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_enc28j60);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_esp_eth.c
+++ b/pkg/lwip/init_devs/auto_init_esp_eth.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for ESP eth network interfaces
+ *
+ * @author  Gunar Schorcht <gunar@schorcht.net>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "esp-eth/esp_eth_netdev.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+extern esp_eth_netdev_t _esp_eth_dev;
+extern void esp_eth_setup(esp_eth_netdev_t* dev);
+
+static struct netif netif;
+
+void auto_init_esp_eth(void)
+{
+    esp_eth_setup(&_esp_eth_dev);
+    if (lwip_add_ethernet(&netif, &_esp_eth_dev.netdev) == NULL) {
+        DEBUG("Could not add esp_eth device\n");
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_esp_eth.c
+++ b/pkg/lwip/init_devs/auto_init_esp_eth.c
@@ -29,11 +29,13 @@ extern void esp_eth_setup(esp_eth_netdev_t* dev);
 
 static struct netif netif;
 
-void auto_init_esp_eth(void)
+static void auto_init_esp_eth(void)
 {
     esp_eth_setup(&_esp_eth_dev);
     if (lwip_add_ethernet(&netif, &_esp_eth_dev.netdev) == NULL) {
         DEBUG("Could not add esp_eth device\n");
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_esp_eth);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_esp_wifi.c
+++ b/pkg/lwip/init_devs/auto_init_esp_wifi.c
@@ -29,11 +29,13 @@ extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
 
 static struct netif netif;
 
-void auto_init_esp_wifi(void)
+static void auto_init_esp_wifi(void)
 {
     esp_wifi_setup(&_esp_wifi_dev);
     if (lwip_add_ethernet(&netif, &_esp_wifi_dev.netdev) == NULL) {
         DEBUG("Could not add esp_eth device\n");
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_esp_wifi);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_esp_wifi.c
+++ b/pkg/lwip/init_devs/auto_init_esp_wifi.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for ESP WiFi network interfaces
+ *
+ * @author  Gunar Schorcht <gunar@schorcht.net>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "esp-wifi/esp_wifi_netdev.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+extern esp_wifi_netdev_t _esp_wifi_dev;
+extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
+
+static struct netif netif;
+
+void auto_init_esp_wifi(void)
+{
+    esp_wifi_setup(&_esp_wifi_dev);
+    if (lwip_add_ethernet(&netif, &_esp_wifi_dev.netdev) == NULL) {
+        DEBUG("Could not add esp_eth device\n");
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_ethos.c
+++ b/pkg/lwip/init_devs/auto_init_ethos.c
@@ -32,7 +32,7 @@ static ethos_t ethos_devs[NETIF_ETHOS_NUMOF];
 
 static uint8_t _inbuf[NETIF_ETHOS_NUMOF][2048];
 
-void auto_init_ethos(void)
+static void auto_init_ethos(void)
 {
     for (unsigned i = 0; i < NETIF_ETHOS_NUMOF; i++) {
         ethos_setup(&ethos_devs[i], &ethos_params[i], i, _inbuf[i], sizeof(_inbuf[i]));
@@ -42,4 +42,6 @@ void auto_init_ethos(void)
         }
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_ethos);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_ethos.c
+++ b/pkg/lwip/init_devs/auto_init_ethos.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for the ethernet-over-serial module
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "ethos.h"
+#include "ethos_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_ETHOS_NUMOF        ARRAY_SIZE(ethos_params)
+
+static struct netif netif[NETIF_ETHOS_NUMOF];
+static ethos_t ethos_devs[NETIF_ETHOS_NUMOF];
+
+static uint8_t _inbuf[NETIF_ETHOS_NUMOF][2048];
+
+void auto_init_ethos(void)
+{
+    for (unsigned i = 0; i < NETIF_ETHOS_NUMOF; i++) {
+        ethos_setup(&ethos_devs[i], &ethos_params[i], i, _inbuf[i], sizeof(_inbuf[i]));
+        if (lwip_add_ethernet(&netif[i], &ethos_devs[i].netdev) == NULL) {
+            DEBUG("Could not add ethos device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_mrf24j40.c
+++ b/pkg/lwip/init_devs/auto_init_mrf24j40.c
@@ -1,0 +1,44 @@
+/*
+￼* Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
+￼*
+￼* This file is subject to the terms and conditions of the GNU Lesser
+￼* General Public License v2.1. See the file LICENSE in the top level
+￼* directory for more details.
+￼*
+￼*/
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for MRF24J40 network interfaces
+ *
+ * @author  Neo Nenaco <neo@nenaco.de>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "mrf24j40.h"
+#include "mrf24j40_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_MRF24J40_NUMOF        ARRAY_SIZE(mrf24j40_params)
+
+static struct netif netif[NETIF_MRF24J40_NUMOF];
+static mrf24j40_t mrf24j40_devs[NETIF_MRF24J40_NUMOF];
+
+void auto_init_mrf24j40(void)
+{
+    for (unsigned i = 0; i < NETIF_MRF24J40_NUMOF; i++) {
+        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
+        if (lwip_add_6lowpan(&netif[i], &mrf24j40_devs[i].netdev.netdev) == NULL) {
+            DEBUG("Could not add mrf24j40 device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_mrf24j40.c
+++ b/pkg/lwip/init_devs/auto_init_mrf24j40.c
@@ -31,7 +31,7 @@
 static struct netif netif[NETIF_MRF24J40_NUMOF];
 static mrf24j40_t mrf24j40_devs[NETIF_MRF24J40_NUMOF];
 
-void auto_init_mrf24j40(void)
+static void auto_init_mrf24j40(void)
 {
     for (unsigned i = 0; i < NETIF_MRF24J40_NUMOF; i++) {
         mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
@@ -41,4 +41,6 @@ void auto_init_mrf24j40(void)
         }
     }
 }
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_mrf24j40);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_netdev_tap.c
+++ b/pkg/lwip/init_devs/auto_init_netdev_tap.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for TAP network interfaces
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "netdev_tap.h"
+#include "netdev_tap_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_TAP_NUMOF        (NETDEV_TAP_MAX)
+
+static struct netif netif[NETIF_TAP_NUMOF];
+static netdev_tap_t netdev_taps[NETIF_TAP_NUMOF];
+
+void auto_init_netdev_tap(void)
+{
+    for (unsigned i = 0; i < NETIF_TAP_NUMOF; i++) {
+        netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i]);
+        if (lwip_add_ethernet(&netif[i], &netdev_taps[i].netdev) == NULL) {
+            DEBUG("Could not add netdev_tap device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_netdev_tap.c
+++ b/pkg/lwip/init_devs/auto_init_netdev_tap.c
@@ -30,7 +30,7 @@
 static struct netif netif[NETIF_TAP_NUMOF];
 static netdev_tap_t netdev_taps[NETIF_TAP_NUMOF];
 
-void auto_init_netdev_tap(void)
+static void auto_init_netdev_tap(void)
 {
     for (unsigned i = 0; i < NETIF_TAP_NUMOF; i++) {
         netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i]);
@@ -40,4 +40,6 @@ void auto_init_netdev_tap(void)
         }
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_netdev_tap);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_nrf802154.c
+++ b/pkg/lwip/init_devs/auto_init_nrf802154.c
@@ -28,7 +28,7 @@
 static struct netif netif;
 static netdev_ieee802154_submac_t nrf802154_netdev;
 
-void auto_init_nrf802154(void)
+static void auto_init_nrf802154(void)
 {
     netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
     netdev_ieee802154_submac_init(&nrf802154_netdev);
@@ -40,4 +40,6 @@ void auto_init_nrf802154(void)
         return;
     }
 }
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_nrf802154);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_nrf802154.c
+++ b/pkg/lwip/init_devs/auto_init_nrf802154.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for NRF802154 network interfaces
+ *
+ * @author  Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "nrf802154.h"
+#include "net/netdev/ieee802154_submac.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+static struct netif netif;
+static netdev_ieee802154_submac_t nrf802154_netdev;
+
+void auto_init_nrf802154(void)
+{
+    netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
+    netdev_ieee802154_submac_init(&nrf802154_netdev);
+
+    nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
+    nrf802154_init();
+    if (lwip_add_6lowpan(&netif, &nrf802154_netdev.dev.netdev) == NULL) {
+        DEBUG("Could not add nrf802154 device\n");
+        return;
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_sam0_eth.c
+++ b/pkg/lwip/init_devs/auto_init_sam0_eth.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for sam0_eth network interfaces
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "sam0_eth_netdev.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+static netdev_t sam0_eth;
+extern void sam0_eth_setup(netdev_t *netdev);
+
+static struct netif netif;
+
+void auto_init_sam0_eth(void)
+{
+    sam0_eth_setup(&sam0_eth);
+    if (lwip_add_ethernet(&netif, &sam0_eth) == NULL) {
+        DEBUG("Could not add sam0_eth device\n");
+        return;
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_sam0_eth.c
+++ b/pkg/lwip/init_devs/auto_init_sam0_eth.c
@@ -29,7 +29,7 @@ extern void sam0_eth_setup(netdev_t *netdev);
 
 static struct netif netif;
 
-void auto_init_sam0_eth(void)
+static void auto_init_sam0_eth(void)
 {
     sam0_eth_setup(&sam0_eth);
     if (lwip_add_ethernet(&netif, &sam0_eth) == NULL) {
@@ -37,4 +37,6 @@ void auto_init_sam0_eth(void)
         return;
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_sam0_eth);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_socket_zep.c
+++ b/pkg/lwip/init_devs/auto_init_socket_zep.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for socket_zep network interfaces
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "socket_zep.h"
+#include "socket_zep_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_SOCKET_ZEP_NUMOF        ARRAY_SIZE(socket_zep_params)
+
+static struct netif netif[NETIF_SOCKET_ZEP_NUMOF];
+static socket_zep_t socket_zep_devs[NETIF_SOCKET_ZEP_NUMOF];
+
+void auto_init_socket_zep(void)
+{
+    for (unsigned i = 0; i < NETIF_SOCKET_ZEP_NUMOF; i++) {
+        socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
+        if (lwip_add_6lowpan(&netif[i], &socket_zep_devs[i].netdev.netdev) == NULL) {
+            DEBUG("Could not add socket_zep device\n");
+            return;
+        }
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_socket_zep.c
+++ b/pkg/lwip/init_devs/auto_init_socket_zep.c
@@ -30,7 +30,7 @@
 static struct netif netif[NETIF_SOCKET_ZEP_NUMOF];
 static socket_zep_t socket_zep_devs[NETIF_SOCKET_ZEP_NUMOF];
 
-void auto_init_socket_zep(void)
+static void auto_init_socket_zep(void)
 {
     for (unsigned i = 0; i < NETIF_SOCKET_ZEP_NUMOF; i++) {
         socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
@@ -40,4 +40,6 @@ void auto_init_socket_zep(void)
         }
     }
 }
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_socket_zep);
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_stm32_eth.c
+++ b/pkg/lwip/init_devs/auto_init_stm32_eth.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Wouter Symons
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for stm32_eth network interfaces
+ *
+ * @author  Wouter Symons <wsymons@nalys-group.com>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "stm32_eth.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+static netdev_t stm32_eth;
+extern void stm32_eth_netdev_setup(netdev_t *netdev);
+
+static struct netif netif;
+
+void auto_init_stm32_eth(void)
+{
+    stm32_eth_netdev_setup(&stm32_eth);
+    if (lwip_add_ethernet(&netif, &stm32_eth) == NULL) {
+        DEBUG("Could not add stm32_eth device\n");
+        return;
+    }
+}
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_stm32_eth.c
+++ b/pkg/lwip/init_devs/auto_init_stm32_eth.c
@@ -29,7 +29,7 @@ extern void stm32_eth_netdev_setup(netdev_t *netdev);
 
 static struct netif netif;
 
-void auto_init_stm32_eth(void)
+static void auto_init_stm32_eth(void)
 {
     stm32_eth_netdev_setup(&stm32_eth);
     if (lwip_add_ethernet(&netif, &stm32_eth) == NULL) {
@@ -37,4 +37,6 @@ void auto_init_stm32_eth(void)
         return;
     }
 }
+
+LWIP_INIT_ETH_NETIF(auto_init_stm32_eth);
 /** @} */

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -17,13 +17,18 @@
 
 #include "kernel_defines.h"
 #include "lwip_init_devs.h"
+#include "lwip/tcpip.h"
 #include "lwip/netif/netdev.h"
+#include "netif/lowpan6.h"
 
 /**
  * @brief   Initializes network interfaces
  */
 void lwip_netif_init_devs(void)
 {
+    /* Ethernet interfaces
+     * ------------------- */
+
     if (IS_USED(MODULE_ATWINC15X0)) {
         extern void auto_init_atwinc15x0(void);
         auto_init_atwinc15x0();
@@ -58,6 +63,14 @@ void lwip_netif_init_devs(void)
         extern void auto_init_netdev_tap(void);
         auto_init_netdev_tap();
     }
+
+    /* 6LoWPAN interfaces
+     * ------------------ */
+
+    if (IS_USED(MODULE_MRF24J40)) {
+        extern void auto_init_mrf24j40(void);
+        auto_init_mrf24j40();
+    }
 }
 
 struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state)
@@ -68,6 +81,11 @@ struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state)
         netif_set_default(_if);
     }
     return _if;
+}
+
+struct netif *lwip_add_6lowpan(struct netif *netif, netdev_t *state)
+{
+    return netif_add_noaddr(netif, state, lwip_netdev_init, tcpip_6lowpan_input);
 }
 
 /**@}*/

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -20,6 +20,10 @@
 #include "lwip/tcpip.h"
 #include "lwip/netif/netdev.h"
 #include "netif/lowpan6.h"
+#include "xfa.h"
+
+XFA_INIT_CONST(lwip_netif_setup_func_t, lwip_netif_eth_xfa);
+XFA_INIT_CONST(lwip_netif_setup_func_t, lwip_netif_6lowpan_xfa);
 
 /**
  * @brief   Initializes network interfaces
@@ -31,67 +35,18 @@ void lwip_netif_init_devs(void)
     /* Ethernet interfaces
      * ------------------- */
 
-    if (IS_USED(MODULE_ATWINC15X0)) {
-        extern void auto_init_atwinc15x0(void);
-        auto_init_atwinc15x0();
-    }
-
-    if (IS_USED(MODULE_ENC28J60)) {
-        extern void auto_init_enc28j60(void);
-        auto_init_enc28j60();
-    }
-
-    if (IS_USED(MODULE_ESP_ETH)) {
-        extern void auto_init_esp_eth(void);
-        auto_init_esp_eth();
-    }
-
-    if (IS_USED(MODULE_ESP_WIFI)) {
-        extern void auto_init_esp_wifi(void);
-        auto_init_esp_wifi();
-    }
-
-    if (IS_USED(MODULE_ETHOS)) {
-        extern void auto_init_ethos(void);
-        auto_init_ethos();
-    }
-
-    if (IS_USED(MODULE_SAM0_ETH)) {
-        extern void auto_init_sam0_eth(void);
-        auto_init_sam0_eth();
-    }
-
-    if (IS_USED(MODULE_STM32_ETH)) {
-        extern void auto_init_stm32_eth(void);
-        auto_init_stm32_eth();
-    }
-
-    if (IS_USED(MODULE_NETDEV_TAP)) {
-        extern void auto_init_netdev_tap(void);
-        auto_init_netdev_tap();
+    int i;
+    const int eth_devs = XFA_LEN(lwip_netif_setup_func_t, lwip_netif_eth_xfa);
+    for (i = 0; i < eth_devs; i++) {
+        lwip_netif_eth_xfa[i]();
     }
 
     /* 6LoWPAN interfaces
      * ------------------ */
 
-    if (IS_USED(MODULE_AT86RF2XX)) {
-        extern void auto_init_at86rf2xx(void);
-        auto_init_at86rf2xx();
-    }
-
-    if (IS_USED(MODULE_MRF24J40)) {
-        extern void auto_init_mrf24j40(void);
-        auto_init_mrf24j40();
-    }
-
-    if (IS_USED(MODULE_NRF802154)) {
-        extern void auto_init_nrf802154(void);
-        auto_init_nrf802154();
-    }
-
-    if (IS_USED(MODULE_SOCKET_ZEP)) {
-        extern void auto_init_socket_zep(void);
-        auto_init_socket_zep();
+    const int sixlowpan_devs = XFA_LEN(lwip_netif_setup_func_t, lwip_netif_6lowpan_xfa);
+    for (i = 0; i < sixlowpan_devs; i++) {
+        lwip_netif_6lowpan_xfa[i]();
     }
 }
 

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief       Initializes the supported network interfaces for lwIP
+ * @author      Erik Ekman <eekman@google.com>
+ */
+
+#include "kernel_defines.h"
+#include "lwip_init_devs.h"
+#include "lwip/netif/netdev.h"
+
+/**
+ * @brief   Initializes network interfaces
+ */
+void lwip_netif_init_devs(void)
+{
+    if (IS_USED(MODULE_NETDEV_TAP)) {
+        extern void auto_init_netdev_tap(void);
+        auto_init_netdev_tap();
+    }
+}
+
+struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state)
+{
+    return netif_add_noaddr(netif, state, lwip_netdev_init, tcpip_input);
+}
+
+/**@}*/

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -24,6 +24,11 @@
  */
 void lwip_netif_init_devs(void)
 {
+    if (IS_USED(MODULE_ESP_ETH)) {
+        extern void auto_init_esp_eth(void);
+        auto_init_esp_eth();
+    }
+
     if (IS_USED(MODULE_NETDEV_TAP)) {
         extern void auto_init_netdev_tap(void);
         auto_init_netdev_tap();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -32,7 +32,12 @@ void lwip_netif_init_devs(void)
 
 struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state)
 {
-    return netif_add_noaddr(netif, state, lwip_netdev_init, tcpip_input);
+    struct netif *_if = netif_add_noaddr(netif, state, lwip_netdev_init,
+                                         tcpip_input);
+    if (_if && netif_default == NULL) {
+        netif_set_default(_if);
+    }
+    return _if;
 }
 
 /**@}*/

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -44,6 +44,11 @@ void lwip_netif_init_devs(void)
         auto_init_esp_wifi();
     }
 
+    if (IS_USED(MODULE_SAM0_ETH)) {
+        extern void auto_init_sam0_eth(void);
+        auto_init_sam0_eth();
+    }
+
     if (IS_USED(MODULE_NETDEV_TAP)) {
         extern void auto_init_netdev_tap(void);
         auto_init_netdev_tap();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -29,6 +29,11 @@ void lwip_netif_init_devs(void)
         auto_init_esp_eth();
     }
 
+    if (IS_USED(MODULE_ESP_WIFI)) {
+        extern void auto_init_esp_wifi(void);
+        auto_init_esp_wifi();
+    }
+
     if (IS_USED(MODULE_NETDEV_TAP)) {
         extern void auto_init_netdev_tap(void);
         auto_init_netdev_tap();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -51,6 +51,11 @@ void lwip_netif_init_devs(void)
         auto_init_esp_wifi();
     }
 
+    if (IS_USED(MODULE_ETHOS)) {
+        extern void auto_init_ethos(void);
+        auto_init_ethos();
+    }
+
     if (IS_USED(MODULE_SAM0_ETH)) {
         extern void auto_init_sam0_eth(void);
         auto_init_sam0_eth();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -24,6 +24,11 @@
  */
 void lwip_netif_init_devs(void)
 {
+    if (IS_USED(MODULE_ATWINC15X0)) {
+        extern void auto_init_atwinc15x0(void);
+        auto_init_atwinc15x0();
+    }
+
     if (IS_USED(MODULE_ESP_ETH)) {
         extern void auto_init_esp_eth(void);
         auto_init_esp_eth();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -29,6 +29,11 @@ void lwip_netif_init_devs(void)
         auto_init_atwinc15x0();
     }
 
+    if (IS_USED(MODULE_ENC28J60)) {
+        extern void auto_init_enc28j60(void);
+        auto_init_enc28j60();
+    }
+
     if (IS_USED(MODULE_ESP_ETH)) {
         extern void auto_init_esp_eth(void);
         auto_init_esp_eth();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -49,6 +49,11 @@ void lwip_netif_init_devs(void)
         auto_init_sam0_eth();
     }
 
+    if (IS_USED(MODULE_STM32_ETH)) {
+        extern void auto_init_stm32_eth(void);
+        auto_init_stm32_eth();
+    }
+
     if (IS_USED(MODULE_NETDEV_TAP)) {
         extern void auto_init_netdev_tap(void);
         auto_init_netdev_tap();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -26,6 +26,8 @@
  */
 void lwip_netif_init_devs(void)
 {
+    /* TODO: do for every eligible netdev */
+
     /* Ethernet interfaces
      * ------------------- */
 
@@ -80,6 +82,11 @@ void lwip_netif_init_devs(void)
     if (IS_USED(MODULE_NRF802154)) {
         extern void auto_init_nrf802154(void);
         auto_init_nrf802154();
+    }
+
+    if (IS_USED(MODULE_SOCKET_ZEP)) {
+        extern void auto_init_socket_zep(void);
+        auto_init_socket_zep();
     }
 }
 

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -67,6 +67,11 @@ void lwip_netif_init_devs(void)
     /* 6LoWPAN interfaces
      * ------------------ */
 
+    if (IS_USED(MODULE_AT86RF2XX)) {
+        extern void auto_init_at86rf2xx(void);
+        auto_init_at86rf2xx();
+    }
+
     if (IS_USED(MODULE_MRF24J40)) {
         extern void auto_init_mrf24j40(void);
         auto_init_mrf24j40();

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -76,6 +76,11 @@ void lwip_netif_init_devs(void)
         extern void auto_init_mrf24j40(void);
         auto_init_mrf24j40();
     }
+
+    if (IS_USED(MODULE_NRF802154)) {
+        extern void auto_init_nrf802154(void);
+        auto_init_nrf802154();
+    }
 }
 
 struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state)

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -79,6 +79,14 @@
  */
 
 /**
+ * @defgroup    sys_auto_init_lwip_netif lwIP netif drivers auto-initialization
+ * @ingroup     sys_auto_init
+ * @brief       Provides auto-initialization of network device drivers for lwIP
+ *
+ * @see @ref pkg_lwip, @ref sys_auto_init
+ */
+
+/**
  * @defgroup    sys_auto_init_multimedia Multimedia driver auto-initialization
  * @ingroup     sys_auto_init
  * @brief       Provides auto-initialization of Multimedia drivers


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Split lwip netif setup into auto_init files, same as gnrc does.

To simplify init.c XFA can be used to group the init functions,
and then call them in a for loop. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

* `tests/lwip` still passes
*  Flash apps using lwIP (such as `examples/paho-mqtt`) and see that the expected interfaces show up in `ifconfig` and work

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Depends on and includes #16153, same goal as #14382 