### PR TITLE
pkg/nimble/netif: allow to apply and enforce random and unique connection intervals

### DIFF
--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -68,6 +68,7 @@ endif
 
 ifneq (,$(filter nimble_netif,$(USEMODULE)))
   FEATURES_REQUIRED += ble_nimble_netif
+  USEMODULE += random
   USEMODULE += l2util
   USEMODULE += bluetil_addr
   ifneq (,$(filter gnrc_ipv6_%,$(USEMODULE)))

--- a/pkg/nimble/autoconn/include/nimble_autoconn.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn.h
@@ -145,8 +145,11 @@ typedef struct {
     uint32_t scan_win;
     /** opening a new connection is aborted after this time [in ms] */
     uint32_t conn_timeout;
-    /** connection interval used when opening a new connection [in ms] */
-    uint32_t conn_itvl;
+    /** connection interval used when opening a new connection, lower bound.
+     *  [in ms] */
+    uint32_t conn_itvl_min;
+    /** connection interval, upper bound [in ms] */
+    uint32_t conn_itvl_max;
     /** slave latency used for new connections [in ms] */
     uint16_t conn_latency;
     /** supervision timeout used for new connections [in ms] */

--- a/pkg/nimble/autoconn/include/nimble_autoconn_params.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn_params.h
@@ -51,8 +51,11 @@ extern "C" {
 #ifndef NIMBLE_AUTOCONN_CONN_TIMEOUT_MS
 #define NIMBLE_AUTOCONN_CONN_TIMEOUT_MS     (3 * NIMBLE_AUTOCONN_SCAN_WIN_MS)
 #endif
-#ifndef NIMBLE_AUTOCONN_CONN_ITVL_MS
-#define NIMBLE_AUTOCONN_CONN_ITVL_MS        (75U)           /* 75ms */
+#ifndef NIMBLE_AUTOCONN_CONN_ITVL_MIN_MS
+#define NIMBLE_AUTOCONN_CONN_ITVL_MIN_MS    75U             /* 75ms */
+#endif
+#ifndef NIMBLE_AUTOCONN_CONN_ITVL_MAX_MS
+#define NIMBLE_AUTOCONN_CONN_ITVL_MAX_MS    75U             /* 75ms */
 #endif
 #ifndef NIMBLE_AUTOCONN_CONN_LATENCY
 #define NIMBLE_AUTOCONN_CONN_LATENCY        (0)
@@ -74,7 +77,8 @@ extern "C" {
       .scan_itvl     = NIMBLE_AUTOCONN_SCAN_ITVL_MS,     \
       .scan_win      = NIMBLE_AUTOCONN_SCAN_WIN_MS,      \
       .conn_timeout  = NIMBLE_AUTOCONN_CONN_TIMEOUT_MS,  \
-      .conn_itvl     = NIMBLE_AUTOCONN_CONN_ITVL_MS,     \
+      .conn_itvl_min = NIMBLE_AUTOCONN_CONN_ITVL_MIN_MS, \
+      .conn_itvl_max = NIMBLE_AUTOCONN_CONN_ITVL_MAX_MS, \
       .conn_latency  = NIMBLE_AUTOCONN_CONN_LATENCY,     \
       .conn_super_to = NIMBLE_AUTOCONN_CONN_SVTO_MS,     \
       .node_id       = NIMBLE_AUTOCONN_NODE_ID, }

--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -277,8 +277,8 @@ int nimble_autoconn_update(const nimble_autoconn_params_t *params,
     /* populate the connection parameters */
     _conn_params.scan_itvl = BLE_GAP_SCAN_ITVL_MS(params->scan_win);
     _conn_params.scan_window = _conn_params.scan_itvl;
-    _conn_params.itvl_min = BLE_GAP_CONN_ITVL_MS(params->conn_itvl);
-    _conn_params.itvl_max = _conn_params.itvl_min;
+    _conn_params.itvl_min = BLE_GAP_CONN_ITVL_MS(params->conn_itvl_min);
+    _conn_params.itvl_max = BLE_GAP_CONN_ITVL_MS(params->conn_itvl_max);
     _conn_params.latency = 0;
     _conn_params.supervision_timeout = BLE_GAP_SUPERVISION_TIMEOUT_MS(
                                                          params->conn_super_to);

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -103,6 +103,37 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Set to > 0 to enforce different connection intervals for each of the
+ *          nodes BLE connections
+ *
+ * Enabling this option will enforce that every BLE connection a node maintains,
+ * independent of the nodes role, uses a different connection interval. The
+ * value of NIMBLE_NETIF_CONN_ITVL_SPACING specifies the minimum spacing between
+ * connection intervals as multiple of 1,25ms. E.g. a value of 2 will force each
+ * connection to use a connection interval that is at least 2.5ms different from
+ * all other used connection intervals.
+ *
+ * If a node is the coordinator of a connection, it will generate a connection
+ * interval for each new connection based on a random value by adhering to the
+ * spacing constraint.
+ *
+ * If a node is the subordinate of a new connection, it will check if the given
+ * connection interval is fulfilling the spacing constraint with respect to
+ * already existing connections of that node. If the connection interval of the
+ * new connection is not properly spaced, the node will drop the connection
+ * right away, giving the coordinator node the possibly to reconnect with a
+ * different connection interval.
+ */
+#ifndef NIMBLE_NETIF_CONN_ITVL_SPACING
+#define NIMBLE_NETIF_CONN_ITVL_SPACING          0
+#endif
+
+/**
+ * @brief   Minimum spacing of connection interval when using randomized
+ *          intervals, in multiples of 1.25ms
+ */
+
+/**
  * @brief   Return codes used by the NimBLE netif module
  */
 enum {
@@ -183,16 +214,18 @@ void nimble_netif_eventcb(nimble_netif_eventcb_t cb);
  *
  * @param[in] addr          address of the advertising BLE slave, in the NimBLE
  *                          addr format (little endian)
- * @param[in] conn_params   connection (timing) parameters
+ * @param[in] conn_params   connection (timing) parameters, set to NULL to use
+ *                          NimBLEs default parameters
  * @param[in] timeout       connect timeout [in ms]
  *
  * @return  the used connection handle on success
  * @return  NIMBLE_NETIF_BUSY if already connected to the given address or if
  *          a connection setup procedure is in progress
  * @return  NIMBLE_NETIF_NOMEM if no connection context memory is available
+ * @return  NIMBLE_NETIF_NOTFOUND if unable to find valid connection interval
  */
 int nimble_netif_connect(const ble_addr_t *addr,
-                         const struct ble_gap_conn_params *conn_params,
+                         struct ble_gap_conn_params *conn_params,
                          uint32_t timeout);
 
 /**

--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -23,6 +23,7 @@
 #define NIMBLE_NETIF_CONN_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "nimble_netif.h"
 
@@ -174,6 +175,57 @@ int nimble_netif_conn_start_adv(void);
  * @brief   Free the connection context with the given handle
  */
 void nimble_netif_conn_free(int handle, uint8_t *addr);
+
+/**
+ * @brief   Get the used connection interval for the given connection handle
+ *
+ * @param[in] handle        connection handle
+ *
+ * @return  used connection interval on success, multiples of 1.25ms
+ * @return  0 if unable to get connection interval
+ */
+uint16_t nimble_netif_conn_get_itvl(int handle);
+
+/**
+ * @brief   Check if the given connection interval is used, taking the minimal
+ *          spacing as defined by NIMBLE_NETIF_CONN_ITVL_SPACING into account
+ *
+ * @param[in] itvl          connection interval to check, multiples of 1.25ms
+ * @param[in] skip_handle   do not compare against connection interval for this
+ *                          handle, set to NIMBLE_NETIF_CONN_INVALID to check
+ *                          all
+ *
+ * @return  true if given interval is used
+ * @return  false if given interval is not used
+ */
+bool nimble_netif_conn_itvl_used(uint16_t itvl, int skip_handle);
+
+/**
+ * @brief   Check if connection interval used by the given connection is valid
+ *
+ * @param[in] handle        connection to verify
+ *
+ * @return  true if the connection interval of the given connection collides
+ *          with the connection interval of another BLE connection
+ * @return  false if the connection interval of the given connection is valid
+ */
+bool nimble_netif_conn_itvl_invalid(int handle);
+
+/**
+ * @brief   Generate a pseudorandom connection interval from the given range
+ *
+ * If the NIMBLE_NETIF_CONN_ITVL_SPACING option is enabled, this function
+ * ensures that the generated connection interval is spaced at least
+ * NIMBLE_NETIF_CONN_ITVL_SPACING from the connection interval of each open
+ * BLE connection.
+ *
+ * @param[in] min           minimum connection interval
+ * @param[in] max           maximum connection interval
+ *
+ * @return  generated connection interval on success, multiples of 1.25ms
+ * @return  0 if no valid connection interval could be generated
+ */
+uint16_t nimble_netif_conn_gen_itvl(uint16_t min, uint16_t max);
 
 /**
  * @brief   Find the connection context with a given GAP handle and return a

--- a/pkg/nimble/statconn/nimble_statconn.c
+++ b/pkg/nimble/statconn/nimble_statconn.c
@@ -27,13 +27,9 @@
 
 #include "host/ble_hs.h"
 
-#if NIMBLE_STATCONN_CONN_ITVL_MIN_MS != NIMBLE_STATCONN_CONN_ITVL_MAX_MS
-#include "random.h"
-
 /* sanity check on the conn interval range to catch configuration errors */
 #if NIMBLE_STATCONN_CONN_ITVL_MIN_MS > NIMBLE_STATCONN_CONN_ITVL_MAX_MS
 #error "nimble_statconn: CONN_ITVL_MIN_MS must be <= CONN_ITVL_MAX_MS"
-#endif
 #endif
 
 #define ENABLE_DEBUG    0
@@ -91,16 +87,6 @@ static void _activate(uint8_t role)
         ble_addr_t peer;
         peer.type = BLE_ADDR_RANDOM;
         bluetil_addr_swapped_cp(slot->addr, peer.val);
-        /* compute a random new random connection interval if configured */
-#if NIMBLE_STATCONN_CONN_ITVL_MIN_MS != NIMBLE_STATCONN_CONN_ITVL_MAX_MS
-        uint32_t itvl = random_uint32_range(NIMBLE_STATCONN_CONN_ITVL_MIN_MS,
-                                            NIMBLE_STATCONN_CONN_ITVL_MAX_MS);
-        _conn_params.itvl_min = BLE_GAP_CONN_ITVL_MS(itvl);
-#else
-        _conn_params.itvl_min = BLE_GAP_CONN_ITVL_MS(
-                                            NIMBLE_STATCONN_CONN_ITVL_MIN_MS);
-#endif
-        _conn_params.itvl_max = _conn_params.itvl_min;
         /* try to (re)open the connection */
         nimble_netif_connect(&peer, &_conn_params, _conn_timeout);
     }
@@ -208,6 +194,10 @@ void nimble_statconn_init(void)
     _conn_params.latency = NIMBLE_STATCONN_CONN_LATENCY;
     _conn_params.supervision_timeout = BLE_GAP_SUPERVISION_TIMEOUT_MS(
                                                NIMBLE_STATCONN_CONN_SUPERTO_MS);
+    _conn_params.itvl_min = BLE_GAP_CONN_ITVL_MS(
+                                            NIMBLE_STATCONN_CONN_ITVL_MIN_MS);
+    _conn_params.itvl_max = BLE_GAP_CONN_ITVL_MS(
+                                            NIMBLE_STATCONN_CONN_ITVL_MAX_MS);
     _conn_params.min_ce_len = 0;
     _conn_params.max_ce_len = 0;
     _conn_timeout = NIMBLE_STATCONN_CONN_TIMEOUT_MS;


### PR DESCRIPTION
### Contribution description
As we were able to show in our research, using the same connection interval for multiple connections of a node can decrease network performance significantly. To prevent this, one solution is to use random connection intervals chosen from a configured range. This is already in the RIOT code base specifically for the `nimble_statconn` module. This PR generalizes this approach to be applicable for all modules using `nimble_netif`.

On top, this PR adds the option to enforce different connection intervals for each of a nodes connection. If a nodes opens a new connection as master, it will generate random intervals and check them against the interval of each existing connections, until it finds a connection interval that is spaced at least `NIMBLE_NETIF_CONN_ITVL_SPACING_MS` ticks apart from the ones of the existing connections. If a node is accepting a new connection in the slave role, it will also check the connection interval of the newly created connection against the intervals of all of its existing connections. If the interval of the new connection is not unique w.r.t. to the spacing contraints, the newly created connection is closed again.

As it improves the network behavior quite a bit, this enforcing feature (`NIMBLE_NETIF_FORCE_CONN_ITVL_SPACING`)  is enabled by default and is used anytime a range for minimum and maximum connection intervals is configured.

### Testing procedure
a) verify using vanilla `gnrc_networking` using `nimble_netif` that everything is working as before

b) run `gnrc_networking` using `nimble_autoconn` and specifying a connection interval range, e.g.
`CFLAGS="-DNIMBLE_AUTOCONN_CONN_ITVL_MIN_MS=50 -DNIMBLE_AUTOCONN_CONN_ITVL_MAX_MS=70" make ...`
on at least two BLE nodes in radio range. The nodes should automatically open a connection. If you close the connection using `ble close X`  the connection should be re-opened. Everytime this happens, the connection should have a random connection interval from the given range applied.

c) do the same using `nimble_statconn` -> when manually closing a connection it should be re-established with a random connection interval from the specified range.

### Issues/PRs references
none