### PR TITLE
pkg/nimble: temporary fix to NimBLE PRNG seed issue

### DIFF
--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -50,6 +50,7 @@
 #if defined(CPU_FAM_NRF52) || defined(CPU_FAM_NRF51)
 #include "nrf_clock.h"
 #endif
+#include "controller/ble_ll.h"
 
 static char _stack_controller[NIMBLE_CONTROLLER_STACKSIZE];
 #endif
@@ -81,6 +82,15 @@ static void *_host_thread(void *arg)
                   THREAD_CREATE_STACKTEST,
                   (thread_task_func_t)nimble_port_ll_task_func, NULL,
                   "nimble_ctrl");
+
+    /* XXX: seeding of the used PRNG is done when this function is called the
+     *      first time. However, this could potentially be in interrupt context,
+     *      leading to an malloc call in that context, breaking with the used
+     *      thread safe malloc wrapper in RIOT. So we better do this seeding in
+     *      a deterministic fashion right here.
+     *      -> this fix is temporary until a proper fix is merged to NimBLE
+     *         upstream */
+    ble_ll_rand();
 #endif
 
     nimble_port_run();


### PR DESCRIPTION
### Contribution description
As discovered in  #16317 the `nimble_scanner` and other NimBLE applications are currently buggy in RIOT due to a issue with the late initialization/seed of the PRNG module in NimBLEs controller. A proper fix is already proposed to NimBLE upstream: https://github.com/apache/mynewt-nimble/pull/970. But until that fix is merged, I would like to merge this work-around into RIOT temporarily so we at least have the NimBLE port in a working state right away...

### Testing procedure
Run `examples/nimble_scanner` on some fitting board. Currently the board hard-faults every ~2nd time or so the `scan` shell command is triggered after the node is freshly rebootet. With this fix that should not happen anymore.

### Issues/PRs references
Work-around until https://github.com/apache/mynewt-nimble/pull/970 is merged and the NimBLE package is updated to it includes that fix.
