### PR TITLE
cpu/esp*: add CLOCK_CORECLOCK

### DIFF
--- a/cpu/esp32/include/sdk_conf.h
+++ b/cpu/esp32/include/sdk_conf.h
@@ -29,11 +29,17 @@ extern "C" {
 #endif
 
 /**
+* @name    Clock configuration
+* @{
+*/
+/**
  * @brief   Defines the CPU frequency [values = 2, 40, 80, 160 and 240]
  */
 #ifndef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ
 #define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   80
 #endif
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
+/** @} */
 
 /**
  * Default console configuration

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -30,6 +30,10 @@ extern "C" {
 #endif
 
 /**
+* @name    Clock configuration
+* @{
+*/
+/**
  * @brief   Defines the CPU frequency in MHz
  *
  * Possible values are 80 and 160 MHz.
@@ -37,6 +41,8 @@ extern "C" {
 #ifndef ESP8266_CPU_FREQUENCY
 #define ESP8266_CPU_FREQUENCY   (80)
 #endif
+#define CLOCK_CORECLOCK         (1000000UL * ESP8266_CPU_FREQUENCY)
+/** @} */
 
 /**
  * @name   Stack size configurations


### PR DESCRIPTION
### Contribution description

All other cpu define this variable so added without replacing the defines that come from upstream as stated in https://github.com/RIOT-OS/RIOT/pull/16341#issuecomment-821041343

### Testing procedure

- green murdock.

### Issues/PRs references

Split from #16341
