### PR TITLE
core: add functionality to check queue state of another thread 

### DIFF
--- a/core/include/cib.h
+++ b/core/include/cib.h
@@ -66,6 +66,19 @@ static inline void cib_init(cib_t *__restrict cib, unsigned int size)
 }
 
 /**
+ * @brief   Returns the total capacity (`size` parameter of @ref cib_init()) of
+ *          a cib_t
+ *
+ * @param[in] cib   the cib_t to check.
+ *                  Must not be NULL.
+ * @return  The total size of @p cib.
+ */
+static inline unsigned int cib_size(const cib_t *cib)
+{
+    return cib->mask + 1;
+}
+
+/**
  * @brief Calculates difference between cib_put() and cib_get() accesses.
  *
  * @param[in] cib       the cib_t to check.

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -370,12 +370,31 @@ int msg_reply(msg_t *m, msg_t *reply);
 int msg_reply_int(msg_t *m, msg_t *reply);
 
 /**
- * @brief Check how many messages are available in the message queue
+ * @brief Check how many messages are available (waiting) in the message queue
+ *        of a specific thread
+ *
+ * @param[in] pid    a PID
+ *
+ * @return Number of messages available in queue of @p pid on success
+ * @return 0, if no caller's message queue is initialized
+ */
+unsigned msg_avail_thread(kernel_pid_t pid);
+
+/**
+ * @brief Check how many messages are available (waiting) in the message queue
  *
  * @return Number of messages available in our queue on success
  * @return 0, if no caller's message queue is initialized
  */
 unsigned msg_avail(void);
+
+/**
+ * @brief Get maximum capacity of a thread's queue length
+ *
+ * @return Number of total messages that fit in the queue of @p pid on success
+ * @return 0, if no caller's message queue is initialized
+ */
+unsigned msg_queue_capacity(kernel_pid_t pid);
 
 /**
  * @brief Initialize the current thread's message queue.

--- a/core/msg.c
+++ b/core/msg.c
@@ -433,20 +433,43 @@ static int _msg_receive(msg_t *m, int block)
     DEBUG("This should have never been reached!\n");
 }
 
-unsigned msg_avail(void)
+static unsigned _msg_avail(thread_t *thread)
 {
     DEBUG("msg_available: %" PRIkernel_pid ": msg_available.\n",
-          thread_getpid());
-
-    thread_t *me = thread_get_active();
+          thread->pid);
 
     unsigned queue_count = 0;
 
-    if (thread_has_msg_queue(me)) {
-        queue_count = cib_avail(&(me->msg_queue));
+    if (thread_has_msg_queue(thread)) {
+        queue_count = cib_avail(&(thread->msg_queue));
     }
 
     return queue_count;
+}
+
+unsigned msg_avail_thread(kernel_pid_t pid)
+{
+    return _msg_avail(thread_get(pid));
+}
+
+unsigned msg_avail(void)
+{
+    return _msg_avail(thread_get_active());
+}
+
+unsigned msg_queue_capacity(kernel_pid_t pid)
+{
+    DEBUG("msg_queue_capacity: %" PRIkernel_pid ": msg_queue_capacity.\n",
+          pid);
+
+    thread_t *thread = thread_get(pid);
+    int queue_cap = 0;
+
+    if (thread_has_msg_queue(thread)) {
+        queue_cap = cib_size(&(thread->msg_queue));
+    }
+
+    return queue_cap;
 }
 
 void msg_init_queue(msg_t *array, int num)

--- a/tests/msg_queue_capacity/Makefile
+++ b/tests/msg_queue_capacity/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/msg_queue_capacity/main.c
+++ b/tests/msg_queue_capacity/main.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ *               2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief Thread test application
+ *
+ * @author Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ * @author Sebastian Meiling <s@mlng.net>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "embUnit/embUnit.h"
+#include "embUnit.h"
+#include "msg.h"
+#include "thread.h"
+
+#define MSG_QUEUE_LENGTH                (8)
+
+static msg_t msg_queue[MSG_QUEUE_LENGTH];
+
+static void test_msg_queue_capacity(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, msg_queue_capacity(thread_getpid()));
+    msg_init_queue(msg_queue, MSG_QUEUE_LENGTH);
+    TEST_ASSERT_EQUAL_INT(MSG_QUEUE_LENGTH, msg_queue_capacity(thread_getpid()));
+}
+
+static Test *tests_msg_queue_capacity_suite(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_msg_queue_capacity),
+    };
+
+    EMB_UNIT_TESTCALLER(tests, NULL, NULL, fixtures);
+
+    return (Test *)&tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_msg_queue_capacity_suite());
+    TESTS_END();
+    return 0;
+}

--- a/tests/msg_queue_capacity/tests/01-run.py
+++ b/tests/msg_queue_capacity/tests/01-run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#               2017 Sebastian Meiling <s@mlng.net>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run_check_unittests
+
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds functions to get the message slots still available in a queue as well as its total length from another thread. Using those a GNRC module can gauge how congested the input queue of a module it wants to send to is.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
make -C tests/msg_avail -j flash test
make -C tests/msg_queue_len -j flash test
```

should both pass, `msg_avail` does not increase in size when build with `RIOT_CI_BUILD=1` compared to master (I tested on `nrf52dk`, `z1`, and `arduino-mega2560`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
