### PR TITLE
cpu/stm32/periph_ptp: bugfix & better debug output

### DIFF
--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -71,9 +71,9 @@ void isr_eth(void)
 
     if (IS_USED(MODULE_PERIPH_PTP_TIMER)) {
         if (ETH->MACSR & ETH_MACSR_TSTS) {
-            ptp_timer_cb();
             /* clear interrupt by reading PTPTSSR */
             (void)ETH->PTPTSSR;
+            ptp_timer_cb();
         }
     }
 

--- a/cpu/stm32/periph/ptp.c
+++ b/cpu/stm32/periph/ptp.c
@@ -29,7 +29,8 @@
 #include "periph_cpu.h"
 #include "timex.h"
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG    0
+#define DEBUG_VERBOSE   0
 #include "debug.h"
 
 /* Workaround for typos in vendor files; drop when fixed upstream */
@@ -198,7 +199,7 @@ void ptp_timer_clear(void)
 void ptp_timer_set_absolute(const ptp_timestamp_t *target)
 {
     assert(target);
-    DEBUG("[periph_ptp] Set timer: %" PRIu32 ".%" PRIu32 "\n",
+    DEBUG("[periph_ptp] Set timer: %" PRIu32 ".%09" PRIu32 "\n",
           (uint32_t)target->seconds, target->nanoseconds);
     unsigned state = irq_disable();
     /* Mask PTP timer IRQ first, so that an interrupt is not triggered
@@ -212,7 +213,9 @@ void ptp_timer_set_absolute(const ptp_timestamp_t *target)
     /* Unmask the time stamp trigger interrupt */
     ETH->MACIMR &= ~ETH_MACIMR_TSTIM;
     irq_restore(state);
-    DEBUG("PTPTSCR: 0x%08x, MACIMR: 0x%08x, MACSR: 0x%08x\n",
-          (unsigned)ETH->PTPTSCR, (unsigned)ETH->MACIMR, (unsigned)ETH->MACSR);
+    if (IS_ACTIVE(DEBUG_VERBOSE)) {
+        DEBUG("PTPTSCR: 0x%08x, MACIMR: 0x%08x, MACSR: 0x%08x\n",
+              (unsigned)ETH->PTPTSCR, (unsigned)ETH->MACIMR, (unsigned)ETH->MACSR);
+    }
 }
 #endif /* IS_USED(MODULE_PTP_TIMER) */


### PR DESCRIPTION
### Contribution description

- Clear the PTP timer interrupt *after* the user callback is executed
    - Otherwise it would be possible that the ISR sets another super
      short timeout that triggers during ISR, which also gets cleared
    - This is a pretty nasty race condition :-/
- The debug output was a bit too verbose to be generally useful. Some
  noise is now silenced unless `DEBUG_VERBOSE` is `#define`d to 1

### Testing procedure

Should be simple enough to go in by code review only. But one could use https://github.com/RIOT-OS/RIOT/pull/15960#pullrequestreview-619074700 which triggers the race condition for me without the fix.

### Issues/PRs references

Found while testing https://github.com/RIOT-OS/RIOT/pull/15960