### PR TITLE
.github/workflows: add riot-ryot.yml

### DIFF
--- a/.github/workflows/test-on-ryot.yml
+++ b/.github/workflows/test-on-ryot.yml
@@ -1,0 +1,105 @@
+---
+# Run 'compile_and_test_for_board.py' on connected boards.
+#
+# This workflow will run on a RYOT (Run Your Own Test) machine and launch
+# all tests on all boards currently connected to that machine. This
+# workflow relies on self-hosted runners, this means building and
+# flashing happens on the self-hosted runner (all in docker). An alternative
+# approach was used in https://github.com/RIOT-OS/RIOT/pull/14600, where
+# the RYOT machine was only used for remote flashing, this is a better
+# alternative if ssh access is possible.
+#
+# Documentation:
+#
+# * Setup a RYOT machine:
+#   https://github.com/fjmolinas/riot-ryot/blob/master/setup.md
+#
+# * Requirements (already filled by a RYOT machine):
+#   * Add one or more self-hosted runners:
+#     https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners
+#   * All required flashing tools installed
+#   * udev rules that map all BOARD to /dev/riot/tty-$(BOARD), see
+#     http://riot-os.org/api/advanced-build-system-tricks.html#multiple-boards-udev
+#   * RIOT_MAKEFILES_GLOBAL_PRE that sets PORT and DEBUG_ADAPTER_ID for each
+#     BOARD
+#   * A list of connected BOARDs in JSON format so that fromJSON can be used
+#     to dynamically setup the matrix, e.g. make target providing this:
+#     https://github.com/fjmolinas/riot-ryot/blob/72fc9ad710a2219e942c5965a014e934822e9da5/template/conf/makefiles.pre#L19-L24
+# * RYOT: https://github.com/fjmolinas/riot-ryot
+
+name: test-on-ryot
+
+on:
+  # Schedule weekly runs Saturday at 00:00 on master
+  schedule:
+    - cron: '0 0 * * 6'
+  push:
+    # Run on all new release candidates
+    tags:
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9]-RC[0-9]*'
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9]'
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].*'
+env:
+  # self-hosted runners are started by a systemd which is not a "login" shell
+  # this means that no local environment variables are loaded (e.g. /etc/environment)
+  # when the runner is started. So explicitly set RIOT_MAKEFILES_GLOBAL_PRE
+  # to set PORT and DEBUG_ADAPTER_ID per BOARD
+  RIOT_MAKEFILES_GLOBAL_PRE: '/builds/conf/makefiles.pre'
+
+jobs:
+  connected_boards:
+    name: Get Connected Boards
+    runs-on: self-hosted
+    outputs:
+      boards: ${{ steps.ci-connected-boards.outputs.boards }}
+    steps:
+      # Get all currently connected boards if not passed through an input
+      - id: ci-connected-boards
+        run: echo "::set-output name=boards::$(make -C /builds/boards/ list-boards-json --no-print-directory)"
+
+  # Runs all tests on connected boards
+  compile_and_test_for_board:
+    name: ${{ matrix.board }}
+    runs-on: self-hosted
+    needs: connected_boards
+    # ci-riot-tribe has 8 cores, parallelism will depend on actually configured
+    # runners
+    strategy:
+      max-parallel: 7
+      fail-fast: false
+      matrix:
+        board: ${{ fromJson(needs.connected_boards.outputs.boards) }}
+    env:
+      BUILD_IN_DOCKER: 1
+      COMPILE_AND_TEST_FOR_BOARD: /builds/boards/RIOT/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+      # args for compile_and_test_for_board script
+      COMPILE_AND_TEST_ARGS: --with-test-only --report-xml --incremental
+      # environment vars for compile_and_test_for_board script to pass
+      # USEMODULE and CFLAGS use:
+      #    DOCKER_ENVIRONMENT_CMDLINE=\'-e USEMODULE=<name>\'
+      #    DOCKER_ENVIRONMENT_CMDLINE=\'-e CFLAGS=-D<flag>\'
+      COMPILE_AND_TEST_VARS: ''
+      APPLICATIONS: ''
+      # Exclude 'tests/periph_timer_short_relative_set' since its expected
+      # to fail on most BOARDs
+      APPLICATIONS_EXCLUDE: 'tests/periph_timer_short_relative_set'
+    steps:
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.riot_version }}
+          # Make sure it runs git clean -xdff before fetching
+          clean: true
+      - name: Run compile_and_test_for_board.py
+        run: |
+          ${COMPILE_AND_TEST_VARS} ${COMPILE_AND_TEST_FOR_BOARD} . \
+            ${{ matrix.board }} results-${{ matrix.board }} \
+            ${COMPILE_AND_TEST_ARGS} \
+            --applications="${APPLICATIONS}" \
+            --applications-exclude="${APPLICATIONS_EXCLUDE}"
+      - name: Archive results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.board }}
+          path: results-${{ matrix.board }}


### PR DESCRIPTION
### Contribution description

This PR adds a github action workflow that launch `compile_and_test_for_board` on all boards currently connected to a [RYOT](https://github.com/fjmolinas/riot-ryot) machine.

For each board compile_and_test script starts. And the end result are archived.

For each board, jobs are run in parallel, I limited it at 7 for this particular configuration (since I have 7 cores), it takes quite some time to run all tests since about 30 boards are connected, the time to execute each test varies depending on the supported applications.

Since it takes a lot of time to complete, it's not ~possible~ acceptable to perform this check on PR basis, so the action is configured to be run on a weekly basis on master and for each RC tag pushed. I have a [similar version](https://github.com/fjmolinas/RIOT/blob/49ef69c96dca4a186269ac05704605220d2b8ae1/.github/workflows/riot-ryot.yml) with a workflow_dispatch on my branch. I rather keep it that way for now since I would want to keep control over when tests I are run since I uses those BOARD's for my day to day work, having tests ran over the weekend over releases is fine, otherwise I would rather know before hand. Otherwise I would be OK with adding a dispatch but if it only runs if some people set it, e.g. the ci group.

This could be extended to many more machine individually hosting many boards, different maintainers could contribute a different set of boards. Since tests are not ran on a fix set of boards, they can be plugged/unplugged when needed by that maintainer. Checkout the [RYOT repo](https://github.com/fjmolinas/riot-ryot) for more information.

This could definitively have been done with Murdock as well, but here I had already done most of the work already in #14600, I can look into a Murdock version further down the line when I have more time, but this at least gives the tests results more visibility, which they did not have when ran through jenkins. FYI by default my machine always builds in docker, toolchains are not even installed.

What I would need to add this to `RIOT-OS/RIOT` is a token for adding self hosted runners, then I can do the rest.

Note that compared to IoT-LAB since BOARDs are never power cycled but it also always builds in Docker. It has the advantage that with `scapy-on-root` a lot of `test-with-config` could be ran as well.

### Testing procedure

See [here](https://github.com/fjmolinas/RIOT/runs/2187173113?check_suite_focus=true) to see what it looks like, I'm running it on my ryot machine which has around 30 boards connected to. Otherwise, no other way to test than merging and seeing it work.

### Issues/PRs references

Runners based alternative to #14600