### PR TITLE
pkg/semtech-loramac: add support for sx126x/llcc68 radios

### DIFF
--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -32,9 +32,17 @@
 #include "net/loramac.h"
 #include "semtech_loramac.h"
 
+#if IS_USED(MODULE_SX127X)
 #include "sx127x.h"
 #include "sx127x_netdev.h"
 #include "sx127x_params.h"
+#endif
+
+#if IS_USED(MODULE_SX126X)
+#include "sx126x.h"
+#include "sx126x_netdev.h"
+#include "sx126x_params.h"
+#endif
 
 /* Messages are sent every 20s to respect the duty cycle on each channel */
 #define PERIOD              (20U)
@@ -114,9 +122,17 @@ int main(void)
     fmt_hex_bytes(appkey, CONFIG_LORAMAC_APP_KEY_DEFAULT);
 
     /* Initialize the radio driver */
+#if IS_USED(MODULE_SX127X)
     sx127x_setup(&sx127x, &sx127x_params[0], 0);
     loramac.netdev = (netdev_t *)&sx127x;
     loramac.netdev->driver = &sx127x_driver;
+#endif
+
+#if IS_USED(MODULE_SX126X)
+    sx126x_setup(&sx126x, &sx126x_params[0], 0);
+    loramac.netdev = (netdev_t *)&sx126x;
+    loramac.netdev->driver = &sx126x_driver;
+#endif
 
     /* Initialize the loramac stack */
     semtech_loramac_init(&loramac);

--- a/sys/auto_init/loramac/auto_init_loramac.c
+++ b/sys/auto_init/loramac/auto_init_loramac.c
@@ -18,19 +18,46 @@
  */
 
 #include "log.h"
+#include "kernel_defines.h"
+
+#if IS_USED(MODULE_SX127X)
 #include "sx127x.h"
 #include "sx127x_netdev.h"
 #include "sx127x_params.h"
+#endif
+
+#if IS_USED(MODULE_SX126X)
+#include "sx126x.h"
+#include "sx126x_netdev.h"
+#include "sx126x_params.h"
+#endif
+
 #include "semtech_loramac.h"
 
 semtech_loramac_t loramac;
+
+#if IS_USED(MODULE_SX127X)
 static sx127x_t sx127x;
+#endif
+
+#if IS_USED(MODULE_SX126X)
+static sx126x_t sx126x;
+#endif
 
 void auto_init_loramac(void)
 {
+#if IS_USED(MODULE_SX127X)
     sx127x_setup(&sx127x, &sx127x_params[0], 0);
     loramac.netdev = (netdev_t *)&sx127x;
     loramac.netdev->driver = &sx127x_driver;
+#endif
+
+#if IS_USED(MODULE_SX126X)
+    sx126x_setup(&sx126x, &sx126x_params[0], 0);
+    loramac.netdev = (netdev_t *)&sx126x;
+    loramac.netdev->driver = &sx126x_driver;
+#endif
+
     semtech_loramac_init(&loramac);
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/init.c
+++ b/sys/net/gnrc/netif/init_devs/init.c
@@ -167,7 +167,7 @@ void gnrc_netif_init_devs(void)
         auto_init_nrf802154();
     }
 
-    if (IS_USED(MODULE_SX126X)) {
+    if (IS_USED(MODULE_SX126X) && !IS_USED(MODULE_SEMTECH_LORAMAC)) {
         extern void auto_init_sx126x(void);
         auto_init_sx126x();
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the missing logic to be able to use the semtech-loramac package with sx126x and llcc68 radios.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

One can test this PR out-of-the-box using an sx1261/sx1262/llcc68 mbed shield and a nucleo 64 board (I tested with nucleo-l476rg and nucleo-g431rb): just flash the `tests/pkg_semtech-loramac` application and verify that OTAA join procedures are successful and data can be sent to a LoRaWAN backend:


<details><summary>some basic tests with TTN</summary>

```
$ LORA_DRIVER=sx1261 make BOARD=nucleo-g431rb -C tests/pkg_semtech-loramac/ flash term
make: Entering directory '/work/riot/RIOT/tests/pkg_semtech-loramac'
Building application "tests_pkg_semtech-loramac" for "nucleo-g431rb" with MCU "stm32".

[INFO] updating driver_sx126x /work/riot/RIOT/build/pkg/driver_sx126x/.pkg-state.git-downloaded
echo ba61312213450ae94a4293d75285c1d8f30c04b3 > /work/riot/RIOT/build/pkg/driver_sx126x/.pkg-state.git-downloaded
[INFO] patch driver_sx126x
"make" -C /work/riot/RIOT/pkg/driver_sx126x
"make" -C /work/riot/RIOT/build/pkg/driver_sx126x/src -f /work/riot/RIOT/pkg/driver_sx126x/driver_sx126x.mk
"make" -C /work/riot/RIOT/pkg/semtech-loramac
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/boards/mcu -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_arch
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/system/crypto -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_crypto
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/mac -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_mac
"make" -C /work/riot/RIOT/build/pkg/semtech-loramac/src/mac/region -f /work/riot/RIOT/pkg/semtech-loramac/Makefile.loramac_region
"make" -C /work/riot/RIOT/boards/nucleo-g431rb
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/sx126x
"make" -C /work/riot/RIOT/pkg/driver_sx126x/contrib
"make" -C /work/riot/RIOT/pkg/semtech-loramac/contrib
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/loramac
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/frac
"make" -C /work/riot/RIOT/sys/iolist
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  51460	    292	   7268	  59020	   e68c	/work/riot/RIOT/tests/pkg_semtech-loramac/bin/nucleo-g431rb/tests_pkg_semtech-loramac.elf
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'openocd' - duration: 3.01s)
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-03-27 16:44:05,345 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
loramac set deveui 00AB22849FF4885C
2021-03-27 16:44:15,503 # loramac set deveui 00AB22849FF4885C
loramac set appeui 70B3D57ED000B02F
2021-03-27 16:44:17,990 # loramac set appeui 70B3D57ED000B02F
loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
2021-03-27 16:44:21,000 # loramac set appkey 45C8E67A4FD8871D6943CEE3A305177C
> loramac set dr 5
2021-03-27 16:44:25,845 # loramac set dr 5
> loramac join otaa
2021-03-27 16:44:28,667 # loramac join otaa
2021-03-27 16:44:33,809 # Join procedure succeeded!
> loramac tx "This is RIOT!"
2021-03-27 16:45:23,853 # loramac tx "This is RIOT!"
2021-03-27 16:45:24,963 # Received ACK from network
2021-03-27 16:45:24,965 # Message sent with success
> loramac tx "This is RIOT!"
2021-03-27 16:45:46,246 # loramac tx "This is RIOT!"
2021-03-27 16:45:52,366 # Data received: ABCD, port: 42
2021-03-27 16:45:52,368 # Received ACK from network
2021-03-27 16:45:52,370 # Message sent with success
> 

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This is based on #16177 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
