### PR TITLE
cpu/native: add `-no-pie` to LINKFLAGS

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -70,6 +70,13 @@ endif
 # XFA (cross file array) support
 LINKFLAGS += -T$(RIOTBASE)/cpu/native/ldscripts/xfa.ld
 
+# fix this warning:
+# ```
+# /usr/bin/ld: examples/hello-world/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
+# /usr/bin/ld: warning: creating DT_TEXTREL in a PIE
+# ```
+LINKFLAGS += -no-pie
+
 # clean up unused functions
 CFLAGS += -ffunction-sections -fdata-sections
 ifeq ($(OS),Darwin)

--- a/tests/backtrace/tests/01-run.py
+++ b/tests/backtrace/tests/01-run.py
@@ -14,7 +14,7 @@ def testfunc(child):
     child.expect(r"BACKTRACE_SIZE: (\d+)\r\n")
     trace_size = int(child.match.group(1))
     for i in range(trace_size):
-        child.expect(r"0x[0-9a-f]{7,8}")
+        child.expect(r"0x[0-9a-f]+")
 
     print("All tests successful")
 


### PR DESCRIPTION
### Contribution description

This fixes the following warning on newer gcc/ld:

```
/usr/bin/ld: examples/hello-world/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
```

I've had this warning for many months and finally found a way to silence it.
~~As far as I can tell, the resulting binaries are identical.~~

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI runs all tests, should suffice.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
