### PR TITLE
sys/shell/saul: Don't print from NULL

### DIFF
--- a/sys/shell/commands/sc_saul_reg.c
+++ b/sys/shell/commands/sc_saul_reg.c
@@ -26,6 +26,14 @@
 
 #include "saul_reg.h"
 
+static const char *_devname(saul_reg_t *dev) {
+    if (dev->name == NULL) {
+        return "(no name)";
+    } else {
+        return dev->name;
+    }
+}
+
 /* this function does not check, if the given device is valid */
 static void probe(int num, saul_reg_t *dev)
 {
@@ -38,7 +46,7 @@ static void probe(int num, saul_reg_t *dev)
         return;
     }
     /* print results */
-    printf("Reading from #%i (%s|%s)\n", num, dev->name,
+    printf("Reading from #%i (%s|%s)\n", num, _devname(dev),
            saul_class_to_str(dev->driver->type));
     phydat_dump(&res, dim);
 }
@@ -68,7 +76,7 @@ static void list(void)
     }
     while (dev) {
         printf("#%i\t%s\t%s\n",
-               i++, saul_class_to_str(dev->driver->type), dev->name);
+               i++, saul_class_to_str(dev->driver->type), _devname(dev));
         dev = dev->next;
     }
 }
@@ -120,7 +128,7 @@ static void write(int argc, char **argv)
         data.val[i] = atoi(argv[i + 3]);
     }
     /* print values before writing */
-    printf("Writing to device #%i - %s\n", num, dev->name);
+    printf("Writing to device #%i - %s\n", num, _devname(dev));
     phydat_dump(&data, dim);
     /* write values to device */
     dim = saul_reg_write(dev, &data);


### PR DESCRIPTION
### Contribution description

SAUL devices can legitimately be unnamed; catching all attempts to read
their names with a generic "(no name)" name.

### Testing procedure

* Create a SAUL device with a NULL name (whichever board you have, run the saul example and search where the available device's name comes from).
* Replace that with NULL
* Run the saul example, observe the memory dump produced by any `saul` command on that device.

(Some libc may catch this; the ones used with both LLVM and GCC by default with my particle-xenon does not)

* After applying the patch, try again: it prints (no name) there.