### PR TITLE
tests/driver_ccs811%: fix read return code check

### DIFF
--- a/tests/driver_ccs811/main.c
+++ b/tests/driver_ccs811/main.c
@@ -58,7 +58,7 @@ int main(void)
         }
 
         /* read the data and print them on success */
-        if (ccs811_read_iaq(&sensor, &tvoc, &eco2, 0, 0) != CCS811_OK) {
+        if (ccs811_read_iaq(&sensor, &tvoc, &eco2, 0, 0) == CCS811_OK) {
             printf("TVOC [ppb]: %d\neCO2 [ppm]: %d\n", tvoc, eco2);
             puts("+-------------------------------------+");
         }

--- a/tests/driver_ccs811_full/main.c
+++ b/tests/driver_ccs811_full/main.c
@@ -89,7 +89,7 @@ int main(void)
         msg_receive(&msg);
 
         /* read the data */
-        if (ccs811_read_iaq(&sensor, &tvoc, &eco2, 0, 0) != CCS811_OK) {
+        if (ccs811_read_iaq(&sensor, &tvoc, &eco2, 0, 0) == CCS811_OK) {
             /* print values */
             printf("TVOC [ppb]: %d\neCO2 [ppm]: %d\n", tvoc, eco2);
             puts("+-------------------------------------+");


### PR DESCRIPTION
### Contribution description

I was trying to run the test, but was puzzled why it was failing on reading when everything else seemed fine. Seems the error code check is wrong. This PR fixes it.

### Testing procedure

The test now works...

```
2021-03-21 20:41:33,607 # main(): This is RIOT! (Version: 2021.04-devel-1038-g488d7-riotfp-demo)
2021-03-21 20:41:33,609 # CCS811 test application
2021-03-21 20:41:33,610 #
2021-03-21 20:41:33,613 # +------------Initializing------------+
2021-03-21 20:41:33,821 #
2021-03-21 20:41:33,824 # +--------Starting Measurements--------+
2021-03-21 20:41:37,808 # TVOC [ppb]: 0
2021-03-21 20:41:37,809 # eCO2 [ppm]: 400
2021-03-21 20:41:37,813 # +-------------------------------------+
2021-03-21 20:41:38,803 # TVOC [ppb]: 0
2021-03-21 20:41:38,804 # eCO2 [ppm]: 400
2021-03-21 20:41:38,808 # +-------------------------------------
```

### Realted issues

 #10033, I suspect only SAUL was tested at that time.