### PR TITLE
gh-actions: release-tests: add filter input

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -34,6 +34,9 @@ on:
         description: 'riot/riotbuild docker image version'
         required: true
         default: 'latest'
+      filter:
+        description: 'Pytest filter. Leave empty for all.'
+        required: false
 
 env:
   DOCKER_MAKE_ARGS: -j
@@ -116,6 +119,9 @@ jobs:
               grep -q "[0-9]\{4\}.[0-9]\{2\}-RC[0-9]\+"; then
           TOX_ARGS+="--non-RC "
         fi
+        if [ -n "${{ github.event.inputs.filter }}" ]; then
+          K="-k"
+        fi
 
         cd Release-Specs
         # definition in env does not work since $GITHUB_WORKSPACE seems not to
@@ -138,7 +144,8 @@ jobs:
           TTN_DEV_ID="riot_lorawan_1" \
           TTN_DEV_ID_ABP="riot_lorawan_1_abp" \
           RIOTBASE=${RIOTBASE} \
-          $(which tox) -e test -- ${TOX_ARGS} -m "${{ matrix.pytest_mark }}"
+          $(which tox) -e test -- ${TOX_ARGS} \
+            ${K} "${{ github.event.inputs.filter }}" -m "${{ matrix.pytest_mark }}"
     - name: junit2html and XML deploy
       if: always()
       run: |


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This way, the tests that shall be run can be determined using [`pytest -k` expressions][k]. E.g. `spec04 and task04` would only run task 4.4.

[k]: https://docs.pytest.org/en/stable/usage.html#specifying-tests-selecting-tests
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See https://github.com/miri64/RIOT/actions/runs/807124859 for a run with the filter and https://github.com/miri64/RIOT/actions/runs/807138408 for a run without.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Unrelated, but had this idea for testing https://github.com/RIOT-OS/RIOT/pull/16430.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
