### PR TITLE
core/sched: keep scheduler clist internal to sched

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -278,6 +278,26 @@ typedef void (*sched_callback_t)(kernel_pid_t active, kernel_pid_t next);
 void sched_register_cb(sched_callback_t callback);
 #endif /* MODULE_SCHED_CB */
 
+/**
+ * @brief   Advance a runqueue
+ *
+ *  Advances the runqueue of that priority by one step to the next thread in
+ *  that priority.
+ *  Next time that priority is scheduled the now first thread will get activated.
+ *  Calling this will not start the scheduler.
+ *
+ * @warning This API is not intended for out of tree users.
+ *          Breaking API changes will be done without notice and
+ *          without deprecation. Consider yourself warned!
+ *
+ * @param   prio      The priority of the runqueue to advance
+ *
+ */
+static inline void sched_runq_advance(uint8_t prio)
+{
+    clist_lpoprpush(&sched_runqueues[prio]);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/thread.c
+++ b/core/thread.c
@@ -143,7 +143,7 @@ void thread_yield(void)
     thread_t *me = thread_get_active();
 
     if (me->status >= STATUS_ON_RUNQUEUE) {
-        clist_lpoprpush(&sched_runqueues[me->priority]);
+        sched_runq_advance(me->priority);
     }
     irq_restore(old_state);
 

--- a/tests/malloc_thread_safety/main.c
+++ b/tests/malloc_thread_safety/main.c
@@ -81,12 +81,6 @@ void * t1_t2_realloc_func(void *arg)
     return NULL;
 }
 
-static void evil_schedule_hack_dont_do_this_at_home(uint8_t prio)
-{
-    extern clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
-    clist_lpoprpush(&sched_runqueues[prio]);
-}
-
 int main(void)
 {
     kernel_pid_t t1, t2;
@@ -128,7 +122,7 @@ int main(void)
             /* shuffle t1 and t2 in their run queue. This should eventually hit
              * during a call to malloc() or free() and disclose any missing
              * guards */
-            evil_schedule_hack_dont_do_this_at_home(THREAD_PRIORITY_MAIN + 1);
+            sched_runq_advance(THREAD_PRIORITY_MAIN + 1);
         }
 
         /* Don't keep threads spinning */


### PR DESCRIPTION
While developing #16126 i got the request to split out this Part of the PR.

### Contribution description

- this adds sched_runq_advance(prio)
- used it in core/thread and 
- in the test malloc_thread_safety

this also enables (dumb and simple) schedulers like #14810 that need no information about the runqueue(s) they are working on

### Testing procedure
test
malloc_thread_safety
```
tests/malloc_thread_safety$ make flash; make test
```
> this tests its own modification

and

sched_testing
```
tests/sched_testing$ make flash; make test
```
> this test modifications made to thread_yield()

### Issues/PRs references

hopefully makes the review process of #16126 smoother