### PR TITLE
stm32: get bytes left to transfer via DMA and set transfer complete callback

### DIFF
--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -1046,7 +1046,7 @@ void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem);
  * @param[in]   callback    Callback to execute during the Transfer Complete interrupt
  * @param[in]   arg         Argument to pass to the callback
  */
-void dma_transfer_complete(dma_t dma, void (*callback)(void*, dma_t), void* arg);
+void dma_set_transfer_complete_cb(dma_t dma, void (*callback)(void*, dma_t), void* arg);
 
 #endif /* MODULE_PERIPH_DMA */
 

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -1039,6 +1039,15 @@ void dma_setup(dma_t dma, int chan, void *periph_addr, dma_mode_t mode,
  */
 void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem);
 
+/**
+ * @brief   Sets the callback which is executed after a DMA transfer is completed.
+ *
+ * @param[in]   dma         Logical DMA stream
+ * @param[in]   callback    Callback to execute during the Transfer Complete interrupt
+ * @param[in]   arg         Argument to pass to the callback
+ */
+void dma_transfer_complete(dma_t dma, void (*callback)(void*, dma_t), void* arg);
+
 #endif /* MODULE_PERIPH_DMA */
 
 #ifdef MODULE_PERIPH_CAN

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -966,6 +966,15 @@ void dma_start(dma_t dma);
 uint16_t dma_suspend(dma_t dma);
 
 /**
+ * @brief   Gets the number of bytes that have yet to be transferred
+ *
+ * @param[in] dma    logical DMA stream
+ *
+ * @return the remaining number of bytes to transfer.
+ */
+uint16_t dma_left(dma_t dma);
+
+/**
  * @brief   Resume a suspended DMA transfer on a stream
  *
  * @param[in] dma         logical DMA stream

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -447,7 +447,7 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
     return 0;
 }
 
-void dma_transfer_complete(dma_t dma, void (*callback)(void*, dma_t), void *arg)
+void dma_set_transfer_complete_cb(dma_t dma, void (*callback)(void*, dma_t), void *arg)
 {
     struct dma_ctx *ctx = &dma_ctx[dma];
     ctx->callback = callback;

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -450,8 +450,10 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
 void dma_set_transfer_complete_cb(dma_t dma, void (*callback)(void*, dma_t), void *arg)
 {
     struct dma_ctx *ctx = &dma_ctx[dma];
+    unsigned int state = irq_disable();
     ctx->callback = callback;
     ctx->callback_arg = arg;
+    irq_restore(state);
 }
 
 void dma_start(dma_t dma)

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -472,6 +472,14 @@ uint16_t dma_suspend(dma_t dma)
 
 }
 
+uint16_t dma_left(dma_t dma)
+{
+    assert(dma < DMA_NUMOF);
+
+    STM32_DMA_Stream_Type *stream = dma_ctx[dma].stream;
+    return stream->NDTR_REG;
+}
+
 void dma_resume(dma_t dma, uint16_t remaining)
 {
     assert(dma < DMA_NUMOF);


### PR DESCRIPTION
### Contribution description
This PR adds two additional functions to the STM32 DMA API:
 - `dma_left(dma)` - Gets the number of bytes that still have to be transferred by the DMA controller. This allows retrieving this number without having to suspend and resume the transfer using `dma_suspend` and `dma_resume`.
 - `dma_transfer_callback(dma, callback, arg)` - Allows setting a user-defined callback which gets executed when the Transfer Complete interrupt is fired.