### PR TITLE
tools/programmer: do not use programmer wrapper

### DIFF
--- a/makefiles/tools/programmer.inc.mk
+++ b/makefiles/tools/programmer.inc.mk
@@ -5,24 +5,8 @@ ifeq (0,$(PROGRAMMER_QUIET))
   PROGRAMMER_VERBOSE_OPT ?= --verbose
 endif
 
-# When multiple debuggers are connected then pyocd shows an interactive
-# UI to select the user interface to flash, with the python wrapper this
-# is lost and will also cause the wrapper to hang waiting for user input.
-# As long as a similar functionality is not provided by the wrapper
-# then disable it for pyocd.
-PROGRAMMER_WRAPPER_BLACKLIST ?= pyocd
-
-# Don't use the programmer wrapper for the CI (where speed and verbose output
-# are important)
-ifneq (1,$(RIOT_CI_BUILD))
-  ifneq (,$(filter $(PROGRAMMER),$(PROGRAMMER_WRAPPER_BLACKLIST)))
-    USE_PROGRAMMER_WRAPPER_SCRIPT ?= 0
-  else
-    USE_PROGRAMMER_WRAPPER_SCRIPT ?= 1
-  endif
-else
-  USE_PROGRAMMER_WRAPPER_SCRIPT ?= 0
-endif
+# Don't use the programmer wrapper
+USE_PROGRAMMER_WRAPPER_SCRIPT ?= 0
 
 ifeq (1,$(USE_PROGRAMMER_WRAPPER_SCRIPT))
   PROGRAMMER_FLASH ?= @$(RIOTTOOLS)/programmer/programmer.py \


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While nice at first, this causes more issues than it's worth for a slightly more pretty output.

Hiding information from developers is not a good idea, especially when it comes to an often finicky programming step.

While in theory error output should be caught, there are enough cases where the programmer will get stuck in a loop or require user input that hiding programmer output by default is a bad idea.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #16370 and #16360
