### PR TITLE
cpu/stm32/periph_eth: Provide confirm_send()

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -139,7 +139,7 @@ static void _debug_rx_descriptor_info(unsigned line)
         DEBUG("[stm32_eth:%u] RX descriptors:\n", line);
         for (unsigned i = 0; i < ETH_RX_DESCRIPTOR_COUNT; i++) {
             uint32_t status = rx_desc[i].status;
-            DEBUG("    %s %u: OWN=%c, FS=%c, LS=%c, ES=%c, DE=%c, FL=%lu\n",
+            DEBUG("    %s %u: OWN=%c, FS=%c, LS=%c, ES=%c, DE=%c, FL=%" PRIu32 "\n",
                   (rx_curr == rx_desc + i) ? "-->" : "   ",
                   i,
                   (status & RX_DESC_STAT_OWN) ? '1' : '0',

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -79,13 +79,13 @@ void isr_eth(void)
 
     if (IS_USED(MODULE_STM32_ETH)) {
         extern netdev_t *stm32_eth_netdev;
-        extern mutex_t stm32_eth_tx_completed;
         unsigned tmp = ETH->DMASR;
 
         if ((tmp & ETH_DMASR_TS)) {
             ETH->DMASR = ETH_DMASR_NIS | ETH_DMASR_TS;
             DEBUG("isr_eth: TX completed\n");
-            mutex_unlock(&stm32_eth_tx_completed);
+            stm32_eth_netdev->event_callback(stm32_eth_netdev,
+                                             NETDEV_EVENT_TX_COMPLETE);
         }
 
         if ((tmp & ETH_DMASR_RS)) {

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -45,7 +45,6 @@ PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_bus
-PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_netif_timestamp
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -246,6 +246,7 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += l2util
   USEMODULE += fmt
+  USEMODULE += core_thread_flags
   ifneq (,$(filter netdev_ieee802154_submac,$(USEMODULE)))
     USEMODULE += gnrc_netif_pktq
   endif
@@ -262,11 +263,6 @@ endif
 
 ifneq (,$(filter gnrc_netif_bus,$(USEMODULE)))
   USEMODULE += core_msg_bus
-endif
-
-ifneq (,$(filter gnrc_netif_events,$(USEMODULE)))
-  USEMODULE += core_thread_flags
-  USEMODULE += event
 endif
 
 ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -139,16 +139,6 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS) || defined(DOXYGEN)
-    /**
-     * @brief   Event queue for asynchronous events
-     */
-    event_queue_t evq;
-    /**
-     * @brief   ISR event for the network device
-     */
-    event_t event_isr;
-#endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0) || DOXYGEN
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -162,7 +162,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #endif
     res = dev->driver->send(dev, &iolist);
 
-    gnrc_pktbuf_release(pkt);
+    if (!dev->driver->confirm_send) {
+        /* only for legacy drivers we need to release pkt here */
+        gnrc_pktbuf_release(pkt);
+    }
 
     return res;
 }

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f070rb \
     nucleo-f072rb \
+    nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l011k4 \
@@ -35,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
+    stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
     z1 \


### PR DESCRIPTION
### Contribution description

- Update `sys/net/gnrc/netif/ethernet` to allow Ethernet drivers to provide the new netdev API
- Update `cpu/stm32/periph_eth` to provide `confirm_send()`

### Testing procedure

E.g. `examples/gnrc_networking` on e.g. a Nucleo-F767Zi should still work.

### Issues/PRs references

Depends on:

- [ ] https://github.com/RIOT-OS/RIOT/pull/15821
- [x] https://github.com/RIOT-OS/RIOT/pull/16261
- [ ] Updating lwIP package to make use of confirm_send (not PR yet)
