### PR TITLE
pkg: Update to tensorflow-lite:2.2.2, flatbuffers:1.12, gemmlowp:09.2018

### DIFF
--- a/pkg/flatbuffers/Makefile
+++ b/pkg/flatbuffers/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=flatbuffers
 PKG_URL=https://github.com/google/flatbuffers
-PKG_VERSION=v1.11.0
+PKG_VERSION=6df40a2471737b27271bdd9b900ab5f3aec746c7
 PKG_LICENSE=Apache2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/gemmlowp/Makefile
+++ b/pkg/gemmlowp/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gemmlowp
 PKG_URL=https://github.com/google/gemmlowp
-PKG_VERSION=dc69acdf61d7a64260ae0eb9c17421fef0488c02
+PKG_VERSION=719139ce755a0f31cbf1c37f7f98adcc7fc9f425
 PKG_LICENSE=Apache2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tensorflow-lite/Makefile
+++ b/pkg/tensorflow-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tensorflow-lite
 PKG_URL=https://github.com/tensorflow/tensorflow
-PKG_VERSION=1768c8f2fa155d4c6406e8ff7addf374c83de7ad
+PKG_VERSION=d745ff2a48cebf18e847e8b602a744e97e058946
 PKG_LICENSE=Apache2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the tensorflow-lite pkg version to v2.2.2. This was done to support new operations and optimization features available in newer versions of tflite. Flatbuffers was updated to v1.12 and gemmlowp:09.2018 to ensure compatibility.

### Testing procedure

I ran the pkg_tensorflow-lite test with the updated packages on the samr21-xpro. This returned the nominal output: 'Digit prediction: 7'

### Issues/PRs references

-
