### PR TITLE
cpu/sam0_common: ethernet: fix RX detection

### DIFF
--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -151,7 +151,7 @@ void isr_gmac(void)
     tsr = GMAC->TSR.reg;
     rsr = GMAC->RSR.reg;
 
-    if (rsr == GMAC_RSR_REC) {
+    if (rsr & GMAC_RSR_REC) {
         netdev_trigger_event_isr(_sam0_eth_dev.netdev);
     }
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Detect RX of frame also when other bits of RSR are set.



### Testing procedure

see https://github.com/RIOT-OS/RIOT/issues/16298#issuecomment-825743257


### Issues/PRs references

fixes #16298

