### PR TITLE
riscv_common: Increase ISR stack size if DEVELHELP is enabled

### DIFF
--- a/cpu/riscv_common/Makefile.include
+++ b/cpu/riscv_common/Makefile.include
@@ -21,6 +21,13 @@ ifneq (,$(ITIM_START_ADDR))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_itim_length=$(ITIM_LEN)
 endif
 
+# Increase stack size of ISR stack if DEVELHELP is enabled. This is
+# needed because handle_trap() uses printf on the ISR stack and printf
+# usage results in a stack overflow with the default stack size.
+ifeq (1,$(DEVELHELP))
+  LINKFLAGS += $(LINKFLAGPREFIX)--defsym=__stack_size=512
+endif
+
 LINKER_SCRIPT ?= riscv.ld
 
 include $(RIOTMAKE)/arch/riscv.inc.mk


### PR DESCRIPTION
### Contribution description

The `handle_trap()` implementation for `riscv_common` includes the following debugging code if `DEVELHELP` is enabled:

https://github.com/RIOT-OS/RIOT/blob/2692957c0ea7030f4711d4ffdbe44cf3227ac5cd/cpu/riscv_common/irq_arch.c#L116-L121

This code is executed on the ISR stack and not on any standard RIOT thread stack. The stack size of this ISR stack is defined in the ldscript for `riscv_common` as follows:

https://github.com/RIOT-OS/RIOT/blob/2692957c0ea7030f4711d4ffdbe44cf3227ac5cd/cpu/riscv_common/ldscripts/riscv_base.ld#L35

Unfortunately, 256 Bytes is insufficient for newlib `printf()` usage and thus causes a stack overflow on the ISR stack if `DEVELHELP` is enabled and this code path in `handle_trap()` is triggered. One solution to avoid this problem is to increase the size of the ISR stack if `DEVELHELP` is enabled, this is the solution this PR proposes. Alternatively, it would also be possible to simply remove the `printf()` invocations from `handle_trap()`.

### Testing procedure

I discovered this through an external tool I am currently working on which I cannot share at this point. Similar to #16395, this bug can be confirmed independently by checking the value of the `sp` register after each instruction in `handle_trap()` using GDB. I am not sure if there is any interest in these ISR stack overflow edge cases but I wanted to document this anyhow in case some else runs into them by accident. If you don't consider it worthwhile to fix these edge cases let me know.

### Issues/PRs references

This is similar to the aforementioned issue #16395 which is also a stack overflow on the ISR stack which occurs due to `printf()` usage on this stack. This issue is, however, not fixed by this PR as `ENABLE_DEBUG` can be enabled independent of `DEVELHELP`.
