### PR TITLE
examples/nanocoap_server: add check for payload size

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -97,11 +97,16 @@ static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, vo
     case COAP_PUT:
     case COAP_POST:
     {
-        /* convert the payload to an integer and update the internal value */
-        char payload[16] = { 0 };
-        memcpy(payload, (char*)pkt->payload, pkt->payload_len);
-        internal_value = strtol(payload, NULL, 10);
-        code = COAP_CODE_CHANGED;
+        if (pkt->payload_len <= 15) {
+            /* convert the payload to an integer and update the internal value */
+            char payload[16] = { 0 };
+            memcpy(payload, (char*)pkt->payload, pkt->payload_len);
+            internal_value = strtol(payload, NULL, 10);
+            code = COAP_CODE_CHANGED;
+        }
+        else {
+            code = COAP_CODE_BAD_REQUEST;
+        }
     }
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds a check for the payload size for the resource /riot/value
Without this check it is possible to force a stack overflow by sending a CoAP message with a payload greater than 15. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Sending a message, to the resource /riot/value, with a payload size of over 15 should be answered with a 4.00 Bad Request
(eg.` coap-client -m put coap://[fe80::1843:8eff:fe40:4eaa%tap0]/riot/value -e 9999999999999999`)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

