### PR TITLE
cpu/sam3/periph_rtt: fix rtt_get_alarm()

### DIFF
--- a/cpu/sam3/periph/rtt.c
+++ b/cpu/sam3/periph/rtt.c
@@ -75,7 +75,8 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
 uint32_t rtt_get_alarm(void)
 {
     if (RTT->RTT_MR & RTT_MR_ALMIEN) {
-        return RTT->RTT_AR;
+        /* the alarm value is RTT_AR + 1, see rtt_set_alarm() */
+        return RTT->RTT_AR + 1;
     }
     return 0;
 }

--- a/tests/periph_rtt/main.c
+++ b/tests/periph_rtt/main.c
@@ -93,8 +93,10 @@ int main(void)
     printf("Setting initial alarm to now + 5 s (%" PRIu32 ")\n", last);
     rtt_set_alarm(last, cb, 0);
 
-    if (rtt_get_alarm() != last) {
-        puts("Error: rtt_get_alarm() not working");
+    uint32_t tmp = rtt_get_alarm();
+    if (tmp != last) {
+        printf("Error: rtt_get_alarm() not working (expected %" PRIu32 " but got %" PRIu32 ")\n",
+               last, tmp);
         return 1;
     }
     else {


### PR DESCRIPTION
### Contribution description

- Previously, the return value was off by one. The second commit fixes this
- The first commit sneaks in some enhancement of `tests/periph_rtt` to ease debugging, as this might be useful in the future as well

### Testing procedure

`make BOARD=arduino-due -C tests/periph_rtt` should now pass

### Issues/PRs references

Noticed in https://github.com/RIOT-OS/RIOT/pull/16257