### PR TITLE
net/emcute: Allow RETAIN flag to be set on incoming PUBLISHs

### DIFF
--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -167,7 +167,7 @@ static void on_publish(size_t len, size_t pos)
 
     /* return error code in case we don't support/understand active flags. So
      * far we only understand QoS 1... */
-    if (rbuf[pos + 1] & ~(EMCUTE_QOS_1 | EMCUTE_TIT_SHORT)) {
+    if (rbuf[pos + 1] & ~(EMCUTE_QOS_1 | EMCUTE_TIT_SHORT | EMCUTE_RETAIN)) {
         buf[6] = REJ_NOTSUP;
         sock_udp_send(&sock, &buf, 7, &gateway);
         return;

--- a/tests/emcute/README.md
+++ b/tests/emcute/README.md
@@ -4,5 +4,5 @@ This is a test application for emcute. It is supposed to be run with the test
 scripts in `tests/`:
 
 ```
-BOARD="<your choice> make flash test"
+BOARD="<your choice> make flash test-as-root"
 ```


### PR DESCRIPTION
### Contribution description

This is a bug fix for emcute. Without it, emcute rejects incoming PUBLISH messages that have the RETAIN flag set (when the client subscribes to a topic for which a retained message is present). I don't see any reason to do this.

### Testing procedure

I added some test cases to the existing test suite that send PUBLISH messages with the RETAIN flag set to the RIOT node, and ran them with:

`BOARD=native make -C tests/emcute flash test-as-root`

Without my change in emcute, they fail:

```
Run test case
{'data_len_end': 503,
 'data_len_start': 0,
 'data_len_step': 50,
 'mode': 'sub',
 'qos_level': 0,
 'retain': True,
 'topic_name': '/test'}
Timeout in expect script at "self.spawn.expect_exact(" (tests/emcute/tests-as-root/01-run.py:246)
```

(Side note: tests/emcute/README.md says to run the tests with `make test`, which doesn't work anymore as far as I can tell. Should the README be changed?)

### Issues/PRs references

None