### PR TITLE
doc/SAUL: State expectations on blocking and interrupts

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -27,6 +27,10 @@
  * actuators/sensor via auto_init and the access to all available devices via
  * one unified shell command.
  *
+ * SAUL drivers may rely on being called from a thread, and often block for
+ * short amounts of time to obtain a value. Conversely, requests through the
+ * @ref sys_saul_reg must not be issued from an interrupt context.
+ *
  * @todo        So far, the interface only supports simple read and set
  *              operations. It probably needs to be extended to handling events,
  *              thresholds, and so on.


### PR DESCRIPTION
### Contribution description

SAUL drivers habitually do things like mutex locking that are forbidden in interrupt contexts. This change makes that explicit in the documentation, and puts the reposnsibility on the SAUL callers (and not the drivers) to check that no calls come from an interrupt context.

The note is placed with the driver documentation, as that's where general SAUL text resides; the SAUL registry documentation page primarily contains a link there, and it's not repeated for the individual functions.

### Testing procedure

Read the documentation.