### PR TITLE
cpu/stm32/periph_eth: fix format specifier in DEBUG()

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -142,7 +142,7 @@ static void _debug_rx_descriptor_info(unsigned line)
         DEBUG("[stm32_eth:%u] RX descriptors:\n", line);
         for (unsigned i = 0; i < ETH_RX_DESCRIPTOR_COUNT; i++) {
             uint32_t status = rx_desc[i].status;
-            DEBUG("    %s %u: OWN=%c, FS=%c, LS=%c, ES=%c, DE=%c, FL=%lu\n",
+            DEBUG("    %s %u: OWN=%c, FS=%c, LS=%c, ES=%c, DE=%c, FL=%" PRIu32 "\n",
                   (rx_curr == rx_desc + i) ? "-->" : "   ",
                   i,
                   (status & RX_DESC_STAT_OWN) ? '1' : '0',


### PR DESCRIPTION
### Contribution description

In a `DEBUG()` statement in `cpu/stm32/periph_eth`: Use `PRIu32` instead of `lu` to make LLVM happy.

### Testing procedure

Not needed. `unsigned long` and `uint32_t` have the same size on STM32. This doesn't change anything.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/15821