### PR TITLE
tests/dbgpin: user port 1 for frdm-k64f

### DIFF
--- a/tests/dbgpin/Makefile
+++ b/tests/dbgpin/Makefile
@@ -3,7 +3,20 @@ include ../Makefile.tests_common
 USEMODULE += dbgpin
 USEMODULE += xtimer
 
-DBGPIN_PINS ?= GPIO_PIN(0,0)
+# Default port used is PORT 1
+# - frdm-64f port A0-4 are connected to the JTAG, setting GPIO(0,0) will
+#   cause flashing to fail
+BOARDS_DEBUG_PORT_1 = \
+    frdm-k64f \
+    #
+
+ifneq (,$(filter $(BOARD),$(BOARDS_DEBUG_PORT_1)))
+  TEST_PORT ?= 1
+else
+  TEST_PORT ?= 0
+endif
+
+DBGPIN_PINS ?= GPIO_PIN($(TEST_PORT),0)
 CFLAGS += -DDBGPIN_PINS="$(DBGPIN_PINS)"
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The test fails because the default pin is connected to the jtag, with this PR it does not.

### Testing procedure

See `test-ryot` for a failed flash, with this pr:

```
READY
s
START
main(): This is RIOT! (Version: 2021.07-devel-1-gd10f9-pr_test_dbgpin_frdm-k64f)
Found 1 configured debug pin(s)
Testing pin 0
Test successful.
```


