### PR TITLE
makefiles/info-global.inc.mk: fix DEFAULT_MODULE inclusion

### DIFF
--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -60,7 +60,7 @@ define board_unsatisfied_features
   else
     # add default modules
     include $(RIOTMAKE)/defaultmodules.inc.mk
-    USEMODULE += $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE))
+    USEMODULE += $$(filter-out $$(DISABLE_MODULE),$$(DEFAULT_MODULE))
 
     include $(RIOTMAKE)/dependency_resolution.inc.mk
 


### PR DESCRIPTION

### Contribution description

Since we are using `eval` for `board_unsatisfied_features` we are currently using the previous iteration of `DEFAULT_MODULE` for the next one, which leads to the bug exposed in https://github.com/RIOT-OS/RIOT/pull/16397 , this PR fixes it.

### Testing procedure

Rebase on #16397 and see that `make -C examples/hello-world/ info-boards-supported  | grep arduino-uno` is not empty.

Also print every iteration `DEFAULT_MODULE` and the `BOARD` name and you would see it's off by one.

