### PR TITLE
cpu/avr8_common: Improve isr state for nested interrupts

### DIFF
--- a/boards/atxmega-a1u-xpro/include/board.h
+++ b/boards/atxmega-a1u-xpro/include/board.h
@@ -72,6 +72,10 @@ extern "C" {
 #define BTN0_PIN            GPIO_PIN(PORT_Q, 2)
 #define BTN0_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
 #define BTN0_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN1_PIN            GPIO_PIN(PORT_C, 2)
+#define BTN1_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN1_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
 /** @} */
 
 /**

--- a/cpu/atmega_common/atmega_cpu.c
+++ b/cpu/atmega_common/atmega_cpu.c
@@ -95,7 +95,7 @@ ISR(BADISR_vect)
 }
 
 #if defined(CPU_ATMEGA128RFA1) || defined (CPU_ATMEGA256RFR2)
-ISR(BAT_LOW_vect, ISR_BLOCK)
+ISR(BAT_LOW_vect, ISR_NAKED)
 {
     avr8_enter_isr();
     DEBUG("BAT_LOW\n");

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -371,16 +371,13 @@ void gpio_irq_disable(gpio_t pin)
 
 static inline void irq_handler(uint8_t int_num)
 {
-    avr8_enter_isr();
     config[int_num].cb(config[int_num].arg);
-    avr8_exit_isr();
 }
 
 #ifdef ENABLE_PCINT
 /* inline function that is used by the PCINT ISR */
 static inline void pcint_handler(uint8_t bank, uint8_t enabled_pcints)
 {
-    avr8_enter_isr();
     /* Find right item */
     uint8_t idx = 0;
 
@@ -409,88 +406,110 @@ static inline void pcint_handler(uint8_t bank, uint8_t enabled_pcints)
         enabled_pcints = enabled_pcints >> 1;
         idx++;
     }
-
-    avr8_exit_isr();
 }
 #ifdef MODULE_ATMEGA_PCINT0
-ISR(PCINT0_vect, ISR_BLOCK)
+ISR(PCINT0_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     pcint_handler(PCINT0_IDX, PCMSK0);
+    avr8_exit_isr();
 }
 #endif /* MODULE_ATMEGA_PCINT0 */
 
 #ifdef MODULE_ATMEGA_PCINT1
-ISR(PCINT1_vect, ISR_BLOCK)
+ISR(PCINT1_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     pcint_handler(PCINT1_IDX, PCMSK1);
+    avr8_exit_isr();
 }
 #endif  /* MODULE_ATMEGA_PCINT1 */
 
 #ifdef MODULE_ATMEGA_PCINT2
-ISR(PCINT2_vect, ISR_BLOCK)
+ISR(PCINT2_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     pcint_handler(PCINT2_IDX, PCMSK2);
+    avr8_exit_isr();
 }
 #endif  /* MODULE_ATMEGA_PCINT2 */
 
 #ifdef MODULE_ATMEGA_PCINT3
-ISR(PCINT3_vect, ISR_BLOCK)
+ISR(PCINT3_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     pcint_handler(PCINT3_IDX, PCMSK3);
+    avr8_exit_isr();
 }
 #endif  /* MODULE_ATMEGA_PCINT3 */
 
 #endif  /* ENABLE_PCINT */
 
-ISR(INT0_vect, ISR_BLOCK)
+ISR(INT0_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(0); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 
-ISR(INT1_vect, ISR_BLOCK)
+ISR(INT1_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(1); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 
 #if defined(INT2_vect)
-ISR(INT2_vect, ISR_BLOCK)
+ISR(INT2_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(2); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(INT3_vect)
-ISR(INT3_vect, ISR_BLOCK)
+ISR(INT3_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(3); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(INT4_vect)
-ISR(INT4_vect, ISR_BLOCK)
+ISR(INT4_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(4); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(INT5_vect)
-ISR(INT5_vect, ISR_BLOCK)
+ISR(INT5_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(5); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(INT6_vect)
-ISR(INT6_vect, ISR_BLOCK)
+ISR(INT6_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(6); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(INT7_vect)
-ISR(INT7_vect, ISR_BLOCK)
+ISR(INT7_vect, ISR_NAKED)
 {
+    avr8_enter_isr();
     irq_handler(7); /**< predefined interrupt pin */
+    avr8_exit_isr();
 }
 #endif
 

--- a/cpu/atmega_common/periph/rtc.c
+++ b/cpu/atmega_common/periph/rtc.c
@@ -32,7 +32,7 @@ static rtc_alarm_cb_t alarm_cb;
 static void *alarm_cb_arg;
 
 /* will be called every second */
-ISR(TIMER2_OVF_vect)
+ISR(TIMER2_OVF_vect, ISR_NAKED)
 {
     avr8_enter_isr();
 

--- a/cpu/atmega_common/periph/rtt.c
+++ b/cpu/atmega_common/periph/rtt.c
@@ -445,7 +445,7 @@ void rtt_poweroff(void)
 }
 
 #if RTT_BACKEND_SC
-ISR(SCNT_OVFL_vect)
+ISR(SCNT_OVFL_vect, ISR_NAKED)
 {
     avr8_enter_isr();
     /* Execute callback */
@@ -456,7 +456,7 @@ ISR(SCNT_OVFL_vect)
     avr8_exit_isr();
 }
 #else
-ISR(TIMER2_OVF_vect)
+ISR(TIMER2_OVF_vect, ISR_NAKED)
 {
     avr8_enter_isr();
 
@@ -484,9 +484,9 @@ ISR(TIMER2_OVF_vect)
 #endif
 
 #if RTT_BACKEND_SC
-ISR(SCNT_CMP2_vect)
+ISR(SCNT_CMP2_vect, ISR_NAKED)
 #else
-ISR(TIMER2_COMPA_vect)
+ISR(TIMER2_COMPA_vect, ISR_NAKED)
 #endif
 {
     avr8_enter_isr();

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -277,8 +277,6 @@ static inline void _isr(tim_t tim, int chan)
     DEBUG_TIMER_PORT |= (1 << DEBUG_TIMER_PIN);
 #endif
 
-    avr8_enter_isr();
-
     if (is_oneshot(tim, chan)) {
         *ctx[tim].mask &= ~(1 << (chan + OCIE1A));
     }
@@ -287,79 +285,101 @@ static inline void _isr(tim_t tim, int chan)
 #if defined(DEBUG_TIMER_PORT)
     DEBUG_TIMER_PORT &= ~(1 << DEBUG_TIMER_PIN);
 #endif
-
-    avr8_exit_isr();
 }
 #endif
 
 #ifdef TIMER_0
-ISR(TIMER_0_ISRA, ISR_BLOCK)
+ISR(TIMER_0_ISRA, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(0, 0);
+    avr8_exit_isr();
 }
 
-ISR(TIMER_0_ISRB, ISR_BLOCK)
+ISR(TIMER_0_ISRB, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(0, 1);
+    avr8_exit_isr();
 }
 
 #ifdef TIMER_0_ISRC
-ISR(TIMER_0_ISRC, ISR_BLOCK)
+ISR(TIMER_0_ISRC, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(0, 2);
+    avr8_exit_isr();
 }
 #endif  /* TIMER_0_ISRC */
 #endif  /* TIMER_0 */
 
 #ifdef TIMER_1
-ISR(TIMER_1_ISRA, ISR_BLOCK)
+ISR(TIMER_1_ISRA, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(1, 0);
+    avr8_exit_isr();
 }
 
-ISR(TIMER_1_ISRB, ISR_BLOCK)
+ISR(TIMER_1_ISRB, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(1, 1);
+    avr8_exit_isr();
 }
 
 #ifdef TIMER_1_ISRC
-ISR(TIMER_1_ISRC, ISR_BLOCK)
+ISR(TIMER_1_ISRC, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(1, 2);
+    avr8_exit_isr();
 }
 #endif  /* TIMER_1_ISRC */
 #endif  /* TIMER_1 */
 
 #ifdef TIMER_2
-ISR(TIMER_2_ISRA, ISR_BLOCK)
+ISR(TIMER_2_ISRA, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(2, 0);
+    avr8_exit_isr();
 }
 
-ISR(TIMER_2_ISRB, ISR_BLOCK)
+ISR(TIMER_2_ISRB, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(2, 1);
+    avr8_exit_isr();
 }
 
-ISR(TIMER_2_ISRC, ISR_BLOCK)
+ISR(TIMER_2_ISRC, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(2, 2);
+    avr8_exit_isr();
 }
 #endif /* TIMER_2 */
 
 #ifdef TIMER_3
-ISR(TIMER_3_ISRA, ISR_BLOCK)
+ISR(TIMER_3_ISRA, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(2, 0);
+    avr8_exit_isr();
 }
 
-ISR(TIMER_3_ISRB, ISR_BLOCK)
+ISR(TIMER_3_ISRB, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(2, 1);
+    avr8_exit_isr();
 }
 
-ISR(TIMER_3_ISRC, ISR_BLOCK)
+ISR(TIMER_3_ISRC, ISR_NAKED)
 {
+    avr8_enter_isr();
     _isr(2, 2);
+    avr8_exit_isr();
 }
 #endif /* TIMER_3 */

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -174,7 +174,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         /* start of TX won't finish until no data in UDRn and transmit shift
            register is empty */
         unsigned long state = irq_disable();
-        avr8_state |= AVR8_STATE_FLAG_UART_TX(uart);
+        avr8_uart_tx_set_pending(uart);
         irq_restore(state);
         dev[uart]->DR = data[i];
     }
@@ -207,11 +207,10 @@ static inline void _tx_isr_handler(int num)
 
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
-    avr8_state &= ~AVR8_STATE_FLAG_UART_TX(num);
+    avr8_uart_tx_clear_pending(num);
 
     avr8_exit_isr();
 }
-
 
 #ifdef UART_0_ISR
 ISR(UART_0_ISR, ISR_BLOCK)

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -173,9 +173,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 #endif
         /* start of TX won't finish until no data in UDRn and transmit shift
            register is empty */
-        unsigned long state = irq_disable();
         avr8_uart_tx_set_pending(uart);
-        irq_restore(state);
         dev[uart]->DR = data[i];
     }
 }

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -192,76 +192,84 @@ void uart_poweroff(uart_t uart)
 
 static inline void _rx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);
-
-    avr8_exit_isr();
 }
 
 static inline void _tx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
     avr8_uart_tx_clear_pending(num);
-
-    avr8_exit_isr();
 }
 
 #ifdef UART_0_ISR
-ISR(UART_0_ISR, ISR_BLOCK)
+ISR(UART_0_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(0);
+    avr8_exit_isr();
 }
 #endif /* UART_0_ISR */
 
 #ifdef UART_1_ISR
-ISR(UART_1_ISR, ISR_BLOCK)
+ISR(UART_1_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(1);
+    avr8_exit_isr();
 }
 #endif /* UART_1_ISR */
 
 #ifdef UART_2_ISR
-ISR(UART_2_ISR, ISR_BLOCK)
+ISR(UART_2_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(2);
+    avr8_exit_isr();
 }
 #endif /* UART_2_ISR */
 
 #ifdef UART_3_ISR
-ISR(UART_3_ISR, ISR_BLOCK)
+ISR(UART_3_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(3);
+    avr8_exit_isr();
 }
 #endif /* UART_3_ISR */
 
 #ifdef UART_0_ISR_TX
-ISR(UART_0_ISR_TX, ISR_BLOCK)
+ISR(UART_0_ISR_TX, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(0);
+    avr8_exit_isr();
 }
 #endif /* UART_0_ISR_TX */
 
 #ifdef UART_1_ISR_TX
-ISR(UART_1_ISR_TX, ISR_BLOCK)
+ISR(UART_1_ISR_TX, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(1);
+    avr8_exit_isr();
 }
 #endif /* UART_1_ISR_TX */
 
 #ifdef UART_2_ISR_TX
-ISR(UART_2_ISR_TX, ISR_BLOCK)
+ISR(UART_2_ISR_TX, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(2);
+    avr8_exit_isr();
 }
 #endif /* UART_2_ISR_TX */
 
 #ifdef UART_3_ISR_TX
-ISR(UART_3_ISR_TX, ISR_BLOCK)
+ISR(UART_3_ISR_TX, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(3);
+    avr8_exit_isr();
 }
 #endif /* UART_3_ISR_TX */

--- a/cpu/atxmega/periph/gpio.c
+++ b/cpu/atxmega/periph/gpio.c
@@ -317,11 +317,9 @@ void gpio_write(gpio_t pin, int value)
     }
 }
 
-static inline void irq_handler(uint8_t port_num, uint8_t isr_vct_num)
+static inline void _gpio_isr(uint8_t port_num, uint8_t isr_vct_num)
 {
-    avr8_enter_isr();
-
-    DEBUG("irq_handler port = 0x%02x, vct_num = %d \n", port_num, isr_vct_num);
+    DEBUG("_gpio_isr port = 0x%02x, vct_num = %d \n", port_num, isr_vct_num);
 
     if (isr_vct_num) {
         port_num += PORT_MAX;
@@ -331,216 +329,278 @@ static inline void irq_handler(uint8_t port_num, uint8_t isr_vct_num)
         config_ctx[port_num].cb(config_ctx[port_num].arg);
     }
     else {
-        DEBUG("WARNING! irq_handler without callback\n");
+        DEBUG("WARNING! _gpio_isr without callback\n");
     }
-
-    avr8_exit_isr();
 }
 
 #if defined(PORTA_INT0_vect)
-ISR(PORTA_INT0_vect, ISR_BLOCK)
+ISR(PORTA_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_A, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_A, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTA_INT1_vect)
-ISR(PORTA_INT1_vect, ISR_BLOCK)
+ISR(PORTA_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_A, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_A, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTB_INT0_vect)
-ISR(PORTB_INT0_vect, ISR_BLOCK)
+ISR(PORTB_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_B, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_B, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTB_INT1_vect)
-ISR(PORTB_INT1_vect, ISR_BLOCK)
+ISR(PORTB_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_B, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_B, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTC_INT0_vect)
-ISR(PORTC_INT0_vect, ISR_BLOCK)
+ISR(PORTC_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_C, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_C, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTC_INT1_vect)
-ISR(PORTC_INT1_vect, ISR_BLOCK)
+ISR(PORTC_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_C, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_C, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTD_INT0_vect)
-ISR(PORTD_INT0_vect, ISR_BLOCK)
+ISR(PORTD_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_D, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_D, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTD_INT1_vect)
-ISR(PORTD_INT1_vect, ISR_BLOCK)
+ISR(PORTD_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_D, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_D, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTE_INT0_vect)
-ISR(PORTE_INT0_vect, ISR_BLOCK)
+ISR(PORTE_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_E, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_E, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTE_INT1_vect)
-ISR(PORTE_INT1_vect, ISR_BLOCK)
+ISR(PORTE_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_E, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_E, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTF_INT0_vect)
-ISR(PORTF_INT0_vect, ISR_BLOCK)
+ISR(PORTF_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_F, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_F, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTF_INT1_vect)
-ISR(PORTF_INT1_vect, ISR_BLOCK)
+ISR(PORTF_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_F, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_F, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTG_INT0_vect)
-ISR(PORTG_INT0_vect, ISR_BLOCK)
+ISR(PORTG_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_G, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_G, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTG_INT1_vect)
-ISR(PORTG_INT1_vect, ISR_BLOCK)
+ISR(PORTG_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_G, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_G, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTH_INT0_vect)
-ISR(PORTH_INT0_vect, ISR_BLOCK)
+ISR(PORTH_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_H, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_H, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTH_INT1_vect)
-ISR(PORTH_INT1_vect, ISR_BLOCK)
+ISR(PORTH_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_H, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_H, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTJ_INT0_vect)
-ISR(PORTJ_INT0_vect, ISR_BLOCK)
+ISR(PORTJ_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_J, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_J, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTJ_INT1_vect)
-ISR(PORTJ_INT1_vect, ISR_BLOCK)
+ISR(PORTJ_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_J, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_J, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTK_INT0_vect)
-ISR(PORTK_INT0_vect, ISR_BLOCK)
+ISR(PORTK_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_K, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_K, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTK_INT1_vect)
-ISR(PORTK_INT1_vect, ISR_BLOCK)
+ISR(PORTK_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_K, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_K, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTL_INT0_vect)
-ISR(PORTL_INT0_vect, ISR_BLOCK)
+ISR(PORTL_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_L, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_L, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTL_INT1_vect)
-ISR(PORTL_INT1_vect, ISR_BLOCK)
+ISR(PORTL_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_L, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_L, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTM_INT0_vect)
-ISR(PORTM_INT0_vect, ISR_BLOCK)
+ISR(PORTM_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_M, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_M, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTM_INT1_vect)
-ISR(PORTM_INT1_vect, ISR_BLOCK)
+ISR(PORTM_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_M, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_M, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTN_INT0_vect)
-ISR(PORTN_INT0_vect, ISR_BLOCK)
+ISR(PORTN_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_N, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_N, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTN_INT1_vect)
-ISR(PORTN_INT1_vect, ISR_BLOCK)
+ISR(PORTN_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_N, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_N, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTP_INT0_vect)
-ISR(PORTP_INT0_vect, ISR_BLOCK)
+ISR(PORTP_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_P, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_P, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTP_INT1_vect)
-ISR(PORTP_INT1_vect, ISR_BLOCK)
+ISR(PORTP_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_P, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_P, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTQ_INT0_vect)
-ISR(PORTQ_INT0_vect, ISR_BLOCK)
+ISR(PORTQ_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_Q, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_Q, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTQ_INT1_vect)
-ISR(PORTQ_INT1_vect, ISR_BLOCK)
+ISR(PORTQ_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_Q, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_Q, 1);
+    avr8_exit_isr();
 }
 #endif
 
 #if defined(PORTR_INT0_vect)
-ISR(PORTR_INT0_vect, ISR_BLOCK)
+ISR(PORTR_INT0_vect, ISR_NAKED)
 {
-    irq_handler(PORT_R, 0);
+    avr8_enter_isr();
+    _gpio_isr(PORT_R, 0);
+    avr8_exit_isr();
 }
 #endif
 #if defined(PORTR_INT1_vect)
-ISR(PORTR_INT1_vect, ISR_BLOCK)
+ISR(PORTR_INT1_vect, ISR_NAKED)
 {
-    irq_handler(PORT_R, 1);
+    avr8_enter_isr();
+    _gpio_isr(PORT_R, 1);
+    avr8_exit_isr();
 }
 #endif

--- a/cpu/atxmega/periph/timer.c
+++ b/cpu/atxmega/periph/timer.c
@@ -314,10 +314,8 @@ void timer_start(tim_t tim)
 }
 
 #ifdef TIMER_NUMOF
-static inline void _isr(tim_t tim, int channel)
+static inline void _tmr_isr(tim_t tim, int channel)
 {
-    avr8_enter_isr();
-
     DEBUG("timer %d _isr channel %d\n", tim, channel);
 
     if (is_oneshot(tim, channel)) {
@@ -327,207 +325,269 @@ static inline void _isr(tim_t tim, int channel)
     if (ctx[tim].cb) {
         ctx[tim].cb(ctx[tim].arg, channel);
     }
-
-    avr8_exit_isr();
 }
 #endif
 
 #ifdef TIMER_0_ISRA
-ISR(TIMER_0_ISRA, ISR_BLOCK)
+ISR(TIMER_0_ISRA, ISR_NAKED)
 {
-    _isr(0, 0);
+    avr8_enter_isr();
+    _tmr_isr(0, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_0_ISRB
-ISR(TIMER_0_ISRB, ISR_BLOCK)
+ISR(TIMER_0_ISRB, ISR_NAKED)
 {
-    _isr(0, 1);
+    avr8_enter_isr();
+    _tmr_isr(0, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_0_ISRC
-ISR(TIMER_0_ISRC, ISR_BLOCK)
+ISR(TIMER_0_ISRC, ISR_NAKED)
 {
-    _isr(0, 2);
+    avr8_enter_isr();
+    _tmr_isr(0, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_0_ISRD
-ISR(TIMER_0_ISRD, ISR_BLOCK)
+ISR(TIMER_0_ISRD, ISR_NAKED)
 {
-    _isr(0, 3);
+    avr8_enter_isr();
+    _tmr_isr(0, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_0 */
 
 #ifdef TIMER_1_ISRA
-ISR(TIMER_1_ISRA, ISR_BLOCK)
+ISR(TIMER_1_ISRA, ISR_NAKED)
 {
-    _isr(1, 0);
+    avr8_enter_isr();
+    _tmr_isr(1, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_1_ISRB
-ISR(TIMER_1_ISRB, ISR_BLOCK)
+ISR(TIMER_1_ISRB, ISR_NAKED)
 {
-    _isr(1, 1);
+    avr8_enter_isr();
+    _tmr_isr(1, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_1_ISRC
-ISR(TIMER_1_ISRC, ISR_BLOCK)
+ISR(TIMER_1_ISRC, ISR_NAKED)
 {
-    _isr(1, 2);
+    avr8_enter_isr();
+    _tmr_isr(1, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_1_ISRD
-ISR(TIMER_1_ISRD, ISR_BLOCK)
+ISR(TIMER_1_ISRD, ISR_NAKED)
 {
-    _isr(1, 3);
+    avr8_enter_isr();
+    _tmr_isr(1, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_1 */
 
 #ifdef TIMER_2_ISRA
-ISR(TIMER_2_ISRA, ISR_BLOCK)
+ISR(TIMER_2_ISRA, ISR_NAKED)
 {
-    _isr(2, 0);
+    avr8_enter_isr();
+    _tmr_isr(2, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_2_ISRB
-ISR(TIMER_2_ISRB, ISR_BLOCK)
+ISR(TIMER_2_ISRB, ISR_NAKED)
 {
-    _isr(2, 1);
+    avr8_enter_isr();
+    _tmr_isr(2, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_2_ISRC
-ISR(TIMER_2_ISRC, ISR_BLOCK)
+ISR(TIMER_2_ISRC, ISR_NAKED)
 {
-    _isr(2, 2);
+    avr8_enter_isr();
+    _tmr_isr(2, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_2_ISRD
-ISR(TIMER_2_ISRD, ISR_BLOCK)
+ISR(TIMER_2_ISRD, ISR_NAKED)
 {
-    _isr(2, 3);
+    avr8_enter_isr();
+    _tmr_isr(2, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_2 */
 
 #ifdef TIMER_3_ISRA
-ISR(TIMER_3_ISRA, ISR_BLOCK)
+ISR(TIMER_3_ISRA, ISR_NAKED)
 {
-    _isr(3, 0);
+    avr8_enter_isr();
+    _tmr_isr(3, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_3_ISRB
-ISR(TIMER_3_ISRB, ISR_BLOCK)
+ISR(TIMER_3_ISRB, ISR_NAKED)
 {
-    _isr(3, 1);
+    avr8_enter_isr();
+    _tmr_isr(3, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_3_ISRC
-ISR(TIMER_3_ISRC, ISR_BLOCK)
+ISR(TIMER_3_ISRC, ISR_NAKED)
 {
-    _isr(3, 2);
+    avr8_enter_isr();
+    _tmr_isr(3, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_3_ISRD
-ISR(TIMER_3_ISRD, ISR_BLOCK)
+ISR(TIMER_3_ISRD, ISR_NAKED)
 {
-    _isr(3, 3);
+    avr8_enter_isr();
+    _tmr_isr(3, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_3 */
 
 #ifdef TIMER_4_ISRA
-ISR(TIMER_4_ISRA, ISR_BLOCK)
+ISR(TIMER_4_ISRA, ISR_NAKED)
 {
-    _isr(4, 0);
+    avr8_enter_isr();
+    _tmr_isr(4, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_4_ISRB
-ISR(TIMER_4_ISRB, ISR_BLOCK)
+ISR(TIMER_4_ISRB, ISR_NAKED)
 {
-    _isr(4, 1);
+    avr8_enter_isr();
+    _tmr_isr(4, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_4_ISRC
-ISR(TIMER_4_ISRC, ISR_BLOCK)
+ISR(TIMER_4_ISRC, ISR_NAKED)
 {
-    _isr(4, 2);
+    avr8_enter_isr();
+    _tmr_isr(4, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_4_ISRD
-ISR(TIMER_4_ISRD, ISR_BLOCK)
+ISR(TIMER_4_ISRD, ISR_NAKED)
 {
-    _isr(4, 3);
+    avr8_enter_isr();
+    _tmr_isr(4, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_4 */
 
 #ifdef TIMER_5_ISRA
-ISR(TIMER_5_ISRA, ISR_BLOCK)
+ISR(TIMER_5_ISRA, ISR_NAKED)
 {
-    _isr(5, 0);
+    avr8_enter_isr();
+    _tmr_isr(5, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_5_ISRB
-ISR(TIMER_5_ISRB, ISR_BLOCK)
+ISR(TIMER_5_ISRB, ISR_NAKED)
 {
-    _isr(5, 1);
+    avr8_enter_isr();
+    _tmr_isr(5, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_5_ISRC
-ISR(TIMER_5_ISRC, ISR_BLOCK)
+ISR(TIMER_5_ISRC, ISR_NAKED)
 {
-    _isr(5, 2);
+    avr8_enter_isr();
+    _tmr_isr(5, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_5_ISRD
-ISR(TIMER_5_ISRD, ISR_BLOCK)
+ISR(TIMER_5_ISRD, ISR_NAKED)
 {
-    _isr(5, 3);
+    avr8_enter_isr();
+    _tmr_isr(5, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_5 */
 
 #ifdef TIMER_6_ISRA
-ISR(TIMER_6_ISRA, ISR_BLOCK)
+ISR(TIMER_6_ISRA, ISR_NAKED)
 {
-    _isr(6, 0);
+    avr8_enter_isr();
+    _tmr_isr(6, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_6_ISRB
-ISR(TIMER_6_ISRB, ISR_BLOCK)
+ISR(TIMER_6_ISRB, ISR_NAKED)
 {
-    _isr(6, 1);
+    avr8_enter_isr();
+    _tmr_isr(6, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_6_ISRC
-ISR(TIMER_6_ISRC, ISR_BLOCK)
+ISR(TIMER_6_ISRC, ISR_NAKED)
 {
-    _isr(6, 2);
+    avr8_enter_isr();
+    _tmr_isr(6, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_6_ISRD
-ISR(TIMER_6_ISRD, ISR_BLOCK)
+ISR(TIMER_6_ISRD, ISR_NAKED)
 {
-    _isr(6, 3);
+    avr8_enter_isr();
+    _tmr_isr(6, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_6 */
 
 #ifdef TIMER_7_ISRA
-ISR(TIMER_7_ISRA, ISR_BLOCK)
+ISR(TIMER_7_ISRA, ISR_NAKED)
 {
-    _isr(7, 0);
+    avr8_enter_isr();
+    _tmr_isr(7, 0);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_7_ISRB
-ISR(TIMER_7_ISRB, ISR_BLOCK)
+ISR(TIMER_7_ISRB, ISR_NAKED)
 {
-    _isr(7, 1);
+    avr8_enter_isr();
+    _tmr_isr(7, 1);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_7_ISRC
-ISR(TIMER_7_ISRC, ISR_BLOCK)
+ISR(TIMER_7_ISRC, ISR_NAKED)
 {
-    _isr(7, 2);
+    avr8_enter_isr();
+    _tmr_isr(7, 2);
+    avr8_exit_isr();
 }
 #endif
 #ifdef TIMER_7_ISRB
-ISR(TIMER_7_ISRD, ISR_BLOCK)
+ISR(TIMER_7_ISRD, ISR_NAKED)
 {
-    _isr(7, 3);
+    avr8_enter_isr();
+    _tmr_isr(7, 3);
+    avr8_exit_isr();
 }
 #endif /* TIMER_7 */

--- a/cpu/atxmega/periph/uart.c
+++ b/cpu/atxmega/periph/uart.c
@@ -305,9 +305,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
         /* start of TX won't finish until no data in DATAn and transmit shift
            register is empty */
-        uint8_t irq_state = irq_disable();
         avr8_uart_tx_set_pending(uart);
-        irq_restore(irq_state);
 
         dev(uart)->DATA = data[i];
     }

--- a/cpu/atxmega/periph/uart.c
+++ b/cpu/atxmega/periph/uart.c
@@ -306,7 +306,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         /* start of TX won't finish until no data in DATAn and transmit shift
            register is empty */
         uint8_t irq_state = irq_disable();
-        avr8_state |= AVR8_STATE_FLAG_UART_TX(uart);
+        avr8_uart_tx_set_pending(uart);
         irq_restore(irq_state);
 
         dev(uart)->DATA = data[i];
@@ -336,13 +336,13 @@ static inline void _rx_isr_handler(int num)
     avr8_exit_isr();
 }
 
-static inline void _tx_isr_handler(int num)
+static inline void _tx_isr_handler(int uart)
 {
     avr8_enter_isr();
 
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
-    avr8_state &= ~AVR8_STATE_FLAG_UART_TX(num);
+    avr8_uart_tx_clear_pending(uart);
 
     avr8_exit_isr();
 }

--- a/cpu/atxmega/periph/uart.c
+++ b/cpu/atxmega/periph/uart.c
@@ -325,99 +325,119 @@ void uart_poweroff(uart_t uart)
 
 static inline void _rx_isr_handler(int num)
 {
-    avr8_enter_isr();
-
     if (isr_ctx[num].rx_cb) {
         isr_ctx[num].rx_cb(isr_ctx[num].arg, dev(num)->DATA);
     }
-
-    avr8_exit_isr();
 }
 
 static inline void _tx_isr_handler(int uart)
 {
-    avr8_enter_isr();
-
     /* entire frame in the Transmit Shift Register has been shifted out and
        there are no new data currently present in the transmit buffer */
     avr8_uart_tx_clear_pending(uart);
-
-    avr8_exit_isr();
 }
 
 #ifdef UART_0_RXC_ISR
-ISR(UART_0_RXC_ISR, ISR_BLOCK)
+ISR(UART_0_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(0);
+    avr8_exit_isr();
 }
-ISR(UART_0_TXC_ISR, ISR_BLOCK)
+ISR(UART_0_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(0);
+    avr8_exit_isr();
 }
 #endif /* UART_0_ISR */
 
 #ifdef UART_1_RXC_ISR
-ISR(UART_1_RXC_ISR, ISR_BLOCK)
+ISR(UART_1_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(1);
+    avr8_exit_isr();
 }
-ISR(UART_1_TXC_ISR, ISR_BLOCK)
+ISR(UART_1_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(1);
+    avr8_exit_isr();
 }
 #endif /* UART_1_ISR */
 
 #ifdef UART_2_RXC_ISR
-ISR(UART_2_RXC_ISR, ISR_BLOCK)
+ISR(UART_2_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(2);
+    avr8_exit_isr();
 }
-ISR(UART_2_TXC_ISR, ISR_BLOCK)
+ISR(UART_2_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(2);
+    avr8_exit_isr();
 }
 #endif /* UART_2_ISR */
 
 #ifdef UART_3_RXC_ISR
-ISR(UART_3_RXC_ISR, ISR_BLOCK)
+ISR(UART_3_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(3);
+    avr8_exit_isr();
 }
-ISR(UART_3_TXC_ISR, ISR_BLOCK)
+ISR(UART_3_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(3);
+    avr8_exit_isr();
 }
 #endif /* UART_3_ISR */
 
 #ifdef UART_4_RXC_ISR
-ISR(UART_4_RXC_ISR, ISR_BLOCK)
+ISR(UART_4_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(4);
+    avr8_exit_isr();
 }
-ISR(UART_4_TXC_ISR, ISR_BLOCK)
+ISR(UART_4_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(4);
+    avr8_exit_isr();
 }
 #endif /* UART_4_ISR */
 
 #ifdef UART_5_RXC_ISR
-ISR(UART_5_RXC_ISR, ISR_BLOCK)
+ISR(UART_5_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(5);
+    avr8_exit_isr();
 }
-ISR(UART_5_TXC_ISR, ISR_BLOCK)
+ISR(UART_5_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(5);
+    avr8_exit_isr();
 }
 #endif /* UART_5_ISR */
 
 #ifdef UART_6_RXC_ISR
-ISR(UART_6_RXC_ISR, ISR_BLOCK)
+ISR(UART_6_RXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _rx_isr_handler(6);
+    avr8_exit_isr();
 }
-ISR(UART_6_TXC_ISR, ISR_BLOCK)
+ISR(UART_6_TXC_ISR, ISR_NAKED)
 {
+    avr8_enter_isr();
     _tx_isr_handler(6);
+    avr8_exit_isr();
 }
 #endif /* UART_6_ISR */

--- a/cpu/avr8_common/avr8_cpu.c
+++ b/cpu/avr8_common/avr8_cpu.c
@@ -70,7 +70,6 @@
 */
 uint8_t mcusr_mirror __attribute__((section(".noinit")));
 uint8_t soft_rst __attribute__((section(".noinit")));
-uint8_t avr8_state = 0;
 
 void get_mcusr(void) __attribute__((naked, section(".init0"), used));
 
@@ -116,6 +115,10 @@ void cpu_init(void)
               |  PMIC_MEDLVLEN_bm
               |  PMIC_LOLVLEN_bm;
 #endif
+
+    /* Set global resources initial state */
+    GPIOR0 = 0; /* MCU UART TX pending state */
+    GPIOR1 = 0; /* MCU ISR State */
 
     irq_enable();
 }

--- a/cpu/avr8_common/include/irq_arch.h
+++ b/cpu/avr8_common/include/irq_arch.h
@@ -99,8 +99,11 @@ __attribute__((always_inline)) static inline void irq_restore(unsigned int _stat
  */
 __attribute__((always_inline)) static inline int irq_is_in(void)
 {
-    uint8_t state = avr8_get_state();
-    return (state & AVR8_STATE_FLAG_ISR);
+#if !defined(CPU_ATXMEGA)
+    return GPIOR1;
+#else
+    return PMIC.STATUS;
+#endif
 }
 
 #ifdef __cplusplus

--- a/cpu/avr8_common/thread_arch.c
+++ b/cpu/avr8_common/thread_arch.c
@@ -34,23 +34,9 @@
 #include "board.h"
 #include "macros/xtstr.h"
 
-#define CHECK_EIND_REG          FLASHEND > 0x1ffff
-
-#if defined(DATAMEM_SIZE)
-#define CHECK_RAMPZ_REG         DATAMEM_SIZE > 0xffff || FLASHEND > 0xffff
-#define CHECK_RAMPDXY_REG       DATAMEM_SIZE > 0xffff
-#else
-#define CHECK_RAMPZ_REG         FLASHEND > 0xffff
-#define CHECK_RAMPDXY_REG       0
-#endif
-
-#if (CHECK_EIND_REG)
-#ifndef __EIND__
-#define __EIND__                0x3C
-#endif
-#endif
-
-static void avr8_context_save(void);
+static void avr8_context_save_header_in_thread(void);
+static void avr8_context_save_header_in_isr(void);
+static void avr8_context_save_body(void);
 static void avr8_context_restore(void);
 static void avr8_enter_thread_mode(void);
 
@@ -266,51 +252,197 @@ void NORETURN avr8_enter_thread_mode(void)
     UNREACHABLE();
 }
 
-__attribute__((always_inline)) static inline void avr8_context_switch(void)
-{
-    avr8_context_save();
-    sched_run();
-    avr8_context_restore();
-}
-
 void thread_yield_higher(void)
 {
     if (irq_is_in() == 0) {
-        avr8_context_switch();
+        avr8_context_save_header_in_thread();
+        avr8_context_save_body();
+        sched_run();
+        avr8_context_restore();
     }
     else {
         sched_context_switch_request = 1;
     }
 }
 
-__attribute__((always_inline)) static inline int avr8_nested_isr_allows_ctx_switch(void)
+/**
+ * @brief Restore remaining thread context
+ *
+ * The tail part is responsible to restore r1, r25 and r24.  Those register
+ * were used to update GPIOR1 and perform tests related to switch context.
+ */
+__attribute__((always_inline))
+static inline void avr8_isr_epilog_tail(void)
 {
-#if !defined(CPU_ATXMEGA)
-    return GPIOR1 == 0;
-#else
-    return PMIC.STATUS <= PMIC_LOLVLEX_bm;
-#endif
+    __asm__ volatile (
+        "pop    __zero_reg__           \n\t"
+        "pop    r25                    \n\t"
+        "pop    r24                    \n\t"
+        :
+        :
+        : "memory"
+    );
 }
 
-void avr8_exit_isr(void)
+/**
+ * @brief Restore thread/IRQ context
+ *
+ * To allow nested interrupts in RIOT-OS multi thread environment, GPIOR1 is
+ * used as IRQ global state.  This means that a context switch may happen
+ * when GPIOR1 have value 0 (no nested condition).  The the pair r24/r25 have
+ * delayed restore at IRQ epilog.  Those are used to update GPIOR1 value and
+ * execute branch condition tests.  All AVR-8 variations require a critical
+ * section when executing GPIOR1 update and branch tests at epilog.  This will
+ * avoid that another IRQ uses an invalid value from GPIOR1 and start a context
+ * switch, which may create an epilog corruption.
+ */
+void avr8_isr_epilog(void)
 {
-#if !defined(CPU_ATXMEGA)
-    --GPIOR1;
+    uint8_t isr_sts;
+
+    __asm__ volatile (
+        "pop    r31                        \n\t"
+        "pop    r30                        \n\t"
+        "pop    r27                        \n\t"
+        "pop    r26                        \n\t"
+        "pop    r23                        \n\t"
+        "pop    r22                        \n\t"
+        "pop    r21                        \n\t"
+        "pop    r20                        \n\t"
+        "pop    r19                        \n\t"
+        "pop    r18                        \n\t"
+#if (CHECK_RAMPZ_REG)
+        "pop    __tmp_reg__                \n\t"
+        "out    __RAMPZ__, __tmp_reg__     \n\t"
 #endif
-    if (avr8_nested_isr_allows_ctx_switch() && sched_context_switch_request) {
-        avr8_context_switch();
-        __asm__ volatile ("reti" : : : "memory");
+#if (CHECK_RAMPDXY_REG)
+        "pop    __tmp_reg__                \n\t"
+        "out    __RAMPX__, __tmp_reg__     \n\t"
+        "pop    __tmp_reg__                \n\t"
+        "out    __RAMPD__, __tmp_reg__     \n\t"
+#endif
+        "pop    __tmp_reg__                \n\t"
+        "out    __SREG__, __tmp_reg__      \n\t"
+        "pop    __tmp_reg__                \n\t"
+    /* Force zero_reg to ensure ISR body not changed it, this is be necessary
+     * to test isr_sts value
+     */
+        "eor    __zero_reg__, __zero_reg__ \n\t"
+    /**
+     * Epilog Nested ISR State - critical section
+     *
+     * This critical section may be finished in following situations:
+     * - Last 'pop' instruction in @ref avr8_context_restore;
+     * - Last instructions from current avr8_isr_epilog.
+     * This critical section is necessary to avoid GPIOR1 and Epilog
+     * corruption on all AVR-8 cores.
+     *
+     * Note:
+     * - ATmega may be affected when IRQ is re-enabled on ISR body by the user
+     */
+        "cli                               \n\t"
+        "in     r24, %[state]              \n\t"
+        "subi   r24, 0x01                  \n\t"
+        "out    %[state], r24              \n\t"
+        : [isr_sts] "=r" (isr_sts)
+        : [state] "I" (_SFR_IO_ADDR(GPIOR1))
+        : "memory"
+    );
+
+    /* Branch Tests - critical section.
+     * Note: isr_sts was optimized to avoid a second load and perform fastest
+     * tests for critical tasks.  Do not switch position from isr_sts with
+     * sched_context_switch_request. Care is necessary to test r24 before
+     * reloaded with sched_context_switch_request value.
+     */
+    if (isr_sts == 0 && sched_context_switch_request) {
+        /* A context switch was requested in the body of interrupt:
+         *
+         * GPIOR1 is 0 and sched_context_switch_request is greater than 0
+         *
+         * - Restore remaining context register r24/25
+         * - Start context save using the current critical section at #ref
+         *   avr8_context_save_header_in_isr
+         * -    For ATxmega, IRQ should be re-enabled because reti instruction
+         *      don't do it!  In this case, it should be re-enabled because a
+         *      context switch may occor by @ref thread_yield_higher and
+         *      epilog needs guarantee that IRQ are enabled for that case.
+         *      However, care is required because it can broke the critical
+         *      section.  This will be performed at avr8_context_save_header_in_isr
+         * - Context switch
+         * - At top of stack, the previous context can be found or a another
+         *   one that was just reload from @ref sched_run.
+         */
+        avr8_isr_epilog_tail();
+        avr8_context_save_header_in_isr();
+        avr8_context_save_body();
+        sched_run();
+        avr8_context_restore();
     }
+    else {
+        /* Don't perform a context switch.  Simple finish context restore
+         * before leave ISR.
+         */
+        avr8_isr_epilog_tail();
+    }
+
+    /* ATxmega always runs with IRQ enabled, let's enabled it!  For ATmega,
+     * reti instruction will do it!
+     */
+    __asm__ volatile (
+#if defined(CPU_ATXMEGA)
+        "sei                               \n\t"
+#endif
+        "reti                              \n\t"
+        : : : "memory"
+    );
 }
 
-__attribute__((always_inline)) static inline void avr8_context_save(void)
+/**
+ * @brief Saves context header in thread context
+ *
+ * This saves temporary register and SREG.  Keep SREG with their original
+ * value.  The normal procedure should use this context save header.
+ */
+__attribute__((always_inline))
+static inline void avr8_context_save_header_in_thread(void)
 {
     __asm__ volatile (
         "push __tmp_reg__                        \n\t"
         "in   __tmp_reg__, __SREG__              \n\t"
         "cli                                     \n\t"
-        "push __tmp_reg__                        \n\t"
+        "push __tmp_reg__                        \n\t");
+}
 
+/**
+ * @brief Saves context header in ISR
+ *
+ * This saves temporary register and SREG.  The epilog critical section
+ * disables global IRQ.  This code must re-enabled the context IRQ without
+ * disabling the current critical section.
+ */
+__attribute__((always_inline))
+static inline void avr8_context_save_header_in_isr(void)
+{
+    __asm__ volatile (
+        "push __tmp_reg__                        \n\t"
+        "push r24                                \n\t"
+        "in   r24, __SREG__                      \n\t"
+        "sbr  r24, 0x80                          \n\t"
+        "mov  __tmp_reg__, r24                   \n\t"
+        "pop  r24                                \n\t"
+        "push __tmp_reg__                        \n\t");
+}
+
+/**
+ * @brief Saves context body
+ *
+ * This saves remaining context registers.
+ */
+__attribute__((always_inline))
+static inline void avr8_context_save_body(void)
+{
+    __asm__ volatile (
 #if (CHECK_RAMPZ_REG)
         "in     __tmp_reg__, __RAMPZ__           \n\t"
         "push   __tmp_reg__                      \n\t"
@@ -370,7 +502,8 @@ __attribute__((always_inline)) static inline void avr8_context_save(void)
         "st   x+, __tmp_reg__                    \n\t");
 }
 
-__attribute__((always_inline)) static inline void avr8_context_restore(void)
+__attribute__((always_inline))
+static inline void avr8_context_restore(void)
 {
     __asm__ volatile (
         "lds  r26, sched_active_thread           \n\t"

--- a/tests/isr_context_switch_by_ext_int/Makefile
+++ b/tests/isr_context_switch_by_ext_int/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += periph_gpio
+FEATURES_OPTIONAL += periph_gpio_irq
+
+include $(RIOTBASE)/Makefile.include
+
+CFLAGS += -DSCHED_TEST_STACK

--- a/tests/isr_context_switch_by_ext_int/main.c
+++ b/tests/isr_context_switch_by_ext_int/main.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   Application for testing context switching triggered from IRQ
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "mutex.h"
+#include "thread.h"
+#include "periph/gpio.h"
+#include "board.h"
+
+#ifndef TEST_REPETITIONS
+#define TEST_REPETITIONS    500
+#endif
+
+static mutex_t mut1 = MUTEX_INIT_LOCKED;
+static mutex_t mut2 = MUTEX_INIT_LOCKED;
+static mutex_t mut3 = MUTEX_INIT_LOCKED;
+
+static char t2_stack[THREAD_STACKSIZE_DEFAULT];
+static char t3_stack[THREAD_STACKSIZE_DEFAULT];
+
+static uint16_t counter = 0;
+
+static void cb_btn0(void *arg)
+{
+    (void) arg;
+    thread_yield_higher();
+    if (counter++ == TEST_REPETITIONS) {
+        mutex_unlock(&mut1);
+    }
+    else {
+        mutex_unlock(&mut2);
+        gpio_toggle(BTN1_PIN);
+        gpio_toggle(BTN1_PIN);
+    }
+}
+
+static void cb_btn1(void *arg)
+{
+    (void) arg;
+    thread_yield_higher();
+    if (counter++ == TEST_REPETITIONS) {
+        mutex_unlock(&mut1);
+    }
+    else {
+        mutex_unlock(&mut3);
+        gpio_toggle(BTN0_PIN);
+        gpio_toggle(BTN0_PIN);
+    }
+}
+
+static void *t2_impl(void *unused)
+{
+    (void)unused;
+    while (1) {
+	mutex_lock(&mut2);
+    }
+    return NULL;
+}
+
+static void *t3_impl(void *unused)
+{
+    (void)unused;
+    while (1) {
+	mutex_lock(&mut3);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    printf("Testing %u context switches triggered from ISR\n", (unsigned)TEST_REPETITIONS);
+    thread_create(t2_stack, sizeof(t2_stack),
+                  THREAD_PRIORITY_MAIN - 1,
+                  THREAD_CREATE_STACKTEST,
+                  t2_impl, NULL, "t2");
+
+    thread_create(t3_stack, sizeof(t3_stack),
+                  THREAD_PRIORITY_MAIN - 1,
+                  THREAD_CREATE_STACKTEST,
+                  t3_impl, NULL, "t3");
+
+    gpio_init_int(BTN0_PIN, GPIO_OUT, BTN0_INT_FLANK, cb_btn0, NULL);
+    gpio_init_int(BTN1_PIN, GPIO_OUT, BTN1_INT_FLANK, cb_btn1, NULL);
+
+    gpio_toggle(BTN0_PIN);
+    gpio_toggle(BTN0_PIN);
+
+    mutex_lock(&mut1);
+
+    puts("TEST PASSED");
+
+    return 0;
+}

--- a/tests/isr_context_switch_by_ext_int/tests/01-run.py
+++ b/tests/isr_context_switch_by_ext_int/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

ATxmega supports nested interrupts but there is no infrastructure to use that.  Split **avr8_state** into two new variables: **avr8_isr_state** and **avr8_uart_state**. Those variables are stored using GPIOR1 and GPIOR0.

The **avr8_isr_state** is a count responsible to store how deep is the nested interrupt level.  The scheduler need check if deep is zero to perform a switch context.

The **avr8_uart_state** continue with same meaning before.  The big difference now is, it supports up to 8 uarts and there is a dedicated method to set/unset tx pending.

The code was refactored to allow nested interrupts on AVR-8 cores. To do that, dedicated ISR prolog/epilog were designed.

### Testing procedure

Tests were conducted with below AVR-8 cores:
- atxmega128a1u
- atmega128rfa1

### Issues/PRs references

This is part of #15703.

CC: @benpicco