### PR TITLE
sys/ztimer: add support for 64-bit timer

### DIFF
--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -55,7 +55,9 @@ endif
 
 ifneq (,$(filter ztimer_%,$(USEMODULE)))
   USEMODULE += ztimer_core
-  USEMODULE += ztimer_extend
+  ifneq (ztimer_periph_ptp, $(filter ztimer_periph_ptp,$(USEMODULE)))
+    USEMODULE += ztimer_extend
+  endif
 endif
 
 ifneq (,$(filter ztimer_convert_%,$(USEMODULE)))

--- a/sys/ztimer/periph_ptp.c
+++ b/sys/ztimer/periph_ptp.c
@@ -34,16 +34,16 @@ void ptp_timer_cb(void)
     ztimer_handler(clock_timer);
 }
 
-static void _ztimer_periph_ptp_set(ztimer_clock_t *clock, uint32_t val)
+static void _ztimer_periph_ptp_set64(ztimer_clock_t *clock, uint64_t val)
 {
     (void)clock;
     ptp_timer_set_u64(val);
 }
 
-static uint32_t _ztimer_periph_ptp_now(ztimer_clock_t *clock)
+static uint64_t _ztimer_periph_ptp_now64(ztimer_clock_t *clock)
 {
     (void)clock;
-    return (uint32_t)ptp_clock_read_u64();
+    return ptp_clock_read_u64();
 }
 
 static void _ztimer_periph_ptp_cancel(ztimer_clock_t *clock)
@@ -53,16 +53,13 @@ static void _ztimer_periph_ptp_cancel(ztimer_clock_t *clock)
 }
 
 static const ztimer_ops_t _ztimer_periph_ptp_ops = {
-    .set = _ztimer_periph_ptp_set,
-    .now = _ztimer_periph_ptp_now,
+    .set64 = _ztimer_periph_ptp_set64,
+    .now64 = _ztimer_periph_ptp_now64,
     .cancel = _ztimer_periph_ptp_cancel,
 };
 
 void ztimer_periph_ptp_init(ztimer_periph_ptp_t *clock)
 {
     clock->ops = &_ztimer_periph_ptp_ops;
-    clock->max_value = UINT32_MAX;
     clock_timer = clock;
-
-    ztimer_init_extend(clock);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds support for 64-bit timers in ztimer. It allows to read 64-bit timestamps in `ztimer_now` and setting 64-bit timestamps in `ztimer_set`. At present, this can be used for the ptp timer.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I adapted the example in `ztimer_periodic` to use  `ztimer_periph_ptp`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
