### PR TITLE
sys/shell/sc_nimble_netif: switch to ztimer

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = cd7d7aa286ee1083818cbaac1e89bf69fe554f42
+PKG_VERSION = 7a2bf2420a1a2bcd8bbb5bf8f5927882b3c499c0
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -61,6 +61,7 @@ endif
 ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
   USEMODULE += nimble_addr
   USEMODULE += bluetil_ad
+  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter nimble_statconn,$(USEMODULE)))

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -1,7 +1,11 @@
 # RIOT specific dependencies
-USEMODULE += posix_semaphore
+USEMODULE += sema
 USEMODULE += event_callback
-USEMODULE += xtimer
+USEMODULE += ztimer_msec
+# all nRF CPUs support hardware RTT, so we use it
+ifneq (,$(filter nrf5%,$(CPU_FAM)))
+  USEMODULE += ztimer_periph_rtt
+endif
 
 # Requires nimble feature
 FEATURES_REQUIRED += ble_nimble

--- a/pkg/nimble/scanlist/nimble_scanlist.c
+++ b/pkg/nimble/scanlist/nimble_scanlist.c
@@ -21,7 +21,7 @@
 #include <assert.h>
 #include <limits.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "net/bluetil/ad.h"
 
 #include "nimble_scanlist.h"
@@ -72,7 +72,7 @@ void nimble_scanlist_update(uint8_t type, const ble_addr_t *addr, int8_t rssi,
     assert(addr);
     assert(len <= BLE_ADV_PDU_LEN);
 
-    uint32_t now = xtimer_now_usec();
+    uint32_t now = (uint32_t)ztimer_now(ZTIMER_USEC);
     nimble_scanlist_entry_t *e = _find(addr);
 
     if (!e) {

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <stdio.h>
 #include <assert.h>
 
 #include "net/bluetil/ad.h"

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 
 #include "fmt.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "nimble_riot.h"
 #include "nimble_netif.h"
 #include "nimble_netif_conn.h"
@@ -265,13 +265,13 @@ static void _do_scan(nimble_scanner_cb cb, unsigned duration)
     nimble_scanner_init(NULL, cb);
     nimble_scanlist_clear();
     nimble_scanner_start();
-    xtimer_usleep(duration);
+    ztimer_sleep(ZTIMER_MSEC, duration);
     nimble_scanner_stop();
 }
 
 static void _cmd_scan(unsigned duration)
 {
-    printf("scanning (for %ums) ...\n", (duration / 1000));
+    printf("scanning (for %ums) ...\n", duration);
     _do_scan(nimble_scanlist_update, duration);
     puts("done");
     nimble_scanlist_print();
@@ -419,7 +419,7 @@ int _nimble_netif_handler(int argc, char **argv)
             }
             duration = atoi(argv[2]);
         }
-        _cmd_scan(duration * 1000);
+        _cmd_scan(duration);
     }
     else if (memcmp(argv[1], "connect", 7) == 0) {
         if ((argc < 3) || _ishelp(argv[2])) {

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -32,6 +32,7 @@
 #include "thread.h"
 #include "thread_flags.h"
 #include "net/bluetil/ad.h"
+#include "xtimer.h"
 
 #include "nimble_l2cap_test_conf.h"
 


### PR DESCRIPTION
### Contribution description
While the NimBLE pkg including `nimble_netif` is on its way to be migrated to `ztimer`, the nimble_netif shell command still depends on xtimer. This PR changes this by using `ZTIMER_MSEC` also for the `nimble_netif` shell commands.

To prevent pulling in the `ztimer_msec` module explicitly for the shell command, I rebased this PR on top of #16317, as that PR pulls in the needed dep...

### Testing procedure
Simply flash `examples/gnrc_networking` (using NimBLE -> `USEMODULE+=nimble_netif`) on any applicable Nordic board and run the `ble scan X` shell command. If the scan duration fits the given duration, everything is still in order.

### Issues/PRs references
depends on #16317