### PR TITLE
boards/msbiot: fix param for MPU9150

### DIFF
--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -41,7 +41,7 @@ extern "C" {
  * @name    Configure connected MPU-9150 device
  * @{
  */
-#define MPU9150_PARAM_COMP_ADDR   (0x0E)            /**< I2C address of the MPU9150 */
+#define MPU9X50_PARAM_COMP_ADDR   (0x0E)            /**< I2C address of the MPU9150 */
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

When the driver for the mpu9150 has been renamed to mpu9x50, the
corresponding macro in the MSB-IoT board was forgotten to be renamed
as well. This fixes the issue.

### Testing procedure

With `master`:

```
> [auto_init_saul] error initializing mpu9x50 #0
main(): This is RIOT! (Version: 2021.04-devel-1223-g9eac73-sys/Makefile.dep)
```

This PR:

```
main(): This is RIOT! (Version: 2021.04-devel-1223-g9eac73-sys/Makefile.dep)
Welcome to RIOT!
> saul
ID	Class		Name
#0	ACT_SWITCH	red LED
#1	ACT_SWITCH	yellow LED
#2	ACT_SWITCH	green LED
#3	SENSE_BTN	left button
#4	SENSE_BTN	right button
#5	SENSE_ACCEL	mpu9x50
#6	SENSE_GYRO	mpu9x50
#7	SENSE_MAG	mpu9x50
> saul read 5
Reading from #5 (mpu9x50|SENSE_ACCEL)
Data:	[0]         203 mg
	[1]         -12 mg
	[2]         968 mg
> saul read 6
Reading from #6 (mpu9x50|SENSE_GYRO)
Data:	[0]         0.0 dps
	[1]         0.2 dps
	[2]         0.0 dps
> saul read 7
Reading from #7 (mpu9x50|SENSE_MAG)
Data:	[0]       -0.15 Gs
	[1]       -0.06 Gs
	[2]        0.72 Gs
```

### Issues/PRs references

Broken since https://github.com/RIOT-OS/RIOT/pull/12103