### PR TITLE
pkg: silent make commands with RIOT_CI_BUILD=1

### DIFF
--- a/pkg/c25519/Makefile
+++ b/pkg/c25519/Makefile
@@ -17,7 +17,7 @@ endif
 prepare: $(PKG_SOURCE_DIR)/
 
 all: $(PKG_SOURCE_DIR)/
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
 
 $(PKG_SOURCE_DIR)/: $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
 	test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "${PKG_ZIPFILE}")"

--- a/pkg/cayenne-lpp/Makefile
+++ b/pkg/cayenne-lpp/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=LGPLv2.1
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/cifra/Makefile
+++ b/pkg/cifra/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=CC-0
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.cifra
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.cifra

--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -10,4 +10,4 @@ CFLAGS += -DCBOR_ALIGN_READS
 CFLAGS += -Wno-return-local-addr
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -39,10 +39,10 @@ $(TOOLCHAIN_FILE): git-download
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 build_tests:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/test -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/test/jwt -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_jwt
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/test/tng -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_tng
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/test/atcacert -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_atcacert
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/test -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/test/jwt -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_jwt
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/test/tng -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_tng
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/test/atcacert -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_atcacert
 
 git-download: | ..cmake_version_supported
 

--- a/pkg/driver_atwinc15x0/Makefile
+++ b/pkg/driver_atwinc15x0/Makefile
@@ -17,6 +17,6 @@ CFLAGS += -I$(PKG_SOURCE_DIR)/src
 CFLAGS += -Wno-pedantic
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/driver/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/common/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_common
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/spi_flash/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_spi_flash
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/driver/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/common/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_common
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/spi_flash/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_spi_flash

--- a/pkg/driver_bme680/Makefile
+++ b/pkg/driver_bme680/Makefile
@@ -12,4 +12,4 @@ endif
 .PHONY: all
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/fatfs/Makefile
+++ b/pkg/fatfs/Makefile
@@ -10,4 +10,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-overflow
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/source -f $(RIOTBASE)/Makefile.base MODULE=fatfs
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/source -f $(RIOTBASE)/Makefile.base MODULE=fatfs

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -14,4 +14,4 @@ ifneq (llvm,$(TOOLCHAIN))
 endif
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/dist
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/dist

--- a/pkg/hacl/Makefile
+++ b/pkg/hacl/Makefile
@@ -10,4 +10,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -DKRML_NOUINT128 -Wno-unused-parameter
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/heatshrink/Makefile
+++ b/pkg/heatshrink/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=ISC-License
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.heatshrink
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.heatshrink

--- a/pkg/jsmn/Makefile
+++ b/pkg/jsmn/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/libb2/Makefile
+++ b/pkg/libb2/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE = CC0-1.0
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/libbase58/Makefile
+++ b/pkg/libbase58/Makefile
@@ -8,4 +8,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 .PHONY: all
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -13,4 +13,4 @@ ifeq (llvm,$(TOOLCHAIN))
 endif
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)

--- a/pkg/libcose/Makefile
+++ b/pkg/libcose/Makefile
@@ -6,5 +6,5 @@ PKG_LICENSE=LGPL
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/crypt -f $(CURDIR)/Makefile.$(PKG_NAME)_crypt
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/crypt -f $(CURDIR)/Makefile.$(PKG_NAME)_crypt

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -6,7 +6,7 @@ PKG_LICENSE  := MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all: $(filter libfixmath-unittests,$(USEMODULE))
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(PKG_NAME) -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(PKG_NAME) -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 libfixmath-unittests:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/unittests -f $(CURDIR)/Makefile.$(PKG_NAME)-unittests
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/unittests -f $(CURDIR)/Makefile.$(PKG_NAME)-unittests

--- a/pkg/libhydrogen/Makefile
+++ b/pkg/libhydrogen/Makefile
@@ -9,4 +9,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-type-limits
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/littlefs/Makefile
+++ b/pkg/littlefs/Makefile
@@ -17,4 +17,4 @@ ifneq ($(DEVELHELP),1)
 endif
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/littlefs2/Makefile
+++ b/pkg/littlefs2/Makefile
@@ -17,4 +17,4 @@ ifneq ($(DEVELHELP),1)
 endif
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/lora-serialization/Makefile
+++ b/pkg/lora-serialization/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=LGPLv2.1
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/lua/Makefile
+++ b/pkg/lua/Makefile
@@ -7,4 +7,4 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all: Makefile.lua
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.lua
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.lua

--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -20,4 +20,4 @@ LVGL_MODULES =      \
 all: $(LVGL_MODULES)
 
 lvgl_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/lv_$* -f $(CURDIR)/Makefile.lvgl_module MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/lv_$* -f $(CURDIR)/Makefile.lvgl_module MODULE=$@

--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -15,7 +15,7 @@ LWIP_MODULE_MAKEFILE = $(RIOTBASE)/Makefile.base
 
 CFLAGS += -Wno-address
 
-make_module = +"$(MAKE)" -C $(2) -f $(LWIP_MODULE_MAKEFILE) MODULE=$(1)
+make_module = +$(QQ)"$(MAKE)" -C $(2) -f $(LWIP_MODULE_MAKEFILE) MODULE=$(1)
 
 all: lwip
 

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=BSD-2-Clause
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)

--- a/pkg/minmea/Makefile
+++ b/pkg/minmea/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=WTFPL
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -8,7 +8,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -DBLAKE2_NO_UNROLLING
 
 all: $(filter monocypher_optional,$(USEMODULE))
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
 
 monocypher_optional:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/optional -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/optional -f $(RIOTBASE)/Makefile.base MODULE=$@

--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE = CC-0
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/ndn-riot/Makefile
+++ b/pkg/ndn-riot/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=LGPLv2.1
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -32,65 +32,65 @@ all: $(SUBMODS)
 
 # blue code and RIOT port modules
 nimble_riot_contrib:
-	"$(MAKE)" -C $(TDIR)/contrib/
+	$(QQ)"$(MAKE)" -C $(TDIR)/contrib/
 
 nimble_porting_nimble:
-	"$(MAKE)" -C $(PDIR)/porting/nimble/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/porting/nimble/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_npl_riot:
-	"$(MAKE)" -C $(PDIR)/porting/npl/riot/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/porting/npl/riot/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 # host modules
 nimble_host:
-	"$(MAKE)" -C $(PDIR)/nimble/host/src/ -f $(TDIR)/nimble.host.mk
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/src/ -f $(TDIR)/nimble.host.mk
 
 nimble_host_util:
-	"$(MAKE)" -C $(PDIR)/nimble/host/util/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/util/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_host_store_ram:
-	"$(MAKE)" -C $(PDIR)/nimble/host/store/ram/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/store/ram/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_tinycrypt:
-	"$(MAKE)" -C $(PDIR)/ext/tinycrypt/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/ext/tinycrypt/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 # service implementations
 nimble_svc_gap:
-	"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_svc_gatt:
-	"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_svc_ipss:
-	"$(MAKE)" -C $(PDIR)/nimble/host/services/ipss/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/host/services/ipss/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 # controller specific modules
 nimble_transport_ram:
-	"$(MAKE)" -C $(PDIR)/nimble/transport/ram/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/transport/ram/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_controller:
-	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 nimble_drivers_nrf5x:
-	"$(MAKE)" -C $(PDIR)/nimble/drivers/$(CPU_FAM)/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PDIR)/nimble/drivers/$(CPU_FAM)/src/ -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 # additional, RIOT specific nimble modules
 nimble_addr:
-	"$(MAKE)" -C $(TDIR)/addr/
+	$(QQ)"$(MAKE)" -C $(TDIR)/addr/
 
 nimble_autoadv:
-	"$(MAKE)" -C $(TDIR)/autoadv
+	$(QQ)"$(MAKE)" -C $(TDIR)/autoadv
 
 nimble_autoconn:
-	"$(MAKE)" -C $(TDIR)/autoconn
+	$(QQ)"$(MAKE)" -C $(TDIR)/autoconn
 
 nimble_netif:
-	"$(MAKE)" -C $(TDIR)/netif/
+	$(QQ)"$(MAKE)" -C $(TDIR)/netif/
 
 nimble_scanlist:
-	"$(MAKE)" -C $(TDIR)/scanlist
+	$(QQ)"$(MAKE)" -C $(TDIR)/scanlist
 
 nimble_scanner:
-	"$(MAKE)" -C $(TDIR)/scanner
+	$(QQ)"$(MAKE)" -C $(TDIR)/scanner
 
 nimble_statconn:
-	"$(MAKE)" -C $(TDIR)/statconn
+	$(QQ)"$(MAKE)" -C $(TDIR)/statconn

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -57,4 +57,4 @@ OPENWSN_PATH_crosslayers    = openstack/cross-layers
 all: $(OPENWSN_MODULES)
 
 openwsn_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(OPENWSN_PATH_$*) -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(OPENWSN_PATH_$*) -f $(RIOTBASE)/Makefile.base MODULE=$@

--- a/pkg/paho-mqtt/Makefile
+++ b/pkg/paho-mqtt/Makefile
@@ -6,5 +6,5 @@ PKG_LICENSE = EDL
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/MQTTPacket/src/ -f $(CURDIR)/Makefile.$(PKG_NAME)-packet
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/MQTTClient-C/src/ -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/MQTTPacket/src/ -f $(CURDIR)/Makefile.$(PKG_NAME)-packet
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/MQTTClient-C/src/ -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/qDSA/Makefile
+++ b/pkg/qDSA/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=PD
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(QDSA_IMPL)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(QDSA_IMPL)

--- a/pkg/qcbor/Makefile
+++ b/pkg/qcbor/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE = BSD-3-Clause
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/semtech-loramac/Makefile
+++ b/pkg/semtech-loramac/Makefile
@@ -22,4 +22,4 @@ DIR_loramac_region = mac/region
 all: $(LORAMAC_MODULES)
 
 loramac_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/$(DIR_$@) -f $(CURDIR)/Makefile.$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/$(DIR_$@) -f $(CURDIR)/Makefile.$@

--- a/pkg/spiffs/Makefile
+++ b/pkg/spiffs/Makefile
@@ -9,4 +9,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-pedantic
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/talking_leds/Makefile
+++ b/pkg/talking_leds/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/tensorflow-lite/Makefile
+++ b/pkg/tensorflow-lite/Makefile
@@ -17,13 +17,13 @@ CFLAGS += -DTF_LITE_USE_GLOBAL_ROUND
 all: tensorflow-lite
 
 tensorflow-lite: $(TF_USEMODULE)
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/c -f $(CURDIR)/Makefile.$(PKG_NAME)-c
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/core/api -f $(CURDIR)/Makefile.$(PKG_NAME)-core
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/kernels -f $(CURDIR)/Makefile.$(PKG_NAME)-kernels
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/kernels/internal -f $(CURDIR)/Makefile.$(PKG_NAME)-kernels-internal
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro/kernels -f $(CURDIR)/Makefile.$(PKG_NAME)-micro-kernels
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro/memory_planner -f $(CURDIR)/Makefile.$(PKG_NAME)-memory
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/c -f $(CURDIR)/Makefile.$(PKG_NAME)-c
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/core/api -f $(CURDIR)/Makefile.$(PKG_NAME)-core
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/kernels -f $(CURDIR)/Makefile.$(PKG_NAME)-kernels
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/kernels/internal -f $(CURDIR)/Makefile.$(PKG_NAME)-kernels-internal
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro/kernels -f $(CURDIR)/Makefile.$(PKG_NAME)-micro-kernels
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro/memory_planner -f $(CURDIR)/Makefile.$(PKG_NAME)-memory
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 tensorflow-lite-%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro/examples/$* -f $(CURDIR)/Makefile.$(PKG_NAME)-$*
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/tensorflow/lite/micro/examples/$* -f $(CURDIR)/Makefile.$(PKG_NAME)-$*

--- a/pkg/tiny-asn1/Makefile
+++ b/pkg/tiny-asn1/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE = LGPL-3
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/tinycbor/Makefile
+++ b/pkg/tinycbor/Makefile
@@ -7,4 +7,4 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.tinycbor
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.tinycbor

--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=BSD-3-Clause
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/lib/source/ -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/lib/source/ -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -11,9 +11,9 @@ CFLAGS += -Wno-implicit-fallthrough
 CFLAGS += -D_XOPEN_SOURCE=600
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(PKG_SOURCE_DIR)/Makefile.riot
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/aes -f $(PKG_SOURCE_DIR)/aes/Makefile.riot
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/ecc -f $(PKG_SOURCE_DIR)/ecc/Makefile.riot
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(PKG_SOURCE_DIR)/Makefile.riot
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/aes -f $(PKG_SOURCE_DIR)/aes/Makefile.riot
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/ecc -f $(PKG_SOURCE_DIR)/ecc/Makefile.riot
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-format-nonliteral

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=BSD
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/tweetnacl/Makefile
+++ b/pkg/tweetnacl/Makefile
@@ -6,4 +6,4 @@ PKG_LICENSE=PD
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/u8g2/Makefile
+++ b/pkg/u8g2/Makefile
@@ -6,7 +6,7 @@ PKG_LICENSE=BSD-2-Clause
 include $(RIOTBASE)/pkg/pkg.mk
 
 all: $(filter u8g2_%,$(filter-out u8g2_csrc%, $(USEMODULE)))
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/csrc -f $(CURDIR)/Makefile.$(PKG_NAME)_csrc
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/csrc -f $(CURDIR)/Makefile.$(PKG_NAME)_csrc
 
 u8g2_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/sys/$*/common -f $(CURDIR)/Makefile.$(PKG_NAME)_$*
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/sys/$*/common -f $(CURDIR)/Makefile.$(PKG_NAME)_$*

--- a/pkg/ubasic/Makefile
+++ b/pkg/ubasic/Makefile
@@ -12,7 +12,7 @@ UBASIC_USEMODULE = $(filter $(UBASIC_MODULES),$(USEMODULE))
 
 all: ubasic
 
-make_module = +"$(MAKE)" -f $(RIOTPKG)/ubasic/$(1).mk -C $(2)
+make_module = +$(QQ)"$(MAKE)" -f $(RIOTPKG)/ubasic/$(1).mk -C $(2)
 
 ubasic: $(UBASIC_USEMODULE)
 	$(call make_module,$@,$(PKG_SOURCE_DIR))

--- a/pkg/ucglib/Makefile
+++ b/pkg/ucglib/Makefile
@@ -8,8 +8,8 @@ include $(RIOTBASE)/pkg/pkg.mk
 .PHONY: ucglib_sdl
 
 all: $(filter ucglib_sdl,$(USEMODULE))
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.ucglib
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/csrc -f $(CURDIR)/Makefile.ucglib_csrc
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.ucglib
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/csrc -f $(CURDIR)/Makefile.ucglib_csrc
 
 ucglib_sdl:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/sys/sdl/dev -f $(CURDIR)/Makefile.ucglib_sdl
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/sys/sdl/dev -f $(CURDIR)/Makefile.ucglib_sdl

--- a/pkg/umorse/Makefile
+++ b/pkg/umorse/Makefile
@@ -8,4 +8,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -D_XOPEN_SOURCE=600
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/utensor/Makefile
+++ b/pkg/utensor/Makefile
@@ -6,6 +6,6 @@ PKG_LICENSE=Apache2.0
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/uTensor/core -f $(CURDIR)/Makefile.$(PKG_NAME)
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/uTensor/util -f $(CURDIR)/Makefile.$(PKG_NAME).util
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/uTensor/ops -f $(CURDIR)/Makefile.$(PKG_NAME).ops
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/uTensor/core -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/uTensor/util -f $(CURDIR)/Makefile.$(PKG_NAME).util
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/uTensor/ops -f $(CURDIR)/Makefile.$(PKG_NAME).ops

--- a/pkg/uwb-core/Makefile
+++ b/pkg/uwb-core/Makefile
@@ -43,11 +43,11 @@ UWB_CORE_PATH_twr_ds     = lib/twr_ds/src
 UWB_CORE_PATH_twr_ds_ext = lib/twr_ds_ext/src
 
 all: $(UWB_CORE_MODULES)
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/hw/drivers/uwb/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/hw/drivers/uwb/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
 
 uwb-core_config:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/porting/dpl/riot/src -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/porting/dpl/riot/src -f $(RIOTBASE)/Makefile.base MODULE=$@
 
 uwb-core_uwbcfg: uwb-core_config
 uwb-core_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(UWB_CORE_PATH_$*) -f $(RIOTBASE)/Makefile.base MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(UWB_CORE_PATH_$*) -f $(RIOTBASE)/Makefile.base MODULE=$@

--- a/pkg/uwb-dw1000/Makefile
+++ b/pkg/uwb-dw1000/Makefile
@@ -23,4 +23,4 @@ ifneq (,$(filter llvm,$(TOOLCHAIN)))
 endif
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/hw/drivers/uwb/uwb_dw1000/src -f $(RIOTPKG)/uwb-dw1000/uwb-dw1000.mk MODULE=uwb-dw1000
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/hw/drivers/uwb/uwb_dw1000/src -f $(RIOTPKG)/uwb-dw1000/uwb-dw1000.mk MODULE=uwb-dw1000

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -6,6 +6,6 @@ PKG_LICENSE=EDL-1.0,EPL-1.0
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/core -f $(RIOTBASE)/Makefile.base MODULE=wakaama_core
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/core/er-coap-13 -f $(RIOTBASE)/Makefile.base MODULE=wakaama_core_coap13
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/examples/client -f $(CURDIR)/wakaama_client.mk
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/core -f $(RIOTBASE)/Makefile.base MODULE=wakaama_core
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/core/er-coap-13 -f $(RIOTBASE)/Makefile.base MODULE=wakaama_core_coap13
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/examples/client -f $(CURDIR)/wakaama_client.mk

--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -8,10 +8,10 @@ include $(RIOTBASE)/pkg/pkg.mk
 .PHONY: wolfcrypt%
 
 all: $(filter wolfcrypt wolfcrypt-test wolfcrypt-benchmark,$(USEMODULE))
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.wolfssl
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.wolfssl
 
 wolfcrypt:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/wolfcrypt/src -f $(CURDIR)/Makefile.wolfcrypt
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/wolfcrypt/src -f $(CURDIR)/Makefile.wolfcrypt
 
 wolfcrypt-%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/wolfcrypt/$* -f $(CURDIR)/Makefile.wolfcrypt-$*
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/wolfcrypt/$* -f $(CURDIR)/Makefile.wolfcrypt-$*

--- a/pkg/yxml/Makefile
+++ b/pkg/yxml/Makefile
@@ -8,4 +8,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-unused-parameter
 
 all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR prepends the `$(QQ)` make variable to each make commands used to build package modules. This gives a consistent output when building packages with `RIOT_CI_BUILD=1`.

Hopefully doing this could easily be automatized using the following command:

```
$ git grep -l \"\$\(MAKE\)\" pkg/ | xargs sed -i 's/\"$(MAKE)\"/$(QQ)\"$(MAKE)\"/g'
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- Build packages with `RIOT_CI_BUILD=1` and verify that the make commands are silenced:

<details><summary>this PR:</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C tests/pkg_cayenne-lpp/ --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/tests/pkg_cayenne-lpp/' 'riot/riotbuild:latest' make     
Building application "tests_pkg_cayenne-lpp" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
  30211	    628	  47812	  78651	  1333b	/data/riotbuild/riotbase/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf


$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C examples/nimble_gatt --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/examples/nimble_gatt/' 'riot/riotbuild:latest' make     
Building application "nimble_gatt" for "nrf52dk" with MCU "nrf52".

   text	   data	    bss	    dec	    hex	filename
  76836	    592	  10660	  88088	  15818	/data/riotbuild/riotbase/examples/nimble_gatt/bin/nrf52dk/nimble_gatt.elf


$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C tests/pkg_semtech-loramac --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/tests/pkg_semtech-loramac/' 'riot/riotbuild:latest' make     
Building application "tests_pkg_semtech-loramac" for "b-l072z-lrwan1" with MCU "stm32".

   text	   data	    bss	    dec	    hex	filename
  58976	    292	   7356	  66624	  10440	/data/riotbuild/riotbase/tests/pkg_semtech-loramac/bin/b-l072z-lrwan1/tests_pkg_semtech-loramac.elf
```

</details>

<details><summary>master:</summary>

```
$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C tests/pkg_cayenne-lpp/ --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/tests/pkg_cayenne-lpp/' 'riot/riotbuild:latest' make     
Building application "tests_pkg_cayenne-lpp" for "native" with MCU "native".

[INFO] updating cayenne-lpp /data/riotbuild/riotbase/build/pkg/cayenne-lpp/.pkg-state.git-downloaded
echo 0.1.1 > /data/riotbuild/riotbase/build/pkg/cayenne-lpp/.pkg-state.git-downloaded
[INFO] patch cayenne-lpp
"make" -C /data/riotbuild/riotbase/build/pkg/cayenne-lpp -f /data/riotbuild/riotbase/Makefile.base
   text	   data	    bss	    dec	    hex	filename
  30211	    628	  47812	  78651	  1333b	/data/riotbuild/riotbase/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf


$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C examples/nimble_gatt --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/examples/nimble_gatt/' 'riot/riotbuild:latest' make     
Building application "nimble_gatt" for "nrf52dk" with MCU "nrf52".

"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/controller/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_controller
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/drivers/nrf52/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_drivers_nrf5x
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/host/src/ -f /data/riotbuild/riotbase/pkg/nimble/nimble.host.mk
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/host/store/ram/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_host_store_ram
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/host/util/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_host_util
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/porting/npl/riot/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_npl_riot
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/porting/nimble/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_porting_nimble
"make" -C /data/riotbuild/riotbase/pkg/nimble/contrib/
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/host/services/gap/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_svc_gap
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/host/services/gatt/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_svc_gatt
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/ext/tinycrypt/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_tinycrypt
"make" -C /data/riotbuild/riotbase/build/pkg/nimble/nimble/transport/ram/src/ -f /data/riotbuild/riotbase/Makefile.base MODULE=nimble_transport_ram
   text	   data	    bss	    dec	    hex	filename
  76836	    592	  10660	  88088	  15818	/data/riotbuild/riotbase/examples/nimble_gatt/bin/nrf52dk/nimble_gatt.elf


$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C tests/pkg_semtech-loramac --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/tests/pkg_semtech-loramac/' 'riot/riotbuild:latest' make     
Building application "tests_pkg_semtech-loramac" for "b-l072z-lrwan1" with MCU "stm32".

[INFO] updating semtech-loramac /data/riotbuild/riotbase/build/pkg/semtech-loramac/.pkg-state.git-downloaded
echo 1cdd9ccec4c9f05b616e7112059be4a9e358c571 > /data/riotbuild/riotbase/build/pkg/semtech-loramac/.pkg-state.git-downloaded
[INFO] patch semtech-loramac
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/boards/mcu -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_arch
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/system/crypto -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_crypto
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/mac -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_mac
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/mac/region -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_region
   text	   data	    bss	    dec	    hex	filename
  58976	    292	   7356	  66624	  10440	/data/riotbuild/riotbase/tests/pkg_semtech-loramac/bin/b-l072z-lrwan1/tests_pkg_semtech-loramac.elf
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that when comparing firmware sizes in #16188, because I had to build with `RIOT_CI_BUILD=1`

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
