### PR TITLE
Update to wolfssl-4.7.0, removed sock_tls as tls13 dependency

### DIFF
--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=wolfssl
 PKG_URL=https://github.com/wolfssl/wolfssl.git
-PKG_VERSION=0fa5af9929ce2ee99e8789996a3048f41a99830e # v4.5.0
+PKG_VERSION=830de9a9fb99e30f9ac9caa0a7f7bba29c3b4863 # v4.7.0
 PKG_LICENSE=GPLv2
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/wolfssl/Makefile.dep
+++ b/pkg/wolfssl/Makefile.dep
@@ -36,7 +36,6 @@ endif
 
 ifneq (,$(filter wolfssl_tls13,$(USEMODULE)))
   USEMODULE += wolfcrypt_aes
-  USEMODULE += sock_tls
 endif
 
 ifneq (,$(filter wolfssl_dtls,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

- Update wolfSSL library pkg to latest release (v.4.7.0)
- Removed dependency from `sock_tls` on `wolfssl_tls13` submodule, to allow TLS 1.3 sockets in POSIX mode

### Testing procedure

Tests available in: `examples/dtls-wolfssl`


### Issues/PRs references

Additional "POSIX/lwIP" tests available in wolfSSL example repository
https://github.com/wolfSSL/wolfssl-examples/pull/252
currently under review

