### PR TITLE
drivers/lsm303: Tolerate pin inversion

### DIFF
--- a/boards/microbit-v2/Makefile.dep
+++ b/boards/microbit-v2/Makefile.dep
@@ -5,6 +5,7 @@ endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += lsm303dlhc
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/microbit-v2/include/board.h
+++ b/boards/microbit-v2/include/board.h
@@ -72,6 +72,11 @@ extern "C" {
  */
 #define LSM303AGR_PARAM_ACC_ADDR    0x19
 #define LSM303AGR_PARAM_MAG_ADDR    0x1E
+/* The interrupt lines are both connected through an inverter to pin 0.01 */
+#define LSM303DLHC_PARAM_ACC_PIN    (GPIO_PIN(0, 1))
+#define LSM303DLHC_PARAM_MAG_PIN    (GPIO_PIN(0, 1))
+#define LSM303DLHC_PARAM_ACC_PIN_MODE GPIO_IN_PU
+#define LSM303DLHC_PARAM_MAG_PIN_MODE GPIO_IN_PU
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -115,6 +115,8 @@ typedef struct {
     gpio_t mag_pin;                         /**< magnetometer EXTI pin */
     lsm303dlhc_mag_sample_rate_t mag_rate;  /**< magnetometer sample rate */
     lsm303dlhc_mag_gain_t mag_gain;         /**< magnetometer gain */
+    gpio_mode_t acc_pin_mode;               /**< accelerometer EXTI pin mode; setting this to GPIO_IN_PU inverts pin semantics */
+    gpio_mode_t mag_pin_mode;               /**< magnetometer EXTI pin mode; setting this to GPIO_IN_PU inverts pin semantics*/
 } lsm303dlhc_params_t;
 
 /**

--- a/drivers/lsm303dlhc/include/lsm303dlhc_params.h
+++ b/drivers/lsm303dlhc/include/lsm303dlhc_params.h
@@ -58,6 +58,12 @@ extern "C" {
 #ifndef LSM303DLHC_PARAM_MAG_GAIN
 #define LSM303DLHC_PARAM_MAG_GAIN       (LSM303DLHC_MAG_GAIN_450_400_GAUSS)
 #endif
+#ifndef LSM303DLHC_PARAM_ACC_PIN_MODE
+#define LSM303DLHC_PARAM_ACC_PIN_MODE   GPIO_IN
+#endif
+#ifndef LSM303DLHC_PARAM_MAG_PIN_MODE
+#define LSM303DLHC_PARAM_MAG_PIN_MODE   GPIO_IN
+#endif
 
 #ifndef LSM303DLHC_PARAMS
 #define LSM303DLHC_PARAMS               { .i2c       = LSM303DLHC_PARAM_I2C,       \
@@ -68,7 +74,9 @@ extern "C" {
                                           .mag_addr  = LSM303DLHC_PARAM_MAG_ADDR,  \
                                           .mag_pin   = LSM303DLHC_PARAM_MAG_PIN,   \
                                           .mag_rate  = LSM303DLHC_PARAM_MAG_RATE,  \
-                                          .mag_gain  = LSM303DLHC_PARAM_MAG_GAIN }
+                                          .mag_gain  = LSM303DLHC_PARAM_MAG_GAIN,  \
+                                          .acc_pin_mode = LSM303DLHC_PARAM_ACC_PIN_MODE,  \
+                                          .mag_pin_mode = LSM303DLHC_PARAM_MAG_PIN_MODE }
 #endif
 #ifndef LSM303DLHC_SAUL_INFO
 #define LSM303DLHC_SAUL_INFO            { .name = "lsm303dlhc" }

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -34,6 +34,16 @@
 #define DEV_MAG_PIN     (dev->params.mag_pin)
 #define DEV_MAG_RATE    (dev->params.mag_rate)
 #define DEV_MAG_GAIN    (dev->params.mag_gain)
+#define DEV_ACC_PIN_MODE (dev->params.acc_pin_mode)
+#define DEV_MAG_PIN_MODE (dev->params.mag_pin_mode)
+
+static inline bool _pin_is_idle(gpio_t pin, gpio_mode_t mode) {
+    if (mode == GPIO_IN_PU) {
+        return gpio_read(pin) != 0;
+    } else {
+        return gpio_read(pin) == 0;
+    }
+}
 
 int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
 {
@@ -66,7 +76,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
     res += i2c_write_reg(DEV_I2C, DEV_ACC_ADDR,
                          LSM303DLHC_REG_CTRL3_A, LSM303DLHC_CTRL3_A_I1_NONE, 0);
     /* configure acc data ready pin */
-    gpio_init(DEV_ACC_PIN, GPIO_IN);
+    gpio_init(DEV_ACC_PIN, DEV_ACC_PIN_MODE);
 
     /* configure magnetometer and temperature */
     /* enable temperature output and set sample rate */
@@ -81,7 +91,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
                          LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_CONTINUOUS, 0);
     i2c_release(DEV_I2C);
     /* configure mag data ready pin */
-    gpio_init(DEV_MAG_PIN, GPIO_IN);
+    gpio_init(DEV_MAG_PIN, DEV_MAG_PIN_MODE);
     if (IS_ACTIVE(ENABLE_DEBUG) && res == 0) {
         DEBUG("[OK]\n");
     }
@@ -141,7 +151,7 @@ int lsm303dlhc_read_mag(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
     int res;
 
     DEBUG("lsm303dlhc: wait for mag values... ");
-    while (gpio_read(DEV_MAG_PIN) == 0){}
+    while (_pin_is_idle(DEV_MAG_PIN, DEV_MAG_PIN_MODE)){}
 
     DEBUG("read ... ");
 


### PR DESCRIPTION
### Contribution description

At the microbit-v2, the interrupt line from LSM303 is inverted.

This adds a mode option to the driver, and flips the interrupt line semantics for GPIO modes that don't make sense with the original semantics.

### Testing procedure

Well this is where the PR is a bit drafty yet:

There seems not to come an interrupt along for the magnetometer.

This may be because the microbit has an LSM303AGRTR and not a LSM303DLHC (don't know the differences), but also begs the question why the default config is to sample the accelerometer on request but the magnetometer free-running so that it needs to wait for an interrupt in the first place.

Guidance from someone who knows that device would be appreciated.