### PR TITLE
sys/trickle: migrate from xtimer to ZTIMER_MSEC

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -142,7 +142,9 @@ endif
 
 ifneq (,$(filter trickle,$(USEMODULE)))
   USEMODULE += random
-  USEMODULE += xtimer
+  ifeq (,$(filter ztimer_msec,$(USEMODULE)))
+    USEMODULE += xtimer
+  endif
 endif
 
 ifneq (,$(filter eui_provider,$(USEMODULE)))

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -32,8 +32,13 @@
  extern "C" {
 #endif
 
-#include "xtimer.h"
 #include "thread.h"
+#if IS_USED(MODULE_ZTIMER_MSEC)
+#include "ztimer.h"
+#else
+#include "xtimer.h"
+#endif
+
 
 /**
  * @brief Trickle callback function with arguments
@@ -59,8 +64,13 @@ typedef struct {
     trickle_callback_t callback;    /**< callback function and parameter that
                                          trickle calls after each interval */
     msg_t msg;                      /**< the msg_t to use for intervals */
+#if IS_USED(MODULE_ZTIMER_MSEC)
+    ztimer_t msg_timer;             /**< timer to send a msg_t to the target
+                                         thread for a new interval */
+#else
     xtimer_t msg_timer;             /**< xtimer to send a msg_t to the target
                                          thread for a new interval */
+#endif
 } trickle_t;
 
 /**

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -24,7 +24,6 @@
 #include "net/gnrc/rpl/dodag.h"
 #include "utlist.h"
 #include "trickle.h"
-#include "xtimer.h"
 #ifdef MODULE_GNRC_RPL_P2P
 #include "net/gnrc/rpl/p2p.h"
 #include "net/gnrc/rpl/p2p_dodag.h"
@@ -284,7 +283,6 @@ int _gnrc_rpl_dodag_show(void)
 
     gnrc_rpl_dodag_t *dodag = NULL;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    uint64_t tc;
 
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
         if (gnrc_rpl_instances[i].state == 0) {
@@ -298,16 +296,13 @@ int _gnrc_rpl_dodag_show(void)
                 gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
                 gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
 
-        tc = xtimer_left_usec(&dodag->trickle.msg_timer);
-        tc = (int64_t) tc == 0 ? 0 : tc / US_PER_SEC;
-
         printf("\tdodag [%s | R: %d | OP: %s | PIO: %s | "
-               "TR(I=[%d,%d], k=%d, c=%d, TC=%" PRIu32 "s)]\n",
+               "TR(I=[%d,%d], k=%d, c=%d)]\n",
                ipv6_addr_to_str(addr_str, &dodag->dodag_id, sizeof(addr_str)),
                dodag->my_rank, (dodag->node_status == GNRC_RPL_LEAF_NODE ? "Leaf" : "Router"),
                ((dodag->dio_opts & GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO) ? "on" : "off"),
                (1 << dodag->dio_min), dodag->dio_interval_doubl, dodag->trickle.k,
-               dodag->trickle.c, (uint32_t) (tc & 0xFFFFFFFF));
+               dodag->trickle.c);
 
 #ifdef MODULE_GNRC_RPL_P2P
         if (dodag->instance->mop == GNRC_RPL_P2P_MOP) {

--- a/sys/trickle/trickle.c
+++ b/sys/trickle/trickle.c
@@ -53,9 +53,14 @@ void trickle_interval(trickle_t *trickle)
     /* old_interval == trickle->I / 2 */
     trickle->t = random_uint32_range(old_interval, trickle->I);
 
+#if IS_USED(MODULE_ZTIMER_MSEC)
+    ztimer_set_msg(ZTIMER_MSEC, &trickle->msg_timer, (trickle->t + diff),
+                   &trickle->msg, trickle->pid);
+#else
     uint64_t msg_time = (trickle->t + diff) * US_PER_MS;
     xtimer_set_msg64(&trickle->msg_timer, msg_time, &trickle->msg,
                      trickle->pid);
+#endif
 }
 
 void trickle_reset_timer(trickle_t *trickle)
@@ -88,7 +93,11 @@ void trickle_start(kernel_pid_t pid, trickle_t *trickle, uint16_t msg_type,
 
 void trickle_stop(trickle_t *trickle)
 {
+#if IS_USED(MODULE_ZTIMER_MSEC)
+    ztimer_remove(ZTIMER_MSEC, &trickle->msg_timer);
+#else
     xtimer_remove(&trickle->msg_timer);
+#endif
 }
 
 void trickle_increment_counter(trickle_t *trickle)

--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -23,6 +23,11 @@
 #include "trickle.h"
 #include "thread.h"
 #include "msg.h"
+#if IS_USED(MODULE_ZTIMER_MSEC)
+#include "ztimer.h"
+#else
+#include "xtimer.h"
+#endif
 
 #define TRICKLE_MSG     (0xfeef)
 #define TR_IMIN         (8)
@@ -45,7 +50,11 @@ static trickle_t trickle = { .callback = { .func = &callback,
 static void callback(void *args)
 {
     (void) args;
+#if IS_USED(MODULE_ZTIMER_MSEC)
+    uint32_t now = ztimer_now(ZTIMER_MSEC);
+#else
     uint32_t now = xtimer_now_usec();
+#endif
 
     printf("now = %" PRIu32 ", t = %" PRIu32 "\n", now, trickle.t);
 


### PR DESCRIPTION
### Contribution description
This PR migrates `trickle` from xtimer to `ZTIMER_MSEC`. This allows for a) slightly simpler code, and b) for potential energy savings as `xtimer` can (at one point) be left out of a GNRC build.

The acutal changes are pretty straight forward, no surprises here :-) 

### Testing procedure
Running the `test/trickle` test should suffice.

### Issues/PRs references
none