### PR TITLE
examples/gnrc_networking: use ztimer_msec if available

### DIFF
--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -30,7 +30,11 @@
 #include "net/gnrc/pktdump.h"
 #include "timex.h"
 #include "utlist.h"
+#if IS_USED(MODULE_ZTIMER_MSEC)
+#include "ztimer.h"
+#else
 #include "xtimer.h"
+#endif
 
 static gnrc_netreg_entry_t server =
                         GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
@@ -108,7 +112,11 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
          * => use temporary variable for output */
         printf("Success: sent %u byte(s) to [%s]:%u\n", payload_size, addr_str,
                port);
+#if IS_USED(MODULE_ZTIMER_MSEC)
+        ztimer_sleep(ZTIMER_MSEC, delay);
+#else
         xtimer_usleep(delay);
+#endif
     }
 }
 
@@ -159,8 +167,13 @@ int udp_cmd(int argc, char **argv)
         uint32_t num = 1;
         uint32_t delay = 1000000;
         if (argc < 5) {
+#if IS_USED(MODULE_ZTIMER_MSEC)
+            printf("usage: %s send "
+                   "<addr> <port> <data> [<num> [<delay in ms>]]\n", argv[0]);
+#else
             printf("usage: %s send "
                    "<addr> <port> <data> [<num> [<delay in us>]]\n", argv[0]);
+#endif
             return 1;
         }
         if (argc > 5) {

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -32,9 +32,9 @@
 #include "utlist.h"
 #include "xtimer.h"
 
-static gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                               KERNEL_PID_UNDEF);
-
+static gnrc_netreg_entry_t server =
+                        GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                   KERNEL_PID_UNDEF);
 
 static void send(char *addr_str, char *port_str, char *data, unsigned int num,
                  unsigned int delay)
@@ -97,12 +97,14 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
             ip = gnrc_pkt_prepend(ip, netif_hdr);
         }
         /* send packet */
-        if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP, GNRC_NETREG_DEMUX_CTX_ALL, ip)) {
+        if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP,
+                                       GNRC_NETREG_DEMUX_CTX_ALL, ip)) {
             puts("Error: unable to locate UDP thread");
             gnrc_pktbuf_release(ip);
             return;
         }
-        /* access to `payload` was implicitly given up with the send operation above
+        /* access to `payload` was implicitly given up with the send operation
+         * above
          * => use temporary variable for output */
         printf("Success: sent %u byte(s) to [%s]:%u\n", payload_size, addr_str,
                port);
@@ -157,8 +159,8 @@ int udp_cmd(int argc, char **argv)
         uint32_t num = 1;
         uint32_t delay = 1000000;
         if (argc < 5) {
-            printf("usage: %s send <addr> <port> <data> [<num> [<delay in us>]]\n",
-                   argv[0]);
+            printf("usage: %s send "
+                   "<addr> <port> <data> [<num> [<delay in us>]]\n", argv[0]);
             return 1;
         }
         if (argc > 5) {


### PR DESCRIPTION
### Contribution description
This PR makes the `gnrc_networking` example use `ZTIMER_MSEC` whenever `ztimer_msec` is included in the build. Although this PR is not really useful w.r.t. power consumption, as the example includes the shell, which on most platforms blocks low power modes similar to xtimer, it is still helpful in terms of code size and modularity as this prevents xtimer to be pulled into otherwise ztimer only builds...

### Testing procedure
Compile and run the example with `USEMODULE="ztimer_msec ztimer_periph_rtt" make ..` for you favorite platform...

### Issues/PRs references
Similar to e.g. #16339, #16322, #16340
