### PR TITLE
pkg/lwip: Add thread safety check when using DEVELHELP

### DIFF
--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -101,12 +101,15 @@ static uint16_t _ip6_addr_to_netif(const ip6_addr_p_t *_addr)
     ip6_addr_copy_from_packed(addr, *_addr);
     if (!ip6_addr_isany_val(addr)) {
         struct netif *netif;
+        LOCK_TCPIP_CORE();
         /* cppcheck-suppress uninitvar ; assigned by macro */
         NETIF_FOREACH(netif) {
             if (netif_get_ip6_addr_match(netif, &addr) >= 0) {
+                UNLOCK_TCPIP_CORE();
                 return (int)netif->num + 1;
             }
         }
+        UNLOCK_TCPIP_CORE();
     }
     return SOCK_ADDR_ANY_NETIF;
 }

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -116,6 +116,18 @@ static inline void sys_mbox_set_invalid(sys_mbox_t *mbox)
 
 typedef kernel_pid_t sys_thread_t;      /**< Platform specific thread type */
 
+#if DEVELHELP
+/**
+ * @name    Functions for locking/unlocking core to assure thread safety.
+ * @{
+ */
+void sys_lock_tcpip_core(void);
+#define LOCK_TCPIP_CORE()          sys_lock_tcpip_core()
+void sys_unlock_tcpip_core(void);
+#define UNLOCK_TCPIP_CORE()        sys_unlock_tcpip_core()
+/** @} */
+#endif
+
 #ifdef MODULE_RANDOM
 /**
  * @brief   Use `random_uint32()` to generate random numbers, if available

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -171,6 +171,15 @@ extern "C" {
 #define MEM_SIZE                (TCPIP_THREAD_STACKSIZE + 6144)
 #endif
 
+#ifdef DEVELHELP
+void sys_mark_tcpip_thread(void);
+#define LWIP_MARK_TCPIP_THREAD sys_mark_tcpip_thread
+
+bool sys_check_core_locked(void);
+#define LWIP_ASSERT_CORE_LOCKED() \
+    LWIP_ASSERT("Core lock held", sys_check_core_locked())
+#endif
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When `DEVELHELP` is enabled, add checks that unprotected lwip functions are called correctly:

* Not be called from interrupts.
* If called from outside the tcpip thread, the lock must be held

The check is a macro to preserve the file/line of where it fired, to simplify debugging.

Adds locking to some calls in sock implementation to make it safe. \
Having this enabled will make it harder to add new unsafe code.

Netif handling has already been made safe in the switch to `netifapi` functions for dhcp and netif link up/down.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

All lwip tests still work.

When calling `dhcp_start` instead of netifapi version in pkg/lwip/contrib/lwip.c, the following failure occurs (when IPv4 enabled) on native: \
`Assertion "Core lock held" failed at [...]/RIOT/build/pkg/lwip/src/core/ipv4/dhcp.c:742`

Sending data with lwip sock still works when manually using test commands on `tests/lwip`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None