### PR TITLE
tests/dac_dds: Fix sine wave to fit in PCM range

### DIFF
--- a/tests/driver_dac_dds/main.c
+++ b/tests/driver_dac_dds/main.c
@@ -127,6 +127,7 @@ static void _fill_sine_samples_8(uint8_t *buf, size_t len, uint16_t period)
     for (uint16_t i = 0; i < period; ++i) {
         x += step;
         buf[i] = isin(x) >> 5;
+        buf[i] += INT8_MAX + 1;
     }
 
     for (uint16_t i = period; i < len; i += period) {
@@ -145,6 +146,7 @@ static void _fill_sine_samples_16(uint8_t *buf, size_t len, uint16_t period)
         x += step;
 
         uint16_t y = isin(x);
+        y += INT16_MAX + 1;
         buf[i]   = y;
         buf[++i] = y >> 8;
     }


### PR DESCRIPTION
### Contribution description

The previous sine wave cast signed integers into the PCM range, causing
jumps at zero transitions. This shifts everything up by the respective
maximum signed integer, so that the signed idle zero becomes the
unsigned PCM signal's idle half-point and can continuously cover the
whole unsigned range.

(I could be completely wrong and this is all just an artifact of how I convert in the PWM-DAC of #15618 -- but I don't think so because if I flip the bit there, the do sound better but the PCM recording is garbled. Thus, I came to conclude that the intended buffer semantics are the PCM ones of 0=minimum, 255=maximum and 128=DC-free idle).

### Testing procedure

Acoustic test: the sound produced by sine should have fewer overtones; it is quieter over-all (as it only has energy in one frequency rather than jumping frantically).