### PR TITLE
drivers/at86rf215: use channel pages for other modulation and bands

### DIFF
--- a/drivers/at86rf215/at86rf215_fsk.c
+++ b/drivers/at86rf215/at86rf215_fsk.c
@@ -609,7 +609,10 @@ int at86rf215_FSK_set_channel_spacing(at86rf215_t *dev, uint8_t ch_space)
           25UL * at86rf215_reg_read16(dev, dev->RF->RG_CCF0L) + (is_subGHz(dev) ? 0 : CCF0_24G_OFFSET));
 
     /* adjust channel spacing */
-    dev->num_chans = is_subGHz(dev) ? 34 / (ch_space + 1) : (416 / (ch_space + 1)) - (ch_space * 2);
+    dev->chan_min = 0;
+    dev->chan_max = is_subGHz(dev) ? 34 / (ch_space + 1) : (416 / (ch_space + 1)) - (ch_space * 2);
+    dev->chan_max -= 1;
+
     dev->netdev.chan = at86rf215_chan_valid(dev, dev->netdev.chan);
     at86rf215_reg_write16(dev, dev->RF->RG_CNL, dev->netdev.chan);
 

--- a/drivers/at86rf215/at86rf215_internal.c
+++ b/drivers/at86rf215/at86rf215_internal.c
@@ -168,15 +168,19 @@ void at86rf215_get_random(at86rf215_t *dev, void *data, size_t len)
 
 uint16_t at86rf215_chan_valid(at86rf215_t *dev, uint16_t chan)
 {
+    /* If channel is not valid it is set to the lowest channel available.
+     *
+     * This is explained on IEEE Std 802.15.4-2020, Section 10.1.3.1 General,
+     * also specified on the 2006 version */
     if (is_subGHz(dev)) {
         if (chan >= dev->num_chans) {
-            return dev->num_chans - 1;
+            return 0;
         }
     } else {
         if (chan < IEEE802154_CHANNEL_MIN) {
             return IEEE802154_CHANNEL_MIN;
         } else if (chan >= IEEE802154_CHANNEL_MIN + dev->num_chans) {
-            return IEEE802154_CHANNEL_MIN + dev->num_chans - 1;
+            return IEEE802154_CHANNEL_MIN;
         }
     }
 

--- a/drivers/at86rf215/at86rf215_internal.c
+++ b/drivers/at86rf215/at86rf215_internal.c
@@ -172,19 +172,11 @@ uint16_t at86rf215_chan_valid(at86rf215_t *dev, uint16_t chan)
      *
      * This is explained on IEEE Std 802.15.4-2020, Section 10.1.3.1 General,
      * also specified on the 2006 version */
-    if (is_subGHz(dev)) {
-        if (chan >= dev->num_chans) {
-            return 0;
-        }
-    } else {
-        if (chan < IEEE802154_CHANNEL_MIN) {
-            return IEEE802154_CHANNEL_MIN;
-        } else if (chan >= IEEE802154_CHANNEL_MIN + dev->num_chans) {
-            return IEEE802154_CHANNEL_MIN;
-        }
+    if (chan >= dev->chan_min && chan <= dev->chan_max) {
+        return chan;
     }
 
-    return chan;
+    return dev->chan_min;
 }
 
 const char* at86rf215_hw_state2a(uint8_t state)

--- a/drivers/at86rf215/at86rf215_ofdm.c
+++ b/drivers/at86rf215/at86rf215_ofdm.c
@@ -195,8 +195,10 @@ static void _set_option(at86rf215_t *dev, uint8_t option)
 
     at86rf215_reg_write(dev, dev->BBC->RG_OFDMC, option - 1);
 
+    dev->chan_min = 0;
+    dev->chan_max = _get_max_chan(dev, option);
+
     /* make sure channel config is still valid */
-    dev->num_chans = _get_max_chan(dev, option);
     dev->netdev.chan = at86rf215_chan_valid(dev, dev->netdev.chan);
     at86rf215_reg_write16(dev, dev->RF->RG_CNL, dev->netdev.chan);
 }

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -351,7 +351,8 @@ typedef struct at86rf215 {
     uint32_t ack_timeout_usec;              /**< time to wait before retransmission in µs */
     uint32_t csma_backoff_period;           /**< CSMA Backoff period */
     uint16_t flags;                         /**< Device specific flags */
-    uint16_t num_chans;                     /**< Number of legal channel at current modulation */
+    uint16_t chan_min;                      /**< Minimum channel supported in current page */
+    uint16_t chan_max;                      /**< Maximum channel supported in current page */
     uint16_t tx_frame_len;                  /**< length of the current TX frame */
     uint8_t timeout;                        /**< indicates which timeout was reached */
     uint8_t state;                          /**< current state of the radio */
@@ -677,6 +678,14 @@ int at86rf215_enable_batmon(at86rf215_t *dev, unsigned voltage);
  * @param[in] dev           device to configure
  */
 void at86rf215_disable_batmon(at86rf215_t *dev);
+
+/**
+ * @brief   Set the channel page to use.
+ *
+ * @param[in] dev           device to configure
+ * @param[in] page          channel page to set
+ */
+int at86rf215_set_page(at86rf215_t *dev, uint8_t page);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

This adds the code for handling the channel pages, as specified by 2006 and 2012 IEEE 802.15.4 standards,
channel page nine is for SUN PHYs whereas the 0, 1 and 2 are for 2006 modulation and bands.

The `at86rf215_set_page` function uses the following table to set the proper PHY and band for 2006 modulations:

![Screenshot from 2021-04-12 12-18-56](https://user-images.githubusercontent.com/5952531/114379612-4e373d80-9b89-11eb-8885-07e223a24d0d.png)

And for 2012:

![Screenshot from 2021-04-12 12-20-40](https://user-images.githubusercontent.com/5952531/114379778-83dc2680-9b89-11eb-9d42-5efb6a18d895.png)



### Testing procedure

Untested by me, just throwed some code around to see what could come up.

- `make -C examples/gnrc_networking BOARD=openmote-b` and try various combinations of:
- `ifconfig [iface] set page 2` For Sub-GHZ
- `ifconfig [iface] set channel 0` Should now be in 868 MHz
- `ifconfig [iface] set channel 1` Should now be in 915 MHz

And try pinging with at least two nodes.

### Issues/PRs references

Fix for #16420 for IEEE 802.15.4-2006 modulations, for 802.15.4g-2012 there is still work to do though.