### PR TITLE
net/gnrc/rpl: use ztimer_msec if available

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -152,7 +152,6 @@
 #include "net/gnrc/rpl/dodag.h"
 #include "net/gnrc/rpl/of_manager.h"
 #include "net/fib.h"
-#include "xtimer.h"
 #include "trickle.h"
 
 #ifdef MODULE_NETSTATS_RPL

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -99,7 +99,9 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
   USEMODULE += gnrc_ipv6_nib
   USEMODULE += trickle
-  USEMODULE += xtimer
+  ifeq (,$(filter ztimer_msec,$(USEMODULE)))
+    USEMODULE += xtimer
+  endif
   USEMODULE += evtimer
 endif
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -19,6 +19,11 @@
 #include <assert.h>
 #include <string.h>
 #include "kernel_defines.h"
+#if IS_USED(MODULE_ZTIMER_MSEC)
+#include "ztimer.h"
+#else
+#include "xtimer.h"
+#endif
 
 #include "net/af.h"
 #include "net/icmpv6.h"
@@ -322,7 +327,11 @@ gnrc_pktsnip_t *_dio_prefix_info_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *do
     prefix_info->prefix_len = 64;
     if (_get_pl_entry(dodag->iface, &dodag->dodag_id, prefix_info->prefix_len,
                       &ple)) {
+#if IS_USED(MODULE_ZTIMER_MSEC)
+        uint32_t now = (uint32_t)ztimer_now(ZTIMER_MSEC);
+#else
         uint32_t now = (xtimer_now_usec64() / US_PER_MS) & UINT32_MAX;
+#endif
         uint32_t valid_ltime = (ple.valid_until < UINT32_MAX) ?
                                (ple.valid_until - now) / MS_PER_SEC : UINT32_MAX;
         uint32_t pref_ltime = (ple.pref_until < UINT32_MAX) ?


### PR DESCRIPTION
### Contribution description
With this PR RPL will use `ztimer_msec` as timer whenever  `ztimer_msec` is included in the build. This is needed for `xtimer`-free GNRC builds for getting to lower power consumption.

One small quirk: when building with ztimer, the RPL shell commands does not show the remaining seconds until the trickle timer triggers next anymore. This is due to missing functionality in the `ztimer`, and IMO it would be overkill to add this functionality into ztimer (or any other workaround in the trickle timer) just to get this debug information...

### Testing procedure
The default builds (e.g. `examples/gnrc_networking`) should not change, as per default RPL will still use xtimer. But when building with `ztimer_msec` included in the build, RPL should switch to use `ztimer_msec`.

This can be tested e.g. with two samr21-xpro nodes by running the `examples/gnrc_networking` example while building it with `USEMODULE="ztimer_msec ztimer_periph_rtt" make ...`.

### Issues/PRs references
none