### PR TITLE
tests/periph_rtt_min: harden test

### DIFF
--- a/tests/periph_rtt_min/Makefile
+++ b/tests/periph_rtt_min/Makefile
@@ -23,5 +23,3 @@ else
   SAMPLES ?= 1024
 endif
 CFLAGS += -DSAMPLES=$(SAMPLES)
-
-$(call target-export-variables, test, SAMPLES)

--- a/tests/periph_rtt_min/main.c
+++ b/tests/periph_rtt_min/main.c
@@ -44,6 +44,7 @@ void cb(void *arg)
 int main(void)
 {
     uint32_t value = 0;
+    uint32_t samples = 0;
     /* mutex starts out locked, and each time an rtt callback is successfully
        called it will be locked again for the next iteration */
     mutex_t lock = MUTEX_INIT_LOCKED;
@@ -69,10 +70,12 @@ int main(void)
         }
         printf(".");
         fflush(stdout);
+        samples++;
     }
     printf("\n");
 
-    printf("RTT_MIN_OFFSET for %s: %" PRIu32 "\n", RIOT_BOARD, value);
+    printf("RTT_MIN_OFFSET for %s over %" PRIu32 " samples: %" PRIu32 "\n",
+           RIOT_BOARD, samples, value);
 
     return 0;
 }

--- a/tests/periph_rtt_min/tests/01-run.py
+++ b/tests/periph_rtt_min/tests/01-run.py
@@ -6,18 +6,19 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import os
 import sys
 
 from testrunner import run
 
-SAMPLES = int(os.getenv("SAMPLES", "1024"))
-
 
 def testfunc(child):
-    for _ in range(0, SAMPLES):
-        child.expect_exact('.')
-    child.expect(r'RTT_MIN_OFFSET for [a-zA-Z\-\_0-9]+: \d+')
+    child.expect(r"Evaluate RTT_MIN_OFFSET over (\d+) samples")
+
+    exp_samples = int(child.match.group(1))
+    child.expect(
+        r'RTT_MIN_OFFSET for [a-zA-Z\-\_0-9]+ over {samples} samples: \d+'
+        .format(samples=exp_samples)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This fixes a test that regularly fails in the nightlies due to a timeout in catching its flashed dots:

- Better self-containment: read number of expected samples from output
  rather than the environment
- Less reliance on `stdout` timing: Count samples in application and
  output it rather then counting flushed dots.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```console
$ make -C tests/periph_rtt_min -j flash test
```

should still succeed
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
