### PR TITLE
cpu/stm32/gpio_all: fix IRQ handler for G0/L5/MP1 families

### DIFF
--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -338,15 +338,16 @@ void isr_exti(void)
 {
 #if defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
     defined(CPU_FAM_STM32MP1)
-    /* only generate interrupts against lines which have their IMR set */
-    uint32_t pending_rising_isr = (EXTI->RPR1 & EXTI_REG_IMR & EXTI_MASK);
-    uint32_t pending_falling_isr = (EXTI->FPR1 & EXTI_REG_IMR & EXTI_MASK);
+    /* get all interrupts handled by this ISR */
+    uint32_t pending_rising_isr = (EXTI->RPR1 & EXTI_MASK);
+    uint32_t pending_falling_isr = (EXTI->FPR1 & EXTI_MASK);
 
     /* clear by writing a 1 */
     EXTI->RPR1 = pending_rising_isr;
     EXTI->FPR1 = pending_falling_isr;
 
-    uint32_t pending_isr = pending_rising_isr | pending_falling_isr;
+    /* only generate interrupts against lines which have their IMR set */
+    uint32_t pending_isr = (pending_rising_isr | pending_falling_isr) & EXTI_REG_IMR;
 #else
     /* read all pending interrupts wired to isr_exti */
     uint32_t pending_isr = (EXTI_REG_PR & EXTI_MASK);


### PR DESCRIPTION
### Contribution description

This is a follow-up for #16272 for the STM32G0, STM32L5 and STM32MP1 families. The same description applies.

The reference manuals I based this PR on:
- [STM32G0x1 RM](https://www.st.com/resource/en/reference_manual/dm00371828-stm32g0x1-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf): Page 320, Figure 27
- [STM32L552xx and STM32L562xx RM](https://www.st.com/resource/en/reference_manual/dm00346336-stm32l552xx-and-stm32l562xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf): Page 539, Figure 48
- [STM32MP151 RM](https://www.st.com/resource/en/reference_manual/dm00366349-stm32mp151-advanced-armbased-32bit-mpus-stmicroelectronics.pdf): Page 1304, Figure 138

### Testing procedure

I don't own a board with a CPU of the mentioned families. If you do: please verify that GPIO IRQs are still working. `tests/periph_gpio` should be a suitable application.

### Issues/PRs references

#16272