### PR TITLE
cpu/stm32/gpio: fix IRQ handler

### DIFF
--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -348,11 +348,14 @@ void isr_exti(void)
 
     uint32_t pending_isr = pending_rising_isr | pending_falling_isr;
 #else
-    /* only generate interrupts against lines which have their IMR set */
-    uint32_t pending_isr = (EXTI_REG_PR & EXTI_REG_IMR & EXTI_MASK);
+    /* read all pending interrupts wired to isr_exti */
+    uint32_t pending_isr = (EXTI_REG_PR & EXTI_MASK);
 
     /* clear by writing a 1 */
     EXTI_REG_PR = pending_isr;
+
+    /* only generate soft interrupts against lines which have their IMR set */
+    pending_isr &= EXTI_REG_IMR;
 #endif
 
     /* iterate over all set bits */


### PR DESCRIPTION
### Contribution description

I've found a race condition in the GPIO IRQ handling. Without this patch, there is a small probability to get caught in an endless loop since the related *Pending Request* bit is never cleared.

What happend:

1. The GPIO's related `IMR` bit is enabled
2. The condition of the interrupt is met (like the GPIO went from HIGH to LOW) and the corresponding `PR` bit is set
3. The `IMR` bit is cleared by the program
4. The program gets interrupted and `isr_exti()` is called
5. `isr_exti()` reads the `PR` bits and masks out the bit that caused its execution. Thus, the `PR` bit is never cleared and `isr_exti()` is called again after `cortexm_isr_end()`.

### Testing procedure

The [DOSE driver](http://api.riot-os.org/group__drivers__dose.html) uses the GPIO IRQ to detect start bits of Ethernet frames. This IRQ is then disabled during transmission and enabled after the whole frame has been received. Without this patch I was able to trigger the race condition within a few hours by creating some heavy bus traffic. After applying this patch, I was able to run this driver for days (tests are still ongoing).

To verify the mechanics (i.e. the PR bit must be cleared even if the corresponding IMR bit is unset) please see [RM0360 Page 173 Figure 21](https://www.st.com/resource/en/reference_manual/dm00091010-stm32f030x4-x6-x8-xc-and-stm32f070x6-xb-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf)

### Issues/PRs references

*none*