### PR TITLE
sys/net/dhcpv6: Add IA_NA support to the DHCPv6 client

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -26,6 +26,7 @@ PSEUDOMODULES += devfs_%
 PSEUDOMODULES += dhcpv6_%
 PSEUDOMODULES += dhcpv6_client_dns
 PSEUDOMODULES += dhcpv6_client_ia_pd
+PSEUDOMODULES += dhcpv6_client_ia_na
 PSEUDOMODULES += dhcpv6_client_mud_url
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += event_%

--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -61,6 +61,9 @@ extern "C" {
  */
 #define DHCPV6_OPT_CID              (1U)    /**< client identifier option */
 #define DHCPV6_OPT_SID              (2U)    /**< server identifier option */
+#define DHCPV6_OPT_IA_NA            (3U)    /**< identity association for
+                                                 non-temporary addresses option */
+#define DHCPV6_OPT_IAADDR           (5U)    /**< IA address option */
 #define DHCPV6_OPT_ORO              (6U)    /**< option request option */
 #define DHCPV6_OPT_PREF             (7U)    /**< preference option */
 #define DHCPV6_OPT_ELAPSED_TIME     (8U)    /**< elapsed time option */

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -22,6 +22,7 @@
 
 #include <kernel_defines.h>
 
+#include "net/dhcpv6/client.h"
 #include "net/ieee802154.h"
 #include "net/ethernet/hdr.h"
 #include "net/gnrc/ipv6/nib/conf.h"
@@ -108,10 +109,12 @@ extern "C" {
  *          @ref GNRC_NETIF_IPV6_GROUPS_NUMOF is also large enough to fit the
  *          addresses' solicited nodes multicast addresses.
  *
- * Default: 2 (1 link-local + 1 global address)
+ * Default: 2 (1 link-local + 1 global address) + any additional address via
+ * configuration protocol (e.g. DHCPv6 leases).
  */
 #ifndef CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF
-#define CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF    (2)
+#define CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF    (2 + \
+                                               DHCPV6_CLIENT_ADDRS_NUMOF)
 #endif
 
 /**

--- a/sys/net/application_layer/dhcpv6/Kconfig
+++ b/sys/net/application_layer/dhcpv6/Kconfig
@@ -12,6 +12,10 @@ menuconfig KCONFIG_USEMODULE_DHCPV6
 
 if KCONFIG_USEMODULE_DHCPV6
 
+config DHCPV6_CLIENT_ADDR_LEASE_MAX
+    int "Maximum number of leases to be stored"
+    default 1
+
 config DHCPV6_CLIENT_PFX_LEASE_MAX
     int "Maximum number of prefix leases to be stored"
     default 1

--- a/sys/net/application_layer/dhcpv6/_dhcpv6.h
+++ b/sys/net/application_layer/dhcpv6/_dhcpv6.h
@@ -124,6 +124,35 @@ typedef struct __attribute__((packed)) {
 } dhcpv6_opt_duid_t;
 
 /**
+ * @brief   DHCPv6 identity association for non-temporary addresses (IA_NA) option
+ *          format
+ * @see [RFC 8415, section 21.4]
+ *      (https://tools.ietf.org/html/rfc8415#section-21.4)
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t type;          /**< @ref DHCPV6_OPT_IA_NA */
+    network_uint16_t len;           /**< 12 + length of dhcpv6_opt_ia_na_t::opts in byte */
+    network_uint32_t ia_id;         /**< Unique ID for this IA_NA */
+    network_uint32_t t1;            /**< DHCPv6 T1 time (in sec) */
+    network_uint32_t t2;            /**< DHCPv6 T2 time (in sec) */
+    uint8_t opts[];                 /**< IA_NA options */
+} dhcpv6_opt_ia_na_t;
+
+/**
+ * @brief   DHCPv6 IA address option format
+ * @see [RFC 8415, section 21.6]
+ *      (https://tools.ietf.org/html/rfc8415#section-21.6)
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t type;          /**< @ref DHCPV6_OPT_IAADDR */
+    network_uint16_t len;           /**< 25 + length of dhcpv6_opt_iapfx_t::opts in byte */
+    ipv6_addr_t addr;                /**< the address */
+    network_uint32_t pref;          /**< preferred lifetime (in sec) */
+    network_uint32_t valid;         /**< valid lifetime (in sec) */
+    uint8_t opts[];                 /**< IAprefix options */
+} dhcpv6_opt_iaaddr_t;
+
+/**
  * @brief   DHCPv6 option request option format
  * @see [RFC 8415, section 21.7]
  *      (https://tools.ietf.org/html/rfc8415#section-21.7)

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -89,6 +89,43 @@ void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
     }
 }
 
+bool dhcpv6_client_check_ia_na(unsigned iface)
+{
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+
+    return netif->ipv6.aac_mode & GNRC_NETIF_AAC_DHCP;
+}
+
+int dhcpv6_client_add_addr(unsigned iface, ipv6_addr_t *addr)
+{
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+
+    DEBUG("DHCPv6 client: ADD IP ADDRESS\n");
+
+    return gnrc_netif_ipv6_addr_add(netif, addr, 64, 0);
+}
+
+void dhcpv6_client_deprecate_addr(unsigned iface, const ipv6_addr_t *addr)
+{
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+    int i;
+
+    gnrc_netif_acquire(netif);
+    i = gnrc_netif_ipv6_addr_idx(netif, addr);
+    if (i >= 0) {
+        netif->ipv6.addrs_flags[i] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
+        netif->ipv6.addrs_flags[i] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_DEPRECATED;
+    }
+    gnrc_netif_release(netif);
+}
+
+void dhcpv6_client_remove_addr(unsigned iface, ipv6_addr_t *addr)
+{
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+
+    gnrc_netif_ipv6_addr_remove(netif, addr);
+}
+
 uint32_t dhcpv6_client_prefix_valid_until(unsigned netif,
                                           const ipv6_addr_t *pfx,
                                           unsigned pfx_len)

--- a/sys/net/gnrc/netif/Kconfig
+++ b/sys/net/gnrc/netif/Kconfig
@@ -22,6 +22,7 @@ config GNRC_NETIF_MSG_QUEUE_SIZE_EXP
 
 config GNRC_NETIF_IPV6_ADDRS_NUMOF
     int "Maximum number of unicast and anycast addresses per interface"
+    default 3 if DHCPV6_CLIENT_ADDR_LEASE_MAX != 0
     default 2
     help
         If you change this, please make sure that

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -162,10 +162,15 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
         /* Cannot use target address as personal address and can
          * not change hardware address to retry SLAAC => use purely
          * DHCPv6 instead */
-        /* TODO: implement IA_NA for DHCPv6 */
-        /* then => tgt_netif->aac_mode |= GNRC_NETIF_AAC_DHCP; */
-        DEBUG("nib: would set interface %i to DHCPv6, "
-              "but is not implemented yet", netif->pid);
+        if (IS_USED(MODULE_DHCPV6_CLIENT_IA_NA)) {
+            netif->ipv6.aac_mode &= ~GNRC_NETIF_AAC_AUTO;
+            netif->ipv6.aac_mode |= GNRC_NETIF_AAC_DHCP;
+            dhcpv6_client_req_ia_na(netif->pid);
+        }
+        else {
+            DEBUG("nib: would set interface %i to DHCPv6, "
+                  "but DHCPv6 is not provided", netif->pid);
+        }
     }
 }
 

--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -9,6 +9,7 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker ruuvitag thingy52
 
 USEMODULE += dhcpv6_client_ia_pd
+USEMODULE += dhcpv6_client_ia_na
 USEMODULE += gnrc_dhcpv6_client
 USEMODULE += gnrc_ipv6_default
 USEMODULE += xtimer

--- a/tests/gnrc_dhcpv6_client/kea-dhcp6.conf
+++ b/tests/gnrc_dhcpv6_client/kea-dhcp6.conf
@@ -22,8 +22,9 @@
     "subnet6": [
     {    "interface": "tapbr0",
          "subnet": "2001:db8::/32",
-         "pd-pools": [ { "prefix": "2001:db8::",
-                         "prefix-len": 32,
+         "pools": [ { "pool": "2001:db8:1::/64" } ],
+         "pd-pools": [ { "prefix": "2001:db8:8000::",
+                         "prefix-len": 33,
                          "delegated-len": 64 } ] }
     ]
   },

--- a/tests/gnrc_dhcpv6_client/main.c
+++ b/tests/gnrc_dhcpv6_client/main.c
@@ -37,6 +37,8 @@ void *_dhcpv6_client_thread(void *args)
     (void)args;
     /* initialize client event queue */
     event_queue_init(&event_queue);
+    /* Configure client to use DHCPv6 IA_NA */
+    netif->ipv6.aac_mode |= GNRC_NETIF_AAC_DHCP;
     /* initialize DHCPv6 client on any interface */
     dhcpv6_client_init(&event_queue, SOCK_ADDR_ANY_NETIF);
     /* configure client to request prefix delegation of /64 subnet

--- a/tests/gnrc_dhcpv6_client/tests-as-root/01-run.py
+++ b/tests/gnrc_dhcpv6_client/tests-as-root/01-run.py
@@ -8,6 +8,13 @@
 
 import sys
 from testrunner import run
+from ipaddress import (
+    IPv6Address,
+    IPv6Network,
+)
+
+
+IA_NA_ADDRESS_POOL_PREFIX = "2001:db8:1::"
 
 
 def testfunc(child):
@@ -15,17 +22,64 @@ def testfunc(child):
     child.expect(r"inet6 addr:\sfe80:[0-9a-f:]+\s+scope: link")
     child.expect(r"Iface\s+\d+")
     child.expect(r"inet6 addr:\s+fe80:[0-9a-f:]+\s+scope: link")
-    child.expect(r"inet6 addr:\s+(?P<global_addr>[0-9a-f:]+)\s+scope: global")
-    global_addr = child.match.group("global_addr")
+
+    global_addr_1, global_addr_2 = extract_global_addresses(child)
+
+    global_pfx = extract_global_prefix(child)
+
+    test_global_addrs(global_addr_1, global_addr_2, global_pfx)
+
+
+def extract_global_prefix(child):
     child.expect(r"(?P<global_pfx>[0-9a-f:]+)/64\s+dev #\d\s+"
                  r"expires \d+ sec\s+"
                  r"deprecates \d+ sec")
     global_pfx = child.match.group("global_pfx")
+
     if global_pfx.endswith("::"):
         # remove one trailing : in case there are no 0s between prefix and
         # suffix
         global_pfx = global_pfx[0:-1]
-    assert global_addr.startswith(global_pfx)
+
+    return global_pfx
+
+
+def extract_global_address(child):
+    """Expect and extract a global address from the command line."""
+    child.expect(r"inet6 addr:\s+(?P<global_addr>[0-9a-f:]+)\s+scope: global")
+    return child.match.group("global_addr")
+
+
+def extract_global_addresses(child):
+    """Extract two global addresses and return them as a tuple."""
+    return extract_global_address(child), extract_global_address(child)
+
+
+def check_ia_na_addr(ia_na_addr):
+    """Check if the expected IA_NA address has been assigned"""
+    return IPv6Address(ia_na_addr) in IPv6Network("{}/64".format(IA_NA_ADDRESS_POOL_PREFIX))
+
+
+def check_ia_pd_addr(ia_pd_addr, global_pfx):
+    """Check if the expected IA_PD address has been assigned"""
+    return ia_pd_addr.startswith(global_pfx)
+
+
+def check_global_addrs(ia_na_addr, ia_pd_addr, global_pfx):
+    """Perform IA_NA check for the first and IA_PD for the second address"""
+    return {
+        "ia_na_check": check_ia_na_addr(ia_na_addr),
+        "ia_pd_check": check_ia_pd_addr(ia_pd_addr, global_pfx),
+    }
+
+
+def test_global_addrs(global_addr_1, global_addr_2, global_pfx):
+    """Assert that one global address is the IA_NA and the other one is the IA_PD address"""
+    result_1 = check_global_addrs(global_addr_1, global_addr_2, global_pfx)
+    result_2 = check_global_addrs(global_addr_2, global_addr_1, global_pfx)
+    assert result_1 != result_2
+    assert result_1["ia_na_check"] != result_2["ia_na_check"]
+    assert result_1["ia_pd_check"] != result_2["ia_pd_check"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds identity association for non-temporary addresses (IA_NA) to the DHCPv6  client and makes it possible to use the `auto_init_dhcpv6_client` module for auto configuring it.

While requesting a non-temporary address already works (see below), the implementation is probably not finished yet as I wasn't entirely sure how to correctly add the obtained address to the respective net interface and where to remove them if their lifetime passes. There also some other aspects which I wasn't quite sure about (the relevant lines on `IA_NA` in `_nib-slaac.c` for example) and code passages that probably need refactoring.

I would be very grateful to receive some feedback on this and hope that this PR is not too far away from a mergeable state.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
 
You can use the provided test under `tests/gnrc_dhcpv6_client_auto_init` to test the correct assignment of a non-temporary IPv6 address. You can run it by first using `make all` and then `sudo make test-as-root`. 

For the test procedure, the existing test under `tests/gnrc_dhcpv6_client_6lbr` was adapted, which uses the Python library `scapy`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
