### PR TITLE
boards/nucleo-f767zi: Add periph_can support

### DIFF
--- a/boards/nucleo-f767zi/Kconfig
+++ b/boards/nucleo-f767zi/Kconfig
@@ -29,6 +29,7 @@ config BOARD_NUCLEO_F767ZI
     select HAS_PERIPH_PTP_SPEED_ADJUSTMENT
     select HAS_PERIPH_PTP_TIMER
     select HAS_PERIPH_PTP_TXRX_TIMESTAMPS
+    select HAS_PERIPH_CAN
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -16,6 +16,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
stm32f767zi MCU contains CAN 2.0B interface. Makefile.features for board nucleo-f767zi is missing this periph_can.

similar to nucleo-722ze https://github.com/RIOT-OS/RIOT/pull/16161
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Connect pin CAN_TX(PD1) and CAN_RX(PD0) a jumper for loop-back test only, due to hardware limitation.
Compile candev application to test. in RIOT/ folder, run
`CFLAGS=-DCONFIG_USE_LOOPBACK_MODE make BOARD=nucleo-f767zi CAN_DRIVER=PERIPH_CAN -C tests/candev flash term`
In pyterm, type send to send bytes, and check data is looping back to receive FIFO with command receive
My test as following i.e.

```
2021-03-18 20:55:07,652 # help
2021-03-18 20:55:07,655 # Command              Description
2021-03-18 20:55:07,658 # ---------------------------------------
2021-03-18 20:55:07,662 # send                 send some data
2021-03-18 20:55:07,665 # receive              receive some data
> send
2021-03-18 20:55:09,218 # send
> send
2021-03-18 20:55:10,131 # send
> send
2021-03-18 20:55:11,140 # send
> 
2021-03-18 20:55:11,322 # send
> 
2021-03-18 20:55:11,495 # send
> 
2021-03-18 20:55:11,652 # send
> 
2021-03-18 20:55:11,793 # send
> receive
2021-03-18 20:55:13,553 # receive
2021-03-18 20:55:13,555 # Reading from Rxbuf...
2021-03-18 20:55:13,558 # id: 1 dlc: hx Data: 
2021-03-18 20:55:13,559 # 0xAB 0xCD 0xEF 
> 
2021-03-18 20:55:14,475 # receive
2021-03-18 20:55:14,477 # Reading from Rxbuf...
2021-03-18 20:55:14,479 # id: 1 dlc: hx Data: 
2021-03-18 20:55:14,480 # 0xAB 0xCD 0xEF 
> 
2021-03-18 20:55:14,664 # receive
2021-03-18 20:55:14,666 # Reading from Rxbuf...
2021-03-18 20:55:14,668 # id: 1 dlc: hx Data: 
2021-03-18 20:55:14,669 # 0xAB 0xCD 0xEF 
> 
2021-03-18 20:55:14,820 # receive
2021-03-18 20:55:14,822 # Reading from Rxbuf...
2021-03-18 20:55:14,824 # id: 1 dlc: hx Data: 
2021-03-18 20:55:14,825 # 0xAB 0xCD 0xEF 
> 
2021-03-18 20:55:14,994 # receive
2021-03-18 20:55:14,997 # Reading from Rxbuf...
2021-03-18 20:55:14,998 # id: 1 dlc: hx Data: 
2021-03-18 20:55:15,000 # 0xAB 0xCD 0xEF 
> 
2021-03-18 20:55:15,167 # receive
2021-03-18 20:55:15,169 # Reading from Rxbuf...
2021-03-18 20:55:15,171 # id: 1 dlc: hx Data: 
2021-03-18 20:55:15,172 # 0xAB 0xCD 0xEF 
> 
2021-03-18 20:55:15,324 # receive
2021-03-18 20:55:15,326 # Reading from Rxbuf...

```

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/issues/15710
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
