### PR TITLE
tools/dhcpv6-pd_ia: add Linux Mint to installer

### DIFF
--- a/dist/tools/dhcpv6-pd_ia/pkg/__init__.py
+++ b/dist/tools/dhcpv6-pd_ia/pkg/__init__.py
@@ -42,7 +42,7 @@ class PackageManagerFactory(object):
         system = platform.system()
         if system == "Linux":
             system = cls._get_linux_distro()
-        if system in ["Debian", "Ubuntu"]:
+        if system in ["Debian", "Ubuntu", "Linux Mint"]:
             return Apt("Debian")
         if system in ["Arch Linux"]:
             return PacMan("Arch")


### PR DESCRIPTION
### Contribution description
When running `Mint` LInux, the `dhcpv6-pd_ia` tool fails to trigger the kea installation process, as it does not recognize Mint as Debian/Ubuntu family member. This PR fixes this by adding "Linux Mint" to the list of known OSes.

For reference:
```
hauke@schelm:~$ cat /etc/os-release 
NAME="Linux Mint"
VERSION="20.1 (Ulyssa)"
ID=linuxmint
ID_LIKE=ubuntu
PRETTY_NAME="Linux Mint 20.1"
VERSION_ID="20.1"
HOME_URL="https://www.linuxmint.com/"
SUPPORT_URL="https://forums.linuxmint.com/"
BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
PRIVACY_POLICY_URL="https://www.linuxmint.com/"
VERSION_CODENAME=ulyssa
UBUNTU_CODENAME=focal
```
where `NAME` is the field we are comparing with

### Testing procedure
Optimal: do a fresh install of `Linux Mint` and run the `gnrc_border_router` in DHCP6 configuration :-)
Realistic: trust me that this fix just worked on my machine...

### Issues/PRs references
none