### PR TITLE
drivers/ds3231: add alarm support

### DIFF
--- a/drivers/ds3231/Makefile.dep
+++ b/drivers/ds3231/Makefile.dep
@@ -1,1 +1,5 @@
 FEATURES_REQUIRED += periph_i2c
+
+ifneq (,$(filter ds3231_int,$(USEMODULE)))
+   FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/ds3231/include/ds3231_params.h
+++ b/drivers/ds3231/include/ds3231_params.h
@@ -32,11 +32,20 @@ extern "C" {
 #ifndef DS3231_PARAM_OPT
 #define DS3231_PARAM_OPT        (DS3231_OPT_BAT_ENABLE)
 #endif
+#ifndef DS3231_PARAM_INT_PIN
+#define DS3231_PARAM_INT_PIN    (GPIO_UNDEF)
+#endif
 
 #ifndef DS3231_PARAMS
+#if IS_USED(MODULE_DS3231_INT)
 #define DS3231_PARAMS           { .bus = DS3231_PARAM_I2C, \
-                                  .opt = DS3231_PARAM_OPT, }
-#endif
+                                  .opt = DS3231_PARAM_OPT, \
+                                  .int_pin = DS3231_PARAM_INT_PIN}
+#else /* MODULE_DS3231_INT */
+#define DS3231_PARAMS           { .bus = DS3231_PARAM_I2C, \
+                                  .opt = DS3231_PARAM_OPT}
+#endif /* MODULE_DS3231_INT */
+#endif /* DS3231_PARAMS */
 /** @} */
 
 /**

--- a/drivers/include/ds3231.h
+++ b/drivers/include/ds3231.h
@@ -34,6 +34,7 @@
 #include <time.h>
 #include <errno.h>
 
+#include "periph/gpio.h"
 #include "periph/i2c.h"
 
 #ifdef __cplusplus
@@ -46,18 +47,51 @@ extern "C" {
 #define DS3231_I2C_ADDR             0x68
 
 /**
+ * @brief   Alarm flags returned by the ds3231_await_alarm function
+ * @{
+ */
+#define DS3231_FLAG_ALARM_1         0x01
+#define DS3231_FLAG_ALARM_2         0x02
+/** @} */
+
+/**
  * @brief   Configuration options
  */
 enum {
-    DS3231_OPT_BAT_ENABLE = 0x01,   /* enable backup battery on startup */
-    DS2321_OPT_32KHZ_ENABLE = 0x02, /* enable 32KHz output */
+    DS3231_OPT_BAT_ENABLE = 0x01,   /**< enable backup battery on startup */
+    DS3221_OPT_32KHZ_ENABLE = 0x02, /**< enable 32KHz output */
+    DS3231_OPT_INTER_ENABLE = 0x04, /**< enable the interrupt control */
 };
+
+/**
+ * @brief   Alarm trigger type of alarm 1 for DS3231 devices
+ */
+typedef enum {
+    DS3231_AL1_TRIG_PER_S = 0x0F, /**< alarm once per second */
+    DS3231_AL1_TRIG_S = 0x0E, /**< alarm when seconds match */
+    DS3231_AL1_TRIG_M_S = 0x0C, /**< alarm when minutes and seconds match */
+    DS3231_AL1_TRIG_H_M_S = 0x08, /**< alarm when H/M/S match */
+    DS3231_AL1_TRIG_D_H_M_S = 0x00, /**< alarm when D/H/M/S match */
+} ds3231_alm_1_mode_t;
+
+/**
+ * @brief   Alarm trigger type of alarm 2 for DS3231 devices
+ */
+typedef enum {
+    DS3231_AL2_TRIG_PER_M = 0x07,  /**< alarm once per minute */
+    DS3231_AL2_TRIG_M = 0x06,  /**< alarm when minutes match */
+    DS3231_AL2_TRIG_H_M = 0x04,  /**< alarm when hours and minutes match */
+    DS3231_AL2_TRIG_D_H_M_S = 0x00, /**< alarm when D/H/M match */
+} ds3231_alm_2_mode_t;
 
 /**
  * @brief   Device descriptor for DS3231 devices
  */
 typedef struct {
     i2c_t bus;          /**< I2C bus the device is connected to */
+#if IS_USED(MODULE_DS3231_INT)
+    gpio_t int_pin;     /**< alarm interrupt pin */
+#endif /* MODULE_DS3231_INT */
 } ds3231_t;
 
 /**
@@ -66,7 +100,15 @@ typedef struct {
 typedef struct {
     i2c_t bus;          /**< I2C bus the device is connected to */
     uint8_t opt;        /**< additional options */
+#if IS_USED(MODULE_DS3231_INT)
+    gpio_t int_pin;     /**< alarm interrupt pin */
+#endif /* MODULE_DS3231_INT */
 } ds3231_params_t;
+
+#if IS_USED(MODULE_DS3231_INT)
+typedef void (*ds3231_alarm_cb_t)(void *);
+
+#endif /* MODULE_DS3231_INT */
 
 /**
  * @brief   Initialize the given DS3231 device
@@ -78,6 +120,24 @@ typedef struct {
  * @return  -EIO if no DS3231 device was found
  */
 int ds3231_init(ds3231_t *dev, const ds3231_params_t *params);
+
+#if IS_USED(MODULE_DS3231_INT)
+/**
+ * @brief   Initialize the GPIO alarm interrupt
+ *
+ * This function initializes the pin defined as the interrupt pin in the
+ * initialization parameters of the device then blocks until an alarm is
+ * triggered.
+ *
+ * @note This function is only available when module `ds3231_int` is enabled.
+ *
+ * @param[in]   dev     device descriptor of DS3231 device
+ *
+ * @return  status of A1F and A2F on success
+ * @return  -EIO if unable to initialize GPIO interrupt
+ */
+int ds3231_await_alarm(ds3231_t *dev);
+#endif /* MODULE_DS3231_INT */
 
 /**
  * @brief   Get date and time from the device
@@ -100,6 +160,100 @@ int ds3231_get_time(const ds3231_t *dev, struct tm *time);
  * @return  -EIO on I2C communication error
  */
 int ds3231_set_time(const ds3231_t *dev, const struct tm *time);
+
+/**
+ * @brief   Set alarm 1 of the device
+ *
+ * @param[in] dev       DS3231 device descriptor
+ * @param[in] time      target date and time
+ * @param[in] trigger   alarm 1 trigger type
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_set_alarm_1(const ds3231_t *dev, struct tm *time,
+                       ds3231_alm_1_mode_t trigger);
+
+/**
+ * @brief   Set alarm 2 of the device
+ *
+ * @param[in] dev       DS3231 device descriptor
+ * @param[in] time      target date and time
+ * @param[in] trigger   alarm 2 trigger type
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_set_alarm_2(const ds3231_t *dev, struct tm *time,
+                       ds3231_alm_2_mode_t trigger);
+
+/**
+ * @brief   Clear alarm 1 flag (A1F)
+ *
+ * @param[in] dev       DS3231 device descriptor
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_clear_alarm_1_flag(const ds3231_t *dev);
+
+/**
+ * @brief   Clear alarm 2 flag (A2F)
+ *
+ * @param[in] dev       DS3231 device descriptor
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_clear_alarm_2_flag(const ds3231_t *dev);
+
+/**
+ * @brief   Get the state of alarm 1 flag (A1F)
+ *
+ * @note    This function is not needed when ds3231_await_alarm is used
+ *
+ * @param[in] dev       DS3231 device descriptor
+ * @param[out] flag     Current value of the flag
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_get_alarm_1_flag(const ds3231_t *dev, bool *flag);
+
+/**
+ * @brief   Get the state of alarm 2 flag (A2F)
+ *
+ * @note    This function is not needed when ds3231_await_alarm is used
+ *
+ * @param[in] dev       DS3231 device descriptor
+ * @param[out] flag     Current value of the flag
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_get_alarm_2_flag(const ds3231_t *dev, bool *flag);
+
+/**
+ * @brief   Enable/Disable alarm 1 interrupt on the device
+ *
+ * @param[in] dev       DS3231 device descriptor
+ * @param[in] enable    True to enable alarm, false to disable it
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_toggle_alarm_1(const ds3231_t *dev, bool enable);
+
+/**
+ * @brief   Enable/Disable alarm 2 interrupt on the device
+ *
+ * @param[in] dev       DS3231 device descriptor
+ * @param[in] enable    True to enable alarm, false to disable it
+ *
+ * @return  0 on success
+ * @return  -EIO on I2C communication error
+ */
+int ds3231_toggle_alarm_2(const ds3231_t *dev, bool enable);
 
 /**
  * @brief   Get the configured aging offset (see datasheet for more information)

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -205,6 +205,9 @@ PSEUDOMODULES += cc1100
 PSEUDOMODULES += cc1100e
 PSEUDOMODULES += cc1101
 
+# include variants of ds3231 drivers as pseudo modules
+PSEUDOMODULES += ds3231_int
+
 # interrupt variant of the HMC5883L driver
 PSEUDOMODULES += hmc5883l_int
 

--- a/tests/driver_ds3231/Makefile
+++ b/tests/driver_ds3231/Makefile
@@ -4,4 +4,7 @@ USEMODULE += ds3231
 USEMODULE += xtimer
 USEMODULE += shell
 
+#USEMODULE += ds3231_int
+#CFLAGS +="-DDS3231_PARAM_INT_PIN=(GPIO_PIN(1,2))"
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ds3231/main.c
+++ b/tests/driver_ds3231/main.c
@@ -258,8 +258,74 @@ static int _cmd_test(int argc, char **argv)
         return 1;
     }
 
+    /* clear all existing alarm flag */
+    res = ds3231_clear_alarm_1_flag(&_dev);
+    if (res != 0) {
+        puts("error: unable to clear alarm flag");
+        return 1;
+    }
+
+    /* get time to set up next alarm*/
+    res = ds3231_get_time(&_dev, &time);
+    if (res != 0) {
+        puts("error: unable to read time");
+        return 1;
+    }
+
+    time.tm_sec += TEST_DELAY;
+    mktime(&time);
+
+    /* set alarm */
+    res = ds3231_set_alarm_1(&_dev, &time, DS3231_AL1_TRIG_H_M_S);
+    if (res != 0) {
+        puts("error: unable to program alarm");
+        return 1;
+    }
+
+#ifdef MODULE_DS3231_INT
+
+    /* wait for an alarm with GPIO interrupt */
+    res = ds3231_await_alarm(&_dev);
+    if (res < 0){
+        puts("error: unable to program GPIO interrupt or to clear alarm flag");
+    }
+
+    if (!(res & DS3231_FLAG_ALARM_1)){
+        puts("error: alarm was not triggered");
+    }
+
     puts("OK");
     return 0;
+
+#else
+
+    /* wait for the alarm to trigger */
+    xtimer_sleep(TEST_DELAY);
+
+    bool alarm;
+
+    /* check if alarm flag is on */
+    res = ds3231_get_alarm_1_flag(&_dev, &alarm);
+    if (res != 0) {
+        puts("error: unable to get alarm flag");
+        return 1;
+    }
+
+    if (alarm != true){
+        puts("error: alarm was not triggered");
+    }
+
+    /* clear alarm flag */
+    res = ds3231_clear_alarm_1_flag(&_dev);
+    if (res != 0) {
+        puts("error: unable to clear alarm flag");
+        return 1;
+    }
+
+    puts("OK");
+    return 0;
+
+#endif
 }
 
 static const shell_command_t shell_commands[] = {
@@ -279,7 +345,10 @@ int main(void)
     puts("DS3231 RTC test\n");
 
     /* initialize the device */
-    res = ds3231_init(&_dev, &ds3231_params[0]);
+    ds3231_params_t params= ds3231_params[0];
+    params.opt     = DS3231_OPT_BAT_ENABLE;
+    params.opt    |= DS3231_OPT_INTER_ENABLE;
+    res = ds3231_init(&_dev, &params);
     if (res != 0) {
         puts("error: unable to initialize DS3231 [I2C initialization error]");
         return 1;


### PR DESCRIPTION
### Contribution description

See also issue #16155. 

This PR adds support for alarms within the DS3231 drivers. 

I have corrected some alarm registers which were not used before and seemed to be incorrect. 

This is still a work in progress:
- As mentioned in issue #16155 it might be better to hide the alarm functions behind a pseudo module even though, as I mentioned earlier, I do not completely agree with this. You can absolutely use RTC alarms without any kind of callback. Sometimes the alarms are not even intended to the MCU. Meaning in those cases there is no need for a callback.
- I used typedefs for the alarm configuration, it seemed way easier/cleaner to me, but others might disagree/have a better idea. 
- The ITCN bit is for now set during the initialization of the RTC, therefore disabling the square wave output (it was already disabled I think). It might be better to create some kind of options in case someone wants to use the SQW output. Not sure if that is important. 
- ~~This is a basic alarm implementation, I didn't provide anything to read the alarm registers, just the configuration part.~~
- ~~The doxygen documentation for the added function in include/ds3231.h has not been written yet since there might be some modifications.~~

### Testing procedure
I did not modify the tests for the DS3231 driver. I've tested the code myself. I don't know how to test an alarm that would normally trigger for example the next day.  Maybe we can only test a few settings (alarms that would trigger in the next few seconds) ? 

Have a good day. 
