### PR TITLE
Makefile: enable SECONDEXPANSION globally for modules and applications

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -5,7 +5,7 @@ endif
 #
 # enable second expansion of prerequisites.
 #
-# Doing that here enables it globally for all modules and the application.
+# Doing that here enables it globally for all modules
 #
 # See https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html
 # for what it can be used for.

--- a/Makefile.include
+++ b/Makefile.include
@@ -8,6 +8,15 @@ ifeq (,$(filter $(MATCH_MAKE_VERSION),$(MAKE_VERSION)))
       $(MATCH_MAKE_VERSION) or later.)
 endif
 
+#
+# enable second expansion of prerequisites.
+#
+# Doing that here enables it globally for all applications.
+#
+# See https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html
+# for what it can be used for.
+.SECONDEXPANSION:
+
 # Will evaluate to the absolute path of the Makefile it's evaluated in.¹
 #
 # This variable MUST be immediately evaluated (tmp_var := $(LAST_MAKEFILEDIR))


### PR DESCRIPTION
### Contribution description

I realized that actually `SECONDEXPANSION` was not enabled for applications but only for modules since it was in `Makefile.base`, so this PR also enables that.

### Testing procedure

Test build times?

### Issues/PRs references

Split out from #16197.
