### PR TITLE
tree-wide: implement get of NETOPT_IEEE802154_PHY for applicable drivers

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -78,6 +78,13 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             }
             return sizeof(netopt_enable_t);
 
+        case NETOPT_IEEE802154_PHY:
+            if (max_len < sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint8_t *)value) = IEEE802154_PHY_OQPSK;
+            return sizeof(uint8_t);
+
         case NETOPT_CHANNEL:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -421,6 +421,9 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 #endif
 
     switch (opt) {
+        case NETOPT_IEEE802154_PHY:
+            *((uint8_t *)value) = IEEE802154_PHY_OQPSK;
+            return sizeof(uint8_t);
         case NETOPT_CHANNEL:
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)value) = nrf802154_dev->chan;

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -405,8 +405,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_IEEE802154_PHY:
-            assert(max_len >= sizeof(int8_t));
-            *((int8_t *)val) = at86rf215_get_phy_mode(dev);
+            assert(max_len >= sizeof(uint8_t));
+            *((uint8_t *)val) = at86rf215_get_phy_mode(dev);
             res = max_len;
             break;
 #ifdef MODULE_NETDEV_IEEE802154_MR_FSK

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -322,6 +322,13 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
                 !!(dev->netdev.flags & KW2XRF_OPT_AUTOCCA);
             return sizeof(netopt_enable_t);
 
+        case NETOPT_IEEE802154_PHY:
+            if (len < sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint8_t *)value) = IEEE802154_PHY_OQPSK;
+            return sizeof(uint8_t);
+
         case NETOPT_CHANNEL:
             if (len < sizeof(uint16_t)) {
                 return -EOVERFLOW;

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -516,6 +516,11 @@ int kw41zrf_netdev_get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
             *((uint16_t *)value) = 0;
             return sizeof(uint16_t);
 
+        case NETOPT_IEEE802154_PHY:
+            assert(len >= sizeof(uint8_t));
+            *((uint8_t *)value) = IEEE802154_PHY_OQPSK;
+            return sizeof(uint8_t);
+
         default:
             break;
     }

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -330,12 +330,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             }
             break;
 
-#ifdef MODULE_NETDEV_IEEE802154_OQPSK
-
         case NETOPT_IEEE802154_PHY:
             assert(max_len >= sizeof(int8_t));
             *(uint8_t *)val = IEEE802154_PHY_OQPSK;
             return sizeof(uint8_t);
+
+#ifdef MODULE_NETDEV_IEEE802154_OQPSK
 
         case NETOPT_OQPSK_RATE:
             assert(max_len >= sizeof(int8_t));


### PR DESCRIPTION
### Contribution description

While most of these drivers the PHY mode can't be changed it isn't a bad idea that the PHY mode could be retreived, so when using the `ifconfig` command the PHY mode is shown and the user knows how to wire/configure another transceiver to make them talk. This PR tries to standarize the implementation of this netopt across all drivers, and usage of the correct type for this netopt (`uint8_t`) as specified on the documentation.

### Testing procedure

Test each driver with:

- `make -C examples/gnrc_networking flash term BOARD=<...>`, enter the `ifconfig` command on the serial interface, the PHY mode should be shown.

### Issues/PRs references

See also PR #15932 where this was implemented for the IEEE 802.15.4 HAL and it's transceivers.