### PR TITLE
board/feather-nrf52840: add uf2 boot loader

### DIFF
--- a/boards/feather-nrf52840/Kconfig
+++ b/boards/feather-nrf52840/Kconfig
@@ -16,5 +16,6 @@ config BOARD_FEATHER_NRF52840
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO
 
 source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/feather-nrf52840/Makefile.dep
+++ b/boards/feather-nrf52840/Makefile.dep
@@ -1,11 +1,7 @@
-# Use stdio_cdc_acm unless another stdio_% is already used
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
-  USEMODULE += stdio_cdc_acm
-endif
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
 # include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/feather-nrf52840/Makefile.features
+++ b/boards/feather-nrf52840/Makefile.features
@@ -7,5 +7,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/feather-nrf52840/Makefile.include
+++ b/boards/feather-nrf52840/Makefile.include
@@ -1,3 +1,24 @@
+PROGRAMMER ?= uf2conv
+
+UF2CONV_FLAGS = -f 0xADA52840
+
+ifeq (uf2conv,$(PROGRAMMER))
+
+  # Using uf2conv implies using the UF2 bootloader
+  #
+  # It has a static MBR at the first 4k, and a 38k UF2 Bootloader at
+  # the end, leaving 972k for the application. This overwrites any SoftDevice,
+  # but that's what the minimal working example does as well.
+  ROM_OFFSET = 0x1000
+  ROM_LEN    = 0xf3000
+
+  # Driver can take some time to get mounted
+  PREFLASH_DELAY ?= 3
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
+endif
+
+PROGRAMMERS_SUPPORTED += uf2conv
+
 # HACK: replicate dependency resolution in Makefile.dep, only works
 # if `USEMODULE` or `DEFAULT_MODULE` is set by the command line or in the
 # application Makefile.

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -16,10 +16,31 @@ Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
 
 ### Flash the board
 
-See the **Flashing** section in @ref boards_common_nrf52. The easiest way is to
+The board is flashed using its on-board UF2 boot loader by default.
+The boot loader will present a mass storage device that has to be mounted to /media/MDK-DONGLE so
+`uf2conv.py` can find it. If you have an auto-mounter installed this will happen automatically.
+
+The rest of the process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU and enter
+the bootloader.
+If some other firmware is running or RIOT crashed, you need to enter the bootloader
+manually by pressing the board's reset button while plugging the device into the
+
+Otherwise See the **Flashing** section in @ref boards_common_nrf52. The easiest way is to
 use an external Segger J-Link Programmer connected to the [SWD Connector].
 
 [SWD Connector]: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/pinouts#swd-connector-3-12
+
+#### Flashing the uf2 bootloader
+
+To flash the uf2 bootloader (if its no longer present on your BOARD) then with
+a jlink attached to your BOARD and `nrf52prog` installed:
+
+$ git clone git@github.com:adafruit/Adafruit_nRF52_Bootloader.git
+$ cd Adafruit_nRF52_Bootloader
+$ make BOARD=feather_nrf52840_express all
+$ make BOARD=feather_nrf52840_express flash
 
 ### Terminal
 To connect a terminal to the Feather, RIOT chooses Segger RTT per default.

--- a/boards/feather-nrf52840/reset.c
+++ b/boards/feather-nrf52840/reset.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-nrf52840
+ * @{
+ * @file
+ * @brief       Implementation for managing the nrfutil bootloader
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "cpu.h"
+#include "usb_board_reset.h"
+
+/* Set the value used by the bootloader to select between boot in
+   application and boot in bootloader mode. */
+#define NRF52_DOUBLE_TAP_MAGIC_NUMBER       (0x57)
+
+void usb_board_reset_in_bootloader(void)
+{
+    NRF_POWER->GPREGRET = NRF52_DOUBLE_TAP_MAGIC_NUMBER;
+
+    /* Going with a hard reset rather than a pm_off, as that might be altered
+     * to do *anything* -- which is not safe any more now that we've forsaken
+     * the RAM content */
+    NVIC_SystemReset();
+}
+
+#endif /* MODULE_USB_BOARD_RESET */


### PR DESCRIPTION
### Contribution description

Add the uf2 bootloader for the BOARD as its the default bootloader on the BOARD when shipped from adafruit.

### Testing procedure

Flash anything it should work...

```
 BOARD=feather-nrf52840 make -C tests/bloom_bytes/ flash test
Building application "tests_bloom_bytes" for "feather-nrf52840" with MCU "nrf52".

"make" -C /home/francisco/workspace/RIOT/boards/feather-nrf52840
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/vectors
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/auto_init/usb
"make" -C /home/francisco/workspace/RIOT/sys/bloom
"make" -C /home/francisco/workspace/RIOT/sys/crypto
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/event
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/hashes
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/luid
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/random
"make" -C /home/francisco/workspace/RIOT/sys/random/tinymt32
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/sys/usb/usbus
"make" -C /home/francisco/workspace/RIOT/sys/usb/usbus/cdc/acm
"make" -C /home/francisco/workspace/RIOT/sys/usb_board_reset
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
   text    data     bss     dec     hex filename
  21260     160    6220   27640    6bf8 /home/francisco/workspace/RIOT/tests/bloom_bytes/bin/feather-nrf52840/tests_bloom_bytes.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 3
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'uf2conv' - duration: 2.01s)
sleep 2
r
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
Help: Press s to start test, r to print it is ready
READY
Help: Press s to start test, r to print it is ready
START
main(): This is RIOT! (Version: 2021.04-devel-1159-g836a9-pr_nrf52840_feather_uf2)
Testing Bloom filter.

m: 4096 k: 8

adding 512 elements took 148ms
checking 10000 elements took 1252ms

267 elements probably in the filter.
9733 elements not in the filter.
0.026700 false positive rate.

All done!
```