### PR TITLE
drivers/periph_spi: fix Doxygen commands

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -350,10 +350,10 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode);
  * @param[in]   clk     bus clock speed to use for the transaction
  *
  * @retval  0           success
- * @return  -EINVAL     Invalid mode in @p mode
- * @return  -EINVAL     Invalid clock in @p clock
- * @return  -ENOTSUP    Unsupported but valid mode in @p mode
- * @return  -ENOTSUP    Unsupported but valid clock in @p clock
+ * @retval  -EINVAL     Invalid mode in @p mode
+ * @retval  -EINVAL     Invalid clock in @p clock
+ * @retval  -ENOTSUP    Unsupported but valid mode in @p mode
+ * @retval  -ENOTSUP    Unsupported but valid clock in @p clock
  */
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk);
 


### PR DESCRIPTION
### Contribution description

use `@retval` to document individual return values rather than `@return`

### Testing procedure

`make doc`

### Issues/PRs references

none