### PR TITLE
drivers/ds18: missing "board.h" include

### DIFF
--- a/drivers/ds18/include/ds18_params.h
+++ b/drivers/ds18/include/ds18_params.h
@@ -19,6 +19,7 @@
 #ifndef DS18_PARAMS_H
 #define DS18_PARAMS_H
 
+#include "board.h"
 #include "ds18.h"
 #include "saul_reg.h"
 


### PR DESCRIPTION
I wondered why my DS18 parameters were not picked up. It turned out the DS18 driver was missing the include for "board.h".

