### PR TITLE
pkg/nanopb: bump version to 0.4.5 [backport 2021.04]

### DIFF
--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanopb
 PKG_URL=https://github.com/nanopb/nanopb
-PKG_VERSION=2b48a361786dfb1f63d229840217a93aae064667 # nanopb-0.4.4
+PKG_VERSION=nanopb-0.4.5
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
# Backport of #16406

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Update to nanopb 0.4.5: [Changelog](https://github.com/nanopb/nanopb/blob/master/CHANGELOG.txt)


### Testing procedure

`tests/pkg_nanopb` still works.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
