### PR TITLE
gh-actions: release-tests: properly configure GH token for sudo [backport 2021.04]

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -54,7 +54,11 @@ jobs:
     steps:
     - name: Generate .riotgithubtoken
       run: |
-        echo '${{ secrets.RIOT_CI_ACCESS_TOKEN }}' > ~/.riotgithubtoken
+        if [ -z "${{ matrix.sudo }}" ]; then
+          echo '${{ secrets.RIOT_CI_ACCESS_TOKEN }}' > ~/.riotgithubtoken
+        else
+          sudo sh -c "echo '${{ secrets.RIOT_CI_ACCESS_TOKEN }}' > ~/.riotgithubtoken"
+        fi
     - name: Setup IoT-LAB credentials
       if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
       run: |


### PR DESCRIPTION
# Backport of #16350

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Another follow-up on https://github.com/RIOT-OS/RIOT/pull/15637. `pytest` reads the token from the `HOME` directory, which with `sudo` is `root`, so there is none (since it is in the login user's `HOME`), so it can't comment in the tracking issue for `sudo` the tasks.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I started a run in https://github.com/miri64/RIOT/actions/runs/766574330. Murdock should comment from there.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/15637
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
