### PR TITLE
pkg/tlsf,cpu/esp_common: fix possible overflow in calloc implementations

### DIFF
--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -276,9 +276,13 @@ void* IRAM_ATTR __wrap__realloc_r(struct _reent *r, void* ptr, size_t size)
 
 void* IRAM_ATTR __wrap__calloc_r(struct _reent *r, size_t count, size_t size)
 {
-    void *result = heap_caps_malloc_default(count * size);
+    size_t size_total;
+    if (__builtin_mul_overflow(count, size, &size_total)) {
+        return NULL;
+    }
+    void *result = heap_caps_malloc_default(size_total);
     if (result) {
-        bzero(result, count * size);
+        bzero(result, size_total);
     }
     return result;
 }

--- a/pkg/tlsf/contrib/newlib.c
+++ b/pkg/tlsf/contrib/newlib.c
@@ -71,10 +71,14 @@ ATTR_MALLOCR void *_malloc_r(struct _reent *reent_ptr, size_t bytes)
  */
 ATTR_CALLOCR void *_calloc_r(struct _reent *reent_ptr, size_t count, size_t bytes)
 {
-    void *result = _malloc_r(reent_ptr, count * bytes);
+    size_t size_total;
+    if (__builtin_mul_overflow(count, bytes, &size_total)) {
+        return NULL;
+    }
+    void *result = _malloc_r(reent_ptr, size_total);
 
     if (result != NULL) {
-        memset(result, 0, count * bytes);
+        memset(result, 0, size_total);
     }
     return result;
 }


### PR DESCRIPTION
### Contribution description

The documentation of `void *calloc(size_t nmemb, size_t size)` says it should detect overflows in `nmemb * size`, but the two implementation failed to comply. This fixes the issues.

[Some people might consider this a security fix](https://msrc-blog.microsoft.com/2021/04/29/badalloc-memory-allocation-vulnerabilities-could-affect-wide-range-of-iot-and-ot-devices-in-industrial-medical-and-enterprise-networks/). (But honestly, there are few legitimate use cases of dynamic memory management on MCUs in general. And using unchecked user input (including data received via network) to compute allocation sizes is something that will still allow resource exhaustion attacks even after the fix. So an application previously vulnerable is still vulnerable, only with one attack vector fewer.)

The preexisting test in `tests/malloc` was updated to also check for correct behavior of `calloc()`.

### Testing procedure

On a 32 bit system the following should result in a blowing assertion on `master`, but no longer with this PR:

```C
    assert(NULL == calloc((1UL << 30), 2));
```

Update: `tests/malloc` will check for correct behavior of `calloc`. It needs however to be modified to actually make use of tlsf.

### Issues/PRs references

Found on twitter: https://twitter.com/mumblegrepper/status/1388058046908219394

(But I cannot find the original bug report the tweet is referring to.)