### PR TITLE
drivers/sx127x: uncrustify code

### DIFF
--- a/dist/tools/uncrustify/whitelist.txt
+++ b/dist/tools/uncrustify/whitelist.txt
@@ -6,6 +6,8 @@ cpu/fe310/periph/.*\.c
 cpu/riscv_common/.*\.c
 cpu/riscv_common/include/.*\.h
 cpu/riscv_common/periph/.*\.c
+drivers/include/sx127x.h
+drivers/sx127x/.*\.c
 sys/riotboot/.*\.h
 sys/riotboot/.*\.c
 sys/congure.*\.c
@@ -16,3 +18,4 @@ sys/test_utils/result_output/*/.*\h
 sys/test_utils/include/result_output.h
 sys/ztimer/.*\.c
 sys/include/ztimer.*\.h
+tests/driver_sx127x/.*\.c

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -86,13 +86,13 @@ extern "C" {
 #define SX127X_RX_BUFFER_SIZE            (256)                  /**< RX buffer size */
 #define SX127X_RADIO_TX_POWER            (14U)                  /**< Radio power in dBm */
 
-#define SX127X_EVENT_HANDLER_STACK_SIZE  (2048U) /**< Stack size event handler */
-#define SX127X_IRQ_DIO0                  (1<<0)  /**< DIO0 IRQ */
-#define SX127X_IRQ_DIO1                  (1<<1)  /**< DIO1 IRQ */
-#define SX127X_IRQ_DIO2                  (1<<2)  /**< DIO2 IRQ */
-#define SX127X_IRQ_DIO3                  (1<<3)  /**< DIO3 IRQ */
-#define SX127X_IRQ_DIO4                  (1<<4)  /**< DIO4 IRQ */
-#define SX127X_IRQ_DIO5                  (1<<5)  /**< DIO5 IRQ */
+#define SX127X_EVENT_HANDLER_STACK_SIZE  (2048U)                /**< Stack size event handler */
+#define SX127X_IRQ_DIO0                  (1 << 0)               /**< DIO0 IRQ */
+#define SX127X_IRQ_DIO1                  (1 << 1)               /**< DIO1 IRQ */
+#define SX127X_IRQ_DIO2                  (1 << 2)               /**< DIO2 IRQ */
+#define SX127X_IRQ_DIO3                  (1 << 3)               /**< DIO3 IRQ */
+#define SX127X_IRQ_DIO4                  (1 << 4)               /**< DIO4 IRQ */
+#define SX127X_IRQ_DIO5                  (1 << 5)               /**< DIO5 IRQ */
 /** @} */
 
 /**
@@ -112,41 +112,41 @@ extern "C" {
  * @brief   SX127X initialization result.
  */
 enum {
-    SX127X_INIT_OK = 0,                /**< Initialization was successful */
-    SX127X_ERR_SPI,                    /**< Failed to initialize SPI bus or CS line */
-    SX127X_ERR_GPIOS,                  /**< Failed to initialize GPIOs */
-    SX127X_ERR_NODEV                   /**< No valid device version found */
+    SX127X_INIT_OK = 0,                 /**< Initialization was successful */
+    SX127X_ERR_SPI,                     /**< Failed to initialize SPI bus or CS line */
+    SX127X_ERR_GPIOS,                   /**< Failed to initialize GPIOs */
+    SX127X_ERR_NODEV                    /**< No valid device version found */
 };
 
 /**
  * @brief   Radio driver supported modems.
  */
 enum {
-    SX127X_MODEM_FSK = 0,              /**< FSK modem driver */
-    SX127X_MODEM_LORA,                 /**< LoRa modem driver */
+    SX127X_MODEM_FSK = 0,               /**< FSK modem driver */
+    SX127X_MODEM_LORA,                  /**< LoRa modem driver */
 };
 
 /**
  * @brief   Radio driver internal state machine states definition.
  */
 enum {
-    SX127X_RF_IDLE = 0,                /**< Idle state */
-    SX127X_RF_RX_RUNNING,              /**< Sending state */
-    SX127X_RF_TX_RUNNING,              /**< Receiving state */
-    SX127X_RF_CAD,                     /**< Channel activity detection state */
+    SX127X_RF_IDLE = 0,                 /**< Idle state */
+    SX127X_RF_RX_RUNNING,               /**< Sending state */
+    SX127X_RF_TX_RUNNING,               /**< Receiving state */
+    SX127X_RF_CAD,                      /**< Channel activity detection state */
 };
 
 /**
  * @brief   Event types.
  */
 enum {
-    SX127X_RX_DONE = 0,                /**< Receiving complete */
-    SX127X_TX_DONE,                    /**< Sending complete*/
-    SX127X_RX_TIMEOUT,                 /**< Receiving timeout */
-    SX127X_TX_TIMEOUT,                 /**< Sending timeout */
-    SX127X_RX_ERROR_CRC,               /**< Receiving CRC error */
-    SX127X_FHSS_CHANGE_CHANNEL,        /**< Channel change */
-    SX127X_CAD_DONE,                   /**< Channel activity detection complete */
+    SX127X_RX_DONE = 0,                 /**< Receiving complete */
+    SX127X_TX_DONE,                     /**< Sending complete*/
+    SX127X_RX_TIMEOUT,                  /**< Receiving timeout */
+    SX127X_TX_TIMEOUT,                  /**< Sending timeout */
+    SX127X_RX_ERROR_CRC,                /**< Receiving CRC error */
+    SX127X_FHSS_CHANGE_CHANNEL,         /**< Channel change */
+    SX127X_CAD_DONE,                    /**< Channel activity detection complete */
 };
 
 /**
@@ -157,8 +157,8 @@ enum {
  * The power amplifier mode depends on the module hardware configuration.
  */
 enum {
-    SX127X_PA_RFO = 0,                 /**< RFO HF or RFO LF */
-    SX127X_PA_BOOST,                   /**< Power amplifier boost (high power) */
+    SX127X_PA_RFO = 0,                  /**< RFO HF or RFO LF */
+    SX127X_PA_BOOST,                    /**< Power amplifier boost (high power) */
 };
 
 /**
@@ -177,25 +177,25 @@ enum {
  * @brief   LoRa configuration structure.
  */
 typedef struct {
-    uint16_t preamble_len;             /**< Length of preamble header */
-    int8_t power;                      /**< Signal power */
-    uint8_t bandwidth;                 /**< Signal bandwidth */
-    uint8_t datarate;                  /**< Spreading factor rate, e.g datarate */
-    uint8_t coderate;                  /**< Error coding rate */
-    uint8_t freq_hop_period;           /**< Frequency hop period */
-    uint8_t flags;                     /**< Boolean flags */
-    uint32_t rx_timeout;               /**< RX timeout in milliseconds */
-    uint32_t tx_timeout;               /**< TX timeout in milliseconds */
+    uint16_t preamble_len;              /**< Length of preamble header */
+    int8_t power;                       /**< Signal power */
+    uint8_t bandwidth;                  /**< Signal bandwidth */
+    uint8_t datarate;                   /**< Spreading factor rate, e.g datarate */
+    uint8_t coderate;                   /**< Error coding rate */
+    uint8_t freq_hop_period;            /**< Frequency hop period */
+    uint8_t flags;                      /**< Boolean flags */
+    uint32_t rx_timeout;                /**< RX timeout in milliseconds */
+    uint32_t tx_timeout;                /**< TX timeout in milliseconds */
 } sx127x_lora_settings_t;
 
 /**
  * @brief   Radio settings.
  */
 typedef struct {
-    uint32_t channel;                  /**< Radio channel */
-    uint8_t state;                     /**< Radio state */
-    uint8_t modem;                     /**< Driver model (FSK or LoRa) */
-    sx127x_lora_settings_t lora;       /**< LoRa settings */
+    uint32_t channel;                   /**< Radio channel */
+    uint8_t state;                      /**< Radio state */
+    uint8_t modem;                      /**< Driver model (FSK or LoRa) */
+    sx127x_lora_settings_t lora;        /**< LoRa settings */
 } sx127x_radio_settings_t;
 
 /**
@@ -203,30 +203,30 @@ typedef struct {
  */
 typedef struct {
     /* Data that will be passed to events handler in application */
-    ztimer_t tx_timeout_timer;         /**< TX operation timeout timer */
-    ztimer_t rx_timeout_timer;         /**< RX operation timeout timer */
-    uint32_t last_channel;             /**< Last channel in frequency hopping sequence */
-    bool is_last_cad_success;          /**< Sign of success of last CAD operation (activity detected) */
+    ztimer_t tx_timeout_timer;          /**< TX operation timeout timer */
+    ztimer_t rx_timeout_timer;          /**< RX operation timeout timer */
+    uint32_t last_channel;              /**< Last channel in frequency hopping sequence */
+    bool is_last_cad_success;           /**< Sign of success of last CAD operation (activity detected) */
 } sx127x_internal_t;
 
 /**
  * @brief   SX127X hardware and global parameters.
  */
 typedef struct {
-    spi_t spi;                         /**< SPI device */
-    gpio_t nss_pin;                    /**< SPI NSS pin */
-    gpio_t reset_pin;                  /**< Reset pin */
-    gpio_t dio0_pin;                   /**< Interrupt line DIO0 (Tx done) */
-    gpio_t dio1_pin;                   /**< Interrupt line DIO1 (Rx timeout) */
-    gpio_t dio2_pin;                   /**< Interrupt line DIO2 (FHSS channel change) */
-    gpio_t dio3_pin;                   /**< Interrupt line DIO3 (CAD done) */
-    gpio_t dio4_pin;                   /**< Interrupt line DIO4 (not used) */
-    gpio_t dio5_pin;                   /**< Interrupt line DIO5 (not used) */
+    spi_t spi;                          /**< SPI device */
+    gpio_t nss_pin;                     /**< SPI NSS pin */
+    gpio_t reset_pin;                   /**< Reset pin */
+    gpio_t dio0_pin;                    /**< Interrupt line DIO0 (Tx done) */
+    gpio_t dio1_pin;                    /**< Interrupt line DIO1 (Rx timeout) */
+    gpio_t dio2_pin;                    /**< Interrupt line DIO2 (FHSS channel change) */
+    gpio_t dio3_pin;                    /**< Interrupt line DIO3 (CAD done) */
+    gpio_t dio4_pin;                    /**< Interrupt line DIO4 (not used) */
+    gpio_t dio5_pin;                    /**< Interrupt line DIO5 (not used) */
 #if defined(SX127X_USE_TX_SWITCH) || defined(SX127X_USE_RX_SWITCH)
-    gpio_t rx_switch_pin;              /**< Rx antenna switch */
-    gpio_t tx_switch_pin;              /**< Tx antenna switch */
+    gpio_t rx_switch_pin;               /**< Rx antenna switch */
+    gpio_t tx_switch_pin;               /**< Tx antenna switch */
 #endif
-    uint8_t paselect;                  /**< Power amplifier mode (RFO or PABOOST) */
+    uint8_t paselect;                   /**< Power amplifier mode (RFO or PABOOST) */
 } sx127x_params_t;
 
 /**
@@ -239,11 +239,11 @@ typedef uint8_t sx127x_flags_t;
  * @extends netdev_t
  */
 typedef struct {
-    netdev_t netdev;                   /**< Netdev parent struct */
-    sx127x_radio_settings_t settings;  /**< Radio settings */
-    sx127x_params_t params;            /**< Device driver parameters */
-    sx127x_internal_t _internal;       /**< Internal sx127x data used within the driver */
-    sx127x_flags_t irq;                /**< Device IRQ flags */
+    netdev_t netdev;                    /**< Netdev parent struct */
+    sx127x_radio_settings_t settings;   /**< Radio settings */
+    sx127x_params_t params;             /**< Device driver parameters */
+    sx127x_internal_t _internal;        /**< Internal sx127x data used within the driver */
+    sx127x_flags_t irq;                 /**< Device IRQ flags */
 } sx127x_t;
 
 /**

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -75,7 +75,8 @@ static void sx127x_on_dio3_isr(void *arg);
 
 void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params, uint8_t index)
 {
-    netdev_t *netdev = (netdev_t*) dev;
+    netdev_t *netdev = (netdev_t *)dev;
+
     netdev->driver = &sx127x_driver;
     dev->params = *params;
     netdev_register(&dev->netdev, NETDEV_SX127X, index);
@@ -148,7 +149,7 @@ int sx127x_init(sx127x_t *dev)
 
         /* wait till device signals end of POR cycle */
         while ((gpio_read(dev->params.reset_pin) > 0) ==
-               SX127X_POR_ACTIVE_LOGIC_LEVEL ) {};
+               SX127X_POR_ACTIVE_LOGIC_LEVEL) {}
     }
 
     /* wait for the device to become ready */
@@ -182,7 +183,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_freq_hop(dev, IS_ACTIVE(CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT) ? true : false);
     sx127x_set_hop_period(dev, CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
     sx127x_set_fixed_header_len_mode(dev, IS_ACTIVE(CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT) ?
-                                                    true : false);
+                                     true : false);
     sx127x_set_iq_invert(dev, IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false);
     sx127x_set_payload_length(dev, CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT);
     sx127x_set_preamble_length(dev, CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT);
@@ -214,7 +215,7 @@ uint32_t sx127x_random(sx127x_t *dev)
         ztimer_sleep(ZTIMER_MSEC, 1);   /* wait one millisecond */
 
         /* Non-filtered RSSI value reading. Only takes the LSB value */
-        rnd |= ((uint32_t) sx127x_reg_read(dev, SX127X_REG_LR_RSSIWIDEBAND) & 0x01) << i;
+        rnd |= ((uint32_t)sx127x_reg_read(dev, SX127X_REG_LR_RSSIWIDEBAND) & 0x01) << i;
     }
 
     sx127x_set_sleep(dev);
@@ -238,22 +239,22 @@ static void sx127x_on_dio_isr(sx127x_t *dev, sx127x_flags_t flag)
 
 static void sx127x_on_dio0_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO0);
+    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO0);
 }
 
 static void sx127x_on_dio1_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO1);
+    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO1);
 }
 
 static void sx127x_on_dio2_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO2);
+    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO2);
 }
 
 static void sx127x_on_dio3_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t*) arg, SX127X_IRQ_DIO3);
+    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO3);
 }
 
 /* Internal event handlers */
@@ -315,14 +316,14 @@ static int _init_gpios(sx127x_t *dev)
 
 static void _on_tx_timeout(void *arg)
 {
-    netdev_t *dev = (netdev_t *) arg;
+    netdev_t *dev = (netdev_t *)arg;
 
     dev->event_callback(dev, NETDEV_EVENT_TX_TIMEOUT);
 }
 
 static void _on_rx_timeout(void *arg)
 {
-    netdev_t *dev = (netdev_t *) arg;
+    netdev_t *dev = (netdev_t *)arg;
 
     dev->event_callback(dev, NETDEV_EVENT_RX_TIMEOUT);
 }

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -85,21 +85,21 @@ void sx127x_set_modem(sx127x_t *dev, uint8_t modem)
     dev->settings.modem = modem;
 
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            /* Todo */
-            break;
-        case SX127X_MODEM_LORA:
-            sx127x_set_op_mode(dev, SX127X_RF_OPMODE_SLEEP);
-            sx127x_reg_write(dev, SX127X_REG_OPMODE,
-                             (sx127x_reg_read(dev, SX127X_REG_OPMODE) &
-                              SX127X_RF_LORA_OPMODE_LONGRANGEMODE_MASK) |
-                             SX127X_RF_LORA_OPMODE_LONGRANGEMODE_ON);
+    case SX127X_MODEM_FSK:
+        /* Todo */
+        break;
+    case SX127X_MODEM_LORA:
+        sx127x_set_op_mode(dev, SX127X_RF_OPMODE_SLEEP);
+        sx127x_reg_write(dev, SX127X_REG_OPMODE,
+                         (sx127x_reg_read(dev, SX127X_REG_OPMODE) &
+                          SX127X_RF_LORA_OPMODE_LONGRANGEMODE_MASK) |
+                         SX127X_RF_LORA_OPMODE_LONGRANGEMODE_ON);
 
-            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1, 0x00);
-            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING2, 0x00);
-            break;
-        default:
-            break;
+        sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1, 0x00);
+        sx127x_reg_write(dev, SX127X_REG_DIOMAPPING2, 0x00);
+        break;
+    default:
+        break;
     }
 }
 
@@ -129,7 +129,7 @@ void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
     /* Save current operating mode */
     dev->settings.channel = channel;
 
-    channel = (uint32_t)((double) channel / (double)LORA_FREQUENCY_RESOLUTION_DEFAULT);
+    channel = (uint32_t)((double)channel / (double)LORA_FREQUENCY_RESOLUTION_DEFAULT);
 
     /* Write frequency settings into chip */
     sx127x_reg_write(dev, SX127X_REG_FRFMSB, (uint8_t)((channel >> 16) & 0xFF));
@@ -142,56 +142,56 @@ uint32_t sx127x_get_time_on_air(const sx127x_t *dev, uint8_t pkt_len)
     uint32_t air_time = 0;
 
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            /* todo */
-            break;
-        case SX127X_MODEM_LORA:
-        {
-            double bw = 0.0;
-
-            /* Note: When using LoRa modem only bandwidths 125, 250 and 500 kHz are supported. */
-            switch (dev->settings.lora.bandwidth) {
-                case LORA_BW_125_KHZ:
-                    bw = 125e3;
-                    break;
-                case LORA_BW_250_KHZ:
-                    bw = 250e3;
-                    break;
-                case LORA_BW_500_KHZ:
-                    bw = 500e3;
-                    break;
-                default:
-                    DEBUG("Invalid bandwidth: %d\n", dev->settings.lora.bandwidth);
-                    break;
-            }
-
-            /* Symbol rate : time for one symbol [secs] */
-            double rs = bw / (1 << dev->settings.lora.datarate);
-            double ts = 1 / rs;
-
-            /* time of preamble */
-            double t_preamble = (dev->settings.lora.preamble_len + 4.25) * ts;
-
-            /* Symbol length of payload and time */
-            double tmp =
-                ceil(
-                    (8 * pkt_len - 4 * dev->settings.lora.datarate + 28
-                     + 16 * (dev->settings.lora.flags & SX127X_ENABLE_CRC_FLAG)
-                     - (!(dev->settings.lora.flags & SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG) ? 20 : 0))
-                    / (double) (4 * dev->settings.lora.datarate
-                                - (((dev->settings.lora.flags & SX127X_LOW_DATARATE_OPTIMIZE_FLAG)
-                                    > 0) ? 2 : 0)))
-                * (dev->settings.lora.coderate + 4);
-            double n_payload = 8 + ((tmp > 0) ? tmp : 0);
-            double t_payload = n_payload * ts;
-
-            /* Time on air */
-            double t_on_air = t_preamble + t_payload;
-
-            /* return milli seconds */
-            air_time = floor(t_on_air * 1e3 + 0.999);
-        }
+    case SX127X_MODEM_FSK:
+        /* todo */
         break;
+    case SX127X_MODEM_LORA:
+    {
+        double bw = 0.0;
+
+        /* Note: When using LoRa modem only bandwidths 125, 250 and 500 kHz are supported. */
+        switch (dev->settings.lora.bandwidth) {
+        case LORA_BW_125_KHZ:
+            bw = 125e3;
+            break;
+        case LORA_BW_250_KHZ:
+            bw = 250e3;
+            break;
+        case LORA_BW_500_KHZ:
+            bw = 500e3;
+            break;
+        default:
+            DEBUG("Invalid bandwidth: %d\n", dev->settings.lora.bandwidth);
+            break;
+        }
+
+        /* Symbol rate : time for one symbol [secs] */
+        double rs = bw / (1 << dev->settings.lora.datarate);
+        double ts = 1 / rs;
+
+        /* time of preamble */
+        double t_preamble = (dev->settings.lora.preamble_len + 4.25) * ts;
+
+        /* Symbol length of payload and time */
+        double tmp =
+            ceil(
+                (8 * pkt_len - 4 * dev->settings.lora.datarate + 28
+                 + 16 * (dev->settings.lora.flags & SX127X_ENABLE_CRC_FLAG)
+                 - (!(dev->settings.lora.flags & SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG) ? 20 : 0))
+                / (double)(4 * dev->settings.lora.datarate
+                           - (((dev->settings.lora.flags & SX127X_LOW_DATARATE_OPTIMIZE_FLAG)
+                               > 0) ? 2 : 0)))
+            * (dev->settings.lora.coderate + 4);
+        double n_payload = 8 + ((tmp > 0) ? tmp : 0);
+        double t_payload = n_payload * ts;
+
+        /* Time on air */
+        double t_on_air = t_preamble + t_payload;
+
+        /* return milli seconds */
+        air_time = floor(t_on_air * 1e3 + 0.999);
+    }
+    break;
     }
 
     return air_time;
@@ -234,92 +234,97 @@ void sx127x_set_rx(sx127x_t *dev)
 #endif
 
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            /* todo */
-            break;
-        case SX127X_MODEM_LORA:
-        {
-            sx127x_reg_write(dev, SX127X_REG_LR_INVERTIQ,
-                             ((sx127x_reg_read(dev, SX127X_REG_LR_INVERTIQ) &
-                               SX127X_RF_LORA_INVERTIQ_TX_MASK &
-                               SX127X_RF_LORA_INVERTIQ_RX_MASK) |
-                              ((dev->settings.lora.flags & SX127X_IQ_INVERTED_FLAG) ? SX127X_RF_LORA_INVERTIQ_RX_ON :SX127X_RF_LORA_INVERTIQ_RX_OFF) |
-                              SX127X_RF_LORA_INVERTIQ_TX_OFF));
-            sx127x_reg_write(dev, SX127X_REG_LR_INVERTIQ2,
-                             ((dev->settings.lora.flags & SX127X_IQ_INVERTED_FLAG) ? SX127X_RF_LORA_INVERTIQ2_ON : SX127X_RF_LORA_INVERTIQ2_OFF));
+    case SX127X_MODEM_FSK:
+        /* todo */
+        break;
+    case SX127X_MODEM_LORA:
+    {
+        sx127x_reg_write(dev, SX127X_REG_LR_INVERTIQ,
+                         ((sx127x_reg_read(dev, SX127X_REG_LR_INVERTIQ) &
+                           SX127X_RF_LORA_INVERTIQ_TX_MASK &
+                           SX127X_RF_LORA_INVERTIQ_RX_MASK) |
+                          ((dev->settings.lora.flags &
+                            SX127X_IQ_INVERTED_FLAG) ? SX127X_RF_LORA_INVERTIQ_RX_ON :
+                           SX127X_RF_LORA_INVERTIQ_RX_OFF)
+                          |
+                          SX127X_RF_LORA_INVERTIQ_TX_OFF));
+        sx127x_reg_write(dev, SX127X_REG_LR_INVERTIQ2,
+                         ((dev->settings.lora.flags &
+                           SX127X_IQ_INVERTED_FLAG) ? SX127X_RF_LORA_INVERTIQ2_ON :
+                          SX127X_RF_LORA_INVERTIQ2_OFF));
 
 #if defined(MODULE_SX1276)
-            /* ERRATA 2.3 - Receiver Spurious Reception of a LoRa Signal */
-            if (dev->settings.lora.bandwidth < 9) {
-                sx127x_reg_write(dev, SX127X_REG_LR_DETECTOPTIMIZE,
-                                 sx127x_reg_read(dev, SX127X_REG_LR_DETECTOPTIMIZE) & 0x7F);
-                sx127x_reg_write(dev, SX127X_REG_LR_TEST30, 0x00);
-                switch (dev->settings.lora.bandwidth) {
-                    case LORA_BW_125_KHZ: /* 125 kHz */
-                        sx127x_reg_write(dev, SX127X_REG_LR_TEST2F, 0x40);
-                        break;
-                    case LORA_BW_250_KHZ: /* 250 kHz */
-                        sx127x_reg_write(dev, SX127X_REG_LR_TEST2F, 0x40);
-                        break;
+        /* ERRATA 2.3 - Receiver Spurious Reception of a LoRa Signal */
+        if (dev->settings.lora.bandwidth < 9) {
+            sx127x_reg_write(dev, SX127X_REG_LR_DETECTOPTIMIZE,
+                             sx127x_reg_read(dev, SX127X_REG_LR_DETECTOPTIMIZE) & 0x7F);
+            sx127x_reg_write(dev, SX127X_REG_LR_TEST30, 0x00);
+            switch (dev->settings.lora.bandwidth) {
+            case LORA_BW_125_KHZ:         /* 125 kHz */
+                sx127x_reg_write(dev, SX127X_REG_LR_TEST2F, 0x40);
+                break;
+            case LORA_BW_250_KHZ:         /* 250 kHz */
+                sx127x_reg_write(dev, SX127X_REG_LR_TEST2F, 0x40);
+                break;
 
-                    default:
-                        break;
-                }
+            default:
+                break;
             }
-            else {
-                sx127x_reg_write(dev, SX127X_REG_LR_DETECTOPTIMIZE,
-                                 sx127x_reg_read(dev, SX127X_REG_LR_DETECTOPTIMIZE) | 0x80);
-            }
+        }
+        else {
+            sx127x_reg_write(dev, SX127X_REG_LR_DETECTOPTIMIZE,
+                             sx127x_reg_read(dev, SX127X_REG_LR_DETECTOPTIMIZE) | 0x80);
+        }
 #endif
 
-            /* Setup interrupts */
-            if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
-                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
-                                 /* SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
-                                    SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                                    SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
-                                    SX127X_RF_LORA_IRQFLAGS_VALIDHEADER | */
-                                 SX127X_RF_LORA_IRQFLAGS_TXDONE |
-                                 SX127X_RF_LORA_IRQFLAGS_CADDONE |
-                                 /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
-                                 SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
+        /* Setup interrupts */
+        if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
+                             /* SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
+                                SX127X_RF_LORA_IRQFLAGS_RXDONE |
+                                SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                                SX127X_RF_LORA_IRQFLAGS_VALIDHEADER | */
+                             SX127X_RF_LORA_IRQFLAGS_TXDONE |
+                             SX127X_RF_LORA_IRQFLAGS_CADDONE |
+                             /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
+                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
 
-                /* DIO0=RxDone, DIO1=RxTimeout, DIO2=FhssChangeChannel, DIO3=ValidHeader */
-                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO1_00 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO2_00 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
-            }
-            else {
-                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
-                                 /* SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
-                                    SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                                    SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
-                                    SX127X_RF_LORA_IRQFLAGS_VALIDHEADER | */
-                                 SX127X_RF_LORA_IRQFLAGS_TXDONE |
-                                 SX127X_RF_LORA_IRQFLAGS_CADDONE |
-                                 SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
-                                 SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
-
-                /* DIO0=RxDone, DIO1=RxTimeout, DIO3=ValidHeader */
-                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO1_00 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
-            }
-
-            sx127x_reg_write(dev, SX127X_REG_LR_FIFORXBASEADDR, 0);
-            sx127x_reg_write(dev, SX127X_REG_LR_FIFOADDRPTR, 0);
+            /* DIO0=RxDone, DIO1=RxTimeout, DIO2=FhssChangeChannel, DIO3=ValidHeader */
+            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO1_00 |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO2_00 |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
         }
-        break;
+        else {
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
+                             /* SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
+                                SX127X_RF_LORA_IRQFLAGS_RXDONE |
+                                SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                                SX127X_RF_LORA_IRQFLAGS_VALIDHEADER | */
+                             SX127X_RF_LORA_IRQFLAGS_TXDONE |
+                             SX127X_RF_LORA_IRQFLAGS_CADDONE |
+                             SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
+                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
+
+            /* DIO0=RxDone, DIO1=RxTimeout, DIO3=ValidHeader */
+            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO0_00 |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO1_00 |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO3_01);
+        }
+
+        sx127x_reg_write(dev, SX127X_REG_LR_FIFORXBASEADDR, 0);
+        sx127x_reg_write(dev, SX127X_REG_LR_FIFOADDRPTR, 0);
+    }
+    break;
     }
 
     sx127x_set_state(dev, SX127X_RF_RX_RUNNING);
@@ -345,52 +350,51 @@ void sx127x_set_tx(sx127x_t *dev)
     gpio_set(dev->params.tx_switch_pin);
 #endif
 
-     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            /* todo */
-            break;
-        case SX127X_MODEM_LORA:
-        {
-            if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
-                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
-                                 SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
-                                 SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                                 SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
-                                 SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
-                                 /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
-                                 SX127X_RF_LORA_IRQFLAGS_CADDONE |
-                                 /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
-                                 SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
-
-                /* DIO0=TxDone, DIO2=FhssChangeChannel */
-                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1 ) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK) |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_01 |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO2_00);
-            }
-            else
-            {
-                /* Enable TXDONE interrupt */
-                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
-                                 SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
-                                 SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                                 SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
-                                 SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
-                                 /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
-                                 SX127X_RF_LORA_IRQFLAGS_CADDONE |
-                                 SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
-                                 SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
-
-                /* Set TXDONE interrupt to the DIO0 line */
-                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_01);
-            }
-        }
+    switch (dev->settings.modem) {
+    case SX127X_MODEM_FSK:
+        /* todo */
         break;
+    case SX127X_MODEM_LORA:
+    {
+        if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
+                             SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
+                             SX127X_RF_LORA_IRQFLAGS_RXDONE |
+                             SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                             SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                                /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
+                             SX127X_RF_LORA_IRQFLAGS_CADDONE |
+                                /* SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL | */
+                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
+
+            /* DIO0=TxDone, DIO2=FhssChangeChannel */
+            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1 ) &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO2_MASK) |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO0_01 |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO2_00);
+        }
+        else {
+            /* Enable TXDONE interrupt */
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
+                             SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
+                             SX127X_RF_LORA_IRQFLAGS_RXDONE |
+                             SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                             SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                             /* SX127X_RF_LORA_IRQFLAGS_TXDONE | */
+                             SX127X_RF_LORA_IRQFLAGS_CADDONE |
+                             SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL |
+                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
+
+            /* Set TXDONE interrupt to the DIO0 line */
+            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO0_01);
+        }
+    }
+    break;
     }
 
     sx127x_set_state(dev, SX127X_RF_TX_RUNNING);
@@ -407,11 +411,11 @@ void sx127x_set_tx(sx127x_t *dev)
 uint8_t sx127x_get_max_payload_len(const sx127x_t *dev)
 {
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            return sx127x_reg_read(dev, SX127X_REG_PAYLOADLENGTH);
+    case SX127X_MODEM_FSK:
+        return sx127x_reg_read(dev, SX127X_REG_PAYLOADLENGTH);
 
-        case SX127X_MODEM_LORA:
-            return sx127x_reg_read(dev, SX127X_REG_LR_PAYLOADMAXLENGTH);
+    case SX127X_MODEM_LORA:
+        return sx127x_reg_read(dev, SX127X_REG_LR_PAYLOADMAXLENGTH);
     }
 
     /* should never be reached */
@@ -423,13 +427,13 @@ void sx127x_set_max_payload_len(const sx127x_t *dev, uint8_t maxlen)
     DEBUG("[sx127x] Set max payload len: %d\n", maxlen);
 
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            sx127x_reg_write(dev, SX127X_REG_PAYLOADLENGTH, maxlen);
-            break;
+    case SX127X_MODEM_FSK:
+        sx127x_reg_write(dev, SX127X_REG_PAYLOADLENGTH, maxlen);
+        break;
 
-        case SX127X_MODEM_LORA:
-            sx127x_reg_write(dev, SX127X_REG_LR_PAYLOADMAXLENGTH, maxlen);
-            break;
+    case SX127X_MODEM_LORA:
+        sx127x_reg_write(dev, SX127X_REG_LR_PAYLOADMAXLENGTH, maxlen);
+        break;
     }
 }
 
@@ -441,7 +445,7 @@ uint8_t sx127x_get_op_mode(const sx127x_t *dev)
 void sx127x_set_op_mode(const sx127x_t *dev, uint8_t op_mode)
 {
     if (IS_ACTIVE(ENABLE_DEBUG)) {
-        switch(op_mode) {
+        switch (op_mode) {
         case SX127X_RF_OPMODE_SLEEP:
             DEBUG("[sx127x] Set op mode: SLEEP\n");
             break;
@@ -475,13 +479,14 @@ uint8_t sx127x_get_bandwidth(const sx127x_t *dev)
 
 static void _low_datarate_optimize(sx127x_t *dev)
 {
-    if ( ((dev->settings.lora.bandwidth == LORA_BW_125_KHZ) &&
-          ((dev->settings.lora.datarate == LORA_SF11) ||
-           (dev->settings.lora.datarate == LORA_SF12))) ||
-         ((dev->settings.lora.bandwidth == LORA_BW_250_KHZ) &&
-          (dev->settings.lora.datarate == LORA_SF12))) {
+    if (((dev->settings.lora.bandwidth == LORA_BW_125_KHZ) &&
+         ((dev->settings.lora.datarate == LORA_SF11) ||
+          (dev->settings.lora.datarate == LORA_SF12))) ||
+        ((dev->settings.lora.bandwidth == LORA_BW_250_KHZ) &&
+         (dev->settings.lora.datarate == LORA_SF12))) {
         dev->settings.lora.flags |= SX127X_LOW_DATARATE_OPTIMIZE_FLAG;
-    } else {
+    }
+    else {
         dev->settings.lora.flags &= ~SX127X_LOW_DATARATE_OPTIMIZE_FLAG;
     }
 
@@ -501,6 +506,7 @@ static void _low_datarate_optimize(sx127x_t *dev)
 static void _update_bandwidth(const sx127x_t *dev)
 {
     uint8_t config1_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG1);
+
 #if defined(MODULE_SX1272)
     config1_reg &= SX1272_RF_LORA_MODEMCONFIG1_BW_MASK;
     switch (dev->settings.lora.bandwidth) {
@@ -587,13 +593,14 @@ void sx127x_set_spreading_factor(sx127x_t *dev, uint8_t datarate)
     dev->settings.lora.datarate = datarate;
 
     uint8_t config2_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG2);
+
     config2_reg &= SX127X_RF_LORA_MODEMCONFIG2_SF_MASK;
     config2_reg |= datarate << 4;
     sx127x_reg_write(dev, SX127X_REG_LR_MODEMCONFIG2, config2_reg);
 
     _low_datarate_optimize(dev);
 
-    switch(dev->settings.lora.datarate) {
+    switch (dev->settings.lora.datarate) {
     case LORA_SF6:
         sx127x_reg_write(dev, SX127X_REG_LR_DETECTOPTIMIZE,
                          SX127X_RF_LORA_DETECTIONOPTIMIZE_SF6);
@@ -694,6 +701,7 @@ void sx127x_set_hop_period(sx127x_t *dev, uint8_t hop_period)
     dev->settings.lora.freq_hop_period = hop_period;
 
     uint8_t tmp = sx127x_reg_read(dev, SX127X_REG_LR_PLLHOP);
+
     if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
         tmp |= SX127X_RF_LORA_PLLHOP_FASTHOP_ON;
         sx127x_reg_write(dev, SX127X_REG_LR_PLLHOP, tmp);
@@ -713,6 +721,7 @@ void sx127x_set_fixed_header_len_mode(sx127x_t *dev, bool fixed_len)
     _set_flag(dev, SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG, fixed_len);
 
     uint8_t config1_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG1);
+
 #if defined(MODULE_SX1272)
     config1_reg &= SX1272_RF_LORA_MODEMCONFIG1_IMPLICITHEADER_MASK;
     config1_reg |= fixed_len << 2;
@@ -725,7 +734,7 @@ void sx127x_set_fixed_header_len_mode(sx127x_t *dev, bool fixed_len)
 
 uint8_t sx127x_get_payload_length(const sx127x_t *dev)
 {
-    return sx127x_reg_read(dev, SX127X_REG_LR_PAYLOADLENGTH);;
+    return sx127x_reg_read(dev, SX127X_REG_LR_PAYLOADLENGTH);
 }
 
 void sx127x_set_payload_length(sx127x_t *dev, uint8_t len)
@@ -756,6 +765,7 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
     dev->settings.lora.power = power;
 
     uint8_t pa_config = sx127x_reg_read(dev, SX127X_REG_PACONFIG);
+
 #if defined(MODULE_SX1272)
     uint8_t pa_dac = sx127x_reg_read(dev, SX1272_REG_PADAC);
 #else /* MODULE_SX1276 */
@@ -777,7 +787,8 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
         if (power > 17) {
             pa_dac = ((pa_dac & SX127X_RF_PADAC_20DBM_MASK) |
                       SX127X_RF_PADAC_20DBM_ON);
-        } else {
+        }
+        else {
             pa_dac = ((pa_dac & SX127X_RF_PADAC_20DBM_MASK) |
                       SX127X_RF_PADAC_20DBM_OFF);
         }
@@ -791,7 +802,8 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
 
             pa_config = ((pa_config & SX127X_RF_PACONFIG_OUTPUTPOWER_MASK) |
                          (uint8_t)((uint16_t)(power - 5) & 0x0F));
-        } else {
+        }
+        else {
             if (power < 2) {
                 power = 2;
             }
@@ -802,7 +814,8 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
             pa_config = ((pa_config & SX127X_RF_PACONFIG_OUTPUTPOWER_MASK) |
                          (uint8_t)((uint16_t)(power - 2) & 0x0F));
         }
-    } else {
+    }
+    else {
         if (power < -1) {
             power = -1;
         }
@@ -858,6 +871,7 @@ void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout)
     DEBUG("[sx127x] Set symbol timeout: %d\n", timeout);
 
     uint8_t config2_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG2);
+
     config2_reg &= SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
     config2_reg |= (timeout >> 8) & ~SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
     sx127x_reg_write(dev, SX127X_REG_LR_MODEMCONFIG2, config2_reg);
@@ -879,7 +893,7 @@ void sx127x_set_iq_invert(sx127x_t *dev, bool iq_invert)
                      (sx127x_reg_read(dev, SX127X_REG_LR_INVERTIQ) &
                       SX127X_RF_LORA_INVERTIQ_RX_MASK &
                       SX127X_RF_LORA_INVERTIQ_TX_MASK) |
-                      SX127X_RF_LORA_INVERTIQ_RX_OFF |
+                     SX127X_RF_LORA_INVERTIQ_RX_OFF |
                      (iq_invert ? SX127X_RF_LORA_INVERTIQ_TX_ON : SX127X_RF_LORA_INVERTIQ_TX_OFF));
 
     sx127x_reg_write(dev, SX127X_REG_LR_INVERTIQ2,
@@ -890,5 +904,5 @@ void sx127x_set_freq_hop(sx127x_t *dev, bool freq_hop_on)
 {
     DEBUG("[sx127x] Set freq hop: %d\n", freq_hop_on);
 
-     _set_flag(dev, SX127X_CHANNEL_HOPPING_FLAG, freq_hop_on);
+    _set_flag(dev, SX127X_CHANNEL_HOPPING_FLAG, freq_hop_on);
 }

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -86,7 +86,7 @@ void sx127x_reg_write_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
     spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_SPI_MODE, SX127X_SPI_SPEED);
 
     gpio_clear(dev->params.nss_pin);
-    spi_transfer_regs(dev->params.spi, SPI_CS_UNDEF, addr | 0x80, (char *) buffer, NULL, size);
+    spi_transfer_regs(dev->params.spi, SPI_CS_UNDEF, addr | 0x80, (char *)buffer, NULL, size);
     gpio_set(dev->params.nss_pin);
 
     spi_release(dev->params.spi);
@@ -98,7 +98,7 @@ void sx127x_reg_read_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
     spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_SPI_MODE, SX127X_SPI_SPEED);
 
     gpio_clear(dev->params.nss_pin);
-    spi_transfer_regs(dev->params.spi, SPI_CS_UNDEF, addr & 0x7F, NULL, (char *) buffer, size);
+    spi_transfer_regs(dev->params.spi, SPI_CS_UNDEF, addr & 0x7F, NULL, (char *)buffer, size);
     gpio_set(dev->params.nss_pin);
 
     spi_release(dev->params.spi);
@@ -122,9 +122,11 @@ void sx1276_rx_chain_calibration(sx127x_t *dev)
 
     /* Save context */
     reg_pa_config_init_val = sx127x_reg_read(dev, SX127X_REG_PACONFIG);
-    initial_freq = (double) (((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
-                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
-                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * (double)LORA_FREQUENCY_RESOLUTION_DEFAULT;
+    initial_freq = (double)(((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
+                            | ((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
+                            | ((uint32_t)sx127x_reg_read(dev,
+                                                         SX127X_REG_FRFLSB))) *
+                   (double)LORA_FREQUENCY_RESOLUTION_DEFAULT;
 
     /* Cut the PA just in case, RFO output, power = -1 dBm */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, 0x00);
@@ -136,8 +138,7 @@ void sx1276_rx_chain_calibration(sx127x_t *dev)
                      | SX127X_RF_IMAGECAL_IMAGECAL_START);
 
     while ((sx127x_reg_read(dev, SX127X_REG_IMAGECAL) & SX127X_RF_IMAGECAL_IMAGECAL_RUNNING)
-           == SX127X_RF_IMAGECAL_IMAGECAL_RUNNING) {
-    }
+           == SX127X_RF_IMAGECAL_IMAGECAL_RUNNING) {}
 
     /* Set a frequency in HF band */
     sx127x_set_channel(dev, SX127X_HF_CHANNEL_DEFAULT);
@@ -148,8 +149,7 @@ void sx1276_rx_chain_calibration(sx127x_t *dev)
                      (sx127x_reg_read(dev, SX127X_REG_IMAGECAL) & SX127X_RF_IMAGECAL_IMAGECAL_MASK)
                      | SX127X_RF_IMAGECAL_IMAGECAL_START);
     while ((sx127x_reg_read(dev, SX127X_REG_IMAGECAL) & SX127X_RF_IMAGECAL_IMAGECAL_RUNNING)
-           == SX127X_RF_IMAGECAL_IMAGECAL_RUNNING) {
-    }
+           == SX127X_RF_IMAGECAL_IMAGECAL_RUNNING) {}
 
     /* Restore context */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, reg_pa_config_init_val);
@@ -162,24 +162,24 @@ int16_t sx127x_read_rssi(const sx127x_t *dev)
     int16_t rssi = 0;
 
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            rssi = -(sx127x_reg_read(dev, SX127X_REG_RSSIVALUE) >> 1);
-            break;
-        case SX127X_MODEM_LORA:
+    case SX127X_MODEM_FSK:
+        rssi = -(sx127x_reg_read(dev, SX127X_REG_RSSIVALUE) >> 1);
+        break;
+    case SX127X_MODEM_LORA:
 #if defined(MODULE_SX1272)
-            rssi = SX127X_RSSI_OFFSET + sx127x_reg_read(dev, SX127X_REG_LR_RSSIVALUE);
+        rssi = SX127X_RSSI_OFFSET + sx127x_reg_read(dev, SX127X_REG_LR_RSSIVALUE);
 #else /* MODULE_SX1276 */
-            if (dev->settings.channel > SX127X_RF_MID_BAND_THRESH) {
-                rssi = SX127X_RSSI_OFFSET_HF + sx127x_reg_read(dev, SX127X_REG_LR_RSSIVALUE);
-            }
-            else {
-                rssi = SX127X_RSSI_OFFSET_LF + sx127x_reg_read(dev, SX127X_REG_LR_RSSIVALUE);
-            }
+        if (dev->settings.channel > SX127X_RF_MID_BAND_THRESH) {
+            rssi = SX127X_RSSI_OFFSET_HF + sx127x_reg_read(dev, SX127X_REG_LR_RSSIVALUE);
+        }
+        else {
+            rssi = SX127X_RSSI_OFFSET_LF + sx127x_reg_read(dev, SX127X_REG_LR_RSSIVALUE);
+        }
 #endif
-            break;
-        default:
-            rssi = -1;
-            break;
+        break;
+    default:
+        rssi = -1;
+        break;
     }
 
     return rssi;
@@ -188,41 +188,41 @@ int16_t sx127x_read_rssi(const sx127x_t *dev)
 void sx127x_start_cad(sx127x_t *dev)
 {
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            break;
-        case SX127X_MODEM_LORA:
-            /* Disable all interrupts except CAD-related */
-            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
-                             SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
-                             SX127X_RF_LORA_IRQFLAGS_RXDONE |
-                             SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
-                             SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
-                             SX127X_RF_LORA_IRQFLAGS_TXDONE |
-                             /*SX127X_RF_LORA_IRQFLAGS_CADDONE |*/
-                             SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL
-                             /* | SX127X_RF_LORA_IRQFLAGS_CADDETECTED*/
-                             );
+    case SX127X_MODEM_FSK:
+        break;
+    case SX127X_MODEM_LORA:
+        /* Disable all interrupts except CAD-related */
+        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGSMASK,
+                         SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT |
+                         SX127X_RF_LORA_IRQFLAGS_RXDONE |
+                         SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR |
+                         SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                         SX127X_RF_LORA_IRQFLAGS_TXDONE |
+                            /*SX127X_RF_LORA_IRQFLAGS_CADDONE |*/
+                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL
+                            /* | SX127X_RF_LORA_IRQFLAGS_CADDETECTED*/
+                         );
 
-            if (gpio_is_valid(dev->params.dio3_pin)) {
-                /* DIO3 = CADDone */
-                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO3_00);
-            }
-            else {
-                /* DIO0 = CADDone */
-                sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
-                                 (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
-                                  SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
-                                 SX127X_RF_LORA_DIOMAPPING1_DIO0_10);
-            }
+        if (gpio_is_valid(dev->params.dio3_pin)) {
+            /* DIO3 = CADDone */
+            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO3_MASK) |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO3_00);
+        }
+        else {
+            /* DIO0 = CADDone */
+            sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
+                             (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &
+                              SX127X_RF_LORA_DIOMAPPING1_DIO0_MASK) |
+                             SX127X_RF_LORA_DIOMAPPING1_DIO0_10);
+        }
 
-            sx127x_set_state(dev,  SX127X_RF_CAD);
-            sx127x_set_op_mode(dev, SX127X_RF_LORA_OPMODE_CAD);
-            break;
-        default:
-            break;
+        sx127x_set_state(dev,  SX127X_RF_CAD);
+        sx127x_set_op_mode(dev, SX127X_RF_LORA_OPMODE_CAD);
+        break;
+    default:
+        break;
     }
 }
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -48,7 +48,7 @@ void _on_dio3_irq(void *arg);
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     DEBUG("[sx127x] Sending packet now.\n");
-    sx127x_t *dev = (sx127x_t*) netdev;
+    sx127x_t *dev = (sx127x_t *)netdev;
 
     if (sx127x_get_state(dev) == SX127X_RF_TX_RUNNING) {
         DEBUG("[sx127x] Cannot send packet: radio already in transmitting "
@@ -64,40 +64,40 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     }
 
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            /* todo */
-            break;
-        case SX127X_MODEM_LORA:
-            /* Initializes the payload size */
-            if (!sx127x_get_fixed_header_len_mode(dev)) {
-                DEBUG("[sx127x] Modem option is LoRa.\n");
-                sx127x_set_payload_length(dev, size);
-            }
+    case SX127X_MODEM_FSK:
+        /* todo */
+        break;
+    case SX127X_MODEM_LORA:
+        /* Initializes the payload size */
+        if (!sx127x_get_fixed_header_len_mode(dev)) {
+            DEBUG("[sx127x] Modem option is LoRa.\n");
+            sx127x_set_payload_length(dev, size);
+        }
 
-            /* Full buffer used for Tx */
-            sx127x_reg_write(dev, SX127X_REG_LR_FIFOTXBASEADDR, 0x00);
-            sx127x_reg_write(dev, SX127X_REG_LR_FIFOADDRPTR, 0x00);
+        /* Full buffer used for Tx */
+        sx127x_reg_write(dev, SX127X_REG_LR_FIFOTXBASEADDR, 0x00);
+        sx127x_reg_write(dev, SX127X_REG_LR_FIFOADDRPTR, 0x00);
 
-            /* FIFO operations can not take place in Sleep mode
-             * So wake up the chip */
-            if (sx127x_get_op_mode(dev) == SX127X_RF_OPMODE_SLEEP) {
-                sx127x_set_standby(dev);
-                DEBUG("[sx127x] Waiting for chip to wake up.\n");
-                ztimer_sleep(ZTIMER_MSEC, SX127X_RADIO_WAKEUP_TIME); /* wait for chip wake up */
-            }
+        /* FIFO operations can not take place in Sleep mode
+         * So wake up the chip */
+        if (sx127x_get_op_mode(dev) == SX127X_RF_OPMODE_SLEEP) {
+            sx127x_set_standby(dev);
+            DEBUG("[sx127x] Waiting for chip to wake up.\n");
+            ztimer_sleep(ZTIMER_MSEC, SX127X_RADIO_WAKEUP_TIME);     /* wait for chip wake up */
+        }
 
-            /* Write payload buffer */
-            for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-                if(iol->iol_len > 0) {
-                    sx127x_write_fifo(dev, iol->iol_base, iol->iol_len);
-                    DEBUG("[sx127x] Wrote to payload buffer.\n");
-                }
+        /* Write payload buffer */
+        for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+            if (iol->iol_len > 0) {
+                sx127x_write_fifo(dev, iol->iol_base, iol->iol_len);
+                DEBUG("[sx127x] Wrote to payload buffer.\n");
             }
-            break;
-        default:
-            DEBUG("[sx127x] netdev: Unsupported modem (%d)\n",
-                  dev->settings.modem);
-            break;
+        }
+        break;
+    default:
+        DEBUG("[sx127x] netdev: Unsupported modem (%d)\n",
+              dev->settings.modem);
+        break;
     }
 
     sx127x_set_tx(dev);
@@ -107,94 +107,97 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    sx127x_t *dev = (sx127x_t*) netdev;
+    sx127x_t *dev = (sx127x_t *)netdev;
     volatile uint8_t irq_flags = 0;
     uint8_t size = 0;
+
     switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            /* todo */
-            break;
-        case SX127X_MODEM_LORA:
+    case SX127X_MODEM_FSK:
+        /* todo */
+        break;
+    case SX127X_MODEM_LORA:
+        /* Clear IRQ */
+        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_RXDONE);
+
+        irq_flags = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
+        if ((irq_flags & SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR_MASK) ==
+            SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR) {
             /* Clear IRQ */
-            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_RXDONE);
-
-            irq_flags = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
-            if ( (irq_flags & SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR_MASK) ==
-                 SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR) {
-                /* Clear IRQ */
-                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                 SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR);
-
-                if (!(dev->settings.lora.flags & SX127X_RX_CONTINUOUS_FLAG)) {
-                    sx127x_set_state(dev, SX127X_RF_IDLE);
-                }
-
-                ztimer_remove(ZTIMER_MSEC, &dev->_internal.rx_timeout_timer);
-                netdev->event_callback(netdev, NETDEV_EVENT_CRC_ERROR);
-                return -EBADMSG;
-            }
-
-            netdev_lora_rx_info_t *packet_info = info;
-            if (packet_info) {
-                uint8_t snr_value = sx127x_reg_read(dev, SX127X_REG_LR_PKTSNRVALUE);
-                if (snr_value & 0x80) { /* The SNR is negative */
-                    /* Invert and divide by 4 */
-                    packet_info->snr = -1 * ((~snr_value + 1) & 0xFF) >> 2;
-                }
-                else {
-                    /* Divide by 4 */
-                    packet_info->snr = (snr_value & 0xFF) >> 2;
-                }
-
-                int16_t rssi = sx127x_reg_read(dev, SX127X_REG_LR_PKTRSSIVALUE);
-
-                if (packet_info->snr < 0) {
-#if defined(MODULE_SX1272)
-                    packet_info->rssi = SX127X_RSSI_OFFSET + rssi + (rssi >> 4) + packet_info->snr;
-#else /* MODULE_SX1276 */
-                    if (dev->settings.channel > SX127X_RF_MID_BAND_THRESH) {
-                        packet_info->rssi = SX127X_RSSI_OFFSET_HF + rssi + (rssi >> 4) + packet_info->snr;
-                    }
-                    else {
-                        packet_info->rssi = SX127X_RSSI_OFFSET_LF + rssi + (rssi >> 4) + packet_info->snr;
-                    }
-#endif
-                }
-                else {
-#if defined(MODULE_SX1272)
-                    packet_info->rssi = SX127X_RSSI_OFFSET + rssi + (rssi >> 4);
-#else /* MODULE_SX1276 */
-                    if (dev->settings.channel > SX127X_RF_MID_BAND_THRESH) {
-                        packet_info->rssi = SX127X_RSSI_OFFSET_HF + rssi + (rssi >> 4);
-                    }
-                    else {
-                        packet_info->rssi = SX127X_RSSI_OFFSET_LF + rssi + (rssi >> 4);
-                    }
-#endif
-                }
-            }
-
-            size = sx127x_reg_read(dev, SX127X_REG_LR_RXNBBYTES);
-            if (buf == NULL) {
-                return size;
-            }
-
-            if (size > len) {
-                return -ENOBUFS;
-            }
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                             SX127X_RF_LORA_IRQFLAGS_PAYLOADCRCERROR);
 
             if (!(dev->settings.lora.flags & SX127X_RX_CONTINUOUS_FLAG)) {
                 sx127x_set_state(dev, SX127X_RF_IDLE);
             }
 
             ztimer_remove(ZTIMER_MSEC, &dev->_internal.rx_timeout_timer);
-            /* Read the last packet from FIFO */
-            uint8_t last_rx_addr = sx127x_reg_read(dev, SX127X_REG_LR_FIFORXCURRENTADDR);
-            sx127x_reg_write(dev, SX127X_REG_LR_FIFOADDRPTR, last_rx_addr);
-            sx127x_read_fifo(dev, (uint8_t*)buf, size);
-            break;
-        default:
-            break;
+            netdev->event_callback(netdev, NETDEV_EVENT_CRC_ERROR);
+            return -EBADMSG;
+        }
+
+        netdev_lora_rx_info_t *packet_info = info;
+        if (packet_info) {
+            uint8_t snr_value = sx127x_reg_read(dev, SX127X_REG_LR_PKTSNRVALUE);
+            if (snr_value & 0x80) {     /* The SNR is negative */
+                /* Invert and divide by 4 */
+                packet_info->snr = -1 * ((~snr_value + 1) & 0xFF) >> 2;
+            }
+            else {
+                /* Divide by 4 */
+                packet_info->snr = (snr_value & 0xFF) >> 2;
+            }
+
+            int16_t rssi = sx127x_reg_read(dev, SX127X_REG_LR_PKTRSSIVALUE);
+
+            if (packet_info->snr < 0) {
+#if defined(MODULE_SX1272)
+                packet_info->rssi = SX127X_RSSI_OFFSET + rssi + (rssi >> 4) + packet_info->snr;
+#else /* MODULE_SX1276 */
+                if (dev->settings.channel > SX127X_RF_MID_BAND_THRESH) {
+                    packet_info->rssi = SX127X_RSSI_OFFSET_HF + rssi + (rssi >> 4) +
+                                        packet_info->snr;
+                }
+                else {
+                    packet_info->rssi = SX127X_RSSI_OFFSET_LF + rssi + (rssi >> 4) +
+                                        packet_info->snr;
+                }
+#endif
+            }
+            else {
+#if defined(MODULE_SX1272)
+                packet_info->rssi = SX127X_RSSI_OFFSET + rssi + (rssi >> 4);
+#else /* MODULE_SX1276 */
+                if (dev->settings.channel > SX127X_RF_MID_BAND_THRESH) {
+                    packet_info->rssi = SX127X_RSSI_OFFSET_HF + rssi + (rssi >> 4);
+                }
+                else {
+                    packet_info->rssi = SX127X_RSSI_OFFSET_LF + rssi + (rssi >> 4);
+                }
+#endif
+            }
+        }
+
+        size = sx127x_reg_read(dev, SX127X_REG_LR_RXNBBYTES);
+        if (buf == NULL) {
+            return size;
+        }
+
+        if (size > len) {
+            return -ENOBUFS;
+        }
+
+        if (!(dev->settings.lora.flags & SX127X_RX_CONTINUOUS_FLAG)) {
+            sx127x_set_state(dev, SX127X_RF_IDLE);
+        }
+
+        ztimer_remove(ZTIMER_MSEC, &dev->_internal.rx_timeout_timer);
+        /* Read the last packet from FIFO */
+        uint8_t last_rx_addr = sx127x_reg_read(dev, SX127X_REG_LR_FIFORXCURRENTADDR);
+        sx127x_reg_write(dev, SX127X_REG_LR_FIFOADDRPTR, last_rx_addr);
+        sx127x_read_fifo(dev, (uint8_t *)buf, size);
+        break;
+    default:
+        break;
     }
 
     return size;
@@ -202,10 +205,11 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _init(netdev_t *netdev)
 {
-    sx127x_t *sx127x = (sx127x_t*) netdev;
+    sx127x_t *sx127x = (sx127x_t *)netdev;
 
     sx127x->irq = 0;
     sx127x_radio_settings_t settings;
+
     settings.channel = SX127X_CHANNEL_DEFAULT;
     settings.modem = SX127X_MODEM_DEFAULT;
     settings.state = SX127X_RF_IDLE;
@@ -256,95 +260,97 @@ static void _isr(netdev_t *netdev)
 
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
-    (void) max_len;  /* unused when compiled without debug, assert empty */
-    sx127x_t *dev = (sx127x_t*) netdev;
+    (void)max_len;   /* unused when compiled without debug, assert empty */
+    sx127x_t *dev = (sx127x_t *)netdev;
 
     if (dev == NULL) {
         return -ENODEV;
     }
 
-    switch(opt) {
-        case NETOPT_STATE:
-            assert(max_len >= sizeof(netopt_state_t));
-            return _get_state(dev, val);
+    switch (opt) {
+    case NETOPT_STATE:
+        assert(max_len >= sizeof(netopt_state_t));
+        return _get_state(dev, val);
 
-        case NETOPT_DEVICE_TYPE:
-            assert(max_len >= sizeof(uint16_t));
-            *((uint16_t*) val) = NETDEV_TYPE_LORA;
-            return sizeof(uint16_t);
+    case NETOPT_DEVICE_TYPE:
+        assert(max_len >= sizeof(uint16_t));
+        *((uint16_t *)val) = NETDEV_TYPE_LORA;
+        return sizeof(uint16_t);
 
-        case NETOPT_CHANNEL_FREQUENCY:
-            assert(max_len >= sizeof(uint32_t));
-            *((uint32_t*) val) = sx127x_get_channel(dev);
-            return sizeof(uint32_t);
+    case NETOPT_CHANNEL_FREQUENCY:
+        assert(max_len >= sizeof(uint32_t));
+        *((uint32_t *)val) = sx127x_get_channel(dev);
+        return sizeof(uint32_t);
 
-        case NETOPT_BANDWIDTH:
-            assert(max_len >= sizeof(uint8_t));
-            *((uint8_t*) val) = sx127x_get_bandwidth(dev);
-            return sizeof(uint8_t);
+    case NETOPT_BANDWIDTH:
+        assert(max_len >= sizeof(uint8_t));
+        *((uint8_t *)val) = sx127x_get_bandwidth(dev);
+        return sizeof(uint8_t);
 
-        case NETOPT_SPREADING_FACTOR:
-            assert(max_len >= sizeof(uint8_t));
-            *((uint8_t*) val) = sx127x_get_spreading_factor(dev);
-            return sizeof(uint8_t);
+    case NETOPT_SPREADING_FACTOR:
+        assert(max_len >= sizeof(uint8_t));
+        *((uint8_t *)val) = sx127x_get_spreading_factor(dev);
+        return sizeof(uint8_t);
 
-        case NETOPT_CODING_RATE:
-            assert(max_len >= sizeof(uint8_t));
-            *((uint8_t*) val) = sx127x_get_coding_rate(dev);
-            return sizeof(uint8_t);
+    case NETOPT_CODING_RATE:
+        assert(max_len >= sizeof(uint8_t));
+        *((uint8_t *)val) = sx127x_get_coding_rate(dev);
+        return sizeof(uint8_t);
 
-        case NETOPT_MAX_PDU_SIZE:
-            assert(max_len >= sizeof(uint8_t));
-            *((uint8_t*) val) = sx127x_get_max_payload_len(dev);
-            return sizeof(uint8_t);
+    case NETOPT_MAX_PDU_SIZE:
+        assert(max_len >= sizeof(uint8_t));
+        *((uint8_t *)val) = sx127x_get_max_payload_len(dev);
+        return sizeof(uint8_t);
 
-        case NETOPT_INTEGRITY_CHECK:
-            assert(max_len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t*) val) = sx127x_get_crc(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
-            return sizeof(netopt_enable_t);
+    case NETOPT_INTEGRITY_CHECK:
+        assert(max_len >= sizeof(netopt_enable_t));
+        *((netopt_enable_t *)val) = sx127x_get_crc(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
+        return sizeof(netopt_enable_t);
 
-        case NETOPT_CHANNEL_HOP:
-            assert(max_len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t*) val) = (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) ? NETOPT_ENABLE : NETOPT_DISABLE;
-            return sizeof(netopt_enable_t);
+    case NETOPT_CHANNEL_HOP:
+        assert(max_len >= sizeof(netopt_enable_t));
+        *((netopt_enable_t *)val) =
+            (dev->settings.lora.flags &
+             SX127X_CHANNEL_HOPPING_FLAG) ? NETOPT_ENABLE : NETOPT_DISABLE;
+        return sizeof(netopt_enable_t);
 
-        case NETOPT_CHANNEL_HOP_PERIOD:
-            assert(max_len >= sizeof(uint8_t));
-            *((uint8_t*) val) = sx127x_get_hop_period(dev);
-            return sizeof(uint8_t);
+    case NETOPT_CHANNEL_HOP_PERIOD:
+        assert(max_len >= sizeof(uint8_t));
+        *((uint8_t *)val) = sx127x_get_hop_period(dev);
+        return sizeof(uint8_t);
 
-        case NETOPT_SINGLE_RECEIVE:
-            assert(max_len >= sizeof(uint8_t));
-            *((netopt_enable_t*) val) = sx127x_get_rx_single(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
-            return sizeof(netopt_enable_t);
+    case NETOPT_SINGLE_RECEIVE:
+        assert(max_len >= sizeof(uint8_t));
+        *((netopt_enable_t *)val) = sx127x_get_rx_single(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
+        return sizeof(netopt_enable_t);
 
-        case NETOPT_TX_POWER:
-            assert(max_len >= sizeof(int16_t));
-            *((int16_t*) val) = (int16_t)sx127x_get_tx_power(dev);
-            return sizeof(int16_t);
+    case NETOPT_TX_POWER:
+        assert(max_len >= sizeof(int16_t));
+        *((int16_t *)val) = (int16_t)sx127x_get_tx_power(dev);
+        return sizeof(int16_t);
 
-        case NETOPT_SYNCWORD:
-            assert(max_len >= sizeof(uint8_t));
-            *((uint8_t*) val) = (uint8_t) sx127x_get_syncword(dev);
-            return sizeof(uint8_t);
+    case NETOPT_SYNCWORD:
+        assert(max_len >= sizeof(uint8_t));
+        *((uint8_t *)val) = (uint8_t)sx127x_get_syncword(dev);
+        return sizeof(uint8_t);
 
-        case NETOPT_RANDOM:
-            assert(max_len >= sizeof(uint32_t));
-            *((uint32_t*) val) = (uint32_t) sx127x_random(dev);
-            return sizeof(uint32_t);
+    case NETOPT_RANDOM:
+        assert(max_len >= sizeof(uint32_t));
+        *((uint32_t *)val) = (uint32_t)sx127x_random(dev);
+        return sizeof(uint32_t);
 
-        case NETOPT_IQ_INVERT:
-            assert(max_len >= sizeof(uint8_t));
-            *((netopt_enable_t*) val) = sx127x_get_iq_invert(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
-            return sizeof(netopt_enable_t);
+    case NETOPT_IQ_INVERT:
+        assert(max_len >= sizeof(uint8_t));
+        *((netopt_enable_t *)val) = sx127x_get_iq_invert(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
+        return sizeof(netopt_enable_t);
 
-        case NETOPT_RSSI:
-            assert(max_len >= sizeof(int8_t));
-            *((int8_t*) val) = sx127x_read_rssi(dev);
-            return sizeof(int8_t);
+    case NETOPT_RSSI:
+        assert(max_len >= sizeof(int8_t));
+        *((int8_t *)val) = sx127x_read_rssi(dev);
+        return sizeof(int8_t);
 
-        default:
-            break;
+    default:
+        break;
     }
 
     return -ENOTSUP;
@@ -354,141 +360,141 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
     (void)len; /* unused when compiled without debug, assert empty */
 
-    sx127x_t *dev = (sx127x_t*) netdev;
+    sx127x_t *dev = (sx127x_t *)netdev;
     int res = -ENOTSUP;
 
     if (dev == NULL) {
         return -ENODEV;
     }
 
-    switch(opt) {
-        case NETOPT_STATE:
-            assert(len == sizeof(netopt_state_t));
-            return _set_state(dev, *((const netopt_state_t*) val));
+    switch (opt) {
+    case NETOPT_STATE:
+        assert(len == sizeof(netopt_state_t));
+        return _set_state(dev, *((const netopt_state_t *)val));
 
-        case NETOPT_DEVICE_TYPE:
-            assert(len <= sizeof(uint16_t));
-            /* Only LoRa modem is supported for the moment */
-            if (*(const uint16_t*) val == NETDEV_TYPE_LORA) {
-                sx127x_set_modem(dev, SX127X_MODEM_LORA);
-                return sizeof(uint16_t);
-            }
-            else {
-                return -EINVAL;
-            }
-
-        case NETOPT_CHANNEL_FREQUENCY:
-            assert(len <= sizeof(uint32_t));
-            sx127x_set_channel(dev, *((const uint32_t*) val));
-            return sizeof(uint32_t);
-
-        case NETOPT_BANDWIDTH:
-            assert(len <= sizeof(uint8_t));
-            uint8_t bw = *((const uint8_t *)val);
-            if (bw > LORA_BW_500_KHZ) {
-                res = -EINVAL;
-                break;
-            }
-            sx127x_set_bandwidth(dev, bw);
-            return sizeof(uint8_t);
-
-        case NETOPT_SPREADING_FACTOR:
-            assert(len <= sizeof(uint8_t));
-            uint8_t sf = *((const uint8_t *)val);
-            if ((sf < LORA_SF6) || (sf > LORA_SF12)) {
-                res = -EINVAL;
-                break;
-            }
-            sx127x_set_spreading_factor(dev, sf);
-            return sizeof(uint8_t);
-
-        case NETOPT_CODING_RATE:
-            assert(len <= sizeof(uint8_t));
-            uint8_t cr = *((const uint8_t *)val);
-            if ((cr < LORA_CR_4_5) || (cr > LORA_CR_4_8)) {
-                res = -EINVAL;
-                break;
-            }
-            sx127x_set_coding_rate(dev, cr);
-            return sizeof(uint8_t);
-
-        case NETOPT_MAX_PDU_SIZE:
-            assert(len <= sizeof(uint8_t));
-            sx127x_set_max_payload_len(dev, *((const uint8_t*) val));
-            return sizeof(uint8_t);
-
-        case NETOPT_INTEGRITY_CHECK:
-            assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_crc(dev, *((const netopt_enable_t*) val) ? true : false);
-            return sizeof(netopt_enable_t);
-
-        case NETOPT_CHANNEL_HOP:
-            assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_freq_hop(dev, *((const netopt_enable_t*) val) ? true : false);
-            return sizeof(netopt_enable_t);
-
-        case NETOPT_CHANNEL_HOP_PERIOD:
-            assert(len <= sizeof(uint8_t));
-            sx127x_set_hop_period(dev, *((const uint8_t*) val));
-            return sizeof(uint8_t);
-
-        case NETOPT_SINGLE_RECEIVE:
-            assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_rx_single(dev, *((const netopt_enable_t*) val) ? true : false);
-            return sizeof(netopt_enable_t);
-
-        case NETOPT_RX_SYMBOL_TIMEOUT:
-            assert(len <= sizeof(uint16_t));
-            sx127x_set_symbol_timeout(dev, *((const uint16_t*) val));
+    case NETOPT_DEVICE_TYPE:
+        assert(len <= sizeof(uint16_t));
+        /* Only LoRa modem is supported for the moment */
+        if (*(const uint16_t *)val == NETDEV_TYPE_LORA) {
+            sx127x_set_modem(dev, SX127X_MODEM_LORA);
             return sizeof(uint16_t);
+        }
+        else {
+            return -EINVAL;
+        }
 
-        case NETOPT_RX_TIMEOUT:
-            assert(len <= sizeof(uint32_t));
-            sx127x_set_rx_timeout(dev, *((const uint32_t*) val));
-            return sizeof(uint32_t);
+    case NETOPT_CHANNEL_FREQUENCY:
+        assert(len <= sizeof(uint32_t));
+        sx127x_set_channel(dev, *((const uint32_t *)val));
+        return sizeof(uint32_t);
 
-        case NETOPT_TX_TIMEOUT:
-            assert(len <= sizeof(uint32_t));
-            sx127x_set_tx_timeout(dev, *((const uint32_t*) val));
-            return sizeof(uint32_t);
-
-        case NETOPT_TX_POWER:
-            assert(len <= sizeof(int16_t));
-            int16_t power = *((const int16_t *)val);
-            if ((power < INT8_MIN) || (power > INT8_MAX)) {
-                res = -EINVAL;
-                break;
-            }
-            sx127x_set_tx_power(dev, (int8_t)power);
-            return sizeof(int16_t);
-
-        case NETOPT_FIXED_HEADER:
-            assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_fixed_header_len_mode(dev, *((const netopt_enable_t*) val) ? true : false);
-            return sizeof(netopt_enable_t);
-
-        case NETOPT_PDU_SIZE:
-            assert(len <= sizeof(uint16_t));
-            sx127x_set_payload_length(dev, *((const uint16_t*) val));
-            return sizeof(uint16_t);
-
-        case NETOPT_PREAMBLE_LENGTH:
-            assert(len <= sizeof(uint16_t));
-            sx127x_set_preamble_length(dev, *((const uint16_t*) val));
-            return sizeof(uint16_t);
-
-        case NETOPT_SYNCWORD:
-            assert(len <= sizeof(uint8_t));
-            sx127x_set_syncword(dev, *((uint8_t*) val));
-            return sizeof(uint8_t);
-
-        case NETOPT_IQ_INVERT:
-            assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_iq_invert(dev, *((const netopt_enable_t*) val) ? true : false);
-            return sizeof(bool);
-
-        default:
+    case NETOPT_BANDWIDTH:
+        assert(len <= sizeof(uint8_t));
+        uint8_t bw = *((const uint8_t *)val);
+        if (bw > LORA_BW_500_KHZ) {
+            res = -EINVAL;
             break;
+        }
+        sx127x_set_bandwidth(dev, bw);
+        return sizeof(uint8_t);
+
+    case NETOPT_SPREADING_FACTOR:
+        assert(len <= sizeof(uint8_t));
+        uint8_t sf = *((const uint8_t *)val);
+        if ((sf < LORA_SF6) || (sf > LORA_SF12)) {
+            res = -EINVAL;
+            break;
+        }
+        sx127x_set_spreading_factor(dev, sf);
+        return sizeof(uint8_t);
+
+    case NETOPT_CODING_RATE:
+        assert(len <= sizeof(uint8_t));
+        uint8_t cr = *((const uint8_t *)val);
+        if ((cr < LORA_CR_4_5) || (cr > LORA_CR_4_8)) {
+            res = -EINVAL;
+            break;
+        }
+        sx127x_set_coding_rate(dev, cr);
+        return sizeof(uint8_t);
+
+    case NETOPT_MAX_PDU_SIZE:
+        assert(len <= sizeof(uint8_t));
+        sx127x_set_max_payload_len(dev, *((const uint8_t *)val));
+        return sizeof(uint8_t);
+
+    case NETOPT_INTEGRITY_CHECK:
+        assert(len <= sizeof(netopt_enable_t));
+        sx127x_set_crc(dev, *((const netopt_enable_t *)val) ? true : false);
+        return sizeof(netopt_enable_t);
+
+    case NETOPT_CHANNEL_HOP:
+        assert(len <= sizeof(netopt_enable_t));
+        sx127x_set_freq_hop(dev, *((const netopt_enable_t *)val) ? true : false);
+        return sizeof(netopt_enable_t);
+
+    case NETOPT_CHANNEL_HOP_PERIOD:
+        assert(len <= sizeof(uint8_t));
+        sx127x_set_hop_period(dev, *((const uint8_t *)val));
+        return sizeof(uint8_t);
+
+    case NETOPT_SINGLE_RECEIVE:
+        assert(len <= sizeof(netopt_enable_t));
+        sx127x_set_rx_single(dev, *((const netopt_enable_t *)val) ? true : false);
+        return sizeof(netopt_enable_t);
+
+    case NETOPT_RX_SYMBOL_TIMEOUT:
+        assert(len <= sizeof(uint16_t));
+        sx127x_set_symbol_timeout(dev, *((const uint16_t *)val));
+        return sizeof(uint16_t);
+
+    case NETOPT_RX_TIMEOUT:
+        assert(len <= sizeof(uint32_t));
+        sx127x_set_rx_timeout(dev, *((const uint32_t *)val));
+        return sizeof(uint32_t);
+
+    case NETOPT_TX_TIMEOUT:
+        assert(len <= sizeof(uint32_t));
+        sx127x_set_tx_timeout(dev, *((const uint32_t *)val));
+        return sizeof(uint32_t);
+
+    case NETOPT_TX_POWER:
+        assert(len <= sizeof(int16_t));
+        int16_t power = *((const int16_t *)val);
+        if ((power < INT8_MIN) || (power > INT8_MAX)) {
+            res = -EINVAL;
+            break;
+        }
+        sx127x_set_tx_power(dev, (int8_t)power);
+        return sizeof(int16_t);
+
+    case NETOPT_FIXED_HEADER:
+        assert(len <= sizeof(netopt_enable_t));
+        sx127x_set_fixed_header_len_mode(dev, *((const netopt_enable_t *)val) ? true : false);
+        return sizeof(netopt_enable_t);
+
+    case NETOPT_PDU_SIZE:
+        assert(len <= sizeof(uint16_t));
+        sx127x_set_payload_length(dev, *((const uint16_t *)val));
+        return sizeof(uint16_t);
+
+    case NETOPT_PREAMBLE_LENGTH:
+        assert(len <= sizeof(uint16_t));
+        sx127x_set_preamble_length(dev, *((const uint16_t *)val));
+        return sizeof(uint16_t);
+
+    case NETOPT_SYNCWORD:
+        assert(len <= sizeof(uint8_t));
+        sx127x_set_syncword(dev, *((uint8_t *)val));
+        return sizeof(uint8_t);
+
+    case NETOPT_IQ_INVERT:
+        assert(len <= sizeof(netopt_enable_t));
+        sx127x_set_iq_invert(dev, *((const netopt_enable_t *)val) ? true : false);
+        return sizeof(bool);
+
+    default:
+        break;
     }
 
     return res;
@@ -497,34 +503,34 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 static int _set_state(sx127x_t *dev, netopt_state_t state)
 {
     switch (state) {
-        case NETOPT_STATE_SLEEP:
-            sx127x_set_sleep(dev);
-            break;
+    case NETOPT_STATE_SLEEP:
+        sx127x_set_sleep(dev);
+        break;
 
-        case NETOPT_STATE_STANDBY:
-            sx127x_set_standby(dev);
-            break;
+    case NETOPT_STATE_STANDBY:
+        sx127x_set_standby(dev);
+        break;
 
-        case NETOPT_STATE_IDLE:
-            /* set permanent listening */
-            sx127x_set_rx_timeout(dev, 0);
-            sx127x_set_rx(dev);
-            break;
+    case NETOPT_STATE_IDLE:
+        /* set permanent listening */
+        sx127x_set_rx_timeout(dev, 0);
+        sx127x_set_rx(dev);
+        break;
 
-        case NETOPT_STATE_RX:
-            sx127x_set_rx(dev);
-            break;
+    case NETOPT_STATE_RX:
+        sx127x_set_rx(dev);
+        break;
 
-        case NETOPT_STATE_TX:
-            sx127x_set_tx(dev);
-            break;
+    case NETOPT_STATE_TX:
+        sx127x_set_tx(dev);
+        break;
 
-        case NETOPT_STATE_RESET:
-            sx127x_reset(dev);
-            break;
+    case NETOPT_STATE_RESET:
+        sx127x_reset(dev);
+        break;
 
-        default:
-            return -ENOTSUP;
+    default:
+        return -ENOTSUP;
     }
     return sizeof(netopt_state_t);
 }
@@ -532,36 +538,38 @@ static int _set_state(sx127x_t *dev, netopt_state_t state)
 static int _get_state(sx127x_t *dev, void *val)
 {
     uint8_t op_mode;
+
     op_mode = sx127x_get_op_mode(dev);
     netopt_state_t state = NETOPT_STATE_OFF;
-    switch(op_mode) {
-        case SX127X_RF_OPMODE_SLEEP:
-            state = NETOPT_STATE_SLEEP;
-            break;
 
-        case SX127X_RF_OPMODE_STANDBY:
-            state = NETOPT_STATE_STANDBY;
-            break;
+    switch (op_mode) {
+    case SX127X_RF_OPMODE_SLEEP:
+        state = NETOPT_STATE_SLEEP;
+        break;
 
-        case SX127X_RF_OPMODE_TRANSMITTER:
-            state = NETOPT_STATE_TX;
-            break;
+    case SX127X_RF_OPMODE_STANDBY:
+        state = NETOPT_STATE_STANDBY;
+        break;
 
-        case SX127X_RF_OPMODE_RECEIVER:
-        case SX127X_RF_LORA_OPMODE_RECEIVER_SINGLE:
-            /* Sx127x is in receive mode:
-             * -> need to check if the device is currently receiving a packet */
-            if (sx127x_reg_read(dev, SX127X_REG_LR_MODEMSTAT) &
-                SX127X_RF_LORA_MODEMSTAT_MODEM_STATUS_SIGNAL_DETECTED) {
-                state = NETOPT_STATE_RX;
-            }
-            else {
-                state = NETOPT_STATE_IDLE;
-            }
-            break;
+    case SX127X_RF_OPMODE_TRANSMITTER:
+        state = NETOPT_STATE_TX;
+        break;
 
-        default:
-            break;
+    case SX127X_RF_OPMODE_RECEIVER:
+    case SX127X_RF_LORA_OPMODE_RECEIVER_SINGLE:
+        /* Sx127x is in receive mode:
+         * -> need to check if the device is currently receiving a packet */
+        if (sx127x_reg_read(dev, SX127X_REG_LR_MODEMSTAT) &
+            SX127X_RF_LORA_MODEMSTAT_MODEM_STATUS_SIGNAL_DETECTED) {
+            state = NETOPT_STATE_RX;
+        }
+        else {
+            state = NETOPT_STATE_IDLE;
+        }
+        break;
+
+    default:
+        break;
     }
     memcpy(val, &state, sizeof(netopt_state_t));
     return sizeof(netopt_state_t);
@@ -569,181 +577,181 @@ static int _get_state(sx127x_t *dev, void *val)
 
 void _on_dio0_irq(void *arg)
 {
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t*) &dev->netdev;
+    sx127x_t *dev = (sx127x_t *)arg;
+    netdev_t *netdev = (netdev_t *)&dev->netdev;
 
     switch (dev->settings.state) {
-        case SX127X_RF_RX_RUNNING:
-            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
-            break;
-        case SX127X_RF_TX_RUNNING:
-            ztimer_remove(ZTIMER_MSEC, &dev->_internal.tx_timeout_timer);
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_LORA:
-                    /* Clear IRQ */
-                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                     SX127X_RF_LORA_IRQFLAGS_TXDONE);
-                /* Intentional fall-through */
-                case SX127X_MODEM_FSK:
-                default:
-                    sx127x_set_state(dev, SX127X_RF_IDLE);
-                    netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-                    break;
-            }
-            break;
-        case SX127X_RF_IDLE:
-            DEBUG("[sx127x] netdev: sx127x_on_dio0: IDLE state\n");
-            break;
+    case SX127X_RF_RX_RUNNING:
+        netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+        break;
+    case SX127X_RF_TX_RUNNING:
+        ztimer_remove(ZTIMER_MSEC, &dev->_internal.tx_timeout_timer);
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_LORA:
+            /* Clear IRQ */
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                             SX127X_RF_LORA_IRQFLAGS_TXDONE);
+        /* Intentional fall-through */
+        case SX127X_MODEM_FSK:
         default:
-            DEBUG("[sx127x] netdev: sx127x_on_dio0: unknown state [%d]\n",
-                  dev->settings.state);
+            sx127x_set_state(dev, SX127X_RF_IDLE);
+            netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
             break;
+        }
+        break;
+    case SX127X_RF_IDLE:
+        DEBUG("[sx127x] netdev: sx127x_on_dio0: IDLE state\n");
+        break;
+    default:
+        DEBUG("[sx127x] netdev: sx127x_on_dio0: unknown state [%d]\n",
+              dev->settings.state);
+        break;
     }
 }
 
 void _on_dio1_irq(void *arg)
 {
     /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t*) &dev->netdev;
+    sx127x_t *dev = (sx127x_t *)arg;
+    netdev_t *netdev = (netdev_t *)&dev->netdev;
 
     switch (dev->settings.state) {
-        case SX127X_RF_RX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    /* todo */
-                    break;
-                case SX127X_MODEM_LORA:
-                    ztimer_remove(ZTIMER_MSEC, &dev->_internal.rx_timeout_timer);
-                    /*  Clear Irq */
-                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT);
-                    sx127x_set_state(dev, SX127X_RF_IDLE);
-                    netdev->event_callback(netdev, NETDEV_EVENT_RX_TIMEOUT);
-                    break;
-                default:
-                    break;
-            }
+    case SX127X_RF_RX_RUNNING:
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
+            /* todo */
             break;
-        case SX127X_RF_TX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    /* todo */
-                    break;
-                case SX127X_MODEM_LORA:
-                    break;
-                default:
-                    break;
-            }
+        case SX127X_MODEM_LORA:
+            ztimer_remove(ZTIMER_MSEC, &dev->_internal.rx_timeout_timer);
+            /*  Clear Irq */
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT);
+            sx127x_set_state(dev, SX127X_RF_IDLE);
+            netdev->event_callback(netdev, NETDEV_EVENT_RX_TIMEOUT);
             break;
         default:
-            puts("[sx127x] netdev: sx127x_on_dio1: unknown state");
             break;
+        }
+        break;
+    case SX127X_RF_TX_RUNNING:
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
+            /* todo */
+            break;
+        case SX127X_MODEM_LORA:
+            break;
+        default:
+            break;
+        }
+        break;
+    default:
+        puts("[sx127x] netdev: sx127x_on_dio1: unknown state");
+        break;
     }
 }
 
 void _on_dio2_irq(void *arg)
 {
     /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t*) dev;
+    sx127x_t *dev = (sx127x_t *)arg;
+    netdev_t *netdev = (netdev_t *)dev;
 
     switch (dev->settings.state) {
-        case SX127X_RF_RX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    /* todo */
-                    break;
-                case SX127X_MODEM_LORA:
-                    if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
-                        /* Clear IRQ */
-                        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
-
-                        dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
-                                                       SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
-                        netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
-                    }
-
-                    break;
-                default:
-                    break;
-            }
+    case SX127X_RF_RX_RUNNING:
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
+            /* todo */
             break;
-        case SX127X_RF_TX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    break;
-                case SX127X_MODEM_LORA:
-                    if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
-                        /* Clear IRQ */
-                        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
+        case SX127X_MODEM_LORA:
+            if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
+                /* Clear IRQ */
+                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                                 SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
 
-                        dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
-                                                       SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
-                        netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
-                    }
-                    break;
-                default:
-                    break;
+                dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
+                                               SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
+                netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
+            }
+
+            break;
+        default:
+            break;
+        }
+        break;
+    case SX127X_RF_TX_RUNNING:
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
+            break;
+        case SX127X_MODEM_LORA:
+            if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
+                /* Clear IRQ */
+                sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                                 SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
+
+                dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
+                                               SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
+                netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
             }
             break;
         default:
-            puts("[sx127x] netdev: sx127x_on_dio2: unknown state");
             break;
+        }
+        break;
+    default:
+        puts("[sx127x] netdev: sx127x_on_dio2: unknown state");
+        break;
     }
 }
 
 void _on_dio3_irq(void *arg)
 {
     /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t *) dev;
+    sx127x_t *dev = (sx127x_t *)arg;
+    netdev_t *netdev = (netdev_t *)dev;
 
     switch (dev->settings.state) {
-        case SX127X_RF_CAD:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    break;
-                case SX127X_MODEM_LORA:
-                    /* Clear IRQ */
-                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                     SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
-                                     SX127X_RF_LORA_IRQFLAGS_CADDONE);
-
-                    /* Send event message */
-                    dev->_internal.is_last_cad_success = ((sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS) &
-                                                           SX127X_RF_LORA_IRQFLAGS_CADDETECTED) ==
-                                                          SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
-                    netdev->event_callback(netdev, NETDEV_EVENT_CAD_DONE);
-                    break;
-                default:
-                    puts("[sx127x] netdev: sx127x_on_dio3: unknown modem");
-                    break;
-            }
+    case SX127X_RF_CAD:
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
             break;
-        case SX127X_RF_RX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    break;
-                case SX127X_MODEM_LORA:
-                    /* Clear IRQ */
-                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_VALIDHEADER);
-
-                    netdev->event_callback(netdev, NETDEV_EVENT_RX_STARTED);
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            DEBUG("[sx127x] netdev: sx127x_on_dio3: unknown state");
-            /* at least the related interrupts should be cleared in this case */
+        case SX127X_MODEM_LORA:
+            /* Clear IRQ */
             sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                             SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
                              SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
                              SX127X_RF_LORA_IRQFLAGS_CADDONE);
+
+            /* Send event message */
+            dev->_internal.is_last_cad_success = ((sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS) &
+                                                   SX127X_RF_LORA_IRQFLAGS_CADDETECTED) ==
+                                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED);
+            netdev->event_callback(netdev, NETDEV_EVENT_CAD_DONE);
             break;
+        default:
+            puts("[sx127x] netdev: sx127x_on_dio3: unknown modem");
+            break;
+        }
+        break;
+    case SX127X_RF_RX_RUNNING:
+        switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
+            break;
+        case SX127X_MODEM_LORA:
+            /* Clear IRQ */
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_VALIDHEADER);
+
+            netdev->event_callback(netdev, NETDEV_EVENT_RX_STARTED);
+            break;
+        default:
+            break;
+        }
+        break;
+    default:
+        DEBUG("[sx127x] netdev: sx127x_on_dio3: unknown state");
+        /* at least the related interrupts should be cleared in this case */
+        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                         SX127X_RF_LORA_IRQFLAGS_VALIDHEADER |
+                         SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
+                         SX127X_RF_LORA_IRQFLAGS_CADDONE);
+        break;
     }
 }
 

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -67,30 +67,32 @@ int lora_setup_cmd(int argc, char **argv)
     /* Check bandwidth value */
     int bw = atoi(argv[1]);
     uint8_t lora_bw;
+
     switch (bw) {
-        case 125:
-            puts("setup: setting 125KHz bandwidth");
-            lora_bw = LORA_BW_125_KHZ;
-            break;
+    case 125:
+        puts("setup: setting 125KHz bandwidth");
+        lora_bw = LORA_BW_125_KHZ;
+        break;
 
-        case 250:
-            puts("setup: setting 250KHz bandwidth");
-            lora_bw = LORA_BW_250_KHZ;
-            break;
+    case 250:
+        puts("setup: setting 250KHz bandwidth");
+        lora_bw = LORA_BW_250_KHZ;
+        break;
 
-        case 500:
-            puts("setup: setting 500KHz bandwidth");
-            lora_bw = LORA_BW_500_KHZ;
-            break;
+    case 500:
+        puts("setup: setting 500KHz bandwidth");
+        lora_bw = LORA_BW_500_KHZ;
+        break;
 
-        default:
-            puts("[Error] setup: invalid bandwidth value given, "
-                 "only 125, 250 or 500 allowed.");
-            return -1;
+    default:
+        puts("[Error] setup: invalid bandwidth value given, "
+             "only 125, 250 or 500 allowed.");
+        return -1;
     }
 
     /* Check spreading factor value */
     uint8_t lora_sf = atoi(argv[2]);
+
     if (lora_sf < 7 || lora_sf > 12) {
         puts("[Error] setup: invalid spreading factor value given");
         return -1;
@@ -98,6 +100,7 @@ int lora_setup_cmd(int argc, char **argv)
 
     /* Check coding rate value */
     int cr = atoi(argv[3]);
+
     if (cr < 5 || cr > 8) {
         puts("[Error ]setup: invalid coding rate value given");
         return -1;
@@ -106,6 +109,7 @@ int lora_setup_cmd(int argc, char **argv)
 
     /* Configure radio device */
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     netdev->driver->set(netdev, NETOPT_BANDWIDTH,
                         &lora_bw, sizeof(lora_bw));
     netdev->driver->set(netdev, NETOPT_SPREADING_FACTOR,
@@ -125,6 +129,7 @@ int random_cmd(int argc, char **argv)
 
     netdev_t *netdev = (netdev_t *)&sx127x;
     uint32_t rand;
+
     netdev->driver->get(netdev, NETOPT_RANDOM, &rand, sizeof(rand));
     printf("random: number from sx127x: %u\n",
            (unsigned int)rand);
@@ -245,6 +250,7 @@ int send_cmd(int argc, char **argv)
     };
 
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     if (netdev->driver->send(netdev, &iolist) == -ENOTSUP) {
         puts("Cannot send: radio is still transmitting");
     }
@@ -260,12 +266,15 @@ int listen_cmd(int argc, char **argv)
     netdev_t *netdev = (netdev_t *)&sx127x;
     /* Switch to continuous listen mode */
     const netopt_enable_t single = false;
+
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
     const uint32_t timeout = 0;
+
     netdev->driver->set(netdev, NETOPT_RX_TIMEOUT, &timeout, sizeof(timeout));
 
     /* Switch to RX state */
     netopt_state_t state = NETOPT_STATE_RX;
+
     netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(state));
 
     printf("Listen mode set\n");
@@ -282,6 +291,7 @@ int syncword_cmd(int argc, char **argv)
 
     netdev_t *netdev = (netdev_t *)&sx127x;
     uint8_t syncword;
+
     if (strstr(argv[1], "get") != NULL) {
         netdev->driver->get(netdev, NETOPT_SYNCWORD, &syncword,
                             sizeof(syncword));
@@ -315,6 +325,7 @@ int channel_cmd(int argc, char **argv)
 
     netdev_t *netdev = (netdev_t *)&sx127x;
     uint32_t chan;
+
     if (strstr(argv[1], "get") != NULL) {
         netdev->driver->get(netdev, NETOPT_CHANNEL_FREQUENCY, &chan,
                             sizeof(chan));
@@ -349,6 +360,7 @@ int rx_timeout_cmd(int argc, char **argv)
 
     netdev_t *netdev = (netdev_t *)&sx127x;
     uint16_t rx_timeout;
+
     if (strstr(argv[1], "set") != NULL) {
         if (argc < 3) {
             puts("usage: rx_timeout set <rx_timeout>");
@@ -372,15 +384,18 @@ int reset_cmd(int argc, char **argv)
     (void)argc;
     (void)argv;
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     puts("resetting sx127x...");
     netopt_state_t state = NETOPT_STATE_RESET;
+
     netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(netopt_state_t));
     return 0;
 }
 
-static void _set_opt(netdev_t *netdev, netopt_t opt, bool val, char* str_help)
+static void _set_opt(netdev_t *netdev, netopt_t opt, bool val, char *str_help)
 {
     netopt_enable_t en = val ? NETOPT_ENABLE : NETOPT_DISABLE;
+
     netdev->driver->set(netdev, opt, &en, sizeof(en));
     printf("Successfully ");
     if (val) {
@@ -395,12 +410,14 @@ static void _set_opt(netdev_t *netdev, netopt_t opt, bool val, char* str_help)
 int crc_cmd(int argc, char **argv)
 {
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     if (argc < 3 || strcmp(argv[1], "set") != 0) {
         printf("usage: %s set <1|0>\n", argv[0]);
         return 1;
     }
 
     int tmp = atoi(argv[2]);
+
     _set_opt(netdev, NETOPT_INTEGRITY_CHECK, tmp, "CRC check");
     return 0;
 }
@@ -408,12 +425,14 @@ int crc_cmd(int argc, char **argv)
 int implicit_cmd(int argc, char **argv)
 {
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     if (argc < 3 || strcmp(argv[1], "set") != 0) {
         printf("usage: %s set <1|0>\n", argv[0]);
         return 1;
     }
 
     int tmp = atoi(argv[2]);
+
     _set_opt(netdev, NETOPT_FIXED_HEADER, tmp, "implicit header");
     return 0;
 }
@@ -421,12 +440,14 @@ int implicit_cmd(int argc, char **argv)
 int payload_cmd(int argc, char **argv)
 {
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     if (argc < 3 || strcmp(argv[1], "set") != 0) {
         printf("usage: %s set <payload length>\n", argv[0]);
         return 1;
     }
 
     uint16_t tmp = atoi(argv[2]);
+
     netdev->driver->set(netdev, NETOPT_PDU_SIZE, &tmp, sizeof(tmp));
     printf("Successfully set payload to %i\n", tmp);
     return 0;
@@ -444,7 +465,7 @@ static const shell_command_t shell_commands[] = {
     { "register", "Get/Set value(s) of registers of sx127x", register_cmd },
     { "send",     "Send raw payload string",                 send_cmd },
     { "listen",   "Start raw payload listener",              listen_cmd },
-    { "reset",    "Reset the sx127x device",                 reset_cmd},
+    { "reset",    "Reset the sx127x device",                 reset_cmd },
     { NULL, NULL, NULL }
 };
 
@@ -464,35 +485,35 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
         size_t len;
         netdev_lora_rx_info_t packet_info;
         switch (event) {
-            case NETDEV_EVENT_RX_STARTED:
-                puts("Data reception started");
-                break;
+        case NETDEV_EVENT_RX_STARTED:
+            puts("Data reception started");
+            break;
 
-            case NETDEV_EVENT_RX_COMPLETE:
-                len = dev->driver->recv(dev, NULL, 0, 0);
-                dev->driver->recv(dev, message, len, &packet_info);
-                printf(
-                    "{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %" PRIu32 "}\n",
-                    message, (int)len,
-                    packet_info.rssi, (int)packet_info.snr,
-                    sx127x_get_time_on_air((const sx127x_t *)dev, len));
-                break;
+        case NETDEV_EVENT_RX_COMPLETE:
+            len = dev->driver->recv(dev, NULL, 0, 0);
+            dev->driver->recv(dev, message, len, &packet_info);
+            printf(
+                "{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %" PRIu32 "}\n",
+                message, (int)len,
+                packet_info.rssi, (int)packet_info.snr,
+                sx127x_get_time_on_air((const sx127x_t *)dev, len));
+            break;
 
-            case NETDEV_EVENT_TX_COMPLETE:
-                sx127x_set_sleep(&sx127x);
-                puts("Transmission completed");
-                break;
+        case NETDEV_EVENT_TX_COMPLETE:
+            sx127x_set_sleep(&sx127x);
+            puts("Transmission completed");
+            break;
 
-            case NETDEV_EVENT_CAD_DONE:
-                break;
+        case NETDEV_EVENT_CAD_DONE:
+            break;
 
-            case NETDEV_EVENT_TX_TIMEOUT:
-                sx127x_set_sleep(&sx127x);
-                break;
+        case NETDEV_EVENT_TX_TIMEOUT:
+            sx127x_set_sleep(&sx127x);
+            break;
 
-            default:
-                printf("Unexpected netdev event received: %d\n", event);
-                break;
+        default:
+            printf("Unexpected netdev event received: %d\n", event);
+            break;
         }
     }
 }
@@ -502,6 +523,7 @@ void *_recv_thread(void *arg)
     (void)arg;
 
     static msg_t _msg_q[SX127X_LORA_MSG_QUEUE];
+
     msg_init_queue(_msg_q, SX127X_LORA_MSG_QUEUE);
 
     while (1) {
@@ -521,6 +543,7 @@ int main(void)
 {
     sx127x.params = sx127x_params[0];
     netdev_t *netdev = (netdev_t *)&sx127x;
+
     netdev->driver = &sx127x_driver;
 
     if (netdev->driver->init(netdev) < 0) {
@@ -542,6 +565,7 @@ int main(void)
     /* start the shell */
     puts("Initialization successful - starting the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
+
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When working on #16177, I took some "inspiration" from the sx127x driver and where I found lots of style issues. This PR is fixing them by running uncrustify on related files:

```
$ docker run --rm -ti -u $(id -u) -v $(pwd):/data/riotbuild riot/static-test-tools uncrustify -c uncrustify-riot.cfg --replace drivers/sx127x/*.c
$ docker run --rm -ti -u $(id -u) -v $(pwd):/data/riotbuild riot/static-test-tools uncrustify -c uncrustify-riot.cfg --replace drivers/include/sx127x.h
$ docker run --rm -ti -u $(id -u) -v $(pwd):/data/riotbuild riot/static-test-tools uncrustify -c uncrustify-riot.cfg --replace tests/driver_sx127x/main.c
```

All files are whitelisted in the uncrustify check.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
