### PR TITLE
drivers/periph_timer: add timer_query_freqs()

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -36,6 +36,7 @@
 #include <limits.h>
 #include <stdint.h>
 
+#include "architecture.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
 
@@ -231,6 +232,68 @@ void timer_start(tim_t dev);
  * @param[in] dev           the timer to stop
  */
 void timer_stop(tim_t dev);
+
+/**
+ * @brief   Get the number of different frequencies supported by the given
+ *          timer
+ *
+ * If calling @ref timer_query_freqs_numof for the same timer with an index
+ * smaller this number, it hence MUST return a frequency (and not zero).
+ *
+ * @details This function is marked with attribute pure to tell the compiler
+ *          that this function has no side affects and will return the same
+ *          value when called with the same parameter. (E.g. to not call this
+ *          function in every loop iteration when iterating over all
+ *          supported frequencies.)
+ */
+__attribute__((pure))
+uword_t timer_query_freqs_numof(tim_t dev);
+
+/**
+ * @brief   Get the number of timer channels for the given timer
+ *
+ * @details This function is marked with attribute pure to tell the compiler
+ *          that this function has no side affects and will return the same
+ *          value when called with the same timer as parameter.
+ * @details There is a weak default implementation that returns the value of
+ *          `TIMER_CHANNEL_NUMOF`. For some MCUs the number of supported
+ *          channels depends on @p dev - those are expected to provide there
+ *          own implementation of this function.
+ */
+__attribute__((pure))
+uword_t timer_query_channel_numof(tim_t dev);
+
+/**
+ * @brief   Iterate over supported frequencies
+ *
+ * @param   dev     Timer to get the next supported frequency of
+ * @param   index   Index of the frequency to get
+ * @return          The @p index highest frequency supported by the timer
+ * @retval  0       @p index is too high
+ *
+ * @note    Add `FEATURES_REQUIRED += periph_timer_query_freqs` to your `Makefile`.
+ *
+ * When called with a value of 0 for @p index, the highest supported frequency
+ * is returned. For a value 1 the second highest is returned, and so on. For
+ * values out of range, 0 is returned. A program hence can iterate over all
+ * supported frequencies using:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * uint32_t freq:
+ * for (uword_t i; (freq = timer_query_freqs(dev, i)); i++) {
+ *     work_with_frequency(freq);
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * Or alternatively:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * for (uword_t i; i < timer_query_freqs_numof(dev); i++) {
+ *     work_with_frequency(timer_query_freqs(dev, i));
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+uint32_t timer_query_freqs(tim_t dev, uword_t index);
 
 #ifdef __cplusplus
 }

--- a/drivers/periph_common/Kconfig.timer
+++ b/drivers/periph_common/Kconfig.timer
@@ -30,6 +30,10 @@ config MODULE_PERIPH_INIT_TIMER_PERIODIC
     depends on MODULE_PERIPH_TIMER_PERIODIC
     default y if MODULE_PERIPH_INIT
 
+config MODULE_PERIPH_TIMER_QUERY_FREQS
+    bool "Support for querying supported timer frequencies"
+    depends on HAS_PERIPH_TIMER_QUERY_FREQS
+
 endif # MODULE_PERIPH_TIMER
 
 endif # TEST_KCONFIG

--- a/drivers/periph_common/timer.c
+++ b/drivers/periph_common/timer.c
@@ -30,3 +30,12 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     return res;
 }
 #endif
+
+#ifdef MODULE_PERIPH_TIMER_QUERY_FREQS
+__attribute__((weak))
+uword_t timer_query_channel_numof(tim_t dev)
+{
+    (void)dev;
+    return TIMER_CHANNEL_NUMOF;
+}
+#endif

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -572,6 +572,11 @@ config HAS_PERIPH_TIMER_PERIODIC
         Indicates that the Timer peripheral provides the periodic timeout
         functionality.
 
+config HAS_PERIPH_TIMER_QUERY_FREQS
+    bool
+    help
+        Indicates that the driver of the timer supports iterating over supported frequencies.
+
 config HAS_PERIPH_UART
     bool
     help

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -47,6 +47,7 @@ PERIPH_IGNORE_MODULES := \
   periph_rtt_hw_rtc \
   periph_rtt_hw_sys \
   periph_spi_on_qspi \
+  periph_timer_query_freqs \
   periph_uart_collision \
   periph_uart_rxstart_irq \
   periph_wdog \

--- a/tests/periph/timer/Kconfig
+++ b/tests/periph/timer/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config APPLICATION
+    bool
+    default y
+    depends on TEST_KCONFIG
+    imply MODULE_PERIPH_TIMER_QUERY_FREQS

--- a/tests/periph/timer/Makefile
+++ b/tests/periph/timer/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.periph_common
 
 FEATURES_REQUIRED = periph_timer
+FEATURES_OPTIONAL = periph_timer_query_freqs
 
 BOARDS_TIMER_500kHz := \
     atxmega-a1-xplained \

--- a/tests/periph/timer/tests/01-run.py
+++ b/tests/periph/timer/tests/01-run.py
@@ -11,13 +11,10 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r'Available timers: (\d+)\r\n')
-    timers_num = int(child.match.group(1))
-    for timer in range(timers_num):
-        child.expect_exact('Testing TIMER_{}'.format(timer))
-        child.expect_exact('TIMER_{}: initialization successful'.format(timer))
-        child.expect_exact('TIMER_{}: stopped'.format(timer))
-        child.expect_exact('TIMER_{}: starting'.format(timer))
+    # Make sure the expected application is actually flashed
+    child.expect('Test for peripheral TIMERs')
+    # The C application carefully evaluates the test results, no need to
+    # re-implement that wheel in python and just check for the test to succeed
     child.expect('TEST SUCCEEDED')
 
 


### PR DESCRIPTION
### Contribution description

Allow accessing supported timer frequencies with a dedicated API.
This API needs to be implemented per platform and is available with
the feature `periph_timer_query_freqs`.

### Testing procedure

The test in `tests/periph_timer` has been extended to make use of the new API to increase test coverage.

### Issues/PRs references

Implementations:

- [ ] [ATmega](https://github.com/RIOT-OS/RIOT/pull/20142)
- [ ] ATXmega
- [ ] [CC26xx / CC13xx](https://github.com/RIOT-OS/RIOT/pull/20143)
- [ ] CC2538
- [ ] EFM32
- [ ] ESP32
- [ ] ESP8266
- [ ] [Kinetis](https://github.com/RIOT-OS/RIOT/pull/20144)
- [ ] LM4F120
- [ ] LPC1768
- [ ] LPC23xx
- [ ] MSP430
- [ ] native
- [ ] [nRF5x](https://github.com/RIOT-OS/RIOT/pull/20145)
- [ ] [QN908x](https://github.com/RIOT-OS/RIOT/pull/20146)
- [ ] RP2040
- [ ] [SAM0](https://github.com/RIOT-OS/RIOT/pull/20147)
- [ ] [STM32](https://github.com/RIOT-OS/RIOT/pull/20148)