### PR TITLE
pkg/fatfs: bump version to r0.14b

### DIFF
--- a/pkg/fatfs/Makefile
+++ b/pkg/fatfs/Makefile
@@ -2,7 +2,7 @@ PKG_NAME=fatfs
 # upstream server is very unreliable, instead host the extracted
 # .zip file on GitHub and apply only the upstream patches
 PKG_URL=https://github.com/RIOT-OS/FatFS
-PKG_VERSION=fb99d00924fd17c2d9c0789510852c2c286403ab # R0.14a
+PKG_VERSION=246c97b1eb7f1900eb00d5ed7e3bf4cdb4558039 # r0.14b
 PKG_LICENSE=BSD-1-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/fatfs/patches/0001-remove-ffconf.h.patch
+++ b/pkg/fatfs/patches/0001-remove-ffconf.h.patch
@@ -1,24 +1,24 @@
-From af647820a330eae463fdf073908dc6f79014481d Mon Sep 17 00:00:00 2001
+From 6ff7b277e8f148784c5f2fcbabaf651b45ce6873 Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@googlemail.com>
-Date: Sun, 31 Jan 2021 20:00:17 +0100
+Date: Thu, 29 Apr 2021 10:12:36 +0200
 Subject: [PATCH 1/2] remove ffconf.h
 
 ---
- source/ffconf.h | 298 ------------------------------------------------
- 1 file changed, 298 deletions(-)
+ source/ffconf.h | 301 ------------------------------------------------
+ 1 file changed, 301 deletions(-)
  delete mode 100644 source/ffconf.h
 
 diff --git a/source/ffconf.h b/source/ffconf.h
 deleted file mode 100644
-index 632736b..0000000
+index 3eefdf4..0000000
 --- a/source/ffconf.h
 +++ /dev/null
-@@ -1,298 +0,0 @@
+@@ -1,301 +0,0 @@
 -/*---------------------------------------------------------------------------/
 -/  FatFs Functional Configurations
 -/---------------------------------------------------------------------------*/
 -
--#define FFCONF_DEF	80196	/* Revision ID */
+-#define FFCONF_DEF	86631	/* Revision ID */
 -
 -/*---------------------------------------------------------------------------/
 -/ Function Configurations
@@ -39,14 +39,6 @@ index 632736b..0000000
 -/      are removed.
 -/   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
 -/   3: f_lseek() function is removed in addition to 2. */
--
--
--#define FF_USE_STRFUNC	0
--/* This option switches string functions, f_gets(), f_putc(), f_puts() and f_printf().
--/
--/  0: Disable string functions.
--/  1: Enable without LF-CRLF conversion.
--/  2: Enable with LF-CRLF conversion. */
 -
 -
 -#define FF_USE_FIND		0
@@ -78,6 +70,30 @@ index 632736b..0000000
 -
 -#define FF_USE_FORWARD	0
 -/* This option switches f_forward() function. (0:Disable or 1:Enable) */
+-
+-
+-#define FF_USE_STRFUNC	0
+-#define FF_PRINT_LLI	0
+-#define FF_PRINT_FLOAT	0
+-#define FF_STRF_ENCODE	0
+-/* FF_USE_STRFUNC switches string functions, f_gets(), f_putc(), f_puts() and
+-/  f_printf().
+-/
+-/   0: Disable. FF_PRINT_LLI, FF_PRINT_FLOAT and FF_STRF_ENCODE have no effect.
+-/   1: Enable without LF-CRLF conversion.
+-/   2: Enable with LF-CRLF conversion.
+-/
+-/  FF_PRINT_LLI = 1 makes f_printf() support long long argument and FF_PRINT_FLOAT = 1/2
+-   makes f_printf() support floating point argument. These features want C99 or later.
+-/  When FF_LFN_UNICODE >= 1 with LFN enabled, string functions convert the character
+-/  encoding in it. FF_STRF_ENCODE selects assumption of character encoding ON THE FILE
+-/  to be read/written via those functions.
+-/
+-/   0: ANSI/OEM in current CP
+-/   1: Unicode in UTF-16LE
+-/   2: Unicode in UTF-16BE
+-/   3: Unicode in UTF-8
+-*/
 -
 -
 -/*---------------------------------------------------------------------------/
@@ -153,19 +169,6 @@ index 632736b..0000000
 -/  on character encoding. When LFN is not enabled, these options have no effect. */
 -
 -
--#define FF_STRF_ENCODE	3
--/* When FF_LFN_UNICODE >= 1 with LFN enabled, string I/O functions, f_gets(),
--/  f_putc(), f_puts and f_printf() convert the character encoding in it.
--/  This option selects assumption of character encoding ON THE FILE to be
--/  read/written via those functions.
--/
--/   0: ANSI/OEM in current CP
--/   1: Unicode in UTF-16LE
--/   2: Unicode in UTF-16BE
--/   3: Unicode in UTF-8
--*/
--
--
 -#define FF_FS_RPATH		0
 -/* This option configures support for relative path.
 -/
@@ -210,7 +213,7 @@ index 632736b..0000000
 -#define FF_MAX_SS		512
 -/* This set of options configures the range of sector size to be supported. (512,
 -/  1024, 2048 or 4096) Always set both 512 for most systems, generic memory card and
--/  harddisk. But a larger value may be required for on-board flash memory and some
+-/  harddisk, but a larger value may be required for on-board flash memory and some
 -/  type of optical media. When FF_MAX_SS is larger than FF_MIN_SS, FatFs is configured
 -/  for variable sector size mode and disk_ioctl() function needs to implement
 -/  GET_SECTOR_SIZE command. */

--- a/pkg/fatfs/patches/0002-remove-diskio.c.patch
+++ b/pkg/fatfs/patches/0002-remove-diskio.c.patch
@@ -1,6 +1,6 @@
-From 8b62c5ed1cc74007497baf3a93920bf9ebabf068 Mon Sep 17 00:00:00 2001
+From 743850dca90d01697e5829ec7179ef577dcad2de Mon Sep 17 00:00:00 2001
 From: Benjamin Valentin <benpicco@googlemail.com>
-Date: Sun, 31 Jan 2021 20:00:38 +0100
+Date: Thu, 29 Apr 2021 10:12:49 +0200
 Subject: [PATCH 2/2] remove diskio.c
 
 ---

--- a/pkg/fatfs/vendor/include/ffconf.h
+++ b/pkg/fatfs/vendor/include/ffconf.h
@@ -2,7 +2,7 @@
 /  FatFs - Configuration file
 /---------------------------------------------------------------------------*/
 
-#define FFCONF_DEF	80196	/* Revision ID */
+#define FFCONF_DEF	86631	/* Revision ID */
 
 /*---------------------------------------------------------------------------/
 / Function Configurations


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

R0.14b (April 17, 2021)
  - Made FatFs uses standard library <string.h> for copy, compare and search instead of built-in string functions.
  - Added support for long long integer and floating point to f_printf(). (FF_STRF_LLI and FF_STRF_FP)
  - Made path name parser ignores the terminating separator to allow "dir/".
  - Improved the compatibility in Unix style path name feature.
  - Fixed the file gets dead-locked when f_open() failed with some conditions. (appeared at R0.12a)
  - Fixed f_mkfs() can create wrong exFAT volume due to a timing dependent error. (appeared at R0.12)
  - Fixed code page 855 cannot be set by f_setcp(). (appeared at R0.13)
  - Fixed some compiler warnings.

  -- http://elm-chan.org/fsw/ff/updates.txt


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
