### PR TITLE
tests/ztimer_periodic: iterate over clocks

### DIFF
--- a/tests/ztimer_periodic/Makefile.ci
+++ b/tests/ztimer_periodic/Makefile.ci
@@ -1,2 +1,3 @@
 BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l011k4 \
+    #


### PR DESCRIPTION
### Contribution description

Instead of only testing for `ZTIMER_MSEC`, iterate over a list of
clocks and run the test for each. The reasoning is that this test
does not only test `ztimer_periodic`, but also that the used clock
backend operates correctly in a typical use case.

### Testing procedure

The test should still pass.

### Issues/PRs references

Useful for #16172