### PR TITLE
CPU SAML21: fix timers frequency when using slow clocks

### DIFF
--- a/boards/bastwan/include/periph_conf.h
+++ b/boards/bastwan/include/periph_conf.h
@@ -48,7 +48,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk = &MCLK->APBCMASK.reg,
         .mclk_mask = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id = TC0_GCLK_ID,
-        .gclk_src = SAM0_GCLK_8MHZ,
+        .gclk_src = SAM0_GCLK_TIMER,
         .flags = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -51,7 +51,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = SAM0_GCLK_8MHZ,
+        .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };
@@ -124,7 +124,7 @@ static const pwm_conf_t pwm_config[] = {
     { .tim  = TCC_CONFIG(TCC0),
       .chan = pwm_chan0_config,
       .chan_numof = ARRAY_SIZE(pwm_chan0_config),
-      .gclk_src = SAM0_GCLK_8MHZ,
+      .gclk_src = SAM0_GCLK_TIMER,
     },
 #endif
 };
@@ -222,7 +222,7 @@ static const adc_conf_chan_t adc_channels[] = {
  * @{
  */
                             /* Must not exceed 12 MHz */
-#define DAC_CLOCK           SAM0_GCLK_8MHZ
+#define DAC_CLOCK           SAM0_GCLK_TIMER
                             /* use Vcc as reference voltage */
 #define DAC_VREF            DAC_CTRLB_REFSEL_VDDANA
 /** @} */

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -41,7 +41,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = SAM0_GCLK_8MHZ,
+        .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -48,7 +48,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = SAM0_GCLK_8MHZ,
+        .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/yarm/include/periph_conf.h
+++ b/boards/yarm/include/periph_conf.h
@@ -48,7 +48,7 @@ static const tc32_conf_t timer_config[] = {
         .mclk           = &MCLK->APBCMASK.reg,
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
-        .gclk_src       = SAM0_GCLK_8MHZ,
+        .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -37,8 +37,10 @@
 
 #if (CLOCK_CORECLOCK == 48000000U) || defined (MODULE_PERIPH_USBDEV)
 #define USE_DFLL        (1)
+#define GCLK_GENCTRL_SRC_MAIN GCLK_GENCTRL_SRC_DFLL48M
 #else
 #define USE_DFLL        (0)
+#define GCLK_GENCTRL_SRC_MAIN GCLK_GENCTRL_SRC_OSC16M
 #endif
 
 static void _gclk_setup(int gclk, uint32_t reg)
@@ -281,11 +283,6 @@ void cpu_init(void)
     _dfll_setup();
 
     /* Setup GCLK generators */
-#if USE_DFLL
-#define GCLK_GENCTRL_SRC_MAIN GCLK_GENCTRL_SRC_DFLL48M
-#else
-#define GCLK_GENCTRL_SRC_MAIN GCLK_GENCTRL_SRC_OSC16M
-#endif
     _gclk_setup(SAM0_GCLK_MAIN, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_MAIN);
 
     /* Ensure APB Backup domain clock is within the 6MHZ limit, BUPDIV value

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -265,6 +265,7 @@ void cpu_init(void)
 #else
 #error "Please select a valid CPU frequency"
 #endif
+
     OSCCTRL->OSC16MCTRL.bit.ONDEMAND = 1;
     OSCCTRL->OSC16MCTRL.bit.RUNSTDBY = 0;
 
@@ -281,10 +282,11 @@ void cpu_init(void)
 
     /* Setup GCLK generators */
 #if USE_DFLL
-    _gclk_setup(SAM0_GCLK_MAIN, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_DFLL48M);
+#define GCLK_GENCTRL_SRC_MAIN GCLK_GENCTRL_SRC_DFLL48M
 #else
-    _gclk_setup(SAM0_GCLK_MAIN, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
+#define GCLK_GENCTRL_SRC_MAIN GCLK_GENCTRL_SRC_OSC16M
 #endif
+    _gclk_setup(SAM0_GCLK_MAIN, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_MAIN);
 
     /* Ensure APB Backup domain clock is within the 6MHZ limit, BUPDIV value
        must be a power of 2 and between 1(2^0) and 128(2^7) */
@@ -296,7 +298,7 @@ void cpu_init(void)
         }
     }
     /* clock used by timers */
-    _gclk_setup(SAM0_GCLK_TIMER, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M
+    _gclk_setup(SAM0_GCLK_TIMER, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_MAIN
                 | GCLK_GENCTRL_DIV(CLOCK_CORECLOCK/sam0_gclk_freq(SAM0_GCLK_TIMER)));
 
 #ifdef MODULE_PERIPH_PM

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -99,8 +99,12 @@ uint32_t sam0_gclk_freq(uint8_t id)
     switch (id) {
     case SAM0_GCLK_MAIN:
         return CLOCK_CORECLOCK;
-    case SAM0_GCLK_8MHZ:
+    case SAM0_GCLK_TIMER:
+#if (CLOCK_CORECLOCK == 48000000U) || (CLOCK_CORECLOCK == 16000000U) || (CLOCK_CORECLOCK == 8000000U)
         return 8000000;
+#else
+        return 4000000;
+#endif
     case SAM0_GCLK_32KHZ:
         return 32768;
     case SAM0_GCLK_48MHZ:
@@ -292,8 +296,8 @@ void cpu_init(void)
         }
     }
     /* clock used by timers */
-    _gclk_setup(SAM0_GCLK_8MHZ, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M
-                | GCLK_GENCTRL_DIV(2));
+    _gclk_setup(SAM0_GCLK_TIMER, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M
+                | GCLK_GENCTRL_DIV(CLOCK_CORECLOCK/sam0_gclk_freq(SAM0_GCLK_TIMER)));
 
 #ifdef MODULE_PERIPH_PM
     PM->CTRLA.reg = PM_CTRLA_MASK & (~PM_CTRLA_IORET);

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -44,7 +44,7 @@ extern "C" {
  */
 enum {
     SAM0_GCLK_MAIN  = 0,                 /**< Main clock */
-    SAM0_GCLK_8MHZ  = 1,                 /**< 8MHz clock */
+    SAM0_GCLK_TIMER = 1,                 /**< 4/8MHz clock for timers */
     SAM0_GCLK_32KHZ = 2,                 /**< 32 kHz clock */
     SAM0_GCLK_48MHZ = 3,                 /**< 48MHz clock */
 };


### PR DESCRIPTION
My recently merged PR #16433 introduces a bug: when OSC16M is not running at 16MHz, the timer clock SAM0_GCLK_8MHZ is no longer correct.

I've renamed SAM0_GCLK_8MHZ as SAM0_GCLK_TIMER, and compute it as 4MHz or 8MHz depending on the frequency of the core clock - CLOCK_CORECLOCK at 4MHz or at 12MHz result in SAM0_GCLK_TIMER at 4MHz, all other available core clocks still produce the original 8MHz one.