### PR TITLE
drivers/rtt_rtc: implement rtc_get_time_ms()

### DIFF
--- a/cpu/atmega_common/Kconfig
+++ b/cpu/atmega_common/Kconfig
@@ -20,6 +20,7 @@ config CPU_COMMON_ATMEGA
     select HAS_PERIPH_GPIO
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_PM
+    select HAS_PERIPH_RTC_MS
     select HAS_PERIPH_RTT_SET_COUNTER
     select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_WDT

--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_rtc_ms
 FEATURES_PROVIDED += periph_rtt_set_counter
 FEATURES_PROVIDED += periph_timer_periodic
 FEATURES_PROVIDED += periph_wdt

--- a/cpu/atmega_common/periph/rtc.c
+++ b/cpu/atmega_common/periph/rtc.c
@@ -102,6 +102,28 @@ int rtc_get_time(struct tm *time)
     return 0;
 }
 
+int rtc_get_time_ms(struct tm *time, uint16_t *ms)
+{
+    uint8_t cnt_before, cnt_after;
+
+    /* loop in case of overflow */
+    do {
+        cnt_before = TCNT2;
+
+        /* prevent compiler from reordering memory access to tm_now,
+         * including moving it out of the loop
+         */
+        __asm__ volatile ("" : : : "memory");
+        *time = tm_now;
+
+        cnt_after  = TCNT2;
+    } while (cnt_before > cnt_after);
+
+    *ms = (cnt_after * 1000UL) >> 8;
+
+    return 0;
+}
+
 int rtc_get_alarm(struct tm *time)
 {
     *time = tm_alarm;

--- a/cpu/lpc23xx/Kconfig
+++ b/cpu/lpc23xx/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_LPC23XX
     select HAS_PERIPH_GPIO
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER_PERIODIC
+    select HAS_PERIPH_RTC_MS
 
 ## CPU Models
 config CPU_MODEL_LPC2387

--- a/cpu/lpc23xx/Makefile.features
+++ b/cpu/lpc23xx/Makefile.features
@@ -3,5 +3,6 @@ FEATURES_PROVIDED += backup_ram
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer_periodic
+FEATURES_PROVIDED += periph_rtc_ms
 
 include $(RIOTCPU)/arm7_common/Makefile.features

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -91,6 +91,19 @@ int rtc_set_time(struct tm *time);
 int rtc_get_time(struct tm *time);
 
 /**
+ * @brief Get current RTC time with sub-second component.
+ *        Requires the `periph_rtc_ms` feature.
+ *
+ * @param[out] time         Pointer to the struct to write the time to.
+ * @param[out] ms           Pointer to a variable to hold the microsecond
+ *                          component of the current RTC time.
+ *
+ * @return  0 for success
+ * @return -1 an error occurred
+ */
+int rtc_get_time_ms(struct tm *time, uint16_t *ms);
+
+/**
  * @brief Set an alarm for RTC to the specified value.
  *
  * @note Any already set alarm will be overwritten.

--- a/drivers/rtt_rtc/Makefile.features
+++ b/drivers/rtt_rtc/Makefile.features
@@ -1,0 +1,2 @@
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtc_ms

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -252,6 +252,11 @@ config HAS_PERIPH_RTC
     help
         Indicates that an RTC peripheral is present.
 
+config HAS_PERIPH_RTC_MS
+    bool
+    help
+        Indicates that the RTC peripheral can provide sub-second timestamps.
+
 config HAS_PERIPH_RTT
     bool
     help

--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_rtc
+FEATURES_REQUIRED += periph_rtc
+FEATURES_OPTIONAL += periph_rtc_ms
 
 DISABLE_MODULE += periph_init_rtc
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

RTC on RTT usually runs at a frequency greater than 1 Hz, so sub-second precision is available.
Add a function to get the current RTC timestamp together with it's sub-second component.



### Testing procedure

To run `tests/periph_rtc` with `rtt_rtc` instead of the hardware RTC, do

```patch
--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED += periph_rtc
+USEMODULE += rtt_rtc
+# FEATURES_REQUIRED += periph_rtc
 FEATURES_OPTIONAL += periph_rtc_ms
 
 DISABLE_MODULE += periph_init_rtc
```

```
2021-04-19 14:32:06,802 # RIOT RTC low-level driver test
2021-04-19 14:32:06,808 # This test will display 'Alarm!' every 2 seconds for 4 times
2021-04-19 14:32:06,811 #   Setting clock to   2020-02-28 23:59:57
2021-04-19 14:32:06,815 # Clock value is now   2020-02-28 23:59:57.014
2021-04-19 14:32:06,819 #   Setting alarm to   2020-02-28 23:59:59
2021-04-19 14:32:06,823 #    Alarm is set to   2020-02-28 23:59:59
2021-04-19 14:32:06,827 #   Alarm cleared at   2020-02-28 23:59:57.025
2021-04-19 14:32:08,831 #        No alarm at   2020-02-28 23:59:59.029
2021-04-19 14:32:08,834 #   Setting alarm to   2020-02-28 23:59:61
2021-04-19 14:32:08,835 # 
2021-04-19 14:32:10,831 # Alarm!
2021-04-19 14:32:12,832 # Alarm!
2021-04-19 14:32:14,833 # Alarm!
2021-04-19 14:32:16,833 # Alarm!
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
