### PR TITLE
makefiles/tools/programmer: do not use wrapper with jlink

### DIFF
--- a/makefiles/tools/programmer.inc.mk
+++ b/makefiles/tools/programmer.inc.mk
@@ -10,7 +10,7 @@ endif
 # is lost and will also cause the wrapper to hang waiting for user input.
 # As long as a similar functionality is not provided by the wrapper
 # then disable it for pyocd.
-PROGRAMMER_WRAPPER_BLACKLIST ?= pyocd
+PROGRAMMER_WRAPPER_BLACKLIST ?= pyocd jlink
 
 # Don't use the programmer wrapper for the CI (where speed and verbose output
 # are important)


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

J-Link can get stuck in a

 > Mass erase done!

loop that is hidden with the programmer wrapper.


### Testing procedure

This typically happens with a loose wire or somehow odd state of J-Link or the CPU.

The wrapper will spin forever until aborted, the it reveales that it would print

```
Connecting to target via SWD
InitTarget() start
InitTarget()
Secured Atmel SAMD device detected.
For debugger connection the device needs to be unsecured.
Note: Unsecuring will trigger a mass erase of the internal flash.
Executing default behavior previously saved in the registry.
Device will be unsecured now.
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
Mass erase done!
```

in the meantime. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
