### PR TITLE
xtimer: Fix race condition in xtimer_msg_receive_timeout [backport 2021.04]

### DIFF
--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -135,12 +135,12 @@ static void _setup_timer_msg(msg_t *m, xtimer_t *t)
 static int _msg_wait(msg_t *m, msg_t *tmsg, xtimer_t *t)
 {
     msg_receive(m);
+    xtimer_remove(t);
     if (m->type == MSG_XTIMER && m->content.ptr == tmsg) {
         /* we hit the timeout */
         return -1;
     }
     else {
-        xtimer_remove(t);
         return 1;
     }
 }


### PR DESCRIPTION
# Backport of #16374

### Contribution description
This PR fixes a rare race-condition in `xtimer_msg_receive_timeout` which can lead to corruption of the timer list and subsequent hard faults.
The race condition is triggered when:

 1) A message is sent to a thread using `msg_send`.
 2) The `xtimer` which sents the timeout message expires and executes before `xtimer_remove(t)` is called. This will cause the message queue for the thread to contain first a real message and second the timeout message. The timer will not be queued anymore, but the timeout message will still be in the queue.
 3) The `xtimer_msg_receive_timeout` function is called again. This will queue a new xtimer while the timeout message of the previous timer is still in the buffer. `_msg_wait` will see the old timeout message, think that the current xtimer has already expired and will _not_ remove the timer. When `xtimer_msg_receive_timeout` returns, the timer will still be queued. However, as it is allocated on the stack it is no longer valid. This causes the `timer_list_head` to now point to invalid memory. Crashes ensue.


### Testing procedure

This bug was found, validated, and fixed using a proprietary application. I have not written a separate example application which exhibits the problem which I could publish.
