### PR TITLE
examples/gnrc_border_router: enable ethernet uplink

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -11,8 +11,8 @@ RIOTBASE ?= $(CURDIR)/../..
 UPLINK ?= ethos
 
 # Check if the selected Uplink is valid
-ifeq (,$(filter ethos slip cdc-ecm wifi,$(UPLINK)))
-  $(error Supported uplinks are `ethos`, `slip`, `cdc-ecm` and `wifi`)
+ifeq (,$(filter ethos slip cdc-ecm wifi ethernet,$(UPLINK)))
+  $(error Supported uplinks are `ethos`, `slip`, `cdc-ecm`, `ethernet` and `wifi`)
 endif
 
 # Set the SSID and password of your WiFi network here
@@ -43,7 +43,7 @@ USEMODULE += ps
 #USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 # When using a WiFi uplink we should use DHCPv6
-ifeq (wifi,$(UPLINK))
+ifneq (,$(filter wifi ethernet,$(UPLINK)))
   USE_DHCPV6 ?= 1
 else
   USE_DHCPV6 ?= 0

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -43,7 +43,7 @@ USEMODULE += ps
 #USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 # When using a WiFi uplink we should use DHCPv6
-ifneq (,$(filter wifi ethernet,$(UPLINK)))
+ifneq (,$(filter cdc-ecm wifi ethernet,$(UPLINK)))
   USE_DHCPV6 ?= 1
 else
   USE_DHCPV6 ?= 0


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Boards with an ethernet interface already have this as their `netdev_default` so we don't have to enable anything here.


### Testing procedure

`same54-xpro` with ATREB215-XPRO:

    USEMODULE=at86rf215 BOARD=same54-xpro UPLINK=ethernet make -C examples/gnrc_border_router flash

```
2021-03-21 17:49:24,354 # Iface  7  HWaddr: FC:C2:3D:0D:2D:1F 
2021-03-21 17:49:24,359 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2021-03-21 17:49:24,362 #           Source address length: 6
2021-03-21 17:49:24,364 #           Link type: wired
2021-03-21 17:49:24,370 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-03-21 17:49:24,377 #           inet6 addr: 2001:16b8:4531:2300:fec2:3dff:fe0d:2d1f  scope: global  VAL
2021-03-21 17:49:24,380 #           inet6 group: ff02::2
2021-03-21 17:49:24,383 #           inet6 group: ff02::1
2021-03-21 17:49:24,386 #           inet6 group: ff02::1:ff0d:2d1f
2021-03-21 17:49:24,387 #           
2021-03-21 17:49:24,394 # Iface  6  HWaddr: 6A:E4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2021-03-21 17:49:24,395 #           
2021-03-21 17:49:24,399 #           Long HWaddr: E6:EA:AF:F8:AF:5D:EA:E4 
2021-03-21 17:49:24,405 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2021-03-21 17:49:24,412 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2021-03-21 17:49:24,414 #           RTR_ADV  6LO  IPHC  
2021-03-21 17:49:24,417 #           Source address length: 8
2021-03-21 17:49:24,420 #           Link type: wireless
2021-03-21 17:49:24,426 #           inet6 addr: fe80::e4ea:aff8:af5d:eae4  scope: link  VAL
2021-03-21 17:49:24,429 #           inet6 group: ff02::2
2021-03-21 17:49:24,431 #           inet6 group: ff02::1
2021-03-21 17:49:24,435 #           inet6 group: ff02::1:ff5d:eae4
2021-03-21 17:49:24,436 #           
2021-03-21 17:49:24,442 # Iface  5  HWaddr: 6A:E5  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK 
2021-03-21 17:49:24,443 #           
2021-03-21 17:49:24,447 #           Long HWaddr: E6:EA:AF:F8:AF:5D:EA:E5 
2021-03-21 17:49:24,454 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2021-03-21 17:49:24,460 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2021-03-21 17:49:24,463 #           RTR_ADV  6LO  IPHC  
2021-03-21 17:49:24,466 #           Source address length: 8
2021-03-21 17:49:24,469 #           Link type: wireless
2021-03-21 17:49:24,474 #           inet6 addr: fe80::e4ea:aff8:af5d:eae5  scope: link  VAL
2021-03-21 17:49:24,482 #           inet6 addr: 2001:16b8:4531:23f4:e4ea:aff8:af5d:eae5  scope: global  VAL
2021-03-21 17:49:24,484 #           inet6 group: ff02::2
2021-03-21 17:49:24,487 #           inet6 group: ff02::1
2021-03-21 17:49:24,491 #           inet6 group: ff02::1:ff5d:eae5
```

On a second board running `examples/gnrc_networking`:

```
2021-03-21 17:53:02,220 # Iface  6  HWaddr: 0F:96  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK 
2021-03-21 17:53:02,220 #           
2021-03-21 17:53:02,226 #           Long HWaddr: FE:32:91:14:0C:AC:8F:96 
2021-03-21 17:53:02,232 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2021-03-21 17:53:02,238 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2021-03-21 17:53:02,241 #           RTR_ADV  6LO  IPHC  
2021-03-21 17:53:02,244 #           Source address length: 8
2021-03-21 17:53:02,247 #           Link type: wireless
2021-03-21 17:53:02,252 #           inet6 addr: fe80::fc32:9114:cac:8f96  scope: link  VAL
2021-03-21 17:53:02,260 #           inet6 addr: 2001:16b8:4531:23f4:fc32:9114:cac:8f96  scope: global  VAL
2021-03-21 17:53:02,263 #           inet6 group: ff02::2
2021-03-21 17:53:02,266 #           inet6 group: ff02::1
2021-03-21 17:53:02,269 #           inet6 group: ff02::1:ffac:8f96
2021-03-21 17:53:02,270 #           
2021-03-21 17:53:02,272 #           Statistics for Layer 2
2021-03-21 17:53:02,277 #             RX packets 750  bytes 78627
2021-03-21 17:53:02,283 #             TX packets 735 (Multicast: 730)  bytes 77059
2021-03-21 17:53:02,286 #             TX succeeded 733 errors 2
2021-03-21 17:53:02,289 #           Statistics for IPv6
2021-03-21 17:53:02,292 #             RX packets 168  bytes 65204
2021-03-21 17:53:02,297 #             TX packets 168 (Multicast: 163)  bytes 65124
2021-03-21 17:53:02,301 #             TX succeeded 168 errors 0
2021-03-21 17:53:02,301 # 
2021-03-21 17:53:08,094 #  ping 2600::
2021-03-21 17:53:08,237 # 12 bytes from 2600::: icmp_seq=0 ttl=48 rssi=-42 dBm time=136.132 ms
2021-03-21 17:53:09,236 # 12 bytes from 2600::: icmp_seq=1 ttl=48 rssi=-39 dBm time=135.700 ms
2021-03-21 17:53:10,237 # 12 bytes from 2600::: icmp_seq=2 ttl=48 rssi=-39 dBm time=135.686 ms
2021-03-21 17:53:10,237 # 
2021-03-21 17:53:10,240 # --- 2600:: PING statistics ---
2021-03-21 17:53:10,243 # 3 packets transmitted, 3 packets received, 0% packet loss
2021-03-21 17:53:10,249 # round-trip min/avg/max = 135.686/135.839/136.132 ms
```

Note that this required `DISABLE_MODULE += at86rf215_24ghz`, the board would not get a prefix with both interfaces online.
But this is an unrelated issue. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
