### PR TITLE
Fix Cortex-M hard faults when building with -O3 or -Ofast

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -70,8 +70,6 @@ CORTEXM_STATIC_INLINE void cortexm_init_misc(void)
 
 void cortexm_init(void)
 {
-    cortexm_init_fpu();
-
     /* configure the vector table location to internal flash */
 #if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
     defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -99,6 +99,8 @@ void reset_handler_default(void)
     uint32_t *dst;
     const uint32_t *src = &_etext;
 
+    cortexm_init_fpu();
+
 #ifdef MODULE_PUF_SRAM
     puf_sram_init((uint8_t *)&_srelocate, SEED_RAM_LEN);
 #endif


### PR DESCRIPTION
### Contribution description
When building a Cortex-M application and optimisation level `-O3` or `-Ofast`, a hard fault occurs at start up.
The reason that this happens is because the reset handler will copy data stored in flash to their respective locations in RAM.
In order to speed this up, GCC makes use of 64-bit floating point registers and the `vldmia` and `vstmia` instructions.
However, the FPU has not yet been initialised at this point. This causes these instructions to throw hard faults when used.
When building with `-O2` or lower it will use 32 bit data accesses instead.

The body of the following `for`-loop from the `reset_handler_default` function in `vectors_cortmex.c`:
```c
/* load data section from flash to ram */
for (dst = &_srelocate; dst < &_erelocate; ) {
    (dst++) = *(src++);
}
```
Compiles to (using `-O3`):
```
8002cf4:	ecb2 7b02 	vldmia	r2!, {d7}
8002cf8:	eca3 7b02 	vstmia	r3!, {d7}
```
With `-O2`, it compiles to:
```
8002c0e:	f853 0b04 	ldr.w	r0, [r3], #4
8002c12:	f842 0b04 	str.w	r0, [r2], #4
```

To fix this, the FPU is initialised early in the boot process so that it these 64-bit registers can be used during the boot phase.

An alternative would be to add `-fno-tree-loop-vectorize` to the CFLAGS, but this would disable these optimisations in functions where they could perhaps be useful.
A second alternative would be to disable it locally to the reset handler, but this would still allow other functions (such as `pre_startup`, `post_startup`, and `board_init`) to be accidentally optimised in this manner.
