### PR TITLE
driver/bmx280: remove unused xtimer dependency

### DIFF
--- a/drivers/bmx280/Kconfig
+++ b/drivers/bmx280/Kconfig
@@ -46,4 +46,3 @@ endchoice
 config MODULE_BMX280
     bool
     depends on TEST_KCONFIG
-    select MODULE_XTIMER

--- a/drivers/bmx280/Makefile.dep
+++ b/drivers/bmx280/Makefile.dep
@@ -1,5 +1,3 @@
-USEMODULE += xtimer
-
 ifneq (,$(filter bm%280_spi,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -28,7 +28,6 @@
 #include "assert.h"
 #include "bmx280.h"
 #include "bmx280_internals.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG        0
 #include "debug.h"

--- a/tests/driver_bmx280/Makefile
+++ b/tests/driver_bmx280/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 DRIVER ?= bme280_i2c
 
 USEMODULE += fmt
+USEMODULE += xtimer
 USEMODULE += $(DRIVER)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bmx280/app.config.test
+++ b/tests/driver_bmx280/app.config.test
@@ -2,3 +2,4 @@
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_BME280_I2C=y
 CONFIG_MODULE_FMT=y
+CONFIG_MODULE_XTIMER=y


### PR DESCRIPTION
### Contribution description
For some reason the `bmx280` driver does require `xtimer`, although xtimer is never used in the driver code... So this PR removes the xtimer dependency from the driver.

Also, the test application for the driver is using `xtimer`, but not setting this dependency. This is also fixed in this PR.

### Testing procedure
Build test should be sufficient. Also a `git grep xtimer` on the driver code shows that there are not xtimer occurrences in the driver.

### Issues/PRs references
none