### PR TITLE
pkg/lwip: Start DHCP early for all Ethernet interfaces

### DIFF
--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -17,9 +17,6 @@
 #include <sys/uio.h>
 #include <inttypes.h>
 
-#if MODULE_LWIP_DHCP_AUTO
-#include "lwip/dhcp.h"
-#endif
 #include "lwip/err.h"
 #include "lwip/ethip6.h"
 #include "lwip/netif.h"
@@ -297,10 +294,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                 break;
             }
             case NETDEV_EVENT_LINK_UP: {
+                /* Will wake up DHCP state machine */
                 netifapi_netif_set_link_up(netif);
-#ifdef MODULE_LWIP_DHCP_AUTO
-                netifapi_dhcp_start(netif);
-#endif
                 break;
             }
             case NETDEV_EVENT_LINK_DOWN: {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Change the special case hack for native tap interfaces into a general start
of DHCP for all Ethernet interfaces. 

Netifs without link status support will keep sending discover
messages with increasing time between.
    
Netifs that support link status will wait for the link to be up,
and then start sending.
    
Netifs that support link status but send no link status events
will continue to not work (unless link status is up from the
first check when setting it up).



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Test for native board in `tests/lwip` still passes (in dualstack & v6 only)

Boards without link status support will now have DHCP starting properly (there can be a delay from inserting cable until DHCP sends next discover message).

Boards with link status event support will send DHCP discover right away after link comes up.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Depends on and includes #16082 

Removes hack from #14150 