### PR TITLE
tests: add atmega328p-xplained-mini to insufficient memory list

### DIFF
--- a/tests/driver_sx126x/Makefile.ci
+++ b/tests/driver_sx126x/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     stm32f030f4-demo \
     samd10-xmini \

--- a/tests/event_wait_timeout_ztimer/Makefile.ci
+++ b/tests/event_wait_timeout_ztimer/Makefile.ci
@@ -3,5 +3,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    atmega328p-xplained-mini \
     nucleo-l011k4 \
     #


### PR DESCRIPTION
### Contribution description
Add `atmega328p-xplained-mini` to `BOARD_INSUFFICIENT_MEMORY` in `tests/driver_sx126x` and `tests/event_wait_timeout_ztimer`.

### Testing procedure
Green CI

### Issues/PRs references
#16239
