### PR TITLE
boards/microbit-v2: Add buttons

### DIFF
--- a/boards/microbit-v2/doc.txt
+++ b/boards/microbit-v2/doc.txt
@@ -43,4 +43,14 @@ BOARD=microbit make term
 
 The 5x5 LED matrix display can be driven using the @ref boards_common_microbit.
 
+## Button setup
+
+The Microbit logo and the rings are configured in resistive mode, and expressed
+as buttons by default when SAUL is enabled (through @ref saul_gpio_params_t).
+Note that to press them, you have to touch the GND pin at the same time, and
+may need to press hard if you have dry fingers.  See [the micro:bit documentation on touch]
+for more information. Capacitive mode is currently not supported.
+
+[the micro:bit documentation on touch]: https://support.microbit.org/support/solutions/articles/19000116318-touch-sensing-on-the-micro-bit
+
  */

--- a/boards/microbit-v2/include/board.h
+++ b/boards/microbit-v2/include/board.h
@@ -49,6 +49,18 @@ extern "C" {
 #define BTN0_MODE                   GPIO_IN
 #define BTN1_PIN                    GPIO_PIN(0, 23)
 #define BTN1_MODE                   GPIO_IN
+/* The Logo  */
+#define BTN2_PIN                    GPIO_PIN(1, 4)
+#define BTN2_MODE                   GPIO_IN
+/* Ring 0 */
+#define BTN3_PIN                    GPIO_PIN(0, 2)
+#define BTN3_MODE                   GPIO_IN
+/* Ring 1 */
+#define BTN4_PIN                    GPIO_PIN(0, 3)
+#define BTN4_MODE                   GPIO_IN
+/* Ring 2 */
+#define BTN5_PIN                    GPIO_PIN(0, 4)
+#define BTN5_MODE                   GPIO_IN
 /** @} */
 
 /**

--- a/boards/microbit-v2/include/gpio_params.h
+++ b/boards/microbit-v2/include/gpio_params.h
@@ -43,6 +43,30 @@ static const saul_gpio_params_t saul_gpio_params[] =
         .mode = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+    {
+        .name = "Touch Logo",
+        .pin  = BTN2_PIN,
+        .mode = BTN2_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Ring 0",
+        .pin  = BTN3_PIN,
+        .mode = BTN3_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Ring 1",
+        .pin  = BTN4_PIN,
+        .mode = BTN4_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Ring 2",
+        .pin  = BTN5_PIN,
+        .mode = BTN5_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

The microbit v2's logo and rings are touch sensitive, with a resistive (vs. 1MOhm) and a capacitive mode.

This enables them by implementing the resistive mode (which is really trivial button reading, as long as you don't expect debouncing) and documents them.

### Testing procedure

Run the SAUL example, `saul read all` repeatedly, while touching any of the rings, button and GND with at least not completely dry fingers.