### PR TITLE
drivers/cc110x: add power off (sleep) functions

### DIFF
--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -248,17 +248,11 @@ static int cc110x_init(netdev_t *netdev)
     /* Make sure the crystal is stable and the chip ready. This is needed as
      * the reset is done via an SPI command, but the SPI interface must not be
      * used unless the chip is ready according to the data sheet. After the
-     * reset, a second call to cc110x_power_on() is needed to finally have
+     * reset, a second call to cc110x_power_on_and_acquire() is needed to finally have
      * the transceiver in a known state and ready for SPI communication.
      */
-    if (cc110x_power_on(dev)) {
+    if (cc110x_power_on_and_acquire(dev)) {
         DEBUG("[cc110x] netdev_driver_t::init(): Failed to pull CS pin low\n");
-        return -EIO;
-    }
-
-    if (cc110x_acquire(dev) != SPI_OK) {
-        DEBUG("[cc110x] netdev_driver_t::init(): Failed to setup/acquire SPI "
-              "interface\n");
         return -EIO;
     }
 
@@ -267,15 +261,9 @@ static int cc110x_init(netdev_t *netdev)
     cc110x_release(dev);
 
     /* Again, make sure the crystal is stable and the chip ready */
-    if (cc110x_power_on(dev)) {
+    if (cc110x_power_on_and_acquire(dev)) {
         DEBUG("[cc110x] netdev_driver_t::init(): Failed to pull CS pin low "
               "after reset\n");
-        return -EIO;
-    }
-
-    if (cc110x_acquire(dev) != SPI_OK) {
-        DEBUG("[cc110x] netdev_driver_t::init(): Failed to setup/acquire SPI "
-              "interface after reset\n");
         return -EIO;
     }
 
@@ -417,20 +405,23 @@ static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
     }
 
     switch (dev->state) {
-        case CC110X_STATE_FSTXON:
-            /* falls through */
-        case CC110X_STATE_RX_MODE:
-            break;
-        case CC110X_STATE_RECEIVING:
-            cc110x_release(dev);
-            DEBUG("[cc110x] netdev_driver_t::send(): Refusing to send while "
-                  "receiving a frame\n");
-            return -EBUSY;
-        default:
-            cc110x_release(dev);
-            DEBUG("[cc110x] netdev_driver_t::send(): Driver state %i prevents "
-                  "sending\n", (int)dev->state);
-            return -1;
+    case CC110X_STATE_FSTXON:
+        /* falls through */
+    case CC110X_STATE_RX_MODE:
+        break;
+    case CC110X_STATE_RECEIVING:
+        cc110x_release(dev);
+        DEBUG("[cc110x] netdev_driver_t::send(): Refusing to send while "
+              "receiving a frame\n");
+        return -EBUSY;
+    case CC110X_STATE_OFF:
+        cc110x_release(dev);
+        return -ENOTSUP;
+    default:
+        cc110x_release(dev);
+        DEBUG("[cc110x] netdev_driver_t::send(): Driver state %i prevents "
+              "sending\n", (int)dev->state);
+        return -1;
     }
 
     /* Copy data to send into frame buffer */

--- a/drivers/cc110x/include/cc110x_communication.h
+++ b/drivers/cc110x/include/cc110x_communication.h
@@ -35,8 +35,9 @@ extern "C" {
  * @retval  SPI_NOMODE  SPI mode 0 not supported by MCU
  * @retval  SPI_NOCLK   SPI clock given in @ref cc110x_params_t is not supported
  *
- * @pre     @ref cc110x_power_on has be called before calling this function.
- *          (Only needed *once* when the driver initializes.)
+ * @pre     When first acquiring the device either after boot or after having put
+ *          the device to sleep mode, use @ref cc110x_power_on_and_acquire
+ *          instead. Subsequently, this function should be used (it is faster).
  */
 static inline int cc110x_acquire(cc110x_t *dev)
 {
@@ -200,10 +201,13 @@ uint8_t cc110x_status(cc110x_t *dev);
  * of messing with the SPI interface, this driver simply waits for this upper
  * bound, as suggested in the note below Table 22 on page 30 in the data sheet.
  *
+ * @pre     The device was not acquired and in low power mode
+ * @post    The device is in IDLE mode and acquired
+ *
  * @retval  0       Success
  * @retval  -EIO    Couldn't pull the CS pin down (@ref cc110x_params_t::cs)
  */
-int cc110x_power_on(cc110x_t *dev);
+int cc110x_power_on_and_acquire(cc110x_t *dev);
 
 
 #ifdef __cplusplus

--- a/drivers/cc110x/include/cc110x_communication.h
+++ b/drivers/cc110x/include/cc110x_communication.h
@@ -209,7 +209,6 @@ uint8_t cc110x_status(cc110x_t *dev);
  */
 int cc110x_power_on_and_acquire(cc110x_t *dev);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/cc110x/include/cc110x_constants.h
+++ b/drivers/cc110x/include/cc110x_constants.h
@@ -570,6 +570,11 @@ extern "C" {
 #define CC110X_PKTCTRL1_GET_ADDR_MODE   0x03
 /** @} */
 
+/**
+ * @brief   Time in micro seconds the CC110X takes to wake up from SLEEP state
+ */
+#define CC110X_WAKEUP_TIME_US           150
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -241,7 +241,8 @@ extern "C" {
 #endif
 
 /**
- * @defgroup drivers_cc110x_config CC1100/CC1100e/CC1101 Sub-GHz transceiver driver compile configuration
+ * @defgroup drivers_cc110x_config CC1100/CC1100e/CC1101 Sub-GHz transceiver driver
+ *                                 compile time configuration
  * @ingroup config_drivers_netdev
  * @{
  */
@@ -329,7 +330,6 @@ typedef enum {
 typedef struct {
     uint8_t data[8]; /**< Magic number to store in the configuration register */
 } cc110x_patable_t;
-
 
 /**
  * @brief   Configuration of the transceiver to use

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -269,7 +269,7 @@ typedef enum {
      */
     CC110X_STATE_FRAME_READY        = 0x08,
     /**
-     * @brief   Frame received, waiting for upper layer to retrieve it
+     * @brief   Devices is powered down
      *
      * Transceiver is in SLEEP state. There is no matching representation in the
      * status byte, as reading the status byte will power up the transceiver in
@@ -643,6 +643,21 @@ int cc110x_set_channel(cc110x_t *dev, uint8_t channel);
  * @retval  -EIO    Communication with the transceiver failed
  */
 int cc110x_set_tx_power(cc110x_t *dev, cc110x_tx_power_t power);
+
+/**
+ * @brief   Wakes the transceiver from SLEEP mode and enters RX mode
+ *
+ * @retval  0       Success
+ * @retval  -EIO    Communication with the transceiver failed
+ */
+int cc110x_wakeup(cc110x_t *dev);
+
+/**
+ * @brief   Sets the transceiver into SLEEP mode.
+ *
+ * Only @ref cc110x_wakeup can awake the device again.
+ */
+void cc110x_sleep(cc110x_t *dev);
 
 #ifdef __cplusplus
 }

--- a/tests/driver_cc110x/main.c
+++ b/tests/driver_cc110x/main.c
@@ -31,10 +31,14 @@
 
 static int sc_dump(int argc, char **argv);
 int sc_cc110x(int argc, char **argv);
+int sc_cc110x_sleep(int argc, char **argv);
+int sc_cc110x_wakeup(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
     { "dump", "Enable/disable dumping of frames", sc_dump },
     { "cc110x", "Print the low level state of an CC110x device", sc_cc110x },
+    { "sleep", "Set CC110x onto sleep mode", sc_cc110x_sleep },
+    { "wakeup", "Wake-up CC110x device", sc_cc110x_wakeup },
     { NULL, NULL, NULL }
 };
 
@@ -126,7 +130,13 @@ int main(void)
          "- Using \"cc110x\":\n"
          "    - This tool will print low level details for all CC110x devices\n"
          "      attached\n"
-         "    - This will be mostly useful for debugging, not for testing\n");
+         "    - This will be mostly useful for debugging, not for testing\n"
+         "- Using \"sleep\":\n"
+         "    - Puts the given (or all, if no iface is given) transceiver into\n"
+         "      deep sleep mode\n"
+         "- Using \"awake\":\n"
+         "    - Wakes up the given (or all, if no iface is given) transceiver(s)"
+         "      \n");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 


### PR DESCRIPTION
### Contribution description

Add `cc110x_sleep()` and `cc110x_wakeup()` to allow low power operation for the CC110x transceivers.

### Testing procedure

The test in `tests/driver_cc110x` has been extended to also contain the `sleep` and `wakeup` shell commands.

I used a MIoT-Lab Testbed Node (a Nucleo-F767ZI which contains among others a CC1101 transceiver and a 6 channel power monitoring solution, of which one channel is monitoring the CC1101) for testing.

```
2021-03-25 12:50:51,778 # main(): This is RIOT! (Version: 2021.04-devel-1144gNETOPT_RX_END_IRQ not implemented by driver
2021-03-25 12:50:51,782 # NETOPT_TX_END_IRQ not implemented by driver
2021-03-25 12:50:51,784 # ec756-drivers/cc110x)
2021-03-25 12:50:51,786 # cc110x driver test application
2021-03-25 12:50:51,789 # ==============================
2021-03-25 12:50:51,789 # 
2021-03-25 12:50:51,795 # Use the shell and two boards equipped with an CC1100/CC1101
2021-03-25 12:50:51,799 # transceiver to test the driver. Common testing tasks:
2021-03-25 12:50:51,799 # 
2021-03-25 12:50:51,801 # - Using "ifconfig":
2021-03-25 12:50:51,807 #     - Check the information stated for plausibility/correctness
2021-03-25 12:50:51,812 #     - Try to get/set parameters like TX power, channel, address, ...
2021-03-25 12:50:51,818 #     - BEWARE: With short communication distances (<=1m) for boards
2021-03-25 12:50:51,824 #       with high gain antennas a high TX power may result in packet
2021-03-25 12:50:51,829 #       loss: The incoming signal can only be demodulated when the
2021-03-25 12:50:51,834 #       input signal is at most +10 dBm on the CC1101.
2021-03-25 12:50:51,839 #     - Check the statistics for correctness/plausibility (after
2021-03-25 12:50:51,843 #       sending frames using "txtsnd" or "ping6")
2021-03-25 12:50:51,845 # - Using "ping6":
2021-03-25 12:50:51,850 #     - Does the other device respond to the ping?
2021-03-25 12:50:51,855 #     - Does the measured RSSI increase when the nodes are closer
2021-03-25 12:50:51,856 #       together?
2021-03-25 12:50:51,862 #     - Try to increase the size of the pings, so that the TX/RX FIFO
2021-03-25 12:50:51,870 #       needs to be filled/drain more than once per frame. The TX/RX
2021-03-25 12:50:51,871 #       FIFO can hold 64 bytes
2021-03-25 12:50:51,875 #     - Try to increase the size of the pings in order to trigger L2
2021-03-25 12:50:51,881 #       fragmentation. The driver supports frames of up to 255 bytes
2021-03-25 12:50:51,883 # - Using "txtsnd":
2021-03-25 12:50:51,889 #     - Turn on packet dumping using the command "dump y" on node A
2021-03-25 12:50:51,894 #     - Send both unicast and broadcast frame from node B to A
2021-03-25 12:50:51,896 # - Using "cc110x":
2021-03-25 12:50:51,902 #     - This tool will print low level details for all CC110x devices
2021-03-25 12:50:51,903 #       attached
2021-03-25 12:50:51,909 #     - This will be mostly useful for debugging, not for testing
2021-03-25 12:50:51,910 # - Using "sleep":
2021-03-25 12:50:51,916 #     - Puts the given (or all, if no iface is given) transceiver into
2021-03-25 12:50:51,918 #       deep sleep mode
2021-03-25 12:50:51,919 # - Using "awake":
2021-03-25 12:50:51,926 #     - Wakes up the given (or all, if no iface is given) transceiver(s)      
2021-03-25 12:50:51,926 #

    ---- power consumption: varying between 0.0616 W at 0.0623 W ----

> sleep
2021-03-25 12:50:55,460 # sleep
2021-03-25 12:50:55,463 # Putting to sleep CC110x #0:

    ---- power consumption: varying between 0.0000 W and 0.0003 W ----

> wakeup
2021-03-25 12:51:01,247 # wakeup
2021-03-25 12:51:01,248 # Waking up CC110x #0:
>

    ---- power consumption: varying between 0.0616 W at 0.0623 W ----
```

The datasheet say power consumption on RX at 433 MHz receiving at 250 kBaud with settings optimized for current consumption is 17.1 mA (that would be 56.4 mW at 3.3V). In sleep mode current consumption is 200 nA (or ~ 0mW).

Since the driver is not trading in reception quality for lower current consumption, the measurements seem to roughly match the datasheet.

### Issues/PRs references

Based on https://github.com/RIOT-OS/RIOT/pull/12294