### PR TITLE
stm32/ptp: avoid creating a new rounding rule

### DIFF
--- a/cpu/stm32/periph/ptp.c
+++ b/cpu/stm32/periph/ptp.c
@@ -61,10 +61,10 @@
 #endif /* !STM32_PTPSSIR */
 
 /**
- * @brief   Return the result of x / y, scientifically rounded
+ * @brief   Return the rounded result of x / y
  * @param   x       Number to divide
  * @param   y       @p x should be divided by this
- * @return  x/y, scientifically rounded
+ * @return  x/y, rounded to the nearest integer, using "round half up" rule
  * @pre     Both @p x and @p y are compile time constant integers and the
  *          expressions are evaluated without side-effects
  */


### PR DESCRIPTION
Scientific rounding is a very uncommon term (not found in the Wikipedia article about rounding) and no good DDG results.
The edge case *.5  has different resolution methods (none is more scientific than the other one):
- The macro implements what in Germany is called "Kaufmänisches Runden" the English Wikipedia calls it "round half up" 
- An other common tie-breaking rule is "Round half to even", which has the blessing of the IEEE and has many other names assigned to it like in contrast to the german one "bankers rounding".

Both rules may skew further scientific test applied to the data and therefor have to be used with caution.

(the second rule will have a little more even values (that might skew numeral tests e.g. for data validity), the first has a little higher average)

### Contribution description

change the macro description to just don't name the rounding rule

### Testing procedure

none need,
but read

### Issues/PRs references
https://en.wikipedia.org/wiki/Rounding
https://de.wikipedia.org/wiki/Rundung