### PR TITLE
boards/microbit*/doc: Link to matrix display driver

### DIFF
--- a/boards/microbit-v2/doc.txt
+++ b/boards/microbit-v2/doc.txt
@@ -39,4 +39,8 @@ usually available on /dev/ttyACM0. Use the `term` target to access stdio:
 BOARD=microbit make term
 ```
 
+## Display
+
+The 5x5 LED matrix display can be driven using the @ref boards_common_microbit.
+
  */

--- a/boards/microbit/doc.txt
+++ b/boards/microbit/doc.txt
@@ -96,4 +96,8 @@ Use it like this:
     $ BOARD=microbit make clean all -j4
     $ EMULATE=1 BOARD=microbit make term
 
+## Display
+
+The 5x5 LED matrix display can be driven using the @ref boards_common_microbit.
+
  */


### PR DESCRIPTION
### Contribution description

This adds links from the two micro:bit boards to the microbit module that provides display drivers.

The link is relevant because a) for lack of a general display support a user would not expect anything to be there, and b) may not find it due to the different styling of "micro:bit". (OK, I didn't).

### Testing procedure

Look at the built documentation.