### PR TITLE
ztimer: fix `ztimer_is_set()`

### DIFF
--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -281,6 +281,10 @@ static ztimer_t *_now_next(ztimer_clock_t *clock)
             }
 #endif
         }
+        else {
+            /* reset next pointer so ztimer_is_set() works */
+            entry->next = NULL;
+        }
         return (ztimer_t *)entry;
     }
     else {

--- a/tests/unittests/tests-ztimer/tests-ztimer-mock.c
+++ b/tests/unittests/tests-ztimer/tests-ztimer-mock.c
@@ -249,6 +249,41 @@ static void test_ztimer_mock_set16(void)
     TEST_ASSERT_EQUAL_INT(0x100207d2, now);
 }
 
+/**
+ * @brief   Testing ztimer_is_set()
+ */
+static void test_ztimer_mock_is_set(void)
+{
+    ztimer_mock_t zmock;
+    ztimer_clock_t *z = &zmock.super;
+
+    /* Basic sanity test of the mock implementation */
+    ztimer_mock_init(&zmock, 32);
+
+    uint32_t count = 0;
+    ztimer_t alarm = { .callback = cb_incr, .arg = &count, };
+    ztimer_t alarm2 = { .callback = cb_incr, .arg = &count, };
+
+    ztimer_set(z, &alarm, 1000);
+    ztimer_set(z, &alarm2, 2000);
+
+    TEST_ASSERT_EQUAL_INT(0, count);
+    TEST_ASSERT(ztimer_is_set(z, &alarm));
+    TEST_ASSERT(ztimer_is_set(z, &alarm2));
+
+    ztimer_mock_advance(&zmock, 1000);
+
+    TEST_ASSERT_EQUAL_INT(1, count);
+    TEST_ASSERT(!ztimer_is_set(z, &alarm));
+    TEST_ASSERT(ztimer_is_set(z, &alarm2));
+
+    ztimer_mock_advance(&zmock, 1000);
+
+    TEST_ASSERT_EQUAL_INT(2, count);
+    TEST_ASSERT(!ztimer_is_set(z, &alarm));
+    TEST_ASSERT(!ztimer_is_set(z, &alarm2));
+}
+
 Test *tests_ztimer_mock_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -258,6 +293,7 @@ Test *tests_ztimer_mock_tests(void)
         new_TestFixture(test_ztimer_mock_now3),
         new_TestFixture(test_ztimer_mock_set32),
         new_TestFixture(test_ztimer_mock_set16),
+        new_TestFixture(test_ztimer_mock_is_set),
     };
 
     EMB_UNIT_TESTCALLER(ztimer_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

  ztimer's machinery depends on figuring out if a timer is currently set
  or not. It does that using _is_set(), which is also exposed as
  ztimer_is_set().
  Now when a timer expired and got taken of the timer queue using
  _now_next(), the `next` pointer wasn't unset. This caused _is_set() to
  wrongly return `true` for that timer.
  Internally in ztimer, this didn't cause breakage, just an unnecessary
  iteration of the timer queue by _delete_timer_from_list().
  But this also broke the public ztimer_is_set().

  This PR fixes the issue by correctly NULLing the timer's `next`
  pointer when the timer triggers.

There's also an added regression test to ztimer's unittests.

### Testing procedure

The regression test now ensures correct behaviour. To see it fail, uncomment the new lines in sys/ztimer/core.c and run ztimer's unittests. 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
