### PR TITLE
gnrc_sixlowpan_frag_sfr_congure: add congure_abe support

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -236,6 +236,14 @@ PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_stats
 ## @{
 ##
 PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_congure
+## @defgroup net_gnrc_sixlowpan_frag_sfr_congure_abe gnrc_sixlowpan_frag_sfr_congure_abe: TCP Reno with ABE
+## @brief  Congestion control for SFR using the [TCP Reno congestion control algorithm with ABE](@ref sys_congure_abe)
+##
+## Provides an Alternative Backoff with Explicit Content Notification (ABE) to TCP-Reno-based congestion
+## control
+## @{
+PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_congure_abe
+## @}
 ## @defgroup net_gnrc_sixlowpan_frag_sfr_congure_reno gnrc_sixlowpan_frag_sfr_congure_reno: TCP Reno
 ## @brief  Congestion control for SFR using the [TCP Reno congestion control algorithm](@ref sys_congure_reno)
 ## @{

--- a/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/sfr/congure.h
@@ -18,6 +18,7 @@
  * - @ref net_gnrc_sixlowpan_frag_sfr_congure_sfr (the default)
  * - @ref net_gnrc_sixlowpan_frag_sfr_congure_quic
  * - @ref net_gnrc_sixlowpan_frag_sfr_congure_reno
+ * - @ref net_gnrc_sixlowpan_frag_sfr_congure_abe
  * @{
  *
  * @file

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -244,6 +244,11 @@ ifneq (,$(filter gnrc_sixlowpan_frag_sfr_congure_%,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_frag_sfr_congure
 endif
 
+ifneq (,$(filter gnrc_sixlowpan_frag_sfr_congure_abe,$(USEMODULE)))
+  USEMODULE += gnrc_sixlowpan_frag_sfr_congure_reno
+  USEMODULE += congure_abe
+endif
+
 ifneq (,$(filter gnrc_sixlowpan_frag_sfr_congure_quic,$(USEMODULE)))
   USEMODULE += congure_quic
 endif

--- a/tests/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
+++ b/tests/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile
@@ -30,6 +30,9 @@ endif
 
 CONGURE_IMPL ?= congure_sfr
 
+ifeq (congure_abe,$(CONGURE_IMPL))
+  USEMODULE += gnrc_sixlowpan_frag_sfr_congure_abe
+else
 ifeq (congure_quic,$(CONGURE_IMPL))
   USEMODULE += gnrc_sixlowpan_frag_sfr_congure_quic
   USEMODULE += ztimer_msec
@@ -41,6 +44,7 @@ ifeq (congure_sfr,$(CONGURE_IMPL))
   USEMODULE += gnrc_sixlowpan_frag_sfr_congure_sfr
 else
   $(error "Unknown CongURE implementation `$(CONGURE_IMPL)`")
+endif
 endif
 endif
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provisions GNRC's 6LoWPAN SFR implementation with the CongURE implementation of TCP Reno. It also adds that implementation to the `tests/gnrc_sixlowpan_frag_sfr_congure_impl` test application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The test `tests/gnrc_sixlowpan_frag_sfr_congure_impl` where extended to support `congure_abe`:

```sh
CONGURE_IMPL=congure_abe make -C tests/gnrc_sixlowpan_frag_sfr_congure_impl
```

Ping some nodes with at least 1 hop separation with large payloads. Exchange between should work.

Running the tests with `CONGURE_IMPL=congure_reno` also should still work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on ~~#15968~~ (merged) and #16170 and their respective dependencies.

![PR dependency graph](https://page.mi.fu-berlin.de/mlenders/congure.svg)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
