### PR TITLE
tests/periph_rtt_min: adapt for slower RTTs

### DIFF
--- a/tests/periph_rtt_min/main.c
+++ b/tests/periph_rtt_min/main.c
@@ -68,8 +68,7 @@ int main(void)
         if (offset > value) {
             value = offset;
         }
-        printf(".");
-        fflush(stdout);
+        printf("Sample %u\n", i);
         samples++;
     }
     printf("\n");

--- a/tests/periph_rtt_min/tests/01-run.py
+++ b/tests/periph_rtt_min/tests/01-run.py
@@ -15,10 +15,11 @@ def testfunc(child):
     child.expect(r"Evaluate RTT_MIN_OFFSET over (\d+) samples")
 
     exp_samples = int(child.match.group(1))
-    child.expect(
-        r'RTT_MIN_OFFSET for [a-zA-Z\-\_0-9]+ over {samples} samples: \d+'
-        .format(samples=exp_samples)
-    )
+    test_end = r'RTT_MIN_OFFSET for [a-zA-Z\-\_0-9]+ over {samples} ' \
+               r'samples: \d+'.format(samples=exp_samples)
+    test_ongoing = r'Sample \d+'
+    while child.expect([test_end, test_ongoing]):
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The test still occasionally fails in the nightlies which points to a too short timeout.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
We maybe should give Murdock a few spins with that to see if the error reoccurs there.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
