### PR TITLE
cpu/efm32: add RTT_FREQUENCY support to efm32

### DIFF
--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -106,8 +106,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/e180-zg120b-tb/include/periph_conf.h
+++ b/boards/e180-zg120b-tb/include/periph_conf.h
@@ -84,8 +84,9 @@ static const adc_chan_conf_t adc_channel_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -82,8 +82,9 @@ static const adc_chan_conf_t adc_channel_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/slstk3400a/include/periph_conf.h
+++ b/boards/slstk3400a/include/periph_conf.h
@@ -101,8 +101,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -113,8 +113,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -104,8 +104,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -113,8 +113,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/slwstk6220a/include/periph_conf.h
+++ b/boards/slwstk6220a/include/periph_conf.h
@@ -154,8 +154,9 @@ static const pwm_conf_t pwm_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/stk3200/include/periph_conf.h
+++ b/boards/stk3200/include/periph_conf.h
@@ -100,8 +100,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -159,8 +159,9 @@ static const pwm_conf_t pwm_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -159,8 +159,9 @@ static const pwm_conf_t pwm_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xFFFFFF)
-#define RTT_FREQUENCY       (1U)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1U)              /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -32,6 +32,7 @@
 #include "em_timer.h"
 #include "em_usart.h"
 #include "em_wdog.h"
+#include "em_rtc.h"
 #if defined(_SILICON_LABS_32B_SERIES_0)
 #include "em_dac.h"
 #endif
@@ -118,6 +119,23 @@ typedef struct {
     DAC_Ref_TypeDef ref;    /**< channel voltage reference */
 } dac_chan_conf_t;
 #endif
+
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+/* RTT_MAX_VALUE some are 24bit, some are 32bit */
+#ifdef _RTC_CNT_MASK
+#define RTT_MAX_VALUE       _RTC_CNT_MASK        /* mask has all bits set ==> MAX*/
+#endif
+#ifdef _RTCC_CNT_MASK
+#define RTT_MAX_VALUE       _RTCC_CNT_MASK       /* mask has all bits set ==> MAX*/
+#endif
+#define RTT_MAX_FREQUENCY   (32768U)             /* in Hz */
+#define RTT_MIN_FREQUENCY   (1U)                 /* in Hz */
+#define RTT_CLOCK_FREQUENCY (32768U)             /* in Hz, LFCLK*/
+
+/** @} */
 
 /**
  * @brief   Define a custom type for GPIO pins.

--- a/cpu/efm32/periph/rtt_series0.c
+++ b/cpu/efm32/periph/rtt_series0.c
@@ -34,10 +34,47 @@ typedef struct {
 
 static rtt_state_t rtt_state;
 
+/* prescaler of 32768 = 1 s of resolution and overflow each 194 days */
+#if RTT_FREQUENCY == 1
+#define RTT_CMU_CLK_DIV cmuClkDiv_32768
+#elif RTT_FREQUENCY == 2
+#define RTT_CMU_CLK_DIV cmuClkDiv_16384
+#elif RTT_FREQUENCY == 4
+#define RTT_CMU_CLK_DIV cmuClkDiv_8192
+#elif RTT_FREQUENCY == 8
+#define RTT_CMU_CLK_DIV cmuClkDiv_4096
+#elif RTT_FREQUENCY == 16
+#define RTT_CMU_CLK_DIV cmuClkDiv_2048
+#elif RTT_FREQUENCY == 32
+#define RTT_CMU_CLK_DIV cmuClkDiv_1024
+#elif RTT_FREQUENCY == 64
+#define RTT_CMU_CLK_DIV cmuClkDiv_512
+#elif RTT_FREQUENCY == 128
+#define RTT_CMU_CLK_DIV cmuClkDiv_256
+#elif RTT_FREQUENCY == 256
+#define RTT_CMU_CLK_DIV cmuClkDiv_128
+#elif RTT_FREQUENCY == 512
+#define RTT_CMU_CLK_DIV cmuClkDiv_64
+#elif RTT_FREQUENCY == 1024
+#define RTT_CMU_CLK_DIV cmuClkDiv_32
+#elif RTT_FREQUENCY == 2048
+#define RTT_CMU_CLK_DIV cmuClkDiv_16
+#elif RTT_FREQUENCY == 4096
+#define RTT_CMU_CLK_DIV cmuClkDiv_8
+#elif RTT_FREQUENCY == 8192
+#define RTT_CMU_CLK_DIV cmuClkDiv_4
+#elif RTT_FREQUENCY == 16384
+#define RTT_CMU_CLK_DIV cmuClkDiv_2
+#elif RTT_FREQUENCY == 32768
+#define RTT_CMU_CLK_DIV cmuClkDiv_1
+#else
+#warning "no matching prescaler for RTT_FREQUENCY"
+#endif
+
 void rtt_init(void)
 {
-    /* prescaler of 32768 = 1 s of resolution and overflow each 194 days */
-    CMU_ClockDivSet(cmuClock_RTC, cmuClkDiv_32768);
+    /* setup prescaler */
+    CMU_ClockDivSet(cmuClock_RTC, RTT_CMU_CLK_DIV);
 
     /* enable clocks */
     CMU_ClockEnable(cmuClock_CORELE, true);

--- a/cpu/efm32/periph/rtt_series1.c
+++ b/cpu/efm32/periph/rtt_series1.c
@@ -35,6 +35,43 @@ typedef struct {
 
 static rtt_state_t rtt_state;
 
+/* prescaler of 32768 = 1 s of resolution and overflow each 194 days */
+#if RTT_FREQUENCY == 1
+#define RTT_CMU_CLK_DIV rtccCntPresc_32768
+#elif RTT_FREQUENCY == 2
+#define RTT_CMU_CLK_DIV rtccCntPresc_16384
+#elif RTT_FREQUENCY == 4
+#define RTT_CMU_CLK_DIV rtccCntPresc_8192
+#elif RTT_FREQUENCY == 8
+#define RTT_CMU_CLK_DIV rtccCntPresc_4096
+#elif RTT_FREQUENCY == 16
+#define RTT_CMU_CLK_DIV rtccCntPresc_2048
+#elif RTT_FREQUENCY == 32
+#define RTT_CMU_CLK_DIV rtccCntPresc_1024
+#elif RTT_FREQUENCY == 64
+#define RTT_CMU_CLK_DIV rtccCntPresc_512
+#elif RTT_FREQUENCY == 128
+#define RTT_CMU_CLK_DIV rtccCntPresc_256
+#elif RTT_FREQUENCY == 256
+#define RTT_CMU_CLK_DIV rtccCntPresc_128
+#elif RTT_FREQUENCY == 512
+#define RTT_CMU_CLK_DIV rtccCntPresc_64
+#elif RTT_FREQUENCY == 1024
+#define RTT_CMU_CLK_DIV rtccCntPresc_32
+#elif RTT_FREQUENCY == 2048
+#define RTT_CMU_CLK_DIV rtccCntPresc_16
+#elif RTT_FREQUENCY == 4096
+#define RTT_CMU_CLK_DIV rtccCntPresc_8
+#elif RTT_FREQUENCY == 8192
+#define RTT_CMU_CLK_DIV rtccCntPresc_4
+#elif RTT_FREQUENCY == 16384
+#define RTT_CMU_CLK_DIV rtccCntPresc_2
+#elif RTT_FREQUENCY == 32768
+#define RTT_CMU_CLK_DIV rtccCntPresc_1
+#else
+#warning "no matching prescaler for RTT_FREQUENCY"
+#endif
+
 void rtt_init(void)
 {
     /* enable clocks */
@@ -45,7 +82,7 @@ void rtt_init(void)
     RTCC_Init_TypeDef init = RTCC_INIT_DEFAULT;
 
     init.enable = false;
-    init.presc = rtccCntPresc_32768;
+    init.presc = RTT_CMU_CLK_DIV;
 
     RTCC_Reset();
     RTCC_Init(&init);


### PR DESCRIPTION
### Contribution description

make efm32 rtt frequency configurable by setting RTT_FREQUENCY

### Testing procedure

**I can not test that, I don't have such a BOARD**  see **Test results** :arrow_down:

```
tests/ztimer_xsec$ BOARD=<some efm32> USEMODULE=ztimer_periph_rtt CFLAGS=-DRTT_FREQEUNCY=32768 make flash test
```
expected to print SUCCESS and some time information 
(start Time; SEC ~1*10^^6 later; MSEC ~200*10^^3 later; USEC ~100*10^^3 later)
```
tests/periph_rtt$ BOARD=<some efm32> USEMODULE=ztimer_periph_rtt CFLAGS=-DRTT_FREQUENCY=32768 make flash term
```
expected to print Hello every 5 seconds 

RTT_FREQUENCY may be chosen from 2^^0 to 2^^15  other values should fail at precompile-time 

please test with 
```
1024 (2^^10)  
    periph_rtt should print the line "Setting initial alarm to now + 5 s (5ddd) (d any decimal)"
4096 (2^^12)
    periph_rtt should print the line "Setting initial alarm to now + 5 s (20ddd) (d any decimal)"
32768 (2^^15)
    periph_rtt should print the line "Setting initial alarm to now + 5 s (16dddd) (d any decimal)"
``` 
periph_rtt  also prints `RTT_FREQUENCY: ...` after reset if possible please verify

### Test results

The first testing procedure was wrong: 
    I wrongly assumend  an enviroment RTT_FREQUENCY is translated to a define RTT_FREQUENCY somewhere in the build process

many thanks to @chrysn

TEST where successfully redone by @chrysn :+1: 
stk3700 and sltb001a (one of them is a series0 the other series1 one has RTC the other RTCC) -> both code paths are checked
messages where checked (numbers and success)

### Issues/PRs references

https://forum.riot-os.org/t/default-rtt-frequency/3160/4
