### PR TITLE
tests/periph_ptp_clock: fix bug in debug print

### DIFF
--- a/tests/periph_ptp_clock/main.c
+++ b/tests/periph_ptp_clock/main.c
@@ -67,7 +67,8 @@ static int test_speed_adjustment(const int32_t speed)
     print_str(" (~");
     {
         int64_t tmp = speed * 100000ULL;
-        tmp /= UINT32_MAX;
+        /* trusting compiler to use arithmetic right shift, when available instead of division */
+        tmp /= 1LL << 32;
         tmp += 100000ULL;
         char output[16];
         print(output, fmt_s32_dfp(output, (int32_t)tmp, -3));


### PR DESCRIPTION
### Contribution description

The API doc of ptp_clock_adjust_speed says regarding the correction
parameter:

    1. A call with @p correction set to `0` restores the nominal clock speed.
    2. A call with a positive value for @p correction speeds the clock up
       by `correction / (1 << 32)` (so up to ~50% for `INT32_MAX`).
    3. A call with a negative value for @p correction slows the clock down by
       `-correction / (1 << 32)` (so up to 50% for `INT32_MIN`).

So we need to divide by 2^32, not 2^32 - 1 (or `UINT32_MAX`).


### Testing procedure

Output of the test on a Nucleo-F767ZI:

```
READY
s
START
main(): This is RIOT! (Version: 2021.04-devel-1036-g42df5-tests/periph_ptp_clock)
Testing clock at speed 0 (~100.000 % of nominal speed): SUCCEEDED
Testing clock at speed 2147483647 (~149.999 % of nominal speed): SUCCEEDED
Testing clock at speed -2147483648 (~50.000 % of nominal speed): SUCCEEDED
Testing clock at speed 42949673 (~101.000 % of nominal speed): SUCCEEDED
Testing clock at speed -42949673 (~99.000 % of nominal speed): SUCCEEDED
Testing clock at speed 4294967 (~100.099 % of nominal speed): SUCCEEDED
Testing clock at speed -4294967 (~99.901 % of nominal speed): SUCCEEDED
Testing clock at speed 42 (~100.000 % of nominal speed): SUCCEEDED
Testing clock at speed -42 (~100.000 % of nominal speed): SUCCEEDED
Testing clock adjustments for offset 0: SUCCEEDED
Statistics: avg = 0, min = 0, max = 0, σ² = 0
Testing clock adjustments for offset -1337: SUCCEEDED
Statistics: avg = 0, min = 0, max = 0, σ² = 0
Testing clock adjustments for offset 1337: SUCCEEDED
Statistics: avg = 0, min = 0, max = 0, σ² = 0
Testing clock adjustments for offset 2147483647: SUCCEEDED
Statistics: avg = 0, min = 0, max = 0, σ² = 0
TEST SUCCEEDED!
```

I think the printed speeds are still identical to master, but the wrong code might cause confusion. So its better to fix it anyway.

### Issues/PRs references

None