### PR TITLE
boards: introduce atmega328p-xplained-mini

### DIFF
--- a/boards/atmega328p-xplained-mini/Kconfig
+++ b/boards/atmega328p-xplained-mini/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+# Copyright (c) 2021 Gerson Fernando Budke
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "atmega328p-xplained-mini" if BOARD_ATMEGA328P_XPLAINED_MINI
+
+config BOARD_ATMEGA328P_XPLAINED_MINI
+    bool
+    default y
+    select CPU_MODEL_ATMEGA328P
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    # Various other features (if any)

--- a/boards/atmega328p-xplained-mini/Makefile
+++ b/boards/atmega328p-xplained-mini/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/atmega328p-xplained-mini/Makefile.dep
+++ b/boards/atmega328p-xplained-mini/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += boards_common_atmega

--- a/boards/atmega328p-xplained-mini/Makefile.features
+++ b/boards/atmega328p-xplained-mini/Makefile.features
@@ -1,0 +1,9 @@
+CPU = atmega328p
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/atmega328p-xplained-mini/Makefile.include
+++ b/boards/atmega328p-xplained-mini/Makefile.include
@@ -1,0 +1,13 @@
+# configure the terminal program
+BAUD                ?= 9600
+ATMEGA328P_CLOCK    ?=
+
+# Allow overwriting programmer via env variables without affecting other boards
+PROGRAMMER_BOARD_ATMEGA328P_XPLAINED_MINI = xplainedmini
+# ICSP programmer to use for avrdude
+AVRDUDE_PROGRAMMER = $(PROGRAMMER_BOARD_ATMEGA328P_XPLAINED_MINI)
+ifneq (,$(ATMEGA328P_CLOCK))
+  CFLAGS += -DCLOCK_CORECLOCK=$(ATMEGA328P_CLOCK)
+endif
+
+include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/atmega328p-xplained-mini/doc.txt
+++ b/boards/atmega328p-xplained-mini/doc.txt
@@ -1,0 +1,125 @@
+/**
+@defgroup    boards_atmega328p_xplained_mini ATmega328p Xplained Mini
+@ingroup     boards
+@brief       Support for using the ATmega328p Xplained Mini board
+
+## Overview
+
+The ATmega328p MCU is most popular in the Arduino UNO.  The Xplained Mini board
+is a reduced version of Arduino UNO with a EDBG CMSIS-DAP programmer.
+
+The Xplained Mini has two internal oscillators, one clocked at 8MHz and one at
+128kHz and one external 16/8MHz clock at 5/3.3V.  The default fuses of the
+Xplained Mini are configured to use external 16MHz oscillator.  This default
+configuration uses a 5.0V supply voltage.
+
+### MCU
+| MCU           | ATmega328p                                    |
+|:------------- |:--------------------------------------------- |
+| Family        | AVR/ATmega                                    |
+| Vendor        | Microchip (previously Atmel)                  |
+| RAM           | 2KiB                                          |
+| Flash         | 32KiB                                         |
+| EEPROM        | 1KiB                                          |
+| Frequency     | 1MHz/8MHz/16MHz                               |
+| Timers        | 3 (2x 8bit, 1x 16bit)                         |
+| ADCs          | 6 analog input pins                           |
+| UARTs         | 1                                             |
+| SPIs          | 1                                             |
+| I2Cs          | 1 (called TWI)                                |
+| Vcc           | 5.0V USB (when clocked at 16MHz)              |
+| Datasheet     | [Official datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/ATmega48A-PA-88A-PA-168A-PA-328-P-DS-DS40002061A.pdf) |
+| User Manual   | [User Manual](https://ww1.microchip.com/downloads/en/DeviceDoc/ATmega328P-Xplained-Mini-UG-DS50002659B.pdf) |
+| Design files  | [Design files](https://ww1.microchip.com/downloads/en/DeviceDoc/ATmega328P-Xplained-Mini_Design-Documentation.zip) |
+| AN 42552      | [AN_42552](http://ww1.microchip.com/downloads/en/Appnotes/Atmel-42552-AVR-for-IoT-Using-megaAVR-ATWINC1500-802-11bgn-WiFi-Network-Controller-Module_ApplicationNote_AT13041.pdf) |
+
+### Clock Frequency
+
+The Xplained Mini has two internal oscillators clocked at 8MHz and at 128kHz
+that allow it to be operated without any external clock source or crystal.  By
+default the fuses are configured to use the external 16MHz clock without clock
+divider resulting in a CPU clock speed of 16MHz.  There is no need to clear
+the `CKDIV8` fuse once it is already done.
+
+    default fuses: (E:FC, H:D1, L:E0)
+
+This "board" is configured to use 16MHz as core clock, so that the ATmega328p
+runs at the highest frequency possible using the external clock source.
+
+By setting the environment variable `ATMEGA328P_CLOCK` to a custom frequency
+in Hz (e.g. `1000000` for 1MHz), this core clock can be changed easily. Refer
+to the datasheet on how to configure the ATmega328p to use an external crystal,
+an external clock source or the clock divider.
+
+### Relation Between Supply Voltage, Clock Frequency and Power Consumption
+
+A higher supply voltage results in a higher current drawn. Thus, lower power
+consumption can be achieved by using a lower supply voltage. However, higher
+clock frequencies require higher supply voltages for reliable operation.
+
+The lowest possible supply voltage at 8 MHz is 2.7V (with some safety margin),
+which results in an active supply current of less than 3 mA (about 8 mW power
+consumption) according to the datasheet. At 1 MHz core clock a supply voltage
+of 1.8V is possible resulting in an active supply current of less than 0.3 mA
+(about 0.5 mW power consumption). For more details, refer to the official
+datasheet.
+
+## Flashing the Device
+
+The only requirement is `avrdude` tool installed:
+
+    make BOARD=atmega328P-xplained-mini flash
+
+## Serial Terminal
+
+The AVR Xplained Mini already have an USB CDC converter build in.  So, simple
+type to get terminal:
+
+    make BOARD=atmega328P-xplained-mini term
+
+## On-Chip Debugging (OCD)
+
+E.g. with the AVR Xplained Mini and [AVaRICE](http://avarice.sourceforge.net/)
+you can debug the ATmega328P using the debugWIRE interface.  Compared to the
+ATmega MCUs with JTAG interface the debug facilities are however significantly
+reduced: Only a single hardware breakpoint and no watchpoints are supported.
+The hardware breakpoint is used for single-stepping.  If you set breakpoints,
+the AVR Xplained Mini will transparently replace the instruction to break upon
+with a break instruction.  Once the breakpoint is hit, the break instruction
+is overwritten with the original instruction.  Thus, every breakpoint hit
+cause two flash cycles to be performed, which not only results in a slow
+debugging experience, but also causes significant wear.
+
+In order to enable debugWIRE run, replace `<PROGRAMMER>` with the
+`xplainedmini_dw`:
+
+    avrdude -c <PROGRAMMER> -p m328p -U hfuse:w:0x99:m
+
+You can disable it again via:
+
+    avrdude -c <PROGRAMMER> -p m328p -U hfuse:w:0xd9:m
+
+@warning    As the reset pin is repurposed for debugWIRE, a regular ISP will
+            not be able to disable the debugWIRE interface anymore.  The AVR
+            Xplained Mini can temporary disable the debugWIRE interface via a
+            debugWIRE command and avrdude will do so when debugWIRE is used.
+
+For debugging, the ATmega328P Xplained Mini already have a debugger.  Once the
+debugWIRE is enabled via the fuse settings, you can start debugging via:
+
+    make debug
+
+If this fails after flashing the ATmega328P, it is like due to debugWIRE being
+temporary disabled by avrdude in order to use the ISP feature.  Perform a
+cold boot and the ATmega328P will have debugWIRE enabled again.
+
+@note       If you are using a different debugger than the AVR Xplained Mini,
+            you have to export the `AVR_DEBUGDEVICE` environment variable to
+	    the required flag to pass to AVaRICE, e.g. when using the Atmel-ICE
+	    you have to export `AVR_DEBUGDEVICE=--edbg`. If the debug device
+	    is not connected via USB, you also need to export
+	    `AVR_DEBUGINTERFACE` to the correct value.
+
+There is a how to ATWINC1500 802.11 b/g/n Wi-Fi Network with this board
+(AN_42552).
+ */

--- a/boards/atmega328p-xplained-mini/include/board.h
+++ b/boards/atmega328p-xplained-mini/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2016 Laurent Navet <laurent.navet@gmail.com>
+ *               2019 Otto-von-Guericke-Universität Magdeburg
+ *               2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atmega328p_xplained_mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the standalone ATmega328p "board"
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Laurent Navet <laurent.navet@gmail.com>
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    STDIO configuration
+ *
+ * As the CPU is too slow to handle 115200 baud, we set the default
+ * baudrate to 9600 for this board
+ * @{
+ */
+#define STDIO_UART_BAUDRATE         (9600U)
+/** @} */
+
+/**
+ * @name    xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+#if CLOCK_CORECLOCK > 4000000UL
+#define XTIMER_HZ                   (CLOCK_CORECLOCK / 64)
+#else
+#define XTIMER_HZ                   (CLOCK_CORECLOCK / 8)
+#endif
+#define XTIMER_BACKOFF              (40)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/atmega328p-xplained-mini/include/periph_conf.h
+++ b/boards/atmega328p-xplained-mini/include/periph_conf.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
+ *               2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup boards_atmega328p_xplained_mini
+ * @{
+ *
+ * @file
+ * @brief   Peripheral MCU configuration for the ATmega328p xplained mini "board"
+ *
+ * @author  Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @author  Gerson Fernando Budke <nandojve@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+/* Using 16MHz internal oscillator as default clock source */
+#define CLOCK_CORECLOCK     (16000000UL)
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "periph_conf_atmega_common.h"
+
+#endif /* PERIPH_CONF_H */

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     hifive1 \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     chronos \

--- a/examples/default/Makefile.ci
+++ b/examples/default/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stk3200 \
     stm32f030f4-demo \
     #

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/filesystem/Makefile.ci
+++ b/examples/filesystem/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     b-l072z-lrwan1 \
     blackpill \

--- a/examples/gnrc_lorawan/Makefile.ci
+++ b/examples/gnrc_lorawan/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     msb-430 \
     msb-430h \
     nucleo-f031k6 \

--- a/examples/gnrc_minimal/Makefile.ci
+++ b/examples/gnrc_minimal/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     blackpill \
     bluepill \

--- a/examples/nanocoap_server/Makefile.ci
+++ b/examples/nanocoap_server/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/posix_select/Makefile.ci
+++ b/examples/posix_select/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     chronos \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/examples/saul/Makefile.ci
+++ b/examples/saul/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/bench_msg_pingpong/Makefile.ci
+++ b/tests/bench_msg_pingpong/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/bench_mutex_pingpong/Makefile.ci
+++ b/tests/bench_mutex_pingpong/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/bench_sizeof_coretypes/Makefile.ci
+++ b/tests/bench_sizeof_coretypes/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/bench_sys_base64/Makefile.ci
+++ b/tests/bench_sys_base64/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/bench_thread_flags_pingpong/Makefile.ci
+++ b/tests/bench_thread_flags_pingpong/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/bench_thread_yield_pingpong/Makefile.ci
+++ b/tests/bench_thread_yield_pingpong/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/bench_timers/Makefile.ci
+++ b/tests/bench_timers/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     stk3200 \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -79,6 +79,7 @@ SUPER_LOW_MEMORY_BOARDS += \
   arduino-nano \
   arduino-uno \
   atmega328p \
+  atmega328p-xplained-mini \
   nucleo-f031k6 \
   stm32f030f4-demo \
   #

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     im880b \

--- a/tests/bench_xtimer_load/Makefile.ci
+++ b/tests/bench_xtimer_load/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/bloom_bytes/Makefile.ci
+++ b/tests/bloom_bytes/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     telosb \

--- a/tests/can_trx/Makefile.ci
+++ b/tests/can_trx/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/candev/Makefile.ci
+++ b/tests/candev/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/cond_order/Makefile.ci
+++ b/tests/cond_order/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030 \

--- a/tests/congure_test/Makefile.ci
+++ b/tests/congure_test/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/conn_can/Makefile.ci
+++ b/tests/conn_can/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     calliope-mini \
     hifive1 \
     hifive1b \

--- a/tests/disp_dev/Makefile.ci
+++ b/tests/disp_dev/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     derfmega128 \
     mega-xplained \
     microduino-corerf \

--- a/tests/driver_aip31068/Makefile.ci
+++ b/tests/driver_aip31068/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atmega32u4 \
     #

--- a/tests/driver_at/Makefile.ci
+++ b/tests/driver_at/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     nucleo-f031k6 \
     nucleo-l011k4 \

--- a/tests/driver_at24cxxx/Makefile.ci
+++ b/tests/driver_at24cxxx/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/driver_at30tse75x/Makefile.ci
+++ b/tests/driver_at30tse75x/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     #

--- a/tests/driver_at86rf215/Makefile.ci
+++ b/tests/driver_at86rf215/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/driver_at86rf2xx/Makefile.ci
+++ b/tests/driver_at86rf2xx/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/driver_at86rf2xx_aes/Makefile.ci
+++ b/tests/driver_at86rf2xx_aes/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/driver_ata8520e/Makefile.ci
+++ b/tests/driver_ata8520e/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_atwinc15x0/Makefile.ci
+++ b/tests/driver_atwinc15x0/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/driver_bmx055/Makefile.ci
+++ b/tests/driver_bmx055/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     stk3200 \

--- a/tests/driver_bmx280/Makefile.ci
+++ b/tests/driver_bmx280/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/driver_bq2429x/Makefile.ci
+++ b/tests/driver_bq2429x/Makefile.ci
@@ -3,4 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-leonardo \
     arduino-nano \
     arduino-uno \
-    atmega328p
+    atmega328p \
+    atmega328p-xplained-mini \
+    #

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \

--- a/tests/driver_dfplayer/Makefile.ci
+++ b/tests/driver_dfplayer/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/driver_dose/Makefile.ci
+++ b/tests/driver_dose/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/driver_ds1307/Makefile.ci
+++ b/tests/driver_ds1307/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/driver_ds3231/Makefile.ci
+++ b/tests/driver_ds3231/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/driver_dynamixel/Makefile.ci
+++ b/tests/driver_dynamixel/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/driver_encx24j600/Makefile.ci
+++ b/tests/driver_encx24j600/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/driver_feetech/Makefile.ci
+++ b/tests/driver_feetech/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/driver_kw2xrf/Makefile.ci
+++ b/tests/driver_kw2xrf/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \

--- a/tests/driver_lis2dh12/Makefile.ci
+++ b/tests/driver_lis2dh12/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/driver_ltc4150/Makefile.ci
+++ b/tests/driver_ltc4150/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/driver_mpu9x50/Makefile.ci
+++ b/tests/driver_mpu9x50/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     #

--- a/tests/driver_mrf24j40/Makefile.ci
+++ b/tests/driver_mrf24j40/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f031k6 \

--- a/tests/driver_netdev_common/Makefile.ci
+++ b/tests/driver_netdev_common/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/driver_nrf24l01p_lowlevel/Makefile.ci
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/driver_nrf24l01p_ng/Makefile.ci
+++ b/tests/driver_nrf24l01p_ng/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega128rfa1 \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/driver_nvram_spi/Makefile.ci
+++ b/tests/driver_nvram_spi/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/driver_pca9633/Makefile.ci
+++ b/tests/driver_pca9633/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atmega32u4 \
     #

--- a/tests/driver_pca9685/Makefile.ci
+++ b/tests/driver_pca9685/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atmega32u4 \
     #

--- a/tests/driver_pcd8544/Makefile.ci
+++ b/tests/driver_pcd8544/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/driver_pir/Makefile.ci
+++ b/tests/driver_pir/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/driver_rn2xx3/Makefile.ci
+++ b/tests/driver_rn2xx3/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/driver_sdcard_spi/Makefile.ci
+++ b/tests/driver_sdcard_spi/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/driver_sht1x/Makefile.ci
+++ b/tests/driver_sht1x/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     stm32f030f4-demo \

--- a/tests/driver_si1133/Makefile.ci
+++ b/tests/driver_si1133/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atmega32u4 \
     #

--- a/tests/driver_soft_uart/Makefile.ci
+++ b/tests/driver_soft_uart/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/driver_sps30/Makefile.ci
+++ b/tests/driver_sps30/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     #

--- a/tests/driver_srf02/Makefile.ci
+++ b/tests/driver_srf02/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/driver_sx127x/Makefile.ci
+++ b/tests/driver_sx127x/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/driver_tsl4531x/Makefile.ci
+++ b/tests/driver_tsl4531x/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/driver_w5100/Makefile.ci
+++ b/tests/driver_w5100/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/driver_xbee/Makefile.ci
+++ b/tests/driver_xbee/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     nucleo-f030r8 \
     nucleo-f031k6 \

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     b-l072z-lrwan1 \
     blackpill \

--- a/tests/event_threads/Makefile.ci
+++ b/tests/event_threads/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/event_wait_timeout/Makefile.ci
+++ b/tests/event_wait_timeout/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/events/Makefile.ci
+++ b/tests/events/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/evtimer_msg/Makefile.ci
+++ b/tests/evtimer_msg/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/evtimer_underflow/Makefile.ci
+++ b/tests/evtimer_underflow/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     b-l072z-lrwan1 \
     blackpill \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     blackpill \
     bluepill \

--- a/tests/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_opt/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
+++ b/tests/gnrc_ipv6_fwd_w_sub/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ipv6_nib/Makefile.ci
+++ b/tests/gnrc_ipv6_nib/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     msb-430 \
     msb-430h \

--- a/tests/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_dns/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_mac_timeout/Makefile.ci
+++ b/tests/gnrc_mac_timeout/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ndp/Makefile.ci
+++ b/tests/gnrc_ndp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     b-l072z-lrwan1 \
     blackpill \

--- a/tests/gnrc_rpl_p2p/Makefile.ci
+++ b/tests/gnrc_rpl_p2p/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_sixlowpan/Makefile.ci
+++ b/tests/gnrc_sixlowpan/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     hifive1 \

--- a/tests/gnrc_sixlowpan_frag/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     blackpill \
     bluepill \

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_sock_async_event/Makefile.ci
+++ b/tests/gnrc_sock_async_event/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_sock_ip/Makefile.ci
+++ b/tests/gnrc_sock_ip/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/gnrc_sock_neterr/Makefile.ci
+++ b/tests/gnrc_sock_neterr/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/gnrc_sock_udp/Makefile.ci
+++ b/tests/gnrc_sock_udp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     msb-430 \
     msb-430h \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/gnrc_tx_sync/Makefile.ci
+++ b/tests/gnrc_tx_sync/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atmega1281 \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     blackpill \
     bluepill \

--- a/tests/heap_cmd/Makefile.ci
+++ b/tests/heap_cmd/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/ieee802154_security/Makefile.ci
+++ b/tests/ieee802154_security/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/irq/Makefile.ci
+++ b/tests/irq/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/isr_yield_higher/Makefile.ci
+++ b/tests/isr_yield_higher/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/l2util/Makefile.ci
+++ b/tests/l2util/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/malloc_thread_safety/Makefile.ci
+++ b/tests/malloc_thread_safety/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/memarray/Makefile.ci
+++ b/tests/memarray/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/msg_send_receive/Makefile.ci
+++ b/tests/msg_send_receive/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/msg_try_receive/Makefile.ci
+++ b/tests/msg_try_receive/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/mtd_mapper/Makefile.ci
+++ b/tests/mtd_mapper/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     chronos \
     msb-430 \
     msb-430h \

--- a/tests/mtd_raw/Makefile.ci
+++ b/tests/mtd_raw/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/mutex_order/Makefile.ci
+++ b/tests/mutex_order/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \

--- a/tests/nanocoap_cli/Makefile.ci
+++ b/tests/nanocoap_cli/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/netdev_test/Makefile.ci
+++ b/tests/netdev_test/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/netstats_neighbor/Makefile.ci
+++ b/tests/netstats_neighbor/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/pbkdf2/Makefile.ci
+++ b/tests/pbkdf2/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/periph_eeprom/Makefile.ci
+++ b/tests/periph_eeprom/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/periph_gpio/Makefile.ci
+++ b/tests/periph_gpio/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/periph_gpio_arduino/Makefile.ci
+++ b/tests/periph_gpio_arduino/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/periph_i2c/Makefile.ci
+++ b/tests/periph_i2c/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     samd10-xmini \
     #

--- a/tests/periph_pwm/Makefile.ci
+++ b/tests/periph_pwm/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/periph_spi/Makefile.ci
+++ b/tests/periph_spi/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -13,6 +13,7 @@ BOARDS_TIMER_250kHz := \
     arduino-uno \
     atmega256rfr2-xpro \
     atmega328p \
+    atmega328p-xplained-mini \
     #
 
 BOARDS_TIMER_32kHz := \

--- a/tests/periph_uart/Makefile.ci
+++ b/tests/periph_uart/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/periph_uart_mode/Makefile.ci
+++ b/tests/periph_uart_mode/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     #

--- a/tests/periph_wdt/Makefile.ci
+++ b/tests/periph_wdt/Makefile.ci
@@ -3,4 +3,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/pipe/Makefile.ci
+++ b/tests/pipe/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/pkg_c25519/Makefile.ci
+++ b/tests/pkg_c25519/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega256rfr2-xpro \
     atmega328p \
+    atmega328p-xplained-mini \
     avr-rss2 \
     blackpill \
     bluepill \

--- a/tests/pkg_emlearn/Makefile.ci
+++ b/tests/pkg_emlearn/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     blackpill \
     bluepill \

--- a/tests/pkg_fatfs/Makefile.ci
+++ b/tests/pkg_fatfs/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     stm32f030f4-demo \
     #

--- a/tests/pkg_fatfs_vfs/Makefile.ci
+++ b/tests/pkg_fatfs_vfs/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     msb-430 \
     msb-430h \
     nucleo-f031k6 \

--- a/tests/pkg_heatshrink/Makefile.ci
+++ b/tests/pkg_heatshrink/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/pkg_libb2/Makefile.ci
+++ b/tests/pkg_libb2/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega256rfr2-xpro \
     atmega328p \
+    atmega328p-xplained-mini \
     derfmega128 \
     derfmega256 \
     mega-xplained \

--- a/tests/pkg_littlefs/Makefile.ci
+++ b/tests/pkg_littlefs/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/pkg_littlefs2/Makefile.ci
+++ b/tests/pkg_littlefs2/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/pkg_micro-ecc/Makefile.ci
+++ b/tests/pkg_micro-ecc/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/pkg_microcoap/Makefile.ci
+++ b/tests/pkg_microcoap/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/pkg_nanopb/Makefile.ci
+++ b/tests/pkg_nanopb/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     stm32f030f4-demo \
     #

--- a/tests/pkg_qdsa/Makefile.ci
+++ b/tests/pkg_qdsa/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -8,6 +8,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-uno \
                     atmega256rfr2-xpro \
                     atmega328p \
+                    atmega328p-xplained-mini \
                     derfmega128 \
                     derfmega256 \
                     f4vi1 \

--- a/tests/pkg_semtech-loramac/Makefile.ci
+++ b/tests/pkg_semtech-loramac/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/pkg_spiffs/Makefile.ci
+++ b/tests/pkg_spiffs/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/pkg_tiny-asn1/Makefile.ci
+++ b/tests/pkg_tiny-asn1/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/pkg_tweetnacl/Makefile.ci
+++ b/tests/pkg_tweetnacl/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega256rfr2-xpro \
     atmega328p \
+    atmega328p-xplained-mini \
     derfmega128 \
     derfmega256 \
     mega-xplained \

--- a/tests/pkg_u8g2/Makefile.ci
+++ b/tests/pkg_u8g2/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/pkg_ucglib/Makefile.ci
+++ b/tests/pkg_ucglib/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/posix_semaphore/Makefile.ci
+++ b/tests/posix_semaphore/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     mbed_lpc1768 \

--- a/tests/ps_schedstatistics/Makefile.ci
+++ b/tests/ps_schedstatistics/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \

--- a/tests/pthread_condition_variable/Makefile.ci
+++ b/tests/pthread_condition_variable/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/pthread_cooperation/Makefile.ci
+++ b/tests/pthread_cooperation/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega256rfr2-xpro \
     atmega328p \
+    atmega328p-xplained-mini \
     derfmega128 \
     derfmega256 \
     hifive1 \

--- a/tests/pthread_flood/Makefile.ci
+++ b/tests/pthread_flood/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/pthread_rwlock/Makefile.ci
+++ b/tests/pthread_rwlock/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/pthread_tls/Makefile.ci
+++ b/tests/pthread_tls/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \

--- a/tests/rmutex/Makefile.ci
+++ b/tests/rmutex/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \

--- a/tests/rmutex_cpp/Makefile.ci
+++ b/tests/rmutex_cpp/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     nucleo-f030r8 \

--- a/tests/rng/Makefile.ci
+++ b/tests/rng/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/saul/Makefile.ci
+++ b/tests/saul/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/sched_testing/Makefile.ci
+++ b/tests/sched_testing/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/shell/Makefile.ci
+++ b/tests/shell/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/slip/Makefile.ci
+++ b/tests/slip/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \

--- a/tests/sntp/Makefile.ci
+++ b/tests/sntp/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     derfmega128 \

--- a/tests/sock_udp_aux/Makefile.ci
+++ b/tests/sock_udp_aux/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega1284p \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
     calliope-mini \

--- a/tests/struct_tm_utility/Makefile.ci
+++ b/tests/struct_tm_utility/Makefile.ci
@@ -4,4 +4,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     #

--- a/tests/sys_atomic_utils/Makefile.ci
+++ b/tests/sys_atomic_utils/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/sys_crypto/Makefile.ci
+++ b/tests/sys_crypto/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     atxmega-a1u-xpro \
     msb-430 \
     msb-430h \

--- a/tests/sys_sema_inv/Makefile.ci
+++ b/tests/sys_sema_inv/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/thread_cooperation/Makefile.ci
+++ b/tests/thread_cooperation/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/thread_exit/Makefile.ci
+++ b/tests/thread_exit/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/thread_flags/Makefile.ci
+++ b/tests/thread_flags/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/thread_float/Makefile.ci
+++ b/tests/thread_float/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     cc2650stk \
     maple-mini \
     mbed_lpc1768 \

--- a/tests/thread_msg/Makefile.ci
+++ b/tests/thread_msg/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/thread_msg_block_race/Makefile.ci
+++ b/tests/thread_msg_block_race/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     #

--- a/tests/thread_msg_block_w_queue/Makefile.ci
+++ b/tests/thread_msg_block_w_queue/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/thread_msg_block_wo_queue/Makefile.ci
+++ b/tests/thread_msg_block_wo_queue/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     stm32f030f4-demo \

--- a/tests/thread_msg_bus/Makefile.ci
+++ b/tests/thread_msg_bus/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/thread_msg_seq/Makefile.ci
+++ b/tests/thread_msg_seq/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/thread_priority_inversion/Makefile.ci
+++ b/tests/thread_priority_inversion/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/thread_race/Makefile.ci
+++ b/tests/thread_race/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/thread_zombie/Makefile.ci
+++ b/tests/thread_zombie/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/trace/Makefile.ci
+++ b/tests/trace/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     chronos \
     msb-430 \
     msb-430h \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-zero \
     atmega256rfr2-xpro \
     atmega328p \
+    atmega328p-xplained-mini \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/tests/usbus/Makefile.ci
+++ b/tests/usbus/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/xtimer_drift/Makefile.ci
+++ b/tests/xtimer_drift/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/xtimer_hang/Makefile.ci
+++ b/tests/xtimer_hang/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/xtimer_longterm/Makefile.ci
+++ b/tests/xtimer_longterm/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \

--- a/tests/xtimer_msg/Makefile.ci
+++ b/tests/xtimer_msg/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/xtimer_mutex_lock_timeout/Makefile.ci
+++ b/tests/xtimer_mutex_lock_timeout/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_periodic_wakeup/Makefile.ci
+++ b/tests/xtimer_periodic_wakeup/Makefile.ci
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/xtimer_rmutex_lock_timeout/Makefile.ci
+++ b/tests/xtimer_rmutex_lock_timeout/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/ztimer_msg/Makefile.ci
+++ b/tests/ztimer_msg/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/ztimer_rmutex_lock_timeout/Makefile.ci
+++ b/tests/ztimer_rmutex_lock_timeout/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #

--- a/tests/ztimer_underflow/Makefile.ci
+++ b/tests/ztimer_underflow/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #


### PR DESCRIPTION
### Contribution description

Add ATmega328P Xplained Mini board.  The board is an official development kit from MCHP based on the Arduino UNO, reduced hardware, with a xplainedmini debugger and CDC ACM serial converter.

This is a good choice to develop using only one USB cable.

### Testing procedure

Basic tests using example/hello_world