### PR TITLE
doc: README: Add documentation on downloads and release cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ but not limited to:
 * Sigfox
 * LoRaWAN
 
+## GETTING RIOT
+
+The most convenient way to get RIOT is to clone it via Git
+
+```console
+$ git clone https://github.com/RIOT-OS/RIOT
+```
+
+this will ensure that you get all the newest features and bug fixes with the
+caveat of an ever changing work environment.
+
+If you prefer things more stable, you can download the source code of one of our
+quarter annual releases [via Github][releases] as ZIP file or tarball. You can
+also checkout a release in a cloned Git repository using
+
+```console
+$ git pull --tags
+$ git checkout <YYYY.MM>
+```
+
+For more details on our release cycle, check our [documentation][release cycle].
+
+[releases]: https://github.com/RIOT-OS/RIOT/releases
+[release cycle]: https://doc.riot-os.org/release-cycle.html
 
 ## GETTING STARTED
 * You want to start the RIOT? Just follow our

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -774,6 +774,7 @@ INPUT                  = ../../doc.txt \
                          src/using-cpp.md \
                          src/advanced-build-system-tricks.md \
                          src/emulators.md \
+                         src/release-cycle.md \
                          src/changelog.md \
                          ../../LOSTANDFOUND.md
 

--- a/doc/doxygen/src/release-cycle.md
+++ b/doc/doxygen/src/release-cycle.md
@@ -1,0 +1,57 @@
+Release cycle                                                   {#release-cycle}
+=============
+
+RIOT has a new release every three months and is named after the month it
+was feature frozen in. E.g. `2021.01` was feature frozen in January 2021.
+Feature freeze means the branch off point of the `<YYYY.MM>-branch` with
+`<YYYY.MM>` being the releases name. As such, any new feature merged into the
+`master` after that point, will be part of the next release. That branch, which
+we will call the release branch in the following is then the stable branch of
+RIOT.
+
+After feature freeze, the current release candidate in the release branch is
+tested heavily. For more information on the release testing, have a look at our
+[release specifications][release specs]. Bug fixes that are made during this
+testing period are back ported from `master` to the release branch and a new
+release candidate might be created when a certain milestone is found. If all
+major bugs are fixed, the new RIOT release is signed off by the appointed
+release manager, usually within 2 weeks after the feature freeze.
+
+RIOT follows a rolling release cycle, meaning, that support and bug fixes are
+only provided for the most current release.
+
+Download a release                                                   {#download}
+==================
+
+You can download the source code of our releases [via Github][releases] as ZIP
+file or tarball. Alternatively, you can check them out if you already cloned
+RIOT with Git:
+
+~~~~~~~~~~~~~~~~~~~~
+$ git pull --tags
+$ git checkout <YYYY.MM>
+~~~~~~~~~~~~~~~~~~~~
+
+Point releases and hot fixes                                   {#point-releases}
+============================
+
+For major bug fixes, we may provide a point release `YYYY.MM.N` which results in
+a new ZIP file or tarball over at the [release page][releases]. However, minor
+bug fixes are only pushed to the release branch. You can fetch that via Git
+using
+
+~~~~~~~~~~~~~~~~~~~~
+$ git clone -b `<YYYY.MM>-branch` https://github.com/RIOT-OS/RIOT
+~~~~~~~~~~~~~~~~~~~~
+
+or
+
+~~~~~~~~~~~~~~~~~~~~
+$ git pull origin <YYYY.MM-branch>:<YYYY.MM-branch>
+$ git checkout <YYYY.MM-branch>
+~~~~~~~~~~~~~~~~~~~~
+
+if you have RIOT already cloned.
+
+[releases]: https://github.com/RIOT-OS/RIOT/releases
+[release specs]: https://github.com/RIOT-OS/Release-Specs


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This offers an alternative to https://github.com/RIOT-OS/RIOT/pull/16087 for the documentation of our release cycle. The README is amended with a short section how to download RIOT and the doxygen documentation receives a page about our release cycle in detail
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read, doxygen should build properly and all the links should work (except the `[release cycle]` link; for that `https://doc.riot-os.org` needs to be updated with this PR first).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to https://github.com/RIOT-OS/RIOT/pull/16087.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
