### PR TITLE
crypto/ciphers: remove unneeded max_key_size in cipher_interface_st

### DIFF
--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -45,7 +45,6 @@
  */
 static const cipher_interface_t aes_interface = {
     AES_BLOCK_SIZE,
-    AES_KEY_SIZE,
     aes_init,
     aes_encrypt,
     aes_decrypt

--- a/sys/crypto/ciphers.c
+++ b/sys/crypto/ciphers.c
@@ -22,13 +22,8 @@
 int cipher_init(cipher_t *cipher, cipher_id_t cipher_id, const uint8_t *key,
                 uint8_t key_size)
 {
-    if (key_size > cipher_id->max_key_size) {
-        return CIPHER_ERR_INVALID_KEY_SIZE;
-    }
-
     cipher->interface = cipher_id;
     return cipher->interface->init(&cipher->context, key, key_size);
-
 }
 
 

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -73,20 +73,22 @@ typedef struct {
  * @brief   BlockCipher-Interface for the Cipher-Algorithms
  */
 typedef struct cipher_interface_st {
-    /** Blocksize of this cipher */
+    /** @brief Blocksize of this cipher */
     uint8_t block_size;
 
-    /** Maximum key size for this cipher */
-    uint8_t max_key_size;
-
-    /** the init function */
+    /**
+     * @brief the init function.
+     *
+     * This function is responsible for checking that the given key_size is
+     * valid for the chosen cipher.
+     */
     int (*init)(cipher_context_t *ctx, const uint8_t *key, uint8_t key_size);
 
-    /** the encrypt function */
+    /** @brief the encrypt function */
     int (*encrypt)(const cipher_context_t *ctx, const uint8_t *plain_block,
                    uint8_t *cipher_block);
 
-    /** the decrypt function */
+    /** @brief the decrypt function */
     int (*decrypt)(const cipher_context_t *ctx, const uint8_t *cipher_block,
                    uint8_t *plain_block);
 } cipher_interface_t;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the [max_key_size](https://github.com/RIOT-OS/RIOT/blob/3e32d55c33645c7de2107b144f4a712a5eca0997/sys/include/crypto/ciphers.h#L80) member of the `cipher_interface_st`. The only place I found where this struct member is used is [this](https://github.com/RIOT-OS/RIOT/blob/3e32d55c33645c7de2107b144f4a712a5eca0997/sys/crypto/ciphers.c#L25) check. To me this check seems unnecessary. In my opinion it should be the job of the specific cipher modules,  e.g. [aes.c](https://github.com/RIOT-OS/RIOT/blob/master/sys/crypto/aes.c), to have checks related to key size.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This change does not alter the behavior of any cipher. All tests under [/tests/sys_crypto](https://github.com/RIOT-OS/RIOT/tree/master/tests/sys_crypto) should still pass.

### Issues/PRs references
#16183

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
