### PR TITLE
cpu/stm32 : Interface generators support for stm32wl

### DIFF
--- a/cpu/stm32/dist/irqs/gen_irqs.py
+++ b/cpu/stm32/dist/irqs/gen_irqs.py
@@ -86,7 +86,8 @@ def irq_numof(cpu_fam, cpu_line):
         ):
             continue
         # Stop at the end of the IRQn_Type enum definition
-        if "IRQn_Type" in line:
+        if "IRQn_Type" in line \
+                and "#else" not in cmsis_content[line_idx + 1].decode():
             break
 
     # Ensure we are on a valid line, otherwise search in earlier lines

--- a/cpu/stm32/dist/irqs/gen_vectors.py
+++ b/cpu/stm32/dist/irqs/gen_vectors.py
@@ -75,6 +75,7 @@ def parse_cmsis(cpu_line):
             continue
         # start filling lines after interrupt Doxygen comment
         if "typedef enum" in line:
+            irq_lines = []  # Cleanup any previous content
             use_line = True
 
         # use a regexp to get the available IRQs


### PR DESCRIPTION
This PR adds a filter to select only the relevant _IRQ/vectors from the interfaces fetched from ST's upstream repo. ~~Also, refactor the code.~~

**Edit : This PR has been closed and shall be merged to #16255**

### Testing procedure

Tested on the following boards :

1. b-l072z-lrwan1
2. nucleo-f411re

CI should take care of the rest.

### Issues/PRs references
The update is required for the `STM32WL5X` family as it comes with two cores.
