### PR TITLE
sys/net/sock_util: zero out temporary buffer

### DIFF
--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -170,7 +170,7 @@ int _parse_netif(sock_udp_ep_t *ep_out, char *netifstart)
 {
     char *netifend;
     size_t netiflen;
-    char netifbuf[NETIF_STR_LEN + 1];
+    char netifbuf[NETIF_STR_LEN + 1] = {0};
 
     for (netifend = netifstart; *netifend && *netifend != ']';
          netifend++);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Otherwise, the following strncpy() leaves strtol() with a non-terminated
buffer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This caused random errors based on the stack state, so it is hard to reproduce.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/pull/16193.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
