### PR TITLE
cpu/atxmega/atxmega_cpu: Fix clk sel after dfll en

### DIFF
--- a/cpu/atxmega/atxmega_cpu.c
+++ b/cpu/atxmega/atxmega_cpu.c
@@ -98,10 +98,15 @@ void __attribute__((weak)) avr8_clk_init(void)
         != (OSC_RC32KRDY_bm | OSC_RC32MRDY_bm)) {}
 
     /* Enable DFLL - defaults to calibrate against internal 32Khz clock */
-    DFLLRC32M.CTRL = DFLL_ENABLE_bm;
+    DFLLRC2M.CTRL = DFLL_ENABLE_bm;
 
     /* Enable DFLL - defaults to calibrate against internal 32Khz clock */
-    DFLLRC2M.CTRL = DFLL_ENABLE_bm;
+    DFLLRC32M.CTRL = DFLL_ENABLE_bm;
+
+    /* Some ATxmega need sync clocks after enable DFLL.  Otherwise clock may
+     * stay at 2MHz source when try enable.
+     */
+    while ((OSC.STATUS & OSC_RC32MRDY_bm) != OSC_RC32MRDY_bm) {}
 
     atxmega_set_prescaler(CPU_ATXMEGA_CLK_SCALE_INIT,
                           CPU_ATXMEGA_BUS_SCALE_INIT);


### PR DESCRIPTION
### Contribution description

The current ATxmega clock_init enable DFLL to improve the accuracy of the 2MHz and 32MHz internal oscillators.  In some ATxmega revisions, after started DFLL the clock become unstable.  Add another sync point for 32MHz internal oscilator.

This avoid a BUG when clock is is not ready and clock_init try switch from 2MHz to 32MHz as main clock.

### Testing procedure

Detected when try run RIOT-OS an ATxmega128A1 and ATxmega192A3.

CC: @benpicco @maribu 