### PR TITLE
pkg/nimble: migrate to ztimer

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,8 @@
 PKG_NAME    = nimble
-PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = cd7d7aa286ee1083818cbaac1e89bf69fe554f42
+# Temporary URL change until upstream adaption is merged (nimble:#970)
+PKG_URL     = https://github.com/haukepetersen/mynewt-nimble.git
+#PKG_URL     = https://github.com/apache/mynewt-nimble.git
+PKG_VERSION = 7a2bf2420a1a2bcd8bbb5bf8f5927882b3c499c0
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -61,6 +61,7 @@ endif
 ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
   USEMODULE += nimble_addr
   USEMODULE += bluetil_ad
+  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter nimble_statconn,$(USEMODULE)))

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -1,7 +1,11 @@
 # RIOT specific dependencies
-USEMODULE += posix_semaphore
+USEMODULE += sema
 USEMODULE += event_callback
-USEMODULE += xtimer
+USEMODULE += ztimer_msec
+# all nRF CPUs support hardware RTT, so we use it
+ifneq (,$(filter nrf5%,$(CPU_FAM)))
+  USEMODULE += ztimer_periph_rtt
+endif
 
 # Requires nimble feature
 FEATURES_REQUIRED += ble_nimble

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -21,7 +21,7 @@
 #include <assert.h>
 #include <limits.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "net/bluetil/ad.h"
 
 #include "nimble_scanlist.h"
@@ -72,7 +72,7 @@ void nimble_scanlist_update(uint8_t type, const ble_addr_t *addr, int8_t rssi,
     assert(addr);
     assert(len <= BLE_ADV_PDU_LEN);
 
-    uint32_t now = xtimer_now_usec();
+    uint32_t now = (uint32_t)ztimer_now(ZTIMER_USEC);
     nimble_scanlist_entry_t *e = _find(addr);
 
     if (!e) {

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <stdio.h>
 #include <assert.h>
 
 #include "net/bluetil/ad.h"

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 
 #include "fmt.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "nimble_riot.h"
 #include "nimble_netif.h"
 #include "nimble_netif_conn.h"
@@ -265,13 +265,13 @@ static void _do_scan(nimble_scanner_cb cb, unsigned duration)
     nimble_scanner_init(NULL, cb);
     nimble_scanlist_clear();
     nimble_scanner_start();
-    xtimer_usleep(duration);
+    ztimer_sleep(ZTIMER_MSEC, duration);
     nimble_scanner_stop();
 }
 
 static void _cmd_scan(unsigned duration)
 {
-    printf("scanning (for %ums) ...\n", (duration / 1000));
+    printf("scanning (for %ums) ...\n", duration);
     _do_scan(nimble_scanlist_update, duration);
     puts("done");
     nimble_scanlist_print();
@@ -419,7 +419,7 @@ int _nimble_netif_handler(int argc, char **argv)
             }
             duration = atoi(argv[2]);
         }
-        _cmd_scan(duration * 1000);
+        _cmd_scan(duration);
     }
     else if (memcmp(argv[1], "connect", 7) == 0) {
         if ((argc < 3) || _ishelp(argv[2])) {

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -32,6 +32,7 @@
 #include "thread.h"
 #include "thread_flags.h"
 #include "net/bluetil/ad.h"
+#include "xtimer.h"
 
 #include "nimble_l2cap_test_conf.h"
 


### PR DESCRIPTION
### Contribution description
With #15782 merged all prerequisites for migrating NimBLE from `xtimer` to `ztimer` are in. For a next step, I PRed the required NimBLE NPL changes to NimBLE (https://github.com/apache/mynewt-nimble/pull/967). These are needed in conjunction with the changes of this PR and finally allow for `xtimer`-free RIOT/NimBLE builds :-)

As stated in https://github.com/apache/mynewt-nimble/pull/967, appart from simplifying the NPL code in NImBLE, this change allows for significant energy savings. E.g. when running the `examples/nimble_gatt` application without STDIO (`USEMODULE+=stdio_null`) and the node is in connected state with a peer, the average current consumption drops from ~420µA to 72µA.

### Testing procedure
Verify that NimBLE is behaving as before. I suggest to run at least the following on any nrf52x board of you choice:
- `examples/nimble_gatt` -> connect with a smartphone (e.g. using the `nrf connect` APP on Android) and verify GATT services are working
- `examples/nimble_scanner` -> use the `scan` shell command and it should list some devices that it found
- `tests/nimble_l2cap`/`tests/nimble_l2cap_server` -> connect two boards and make sure flooding and inctest are running as expected
- `examples/gnrc_networking` -> connect two IP-over-BLE devices using the `ble` shell command and make sure they can ping each other

### Issues/PRs references
depends on https://github.com/apache/mynewt-nimble/pull/967
