### PR TITLE
board/nrf52840dongle: fix and enhance pin mapping for I2C and SPI

### DIFF
--- a/boards/nrf52840dongle/Kconfig
+++ b/boards/nrf52840dongle/Kconfig
@@ -12,6 +12,7 @@ config BOARD_NRF52840DONGLE
     default y
     select BOARD_COMMON_NRF52
     select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI

--- a/boards/nrf52840dongle/Makefile.features
+++ b/boards/nrf52840dongle/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -24,7 +24,6 @@
 #include "cfg_clock_32_1.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
-#include "cfg_spi_default.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,6 +77,22 @@ static const pwm_conf_t pwm_config[] = {
     },
 };
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = GPIO_PIN(0, 20),
+        .mosi = GPIO_PIN(0, 22),
+        .miso = GPIO_PIN(0, 24),
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *               2021 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Peripheral configuration for the nRF52840-Dongle
  *
  * @author      Christian Amsüss <chrysn@fsfe.org>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  */
 
@@ -93,6 +95,21 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 29),
+        .sda = GPIO_PIN(0, 31),
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -67,7 +67,15 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const pwm_conf_t pwm_config[] = {
-    { NRF_PWM0, { GPIO_PIN(0, 6), GPIO_PIN(0, 8), GPIO_PIN(1, 9), GPIO_PIN(0, 12) } }
+    {
+        NRF_PWM0,
+        {
+            GPIO_PIN(0, 6),
+            GPIO_PIN(0, 8),
+            GPIO_PIN(1, 9),
+            GPIO_PIN(0, 12),
+        },
+    },
 };
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */


### PR DESCRIPTION
### Contribution description
This PR adds a small collection of fixes/enhancements for the default pin configuration of the `nrf52840dongle` board:
- fixes line length issue in PWM configuration
- fixes SPI pin configuration (see below)
- adds I2C pin conifuration and `periph_i2c` feature to the board.

Regarding the SPI pin configuration: currently the board uses the nrf52 default pin config of P0.15, P0.14, and P0.13 (-> `cfg_spi_default.h`). This is problematic for two reasons:

1. pins P0.13 and P0.15 are also used for `UART_DEV(0)`
2. pin P0.14 is not even accessible on the board (see pin mapping below)

![nrf52840dongle_pinout](https://user-images.githubusercontent.com/620834/116221062-8fb11680-a74d-11eb-99c3-6716f94a8285.png)

### Testing procedure
Code review should be fine.

### Issues/PRs references
none

