### PR TITLE
tests/unittests/tests-rtc: do not use DST info for normalization

### DIFF
--- a/tests/unittests/tests-rtc/tests-rtc.c
+++ b/tests/unittests/tests-rtc/tests-rtc.c
@@ -42,7 +42,7 @@ static void test_rtc_compat(void)
         .tm_year = 84,
         .tm_wday = 0,
         .tm_yday = 0,
-        .tm_isdst=1
+        .tm_isdst = -1,
     };
 
     struct tm t2 = t1;
@@ -63,7 +63,7 @@ static void test_rtc_sec_wrap(void)
         .tm_year = 100,
         .tm_wday =   0,
         .tm_yday =   0,
-        .tm_isdst=   1
+        .tm_isdst=  -1,
     };
 
     struct tm t2 = t1;


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`rtc_tm_normalize` does not use it, so `mktime` should not either.

This fixes https://github.com/RIOT-OS/RIOT/issues/16184. Something about the timezone configuration in the newest `ubuntu-latest` runners makes `mktime` confused, when using with DST timestamps. See https://github.com/RIOT-OS/RIOT/issues/16184#issuecomment-818719898.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I ran the test isolated and [it succeeded](https://github.com/miri64/RIOT/actions/runs/744752759). I also started a [full run in the main repo](https://github.com/RIOT-OS/RIOT/actions/runs/744849529) to check it still works in total.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/16184
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
