### PR TITLE
boards/arduino-nano-33-iot: resolved SPI and I2C configuration conflict

### DIFF
--- a/boards/arduino-nano-33-iot/include/periph_conf.h
+++ b/boards/arduino-nano-33-iot/include/periph_conf.h
@@ -229,13 +229,13 @@ static const i2c_conf_t i2c_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {   /* Connected to NINA W102 */
-        .dev      = &SERCOM4->SPI,
+        .dev      = &SERCOM2->SPI,
         .miso_pin = GPIO_PIN(PA, 13),
         .mosi_pin = GPIO_PIN(PA, 12),
         .clk_pin  = GPIO_PIN(PA, 15),
-        .miso_mux = GPIO_MUX_D,
-        .mosi_mux = GPIO_MUX_D,
-        .clk_mux  = GPIO_MUX_D,
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_1,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The configuration for I2C and SPI use the same serial communication interface (SERCOM4). This makes it impossible to use them at the same time. This commit switches the configuration of one of the SPIs from SERCOM4 to SERCOM2 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The modified SPI configuration is responsible for communicating with the NINA W102 device. I tested that after making the changes, interaction with this device works as before (custom driver, missing in RIOT)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
