### PR TITLE
boards: Introduce atxmega-a1-xplained board

### DIFF
--- a/boards/atxmega-a1-xplained/Kconfig
+++ b/boards/atxmega-a1-xplained/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+# Copyright (c) 2021 Gerson Fernando Budle
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "atxmega-a1-xplained" if BOARD_ATXMEGA_A1_XPLAINED
+
+config BOARD_ATXMEGA_A1_XPLAINED
+    bool
+    default y
+    select CPU_MODEL_XMEGA128A1
+
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/boards/atxmega-a1-xplained/Makefile
+++ b/boards/atxmega-a1-xplained/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/atxmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/atxmega-a1-xplained/Makefile.dep
+++ b/boards/atxmega-a1-xplained/Makefile.dep
@@ -1,0 +1,5 @@
+USEMODULE += boards_common_atxmega
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/atxmega-a1-xplained/Makefile.features
+++ b/boards/atxmega-a1-xplained/Makefile.features
@@ -1,0 +1,7 @@
+CPU_MODEL = atxmega128a1
+
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTBOARD)/common/atxmega/Makefile.features

--- a/boards/atxmega-a1-xplained/Makefile.include
+++ b/boards/atxmega-a1-xplained/Makefile.include
@@ -1,0 +1,4 @@
+override RAM_LEN = 65536
+override EXP_RAM = 1
+
+include $(RIOTBOARD)/common/atxmega/Makefile.include

--- a/boards/atxmega-a1-xplained/doc.txt
+++ b/boards/atxmega-a1-xplained/doc.txt
@@ -1,0 +1,52 @@
+/**
+@defgroup    boards_atxmega-a1-xplained ATxmega-A1 Xplained board
+@ingroup     boards
+@brief       Support for the ATxmega-A1 Xplained board
+
+## Overview
+
+The ATxmega-A1 Xplained is an old reference to develop with XMEGA's.
+
+### MCU
+| MCU           | ATxmega128A1                                  |
+|:------------- |:--------------------------------------------- |
+| Family        | AVR/ATxmega                                   |
+| Vendor        | Microchip (previously Atmel)                  |
+| Flash         | 128KiB                                        |
+| RAM           | 8KiB                                          |
+| EBI           | 16MiB SRAM, 128MiB SDRAM                      |
+| EEPROM        | 2KiB                                          |
+| Frequency     | up to 32MHz                                   |
+| Timers        | 8 16bit (32 bit combining 2 x 16 bit)         |
+| ACs           | 4 Analog Comparators                          |
+| ADCs          | 2 - 16 channels - 12 bit - 2msps              |
+| ADCs          | 2 - 2 channels - 12 bit - 1msps               |
+| UARTs         | 8 (can be used in SPI mode) with 1 IrDA       |
+| SPIs          | 4                                             |
+| I2Cs          | 4 (called TWI)                                |
+| DMA           | 4 Channels                                    |
+| Event System  | 8 Channels                                    |
+| Ext. INT      | All GPIOs                                     |
+| Crypto        | AES/DES, CRC-16, CRC-32                       |
+| Vcc           | 2.7V - 5.5V (when clocked at 8MHz)            |
+| Datasheet     | [Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/ATxmega128A1U-64A1U-Data-Sheet-DS40002058A.pdf) |
+| Xmega Manual  | [Manual](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8331-8-and-16-bit-AVR-Microcontroller-XMEGA-AU_Manual.pdf) |
+| Guide         | [AVR1924 PDF](http://ww1.microchip.com/downloads/en/AppNotes/doc8370.pdf) |
+| Schematic     | [AVR1924 ZIP](https://ww1.microchip.com/downloads/en/AppNotes/AVR1924.zip) |
+
+## Flashing the Device
+
+The ATxmega-A1 Xplained needs an external programmer like atmelice.
+
+In order to flash the ATxmega128A1, simple run:
+
+    make BOARD=atxmega-a1-xplained flash
+
+## Serial Terminal
+
+The CDC-ACM will enumerate a /dev/ttyACM device. The STDIO at CDC-ACM shares
+with J4 pins 2/3.
+
+    make BOARD=atxmega-a1-xplained term
+
+ */

--- a/boards/atxmega-a1-xplained/include/board.h
+++ b/boards/atxmega-a1-xplained/include/board.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atxmega-a1-xplained
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the ATxmegaA1 Xplained board.
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Clock configuration
+ */
+#define CLOCK_CORECLOCK     MHZ(32)
+
+/**
+ * @brief Use the UART-2 for STDIO on this board
+ */
+#define STDIO_UART_DEV      UART_DEV(2)
+
+/**
+ * @name   Baudrate for STDIO terminal
+ *
+ * The standard configuration for STDIO in cpu/atxmega/periph/uart.c
+ * is to use double speed.
+ *
+ * For 32MHz F_CPU following Baudrate have good error rates
+ *  115200
+ *
+ * Matches this with BAUD in Board/Makefile.include
+ *
+ * @{
+ */
+#ifndef STDIO_UART_BAUDRATE
+#define STDIO_UART_BAUDRATE (115200U)
+#endif
+/** @} */
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED_PORT            PORTE
+
+#define LED0_PIN            GPIO_PIN(PORT_E, 0)
+#define LED0_MODE           GPIO_OUT
+#define LED0_MASK           (PIN0_bm)
+#define LED0_ON             (LED_PORT.OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL = LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PORT_E, 1)
+#define LED1_MODE           GPIO_OUT
+#define LED1_MASK           (PIN1_bm)
+#define LED1_ON             (LED_PORT.OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT.OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT.OUTTGL = LED1_MASK)
+
+#define LED2_PIN            GPIO_PIN(PORT_E, 2)
+#define LED2_MODE           GPIO_OUT
+#define LED2_MASK           (PIN2_bm)
+#define LED2_ON             (LED_PORT.OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED_PORT.OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT.OUTTGL = LED2_MASK)
+
+#define LED3_PIN            GPIO_PIN(PORT_E, 3)
+#define LED3_MODE           GPIO_OUT
+#define LED3_MASK           (PIN3_bm)
+#define LED3_ON             (LED_PORT.OUTCLR = LED3_MASK)
+#define LED3_OFF            (LED_PORT.OUTSET = LED3_MASK)
+#define LED3_TOGGLE         (LED_PORT.OUTTGL = LED3_MASK)
+
+#define LED4_PIN            GPIO_PIN(PORT_E, 4)
+#define LED4_MODE           GPIO_OUT
+#define LED4_MASK           (PIN4_bm)
+#define LED4_ON             (LED_PORT.OUTCLR = LED4_MASK)
+#define LED4_OFF            (LED_PORT.OUTSET = LED4_MASK)
+#define LED4_TOGGLE         (LED_PORT.OUTTGL = LED4_MASK)
+
+#define LED5_PIN            GPIO_PIN(PORT_E, 5)
+#define LED5_MODE           GPIO_OUT
+#define LED5_MASK           (PIN5_bm)
+#define LED5_ON             (LED_PORT.OUTCLR = LED5_MASK)
+#define LED5_OFF            (LED_PORT.OUTSET = LED5_MASK)
+#define LED5_TOGGLE         (LED_PORT.OUTTGL = LED5_MASK)
+
+#define LED6_PIN            GPIO_PIN(PORT_E, 6)
+#define LED6_MODE           GPIO_OUT
+#define LED6_MASK           (PIN6_bm)
+#define LED6_ON             (LED_PORT.OUTCLR = LED6_MASK)
+#define LED6_OFF            (LED_PORT.OUTSET = LED6_MASK)
+#define LED6_TOGGLE         (LED_PORT.OUTTGL = LED6_MASK)
+
+#define LED7_PIN            GPIO_PIN(PORT_E, 7)
+#define LED7_MODE           GPIO_OUT
+#define LED7_MASK           (PIN7_bm)
+#define LED7_ON             (LED_PORT.OUTCLR = LED7_MASK)
+#define LED7_OFF            (LED_PORT.OUTSET = LED7_MASK)
+#define LED7_TOGGLE         (LED_PORT.OUTTGL = LED7_MASK)
+
+#define LED_PORT_MASK       (LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK | \
+                             LED4_MASK | LED5_MASK | LED6_MASK | LED7_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_D, 0)
+#define BTN0_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN0_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN1_PIN            GPIO_PIN(PORT_D, 1)
+#define BTN1_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN1_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN2_PIN            GPIO_PIN(PORT_D, 2)
+#define BTN2_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN2_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN3_PIN            GPIO_PIN(PORT_D, 3)
+#define BTN3_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN3_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN4_PIN            GPIO_PIN(PORT_D, 4)
+#define BTN4_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN4_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN5_PIN            GPIO_PIN(PORT_D, 5)
+#define BTN5_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN5_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN6_PIN            GPIO_PIN(PORT_R, 0)
+#define BTN6_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN6_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+
+#define BTN7_PIN            GPIO_PIN(PORT_R, 1)
+#define BTN7_MODE           (GPIO_IN | GPIO_OPC_PU | GPIO_SLEW_RATE)
+#define BTN7_INT_FLANK      (GPIO_ISC_FALLING | GPIO_LVL_LOW)
+/** @} */
+
+/**
+ * @name xtimer configuration values
+ * if XTIMER_HZ > 1MHz then (XTIMER_HZ != (1000000ul << XTIMER_SHIFT))
+ * if XTIMER_HZ < 1MHz then ((XTIMER_HZ << XTIMER_SHIFT) != 1000000ul)
+ *
+ * 32MHz Core Clock
+ * XTIMER_HZ 4000000 (clkdiv 8 )    XTIMER_SHIFT 2
+ * XTIMER_HZ 1000000 ()             XTIMER_SHIFT 0
+ * XTIMER_HZ  500000 (clkdiv 64)    XTIMER_SHIFT 1
+ * XTIMER_HZ  250000 (clkdiv 128)   XTIMER_SHIFT 2
+ * XTIMER_HZ   31250 (clkdiv 1024)  XTIMER_SHIFT 5
+ *
+ * @{
+ */
+#define XTIMER_DEV          TIMER_DEV(0)
+#define XTIMER_CHAN         (0)
+#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           KHZ(500)
+#define XTIMER_BACKOFF      (150)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/atxmega-a1-xplained/include/gpio_params.h
+++ b/boards/atxmega-a1-xplained/include/gpio_params.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atxmega-a1-xplained
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "SW0",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW1",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW2",
+        .pin = BTN2_PIN,
+        .mode = BTN2_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW3",
+        .pin = BTN3_PIN,
+        .mode = BTN3_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW4",
+        .pin = BTN4_PIN,
+        .mode = BTN4_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW5",
+        .pin = BTN5_PIN,
+        .mode = BTN5_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW6",
+        .pin = BTN6_PIN,
+        .mode = BTN6_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "SW7",
+        .pin = BTN7_PIN,
+        .mode = BTN7_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED0",
+        .pin = LED0_PIN,
+        .mode = LED0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED1",
+        .pin = LED1_PIN,
+        .mode = LED1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED2",
+        .pin = LED2_PIN,
+        .mode = LED2_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED3",
+        .pin = LED3_PIN,
+        .mode = LED3_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED4",
+        .pin = LED4_PIN,
+        .mode = LED4_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED5",
+        .pin = LED5_PIN,
+        .mode = LED5_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED6",
+        .pin = LED6_PIN,
+        .mode = LED6_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "LED7",
+        .pin = LED7_PIN,
+        .mode = LED7_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/atxmega-a1-xplained/include/periph_conf.h
+++ b/boards/atxmega-a1-xplained/include/periph_conf.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2021 Gerson Fernando Budke
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_atxmega-a1-xplained
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the ATxmegaA1 Xplained board.
+ *
+ * @author      Gerson Fernando Budke <nandojve@gmail.com>
+ */
+#include "mutex.h"
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <avr/io.h>
+
+#include "periph_cpu.h"
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev            = (void *)&TCC1,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_TC1_bm),
+        .type           = TC_TYPE_1,
+        .int_lvl        = { CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_OFF,
+                            CPU_INT_LVL_OFF,
+                            CPU_INT_LVL_OFF },
+    },
+    {
+        .dev            = (void *)&TCC0,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_TC0_bm),
+        .type           = TC_TYPE_0,
+        .int_lvl        = { CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_LOW,
+                            CPU_INT_LVL_LOW },
+    }
+};
+
+#define TIMER_0_ISRA      TCC1_CCA_vect
+
+#define TIMER_1_ISRA      TCC0_CCA_vect
+#define TIMER_1_ISRB      TCC0_CCB_vect
+#define TIMER_1_ISRC      TCC0_CCC_vect
+#define TIMER_1_ISRD      TCC0_CCD_vect
+
+#define TIMER_NUMOF       ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {   /* J1 */
+        .dev            = &USARTF0,
+        .pwr            = PWR_RED_REG(PWR_PORT_F, PR_USART0_bm),
+        .rx_pin         = GPIO_PIN(PORT_F, 2),
+        .tx_pin         = GPIO_PIN(PORT_F, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin        = GPIO_UNDEF,
+        .cts_pin        = GPIO_UNDEF,
+#endif
+        .rx_int_lvl     = CPU_INT_LVL_LOW,
+        .tx_int_lvl     = CPU_INT_LVL_LOW,
+        .dre_int_lvl    = CPU_INT_LVL_OFF,
+    },
+    {   /* J3 - Shared with SAUL */
+        .dev            = &USARTD0,
+        .pwr            = PWR_RED_REG(PWR_PORT_D, PR_USART0_bm),
+        .rx_pin         = GPIO_PIN(PORT_D, 2),
+        .tx_pin         = GPIO_PIN(PORT_D, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin        = GPIO_UNDEF,
+        .cts_pin        = GPIO_UNDEF,
+#endif
+        .rx_int_lvl     = CPU_INT_LVL_LOW,
+        .tx_int_lvl     = CPU_INT_LVL_LOW,
+        .dre_int_lvl    = CPU_INT_LVL_OFF,
+    },
+    {   /* J4 */
+        .dev            = &USARTC0,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_USART0_bm),
+        .rx_pin         = GPIO_PIN(PORT_C, 2),
+        .tx_pin         = GPIO_PIN(PORT_C, 3),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin        = GPIO_UNDEF,
+        .cts_pin        = GPIO_UNDEF,
+#endif
+        .rx_int_lvl     = CPU_INT_LVL_LOW,
+        .tx_int_lvl     = CPU_INT_LVL_LOW,
+        .dre_int_lvl    = CPU_INT_LVL_OFF,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_RXC_ISR    USARTF0_RXC_vect    /* Reception Complete Interrupt */
+#define UART_0_DRE_ISR    USARTF0_DRE_vect    /* Data Register Empty Interrupt */
+#define UART_0_TXC_ISR    USARTF0_TXC_vect    /* Transmission Complete Interrupt */
+
+#define UART_1_RXC_ISR    USARTD0_RXC_vect
+#define UART_1_DRE_ISR    USARTD0_DRE_vect
+#define UART_1_TXC_ISR    USARTD0_TXC_vect
+
+#define UART_2_RXC_ISR    USARTC0_RXC_vect
+#define UART_2_DRE_ISR    USARTC0_DRE_vect
+#define UART_2_TXC_ISR    USARTC0_TXC_vect
+
+#define UART_NUMOF        ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev                = &TWIF,
+        .pwr                = PWR_RED_REG(PWR_PORT_F, PR_TWI_bm),
+        .sda_pin            = GPIO_PIN(PORT_F, 0),
+        .scl_pin            = GPIO_PIN(PORT_F, 1),
+        .speed              = I2C_SPEED_NORMAL,
+        .int_lvl            = CPU_INT_LVL_LOW,
+    },
+    {
+        .dev                = &TWIC,
+        .pwr                = PWR_RED_REG(PWR_PORT_C, PR_TWI_bm),
+        .sda_pin            = GPIO_PIN(PORT_C, 0),
+        .scl_pin            = GPIO_PIN(PORT_C, 1),
+        .speed              = I2C_SPEED_NORMAL,
+        .int_lvl            = CPU_INT_LVL_LOW,
+    },
+};
+
+#define I2C_0_ISR           TWIF_TWIM_vect
+#define I2C_1_ISR           TWIC_TWIM_vect
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev            = &SPIF,
+        .pwr            = PWR_RED_REG(PWR_PORT_F, PR_SPI_bm),
+        .sck_pin        = GPIO_PIN(PORT_F, 7),
+        .miso_pin       = GPIO_PIN(PORT_F, 6),
+        .mosi_pin       = GPIO_PIN(PORT_F, 5),
+        .ss_pin         = GPIO_PIN(PORT_F, 4),
+    },
+    {
+        .dev            = &SPIC,
+        .pwr            = PWR_RED_REG(PWR_PORT_C, PR_SPI_bm),
+        .sck_pin        = GPIO_PIN(PORT_C, 7),
+        .miso_pin       = GPIO_PIN(PORT_C, 6),
+        .mosi_pin       = GPIO_PIN(PORT_C, 5),
+        .ss_pin         = GPIO_PIN(PORT_C, 4),
+    },
+};
+
+#define SPI_NUMOF         ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name EBI configuration
+ *
+ * For more information, see ebi_conf_t structure.
+ *
+ * @{
+ */
+static const ebi_conf_t ebi_config = {
+    .addr_bits              = 12,
+    .flags                  = (EBI_PORT_SDRAM | EBI_PORT_3PORT),
+    .sram_ale               = 0,
+    .lpc_ale                = 0,
+    .sdram                  = {
+                                  0,
+                                  1024,
+                                  6400,
+                                  EBI_CS_SDMODE_NORMAL_gc,
+                                  EBI_SDRAM_CAS_LAT_3CLK,
+                                  EBI_SDRAM_ROW_BITS_12,
+                                  EBI_SDCOL_10BIT_gc,
+                                  EBI_MRDLY_2CLK_gc,
+                                  EBI_ROWCYCDLY_7CLK_gc,
+                                  EBI_RPDLY_7CLK_gc,
+                                  EBI_WRDLY_1CLK_gc,
+                                  EBI_ESRDLY_7CLK_gc,
+                                  EBI_ROWCOLDLY_7CLK_gc,
+                              },
+    .cs                     = { { EBI_CS_MODE_DISABLED_gc,
+                                  0,
+                                  EBI_CS_SRWS_0CLK_gc,
+                                  0x0UL,
+                                },
+                                { EBI_CS_MODE_DISABLED_gc,
+                                  0,
+                                  EBI_CS_SRWS_0CLK_gc,
+                                  0x0UL,
+                                },
+                                { EBI_CS_MODE_DISABLED_gc,
+                                  0,
+                                  EBI_CS_SRWS_0CLK_gc,
+                                  0x0UL,
+                                },
+                                { EBI_CS_MODE_SDRAM_gc,
+                                  EBI_CS_ASIZE_8MB_gc,
+                                  EBI_CS_SRWS_0CLK_gc,
+                                  0x0UL,
+                                },
+                              },
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/tests/cpu_avr8_xmega_drivers/Makefile
+++ b/tests/cpu_avr8_xmega_drivers/Makefile
@@ -4,6 +4,7 @@ include ../Makefile.tests_common
 
 # list of ATxmega boards
 BOARD_WHITELIST = \
+  atxmega-a1-xplained \
   atxmega-a1u-xpro \
   atxmega-a3bu-xplained \
   #

--- a/tests/cpu_avr8_xmega_drivers/test_ebi.c
+++ b/tests/cpu_avr8_xmega_drivers/test_ebi.c
@@ -36,6 +36,16 @@
  */
 #define BOARD_EBI_RAM_BASE      (0x10000)
 #define BOARD_EBI_RAM_SIZE      (0x30000)
+#elif defined(BOARD_ATXMEGA_A1_XPLAINED)
+/**
+ * 8MB  bytes installed
+ * 64k  bytes reserved for RIOT-OS
+ *
+ * The remaining memory can be addressable by hugemem methods.
+ * It is free for user and it is tested here
+ */
+#define BOARD_EBI_RAM_BASE      (0x10000)
+#define BOARD_EBI_RAM_SIZE      (0x7F0000)
 #else
 /**
  * 128k bytes installed

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_timer
 
 BOARDS_TIMER_500kHz := \
+    atxmega-a1-xplained \
     atxmega-a1u-xpro \
     atxmega-a3bu-xplained \
     #

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega256rfr2-xpro \
     atmega328p \
     atmega328p-xplained-mini \
+    atxmega-a1-xplained \
     atxmega-a1u-xpro \
     atxmega-a3bu-xplained \
     avr-rss2 \


### PR DESCRIPTION
### Contribution description

Add initial version of [atxmega-a1-xplained](https://www.microchip.com/DevelopmentTools/ProductDetails/PartNO/ATAVRXPLAIN) board. This is another ATxmega development board based on the A1 version. This board shows how to use external SDRAM memory interface.

### Testing procedure

The test was conducted using Tutorials/task-06 application.

### Issues/PRs references

This is part of #15703 and depends on #16288.

CC: @benpicco @maribu 