### PR TITLE
boards/common/esp8266: Set RTS and DTR to 0 on pyterm.

### DIFF
--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -1,3 +1,7 @@
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# Set RTS and DTR to 0 to release reset when RTS is connected to the reset pin
+# and DTR to GPIO0.
+PYTERMFLAGS += --set-rts 0 --set-dtr 0


### PR DESCRIPTION
### Contribution description

When flashing the ESP8266 with the flash tool it is possible to connect
RTS to the reset line and DTR to GPIO0 to automatically reboot the
device into flash mode and then reboot the device again into normal
mode.

pyterm leaves these two signals unset unless we specify a --set-rts=0 or
1, and the value of these lines would depend on the UART driver.

This patch explicitly sets RTS and DTR to 0 (high level) in the
Makefile.include config so `make term` releases the reset line,
otherwise the device may be left in reset mode after pyterm starts.

### Testing procedure

Using an FTDI FT2232H-based UART adapter, connect RX,TX as normal, then RTS to the reset pin, DTR to the GPIO0 and follow these steps:

`make BOARD=esp8266-esp-12x -C tests/lwip flash term`

Type `help` in the terminal and see the list of commands. Without this patch the device may be left on reset mode and not respond to commands.

### Issues/PRs references

None.