### PR TITLE
pkg/tinydtls: handling of close_notify

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -561,7 +561,11 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
 
 void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote)
 {
-    dtls_close(sock->dtls_ctx, &remote->dtls_session);
+    dtls_peer_t *peer = dtls_get_peer(sock->dtls_ctx, &remote->dtls_session);
+    if (peer) {
+        /* dtls_reset_peer() also sends close_notify if not already sent */
+        dtls_reset_peer(sock->dtls_ctx, peer);
+    }
 }
 
 void sock_dtls_session_get_udp_ep(const sock_dtls_session_t *session,

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -702,6 +702,11 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
  *
  * @param[in] sock      @ref sock_dtls_t, which the session is created on
  * @param[in] remote    Remote session to destroy
+ *
+ * @note For tinyDTLS this function destroys the session object right after notifying the remote
+ *       peer about the closing. This is an interim solution, preventing endlessly blocked session
+ *       slots, but allows as a consequence truncation attacks.
+ *       More details in the [issue](https://github.com/eclipse/tinydtls/issues/95).
  */
 void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote);
 


### PR DESCRIPTION
### Contribution description

Right now `sock_dtls_session_destroy()` does not do all the time what the API states.
https://github.com/RIOT-OS/RIOT/blob/08f1f9768d23bd934d4707a37d19744e7279a598/sys/include/net/sock/dtls.h#L699
The sock implementation for tinyDTLS only initiates closing of a session, which results in sending a `close_notify`. But when the remote peer never ACK's the closing (e.g. not receiving or not answering), the session slot is blocked until device reboot. TinyDTLS endlessly stays in a `STATE_CLOSING` session state for that peer and there is no way of resetting a peer with the current DTLS sock API. 

The main problem is that `sock_dtls_session_destroy()` does not allow a return value for feedback. This is easily fixable...but currently it is not possible to get the success of the session closing procedure for tinyDTLS since it only sends the `close_notify` and then returns.

I've looked into e.g. wolfSSL and their session close function seems to work a bit different: They send the `close_notify` and block for a short time and then return the success at this point of time. The user can decide how to handle a possible failure, e.g. try again or simply destroy the session object. DTLS libraries like wolfSSL, mbedTLS, tinyDTLS provide two distinct functions for that: session_close and peer_reset (= freeing of the peer object). 

Our DTLS sock API should also provide two functions for that (and allow a return value!). No single function can provide a solution for all needs here. How dangerous that is shows the current WIP wolfSSL implementation (#15698) for the sock API of @pokgak. In the current WIP approach `sock_dtls_session_destroy()` tries to close the session two times (recommended by wolfSSL), and when it fails two times it just returns. There is no way to tell the user that the session is not destroyed. And since there is also no force destroy, you cannot destroy the session.

Road to fix this:
1) This PR simply resets the peer after `close_notify` was sent by tinyDTLS. [It's allowed by the RFC]( https://tools.ietf.org/html/rfc8446#section-6.1), but mentions the possibility of truncation attack. 
But the current alternative is to live with the possibility of getting entire unusable peer slots in tinyDTLS (not detectable on user level). Note, in wireless networks it is not that unlikely that packets are not received depending on the link.
2) Mid-term we should provide two distinct functions with return value by the API. IMHO `session_destroy` should be renamed to `session_close`. For tinyDTLS we need to find a solution to provide feedback.
3) Additionally, maybe a generic `session_get_status()` would also make sense.

I would suggest this PR as an interim solution.

Feedback or other opinions are appreciated.
 <!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure



### Issues/PRs references
#16108 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->