### PR TITLE
dist/tools/avarice/debug.sh: less noise

### DIFF
--- a/dist/tools/avarice/debug.sh
+++ b/dist/tools/avarice/debug.sh
@@ -3,9 +3,9 @@
 # The setsid command is needed so that Ctrl+C in GDB doesn't kill avarice
 : ${SETSID:=setsid}
 
-if avr-gdb -v > /dev/null; then
+if avr-gdb -v &> /dev/null; then
     GDB=avr-gdb
-elif gdb-multiarch -v > /dev/null; then
+elif gdb-multiarch -v &> /dev/null; then
     GDB=gdb-multiarch
 else
     echo "Couldn't find multiarch GDB or AVR GDB. Check \$PATH."


### PR DESCRIPTION
### Contribution description

Redirect also stderr to /dev/null when trying to detect the correct binary name for GDB for AVR.

### Testing procedure

`make debug` for an AVR board should still work.

### Issues/PRs references

None