### PR TITLE
makefiles/boot/riotboot: clean bootloader when cleaning application

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -76,7 +76,8 @@ riotboot: $(SLOT_RIOT_BINS)
 
 # riotboot bootloader compile target
 riotboot/flash-bootloader: riotboot/bootloader/flash
-riotboot/bootloader/%: $(BUILDDEPS) pkg-prepare
+# avoid circular dependency against clean
+riotboot/bootloader/%: $$(if $$(filter riotboot/bootloader/clean,$$@),,$$(BUILDDEPS) pkg-prepare)
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
@@ -95,6 +96,7 @@ $(BOOTLOADER_BIN)/riotboot.extended.bin: $(BOOTLOADER_BIN)/riotboot.bin
 
 # Only call sub make if not already in riotboot
 ifneq ($(BOOTLOADER_BIN)/riotboot.bin,$(BINFILE))
+  clean: riotboot/bootloader/clean
   $(BOOTLOADER_BIN)/riotboot.bin: riotboot/bootloader/binfile
 endif
 


### PR DESCRIPTION
### Contribution description

When using `riotboot` conveniently the extended binary is used. But if `clean` is also used then the bootloader binary is not cleaned, this can lead to unexpected behavior where a previous bootloader (eg: different start addresses) is used.

### Testing procedure

- `make -C tests/riotboot flash`
- `make -C tests/riotboot clean flash -j3` you should see that that the bootloader and application are compiled while in master only the application is:

```
# application
"make" -C /home/francisco/workspace/RIOT2/boards/stm32f429i-disc1
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32/stmclk
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32/vectors
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/auto_init
"make" -C /home/francisco/workspace/RIOT2/sys/checksum
"make" -C /home/francisco/workspace/RIOT2/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT2/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT2/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT2/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT2/sys/riotboot
"make" -C /home/francisco/workspace/RIOT2/sys/shell
"make" -C /home/francisco/workspace/RIOT2/sys/shell/commands
"make" -C /home/francisco/workspace/RIOT2/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT2/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT2/sys/tsrb
# bootloader
"make" -C /home/francisco/workspace/RIOT2/boards/stm32f429i-disc1
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32/stmclk
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32/vectors
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/checksum
"make" -C /home/francisco/workspace/RIOT2/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT2/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT2/sys/riotboot
"make" -C /home/francisco/workspace/RIOT2/sys/stdio_null
```

What is actually called can be seen with this patch easily:

```diff
diff --git a/makefiles/boot/riotboot.mk b/makefiles/boot/riotboot.mk
index 164b6f7062..440f669b79 100644
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -79,7 +79,7 @@ RIOTBOOT_CLEAN = $(if $(filter clean, $(MAKECMDGOALS)),riotboot/bootloader/clean
 # riotboot bootloader compile target
 riotboot/flash-bootloader: riotboot/bootloader/flash
 riotboot/bootloader/%: $(BUILDDEPS) | $$(filter-out $$@,$$(RIOTBOOT_CLEAN))
-       $(Q)/usr/bin/env -i \
+       /usr/bin/env -i \
                QUIET=$(QUIET) PATH="$(PATH)"\
                EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
                DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID) \
```
