### PR TITLE
makefiles/stdio.inc.mk: stdio_uart require uart or lpuart

### DIFF
--- a/boards/i-nucleo-lrwan1/Makefile.dep
+++ b/boards/i-nucleo-lrwan1/Makefile.dep
@@ -1,5 +1,6 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx1272
 endif

--- a/boards/nucleo-g431rb/Makefile.dep
+++ b/boards/nucleo-g431rb/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-g474re/Makefile.dep
+++ b/boards/nucleo-g474re/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l433rc/Makefile.dep
+++ b/boards/nucleo-l433rc/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l496zg/Makefile.dep
+++ b/boards/nucleo-l496zg/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l4r5zi/Makefile.dep
+++ b/boards/nucleo-l4r5zi/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l552ze-q/Makefile.dep
+++ b/boards/nucleo-l552ze-q/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-wl55jc/Makefile.dep
+++ b/boards/nucleo-wl55jc/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/p-nucleo-wb55/Makefile.dep
+++ b/boards/p-nucleo-wb55/Makefile.dep
@@ -1,3 +1,4 @@
-FEATURES_REQUIRED += periph_lpuart
-
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -41,7 +41,7 @@ ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
 endif
 
 ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
+  FEATURES_REQUIRED_ANY += periph_uart|periph_lpuart
 endif
 
 ifneq (,$(filter stdio_semihosting,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

Currently, BOARDs are requiring `lpuart` even when it's not used or needed. This PR fixes this by requiring it only if `stdio_uart` is used.

It also makes `stdio_uart` depend on either `uart` or `lpuart` being selected. Because of inclusion order, both might be required, but currently, there is not much that can be done about that, worst case both get selected, but as long as a BOARD defaulting to `lpuart` requires it (as it is now), then there will be no issues.

### Testing procedure

- pr
```
BOARD=p-nucleo-wb55 make -C tests/minimal/ info-modules | grep uart
# empty
```

- master;

```
BOARD=p-nucleo-wb55 make -C tests/minimal/ info-modules | grep uart
periph_init_lpuart
periph_lpuart
```
