### PR TITLE
boards/bastwan: Support BastWAN Board

### DIFF
--- a/boards/bastwan/Kconfig
+++ b/boards/bastwan/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "bastwan" if BOARD_BASTWAN
+
+config BOARD_BASTWAN
+    bool
+    default y
+    select CPU_MODEL_SAMR34J18B
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT
+    select HAS_HIGHLEVEL_STDIO

--- a/boards/bastwan/Makefile
+++ b/boards/bastwan/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/bastwan/Makefile.dep
+++ b/boards/bastwan/Makefile.dep
@@ -1,0 +1,9 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1276
+endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/makefiles/stdio_cdc_acm.dep.mk

--- a/boards/bastwan/Makefile.features
+++ b/boards/bastwan/Makefile.features
@@ -1,0 +1,17 @@
+# cpu used by the samr34-xpro board is based on saml21
+CPU = saml21
+CPU_MODEL = samr34j18b
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+FEATURES_PROVIDED += highlevel_stdio

--- a/boards/bastwan/Makefile.include
+++ b/boards/bastwan/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/bastwan/board.c
+++ b/boards/bastwan/board.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021  Lokotius Filzer
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bastwan
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for the bastwan board
+ *
+ *
+ * @author      Lokotius Filzer <h-filzer@pixelsalat.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/gpio.h"
+
+#ifdef MODULE_SX127X
+#include "sx127x_params.h"
+#endif
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+
+#ifdef TX_SWITCH_PWR_PIN
+    /* Enables pwr to the Antenna switch circuit */
+    gpio_init(TX_SWITCH_PWR_PIN, GPIO_OUT);
+    gpio_set(TX_SWITCH_PWR_PIN);
+#endif /* TX_SWITCH_PWR_PIN */
+       /* initialize board specific pins for LoRa */
+#ifdef MODULE_SX127X
+    /* Enable the pwr for the tcxo of the radio module*/
+    gpio_init(TCXO_PWR_PIN, GPIO_OUT);
+    gpio_set(TCXO_PWR_PIN);
+    /* Enable Toggling on TX/RX between RFI and RFO on the antenna switch SKY13373 */
+    gpio_init(TX_OUTPUT_SEL_PIN, GPIO_OUT);
+    gpio_write(TX_OUTPUT_SEL_PIN, !SX127X_PARAM_PASELECT);
+#endif /* USEMODULE_SX127X */
+}

--- a/boards/bastwan/include/board.h
+++ b/boards/bastwan/include/board.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021  Lokotius Filzer
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_bastwan BastWAN board
+ * @ingroup     boards
+ * @brief       Support for the BASTWAN SAM R34 board.
+ * @{
+ *
+ * @file
+ * @brief       Support for the BASTWAN SAM R34 board.
+ *              Based on the work from
+ *              Dylan Laduranty <dylan.laduranty@mesotic.com> for the  Microchip
+ *              SAM R34 Xplained Pro board.
+ *
+ * @author      Lokotius Filzer <h-filzer@pixelsalat.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph/pm.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name Semtech SX1276 configuration
+ * @{
+ */
+#define SX127X_PARAM_SPI (SPI_DEV(1))
+#define SX127X_PARAM_SPI_NSS GPIO_PIN(PB, 31)   /* D10 */
+#define SX127X_PARAM_RESET GPIO_PIN(PB, 15)     /* A0 */
+#define SX127X_PARAM_DIO0 GPIO_PIN(PB, 16)      /* D2 */
+#define SX127X_PARAM_DIO1 GPIO_PIN(PA, 11)      /* D3 */
+#define SX127X_PARAM_DIO2 GPIO_PIN(PA, 12)      /* D4 */
+#define SX127X_PARAM_DIO3 GPIO_PIN(PB, 17)      /* D5 */
+#define SX127X_PARAM_PASELECT (SX127X_PA_RFO)
+/** @}*/
+
+/**
+ * @name Board specific configuration
+ *  @{
+ */
+#define TCXO_PWR_PIN GPIO_PIN(PB, 3)
+#define TX_OUTPUT_SEL_PIN GPIO_PIN(PA, 13)
+#define TX_SWITCH_PWR_PIN GPIO_PIN(PA, 28)
+/** @}*/
+
+/**
+ * @name LED pin definitions and handlers
+ * @{
+ */
+#define LED_PORT PORT->Group[0]
+#define LED0_PIN GPIO_PIN(PA, 22)
+#define LED0_MASK (1 << 22)
+#define LED0_ON (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_OFF (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_TOGGLE (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @}*/
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ *
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/bastwan/include/gpio_params.h
+++ b/boards/bastwan/include/gpio_params.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021  Lokotius Filzer
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_bastwan
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Lokotius Filzer <h-filzer@pixelsalat.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(blue)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/bastwan/include/periph_conf.h
+++ b/boards/bastwan/include/periph_conf.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2019  Lokotius Filzer
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bastwan
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the bastwan board.
+ *
+ * @author      Lokotius Filzer <h-filzer@pixelsalat.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GCLK reference speed
+ */
+#define CLOCK_CORECLOCK     MHZ(48)
+
+/**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev = TC0,
+        .irq = TC0_IRQn,
+        .mclk = &MCLK->APBCMASK.reg,
+        .mclk_mask = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
+        .gclk_id = TC0_GCLK_ID,
+        .gclk_src = SAM0_GCLK_8MHZ,
+        .flags = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_ISR         isr_tc0
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    usart configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {    /* Virtual COM Port */
+        .dev = &SERCOM3->USART,
+        .rx_pin = GPIO_PIN(PA, 18),
+        .tx_pin = GPIO_PIN(PA, 19),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin = GPIO_UNDEF,
+        .cts_pin = GPIO_UNDEF,
+#endif
+        .mux = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_3,
+        .tx_pad = UART_PAD_TX_2,
+        .flags = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom3
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+/* SERCOM5 does not support DMA at the moment. See Datasheet samr34, Figure 4-2 */
+static const spi_conf_t spi_config[] = {
+
+    {
+        .dev = &(SERCOM5->SPI),
+        .miso_pin = GPIO_PIN(PA, 23),
+        .mosi_pin = GPIO_PIN(PB, 02),
+        .clk_pin = GPIO_PIN(PB, 23),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_1,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = DMA_TRIGGER_DISABLED,
+        .rx_trigger = DMA_TRIGGER_DISABLED,
+#endif
+    },
+    {
+        .dev = &(SERCOM4->SPI),
+        .miso_pin = GPIO_PIN(PC, 19),
+        .mosi_pin = GPIO_PIN(PB, 30),
+        .clk_pin = GPIO_PIN(PC, 18),
+        .miso_mux = GPIO_MUX_F,
+        .mosi_mux = GPIO_MUX_F,
+        .clk_mux = GPIO_MUX_F,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = &(SERCOM1->I2CM),
+        .speed = I2C_SPEED_NORMAL,
+        .scl_pin = GPIO_PIN(PA, 17),
+        .sda_pin = GPIO_PIN(PA, 16),
+        .mux = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_MAIN,
+        .flags = I2C_FLAG_NONE
+    }
+};
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
+/** @} */
+/**
+ * @name    RTC configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                   1
+#define INTERNAL_OSC32_SOURCE                   0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE     0
+/** @} */
+
+/**
+ * @name    RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
+/** @} */
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC 0 Default values */
+#define ADC_PRESCALER                           ADC_CTRLB_PRESCALER_DIV256
+
+#define ADC_NEG_INPUT                           ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                         ADC_REFCTRL_REFSEL_INTVCC2
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    { GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN17) },
+    { GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN16) },
+    { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7) },
+    { GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6) },
+    { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN4) }
+};
+
+#define ADC_NUMOF                               ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm = GPIO_PIN(PA, 24),
+        .dp = GPIO_PIN(PA, 25),
+        .d_mux = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    }
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano-33-iot \
     arduino-zero \
     b-l072z-lrwan1 \
+    bastwan \
     blackpill \
     blackpill-128kib \
     bluepill \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -14,6 +14,7 @@ LOW_MEMORY_BOARDS += \
   arduino-nano-33-iot \
   atmega1284p \
   b-l072z-lrwan1 \
+  bastwan \
   blackpill \
   blackpill-128kib \
   bluepill \


### PR DESCRIPTION


### Contribution description

Add RIOT OS support for [BastWAN Board](https://github.com/ElectronicCats/BastWAN).
Board uses on rak4260 which itself uses on samr34 with integrated Lora.
Based on samr34 xplained pro board (`boards/samr34-xpro`) and adopted to RAK specific pin mappings. 

### Testing procedure

Fieldtested with SX127X module and semtech stack from `examples/lorawan`.
Tested all ADC channels.
UART, USB and GPIOS/LEDs are working as defined.


### Issues/PRs references

not known
