### PR TITLE
gh-actions: release-tests: do not run linters for release tests [backport 2021.04]

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -138,7 +138,7 @@ jobs:
           TTN_DEV_ID="riot_lorawan_1" \
           TTN_DEV_ID_ABP="riot_lorawan_1_abp" \
           RIOTBASE=${RIOTBASE} \
-          $(which tox) -- ${TOX_ARGS} -m "${{ matrix.pytest_mark }}"
+          $(which tox) -e test -- ${TOX_ARGS} -m "${{ matrix.pytest_mark }}"
     - name: junit2html and XML deploy
       if: always()
       run: |


### PR DESCRIPTION
# Backport of #16379

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The release tests are marked as failing currenty since there is a bug in `pylint` (or one of its libraries). There is not much sense to run the linter for the release tests on the test scripts, as this is already done in the [CI of the release tests](https://github.com/RIOT-OS/Release-Specs/blob/master/.github/workflows/self-test.yml#L46). As such, we only need to run the test environment of `tox`, which executes the release tests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I'll run the workflow in my fork, just to see if everything works (to shorten the runtime a REMOVE ME commit is included).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/Release-Specs/issues/213#issuecomment-823210031
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
