### PR TITLE
cpu: make newlib_nano a DEFAULT_MODULE

### DIFF
--- a/cpu/arm7_common/Makefile.dep
+++ b/cpu/arm7_common/Makefile.dep
@@ -4,7 +4,7 @@ USEMODULE += arm7_common_periph
 FEATURES_REQUIRED_ANY += newlib|picolibc
 ifneq (,$(filter newlib,$(USEMODULE)))
   # use the nano-specs of Newlib when available
-  USEMODULE += newlib_nano
+  DEFAULT_MODULE += newlib_nano
 endif
 
 # Make calls to malloc and friends thread-safe

--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -7,7 +7,7 @@ USEMODULE += cortexm_common_periph
 FEATURES_REQUIRED_ANY += newlib|picolibc
 ifneq (,$(filter newlib,$(USEMODULE)))
   # use the nano-specs of Newlib when available
-  USEMODULE += newlib_nano
+  DEFAULT_MODULE += newlib_nano
 endif
 
 # Export the peripheral drivers to be linked into the final binary:

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -7,7 +7,7 @@ USEMODULE += esp_idf_esp32
 USEMODULE += esp_idf_soc
 
 ifneq (,$(filter newlib,$(USEMODULE)))
-  USEMODULE += newlib_nano
+  DEFAULT_MODULE += newlib_nano
 endif
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))

--- a/cpu/fe310/Makefile.dep
+++ b/cpu/fe310/Makefile.dep
@@ -1,7 +1,7 @@
 
 FEATURES_REQUIRED_ANY += newlib|picolibc
 ifneq (,$(filter newlib,$(USEMODULE)))
-  USEMODULE += newlib_nano
+  DEFAULT_MODULE += newlib_nano
   USEMODULE += newlib_syscalls_default
 endif
 

--- a/cpu/msp430_common/Makefile.dep
+++ b/cpu/msp430_common/Makefile.dep
@@ -1,7 +1,7 @@
 USEMODULE += msp430_common msp430_common_periph
 
 ifneq (,$(filter newlib,$(USEMODULE)))
-  USEMODULE += newlib_nano
+  DEFAULT_MODULE += newlib_nano
 endif
 
 # Make calls to malloc and friends thread-safe


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This allows to disable nanospecs with

    DISABLE_MODULE += newlib_nano

if a full-features version of newlib is desired.


### Testing procedure

#### examples/default

```
   text	   data	    bss	    dec	    hex	filename
  43144	    144	  18040	  61328	   ef90	/home/benpicco/dev/RIOT/examples/default/bin/same54-xpro/default.elf
```

#### examples/default with `DISABLE_MODULE += newlib_nano`

```
   text	   data	    bss	    dec	    hex	filename
  70748	   2520	  18084	  91352	  164d8	/home/benpicco/dev/RIOT/examples/default/bin/same54-xpro/default.elf
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
