### PR TITLE
lwip_sock: Make sock_tcp_read return more data if available and test it

### DIFF
--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -353,7 +353,12 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
             sock->last_buf = NULL;
             sock->last_offset = 0;
             pbuf_free(buf);
-            break;
+            /* Exit the loop only when there's no more data available in the
+             * connection. This allows to copy more data in a single read if
+             * available. */
+            if (!mbox_avail(&sock->base.conn->recvmbox.mbox)) {
+                break;
+            }
         }
     }
     if (offset > 0) {


### PR DESCRIPTION
### Contribution description

`sock_tcp_read` reads (copies) from the internal lwip connection buffer to the data buffer passed by the app. If any data is available, the function would copy as much as possible to the app buffer but only from a single internal connection buffer. For example, if multiple small network packets are received but app passes a large enough buffer, `sock_tcp_read` would only copy at most one internal buffer to the output. This patch makes `sock_tcp_read` copy as much as possible from all the available buffers at the time of the call.

This also adds a test for this case and the recently fixed issue #16124.

### Testing procedure
`RIOT_CI_BUILD=1 make -C tests/lwip flash test`

### Issues/PRs references

This is related to issue #16124 which was fixed in #16278. 
