### PR TITLE
boards: use BTNx_MODE when defined

### DIFF
--- a/boards/calliope-mini/board.c
+++ b/boards/calliope-mini/board.c
@@ -27,6 +27,6 @@ void board_init(void)
     cpu_init();
 
     /* initialize the mini's buttons */
-    gpio_init(BTN0_PIN, GPIO_IN);
-    gpio_init(BTN1_PIN, GPIO_IN);
+    gpio_init(BTN0_PIN, BTN0_MODE);
+    gpio_init(BTN1_PIN, BTN1_MODE);
 }

--- a/boards/microbit-v2/board.c
+++ b/boards/microbit-v2/board.c
@@ -27,6 +27,6 @@ void board_init(void)
     cpu_init();
 
     /* initialize the on board buttons */
-    gpio_init(BTN0_PIN, GPIO_IN);
-    gpio_init(BTN1_PIN, GPIO_IN);
+    gpio_init(BTN0_PIN, BTN0_MODE);
+    gpio_init(BTN1_PIN, BTN1_MODE);
 }

--- a/boards/microbit/board.c
+++ b/boards/microbit/board.c
@@ -27,6 +27,6 @@ void board_init(void)
     cpu_init();
 
     /* initialize the micro:bit's buttons */
-    gpio_init(BTN0_PIN, GPIO_IN);
-    gpio_init(BTN1_PIN, GPIO_IN);
+    gpio_init(BTN0_PIN, BTN0_MODE);
+    gpio_init(BTN1_PIN, BTN1_MODE);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR makes use of BTNx_MODE for some boards which were not using them in their board.c file. This is purely cosmetic as the right configuration was already set but change it anyway for consistency.


### Testing procedure
A green CI should be enough.


### Issues/PRs references
None
