### PR TITLE
sys/net/gcoap: Use socket _buf API to recognize truncated requests

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -464,6 +464,8 @@ extern "C" {
 #define GCOAP_MEMO_RESP         (3)     /**< Got response */
 #define GCOAP_MEMO_TIMEOUT      (4)     /**< Timeout waiting for response */
 #define GCOAP_MEMO_ERR          (5)     /**< Error processing response packet */
+#define GCOAP_MEMO_RESP_TRUNC   (6)     /**< Got response, but it got truncated into the receive
+                                             buffer that is now incomplete */
 /** @} */
 
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -46,7 +46,7 @@
 static void *_event_loop(void *arg);
 static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg);
 static void _process_coap_pdu(sock_udp_t *sock, sock_udp_ep_t *remote,
-                              uint8_t *buf, size_t len);
+                              uint8_t *buf, size_t len, bool truncated);
 static ssize_t _well_known_core_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static void _cease_retransmission(gcoap_request_memo_t *memo);
 static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
@@ -141,19 +141,46 @@ static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg)
     sock_udp_ep_t remote;
 
     if (type & SOCK_ASYNC_MSG_RECV) {
-        ssize_t res = sock_udp_recv(sock, _listen_buf, sizeof(_listen_buf),
-                                    0, &remote);
-        if (res <= 0) {
-            DEBUG("gcoap: udp recv failure: %d\n", (int)res);
-            return;
+        void *stackbuf;
+        void *buf_ctx = NULL;
+        bool truncated = false;
+        size_t cursor = 0;
+
+        /* The zero-copy _buf API is not used to its full potential here -- we
+         * still copy out data in what is a manual version of sock_udp_recv,
+         * but this gives the direly needed overflow information.
+         *
+         * A version that actually doesn't copy would vastly change the way
+         * gcoap passes the buffer to be read from and written into to the
+         * handler. Also, given that neither nanocoap nor the handler expects
+         * to gather scattered data, it'd need to rely on the data coming in a
+         * single slice (but that may be a realistic assumption).
+         */
+        while (true) {
+            ssize_t res = sock_udp_recv_buf(sock, &stackbuf, &buf_ctx,
+                                        0, &remote);
+            if (res < 0) {
+                DEBUG("gcoap: udp recv failure: %d\n", (int)res);
+                return;
+            }
+            if (res == 0) {
+                break;
+            }
+            if (cursor + res > sizeof(_listen_buf)) {
+                res = sizeof(_listen_buf) - cursor;
+                truncated = true;
+            }
+            memcpy(&_listen_buf[cursor], stackbuf, res);
+            cursor += res;
         }
-        _process_coap_pdu(sock, &remote, _listen_buf, res);
+
+        _process_coap_pdu(sock, &remote, _listen_buf, cursor, truncated);
     }
 }
 
 /* Processes and evaluates the coap pdu */
 static void _process_coap_pdu(sock_udp_t *sock, sock_udp_ep_t *remote,
-                              uint8_t *buf, size_t len)
+                              uint8_t *buf, size_t len, bool truncated)
 {
     coap_pkt_t pdu;
     gcoap_request_memo_t *memo = NULL;
@@ -198,8 +225,16 @@ static void _process_coap_pdu(sock_udp_t *sock, sock_udp_ep_t *remote,
         /* normal request */
         else if (coap_get_type(&pdu) == COAP_TYPE_NON
                 || coap_get_type(&pdu) == COAP_TYPE_CON) {
-            size_t pdu_len = _handle_req(&pdu, _listen_buf, sizeof(_listen_buf),
+            size_t pdu_len;
+
+            if (truncated) {
+                /* TBD: Set a Size1 */
+                pdu_len = gcoap_response(&pdu, _listen_buf, sizeof(_listen_buf), COAP_CODE_REQUEST_ENTITY_TOO_LARGE);
+            } else {
+                pdu_len = _handle_req(&pdu, _listen_buf, sizeof(_listen_buf),
                                             remote);
+            }
+
             if (pdu_len > 0) {
                 ssize_t bytes = sock_udp_send(sock, _listen_buf, pdu_len,
                                                 remote);
@@ -229,7 +264,7 @@ static void _process_coap_pdu(sock_udp_t *sock, sock_udp_ep_t *remote,
                 if (memo->resp_evt_tmout.queue) {
                     event_timeout_clear(&memo->resp_evt_tmout);
                 }
-                memo->state = GCOAP_MEMO_RESP;
+                memo->state = truncated ? GCOAP_MEMO_RESP_TRUNC : GCOAP_MEMO_RESP;
                 if (memo->resp_handler) {
                     memo->resp_handler(memo, &pdu, remote);
                 }


### PR DESCRIPTION
### Contribution description

Gcoap used to behave quite bad with large requests (see https://github.com/RIOT-OS/RIOT/issues/14167); this uses the experimental _buf API to detect overflows and react accordingly.

### Testing procedure

TBD. Especially, I don't think that GNRC gives more than one fragment, so it'd need explicit testing with a fragmenting stack.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/14167

See also https://github.com/RIOT-OS/RIOT/pull/16377 for the worse alternative resolution, and a hint at how often this comes up.