### PR TITLE
make/ztimer: auto-pull timer backend deps for ztimer_msec

### DIFF
--- a/drivers/sx127x/Makefile.dep
+++ b/drivers/sx127x/Makefile.dep
@@ -6,12 +6,6 @@ USEMODULE += iolist
 USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec
 
-# If RTT feature is available use the RTT backend of ztimer
-FEATURES_OPTIONAL += periph_rtt
-ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-  USEMODULE += ztimer_periph_rtt
-endif
-
 USEMODULE += lora
 
 ifneq (,$(filter gnrc,$(USEMODULE)))

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -2,10 +2,6 @@
 USEMODULE += sema
 USEMODULE += event_callback
 USEMODULE += ztimer_msec
-# all nRF CPUs support hardware RTT, so we use it
-ifneq (,$(filter nrf5%,$(CPU_FAM)))
-  USEMODULE += ztimer_periph_rtt
-endif
 
 # Requires nimble feature
 FEATURES_REQUIRED += ble_nimble

--- a/pkg/openwsn/Makefile.dep
+++ b/pkg/openwsn/Makefile.dep
@@ -75,10 +75,6 @@ endif
 ifneq (,$(filter openwsn_sctimer_ztimer,$(USEMODULE)))
   USEMODULE += ztimer_usec
   USEMODULE += ztimer_msec
-  FEATURES_OPTIONAL += periph_rtt
-  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-    USEMODULE += ztimer_periph_rtt
-  endif
 endif
 
 ifneq (,$(filter openwsn_sctimer_rtt,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -615,9 +615,6 @@ endif
 
 ifneq (,$(filter posix_sleep,$(USEMODULE)))
   USEMODULE += ztimer_msec
-  ifneq (,$(filter periph_rtt,$(USEMODULE)))
-    USEMODULE += ztimer_periph_rtt
-  endif
   USEMODULE += ztimer_usec
   USEMODULE += posix_headers
 endif
@@ -931,9 +928,6 @@ ifneq (,$(filter skald,$(USEMODULE)))
   USEMODULE += nrfble
   USEMODULE += random
   USEMODULE += ztimer_msec
-   ifneq (,$(filter periph_rtt,$(USEMODULE)))
-    USEMODULE += ztimer_periph_rtt
-  endif
 endif
 
 ifneq (,$(filter bluetil_addr,$(USEMODULE)))

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -89,4 +89,9 @@ endif
 
 ifneq (,$(filter ztimer_msec,$(USEMODULE)))
   USEMODULE += ztimer
+  ifneq (,$(filter periph_rtt,$(FEATURES_PROVIDED)))
+    USEMODULE += ztimer_periph_rtt
+  else
+    USEMODULE += ztimer_periph_timer
+  endif
 endif


### PR DESCRIPTION
### Contribution description
For `ZTIMER_MSEC` we have currently a slightly screwed situation, where every (or at least many) modules that use that timer try to figure out the best underlying timer for themselves, leading to duplicated dependency definitions throughout the build system. On top one can easily run into trouble when using `ztimer_msec` in a application, but at the same time there is no fitting ztimer backend included by any other module in the build (e.g. see  #16322).

So my suggested solution is to pull in `ztimer_periph_rtt` if available, or `ztimer_periph_timer` otherwise in the case `ztimer_msec` is used.

### Testing procedure
Use `make info-modules` on all effected test/example applications an verify that the `ztimer_periph_rtt` and `periph_rtt` modules are still included as before.

### Issues/PRs references
#16322 pointed towards this problem
