### PR TITLE
examples/suit_update: use aiocoap 0.4.1

### DIFF
--- a/examples/suit_update/README.md
+++ b/examples/suit_update/README.md
@@ -37,7 +37,7 @@ Table of contents:
 
 - Install aiocoap from the source
 
-      $ pip3 install --user --upgrade "git+https://github.com/chrysn/aiocoap#egg=aiocoap[all]"
+      $ pip3 install --user aiocoap>=0.4.1
 
   See the [aiocoap installation instructions](https://aiocoap.readthedocs.io/en/latest/installation.html)
   for more details.


### PR DESCRIPTION
### Contribution description

In documentation use the release version of aiocoap instead of master, this should be done in Murdock as well, can you make the change @kaspar030? I could do it as well (but I rather go by you).

### Testing procedure

- pip3 install aiocoap==0.4.1
- make -C examples/suit_update flash test

```
> ifconfig
current-slot
Running from slot 0
> ifconfig
Iface  4  HWaddr: AA:04:26:28:64:38
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::a804:26ff:fe28:6438  scope: link  VAL
pinging node...
PING fe80::a804:26ff:fe28:6438%riot0(fe80::a804:26ff:fe28:6438%riot0) 56 data bytes

--- fe80::a804:26ff:fe28:6438%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 40.626/40.626/40.626/0.000 ms
pinging node succeeded.
TEST PASSED
```
