### PR TITLE
sys/net/gcoap: Increase default GCOAP_PDU_BUF_SIZE

### DIFF
--- a/examples/cord_lc/Makefile
+++ b/examples/cord_lc/Makefile
@@ -18,11 +18,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# The default size of GCOAP_PDU_BUF_SIZE can be too small for the response
-# from the RD server. Use a larger value if the client drops response packet
-# from RD server.
-CFLAGS += -DCONFIG_GCOAP_PDU_BUF_SIZE=512
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -52,4 +52,9 @@ ifndef CONFIG_KCONFIG_MODULE_GCOAP
 # Increase from default for confirmable block2 follow-on requests
 GCOAP_RESEND_BUFS_MAX ?= 2
 CFLAGS += -DCONFIG_GCOAP_RESEND_BUFS_MAX=$(GCOAP_RESEND_BUFS_MAX)
+
+# A GCOAP_PDU_BUF_SIZE'd buffer is allocated in the CLI command, making the requirements larger than usual.
+# The number is hardcoded because the symbolic value CONFIG_GCOAP_PDU_BUF_SIZE
+# is unavailable at the point where the main stack size is used.
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(THREAD_STACKSIZE_DEFAULT\ +\ 1152\)
 endif

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -408,7 +408,7 @@ extern "C" {
  * @brief   Size of the buffer used to build a CoAP request or response
  */
 #ifndef CONFIG_GCOAP_PDU_BUF_SIZE
-#define CONFIG_GCOAP_PDU_BUF_SIZE      (128)
+#define CONFIG_GCOAP_PDU_BUF_SIZE      (1152)
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

This bumps the default gcoap receive and retransmit buffer size from 128 to about 1k; questions about this come in again and again, quoting IRC:

> tobi: does anyone know why the GCOAP_PDU_BUF_SIZE is 128?
> Kaspar: This is an FAQ by now. It used to be (and probably is) allocated on stack once or twice by gcoap, so 128 was chosen as a low default.

In most cases, GCOAP_PDU_BUF_SIZE buffers are only ever allocated statically. The one exception is the gcoap shell application where there's a stack allocated buffer as well, and the default stack size has been increased there.

### Testing procedure

* Running the gcoap example, send a large payload eg. using `aiocoap-client 'coap://[fe80::3c63:beff:fe85:ca96%tapbr0]/' -m PUT --payload @README.rst`; before this, it'll just retransmit and time out; after, it'll just return 4.04 as it should.
  This demonstrates how #14167 is worked around.
* Send a request from gcoap to see it doesn't overflow the stack: `coap get -c 2a01:4f8:190:3064::5 5683 /.well-known/core`

(But primarily, I'm interested if any builds now overflow the RAM in the CI tests)

### Issues/PRs references

While this does not resolve https://github.com/RIOT-OS/RIOT/issues/14167, it mitigates it -- we can now receive reasonably sized packages, ie. those that are sent by a client that does not do path MTU discovery.

It doesn't look like any other resolution is imminent, and the behavior resulting from large requests and small buffers is confusing to newcomers.

### Open questions

* Do we really want to do it this way?
* Is there a clean way to get the GCOAP_PDU_BUF_SIZE into the main thread size of the gcoap example? (Right now I'm adding the default size in hardcoded numbers, because the default define is not available at the point where the stack size is evaluated.)