### PR TITLE
gnrc_netif_pktq: add function to check usage

### DIFF
--- a/sys/include/net/gnrc/netif/pktq.h
+++ b/sys/include/net/gnrc/netif/pktq.h
@@ -47,6 +47,13 @@ extern "C" {
 int gnrc_netif_pktq_put(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 
 /**
+ * @brief   Returns the overall usage of the packet queue resources
+ *
+ * @return  Number of gnrc_pktqueue_t entries currently in use.
+ */
+unsigned gnrc_netif_pktq_usage(void);
+
+/**
  * @brief   Gets a packet from the packet send queue of a network interface
  *
  * @pre `netif != NULL`

--- a/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
+++ b/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
@@ -32,6 +32,18 @@ static gnrc_pktqueue_t *_get_free_entry(void)
     return NULL;
 }
 
+unsigned gnrc_netif_pktq_usage(void)
+{
+    unsigned res = 0;
+
+    for (unsigned i = 0; i < CONFIG_GNRC_NETIF_PKTQ_POOL_SIZE; i++) {
+        if (_pool[i].pkt != NULL) {
+            res++;
+        }
+    }
+    return res;
+}
+
 int gnrc_netif_pktq_put(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     assert(netif != NULL);

--- a/tests/unittests/tests-gnrc_netif_pktq/tests-gnrc_netif_pktq.c
+++ b/tests/unittests/tests-gnrc_netif_pktq/tests-gnrc_netif_pktq.c
@@ -32,6 +32,11 @@ static void test_pktq_get__empty(void)
     TEST_ASSERT_NULL(gnrc_netif_pktq_get(&_netif));
 }
 
+static void test_pktq_usage__empty(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_usage());
+}
+
 static void test_pktq_put__full(void)
 {
     gnrc_pktsnip_t pkt;
@@ -40,6 +45,8 @@ static void test_pktq_put__full(void)
         TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_put(&_netif, &pkt));
     }
     TEST_ASSERT_EQUAL_INT(-1, gnrc_netif_pktq_put(&_netif, &pkt));
+    TEST_ASSERT_EQUAL_INT(CONFIG_GNRC_NETIF_PKTQ_POOL_SIZE,
+                          gnrc_netif_pktq_usage());
 }
 
 static void test_pktq_put_get1(void)
@@ -47,8 +54,10 @@ static void test_pktq_put_get1(void)
     gnrc_pktsnip_t pkt_in, *pkt_out;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_put(&_netif, &pkt_in));
+    TEST_ASSERT_EQUAL_INT(1, gnrc_netif_pktq_usage());
     TEST_ASSERT_NOT_NULL((pkt_out = gnrc_netif_pktq_get(&_netif)));
     TEST_ASSERT(&pkt_in == pkt_out);
+    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_usage());
 }
 
 static void test_pktq_put_get3(void)
@@ -58,12 +67,14 @@ static void test_pktq_put_get3(void)
     for (unsigned i = 0; i < 3; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_put(&_netif, &pkt_in[i]));
     }
+    TEST_ASSERT_EQUAL_INT(3, gnrc_netif_pktq_usage());
     for (unsigned i = 0; i < 3; i++) {
         gnrc_pktsnip_t *pkt_out;
 
         TEST_ASSERT_NOT_NULL((pkt_out = gnrc_netif_pktq_get(&_netif)));
         TEST_ASSERT(&pkt_in[i] == pkt_out);
     }
+    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_usage());
 }
 
 static void test_pktq_push_back__full(void)
@@ -74,6 +85,8 @@ static void test_pktq_push_back__full(void)
         TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_put(&_netif, &pkt));
     }
     TEST_ASSERT_EQUAL_INT(-1, gnrc_netif_pktq_push_back(&_netif, &pkt));
+    TEST_ASSERT_EQUAL_INT(CONFIG_GNRC_NETIF_PKTQ_POOL_SIZE,
+                          gnrc_netif_pktq_usage());
 }
 
 static void test_pktq_push_back_get1(void)
@@ -81,8 +94,10 @@ static void test_pktq_push_back_get1(void)
     gnrc_pktsnip_t pkt_in, *pkt_out;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_push_back(&_netif, &pkt_in));
+    TEST_ASSERT_EQUAL_INT(1, gnrc_netif_pktq_usage());
     TEST_ASSERT_NOT_NULL((pkt_out = gnrc_netif_pktq_get(&_netif)));
     TEST_ASSERT(&pkt_in == pkt_out);
+    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_usage());
 }
 
 static void test_pktq_push_back_get3(void)
@@ -92,12 +107,14 @@ static void test_pktq_push_back_get3(void)
     for (unsigned i = 0; i < 3; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_push_back(&_netif, &pkt_in[i]));
     }
+    TEST_ASSERT_EQUAL_INT(3, gnrc_netif_pktq_usage());
     for (unsigned i = 0; i < 3; i++) {
         gnrc_pktsnip_t *pkt_out;
 
         TEST_ASSERT_NOT_NULL((pkt_out = gnrc_netif_pktq_get(&_netif)));
         TEST_ASSERT(&pkt_in[3 - i - 1] == pkt_out);
     }
+    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_pktq_usage());
 }
 
 static void test_pktq_empty(void)
@@ -119,6 +136,7 @@ static Test *test_gnrc_netif_pktq(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_pktq_get__empty),
+        new_TestFixture(test_pktq_usage__empty),
         new_TestFixture(test_pktq_put__full),
         new_TestFixture(test_pktq_put_get1),
         new_TestFixture(test_pktq_put_get3),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds a new function to the API of `gnrc_netif_pktq` to check how much resources (i.e. number of entries in the pool) are currently in use.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I extended the unittests, so they should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->gnrc_netif_pktq: add function to check usage


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
