### PR TITLE
cpu/stm32/dist: fix and improve genkconfig script

### DIFF
--- a/cpu/stm32/dist/kconfig/Kconfig.lines.j2
+++ b/cpu/stm32/dist/kconfig/Kconfig.lines.j2
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Inria
+# Copyright (c) {{ year }} Inria
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level

--- a/cpu/stm32/dist/kconfig/Kconfig.models.j2
+++ b/cpu/stm32/dist/kconfig/Kconfig.models.j2
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Inria
+# Copyright (c) {{ year }} Inria
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level

--- a/cpu/stm32/dist/kconfig/gen_kconfig.py
+++ b/cpu/stm32/dist/kconfig/gen_kconfig.py
@@ -8,6 +8,7 @@
 
 import os
 import argparse
+import datetime
 
 import xlrd
 from jinja2 import FileSystemLoader, Environment
@@ -110,6 +111,7 @@ def generate_kconfig(kconfig, context, overwrite, verbose):
     template_file = os.path.join("Kconfig.{}.j2".format(kconfig))
     env.globals.update(zip=zip)
     template = env.get_template(template_file)
+    context.update({"year": datetime.datetime.now().year})
     render = template.render(**context)
 
     kconfig_dir = os.path.join(STM32_KCONFIG_DIR, context["fam"])

--- a/cpu/stm32/dist/kconfig/requirements.txt
+++ b/cpu/stm32/dist/kconfig/requirements.txt
@@ -1,2 +1,2 @@
-xlrd
+openpyxl
 jinja2


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When the kconfig generator for STM32 script was written the [xlrd package](https://pypi.org/project/xlrd/) was still able to read xls**x** files and this is no longer the case starting from version 2.0 (end of 2020).

This PR is replacing the xlrd package with [openpyxl](https://pypi.org/project/openpyxl/) which seems to be the preferred solution.

There's also an small improvement regarding dynamic copyright date (otherwise, newly generated files still have 2020) with the kconfig template.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The script still works. Tested with G0, only the year is changed but not the rest of the content:

```
$ rm -f cpu/stm32/kconfig/g0/{Kconfig.lines,Kconfig.models}
$ ./cpu/stm32/dist/kconfig/gen_kconfig.py g0 --sheets ~/Downloads/G0ProductsList.xlsx
$ git diff
diff --git a/cpu/stm32/kconfigs/g0/Kconfig.lines b/cpu/stm32/kconfigs/g0/Kconfig.lines
index d75559befe..cdd4aff6da 100644
--- a/cpu/stm32/kconfigs/g0/Kconfig.lines
+++ b/cpu/stm32/kconfigs/g0/Kconfig.lines
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Inria
+# Copyright (c) 2021 Inria
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
diff --git a/cpu/stm32/kconfigs/g0/Kconfig.models b/cpu/stm32/kconfigs/g0/Kconfig.models
index da7b8415e5..6aaf112331 100644
--- a/cpu/stm32/kconfigs/g0/Kconfig.models
+++ b/cpu/stm32/kconfigs/g0/Kconfig.models
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Inria
+# Copyright (c) 2021 Inria
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

I hit that issue when adding H7 CPUs models and after updating my Ubuntu (with a Python version which required  to reinstall xlrd).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
