### PR TITLE
lwip_sock: Fix computation of last_offset on partial reads.

### DIFF
--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -347,7 +347,7 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
         if (buf_len > copylen) {
             /* there is still data in the buffer */
             sock->last_buf = buf;
-            sock->last_offset = copylen;
+            sock->last_offset += copylen;
         }
         else {
             sock->last_buf = NULL;


### PR DESCRIPTION
### Contribution description

lwip receives network buffers that are made available to lwip_sock_tcp
calling `netconn_recv_tcp_pbuf`. The size of these buffers depends on
the size of the network packets. An application calling `sock_tcp_read`
can pass any arbitrary buffer size to read (copy) from these internal
network buffers, which may be smaller. lwip_sock_tcp keeps around the
last network buffer (`struct pbuf last_buf`) and the offset into this
buffer already consumed by the application (`last_offset`).

However, when multiple application reads from the same `pbuf` buffer
occur, the `last_offset` must be updated incrementing it. The code had
a bug that would work only when `last_offset` was either 0 (no previous
partial read) or when the current read was consuming all the remaining
data (when `buf_len == copylen`).

This patch fixes the issue an allows multiple reads from the same
buffer.

### Testing procedure

Tested using `tests/lwip` with TCP network payloads of 536 bytes and reading 256 bytes at a time.

### Issues/PRs references

Fixes #16124