### PR TITLE
drivers/sgp30: unused variable when DEVELHELP=0

### DIFF
--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -238,6 +238,7 @@ int sgp30_reset(sgp30_t *dev)
 
 int sgp30_read_serial_number(sgp30_t *dev, uint8_t *buf, size_t len)
 {
+    (void) len;
     assert(dev && buf && (len == SGP30_SERIAL_ID_LEN));
     uint8_t frame[9];
     if (_rx_tx_data(dev, SGP30_CMD_READ_SERIAL, (uint8_t *)frame, sizeof(frame),


### PR DESCRIPTION
### Contribution description

There is an unused var if no assert.

### Testing procedure

```
DEVELHELP=0 make -C tests/driver_sgp30/
Building application "tests_driver_sgp30" for "samr21-xpro" with MCU "samd21".
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


"make" -C /home/francisco/workspace/RIOT/boards/samr21-xpro
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/samd21
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/samd21/periph
"make" -C /home/francisco/workspace/RIOT/cpu/samd21/vectors
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/drivers/sgp30
/home/francisco/workspace/RIOT/drivers/sgp30/sgp30.c: In function 'sgp30_read_serial_number':
/home/francisco/workspace/RIOT/drivers/sgp30/sgp30.c:239:65: error: unused parameter 'len' [-Werror=unused-parameter]
  239 | int sgp30_read_serial_number(sgp30_t *dev, uint8_t *buf, size_t len)
      |                                                          ~~~~~~~^~~
cc1: all warnings being treated as errors
make[3]: *** [/home/francisco/workspace/RIOT/Makefile.base:107: /home/francisco/workspace/RIOT/tests/driver_sgp30/bin/samr21-xpro/sgp30/sgp30.o] Error 1
make[2]: *** [/home/francisco/workspace/RIOT/Makefile.base:30: ALL--/home/francisco/workspace/RIOT/drivers/sgp30] Error 2
make[1]: *** [/home/francisco/workspace/RIOT/Makefile.base:30: ALL--/home/francisco/workspace/RIOT/drivers] Error 2
make: *** [/home/francisco/workspace/RIOT/tests/driver_sgp30/../../Makefile.include:643: application_tests_driver_sgp30.module] Error 2
```

