### PR TITLE
tests: small fixes

### DIFF
--- a/boards/nucleo-f303k8/Kconfig
+++ b/boards/nucleo-f303k8/Kconfig
@@ -18,7 +18,6 @@ config BOARD_NUCLEO_F303K8
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_PWM
-    select HAS_PERIPH_RTC
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -5,7 +5,6 @@ CPU_MODEL = stm32f303k8
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_pwm
-FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/tests/pkg_tensorflow-lite/Makefile.ci
+++ b/tests/pkg_tensorflow-lite/Makefile.ci
@@ -26,6 +26,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g071rb \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 # nucleo-f303k8 doesn't have enough RAM to run the test so we reduce the stack
 # size for every thread
-ifneq (,$(filter nucleo-f303k8,$(BOARD)))
+ifneq (,$(filter nucleo-f303k8 nucleo-f334r8,$(BOARD)))
   CFLAGS += -DTHREAD_STACKSIZE_DEFAULT=512
 endif
 


### PR DESCRIPTION
### Contribution description

Some tests in https://github.com/RIOT-OS/RIOT/runs/2480009583?check_suite_focus=true are failing do to some setup issues:

- `tests/pkg_tensorflowlite` should not be ran on `nucleo-g071rb`
- stack size should be reduced for `nucleo-f334r8` on `tests/pthread_cooperation/`
- `periph_rtc` should not be provided for  `nucleo-f303k8`

### Testing procedure

- `BOARD=nucleo-f334r8 make -C tests/pthread_cooperation/ flash test`

```
main(): This is RIOT! (Version: 2021.07-devel-95-gd8287-pr_small_test_fixes)
START
Creating thread with arg 1
Creating thread with arg 2
Creating thread with arg 3
Creating thread with arg 4
Creating thread with arg 5
Creating thread with arg 6
Creating thread with arg 7
Creating thread with arg 8
Creating thread with arg 9
Creating thread with arg 10
Creating thread with arg 11
Creating thread with arg 12
join thread 1
My arg: 1
val = 1
My arg: 2
val = 2
My arg: 3
val = 6
My arg: 4
val = 24
My arg: 5
val = 120
My arg: 6
val = 720
join thread 2
join thread 3
join thread 4
join thread 5
join thread 6
join thread 7
```

- 

```
BOARD=nucleo-f303k8 make -C tests/periph_rtc/
There are unsatisfied feature requirements: periph_rtc
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
