### PR TITLE
boards/arduino-due: allow changing frequency

### DIFF
--- a/boards/common/arduino-due/include/periph_conf.h
+++ b/boards/common/arduino-due/include/periph_conf.h
@@ -76,7 +76,9 @@ static const timer_conf_t timer_config[] = {
  * @name    RTT configuration
  * @{
  */
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (1U)        /* 1Hz */
+#endif
 /** @} */
 
 /**

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -76,9 +76,14 @@ typedef uint32_t gpio_t;
 #define TIMER_CHANNEL_NUMOF (1)
 
 /**
- * @brief   The RTT width is fixed to 32-bit
+ * @name    RTT configuration
+ * @{
  */
 #define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (CHIP_FREQ_XTAL_32K)          /* in Hz */
+#define RTT_MIN_FREQUENCY   (1) /* in Hz */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
+/** @} */
 
 /**
  * @brief   Generate GPIO mode bitfields


### PR DESCRIPTION
### Contribution description

This PR allows overriding the default value for the rtt frequency, it's one I missed in #14303.

### Testing procedure

Sadly I do not have a BOARD to test, but this should be the testing procedure:

- `tests/periph_rtt` should still pass on `sam3` boards with different frequencies

- `BOARD=arduino-due make -C tests/periph_rtt flash test --no-print-directory -j3`

- `CFLAGS+=-DRTT_FREQUENCY=1024 BOARD=arduino-due make -C tests/periph_rtt clean flash test --no-print-directory -j3`

Although IMO a green Murdock should be enough.

### Issues/PRs references

Realized I missed this `sam*` family while looking at  #16254
