### PR TITLE
sys/malloc_thread_safety: fix potential overflow in multiplication

### DIFF
--- a/cpu/esp32/vendor/esp-idf/heap/heap_trace.c
+++ b/cpu/esp32/vendor/esp-idf/heap/heap_trace.c
@@ -407,10 +407,13 @@ IRAM_ATTR void *__wrap_realloc(void *p, size_t size)
 
 IRAM_ATTR void *__wrap_calloc(size_t nmemb, size_t size)
 {
-    size = size * nmemb;
-    void *result = trace_malloc(size, 0, TRACE_MALLOC_DEFAULT);
+    size_t total_size;
+    if (__builtin_mul_overflow(nmemb, size, &total_size)) {
+        return NULL;
+    }
+    void *result = trace_malloc(total_size, 0, TRACE_MALLOC_DEFAULT);
     if (result != NULL) {
-        memset(result, 0, size);
+        memset(result, 0, total_size);
     }
     return result;
 }

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -85,6 +85,12 @@ LINKFLAGS += -L$(ESP_SDK_DIR)/components/$(CPU)
 LINKFLAGS += -L$(ESP_SDK_DIR)/components/$(CPU)/lib
 LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 
+ifeq (,$(filter esp_idf_heap,$(USEMODULE)))
+  # use the wrapper functions for calloc to add correct overflow detection missing
+  # in the newlib's version.
+  LINKFLAGS += -Wl,-wrap=calloc
+endif
+
 # LINKFLAGS += -Wl,--verbose
 # LINKFLAGS += -Wl,--print-gc-sections
 

--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -289,6 +289,25 @@ void* IRAM_ATTR __wrap__calloc_r(struct _reent *r, size_t count, size_t size)
 
 #else /* MODULE_ESP_IDF_HEAP */
 
+void *__wrap_calloc(size_t nmemb, size_t size)
+{
+    /* The xtensa support has not yet upstreamed to newlib. Hence, the fixed
+     * calloc implementation of newlib >= 4.0.0 is not available to the ESP
+     * platform. We fix this by implementing calloc on top of malloc ourselves */
+    size_t total_size;
+    if (__builtin_mul_overflow(nmemb, size, &total_size)) {
+        return NULL;
+    }
+
+    void *res = malloc(total_size);
+
+    if (res) {
+        memset(res, 0, total_size);
+    }
+
+    return res;
+}
+
 /* for compatibility with ESP-IDF heap functions */
 
 void* _heap_caps_malloc(size_t size, uint32_t caps, const char *file, size_t line)

--- a/sys/malloc_thread_safe/malloc_wrappers.c
+++ b/sys/malloc_thread_safe/malloc_wrappers.c
@@ -14,13 +14,14 @@
  * @author  Gunar Schorcht <gunar@schorcht.net>
  */
 
+#include <string.h>
+
 #include "assert.h"
 #include "irq.h"
 #include "mutex.h"
 
 extern void *__real_malloc(size_t size);
 extern void __real_free(void *ptr);
-extern void *__real_calloc(size_t nmemb, size_t size);
 extern void *__real_realloc(void *ptr, size_t size);
 
 static mutex_t _lock;
@@ -44,11 +45,20 @@ void __wrap_free(void *ptr)
 
 void *__wrap_calloc(size_t nmemb, size_t size)
 {
-    assert(!irq_is_in());
-    mutex_lock(&_lock);
-    void *ptr = __real_calloc(nmemb, size);
-    mutex_unlock(&_lock);
-    return ptr;
+    /* some c libs don't perform proper overflow check (e.g. newlib < 4.0.0). Hence, we
+     * just implement calloc on top of malloc ourselves. In addition to ensuring proper
+     * overflow checks, this likely saves a bit of ROM */
+    size_t total_size;
+    if (__builtin_mul_overflow(nmemb, size, &total_size)) {
+        return NULL;
+    }
+
+    void *res = __wrap_malloc(total_size);
+    if (res) {
+        memset(res, 0, total_size);
+    }
+
+    return res;
 }
 
 void *__wrap_realloc(void *ptr, size_t size)

--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -24,6 +24,8 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "test_utils/expect.h"
+
 #ifndef CHUNK_SIZE
 #ifdef BOARD_NATIVE
 #define CHUNK_SIZE          (1024 * 1024U)
@@ -110,6 +112,17 @@ static void free_memory(struct node *head)
 int main(void)
 {
     uint32_t allocations = 0;
+
+    /* modern compilers warn about nonsense calls to calloc, but this is exactly what we want to
+     * test */
+#pragma GCC diagnostic push
+#if !defined(__clang__) && (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+#endif
+    /* test if an overflow is correctly detected by calloc(): the size below overflows by 1 byte */
+    /* cppcheck-suppress leakReturnValNotUsed (should return NULL, so nothing to free anyway) */
+    expect(NULL == calloc(SIZE_MAX / 16 + 1, 16));
+#pragma GCC diagnostic pop
 
     printf("CHUNK_SIZE: %"PRIu32"\n", (uint32_t)CHUNK_SIZE);
     printf("NUMBER_OF_TESTS: %d\n", NUMBER_OF_TESTS);


### PR DESCRIPTION
### Contribution description

The already in place wrapper for calloc (that is used to ensure thread-safety for concurrent calls to *alloc() and free) has been re-written on top of malloc to manually include an check for a potential overflow in the multiplication. Likely, this will be a bit more efficient in terms of ROM, so it won't hurt to be done this way even if the underlying calloc implementation would be correct.

In addition, the test in `tests/malloc` was extended to ensure correct behavior.

Some might consider this a security fix.

### Testing procedure

The extended test in `tests/malloc` should fail with older newlibs (before 4.0.0 release) when build against `master`, but work in this PR.

### Issues/PRs references

Partially split out of https://github.com/RIOT-OS/RIOT/pull/16438