### PR TITLE
esp8266: Support UART1 and other UART0 pins.

### DIFF
--- a/boards/common/esp8266/include/periph_conf_common.h
+++ b/boards/common/esp8266/include/periph_conf_common.h
@@ -208,17 +208,41 @@ static const spi_conf_t spi_config[] = {
 /**
  * @name   UART configuration
  *
- * All ESP8266 boards have exactly one UART device with fixed pin mapping.
- * This UART device is used for flashing and as a console interface.
- * Therefore, the number of UART devices is fixed and can not be overridden.
- * Used pins are determined by the MCU implementation and are defined here
- * only for documentation reasons.
+ * All ESP8266 boards have two UART devices with two options of pin mappings
+ * each, however most board will only expose only UART0 and in the GPIO1 and
+ * GPIO3 pins, although other combinations are possible. In particular, the
+ * boot ROM will map both GPIO1 and GPIO2 as TX for UART0 on boot, so either
+ * one can be used for serial communication or flashing the device.
+ * While UART1 is also available, the only option for UART1 RX pin (GPIO8) is
+ * used for the board flash, but UART1 TX can be used separately
+ *
+ * Pin mapping available:
+ *  UART0 TX:  GPIO1 and GPIO2  (both enabled by the boot ROM)
+ *  UART0 RX:  GPIO3
+ *  UART1 TX:  GPIO2 and GPIO7  (GPIO7 is used by the flash)
+ *  UART0 RX:  GPIO8            (GPIO8 is used by the flash)
+ *
+ * UART0 device is used for flashing and as a console interface. UART1 if
+ * UART1_TXD is defined can be used for communication with other peripherals at
+ * a different baudrate if desired.
  *
  * @{
  */
-
+#ifndef UART0_TXD
 #define UART0_TXD   GPIO1               /**< TxD pin of UART_DEV(0) */
+#endif /* UART0_TXD */
+
+#ifndef UART0_RXD
 #define UART0_RXD   GPIO3               /**< RxD pin of UART_DEV(0) */
+#endif /* UART0_RXD */
+
+#ifdef DOXYGEN
+#define UART1_TXD   GPIO2               /**< TxD pin of UART_DEV(1) */
+#endif /* DOXYGEN */
+
+#ifndef UART1_RXD
+#define UART1_RXD   GPIO_UNDEF          /**< RxD pin of UART_DEV(1) */
+#endif /* UART1_RXD */
 
 /**
  * @brief   Static array with configuration for declared UART devices
@@ -228,6 +252,12 @@ static const uart_conf_t uart_config[] = {
         .txd = UART0_TXD,
         .rxd = UART0_RXD,
     },
+#ifdef UART1_TXD
+    {
+        .txd = UART1_TXD,
+        .rxd = UART1_RXD,
+    },
+#endif /* UART1_TXD */
 };
 
 /**

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #define PERIPH_CPU_H
 
 #include <stdint.h>
+#include <limits.h>
 
 #include "eagle_soc.h"
 
@@ -302,7 +303,7 @@ typedef struct {
 /**
  * @brief   Maximum number of UART interfaces
  */
-#define UART_NUMOF_MAX  (1)
+#define UART_NUMOF_MAX  (2)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -52,9 +52,11 @@ gpio_pin_usage_t _gpio_pin_usage [GPIO_PIN_NUMOF] =
 {
    _GPIO,   /* gpio0 */
 
-   _UART,   /* gpio1  UART0 RxD */
-   _GPIO,   /* gpio2 */
-   _UART,   /* gpio3  UART0 TxD */
+   /* UART0 is initialized by the boot ROM, this only reflects our selection so
+    * other devices don't step on it. */
+   UART0_TXD == GPIO1 ? _UART : _GPIO,   /* gpio1 */
+   UART0_TXD == GPIO2 ? _UART : _GPIO,   /* gpio2 */
+   UART0_RXD == GPIO3 ? _UART : _GPIO,   /* gpio3 */
    _GPIO,   /* gpio4 */
    _GPIO,   /* gpio5 */
    _SPIF,   /* gpio6  SPI flash CLK */


### PR DESCRIPTION
### Contribution description

The esp8266 CPU has actually two hardware UART peripherals. UART0 is
used by the boot ROM for flashing and serial output during boot,
typically at a baudrate of 74880 bps until the bootloader or application
sets the more standard 115200 baudrate. This UART0 device has two
possible pins for TXD, GPIO1 and GPIO2, which are both set to TXD by the
boot ROM. esp8266 modules will typically have GPIO1 labeled as the TX
pin, but it is possible to use GPIO2 for that purpose even while
flashing the device with esptool.py.

The second device, UART1, also has two options for TXD, GPIO2 and GPIO7,
and only one option for RXD, GPIO8. However, GPIO7 and GPIO8 are used
by the flash internally so those options are not very useful unless
maybe while running from IRAM with the flash disabled, for example for
a debugger over UART1.

This patch allows boards to override UART{0,1}_{R,T}XD in their
periph_conf.h to configure the uart selection. Defining UART1_TX will
make the UART_DEV(1) device available.

### Testing procedure

Tested with:

```CFLAGS='-DUART1_TXD=GPIO2' make -C tests/periph_uart BOARD=esp8266-esp-12x flash term```

* Connected one USB-UART to the standard GPIO1 and GPIO3 for flashing
  and console. After flashing we see the manual test output at 115200
  bps

* Connected a second USB-UART with RX to GPIO2 running at 74880.

Then run on the first console:
```
> init 1 74880
> send 1 hello
```

The word "hello" appears on the second UART connection.

Note that GPIO2 is used during boot for UART0's TX until the application
or bootloader set it to a regular GPIO, so some boot ROM messages at
74880 bps are visible. After running `init 1 74880` it is set to UART1's
TX.

### Issues/PRs references

None.