### PR TITLE
drivers/ccs811: fix default config for ccs811_full

### DIFF
--- a/drivers/ccs811/include/ccs811_params.h
+++ b/drivers/ccs811/include/ccs811_params.h
@@ -56,8 +56,8 @@ extern "C" {
 #define CCS811_PARAMS    { .i2c_dev   = CCS811_PARAM_I2C_DEV,  \
                            .i2c_addr  = CCS811_PARAM_I2C_ADDR, \
                            .mode      = CCS811_PARAM_MODE,     \
-                           .int_mode  = CCS811_PARAM_INT_MODE, \
                            .int_pin   = CCS811_PARAM_INT_PIN,  \
+                           .int_mode  = CCS811_PARAM_INT_MODE, \
                            .wake_pin  = CCS811_PARAM_WAKE_PIN, \
                            .reset_pin = CCS811_PARAM_RESET_PIN \
                          }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Using the ccs811_full module, with default configuration, results in a compilation error:
RIOT/drivers/ccs811/include/ccs811_params.h:84:1: error: missing initializer for member 'ccs811_params_t::int_pin' [-Werror=missing-field-initializers]

This commit fixes this bug. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
