### PR TITLE
shell/sc_nimble_netif: fix _connect_name scan dur

### DIFF
--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -443,7 +443,7 @@ int _nimble_netif_handler(int argc, char **argv)
             if (argc > 3) {
                 duration = atoi(argv[3]);
             }
-            _cmd_connect_name(argv[2], duration * 1000);
+            _cmd_connect_name(argv[2], duration);
             return 0;
         }
 


### PR DESCRIPTION
### Contribution description
When merging #16317 one minor detail slipped through: the scan duration for `_cmd_connect_name()` was not adjusted and still applying us instead of ms -> leading to the shell seeming to be stuck when using the `ble connect SOMENAME` shell command.

This PR fixes this.

### Testing procedure
- run `examples/gnrc_networking` with `nimble_netif` on two nodes
- advertise some name with node A -> `ble adv FOOBAR`
- connect to that node from node B, using that name -> `ble connect FOOBAR`
without this PR, the shell only returns after a loong time, with this PR everything works as expected...

### Issues/PRs references
follow up on #16317