### PR TITLE
sys/shell/sc_gnrc_rpl: Err out early if RPL not even started

### DIFF
--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -236,6 +236,11 @@ int _stats(void)
 
 int _gnrc_rpl_dodag_show(void)
 {
+    if (gnrc_rpl_pid == KERNEL_PID_UNDEF) {
+        printf("RPL not initializied\n");
+        return 1;
+    }
+
     printf("instance table:\t");
     for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
         if (gnrc_rpl_instances[i].state == 0) {


### PR DESCRIPTION
### Contribution description

When RPL was not started, don't show an empty state -- rather, show it was not started.

### Testing procedure

```
$ make BOARD=microbit-v2 -C examples/gnrc_networking all flash term
> rpl
RPL not initializied
> rpl init 6
> rpl
instance table: [ ]
parent table:   [ ]     [ ]     [ ]
```

or run with `USEMODULE+=gnrc_netif_single` and never see the new "RPL not initialized" unless there's something wrong with autoinit.

The more important (not so much testing, but general review) question is: Does this hide any possibly valuable output that could be there even when RPL was not started? My impression is that nothing touches the state before the thread gets started, and that the PID is never removed (even if the RPL thread happened to crash), but never having worked with the RPL implementation this is just gossip, not solid.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/16357

I'd say it sufficiently addresses the issue in that it does provide a distinction between "was never started" and "is running". A list of netifs that use it could be provided by running through the netifs and looking which joined ff02::1a, but that's probably overdoing it. In most situations there's one network interface, and when there is not, users have to take deliberate actions to start RPL on one or the other anyway.

### Overhead

This increases build size by a check and a printed string -- on the shell that's a typical trade-off for more understandable behavior in error situations.