### PR TITLE
doc: fix URLs to the new website

### DIFF
--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -25,7 +25,7 @@ with  multithreading, IPC, system timers, mutexes etc.
 
 A good high-level overview can be found in the article
 [RIOT: An Open Source Operating System for Low-End Embedded Devices in
-the IoT](https://riot-os.org/docs/riot-ieeeiotjournal-2018.pdf)
+the IoT](https://www.riot-os.org/assets/pdfs/riot-ieeeiotjournal-2018.pdf)
 (IEEE Internet of Things Journal, December 2018).
 
 Contribute to RIOT                                        {#contribute-to-riot}

--- a/doc/memos/rdm0001.md
+++ b/doc/memos/rdm0001.md
@@ -321,7 +321,7 @@ www.gnu.org/philosophy/free-sw.en.html.](https://www.gnu.org/philosophy/free-sw.
 [3] [Emmanuel Baccelli, Oliver Hahm, Mesut Günes, Matthias Wählisch, Thomas C.
 Schmidt, "RIOT OS: Towards an OS for the Internet of Things," in Proceedings of
 the 32nd IEEE International Conference on Computer Communications (INFOCOM),
-Poster, p. 79–80, IEEE Press, April 2013.](https://www.riot-os.org/docs/riot-infocom2013-abstract.pdf) \
+Poster, p. 79–80, IEEE Press, April 2013.](https://www.riot-os.org/assets/pdfs/riot-infocom2013-abstract.pdf) \
 [4] [E. Baccelli, C. Gündogan, O. Hahm, P. Kietzmann, M. Lenders, H. Petersen,
 K. Schleiser, T.C. Schmidt, M. Wählisch: "RIOT: an Open Source Operating System
 for Low-end Embedded Devices in the IoT", IEEE Internet of Things Journal, Vol.


### PR DESCRIPTION
### Contribution description
With the new website some links in our documentation are not working anymore. This updates them.

### Testing procedure
- Build the docs and check the link
- Open RDM1 and check the reference link

### Issues/PRs references
https://github.com/RIOT-OS/riot-os.org/pull/82