### PR TITLE
sys/pm_layered: use atomic_utils

### DIFF
--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -20,6 +20,7 @@
 
 #include <assert.h>
 
+#include "atomic_utils.h"
 #include "irq.h"
 #include "periph/pm.h"
 #include "pm_layered.h"
@@ -42,9 +43,7 @@ static pm_blocker_t pm_blocker = { .val_u32 = PM_BLOCKER_INITIAL };
 
 void pm_set_lowest(void)
 {
-    unsigned state = irq_disable();
-    pm_blocker_t blocker = pm_blocker;
-    irq_restore(state);
+    pm_blocker_t blocker = { .val_u32 = atomic_load_u32(&pm_blocker.val_u32) };
     unsigned mode = PM_NUM_MODES;
     while (mode) {
         if (blocker.val_u8[mode-1]) {
@@ -54,7 +53,7 @@ void pm_set_lowest(void)
     }
 
     /* set lowest mode if blocker is still the same */
-    state = irq_disable();
+    unsigned state = irq_disable();
     if (blocker.val_u32 == pm_blocker.val_u32) {
         DEBUG("pm: setting mode %u\n", mode);
         pm_set(mode);
@@ -85,9 +84,7 @@ void pm_unblock(unsigned mode)
 
 pm_blocker_t pm_get_blocker(void)
 {
-    unsigned state = irq_disable();
-    pm_blocker_t result = pm_blocker;
-    irq_restore(state);
+    pm_blocker_t result = { .val_u32 = atomic_load_u32(&pm_blocker.val_u32) };
     return result;
 }
 


### PR DESCRIPTION
### Contribution description

Using atomic_utils for atomically accessing the state of `pm_layered` rather than disabling IRQs. For 32 bit platforms the 32 bit load is implemented lock free, so there should be minor gain in CPU cycles and ROM.

Theoretically, `pm_block()` and `pm_unblock` could use `atomic_fetch_add_u8()` and `atomic_fetch_sub_u8()`. But this increases ROM size when GCC is used, which doesn't optimize out the unused return value.

### Testing procedure

1. `tests/periph_pm` should still behave as before
2. There should be ~8 bytes less ROM for 32 bit Archs

### Issues/PRs references

None