### PR TITLE
cpu/stm32: candev: derive number of CAN interfaces from vendor header

### DIFF
--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -37,13 +37,12 @@ extern "C" {
 
 #include "can/candev.h"
 
-#if defined(CPU_LINE_STM32F413xx) || defined(CPU_LINE_STM32F423xx)
-#define CANDEV_STM32_CHAN_NUMOF 3
-#elif defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
-#define CANDEV_STM32_CHAN_NUMOF 2
-#elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
-      defined(CPU_FAM_STM32L4) || defined(CPU_LINE_STM32F722xx) || DOXYGEN
 /** Number of channels in the device (up to 3) */
+#if defined(CAN3)
+#define CANDEV_STM32_CHAN_NUMOF 3
+#elif defined(CAN2)
+#define CANDEV_STM32_CHAN_NUMOF 2
+#elif defined(CAN1) || defined(CAN) || DOXYGEN
 #define CANDEV_STM32_CHAN_NUMOF 1
 #else
 #error "CAN STM32: CPU not supported"


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

We can deduce the number of available CAN interfaces from the vendor headers so no need to hard-code this number for individual part numbers.


### Testing procedure

The binaries should not change.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16161#discussion_r589645304
