### PR TITLE
examples/nanocoap_server: remove unneed case block

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -96,7 +96,6 @@ static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, vo
         break;
     case COAP_PUT:
     case COAP_POST:
-    {
         if (pkt->payload_len < 16) {
             /* convert the payload to an integer and update the internal value */
             char payload[16] = { 0 };
@@ -107,7 +106,6 @@ static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, vo
         else {
             code = COAP_CODE_REQUEST_ENTITY_TOO_LARGE;
         }
-    }
     }
 
     return coap_reply_simple(pkt, code, buf, len,


### PR DESCRIPTION
### Contribution description

cosmetic

#16389 made the block unnecessary this removes it 
(improve readability, avoids wrong assumptions about switch cases)

### Testing procedure

read 

build and run nanocoap_server

### Issues/PRs references

#16389 #16394 Backport of that