### PR TITLE
tests/periph_flashpage_unittest: lower FLASHPAGE_SIZE for 8bit overflow [backport 2021.04]

### DIFF
--- a/tests/periph_flashpage_unittest/main.c
+++ b/tests/periph_flashpage_unittest/main.c
@@ -26,7 +26,7 @@
 
 /* need to define these values before including the header */
 #ifndef FLASHPAGE_SIZE
-#define FLASHPAGE_SIZE      512
+#define FLASHPAGE_SIZE      256
 #endif
 #ifndef FLASHPAGE_NUMOF
 #define FLASHPAGE_NUMOF     128


### PR DESCRIPTION
# Backport of #16351

### Contribution description

Reduce the fake memory size to avoid an overflow on `AVR_8`. Found while looking at release tests.

### Testing procedure

The test now passes on `arduino-uno`

```
Help: Press s to start test, r to print it is ready
r
READY
s
START
main(): This is RIOT! (Version: 2021.07-devel-5-g94329-pr_avr_flashpage_unittest)
..
OK (2 tests)
```
