### PR TITLE
boards: Introduce atxmega-a3bu-xplained board

### DIFF
--- a/boards/atxmega-a3bu-xplained/Kconfig
+++ b/boards/atxmega-a3bu-xplained/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+# Copyright (c) 2021 Gerson Fernando Budle
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "atxmega-a3bu-xplained" if BOARD_ATXMEGA_A3BU_XPLAINED
+
+config BOARD_ATXMEGA_A3BU_XPLAINED
+    bool
+    default y
+    select CPU_MODEL_XMEGA256A3BU
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_NVM
+    select HAS_PERIPH_PM
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_TIMER_PERIODIC
+    select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/boards/atxmega-a3bu-xplained/Makefile
+++ b/boards/atxmega-a3bu-xplained/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atxmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/atxmega-a3bu-xplained/Makefile.dep
+++ b/boards/atxmega-a3bu-xplained/Makefile.dep
@@ -1,0 +1,5 @@
+USEMODULE += boards_common_atxmega
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/atxmega-a3bu-xplained/Makefile.features
+++ b/boards/atxmega-a3bu-xplained/Makefile.features
@@ -1,0 +1,3 @@
+CPU_MODEL = atxmega256a3bu
+
+include $(RIOTBOARD)/common/atxmega/Makefile.features

--- a/boards/atxmega-a3bu-xplained/Makefile.include
+++ b/boards/atxmega-a3bu-xplained/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/atxmega/Makefile.include

--- a/boards/atxmega-a3bu-xplained/doc.txt
+++ b/boards/atxmega-a3bu-xplained/doc.txt
@@ -1,0 +1,49 @@
+/**
+@defgroup    boards_atxmega-a3bu-xplained ATxmega-A3BU Xplained board
+@ingroup     boards
+@brief       Support for the ATxmega-A3BU Xplained board
+
+The ATxmega-A3BU Xplained is a reference to develop with XMEGA's.
+
+### MCU
+| MCU           | ATxmega256A3BU                                |
+|:------------- |:--------------------------------------------- |
+| Family        | AVR/ATxmega                                   |
+| Vendor        | Microchip (previously Atmel)                  |
+| Flash         | 256KiB                                        |
+| RAM           | 16KiB                                         |
+| EEPROM        | 4KiB                                          |
+| Frequency     | up to 32MHz                                   |
+| Timers        | 7 16bit (32 bit combining 2 x 16 bit)         |
+| ACs           | 4 Analog Comparators                          |
+| ADCs          | 2 - 16 channels - 12 bit - 2msps              |
+| ADCs          | 1 - 2 channels - 12 bit - 1msps               |
+| UARTs         | 6 (can be used in SPI mode) with 1 IrDA       |
+| SPIs          | 2                                             |
+| I2Cs          | 2 (called TWI)                                |
+| USB           | 1 port                                        |
+| DMA           | 4 Channels                                    |
+| Event System  | 8 Channels                                    |
+| Ext. INT      | All GPIOs                                     |
+| Crypto        | AES/DES, CRC-16, CRC-32                       |
+| Vcc           | 1.6V - 3.6V                                   |
+| Datasheet     | [Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8362-8-and-16bit-AVR-microcontroller-ATxmega256A3BU_datasheet.pdf) |
+| Xmega Manual  | [Manual](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8331-8-and-16-bit-AVR-Microcontroller-XMEGA-AU_Manual.pdf) |
+| Guide         | [AVR1923 PDF](http://ww1.microchip.com/downloads/en/Appnotes/doc8394.pdf) |
+| Schematic     | [AVR1923 ZIP](https://ww1.microchip.com/downloads/en/AppNotes/AVR1923.zip) |
+
+## Flashing the Device
+
+The ATxmega-A3BU Xplained needs an external programmer like atmelice.
+
+In order to flash the ATxmega256A3BU, simple run:
+
+    make BOARD=atxmega-a3bu-xplained flash
+
+## Serial Terminal
+
+This board needs a serial converter. The default STDIO is at J1 pins 2/3.
+
+    make BOARD=atxmega-a3bu-xplained term
+
+ */

--- a/boards/atxmega-a3bu-xplained/include/board.h
+++ b/boards/atxmega-a3bu-xplained/include/board.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atxmega-a3bu-xplained
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the ATxmegaA3BU Xplained board.
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Clock configuration
+ */
+#define CLOCK_CORECLOCK     MHZ(32)
+
+/**
+ * @name   Baudrate for STDIO terminal
+ *
+ * The standard configuration for STDIO in cpu/atxmega/periph/uart.c
+ * is to use double speed.
+ *
+ * For 32MHz F_CPU following Baudrate have good error rates
+ *  115200
+ *
+ * Matches this with BAUD in Board/Makefile.include
+ *
+ * @{
+ */
+#ifndef STDIO_UART_BAUDRATE
+#define STDIO_UART_BAUDRATE (115200U)
+#endif
+/** @} */
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED_PORT            PORTR
+
+#define LED0_PIN            GPIO_PIN(PORT_R, 0)
+#define LED0_MODE           GPIO_OUT
+#define LED0_MASK           (PIN0_bm)
+#define LED0_ON             (LED_PORT.OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL = LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PORT_R, 1)
+#define LED1_MODE           GPIO_OUT
+#define LED1_MASK           (PIN1_bm)
+#define LED1_ON             (LED_PORT.OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT.OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT.OUTTGL = LED1_MASK)
+
+#define LED_PORT_MASK       (LED0_MASK | LED1_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_E, 5)
+#define BTN0_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN0_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN1_PIN            GPIO_PIN(PORT_F, 1)
+#define BTN1_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN1_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN2_PIN            GPIO_PIN(PORT_F, 2)
+#define BTN2_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN2_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+/** @} */
+
+/**
+ * @name xtimer configuration values
+ * if XTIMER_HZ > 1MHz then (XTIMER_HZ != (1000000ul << XTIMER_SHIFT))
+ * if XTIMER_HZ < 1MHz then ((XTIMER_HZ << XTIMER_SHIFT) != 1000000ul)
+ *
+ * 32MHz Core Clock
+ * XTIMER_HZ 4000000 (clkdiv 8 )    XTIMER_SHIFT 2
+ * XTIMER_HZ 1000000 ()             XTIMER_SHIFT 0
+ * XTIMER_HZ  500000 (clkdiv 64)    XTIMER_SHIFT 1
+ * XTIMER_HZ  250000 (clkdiv 128)   XTIMER_SHIFT 2
+ * XTIMER_HZ   31250 (clkdiv 1024)  XTIMER_SHIFT 5
+ *
+ * @{
+ */
+#define XTIMER_DEV          TIMER_DEV(0)
+#define XTIMER_CHAN         (0)
+#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           KHZ(500)
+#define XTIMER_BACKOFF      (150)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/atxmega-a3bu-xplained/include/gpio_params.h
+++ b/boards/atxmega-a3bu-xplained/include/gpio_params.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atxmega-a3bu-xplained
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "SW0",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW1",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW2",
+        .pin = BTN2_PIN,
+        .mode = BTN2_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED0",
+        .pin = LED0_PIN,
+        .mode = LED0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED1",
+        .pin = LED1_PIN,
+        .mode = LED1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/atxmega-a3bu-xplained/include/periph_conf.h
+++ b/boards/atxmega-a3bu-xplained/include/periph_conf.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atxmega-a3bu-xplained
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the ATxmegaA3BU Xplained board.
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+#include "mutex.h"
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <avr/io.h>
+
+#include "periph_cpu.h"
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev            = (void *)&TCC1,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_TC1_bm),
+        .type           = TC_TYPE_1,
+        .int_lvl        = { CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_OFF,
+                            CPU_INT_LVL_OFF,
+                            CPU_INT_LVL_OFF },
+    },
+    {
+        .dev            = (void *)&TCC0,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_TC0_bm),
+        .type           = TC_TYPE_0,
+        .int_lvl        = { CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_LOW },
+    }
+};
+
+#define TIMER_0_ISRA      TCC1_CCA_vect
+
+#define TIMER_1_ISRA      TCC0_CCA_vect
+#define TIMER_1_ISRB      TCC0_CCB_vect
+#define TIMER_1_ISRC      TCC0_CCC_vect
+#define TIMER_1_ISRD      TCC0_CCD_vect
+
+#define TIMER_NUMOF       ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {   /* J1 */
+        .dev            = &USARTC0,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_USART0_bm),
+        .rx_pin         = GPIO_PIN(PORT_C, 2),
+        .tx_pin         = GPIO_PIN(PORT_C, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin        = GPIO_UNDEF,
+        .cts_pin        = GPIO_UNDEF,
+#endif
+        .rx_int_lvl     = CPU_INT_LVL_LOW,
+        .tx_int_lvl     = CPU_INT_LVL_LOW,
+        .dre_int_lvl    = CPU_INT_LVL_OFF,
+    },
+    {   /* J4 */
+        .dev            = &USARTE0,
+        .pwr            = PWR_RED_REG(PWR_PORT_E, PR_USART0_bm),
+        .rx_pin         = GPIO_PIN(PORT_E, 2),
+        .tx_pin         = GPIO_PIN(PORT_E, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin        = GPIO_UNDEF,
+        .cts_pin        = GPIO_UNDEF,
+#endif
+        .rx_int_lvl     = CPU_INT_LVL_LOW,
+        .tx_int_lvl     = CPU_INT_LVL_LOW,
+        .dre_int_lvl    = CPU_INT_LVL_OFF,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_RXC_ISR    USARTC0_RXC_vect    /* Reception Complete Interrupt */
+#define UART_0_DRE_ISR    USARTC0_DRE_vect    /* Data Register Empty Interrupt */
+#define UART_0_TXC_ISR    USARTC0_TXC_vect    /* Transmission Complete Interrupt */
+
+#define UART_1_RXC_ISR    USARTE0_RXC_vect
+#define UART_1_DRE_ISR    USARTE0_DRE_vect
+#define UART_1_TXC_ISR    USARTE0_TXC_vect
+
+#define UART_NUMOF        ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     chronos \
     derfmega128 \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \

--- a/examples/ndn-ping/Makefile.ci
+++ b/examples/ndn-ping/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/examples/posix_sockets/Makefile.ci
+++ b/examples/posix_sockets/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     im880b \
     nucleo-l011k4 \

--- a/tests/driver_at/Makefile.ci
+++ b/tests/driver_at/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     nucleo-f031k6 \
     nucleo-l011k4 \
     samd10-xmini \

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \

--- a/tests/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_opt/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_dns/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -4,6 +4,7 @@ FEATURES_REQUIRED = periph_timer
 
 BOARDS_TIMER_500kHz := \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     #
 
 BOARDS_TIMER_250kHz := \

--- a/tests/pkg_emlearn/Makefile.ci
+++ b/tests/pkg_emlearn/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     blackpill \
     bluepill \
     derfmega128 \

--- a/tests/pkg_nanopb/Makefile.ci
+++ b/tests/pkg_nanopb/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     stm32f030f4-demo \
     #

--- a/tests/sock_udp_aux/Makefile.ci
+++ b/tests/sock_udp_aux/Makefile.ci
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a1u-xpro \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     calliope-mini \
     derfmega128 \


### PR DESCRIPTION
### Contribution description

Add initial version of [atxmega-a3bu-xplained](https://www.microchip.com/DevelopmentTools/ProductDetails/PartNo/ATXMEGAA3BU-XPLD) board. This is another ATxmega development board based on the A3BU version.

### Issues/PRs references

This is part of #15703

CC: @benpicco @maribu 