### PR TITLE
CoAP: add remote and local endpoint information to request and response handlers

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -50,9 +50,14 @@ static void _on_ep_event(cord_ep_standalone_event_t event)
 
 /* define some dummy CoAP resources */
 static ssize_t _handler_dummy(coap_pkt_t *pdu,
-                              uint8_t *buf, size_t len, void *ctx)
+                              uint8_t *buf, size_t len,
+                              const coap_ep_t *remote,
+                              const coap_ep_t *local,
+                              void *ctx)
 {
     (void)ctx;
+    (void)remote;
+    (void)local;
 
     /* get random data */
     int16_t val = 23;
@@ -64,9 +69,14 @@ static ssize_t _handler_dummy(coap_pkt_t *pdu,
 }
 
 static ssize_t _handler_info(coap_pkt_t *pdu,
-                             uint8_t *buf, size_t len, void *ctx)
+                             uint8_t *buf, size_t len,
+                             const coap_ep_t *remote,
+                             const coap_ep_t *local,
+                             void *ctx)
 {
     (void)ctx;
+    (void)remote;
+    (void)local;
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -44,14 +44,22 @@ static ssize_t text_resp(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     return resp_len + slen;
 }
 
-static ssize_t handler_info(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t handler_info(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                            const coap_ep_t *remote, const coap_ep_t *local,
+                            void *ctx)
 {
     (void)ctx;
+    (void)remote;
+    (void)local;
     return text_resp(pdu, buf, len, riot_info, COAP_FORMAT_JSON);
 }
 
-static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                            const coap_ep_t *remote, const coap_ep_t *local,
+                            void *ctx)
 {
+    (void)remote;
+    (void)local;
     return text_resp(pdu, buf, len, (char *)ctx, COAP_FORMAT_TEXT);
 }
 

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -21,9 +21,13 @@ static const uint8_t block2_intro[] = "This is RIOT (Version: ";
 static const uint8_t block2_board[] = " running on a ";
 static const uint8_t block2_mcu[] = " board with a ";
 
-static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                             const coap_ep_t *remote, const coap_ep_t *local,
+                             void *context)
 {
     (void)context;
+    (void)remote;
+    (void)local;
     char uri[CONFIG_NANOCOAP_URI_MAX];
 
     if (coap_get_uri_path(pkt, (uint8_t *)uri) <= 0) {
@@ -36,16 +40,24 @@ static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *co
                              (uint8_t *)sub_uri, sub_uri_len);
 }
 
-static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                                   const coap_ep_t *remote, const coap_ep_t *local,
+                                   void *context)
 {
     (void)context;
+    (void)remote;
+    (void)local;
     return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
             COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
 }
 
-static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                                    const coap_ep_t *remote, const coap_ep_t *local,
+                                    void *context)
 {
     (void)context;
+    (void)remote;
+    (void)local;
     coap_block_slicer_t slicer;
     coap_block2_init(pkt, &slicer);
     uint8_t *payload = buf + coap_get_total_hdr_len(pkt);
@@ -77,10 +89,13 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, v
                                    buf, len, payload_len, &slicer);
 }
 
-static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                                   const coap_ep_t *remote, const coap_ep_t *local,
+                                   void *context)
 {
-    (void) context;
-
+    (void)context;
+    (void)remote;
+    (void)local;
     ssize_t p = 0;
     char rsp[16];
     unsigned code = COAP_CODE_EMPTY;
@@ -114,9 +129,13 @@ static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, vo
             COAP_FORMAT_TEXT, (uint8_t*)rsp, p);
 }
 
-ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context)
+ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len,
+                        const coap_ep_t *remote, const coap_ep_t *local,
+                        void *context)
 {
     (void)context;
+    (void)remote;
+    (void)local;
 
     /* using a shared sha256 context *will* break if two requests are handled
      * at the same time.  doing it anyways, as this is meant to showcase block1

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -679,7 +679,8 @@ typedef struct gcoap_request_memo gcoap_request_memo_t;
  */
 typedef void (*gcoap_resp_handler_t)(const gcoap_request_memo_t *memo,
                                      coap_pkt_t* pdu,
-                                     const sock_udp_ep_t *remote);
+                                     const sock_udp_ep_t *remote,
+                                     const sock_udp_ep_t *local);
 
 /**
  * @brief  Extends request memo for resending a confirmable request.

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -195,6 +195,13 @@ typedef struct {
 } coap_pkt_t;
 
 /**
+ * @brief This is a workaround until RIOT
+ *        gets an abstraction of CoAP endpoints
+ *        to support CoAP not only over UDP
+ */
+typedef void coap_ep_t;
+
+/**
  * @brief   Resource handler type
  *
  * Functions that implement this must be prepared to be called multiple times
@@ -208,7 +215,11 @@ typedef struct {
  * For POST, PATCH and other non-idempotent methods, this is an additional
  * requirement introduced by the contract of this type.
  */
-typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context);
+typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt,
+                                  uint8_t *buf, size_t len,
+                                  const coap_ep_t *remote,
+                                  const coap_ep_t *local,
+                                  void *context);
 
 /**
  * @brief   Method flag type
@@ -1551,11 +1562,14 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
  * @param[in]   pkt             pointer to (parsed) CoAP packet
  * @param[out]  resp_buf        buffer for response
  * @param[in]   resp_buf_len    size of response buffer
+ * @param[in]   remote          remote CoAP endpoint
+ * @param[in]   local           local CoAP endpoint, NULL if unsupported
  *
  * @returns     size of reply packet on success
  * @returns     <0 on error
  */
-ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len);
+ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len,
+                        const coap_ep_t *remote, const coap_ep_t *local);
 
 /**
  * @brief   Pass a coap request to a matching handler
@@ -1568,6 +1582,8 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
  * @param[in]   resp_buf_len    size of response buffer
  * @param[in]   resources       Array of coap endpoint resources
  * @param[in]   resources_numof length of the coap endpoint resources
+ * @param[in]   remote          remote CoAP endpoint
+ * @param[in]   local           local CoAP endpoint, NULL if unsupported
  *
  * @returns     size of the reply packet on success
  * @returns     <0 on error
@@ -1575,7 +1591,9 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
 ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
                           unsigned resp_buf_len,
                           const coap_resource_t *resources,
-                          size_t resources_numof);
+                          size_t resources_numof,
+                          const coap_ep_t *remote,
+                          const coap_ep_t *local);
 
 /**
  * @brief   Convert message code (request method) into a corresponding bit field
@@ -1709,8 +1727,10 @@ ssize_t coap_reply_simple(coap_pkt_t *pkt,
  * @brief   Reference to the default .well-known/core handler defined by the
  *          application
  */
-extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
+extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt,
                                                     uint8_t *buf, size_t len,
+                                                    const coap_ep_t *remote,
+                                                    const coap_ep_t *local,
                                                     void *context);
 /**@}*/
 

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -353,6 +353,78 @@ typedef struct {
 } sock_udp_aux_tx_t;
 
 /**
+ * @brief   Access local UDP endpoint information
+ *
+ * @param[in] aux_rx    Received UDP auxiliary data
+ *
+ * @return  Pointer to local UDP endpoint information
+ * @return  NULL if no information is available
+ */
+static inline sock_udp_ep_t *sock_udp_aux_rx_local(sock_udp_aux_rx_t *aux_rx)
+{
+#if defined(MODULE_SOCK_AUX_LOCAL)
+    return &aux_rx->local;
+#else
+    (void)aux_rx;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief   Access auxiliary timestamp of a received datagram
+ *
+ * @param[in] aux_rx    Received UDP auxiliary data
+ *
+ * @return  Pointer to auxiliary timestamp
+ * @return  NULL if no information is available
+ */
+static inline uint64_t *sock_udp_aux_rx_timestamp(sock_udp_aux_rx_t *aux_rx)
+{
+#if defined(MODULE_SOCK_AUX_TIMESTAMP)
+    return &aux_rx->timestamp;
+#else
+    (void)aux_rx;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief   Access auxiliary RSSI of a received datagram
+ *
+ * @param[in] aux_rx    Received UDP auxiliary data
+ *
+ * @return  Pointer to auxiliary RSSI value
+ * @return  NULL if no information is available
+ */
+static inline int16_t *sock_udp_aux_rx_rss(sock_udp_aux_rx_t *aux_rx)
+{
+#if defined(MODULE_SOCK_AUX_RSSI)
+    return &aux_rx->rssi;
+#else
+    (void)aux_rx;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief   Access auxiliary timestamp of a transmitted datagram
+ *
+ * @param[in] aux_rx    Auxiliary data of transmitted UDP datagram
+ *
+ * @return  Pointer to auxiliary timestamp
+ * @return  NULL if no information is available
+ */
+static inline uint64_t *sock_udp_aux_tx_timestamp(sock_udp_aux_tx_t *aux_tx)
+{
+#if defined(MODULE_SOCK_AUX_TIMESTAMP)
+    return &aux_tx->timestamp;
+#else
+    (void)aux_tx;
+    return NULL;
+#endif
+}
+
+/**
  * @brief   Creates a new UDP sock object
  *
  * @pre `(sock != NULL)`

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -82,8 +82,10 @@ static int _sync(void)
 }
 
 static void _on_register(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
-                         const sock_udp_ep_t *remote)
+                         const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
+    (void)local;
+
     thread_flags_t flag = FLAG_ERR;
 
     if ((memo->state == GCOAP_MEMO_RESP) &&
@@ -121,16 +123,18 @@ static void _on_update_remove(unsigned req_state, coap_pkt_t *pdu, uint8_t code)
 }
 
 static void _on_update(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote)
+                       const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
     (void)remote;
+    (void)local;
     _on_update_remove(memo->state, pdu, COAP_CODE_CHANGED);
 }
 
 static void _on_remove(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote)
+                       const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
     (void)remote;
+    (void)local;
     _on_update_remove(memo->state, pdu, COAP_CODE_DELETED);
 }
 
@@ -158,10 +162,11 @@ static int _update_remove(unsigned code, gcoap_resp_handler_t handle)
 }
 
 static void _on_discover(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                         const sock_udp_ep_t *remote)
+                         const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
     thread_flags_t flag = CORD_EP_NORD;
     (void)remote;
+    (void)local;
 
     if (memo->state == GCOAP_MEMO_RESP) {
         unsigned ct = coap_get_content_type(pdu);

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -38,9 +38,10 @@ static uint8_t buf[BUFSIZE];
 static int _state = CORD_EPSIM_ERROR;
 
 static void _req_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
-                         const sock_udp_ep_t *remote)
+                         const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
     (void)remote;
+    (void)local;
     (void)pdu;
     _state = (memo->state == GCOAP_MEMO_RESP) ? CORD_EPSIM_OK : CORD_EPSIM_ERROR;
 }

--- a/sys/net/application_layer/cord/lc/cord_lc.c
+++ b/sys/net/application_layer/cord/lc/cord_lc.c
@@ -60,10 +60,10 @@ static void _lock(void);
 static int _sync(void);
 /* callback for _lookup_raw() request */
 static void _on_lookup(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote);
+                       const sock_udp_ep_t *remote, const sock_udp_ep_t *local);
 /* callback for _send_rd_init_req() */
 static void _on_rd_init(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                        const sock_udp_ep_t *remote);
+                        const sock_udp_ep_t *remote, const sock_udp_ep_t *local);
 static ssize_t _add_filters_to_lookup(coap_pkt_t *pkt, cord_lc_filter_t *filters);
 static int _send_rd_init_req(coap_pkt_t *pkt, const sock_udp_ep_t *remote,
                              void *buf, size_t maxlen);
@@ -103,9 +103,10 @@ static int _sync(void)
 }
 
 static void _on_lookup(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote)
+                       const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
     (void)remote;
+    (void)local;
 
     thread_flags_t flag = FLAG_ERR;
 
@@ -199,9 +200,10 @@ static ssize_t _lookup_raw(const cord_lc_rd_t *rd, unsigned content_format,
 }
 
 static void _on_rd_init(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote)
+                       const sock_udp_ep_t *remote, const sock_udp_ep_t *local)
 {
     (void)remote;
+    (void)local;
 
     thread_flags_t flag = FLAG_NORSC;
 

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -134,7 +134,8 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
     }
 
     while (1) {
-        res = sock_udp_recv(&sock, buf, bufsize, -1, &remote);
+        sock_udp_aux_rx_t aux = { .flags = SOCK_AUX_GET_LOCAL };
+        res = sock_udp_recv_aux(&sock, buf, bufsize, -1, &remote, &aux);
         if (res < 0) {
             DEBUG("error receiving UDP packet %d\n", (int)res);
         }
@@ -144,7 +145,8 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
                 DEBUG("error parsing packet\n");
                 continue;
             }
-            if ((res = coap_handle_req(&pkt, buf, bufsize)) > 0) {
+            sock_udp_ep_t *aux_local = sock_udp_aux_rx_local(&aux);
+            if ((res = coap_handle_req(&pkt, buf, bufsize, &remote, aux_local)) > 0) {
                 sock_udp_send(&sock, buf, res, &remote);
             }
             else {

--- a/tests/nanocoap_cli/nanocli_server.c
+++ b/tests/nanocoap_cli/nanocli_server.c
@@ -63,7 +63,7 @@ static int _nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize,
                 DEBUG("nanocoap: error parsing packet\n");
                 continue;
             }
-            if ((res = coap_handle_req(&pkt, buf, bufsize)) > 0) {
+            if ((res = coap_handle_req(&pkt, buf, bufsize, &remote, NULL)) > 0) {
                 res = sock_udp_send(&sock, buf, res, &remote);
             }
         }

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -31,9 +31,13 @@
 /* internal value that can be read/written via CoAP */
 static uint8_t internal_value = 0;
 
-static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                              const coap_ep_t *remote, const coap_ep_t *local,
+                              void *context)
 {
-    (void) context;
+    (void)context;
+    (void)remote;
+    (void)local;
 
     ssize_t p = 0;
     char rsp[16];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a `const coap_ep_t *remote` and `const coap_ep_t *local` to the CoAP response and request handlers.
A `coap_ep_t *` is actually a `void *` because there is no full support for other sockets than UDP yet and maybe CoAP over TCP will be added some day.
The handlers in the `gcoap` example are caested to `(coap_handler_t)` to gain compatibility and still deal with  `sock_udp_ep_t *`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`examples/gcoap`

```
2021-05-03 09:57:26,415 # gcoap: remote [fe80::4c49:6fff:fe54:5c]:5683
2021-05-03 09:57:26,419 # gcoap: local [fe80::4c49:6fff:fe54:66]:5683
```
```
coap get fe80::4c49:6fff:fe54:66%6 5683 /.well-known/core
2021-05-03 09:57:17,508 # coap get fe80::4c49:6fff:fe54:66%6 5683 /.well-known/core
2021-05-03 09:57:17,512 # gcoap_cli: sending msg ID 51354, 23 bytes
2021-05-03 09:57:17,516 # gcoapgcoap: remote [fe80::4c49:6fff:fe54:66]:5683
2021-05-03 09:57:17,520 # gcoap: local [fe80::4c49:6fff:fe54:5c]:5683
2021-05-03 09:57:17,524 # gcoap: response Success, code 2.05, 46 bytes
2021-05-03 09:57:17,528 # </cli/stats>;ct=0;rt="count";obs,</riot/board>
coap get fe80::4c49:6fff:fe54:66%6 5683 /riot/board
2021-05-03 09:57:26,407 # _stats>;ct=0;rt="count";obs,</rio> coap get fe80::4c49:6fff:fe54:66%6 5683 /riot/board
2021-05-03 09:57:26,411 # gcoap_cli: sending msg ID 51355, 17 bytes
2021-05-03 09:57:26,415 # gcoap_cli: no observer for /cli/stats
> 2021-05-03 09:57:26,423 # gcoap: remote [fe80::4c49:6fff:fe54:66]:5683
2021-05-03 09:57:26,427 # gcoap: local [fe80::4c49:6fff:fe54:5c]:5683
2021-05-03 09:57:26,431 # gcoap: response Success, code 2.05, 18 bytes
2021-05-03 09:57:26,433 # nucleo-f767zi
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Trying to solve #15686
