### PR TITLE
pkg/qDSA: fix backend selection log

### DIFF
--- a/pkg/qDSA/Makefile.dep
+++ b/pkg/qDSA/Makefile.dep
@@ -2,7 +2,7 @@ ifneq (,$(filter cortex-m23 cortex-m0%,$(CPU_CORE)))
   USEMODULE += qDSA_asm
 endif
 
-ifneq (,$(filter atmega_common,$(USEMODULE)))
+ifneq (,$(filter arch_avr8,$(FEATURES_USED)))
   USEMODULE += qDSA_asm
 endif
 

--- a/pkg/qDSA/Makefile.include
+++ b/pkg/qDSA/Makefile.include
@@ -1,11 +1,11 @@
 ifneq (,$(filter cortex-m23 cortex-m0%,$(CPU_CORE)))
   QDSA_IMPL ?= arm
 else
-ifneq (,$(filter atmega_common,$(USEMODULE)))
-  QDSA_IMPL ?= avr
-else
-  QDSA_IMPL ?= cref
-endif
+  ifneq (,$(filter arch_avr8,$(FEATURES_USED)))
+    QDSA_IMPL ?= avr
+  else
+    QDSA_IMPL ?= cref
+  endif
 endif
 
 export QDSA_IMPL


### PR DESCRIPTION
### Contribution description

qDSA as optimized implementations for AVR. The logic to select the optimized
backend predates the architecture features and uses some hand crafted logic.
This updates the logic to select the backend based on the boards architecture
using the feature system instead.

### Testing procedure

No changes in generated binaries.

### Issues/PRs references

Fixes compilation with ATXmega boards introduced in https://github.com/RIOT-OS/RIOT/pull/15758