### PR TITLE
tests/malloc: refactor test

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -78,10 +78,13 @@ static void free_memory(struct node *head)
 {
     struct node *old_head;
 
+    uint32_t freed = 0;
+
     while (head) {
         if (head->ptr) {
             if (total > CHUNK_SIZE) {
                 total -= CHUNK_SIZE;
+                freed++;
             }
             printf("Free %"PRIu32" Bytes at 0x%p, total %"PRIu32"\n",
                    (uint32_t)CHUNK_SIZE, head->ptr, total);
@@ -100,6 +103,8 @@ static void free_memory(struct node *head)
 
         total -= sizeof(struct node);
     }
+
+    printf("Free count: %"PRIu32"\n", freed);
 }
 
 int main(void)

--- a/tests/malloc/tests/01-run.py
+++ b/tests/malloc/tests/01-run.py
@@ -12,6 +12,7 @@ from testrunner import run
 # For BOARD's with large amount of RAM allocating all chunks takes longer
 # than 10s
 ALLOCATION_TIMEOUT = 20
+FREE_TIMEOUT = ALLOCATION_TIMEOUT
 
 
 def testfunc(child):
@@ -30,9 +31,11 @@ def testfunc(child):
         if initial_allocations == 0:
             initial_allocations = allocations
         assert initial_allocations == allocations
-        for _ in range(allocations):
-            child.expect(r"Free {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+\r\n"
-                         .format(chunk_size))
+        child.expect(r"Free {} Bytes at 0x[a-z0-9]+, total [a-z0-9]+\r\n"
+                     .format(chunk_size))
+        child.expect(r'Free count: (\d+)\r\n', timeout=FREE_TIMEOUT)
+        freed = int(child.match.group(1))
+        assert freed == allocations
     child.expect_exact("[SUCCESS]")
 
 


### PR DESCRIPTION
### Contribution description

Matching on every free leads to flimsy test results where all memory
is freed but one line fails to be matched by pexpect, instead, match
the final count.

### Testing procedure

- `test/malloc` still passes:

```
Free 128 Bytes at 0x0x20001c90, total 2048
Free 128 Bytes at 0x0x20001bf8, total 1912
Free 128 Bytes at 0x0x20001b60, total 1776
Free 128 Bytes at 0x0x20001ac8, total 1640
Free 128 Bytes at 0x0x20001a30, total 1504
Free 128 Bytes at 0x0x20001998, total 1368
Free 128 Bytes at 0x0x20001900, total 1232
Free 128 Bytes at 0x0x20001868, total 1096
Free 128 Bytes at 0x0x200017d0, total 960
Free 128 Bytes at 0x0x20001738, total 824
Free 128 Bytes at 0x0x200016a0, total 688
Free 128 Bytes at 0x0x20001608, total 552
Free 128 Bytes at 0x0x20001570, total 416
Free 128 Bytes at 0x0x200014d8, total 280
Free 128 Bytes at 0x0x20001440, total 144
Free 128 Bytes at 0x0x200013a8, total 8
Free count: 398
[SUCCESS]
```


### Issues/PRs references

Can be seen in https://github.com/RIOT-OS/RIOT/actions/runs/801052633
