### PR TITLE
sys/riotboot: remove remaining FLASHPAGE_SIZE dep

### DIFF
--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -213,11 +213,13 @@ int riotboot_flashwrite_invalidate_latest(void)
 int riotboot_flashwrite_finish_raw(riotboot_flashwrite_t *state,
                                    const uint8_t *bytes, size_t len)
 {
+#ifndef PERIPH_FLASHPAGE_CUSTOM_PAGESIZES
     assert(len <= FLASHPAGE_SIZE);
+#endif
 
     uint8_t *slot_start = (uint8_t *)riotboot_slot_get_hdr(state->target_slot);
 
-#if CONFIG_RIOTBOOT_FLASHWRITE_RAW
+#if IS_ACTIVE(CONFIG_RIOTBOOT_FLASHWRITE_RAW)
     memcpy(state->firstblock_buf, bytes, len);
     flashpage_write(slot_start, state->firstblock_buf,
                     RIOTBOOT_FLASHPAGE_BUFFER_SIZE);


### PR DESCRIPTION
### Contribution description

There is still a missing `FLASHPAGE_SIZE` dependency that is not triggered unless `DEVELHELP` is set:

### Testing procedure

- with this PR:

```
DEVELHELP=1 BOARD=nucleo-f446re make -C tests/riotboot_flashwrite/ all -j3
Building application "tests_riotboot_flashwrite" for "nucleo-f446re" with MCU "stm32".

compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
"make" -C /home/francisco/workspace/RIOT/boards/nucleo-f446re
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/boards/common/nucleo
"make" -C /home/francisco/workspace/RIOT/cpu/stm32
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers/netdev
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/periph
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/stmclk
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/vectors
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/checksum
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/evtimer
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/luid
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/net/application_layer/nanocoap
"make" -C /home/francisco/workspace/RIOT/sys/net/crosslayer/inet_csum
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc
"make" -C /home/francisco/workspace/RIOT/sys/net/link_layer/eui_provider
"make" -C /home/francisco/workspace/RIOT/sys/net/link_layer/l2util
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netapi
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netreg
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/icmpv6
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/icmpv6/echo
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6
"make" -C /home/francisco/workspace/RIOT/sys/net/netif
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6/nib
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ndp
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pkt
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pktbuf
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/sock
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/sock/udp
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/icmpv6
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/ipv6/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/transport_layer/udp
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT/sys/random
"make" -C /home/francisco/workspace/RIOT/sys/riotboot
"make" -C /home/francisco/workspace/RIOT/sys/random/tinymt32
"make" -C /home/francisco/workspace/RIOT/boards/nucleo-f446re
"make" -C /home/francisco/workspace/RIOT/boards/common/nucleo
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/stm32
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/periph
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/stmclk
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/vectors
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/checksum
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/riotboot
"make" -C /home/francisco/workspace/RIOT/sys/stdio_null
"make" -C /home/francisco/workspace/RIOT/sys/shell/commands
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
   text    data     bss     dec     hex filename
  46760     116   11660   58536    e4a8 /home/francisco/workspace/RIOT/tests/riotboot_flashwrite/bin/nucleo-f446re/tests_riotboot_flashwrite.elf
creating /home/francisco/workspace/RIOT/tests/riotboot_flashwrite/bin/nucleo-f446re/tests_riotboot_flashwrite-slot0.1615195060.riot.bin...
```

- master:

```
DEVELHELP=1 BOARD=nucleo-f446re make -C tests/riotboot_flashwrite/ all -j3
Building application "tests_riotboot_flashwrite" for "nucleo-f446re" with MCU "stm32".

compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
"make" -C /home/francisco/workspace/RIOT/boards/nucleo-f446re
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/stm32
"make" -C /home/francisco/workspace/RIOT/boards/common/nucleo
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/periph
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/stmclk
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/vectors
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/netdev
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/checksum
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/evtimer
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/luid
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/net/application_layer/nanocoap
"make" -C /home/francisco/workspace/RIOT/sys/net/crosslayer/inet_csum
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc
"make" -C /home/francisco/workspace/RIOT/sys/net/link_layer/eui_provider
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netapi
"make" -C /home/francisco/workspace/RIOT/sys/net/link_layer/l2util
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif
"make" -C /home/francisco/workspace/RIOT/sys/net/netif
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/icmpv6
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netreg
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/icmpv6
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/icmpv6/echo
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6/nib
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ndp
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pkt
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pktbuf
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/sock
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/sock/udp
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/ipv6/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/transport_layer/udp
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT/sys/random
"make" -C /home/francisco/workspace/RIOT/sys/riotboot
"make" -C /home/francisco/workspace/RIOT/sys/random/tinymt32
"make" -C /home/francisco/workspace/RIOT/sys/shell/commands
"make" -C /home/francisco/workspace/RIOT/boards/nucleo-f446re
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
"make" -C /home/francisco/workspace/RIOT/boards/common/nucleo
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/stm32
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/periph
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/stmclk
"make" -C /home/francisco/workspace/RIOT/cpu/stm32/vectors
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/checksum
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/riotboot
"make" -C /home/francisco/workspace/RIOT/sys/stdio_null
In file included from /home/francisco/workspace/RIOT/sys/riotboot/flashwrite.c:23:
/home/francisco/workspace/RIOT/sys/riotboot/flashwrite.c: In function 'riotboot_flashwrite_finish_raw':
/home/francisco/workspace/RIOT/sys/riotboot/flashwrite.c:216:19: error: 'FLASHPAGE_SIZE' undeclared (first use in this function); did you mean 'FLASHPAGE_OK'?
  216 |     assert(len <= FLASHPAGE_SIZE);
      |                   ^~~~~~~~~~~~~~
/home/francisco/workspace/RIOT/core/include/assert.h:107:24: note: in definition of macro 'assert'
  107 | #define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, \
      |                        ^~~~
/home/francisco/workspace/RIOT/sys/riotboot/flashwrite.c:216:19: note: each undeclared identifier is reported only once for each function it appears in
  216 |     assert(len <= FLASHPAGE_SIZE);
      |                   ^~~~~~~~~~~~~~
/home/francisco/workspace/RIOT/core/include/assert.h:107:24: note: in definition of macro 'assert'
  107 | #define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, \
      |                        ^~~~
make[3]: *** [/home/francisco/workspace/RIOT/Makefile.base:107: /home/francisco/workspace/RIOT/tests/riotboot_flashwrite/bin/nucleo-f446re/riotboot/flashwrite.o] Error 1
make[2]: *** [/home/francisco/workspace/RIOT/Makefile.base:30: ALL--/home/francisco/workspace/RIOT/sys/riotboot] Error 2
make[1]: *** [/home/francisco/workspace/RIOT/Makefile.base:30: ALL--/home/francisco/workspace/RIOT/sys] Error 2
make: *** [/home/francisco/workspace/RIOT/tests/riotboot_flashwrite/../../Makefile.include:634: application_tests_riotboot_flashwrite.module] Error 2
make: *** Waiting for unfinished jobs....
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
