### PR TITLE
riscv_common: mark handle_trap as used (fixes LTO on RISC-V)

### DIFF
--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -70,7 +70,7 @@ void riscv_irq_init(void)
 /**
  * @brief Global trap and interrupt handler
  */
-void handle_trap(uint32_t mcause)
+static void __attribute((used)) handle_trap(uint32_t mcause)
 {
     /*  Tell RIOT to set sched_context_switch_request instead of
      *  calling thread_yield(). */


### PR DESCRIPTION
### Contribution description

The handle_trap function is used internally by the trap_entry implementation from the same file. However, the trap_entry implementation calls handle_trap from inline assembly. This makes it difficult for the compiler to infer that the handle_trap function is used at all. This causes issues when LTO is enabled.

Without this patch compiling any RISC-V RIOT code with `LTO=1` causes the following linker error:

	RIOT/cpu/riscv_common/irq_arch.c:134: undefined reference to `handle_trap'
	/tmp/hello-world.elf.Nngidp.ltrans0.ltrans.o:cpu/riscv_common/irq_arch.c:134:(.text.trap_entry+0x34):relocation truncated to fit: R_RISCV_GPREL_I against undefined symbol `handle_trap'

This commit fixes LTO support for RISC-V.

### Testing procedure

Try compiling `examples/hello-world` with and without this patch as follows:

```
$ LTO=1 BOARD=hifive1 make -C examples/hello-world/
```

Without this PR compilation should fail with the error message from above, with it a functioning LTO binary should be produced.

### Issues/PRs references

None.
