### PR TITLE
devfs: Split devfs-random into two files using submodules

### DIFF
--- a/sys/fs/devfs/Makefile
+++ b/sys/fs/devfs/Makefile
@@ -1,2 +1,4 @@
 MODULE=devfs
+SRC = devfs.c auto_init_devfs.c
+SUBMODULES = 1
 include $(RIOTBASE)/Makefile.base

--- a/sys/fs/devfs/hwrng.c
+++ b/sys/fs/devfs/hwrng.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_fs_devfs
+ * @{
+ *
+ * @file
+ * @brief       Random backends for devfs implementation
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include "vfs.h"
+
+#include "periph/hwrng.h"
+
+static ssize_t hwrng_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
+
+const vfs_file_ops_t hwrng_vfs_ops = {
+    .read  = hwrng_vfs_read,
+};
+
+static ssize_t hwrng_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
+{
+    (void)filp;
+
+    hwrng_read(dest, nbytes);
+
+    return nbytes;
+}

--- a/sys/fs/devfs/random.c
+++ b/sys/fs/devfs/random.c
@@ -20,29 +20,6 @@
  */
 
 #include "vfs.h"
-
-#ifdef MODULE_DEVFS_HWRNG
-
-#include "periph/hwrng.h"
-
-static ssize_t hwrng_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
-
-const vfs_file_ops_t hwrng_vfs_ops = {
-    .read  = hwrng_vfs_read,
-};
-
-static ssize_t hwrng_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
-{
-    (void)filp;
-
-    hwrng_read(dest, nbytes);
-
-    return nbytes;
-}
-#endif /* MODULE_PERIPH_HWRNG */
-
-#ifdef MODULE_DEVFS_RANDOM
-
 #include "random.h"
 
 static ssize_t random_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
@@ -58,4 +35,3 @@ static ssize_t random_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
 
     return nbytes;
 }
-#endif /* MODULE_RANDOM */


### PR DESCRIPTION
### Contribution description

`devfs-random` and `devfs-hwrng` are already declared as pseudo modules so it makes little sense to have one file which contains two conditionally compiled implementations.


### Testing procedure

- Check that devfs random works both with and without hwrng present


### Issues/PRs references

None