### PR TITLE
tools/programmer: use timeout to fail when programmer is stuck

### DIFF
--- a/makefiles/tools/programmer.inc.mk
+++ b/makefiles/tools/programmer.inc.mk
@@ -1,5 +1,5 @@
 # Configure the programmer related variables
-
+PROGRAMMER_TIMEOUT ?= 60
 PROGRAMMER_QUIET ?= $(QUIET)
 ifeq (0,$(PROGRAMMER_QUIET))
   PROGRAMMER_VERBOSE_OPT ?= --verbose
@@ -27,10 +27,12 @@ endif
 ifeq (1,$(USE_PROGRAMMER_WRAPPER_SCRIPT))
   PROGRAMMER_FLASH ?= @$(RIOTTOOLS)/programmer/programmer.py \
     --action Flashing --cmd "$(FLASHER) $(FFLAGS)" \
-    --programmer "$(PROGRAMMER)" $(PROGRAMMER_VERBOSE_OPT)
+    --programmer "$(PROGRAMMER)" $(PROGRAMMER_VERBOSE_OPT) \
+    --timeout $(PROGRAMMER_TIMEOUT)
   PROGRAMMER_RESET ?= @$(RIOTTOOLS)/programmer/programmer.py \
   --action Resetting --cmd "$(RESET) $(RESET_FLAGS)" \
-  --programmer "$(PROGRAMMER)" $(PROGRAMMER_VERBOSE_OPT)
+  --programmer "$(PROGRAMMER)" $(PROGRAMMER_VERBOSE_OPT) \
+  --timeout $(PROGRAMMER_TIMEOUT)
 else
   PROGRAMMER_FLASH ?= $(FLASHER) $(FFLAGS)
   PROGRAMMER_RESET ?= $(RESET) $(RESET_FLAGS)

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -109,6 +109,8 @@ export HEXFILE               # The 'intel hex' stripped result of the compilatio
 # PROGRAMMERS_SUPPORTED      # The list of programmers supported by a board
 # PROGRAMMER_QUIET           # Change verbosity of programmer output (only used with flash and reset targets).
                              # Default is 1, not verbose. Use 0 to get normal programmer output.
+# PROGRAMMER_TIMEOUT         # Make programmer fail when timeout is reached, default is 60s. Only used
+                             # when PROGRAMMER_QUIET=1.
 # USE_PROGRAMMER_WRAPPER_SCRIPT     # Use the programmer wrapper Python script. Default is 1 (0 if RIOT_CI_BUILD is set).
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR extends the programmer wrapper script with the management of a timeout when the underlying programmer tool is stuck (in an endless loop as reported in #16360 or because of an interactive prompt, e.g. with pyocd).

The default timeout value is set to 60s which should be enough for most of the case: it's enough to flash `examples/javascript` on a samr21-xpro using openocd (which is a slow programmer here and examples/javascript is a very big application):

<details>

```
$ PROGRAMMER=openocd make BOARD=samr21-xpro -C examples/javascript/ flash
make: Entering directory '/work/riot/RIOT/examples/javascript'
Building application "riot_javascript" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/pkg/jerryscript
"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
 159408	    116	  28476	 188000	  2de60	/work/riot/RIOT/examples/javascript/bin/samr21-xpro/riot_javascript.elf
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'openocd' - duration: 31.09s)
make: Leaving directory '/work/riot/RIOT/examples/javascript'
```

</details>

The default timeout value can be configured using `PROGRAMER_TIMEOUT`. This variable is documented in vars.inc.mk.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

One can play with the `PROGRAMMER_TIMEOUT` to verify the behavior:

<details><summary>timeout not reached</summary>

```
$ make BOARD=samr21-xpro -C examples/hello-world flash --no-print-directory 
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9000	    112	   2304	  11416	   2c98	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'edbg' - duration: 3.01s)
```

</details>

<details><summary>timeout reached</summary>

```
$ PROGRAMMER_TIMEOUT=1 make BOARD=samr21-xpro -C examples/hello-world flash --no-print-directory 
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9000	    112	   2304	  11416	   2c98	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 × Flashing failed! (programmer: 'edbg' - duration: 1.11s)
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification....................................... done.

make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:744: flash] Error 241
```

</details>

It's also possible to set `FLASHER=sleep FFLAGS=<timeout>`  to the command line and check the timeout logic:

<details><summary>short sleep</summary>

```
$ FLASHER=sleep FFLAGS=5 make BOARD=samr21-xpro -C examples/hello-world flash --no-print-directory 
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9000	    112	   2304	  11416	   2c98	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'edbg' - duration: 5.02s)
```

</details>

<details><summary>long sleep</summary>

```
$ FLASHER=sleep FFLAGS=120 make BOARD=samr21-xpro -C examples/hello-world flash --no-print-directory 
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9000	    112	   2304	  11416	   2c98	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 × Flashing failed! (programmer: 'edbg' - duration: 60.18s)

make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:744: flash] Error 241
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Alternative the workaround proposed by #16360 (so closes #16360).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
