### PR TITLE
drivers/cc110x: add hook cc1xxx_eui_get()

### DIFF
--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -24,7 +24,6 @@
 #include "assert.h"
 #include "iolist.h"
 #include "irq.h"
-#include "luid.h"
 #include "mutex.h"
 #include "net/eui64.h"
 #include "net/netdev.h"
@@ -310,13 +309,11 @@ static int cc110x_init(netdev_t *netdev)
         return -EIO;
     }
 
-    /* Setup the layer 2 address, but do not accept CC110X_L2ADDR_AUTO (which
+    /* Setup the layer 2 address, but do not accept CC1XXX_BCAST_ADDR (which
      * has the value 0x00 and is used for broadcast)
      */
-    dev->addr = dev->params.l2addr;
-    while (dev->addr == CC110X_L2ADDR_AUTO) {
-        luid_get(&dev->addr, 1);
-    }
+    cc1xxx_eui_get(&dev->netdev, &dev->addr);
+    assert(dev->addr != CC1XXX_BCAST_ADDR);
     cc110x_write(dev, CC110X_REG_ADDR, dev->addr);
 
     /* Setup interrupt on GDO0  */

--- a/drivers/cc110x/include/cc110x_netdev.h
+++ b/drivers/cc110x/include/cc110x_netdev.h
@@ -19,6 +19,8 @@
 #ifndef CC110X_NETDEV_H
 #define CC110X_NETDEV_H
 
+#include "net/netdev.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -52,13 +52,6 @@ extern "C" {
 #define CC110X_PARAM_SPI_CLOCK      SPI_CLK_5MHZ    /**< SPI clock frequence to use */
 #endif
 
-#ifndef CC110X_PARAM_L2ADDR
-/**
- * @brief   L2 address configure when the driver is initialized
- */
-#define CC110X_PARAM_L2ADDR         CC110X_L2ADDR_AUTO
-#endif
-
 #ifndef CC110X_PARAM_PATABLE
 /**
  * @brief   PA table to use
@@ -97,7 +90,6 @@ extern "C" {
         .cs       = CC110X_PARAM_CS,   \
         .gdo0     = CC110X_PARAM_GDO0, \
         .gdo2     = CC110X_PARAM_GDO2, \
-        .l2addr   = CC110X_PARAM_L2ADDR, \
         .patable  = CC110X_PARAM_PATABLE, \
         .config   = CC110X_PARAM_CONFIG, \
         .channels = CC110X_PARAM_CHANNELS, \

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -26,6 +26,7 @@
 
 #include "assert.h"
 #include "net/gnrc.h"
+#include "luid.h"
 #include "cc1xxx_common.h"
 
 #define ENABLE_DEBUG 0
@@ -171,4 +172,13 @@ int gnrc_netif_cc1xxx_create(gnrc_netif_t *netif, char *stack, int stacksize,
 {
     return gnrc_netif_create(netif, stack, stacksize, priority, name,
                              dev, &cc1xxx_netif_ops);
+}
+
+void __attribute__((weak)) cc1xxx_eui_get(const netdev_t *netdev, uint8_t *eui)
+{
+    (void)netdev;
+    do {
+        luid_get(eui, 1);
+    }
+    while (*eui == CC1XXX_BCAST_ADDR);
 }

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -91,7 +91,7 @@
  * Please note that the layer 2 address by default is derived from the CPU ID.
  * Due to the birthday paradox with only 20 devices the probability of a
  * collision is already bigger than 50%. Thus, manual address assignment is
- * supported by defining `C110X_PARAM_L2ADDR`.
+ * supported by providing an implementation of @ref cc1xxx_eui_get.
  *
  *
  * Base Band, Data Rate, Channel Bandwidth and Channel Map Configuration
@@ -224,12 +224,6 @@ extern "C" {
  * @brief   Maximum number of channels supported by the driver
  */
 #define CC110X_MAX_CHANNELS             8
-
-/**
- * @brief   Special value to indicate that layer 2 address should be derived
- *          from the CPU-ID
- */
-#define CC110X_L2ADDR_AUTO              0x00
 
 /**
  * @brief   Default protocol for data that is coming in
@@ -470,11 +464,6 @@ typedef struct {
     spi_cs_t cs;                        /**< GPIO pin connected to chip select */
     gpio_t gdo0;                        /**< GPIO pin connected to GDO0 */
     gpio_t gdo2;                        /**< GPIO pin connected to GDO2 */
-    /**
-     * @brief Layer-2 address to use or `CC110X_L2ADDR_AUTO` to derive it from
-     *        the CPU ID
-     */
-    uint8_t l2addr;
 } cc110x_params_t;
 
 /**

--- a/drivers/include/cc1xxx_common.h
+++ b/drivers/include/cc1xxx_common.h
@@ -130,6 +130,17 @@ typedef struct netdev_radio_rx_info cc1xxx_rx_info_t;
 int gnrc_netif_cc1xxx_create(gnrc_netif_t *netif, char *stack, int stacksize,
                              char priority, char *name, netdev_t *dev);
 
+/**
+ * @brief   Retrieve a unique layer-2 address for a cc1xxx instance
+ *
+ * @note    This function has __attribute__((weak)) so you can override this, e.g.
+ *          to construct an address. By default @ref luid_get is used.
+ *
+ * @param[in]   dev     The device descriptor of the transceiver
+ * @param[out]  eui     Destination to write the address to
+ */
+void cc1xxx_eui_get(const netdev_t *dev, uint8_t *eui);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR  adds  a hook for the cc110x driver to facilitate address configuration, e.g. if your board has an EUI provider.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Add the function:
```C
#include "net/netdev.h"
bool  cc110x_eui_get(const netdev_t *netdev, void *eui)
{
    (void)netdev;
    *((uint8_t *)eui) = 0x11;
    return true;
}
```
for example in `board.c` and check the address with `ifconfig`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
