### PR TITLE
sys/ztimer: add ZTIMER_NSEC from PTP backend

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -32,9 +32,10 @@
  *
  * As ztimer can use arbitrarily configurable backends, a ztimer clock instance
  * can run at configurable frequencies. Throughout this documentation, one
- * clock step is called `tick`.  For the pre-defined clocks ZTIMER_USEC,
- * ZTIMER_MSEC and ZTIMER_SEC, one clock tick corresponds to one microsecond,
- * one millisecond or one second, respectively.
+ * clock step is called `tick`.  For the pre-defined clocks
+ * ZTIMER_NSEC, ZTIMER_USEC, ZTIMER_MSEC and ZTIMER_SEC, one clock tick
+ * corresponds to one nanosecond, microsecond, millisecond or second,
+ * respectively.
  *
  * ztimer_now() returns the current clock tick count as uint32_t.
  *
@@ -102,6 +103,7 @@
  * - @ref ztimer_periph_rtt_init "ztimer_periph_rtt" interface for periph_rtt
  * - @ref ztimer_periph_rtc_init "ztimer_periph_rtc" interface for periph_rtc
  * - @ref ztimer_periph_timer_init "ztimer_periph_timer" interface for periph_timer
+ * - @ref ztimer_periph_ptp_init "ztimer_periph_ptp" interface for periph_ptp
  *
  * Filter submodules:
  *
@@ -199,6 +201,9 @@
  *
  * For now, there are:
  *
+ * ZTIMER_NSEC: clock providing nanosecond ticks, always uses PTP
+ *              (ztimer_periph_ptp)
+ *
  * ZTIMER_USEC: clock providing microsecond ticks, always uses a basic timer
  *              (ztimer_periph_timer)
  *
@@ -234,7 +239,8 @@
  * 2. due to its implementation details, expect +-1 clock tick systemic
  *    inaccuracy for all clocks.
  *
- * 3. for the predefined clocks (ZTIMER_USEC, ZTIMER_MSEC, ZTIMER_SEC), tick
+ * 3. for the predefined clocks
+ *    (ZTIMER_NSEC, ZTIMER_USEC, ZTIMER_MSEC, ZTIMER_SEC), tick
  *    conversion might be applied using ztimer_convert_*, causing errors due to
  *    integer conversion and rounding. In particular, most RTT's closest match
  *    for milliseconds are 1024Hz, which will be converted using convert_frac to
@@ -621,6 +627,11 @@ static inline void ztimer_init_extend(ztimer_clock_t *clock)
 #endif /* MODULE_ZTIMER_EXTEND */
 
 /* default ztimer virtual devices */
+/**
+ * @brief   Default ztimer nanosecond clock
+ */
+extern ztimer_clock_t *const ZTIMER_NSEC;
+
 /**
  * @brief   Default ztimer microsecond clock
  */

--- a/sys/include/ztimer/config.h
+++ b/sys/include/ztimer/config.h
@@ -136,6 +136,13 @@ extern "C" {
 #  endif
 #endif
 
+/**
+ * @brief   The minimum pm mode required for ZTIMER_PTP to run
+ */
+#ifndef CONFIG_ZTIMER_PTP_BLOCK_PM_MODE
+#  define CONFIG_ZTIMER_PTP_BLOCK_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -72,6 +72,11 @@ ifneq (,$(filter ztimer_convert_frac,$(USEMODULE)))
   USEMODULE += frac
 endif
 
+ifneq (,$(filter ztimer_nsec,$(USEMODULE)))
+  USEMODULE += ztimer
+  USEMODULE += ztimer_periph_ptp
+endif
+
 ifneq (,$(filter ztimer_usec,$(USEMODULE)))
   USEMODULE += ztimer
   USEMODULE += ztimer_periph_timer

--- a/tests/ztimer_msg/Makefile
+++ b/tests/ztimer_msg/Makefile
@@ -8,4 +8,7 @@ USEMODULE += ztimer_usec
 # uncomment this to test using ztimer sec
 #USEMODULE += ztimer_sec
 
+# uncomment this to test using ztimer nsec on ptp
+#USEMODULE += ztimer_nsec
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_msg/main.c
+++ b/tests/ztimer_msg/main.c
@@ -37,6 +37,9 @@
 #elif MODULE_ZTIMER_MSEC
 #define ZTIMER ZTIMER_MSEC
 #define TICKS_PER_SEC MS_PER_SEC
+#elif MODULE_ZTIMER_NSEC
+#define ZTIMER ZTIMER_NSEC
+#define TICKS_PER_SEC NS_PER_SEC
 #else
 #define ZTIMER ZTIMER_USEC
 #define TICKS_PER_SEC US_PER_SEC
@@ -54,7 +57,7 @@ struct timer_msg {
 
 struct timer_msg msg_a = { .interval = (2 * TICKS_PER_SEC),
                            .text = "Hello World" };
-struct timer_msg msg_b = { .interval = (5 * TICKS_PER_SEC),
+struct timer_msg msg_b = { .interval = (3 * TICKS_PER_SEC),
                            .text = "This is a Test" };
 
 void *timer_thread(void *arg)

--- a/tests/ztimer_msg/tests/01-run.py
+++ b/tests/ztimer_msg/tests/01-run.py
@@ -16,14 +16,12 @@ def testfunc(child):
         child.expect(r"sec=\d+ min=\d+ hour=\d+")
         child.expect(r"sec=\d+ min=\d+ hour=\d+")
         child.expect(r"now=\d+:\d+ -> every 2.0s: Hello World")
-    # 2nd check for periodic 5s test message, i.e., 5 output + 1 msg
+    # 2nd check for periodic 3s test message, i.e., 3 output + 1 msg
     for _ in range(3):
         child.expect(r"sec=\d+ min=\d+ hour=\d+")
         child.expect(r"sec=\d+ min=\d+ hour=\d+")
         child.expect(r"sec=\d+ min=\d+ hour=\d+")
-        child.expect(r"sec=\d+ min=\d+ hour=\d+")
-        child.expect(r"sec=\d+ min=\d+ hour=\d+")
-        child.expect(r"now=\d+:\d+ -> every 5.0s: This is a Test")
+        child.expect(r"now=\d+:\d+ -> every 3.0s: This is a Test")
 
 
 if __name__ == "__main__":

--- a/tests/ztimer_xsec/Makefile
+++ b/tests/ztimer_xsec/Makefile
@@ -5,4 +5,6 @@ USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec
 USEMODULE += ztimer_sec
 
+FEATURES_OPTIONAL += periph_ptp_timer
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_xsec/Makefile.board.dep
+++ b/tests/ztimer_xsec/Makefile.board.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter periph_ptp_timer,$(FEATURES_USED)))
+  USEMODULE += ztimer_nsec
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR adds a `ZTIMER_NSEC` clock, based on `periph_ptp`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Try `tests/ztimer_xsec`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#16309
