### PR TITLE
drivers/nrf24l01p_ng: add hook nrf24l01p_ng_eui_get()

### DIFF
--- a/drivers/include/nrf24l01p_ng.h
+++ b/drivers/include/nrf24l01p_ng.h
@@ -424,6 +424,17 @@ int nrf24l01p_ng_set_state(nrf24l01p_ng_t *dev, nrf24l01p_ng_state_t state);
  */
 nrf24l01p_ng_state_t nrf24l01p_ng_get_state(const nrf24l01p_ng_t *dev);
 
+/**
+ * @brief   Retrieve a unique layer-2 address for an nrf24l01p_ng instance
+ *
+ * @note    This function has __attribute__((weak)) so you can override this, e.g.
+ *          to construct an address. By default @ref luid_get_lb is used.
+ *
+ * @param[in]   dev     The device descriptor of the transceiver
+ * @param[out]  eui     Destination to write the address to
+ */
+void nrf24l01p_ng_eui_get(const netdev_t *dev, uint8_t *eui);
+
 #if IS_USED(MODULE_NRF24L01P_NG_DIAGNOSTICS)
 /**
  * @brief Get state variable as a string

--- a/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
@@ -22,6 +22,7 @@
 #include "debug.h"
 
 #include "net/gnrc.h"
+#include "luid.h"
 #include "gnrc_netif_nrf24l01p_ng.h"
 #include "nrf24l01p_ng.h"
 
@@ -233,4 +234,14 @@ int gnrc_netif_nrf24l01p_ng_create(gnrc_netif_t *netif, char *stack,
 {
     return gnrc_netif_create(netif, stack, stacksize, priority, name,
                              dev, &nrf24l01p_ng_netif_ops);
+}
+
+void __attribute__((weak)) nrf24l01p_ng_eui_get(const netdev_t *netdev, uint8_t *eui)
+{
+    (void)netdev;
+    do {
+        luid_get_lb(eui, NRF24L01P_NG_ADDR_WIDTH);
+    }
+    while (eui[NRF24L01P_NG_ADDR_WIDTH - 1] ==
+           ((uint8_t[])NRF24L01P_NG_BROADCAST_ADDR)[NRF24L01P_NG_ADDR_WIDTH - 1]);
 }

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -26,9 +26,6 @@
 #include "kernel_defines.h"
 #include "iolist.h"
 #include "irq.h"
-#include "luid.h"
-#include "mutex.h"
-#include "net/eui64.h"
 #include "net/netdev.h"
 #include "xtimer.h"
 
@@ -196,12 +193,10 @@ static int _init(netdev_t *netdev)
     /* assign to pipe 0 the broadcast address*/
     nrf24l01p_ng_write_reg(dev, NRF24L01P_NG_REG_RX_ADDR_P0,
                            NRF24L01P_NG_ADDR_P0(dev), aw);
-    luid_get_lb(NRF24L01P_NG_ADDR_P1(dev), aw);
-     /* "The LSByte must be unique for all six pipes" [datasheet p.38] */
-    if (NRF24L01P_NG_ADDR_P1(dev)[aw - 1] == bc[aw - 1]) {
-        luid_get_lb(NRF24L01P_NG_ADDR_P1(dev), aw);
-    }
-    /* assign to pipe 0 the "main" listening address */
+    /* "The LSByte must be unique for all six pipes" [datasheet p.38] */
+    nrf24l01p_ng_eui_get(&dev->netdev, NRF24L01P_NG_ADDR_P1(dev));
+    assert(NRF24L01P_NG_ADDR_P1(dev)[aw - 1] != NRF24L01P_NG_ADDR_P0(dev)[aw - 1]);
+    /* assign to pipe 1 the "main" listening address */
     nrf24l01p_ng_write_reg(dev, NRF24L01P_NG_REG_RX_ADDR_P1,
                            NRF24L01P_NG_ADDR_P1(dev), aw);
     /* set the address width */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a hook for the nrf24l01p_ng driver to facilitate address configuration, e.g. if your board has an EUI provider.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
For example add:
```C
#include "nrf24l01p_ng.h"

void nrf24l01p_ng_eui_get(const netdev_t *netdev, uint8_t *eui)
{
    const uint8_t seed[] = {"abcde"};
    memcpy(eui, seed, NRF24L01P_NG_ADDR_WIDTH);
    eui[NRF24L01P_NG_ADDR_WIDTH - 1] = 0x11; /* EUI */
    eui[NRF24L01P_NG_ADDR_WIDTH - 2] ^= netdev->index;
}
```
to your `board.c` and check the address with `ifconfig`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
is related to #16286
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
