### PR TITLE
[TAKEOVER]: pkg/semtech-loramac: switch to RIOT AES

### DIFF
--- a/pkg/semtech-loramac/Makefile.dep
+++ b/pkg/semtech-loramac/Makefile.dep
@@ -1,4 +1,6 @@
 USEMODULE += random
+USEMODULE += hashes
+USEMODULE += crypto_aes
 
 USEMODULE += semtech_loramac_contrib
 USEMODULE += semtech_loramac_mac

--- a/pkg/semtech-loramac/Makefile.loramac_crypto
+++ b/pkg/semtech-loramac/Makefile.loramac_crypto
@@ -1,5 +1,7 @@
 MODULE = semtech_loramac_crypto
 
+SRC = cmac.c
+
 INCLUDES += -I$(PKGDIRBASE)/semtech-loramac/src/boards
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/semtech-loramac/patches/0004-switch-to-riot-aes.patch
+++ b/pkg/semtech-loramac/patches/0004-switch-to-riot-aes.patch
@@ -1,0 +1,206 @@
+From fa275bbb8259fd3ddc9960f85e94bd444e1034d3 Mon Sep 17 00:00:00 2001
+From: Oleg Artamonov <oleg@unwds.com>
+Date: Sun, 7 Oct 2018 21:37:45 +0300
+Subject: [PATCH] Switch to RIOT AES implementation
+
+---
+ src/mac/LoRaMacCrypto.c  | 25 ++++++++++---------------
+ src/system/crypto/cmac.c | 26 +++++++++-----------------
+ src/system/crypto/cmac.h |  5 +++--
+ 3 files changed, 22 insertions(+), 34 deletions(-)
+
+diff --git a/src/mac/LoRaMacCrypto.c b/src/mac/LoRaMacCrypto.c
+index c6837c2..bcf31c2 100644
+--- a/src/mac/LoRaMacCrypto.c
++++ b/src/mac/LoRaMacCrypto.c
+@@ -29,8 +29,6 @@
+  * \author    Daniel Jaeckle ( STACKFORCE )
+  */
+ #include "utilities.h"
+-
+-#include "aes.h"
+ #include "cmac.h"
+ 
+ #include "LoRaMacCrypto.h"
+@@ -67,7 +65,7 @@ static uint8_t sBlock[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ /*!
+  * AES computation context variable
+  */
+-static aes_context AesContext;
++static cipher_context_t AesContext;
+ 
+ /*!
+  * CMAC computation context variable
+@@ -120,8 +118,7 @@ void LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t
+     uint8_t bufferIndex = 0;
+     uint16_t ctr = 1;
+ 
+-    memset1( AesContext.ksch, '\0', 240 );
+-    aes_set_key( key, 16, &AesContext );
++    aes_init(&AesContext, key, 16);
+ 
+     aBlock[5] = dir;
+ 
+@@ -139,7 +136,7 @@ void LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t
+     {
+         aBlock[15] = ( ( ctr ) & 0xFF );
+         ctr++;
+-        aes_encrypt( aBlock, sBlock, &AesContext );
++        aes_encrypt(&AesContext, aBlock, sBlock);
+         for( i = 0; i < 16; i++ )
+         {
+             encBuffer[bufferIndex + i] = buffer[bufferIndex + i] ^ sBlock[i];
+@@ -151,7 +148,7 @@ void LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t
+     if( size > 0 )
+     {
+         aBlock[15] = ( ( ctr ) & 0xFF );
+-        aes_encrypt( aBlock, sBlock, &AesContext );
++        aes_encrypt(&AesContext, aBlock, sBlock);
+         for( i = 0; i < size; i++ )
+         {
+             encBuffer[bufferIndex + i] = buffer[bufferIndex + i] ^ sBlock[i];
+@@ -179,13 +176,12 @@ void LoRaMacJoinComputeMic( const uint8_t *buffer, uint16_t size, const uint8_t
+ 
+ void LoRaMacJoinDecrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint8_t *decBuffer )
+ {
+-    memset1( AesContext.ksch, '\0', 240 );
+-    aes_set_key( key, 16, &AesContext );
+-    aes_encrypt( buffer, decBuffer, &AesContext );
++    aes_init(&AesContext, key, 16);
++    aes_encrypt(&AesContext, buffer, decBuffer);
+     // Check if optional CFList is included
+     if( size >= 16 )
+     {
+-        aes_encrypt( buffer + 16, decBuffer + 16, &AesContext );
++        aes_encrypt(&AesContext, buffer + 16, decBuffer + 16);
+     }
+ }
+ 
+@@ -194,18 +190,17 @@ void LoRaMacJoinComputeSKeys( const uint8_t *key, const uint8_t *appNonce, uint1
+     uint8_t nonce[16];
+     uint8_t *pDevNonce = ( uint8_t * )&devNonce;
+     
+-    memset1( AesContext.ksch, '\0', 240 );
+-    aes_set_key( key, 16, &AesContext );
++    aes_init(&AesContext, key, 16);
+ 
+     memset1( nonce, 0, sizeof( nonce ) );
+     nonce[0] = 0x01;
+     memcpy1( nonce + 1, appNonce, 6 );
+     memcpy1( nonce + 7, pDevNonce, 2 );
+-    aes_encrypt( nonce, nwkSKey, &AesContext );
++    aes_encrypt(&AesContext, nonce, nwkSKey);
+ 
+     memset1( nonce, 0, sizeof( nonce ) );
+     nonce[0] = 0x02;
+     memcpy1( nonce + 1, appNonce, 6 );
+     memcpy1( nonce + 7, pDevNonce, 2 );
+-    aes_encrypt( nonce, appSKey, &AesContext );
++    aes_encrypt(&AesContext, nonce, appSKey);
+ }
+diff --git a/src/system/crypto/cmac.c b/src/system/crypto/cmac.c
+index c7a52cf..4a05849 100644
+--- a/src/system/crypto/cmac.c
++++ b/src/system/crypto/cmac.c
+@@ -35,9 +35,8 @@ DEALINGS WITH THE SOFTWARE
+ //#include <sys/param.h>
+ //#include <sys/systm.h> 
+ #include <stdint.h>
+-#include "aes.h"
+ #include "cmac.h"
+ #include "utilities.h"
+ 
+ #define LSHIFT(v, r) do {                                       \
+   int32_t i;                                                  \
+@@ -59,19 +58,18 @@ void AES_CMAC_Init(AES_CMAC_CTX *ctx)
+ {
+             memset1(ctx->X, 0, sizeof ctx->X);
+             ctx->M_n = 0;
+-        memset1(ctx->rijndael.ksch, '\0', 240);
++        //memset1(ctx->rijndael.ksch, '\0', 240);
+ }
+     
+ void AES_CMAC_SetKey(AES_CMAC_CTX *ctx, const uint8_t key[AES_CMAC_KEY_LENGTH])
+ {
+-           //rijndael_set_key_enc_only(&ctx->rijndael, key, 128);
+-       aes_set_key( key, AES_CMAC_KEY_LENGTH, &ctx->rijndael);
++       aes_init(&ctx->rijndael, key, AES_CMAC_KEY_LENGTH);
+ }
+     
+ void AES_CMAC_Update(AES_CMAC_CTX *ctx, const uint8_t *data, uint32_t len)
+ {
+             uint32_t mlen;
+-        uint8_t in[16];
++            uint8_t in[16];
+     
+             if (ctx->M_n > 0) {
+                   mlen = MIN(16 - ctx->M_n, len);
+@@ -80,18 +78,16 @@ void AES_CMAC_Update(AES_CMAC_CTX *ctx, const uint8_t *data, uint32_t len)
+                     if (ctx->M_n < 16 || len == mlen)
+                             return;
+                    XOR(ctx->M_last, ctx->X);
+-                    //rijndael_encrypt(&ctx->rijndael, ctx->X, ctx->X);
+-            aes_encrypt( ctx->X, ctx->X, &ctx->rijndael);
++                    aes_encrypt(&ctx->rijndael, ctx->X, ctx->X);
+                     data += mlen;
+                     len -= mlen;
+             }
+             while (len > 16) {      /* not last block */
+ 
+                     XOR(data, ctx->X);
+-                    //rijndael_encrypt(&ctx->rijndael, ctx->X, ctx->X);
+ 
+                     memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
+-            aes_encrypt( in, in, &ctx->rijndael);
++                    aes_encrypt(&ctx->rijndael, in, in);
+                     memcpy1(&ctx->X[0], in, 16);
+ 
+                     data += 16;
+@@ -109,9 +105,7 @@ void AES_CMAC_Final(uint8_t digest[AES_CMAC_DIGEST_LENGTH], AES_CMAC_CTX *ctx)
+             /* generate subkey K1 */
+             memset1(K, '\0', 16);
+ 
+-            //rijndael_encrypt(&ctx->rijndael, K, K);
+-
+-            aes_encrypt( K, K, &ctx->rijndael);
++            aes_encrypt(&ctx->rijndael, K, K);
+ 
+             if (K[0] & 0x80) {
+                     LSHIFT(K, K);
+@@ -143,10 +137,8 @@ void AES_CMAC_Final(uint8_t digest[AES_CMAC_DIGEST_LENGTH], AES_CMAC_CTX *ctx)
+            }
+            XOR(ctx->M_last, ctx->X);
+ 
+-           //rijndael_encrypt(&ctx->rijndael, ctx->X, digest);
+-
+-       memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
+-       aes_encrypt(in, digest, &ctx->rijndael);
++           memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
++           aes_encrypt(&ctx->rijndael, in, digest);
+            memset1(K, 0, sizeof K);
+ 
+ }
+diff --git a/src/system/crypto/cmac.h b/src/system/crypto/cmac.h
+index c12e970..7f14e0d 100644
+--- a/src/system/crypto/cmac.h
++++ b/src/system/crypto/cmac.h
+@@ -36,13 +36,14 @@ DEALINGS WITH THE SOFTWARE
+ #ifndef _CMAC_H_
+ #define _CMAC_H_
+ 
+-#include "aes.h" 
++#include "crypto/aes.h"
++#include "crypto/ciphers.h"
+   
+ #define AES_CMAC_KEY_LENGTH     16
+ #define AES_CMAC_DIGEST_LENGTH  16
+  
+ typedef struct _AES_CMAC_CTX {
+-            aes_context    rijndael;
++            cipher_context_t    rijndael;
+             uint8_t        X[16];
+             uint8_t        M_last[16];
+             uint32_t       M_n;
+-- 
+2.17.1
+


### PR DESCRIPTION
### Contribution description

This PR is a take over from https://github.com/RIOT-OS/RIOT/pull/10124:

> 
> Patch to adapt LoRaMAC 4.4.1 to RIOT AES implementation.
> 
> 1) Code size: RIOT AES significantly bigger without #10037, ~1KB bigger with #10037, about the same size as LoRaMAC AES with #10037 and aes_decrypt disabled (LoRaWAN doesn't need it)
> 
> 2) Performance: generally, RIOT AES is significantly (over 2 times) faster, especially on Cortex-M3 and above. On Cortex-M0, decryption is about the same speed, encryption is almost 2 times faster with RIOT AES.
> 
> Such difference is to be expected, as RIOT uses faster T-tables implementation while LoRaMAC uses S-boxes.
> 
> 3) Compatibility: LoRaMAC AES and RIOT AES can't be used simultaneously because of the same function names aes_encrypt() and aes_decrypt(). So, **porting LoRaMAC to RIOT AES is a must if one needs AES for any other function, not just LoRaWAN**.
> 

### Testing procedure

Run: `make -C tests/pkg_semtech-loramac/ clean flash test-with-config`

<details><summary>test result</summary>

```
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac erase

>
> loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set deveui 00D23F63A8D87783
loramac set deveui 00D23F63A8D87783
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
> loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
> loramac set dr 0
loramac set dr 0
> loramac join otaa
loramac join otaa
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
>loramac set deveui 00D23F63A8D87783
 loramac set deveui 00D23F63A8D87783
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
> loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
> loramac set dr 3
loramac set dr 3
> loramac join otaa
loramac join otaa
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set deveui 00D23F63A8D87783
loramac set deveui 00D23F63A8D87783
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
> loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
> loramac set dr 5
loramac set dr 5
> loramac join otaa
loramac join otaa
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
>loramac tx "This is RIOT" uncnf 42
 loramac tx "This is RIOT" uncnf 42
Message sent with success
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac erase
loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set deveui 00D23F63A8D87782
loramac set deveui 00D23F63A8D87782
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
> loramac set devaddr 2601107E
loramac set devaddr 2601107E
> loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
> loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
> loramac set rx2_dr 3
loramac set rx2_dr 3
> loramac set dr 0
loramac set dr 0
> loramac join abp
loramac join abp
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> loramac get ul_cnt
loramac get ul_cnt
Uplink Counter: 2
>reboot
 reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set ul_cnt 2
loramac set ul_cnt 2
> loramac set deveui 00D23F63A8D87782
loramac set deveui 00D23F63A8D87782
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
> loramac set devaddr 2601107E
loramac set devaddr 2601107E
> loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
> loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
> loramac set rx2_dr 3
loramac set rx2_dr 3
>loramac set dr 3
 loramac set dr 3
> loramac join abp
loramac join abp
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> loramac get ul_cnt
loramac get ul_cnt
Uplink Counter: 4
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set ul_cnt 4
loramac set ul_cnt 4
> loramac set deveui 00D23F63A8D87782
loramac set deveui 00D23F63A8D87782
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
>loramac set devaddr 2601107E
 loramac set devaddr 2601107E
>loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
 loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
> loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
>loramac set rx2_dr 3
 loramac set rx2_dr 3
> loramac set dr 5
loramac set dr 5
> loramac join abp
loramac join abp
Join procedure succeeded!
> loramac tx "This is RIOT" cnf 123
loramac tx "This is RIOT" cnf 123
Received ACK from network
Message sent with success
> loramac tx "This is RIOT" uncnf 42
loramac tx "This is RIOT" uncnf 42
Message sent with success
> loramac get ul_cnt
loramac get ul_cnt
Uplink Counter: 6
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set ul_cnt 6
loramac set ul_cnt 6
> loramac help
loramac help
Usage: loramac <get|set|join|tx|link_check|save|erase>
loramac erase
> loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac get deveui
loramac get deveui
DEVEUI: 0000000000000000
> loramac get appeui
loramac get appeui
APPEUI: 0000000000000000
> loramac get appkey
loramac get appkey
APPKEY: 00000000000000000000000000000000
> loramac get devaddr
loramac get devaddr
DEVADDR: 00000000
> loramac get nwkskey
loramac get nwkskey
NWKSKEY: 00000000000000000000000000000000
> loramac get appskey
loramac get appskey
APPSKEY: 00000000000000000000000000000000
> loramac set deveui 00D23F63A8D87783
loramac set deveui 00D23F63A8D87783
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
> loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
loramac set appkey 0A3E1510AEB8DB583B10DCA691522409
> loramac save
loramac save
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac get deveui
loramac get deveui
DEVEUI: 00D23F63A8D87783
> loramac get appeui
loramac get appeui
APPEUI: 70B3D57ED00204EC
> loramac get appkey
loramac get appkey
APPKEY: 0A3E1510AEB8DB583B10DCA691522409
> loramac erase
loramac erase
> reboot
reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac set deveui 00D23F63A8D87782
loramac set deveui 00D23F63A8D87782
> loramac set appeui 70B3D57ED00204EC
loramac set appeui 70B3D57ED00204EC
>loramac set devaddr 2601107E
 loramac set devaddr 2601107E
>loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
 loramac set nwkskey 6CCC73B2681EC60142C5D4933BFE8D34
> loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
loramac set appskey 07683C44D66D201B557B0DF7EFEF8391
> loramac set rx2_dr 3
loramac set rx2_dr 3
> loramac save
loramac save
>reboot
 reboot
main(): This is RIOT! (Version: 2021.04-devel-1304-ga3cbe-riot-loramac-system-aes)
All up, running the shell now
> loramac get devaddr
loramac get devaddr
DEVADDR: 2601107E
> loramac get nwkskey
loramac get nwkskey
NWKSKEY: 6CCC73B2681EC60142C5D4933BFE8D34
> loramac get appskey
loramac get appskey
APPSKEY: 07683C44D66D201B557B0DF7EFEF8391
> TEST PASSED
```
</details
### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/16293