### PR TITLE
tests/malloc_thread_safety: improve test

### DIFF
--- a/tests/malloc_thread_safety/Makefile
+++ b/tests/malloc_thread_safety/Makefile
@@ -1,5 +1,9 @@
 include ../Makefile.tests_common
 
+PICOLIBC ?= 0
+ifneq (0,$(PICOLIBC))
+  FEATURES_REQUIRED += picolibc
+endif
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

- fix false test failure on picolibc
    - For picolibc, the result of mallinfo().uordblks doesn't go back
      to zero after the first allocation. By adding `free(malloc(4))`
      before recording the pre-test mallinfo() value, this issues is
      worked arround
- increase test coverage to also cover realloc()
- ease testing with picolibc by allowing `make PICOLIBC=1 flash test`

### Testing procedure

Test application should still pass. After applzing

```diff
diff --git a/cpu/cortexm_common/Makefile.dep b/cpu/cortexm_common/Makefile.dep
index 856befb6c1..309d8c9a9a 100644
--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -25,4 +25,4 @@ ifeq (1, $(DEVELHELP))
 endif
 
 # Make calls to malloc and friends thread-safe
-USEMODULE += malloc_thread_safe
+#USEMODULE += malloc_thread_safe
```

the test should crash.

### Issues/PRs references

Came up in https://github.com/RIOT-OS/RIOT/pull/15999