### PR TITLE
make: make riotboot target depend on pkg-prepare

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -76,7 +76,7 @@ riotboot: $(SLOT_RIOT_BINS)
 
 # riotboot bootloader compile target
 riotboot/flash-bootloader: riotboot/bootloader/flash
-riotboot/bootloader/%: $(BUILDDEPS)
+riotboot/bootloader/%: $(BUILDDEPS) pkg-prepare
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\


### PR DESCRIPTION
### Contribution description

When riotboot depends on a package for building that the main
application also depends on (e.g., gecko_sdk for efm32), previously,
that package would be checked out twice in parallel, which fails.

This commit adds pkg-prepare as dependency to the bootloader target,
ensuring any packages are already up-to-date before calling the
bootloader submake.

<details>
<summary>example error output</summary>

```

make: Entering directory '/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/tests/riotboot'
rm -rf /tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg-build/gecko_sdk
Building application "tests_riotboot" for "sltb001a" with MCU "efm32".

compiling /tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
[INFO] cloning gecko_sdk
git-cache: cloning from cache. tag=commitb47581a678a53c01dacea9a0a3956c67854b12f4-194366
[INFO] updating gecko_sdk /tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-downloaded
[INFO] updating gecko_sdk /tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-downloaded
echo b47581a678a53c01dacea9a0a3956c67854b12f4 > /tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-downloaded
[INFO] patch gecko_sdk
echo b47581a678a53c01dacea9a0a3956c67854b12f4 > /tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-downloaded
[INFO] patch gecko_sdk
fatal: Unable to create '/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/pkg/pkg.mk:107: recipe for target '/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-patched' failed
make[1]: *** [/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-patched] Error 128
/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/tests/riotboot/../../Makefile.include:696: recipe for target 'pkg-prepare' failed
make: [pkg-prepare] Error 2 (ignored)
[INFO] patch gecko_sdk
fatal: Unable to create '/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/pkg/pkg.mk:107: recipe for target '/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-patched' failed
make[1]: *** [/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/build/pkg/gecko_sdk/.pkg-state.git-patched] Error 128
/tmp/dwq.0.5577578061595997/ee195ef839279feec1409411fe57b39e/tests/riotboot/../../Makefile.include:700: recipe for target 'pkg-build-gecko_sdk' failed
make: *** [pkg-build-gecko_sdk] Error 2
make: *** Waiting for unfinished jobs....

```

</details>

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

For me this reliably fails on master:

    rm -Rf build && BOARD=sltb001a make -Ctests/riotboot -j

It succeeds with this PR.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
