### PR TITLE
cpu/atmega_common: RTC: fix off-by-one second normalization & simplify rtc_get_time()

### DIFF
--- a/cpu/atmega_common/periph/rtc.c
+++ b/cpu/atmega_common/periph/rtc.c
@@ -38,7 +38,7 @@ ISR(TIMER2_OVF_vect)
 
     isr_flag = !isr_flag;
 
-    if (++tm_now.tm_sec > 60) {
+    if (++tm_now.tm_sec > 59) {
         rtc_tm_normalize(&tm_now);
     }
 

--- a/cpu/atmega_common/periph/rtc.c
+++ b/cpu/atmega_common/periph/rtc.c
@@ -27,7 +27,6 @@
 static struct tm tm_now __attribute__((section(".noinit")));
 static struct tm tm_alarm __attribute__((section(".noinit")));
 
-static bool isr_flag;
 static rtc_alarm_cb_t alarm_cb;
 static void *alarm_cb_arg;
 
@@ -35,8 +34,6 @@ static void *alarm_cb_arg;
 ISR(TIMER2_OVF_vect)
 {
     avr8_enter_isr();
-
-    isr_flag = !isr_flag;
 
     if (++tm_now.tm_sec > 59) {
         rtc_tm_normalize(&tm_now);
@@ -89,15 +86,19 @@ int rtc_set_time(struct tm *time)
 
 int rtc_get_time(struct tm *time)
 {
-    bool tmp = isr_flag;
+    uint8_t before;
 
-    *time = tm_now;
+    /* loop in case of overflow */
+    do {
+        before = TCNT2;
 
-    /* check if interrupt happened while
-       reading the time struct */
-    if (isr_flag != tmp) {
+        /* prevent compiler from reordering memory access to tm_now,
+         * including moving it out of the loop
+         */
+        __asm__ volatile ("" : : : "memory");
+
         *time = tm_now;
-    }
+    } while (before > TCNT2);
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`tests/periph_rtc` is now setting an alarm to a full minute (second 0).
This brought a off-by-one error in the RTC driver to light, here the minute counter is only incremented if the second reaches 60.

However, the second in `struct tm` goes from 0 - 59, the normalization is triggered a second too late, yielding second 1.
So the 0 second is never reached and the alarm on that second is never triggered.

Besides that small fix, there is also a small optimization where we can get rid of a global variable by comparing the counter register directly to tell if an overflow occurred. 

### Testing procedure

`tests/periph_rtc` should work again

```
2021-05-04 17:55:01,812 # RIOT RTC low-level driver test
2021-05-04 17:55:01,816 # This test will display 'Alarm!' every 2 seconds for 4 times
2021-05-04 17:55:01,821 #   Setting clock to   2020-02-28 23:59:57
2021-05-04 17:55:01,824 # Clock value is now   2020-02-28 23:59:57
2021-05-04 17:55:01,827 #   Setting alarm to   2020-02-28 23:59:59
2021-05-04 17:55:01,832 #    Alarm is set to   2020-02-28 23:59:59
2021-05-04 17:55:01,835 #   Alarm cleared at   2020-02-28 23:59:57
2021-05-04 17:55:03,839 #        No alarm at   2020-02-28 23:59:58
2021-05-04 17:55:03,843 #   Setting alarm to   2020-02-29 00:00:00
2021-05-04 17:55:03,843 # 
2021-05-04 17:55:04,949 # Alarm!
2021-05-04 17:55:06,949 # Alarm!
2021-05-04 17:55:08,949 # Alarm!
2021-05-04 17:55:10,949 # Alarm!
```


### Issues/PRs references

discovered while testing #16347
