### PR TITLE
gnrc tx-sync: add cast for c++ compatibility

### DIFF
--- a/sys/include/net/gnrc/tx_sync.h
+++ b/sys/include/net/gnrc/tx_sync.h
@@ -108,7 +108,7 @@ gnrc_pktsnip_t * gnrc_tx_sync_split(gnrc_pktsnip_t *pkt);
 static inline void gnrc_tx_complete(gnrc_pktsnip_t *pkt)
 {
     assert(IS_USED(MODULE_GNRC_TX_SYNC) && (pkt->type == GNRC_NETTYPE_TX_SYNC));
-    gnrc_tx_sync_t *sync = pkt->data;
+    gnrc_tx_sync_t *sync = (gnrc_tx_sync_t*)pkt->data;
     mutex_unlock(&sync->signal);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

I'd like to add an explicit cast to the module `gnrc/tx-sync` for it to build with default setting on C++ compilers.

cc @maribu 
