### PR TITLE
core: add clist_is_empty()

### DIFF
--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -33,6 +33,7 @@
  * clist_remove()       | O(n)    | remove and return node
  * clist_sort()         | O(NlogN)| sort list (stable)
  * clist_count()        | O(n)    | count the number of elements in a list
+ * clist_is_empty()     | O(1)    | returns true if the list contains no elements
  *
  * clist can be used as a traditional list, a queue (FIFO) and a stack (LIFO) using
  * fast O(1) operations.
@@ -87,6 +88,7 @@
 #ifndef CLIST_H
 #define CLIST_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include "list.h"
 
@@ -101,6 +103,20 @@ extern "C" {
  *
  */
 typedef list_node_t clist_node_t;
+
+/**
+ * @brief Checks if *list is empty
+ *
+ * @note Complexity: O(1)
+ *
+ * @param[in]   list        Pointer to clist
+ *
+ * @returns     true if list contains no elements, false otherwise
+ */
+static inline bool clist_is_empty(const clist_node_t *list)
+{
+    return list->next == NULL;
+}
 
 /**
  * @brief Appends *new_node* at the end of *list

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -331,6 +331,23 @@ static void test_clist_count(void)
     }
 }
 
+static void test_clist_is_empty(void)
+{
+    TEST_ASSERT(clist_is_empty(&test_clist));
+
+    for (unsigned i = 1; i <= TEST_CLIST_LEN; i++) {
+        clist_rpush(&test_clist, &tests_clist_buf[i - 1]);
+        TEST_ASSERT(!clist_is_empty(&test_clist));
+    }
+    for (unsigned i = TEST_CLIST_LEN; i > 0; i--) {
+        clist_lpop(&test_clist);
+        /* when i == 1 at the beginning of the iteration, there's one element
+           left, which is then dropped in the line above.
+           So in all cases but that last one, the list is not empty. */
+        TEST_ASSERT(clist_is_empty(&test_clist) == (i == 1));
+    }
+}
+
 Test *tests_core_clist_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -349,6 +366,7 @@ Test *tests_core_clist_tests(void)
         new_TestFixture(test_clist_sort_empty),
         new_TestFixture(test_clist_sort),
         new_TestFixture(test_clist_count),
+        new_TestFixture(test_clist_is_empty),
     };
 
     EMB_UNIT_TESTCALLER(core_clist_tests, set_up, NULL,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This adds proper API, docs, test case for determining whether a clist is empty.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The actual logic is a oneliner, so a good look and CI should be sufficient.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
