### PR TITLE
cpu/nrf52: Expose more timers

### DIFF
--- a/boards/common/microbit/microbit.c
+++ b/boards/common/microbit/microbit.c
@@ -137,7 +137,7 @@ static const uint8_t pixmap[ROWS][COLS] = {
 /**
  * @brief   Timer dev
  */
-#define TIMER_DEV_NUM       (1)
+#define TIMER_DEV_NUM       (2)
 #else
 #error "Module only compatible with microbit and microbit-v2 boards."
 #endif

--- a/boards/common/nrf52/include/cfg_timer_default.h
+++ b/boards/common/nrf52/include/cfg_timer_default.h
@@ -42,11 +42,31 @@ static const timer_conf_t timer_config[] = {
         .channels = 3,
         .bitmode  = TIMER_BITMODE_BITMODE_08Bit,
         .irqn     = TIMER2_IRQn
+    },
+    /* The later timers are only present on the larger NRF52 CPUs like NRF52840
+     * or NRF52833, but not small ones like NRF52810 */
+#ifdef NRF_TIMER3
+    {
+        .dev      = NRF_TIMER3,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_08Bit,
+        .irqn     = TIMER3_IRQn
+    },
+#endif
+#ifdef NRF_TIMER4
+    {
+        .dev      = NRF_TIMER4,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_08Bit,
+        .irqn     = TIMER4_IRQn
     }
+#endif
 };
 
 #define TIMER_0_ISR         isr_timer1
 #define TIMER_1_ISR         isr_timer2
+#define TIMER_2_ISR         isr_timer3
+#define TIMER_3_ISR         isr_timer4
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -199,3 +199,10 @@ void TIMER_2_ISR(void)
     irq_handler(2);
 }
 #endif
+
+#ifdef TIMER_3_ISR
+void TIMER_3_ISR(void)
+{
+    irq_handler(3);
+}
+#endif


### PR DESCRIPTION
### Contribution description

Up to now, nrf52 only exposes its timers NRF1 and NRF2 (as TIMER_0 and TIMER_1).

This adds the remaining two NRF3 and NRF4 (as TIMER_2 and TIMER_3).

As a result, the microbit-v2 LED matrix display can be moved to one of the higher timers; until that is done, it breaks the 802.15.4 stack whose NRF802154_TIMER also uses TIMER_1 (and ztimer uses TIMER_0 so we're in a pinch already).

### Testing procedure

* Run the periph_timer test, it still succeeds.
* Run the board_microbit test, it stil shows a running text. (This can also double as a test for timer 2; for timer 3 you can change TIMER_DEV_NUM in the microbit-v2 section of b/c/microbit/microbit.c).

### Open questions

* Why is NRF0 not exposed?
* Is the channel number right? ([The manual](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52833%2Ftimer.html&cp=4_1_0_5_27_4&anchor=topic) indicates that the high ones have 6 rather than 4 channels, but the low ones are already only entered with 3).