### PR TITLE
Documentation: Remove mentions of the users@ and devel@ mailing lists.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,8 +11,7 @@ IF YOUR ISSUE IS RELATED TO SECURITY
 please submit it to the security mailing-list security@riot-os.org.
 
 If your issue is a question related to the usage of RIOT, please submit it to
-our forum at https://forum.riot-os.org, to the user mailing-list
-users@riot-os.org, or to the developer mailing-list devel@riot-os.org.
+our forum at https://forum.riot-os.org.
 -->
 
 #### Description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,8 @@ of this document using the following links:
 * [Writing Documentation][writing-documentation]
 * [Working with Git][working with git]
 
-If you have questions, please write a post over at our [forum], send an email to
-<users@riot-os.org> or <devel@riot-os.org> mailing list or chat on `#riot-os` on
-[IRC] or [Matrix].
+If you have questions, please write a post over at our [forum] or chat on
+`#riot-os` on [IRC] or [Matrix].
 
 As a reminder, all contributors are expected to follow our
 [Code of Conduct](CODE_OF_CONDUCT.md).
@@ -191,8 +190,8 @@ into the source repository.
   preoccupied with other PRs. If it happens that your PR receives no review for
   a long time, don't hesitate to gently solicit a review by commenting or
   by explicitly mentioning a maintainer that you know is knowledgeable in the
-  area of the PR. You can also advertise the PR on devel@riot-os.org mailing
-  list and ask for a review there.
+  area of the PR. You can also advertise the PR on the [forum] and ask for a
+  review there.
 
 * Try to answer reviews as quickly as possible to speed up the review process
   and avoid stalled PRs.

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,8 @@ welcome:
 	@echo ""
 	@echo "Please see our Quick Start Guide at:"
 	@echo "    https://doc.riot-os.org/getting-started.html"
-	@echo "You can ask questions on our forum:"
+	@echo "You can ask questions or discuss with other users on our forum:"
 	@echo "    https://forum.riot-os.org"
-	@echo "Or discuss with other users on the mailing list:"
-	@echo "    users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)"
 
 print-versions:
 	@./dist/tools/ci/print_toolchain_versions.sh

--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ To contribute something to RIOT, please refer to our
 [contributing document](CONTRIBUTING.md).
 
 ## MAILING LISTS
-* RIOT OS kernel developers list: [devel@riot-os.org](https://lists.riot-os.org/mailman/listinfo/devel)
-* RIOT OS users list: [users@riot-os.org](https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits: [commits@riot-os.org](https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications: [notifications@riot-os.org](https://lists.riot-os.org/mailman/listinfo/notifications)
 

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -38,14 +38,6 @@ RIOT is developed by an open community that anyone is welcome to join:
  - Sign-up to our [forum](https://forum.riot-os.org/) to ask for help using RIOT
    or writing an application for RIOT, discuss kernel and network stack
    development as well as hardware support, or to show-case your latest project.
- - [Subscribe](http://lists.riot-os.org/mailman/listinfo/users) to
-   users@riot-os.org to ask for help using RIOT or writing an application for
-   RIOT (or to just stay in the loop). An archive of this list [is available
-   here](https://lists.riot-os.org/pipermail/users/).
- - [Subscribe](http://lists.riot-os.org/mailman/listinfo/devel) to
-   devel@riot-os.org to follow and discuss kernel and network stack
-   development, or hardware support. An archive of this list [is available
-   here](https://lists.riot-os.org/pipermail/devel/).
  - Follow us on [Twitter](https://twitter.com/RIOT_OS) for news from the RIOT
    community.
  - Regarding critical vulnerabilities we would appreciate if you give us a


### PR DESCRIPTION
### Contribution description

The users@ list doesn't exist anymore (is in autoreply mode to notify users). The devel@ address points to the forum category and should not be advertised as mailing list.

### Testing procedure

Read the changes maybe :sweat_smile: 

### Issues/PRs references

See [here](https://forum.riot-os.org/t/start-a-topic-via-email-which-email-addresses/3082/6)