### PR TITLE
cpu/stm32/periph/spi: fix wrong parameter order 

### DIFF
--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -237,16 +237,16 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
                   spi_config[bus].tx_dma_chan,
                   (uint32_t*)&(dev(bus)->DR),
                   DMA_MEM_TO_PERIPH,
-                  0,
-                  DMA_DATA_WIDTH_BYTE);
+                  DMA_DATA_WIDTH_BYTE,
+                  0);
 
         dma_acquire(spi_config[bus].rx_dma);
         dma_setup(spi_config[bus].rx_dma,
                   spi_config[bus].rx_dma_chan,
                   (uint32_t*)&(dev(bus)->DR),
                   DMA_PERIPH_TO_MEM,
-                  0,
-                  DMA_DATA_WIDTH_BYTE);
+                  DMA_DATA_WIDTH_BYTE,
+                  0);
     }
 #endif
     dev(bus)->CR1 = cr1_settings;


### PR DESCRIPTION
### Contribution description

As mentioned in #16308, there an inversion in parameter placement in the DMA function parameters. I don't have any BOARD to test sadly, maybe @bergzand can?

### Testing procedure

- some application that uses spi + dma: `FEATURES_REQUIRED=periph_dma BOARD=nucleo-l476rg make -C tests/periph_spi`

### Issues/PRs references

Ticks one point in #16308
