### PR TITLE
riotboot_dfu: select DFU_ALT automatically when invoking make flash-slotX

### DIFF
--- a/bootloaders/riotboot_dfu/doc.txt
+++ b/bootloaders/riotboot_dfu/doc.txt
@@ -55,9 +55,8 @@ $ FEATURES_REQUIRED+=riotboot USEMODULE+=usbus_dfu make -C examples/saul BOARD=p
 ```
 
 Note that when building and flashing a different slot (eg. `flash-slot1`),
-the DFU utility has to be explicitly prompted to upload it the other slot
-by adding a `DFU_ALT=1` argument.
-
+not only is the image built for that slot, but also dfu-util gets passed
+`--alt 1` (via the `DFU_ALT` build variable) to store it in the right place.
 # Entering DFU mode
 
 When RIOT applications are built with `USEMODULE+=usbus_dfu`,

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -124,12 +124,14 @@ riotboot/flash-extended-slot0: $(RIOTBOOT_EXTENDED_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
 # Flashing rule for slot 0
+riotboot/flash-slot0: DFU_ALT=0
 riotboot/flash-slot0: export IMAGE_OFFSET=$(SLOT0_OFFSET)
 riotboot/flash-slot0: FLASHFILE=$(SLOT0_RIOT_BIN)
 riotboot/flash-slot0: $(SLOT0_RIOT_BIN) $(FLASHDEPS)
 	$(flash-recipe)
 
 # Flashing rule for slot 1
+riotboot/flash-slot1: DFU_ALT=1
 riotboot/flash-slot1: export IMAGE_OFFSET=$(SLOT1_OFFSET)
 riotboot/flash-slot1: FLASHFILE=$(SLOT1_RIOT_BIN)
 riotboot/flash-slot1: $(SLOT1_RIOT_BIN) $(FLASHDEPS)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds an automatic selection for DFU_ALT when invoking `make flash-slotX`. This way, we don't have to manually set it (as I forget it every single time). Update the documentation accordingly.


### Testing procedure

`PROGRAMMER_QUIET=0 PROGRAMMER=dfu-util USEMODULE="usbus_dfu"  make BOARD=saml21-xpro -C tests/buttons riotboot/flash-slot1` and checks DFU_ALT variable in your terminal log.
`PROGRAMMER_QUIET=0 PROGRAMMER=dfu-util USEMODULE="usbus_dfu"  make BOARD=saml21-xpro -C tests/buttons riotboot/flash-slot0` and checks again your DFU_ALT variable.
Everytime, the flash-slotX should match DFU_ALT=X.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None
