### PR TITLE
esptool: Allow to pass the partition table CSV.

### DIFF
--- a/makefiles/tools/esptool.inc.mk
+++ b/makefiles/tools/esptool.inc.mk
@@ -10,10 +10,11 @@ BOOTLOADER_BIN = bootloader$(BOOTLOADER_COLOR)$(BOOTLOADER_INFO).bin
 ESPTOOL ?= $(RIOTTOOLS)/esptool/esptool.py
 
 # The ELFFILE is the base one used for flashing
+ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 FLASHFILE ?= $(ELFFILE)
 
-# Convert .elf to .bin before flashing
-FLASHDEPS += esp-image-convert
+# Convert .elf and .csv to .bin files before flashing
+FLASHDEPS += $(FLASHFILE).bin $(BINDIR)/partitions.bin
 
 # flasher configuration
 ifneq (,$(filter esp_qemu,$(USEMODULE)))
@@ -31,19 +32,26 @@ else
   FFLAGS += 0x10000 $(FLASHFILE).bin
 endif
 
-.PHONY: esp-image-convert esp-qemu
-# prepare image to flash: convert .elf to .bin
-esp-image-convert:
+$(FLASHFILE).bin: $(FLASHFILE)
 	$(Q)$(ESPTOOL) --chip $(FLASH_CHIP) elf2image --flash_mode $(FLASH_MODE) \
 		--flash_size $(FLASH_SIZE)MB --flash_freq $(FLASH_FREQ) $(FLASH_OPTS) \
-		-o $(FLASHFILE).bin $(FLASHFILE)
+		-o $@ $<
+
+# Default partition table with no OTA. Can be replaced with a custom partition
+# table setting PARTITION_TABLE_CSV.
+PARTITION_TABLE_CSV ?= $(BINDIR)/partitions.csv
+
+$(BINDIR)/partitions.csv: $(FLASHFILE).bin
 	$(Q)printf "\n" > $(BINDIR)/partitions.csv
-	$(Q)printf "nvs, data, nvs, 0x9000, 0x6000\n" >> $(BINDIR)/partitions.csv
-	$(Q)printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $(BINDIR)/partitions.csv
-	$(Q)printf "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv
-	$(Q)ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv
-	$(Q)python3 $(RIOTTOOLS)/esptool/gen_esp32part.py --verify \
-		$(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
+	$(Q)printf "nvs, data, nvs, 0x9000, 0x6000\n" >> $@
+	$(Q)printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $@
+	$(Q)printf "factory, app, factory, 0x10000, " >> $@
+	$(Q)ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $@
+
+$(BINDIR)/partitions.bin: $(PARTITION_TABLE_CSV)
+	$(Q)python3 $(RIOTTOOLS)/esptool/gen_esp32part.py --verify $< $@
+
+.PHONY: esp-qemu
 
 esp-qemu:
 	$(Q)dd if=/dev/zero bs=1M count=$(FLASH_SIZE) | \


### PR DESCRIPTION
### Contribution description

The partition table of the device in the esp8266 and esp32 based boards
was set to a default table with one "factory" partition with exactly
the size of the compiled firmware. This is problematic if we want to
update the device on the field.

This patch allows to set the `PARTITION_TABLE_CSV` variable from the
Makefile to a .csv file with a custom partition table, for example this
could be set to a partition table with two ota entries, or with a single
factory entry but of a known fixed size.

As a side effect of the make cleanup in this patch we now support
passing `-j` to the `make flash` command so we can compile in parallel
and still run the flash commands only once at the end. Before this
patch the conversion from .elf to .elf.bin was happening before the
code was recompiled when running in parallel.

### Testing procedure

`make BOARD=esp8266-esp-12x Q= -C tests/lwip flash -j term`

Verified that the compile commands at the end (after the link step) appear in the right order.

`make BOARD=esp8266-esp-12x PARTITION_TABLE_CSV=mytable.csv -C tests/lwip flash -j term`

Verified that the `mytable.csv` file is used instead.

### Issues/PRs references

None