### PR TITLE
riotboot: Build ARCHIVES

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -28,7 +28,7 @@ SLOT_RIOT_BINS = $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 # This results in the equivalent to "make flash-only" for
 # "make riotboot/flash-slot[01]".
 ifneq (1, $(RIOTBOOT_SKIP_COMPILE))
-$(BINDIR_APP)-%.elf: $(BASELIBS)
+$(BINDIR_APP)-%.elf: $(BASELIBS) $(ARCHIVES)
 	$(Q)$(_LINK) -o $@
 endif
 


### PR DESCRIPTION
### Contribution description

The build target for RIOTBOOT fails to depend on ${ARCHIVES}.

With this patch, like in /Makefile.include, it now pulls in ARCHIVES before ELFFILES.

### Testing procedure

How it fails:

* Build anything that uses ARCHIVES (in my case, Rust applications) with `FEATURES_REQUIRED+=riotboot make all riotboot/flash-slot0` and see how it fails with `arm-none-eabi-gcc: error: target/thumbv7em-none-eabihf/debug/libshell.a: No such file or directory`.
* Build without riotboot and see how it gets pulled in
* Build with riotboot and see everything just work

How it works:

* Apply patch and clear bin
* Works the first time