### PR TITLE
cpu/esp8266: Fix typo in esp_gdbstub config.

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -51,7 +51,7 @@ CFLAGS += -D__ESP_FILE__=__FILE__
 
 ifneq (,$(filter esp_gdbstub,$(USEMODULE)))
   GDBSTUB_DIR ?= $(RIOTCPU)/$(CPU)/vendor/esp-gdbstub
-  CFLAGS += -DGDBSTUB_BREAK_ON_INIT=1)
+  CFLAGS += -DGDBSTUB_BREAK_ON_INIT=1
   INCLUDES += -I$(GDBSTUB_DIR)
 endif
 


### PR DESCRIPTION
### Contribution description

The extra `)` was a typo from the commit that changed the makefile
inline "if" to a multi-line "if" block.

### Testing procedure

Tested with `USEMODULE="esp_gdbstub" make BOARD=esp8266-esp-12x -C tests/lwip`

Without this change esp_gdbstub would give a compile error.

### Issues/PRs references

None