### PR TITLE
pkg/semtech-loramac: refactor to use netdev API only

### DIFF
--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -338,6 +338,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             *((netopt_enable_t*) val) = sx127x_get_iq_invert(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
             return sizeof(netopt_enable_t);
 
+        case NETOPT_RSSI:
+            assert(max_len >= sizeof(int8_t));
+            *((int8_t*) val) = sx127x_read_rssi(dev);
+            return sizeof(int8_t);
+
         default:
             break;
     }

--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -32,6 +32,10 @@
 #include "net/loramac.h"
 #include "semtech_loramac.h"
 
+#include "sx127x.h"
+#include "sx127x_netdev.h"
+#include "sx127x_params.h"
+
 /* Messages are sent every 20s to respect the duty cycle on each channel */
 #define PERIOD              (20U)
 
@@ -39,7 +43,8 @@
 static kernel_pid_t sender_pid;
 static char sender_stack[THREAD_STACKSIZE_MAIN / 2];
 
-semtech_loramac_t loramac;
+static semtech_loramac_t loramac;
+static sx127x_t sx127x;
 
 static const char *message = "This is RIOT!";
 
@@ -107,6 +112,11 @@ int main(void)
     fmt_hex_bytes(deveui, CONFIG_LORAMAC_DEV_EUI_DEFAULT);
     fmt_hex_bytes(appeui, CONFIG_LORAMAC_APP_EUI_DEFAULT);
     fmt_hex_bytes(appkey, CONFIG_LORAMAC_APP_KEY_DEFAULT);
+
+    /* Initialize the radio driver */
+    sx127x_setup(&sx127x, &sx127x_params[0], 0);
+    loramac.netdev = (netdev_t *)&sx127x;
+    loramac.netdev->driver = &sx127x_driver;
 
     /* Initialize the loramac stack */
     semtech_loramac_init(&loramac);

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -40,6 +40,10 @@
 #include "LoRaMacTest.h"
 #include "region/Region.h"
 
+#if IS_USED(MODULE_SX127X)
+#include "sx127x.h"
+#endif
+
 #ifdef MODULE_PERIPH_EEPROM
 #include "periph/eeprom.h"
 #endif
@@ -561,6 +565,7 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
             semtech_loramac_radio_events.RxError();
             break;
 
+#if IS_USED(MODULE_SX127X)
         case NETDEV_EVENT_FHSS_CHANGE_CHANNEL:
             DEBUG("[semtech-loramac] FHSS channel change\n");
             if(semtech_loramac_radio_events.FhssChangeChannel) {
@@ -576,6 +581,7 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
                             (sx127x_t *)dev)->_internal.is_last_cad_success);
             }
             break;
+#endif
 
         default:
             DEBUG("[semtech-loramac] unexpected netdev event received: %d\n",

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -520,11 +520,13 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
             break;
 
         case NETDEV_EVENT_TX_COMPLETE:
-            sx127x_set_sleep((sx127x_t *)dev);
+        {
+            netopt_state_t sleep_state = NETOPT_STATE_SLEEP;
+            dev->driver->set(dev, NETOPT_STATE, &sleep_state, sizeof(netopt_state_t));
             semtech_loramac_radio_events.TxDone();
             DEBUG("[semtech-loramac] Transmission completed\n");
             break;
-
+        }
         case NETDEV_EVENT_TX_TIMEOUT:
             msg.type = MSG_TYPE_TX_TIMEOUT;
             if (msg_send(&msg, semtech_loramac_pid) <= 0) {

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -30,8 +30,6 @@ extern "C" {
 #include "net/netdev.h"
 #include "net/loramac.h"
 
-#include "sx127x.h"
-
 /**
  * @name    Definitions for messages exchanged between the MAC and call threads
  * @{
@@ -113,6 +111,7 @@ typedef struct {
  * @brief   Semtech LoRaMAC descriptor
  */
 typedef struct {
+    netdev_t *netdev;                            /**< pointer to internal radio device */
     mutex_t lock;                                /**< loramac access lock */
     uint8_t tx_pid;                              /**< pid of sender thread */
 #if defined(MODULE_SEMTECH_LORAMAC_RX) || DOXYGEN

--- a/sys/auto_init/loramac/auto_init_loramac.c
+++ b/sys/auto_init/loramac/auto_init_loramac.c
@@ -18,12 +18,19 @@
  */
 
 #include "log.h"
+#include "sx127x.h"
+#include "sx127x_netdev.h"
+#include "sx127x_params.h"
 #include "semtech_loramac.h"
 
 semtech_loramac_t loramac;
+static sx127x_t sx127x;
 
 void auto_init_loramac(void)
 {
+    sx127x_setup(&sx127x, &sx127x_params[0], 0);
+    loramac.netdev = (netdev_t *)&sx127x;
+    loramac.netdev->driver = &sx127x_driver;
     semtech_loramac_init(&loramac);
 }
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The current Loramac-node port (that we called semtech-loramac for historical reasons) is tightly coupled with the sx127x radio driver although it should be possible to use other radio devices (such as sx126x or llcc68 see #16177 and I have a branch for sx126x).
This PR is adapting the package to only control the radio via the netdev interface. The radio is either initialized in auto_init (for the `tests/pkg_semtech-loramac` application) or in the application itself (for `examples/lorawan`): this should be considered as an API change, since the user has to take care of this part now.

Some stuff were removed from the loramac radio layer:
- "is channel free" is always true. I don't think this is used by our loramac package port
- "time on air" computation return 0. I could think of a generic solution using a specific netopt struct (because it requires the packet length as input parameter but didn't implement it here).
- radio read/write functions are removed: they are not used by the mac layer
- the CAD done and FHSS events are also removed from the loramac even handler: they are never used and relies on sx127x specific attributes. We could maybe expose them later as netdev netopts.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Applications using `pkg/semtech-loramac` are still working (verified on iot-lab):

<details><summary>examples/lorawan</summary>

```
$ DEVEUI=<your deveui> APPEUI=<your appeui> APPKEY=<your appkey> IOTLAB_NODE=auto-ssh make -C examples/lorawan flash test-with-config --no-print-directory 
Building application "lorawan" for "b-l072z-lrwan1" with MCU "stm32".

"make" -C /work/riot/RIOT/pkg/semtech-loramac
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/boards/mcu -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_arch
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/system/crypto -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_crypto
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/mac -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_mac
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/mac/region -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_region
"make" -C /work/riot/RIOT/boards/b-l072z-lrwan1
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/sx127x
"make" -C /work/riot/RIOT/pkg/semtech-loramac/contrib
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  56196	    376	   6812	  63384	   f798	/work/riot/RIOT/examples/lorawan/bin/b-l072z-lrwan1/lorawan.elf
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'iotlab' - duration: 12.04s)
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:st-lrwan1-1.saclay.iot-lab.info:20000' 
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
LoRaWAN Class A low-power application
=====================================
Starting join procedure
Join procedure succeeded
Sending: This is RIOT!
Sending: This is RIOT!
Sending: This is RIOT!
Sending: This is RIOT!
Sending: This is RIOT!
TEST PASSED
```

</details>


<details><summary>tests/pkg_semtech-loramac</summary>

```
$ DEVEUI_ABP=00EA17067F596D18 APPSKEY=E38E70FD74D768BE36EA753D96D5030C NWKSKEY=C89D06AB37D58373FA50B69B7D288B1C DEVADDR=26011C28 RX2_DR=3 DEVEUI_OTA=00AB22849FF4885C APPEUI=70B3D57ED000B02F APPKEY=45C8E67A4FD8871D6943CEE3A305177C IOTLAB_NODE=auto-ssh make -C tests/pkg_semtech-loramac/ flash test-with-config --no-print-directory 
Building application "tests_pkg_semtech-loramac" for "b-l072z-lrwan1" with MCU "stm32".

"make" -C /work/riot/RIOT/pkg/semtech-loramac
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/boards/mcu -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_arch
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/system/crypto -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_crypto
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/mac -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_mac
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/mac/region -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_region
"make" -C /work/riot/RIOT/boards/b-l072z-lrwan1
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/sx127x
"make" -C /work/riot/RIOT/pkg/semtech-loramac/contrib
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/loramac
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  58896	    292	   7360	  66548	  103f4	/work/riot/RIOT/tests/pkg_semtech-loramac/bin/b-l072z-lrwan1/tests_pkg_semtech-loramac.elf
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'iotlab' - duration: 12.04s)


ssh -t abadie@saclay.iot-lab.info 'socat - tcp:st-lrwan1-1.saclay.iot-lab.info:20000' 
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac erase

> 
> loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set deveui 00AB22849FF4885C
loramac set deveui 00AB22849FF4885C
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
> loramac set dr 0
loramac set dr 0
> loramac join otaa
loramac join otaa
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set deveui 00AB22849FF4885C
loramac set deveui 00AB22849FF4885C
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
>loramac set dr 3
 loramac set dr 3
> loramac join otaa
loramac join otaa
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set deveui 00AB22849FF4885C
loramac set deveui 00AB22849FF4885C
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
> loramac set dr 5
loramac set dr 5
> loramac join otaa
loramac join otaa
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac erase
loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set deveui 00EA17067F596D18
loramac set deveui 00EA17067F596D18
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set devaddr 26011C28
loramac set devaddr 26011C28
> loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
> loramac set appskey E38E70FD74D768BE36EA753D96D5030C
loramac set appskey E38E70FD74D768BE36EA753D96D5030C
> loramac set rx2_dr 3
loramac set rx2_dr 3
> loramac set dr 0
loramac set dr 0
> loramac join abp
loramac join abp
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> loramac get ul_cnt
loramac get ul_cnt
Uplink Counter: 2
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set ul_cnt 2
loramac set ul_cnt 2
> loramac set deveui 00EA17067F596D18
loramac set deveui 00EA17067F596D18
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set devaddr 26011C28
loramac set devaddr 26011C28
> loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
> loramac set appskey E38E70FD74D768BE36EA753D96D5030C
loramac set appskey E38E70FD74D768BE36EA753D96D5030C
> loramac set rx2_dr 3
loramac set rx2_dr 3
> loramac set dr 3
loramac set dr 3
> loramac join abp
loramac join abp
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> loramac get ul_cnt
loramac get ul_cnt
Uplink Counter: 4
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set ul_cnt 4
loramac set ul_cnt 4
> loramac set deveui 00EA17067F596D18
loramac set deveui 00EA17067F596D18
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set devaddr 26011C28
loramac set devaddr 26011C28
> loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
> loramac set appskey E38E70FD74D768BE36EA753D96D5030C
loramac set appskey E38E70FD74D768BE36EA753D96D5030C
> loramac set rx2_dr 3
loramac set rx2_dr 3
> loramac set dr 5
loramac set dr 5
> loramac join abp
loramac join abp
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> loramac get ul_cnt
loramac get ul_cnt
Uplink Counter: 6
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set ul_cnt 6
loramac set ul_cnt 6
> loramac help
loramac help
Usage: loramac <get|set|join|tx|link_check|save|erase>loramac erase

> loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac get deveui
loramac get deveui
DEVEUI: 0000000000000000
> loramac get appeui
loramac get appeui
APPEUI: 0000000000000000
> loramac get appkey
loramac get appkey
APPKEY: 00000000000000000000000000000000
> loramac get devaddr
loramac get devaddr
DEVADDR: 00000000
> loramac get nwkskey
loramac get nwkskey
NWKSKEY: 00000000000000000000000000000000
> loramac get appskey
loramac get appskey
APPSKEY: 00000000000000000000000000000000
> loramac set deveui 00AB22849FF4885C
loramac set deveui 00AB22849FF4885C
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
> loramac save
loramac save
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac get deveui
loramac get deveui
DEVEUI: 00AB22849FF4885C
> loramac get appeui
loramac get appeui
APPEUI: 70B3D57ED000B02F
> loramac get appkey
loramac get appkey
APPKEY: 45C8E67A4FD8871D6943CEE3A305177C
> loramac erase
loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac set deveui 00EA17067F596D18
loramac set deveui 00EA17067F596D18
> loramac set appeui 70B3D57ED000B02F
loramac set appeui 70B3D57ED000B02F
> loramac set devaddr 26011C28
loramac set devaddr 26011C28
> loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
loramac set nwkskey C89D06AB37D58373FA50B69B7D288B1C
> loramac set appskey E38E70FD74D768BE36EA753D96D5030C
loramac set appskey E38E70FD74D768BE36EA753D96D5030C
> loramac set rx2_dr 3
loramac set rx2_dr 3
> loramac save
loramac save
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1041-g47a18-semtech-loramac_netdev)
All up, running the shell now
> loramac get devaddr
loramac get devaddr
DEVADDR: 26011C28
> loramac get nwkskey
loramac get nwkskey
NWKSKEY: C89D06AB37D58373FA50B69B7D288B1C
> loramac get appskey
loramac get appskey
APPSKEY: E38E70FD74D768BE36EA753D96D5030C
> TEST PASSED

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
