### PR TITLE
examples/nanocoap_server: fix a buffer overflow bug [backport 2021.04]

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -97,11 +97,16 @@ static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, vo
     case COAP_PUT:
     case COAP_POST:
     {
-        /* convert the payload to an integer and update the internal value */
-        char payload[16] = { 0 };
-        memcpy(payload, (char*)pkt->payload, pkt->payload_len);
-        internal_value = strtol(payload, NULL, 10);
-        code = COAP_CODE_CHANGED;
+        if (pkt->payload_len < 16) {
+            /* convert the payload to an integer and update the internal value */
+            char payload[16] = { 0 };
+            memcpy(payload, (char*)pkt->payload, pkt->payload_len);
+            internal_value = strtol(payload, NULL, 10);
+            code = COAP_CODE_CHANGED;
+        }
+        else {
+            code = COAP_CODE_REQUEST_ENTITY_TOO_LARGE;
+        }
     }
     }
 


### PR DESCRIPTION
# Backport of #16389

### Contribution description

This branch fixes buffer overflow bug in the nanocoap_server. In the file **coap_handler.c** in function **_riot_value_handler** there was **memcpy** call, which copy user data to the buffer without checking if provided data fits into the buffer. Provided code checks length of received data, and in a case when they are bigger than buffer, copying is denied. Moreover, function returns client error code 4.13 (**COAP_CODE_REQUEST_ENTITY_TOO_LARGE**) and sends response to the user "Max 15 chars".

### Testing procedure

Testing procedure requires connection beetwen RIOT OS for native BOARD and Linux machine. In the provided example, RIOT OS has configured only link-local addres (which is presented in the example console) and connected to the Linux using tap0 interface.  

Before fix, execution of command:  

```
$coap-client -m put coap://[fe80:: ... %tap0]/riot/value -e 123456789012345678901234567890123456789012345678901234567890
```

which sends to many bytes (60 or more) for the CoAP /riot/value URL cause program failure.

For the native board this leads to the "Segmentation Fault". 

Additionally, I tested particle-argon board, compiled using PARTICLE_MONOFIRMWARE=1 option. In this case 40 bytes are enought to cause eror and in effect board resets.  

I did not make exploit, but in my opinion this error coud lead to the remote-code execution.

After the fix, program responds with 4.13 error code, and works without further problems.

```
$coap-client -m put coap://[fe80:: ... %tap0]/riot/value -e 123456789012345678901234567890123456789012345678901234567890
4.13
$
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
