### PR TITLE
TAKEOVER: makefiles/color: Add color functions, new attempt. #12156

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -171,6 +171,7 @@ include $(RIOTMAKE)/utils/checks.mk
 include $(RIOTMAKE)/docker.inc.mk
 
 # include color echo macros
+include $(RIOTMAKE)/utils/ansi.mk
 include $(RIOTMAKE)/color.inc.mk
 
 # include concurrency helpers

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -27,3 +27,11 @@ ifneq ($(CC_NOCOLOR),1)
     endif
   endif
 endif
+
+# Colorizer functions:
+#  These functions wrap a block of text in $(COLOR_X)...$(COLOR_RESET).
+#  Do not nest calls to this functions or the colors will be wrong.
+c_green = $(COLOR_GREEN)$(1)$(COLOR_RESET)
+c_red = $(COLOR_RED)$(1)$(COLOR_RESET)
+c_yellow = $(COLOR_YELLOW)$(1)$(COLOR_RESET)
+c_purple = $(COLOR_PURPLE)$(1)$(COLOR_RESET)

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -3,6 +3,7 @@
 
 COLOR_GREEN  :=
 COLOR_RED    :=
+COLOR_YELLOW :=
 COLOR_PURPLE :=
 COLOR_RESET  :=
 COLOR_ECHO   := /usr/bin/env echo
@@ -13,11 +14,12 @@ ifneq ($(CC_NOCOLOR),1)
   IS_TERMINAL = $(if $(MAKE_TERMOUT),$(MAKE_TERMERR),)
   # Check if terminal support colored output
   ifneq ($(IS_TERMINAL),)
-    COLOR_GREEN  := \033[1;32m
-    COLOR_RED    := \033[1;31m
-    COLOR_YELLOW := \033[1;33m
-    COLOR_PURPLE := \033[1;35m
-    COLOR_RESET  := \033[0m
+    _ANSI_ESC := $(shell printf "\033")
+    COLOR_GREEN  := $(_ANSI_ESC)[1;32m
+    COLOR_RED    := $(_ANSI_ESC)[1;31m
+    COLOR_YELLOW := $(_ANSI_ESC)[1;33m
+    COLOR_PURPLE := $(_ANSI_ESC)[1;35m
+    COLOR_RESET  := $(_ANSI_ESC)[0m
     ifeq ($(OS),Darwin)
       COLOR_ECHO   := echo -e
       SHELL=bash

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -14,12 +14,11 @@ ifneq ($(CC_NOCOLOR),1)
   IS_TERMINAL = $(if $(MAKE_TERMOUT),$(MAKE_TERMERR),)
   # Check if terminal support colored output
   ifneq ($(IS_TERMINAL),)
-    _ANSI_ESC := $(shell printf "\033")
-    COLOR_GREEN  := $(_ANSI_ESC)[1;32m
-    COLOR_RED    := $(_ANSI_ESC)[1;31m
-    COLOR_YELLOW := $(_ANSI_ESC)[1;33m
-    COLOR_PURPLE := $(_ANSI_ESC)[1;35m
-    COLOR_RESET  := $(_ANSI_ESC)[0m
+    COLOR_GREEN  := $(ANSI_GREEN)
+    COLOR_RED    := $(ANSI_RED)
+    COLOR_YELLOW := $(ANSI_YELLOW)
+    COLOR_PURPLE := $(ANSI_PURPLE)
+    COLOR_RESET  := $(ANSI_RESET)
     ifeq ($(OS),Darwin)
       COLOR_ECHO   := echo -e
       SHELL=bash

--- a/makefiles/utils/ansi.mk
+++ b/makefiles/utils/ansi.mk
@@ -1,0 +1,11 @@
+# ANSI Terminal codes and other escape sequences.
+# The objective of this definitions is to be able to write special characters
+# without resorting to shell commands like echo.
+
+include $(RIOTMAKE)/utils/ansi_special.mk
+
+ANSI_GREEN  := $(ANSI_ESC)[1;32m
+ANSI_RED    := $(ANSI_ESC)[1;31m
+ANSI_YELLOW := $(ANSI_ESC)[1;33m
+ANSI_PURPLE := $(ANSI_ESC)[1;35m
+ANSI_RESET  := $(ANSI_ESC)[0m

--- a/makefiles/utils/ansi_special.mk
+++ b/makefiles/utils/ansi_special.mk
@@ -1,0 +1,16 @@
+# Make does not recognize escaped characters (e.g. \t, \033, etc).
+# The following variables contain the characters themselves.
+# This file is inherently fragile (i.e. your editor could destroy the tab
+# without you realizing, to be careful when editing this.
+
+# To generate this: $ printf "ANSI_ESC := \033# comment"
+ANSI_ESC := # you may or may not be able to see that character in your editor
+
+# The third parameter to the subst is a tab - be careful not to replace it with
+# spaces!
+TAB := $(subst ,,	)
+
+define NEWLINE
+
+
+endef


### PR DESCRIPTION
### Contribution description

This PR split out the color functions from #12156 without attempting to replace all usage but allowing to use built-ini make functions instead of shell calls.

### Testing procedure

```
diff --git a/Makefile.include b/Makefile.include
index 5ddce7f8dd..1c50e6881d 100644
--- a/Makefile.include
+++ b/Makefile.include
@@ -583,7 +583,8 @@ flashfile: $(FLASHFILE)
 ifeq (,$(FLASHFILE))
   $(error FLASHFILE is not defined for this board: $(FLASHFILE))
 endif
-
+$(info $(call c_green,Color function test))
+$(info no color)
 # By default always build ELFFILE, BINFILE and FLASHFILE
 ifeq ($(RIOT_CI_BUILD),1)
   # Don't build BINFILE on the CI to save some computation time
```

Compile any application.

### Issues/PRs references

Split out from #12156