### PR TITLE
net/grnc/sixlowpan/ctx: use ztimer_msec if available

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -359,7 +359,9 @@ endif
 
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
   USEMODULE += ipv6_addr
-  USEMODULE += xtimer
+  ifeq (,$(filter ztimer_msec,$(USEMODULE)))
+    USEMODULE += xtimer
+  endif
 endif
 
 ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))

--- a/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/ctx/gnrc_sixlowpan_ctx.c
@@ -17,7 +17,12 @@
 
 #include "mutex.h"
 #include "net/gnrc/sixlowpan/ctx.h"
+#if IS_USED(MODULE_ZTIMER_MSEC)
+#include "ztimer.h"
+#include "timex.h"
+#else
 #include "xtimer.h"
+#endif
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -131,7 +136,11 @@ gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_update(uint8_t id, const ipv6_addr_t *p
 
 static uint32_t _current_minute(void)
 {
-    return xtimer_now_usec() / (US_PER_SEC * 60);
+#if IS_USED(MODULE_ZTIMER_MSEC)
+    return ztimer_now(ZTIMER_MSEC) / (MS_PER_SEC * SEC_PER_MIN);
+#else
+    return xtimer_now_usec() / (US_PER_SEC * SEC_PER_MIN);
+#endif
 }
 
 static void _update_lifetime(uint8_t id)


### PR DESCRIPTION
### Contribution description
This PR makes `gnrc_sixlowpan_ctx` use `ztimer_msec` as time module whenever `ztimer_msec` is included in the build. This is one more step in running a `xtimer`-free network application :-)

### Testing procedure
Run `gnrc_networking` example build with `USEMODULE="ztimer_msec ztimer_periph_rtt" make ...` and verify, that nodes still communicate as expected...

### Issues/PRs references
none