### PR TITLE
core: resolve circular dependency

### DIFF
--- a/core/include/core_types.h
+++ b/core/include/core_types.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    core_types  RIOT's core types
+ * @ingroup     core
+ * @brief       RIOT's core types
+ *
+ * @{
+ *
+ * @file
+ * @brief       RIOT's core types
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef CORE_TYPES_H
+#define CORE_TYPES_H
+
+#include <stdint.h>
+
+#include "cib.h"
+#include "clist.h"
+#include "list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if (defined(DEVELHELP) && !defined(CONFIG_THREAD_NAMES)) || DOXYGEN
+/**
+ * @brief   This global macro enable storage of thread names to help developers.
+ *
+ *          To activate it set environment variable `THREAD_NAMES=1`, or use Kconfig.
+ *          It is automatically enabled if `DEVELHELP` is.
+ */
+#define CONFIG_THREAD_NAMES
+#endif
+
+/**
+ * Unique process identifier
+ */
+typedef int16_t kernel_pid_t;
+
+/**
+ * @brief Prototype for a thread entry function
+ */
+typedef void *(*thread_task_func_t)(void *arg);
+
+/**
+ * @brief Thread states supported by RIOT
+ *
+ *       Keep in sync with OpenOCD src/rtos/riot.c
+ */
+typedef enum {
+    STATUS_STOPPED,                 /**< has terminated                           */
+    STATUS_ZOMBIE,                  /**< has terminated & keeps thread's thread_t */
+    STATUS_SLEEPING,                /**< sleeping                                 */
+    STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex               */
+    STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                    */
+    STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered      */
+    STATUS_REPLY_BLOCKED,           /**< waiting for a message response           */
+    STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask      */
+    STATUS_FLAG_BLOCKED_ALL,        /**< waiting for all flags in flag_mask       */
+    STATUS_MBOX_BLOCKED,            /**< waiting for get/put on mbox              */
+    STATUS_COND_BLOCKED,            /**< waiting for a condition variable         */
+    STATUS_RUNNING,                 /**< currently running                        */
+    STATUS_PENDING,                 /**< waiting to be scheduled to run           */
+    STATUS_NUMOF                    /**< number of supported thread states        */
+} thread_status_t;
+
+/**
+ * @brief Type definition of thread_flags_t
+ */
+typedef uint16_t thread_flags_t;
+
+/**
+ * @brief Describes a message object which can be sent between threads.
+ *
+ * User can set type and one of content.ptr and content.value. (content is a union)
+ * The meaning of type and the content fields is totally up to the user,
+ * the corresponding fields are never read by the kernel.
+ *
+ */
+typedef struct {
+    kernel_pid_t sender_pid;    /**< PID of sending thread. Will be filled in
+                                     by msg_send. */
+    uint16_t type;              /**< Type field. */
+    union {
+        void *ptr;              /**< Pointer content field. */
+        uint32_t value;         /**< Value content field. */
+    } content;                  /**< Content of the message. */
+} msg_t;
+
+/**
+ * @brief @c thread_t holds thread's context data.
+ */
+typedef struct {
+    char *sp;                       /**< thread's stack pointer         */
+    thread_status_t status;         /**< thread's status                */
+    uint8_t priority;               /**< thread's priority              */
+
+    kernel_pid_t pid;               /**< thread's process id            */
+
+#if defined(MODULE_CORE_THREAD_FLAGS) || defined(DOXYGEN)
+    thread_flags_t flags;           /**< currently set flags            */
+#endif
+
+    clist_node_t rq_entry;          /**< run queue entry                */
+
+#if defined(MODULE_CORE_MSG) || defined(MODULE_CORE_THREAD_FLAGS) \
+    || defined(MODULE_CORE_MBOX) || defined(DOXYGEN)
+    void *wait_data;                /**< used by msg, mbox and thread
+                                         flags                          */
+#endif
+#if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
+    list_node_t msg_waiters;        /**< threads waiting for their message
+                                         to be delivered to this thread
+                                         (i.e. all blocked sends)       */
+    cib_t msg_queue;                /**< index of this [thread's message queue]
+                                         (thread_t::msg_array), if any  */
+    msg_t *msg_array;               /**< memory holding messages sent
+                                         to this thread's message queue */
+#endif
+#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) \
+    || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)
+    char *stack_start;              /**< thread's stack start address   */
+#endif
+#if defined(CONFIG_THREAD_NAMES) || defined(DOXYGEN)
+    const char *name;               /**< thread's name                  */
+#endif
+#if defined(DEVELHELP) || defined(DOXYGEN)
+    int stack_size;                 /**< thread's stack size            */
+#endif
+/* enable TLS only when Picolibc is compiled with TLS enabled */
+#ifdef PICOLIBC_TLS
+    void *tls;                      /**< thread local storage ptr */
+#endif
+#ifdef HAVE_THREAD_ARCH_T
+    thread_arch_t arch;             /**< architecture dependent part    */
+#endif
+} thread_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* CORE_TYPES_H */

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -179,29 +179,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "core_types.h"
 #include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief Describes a message object which can be sent between threads.
- *
- * User can set type and one of content.ptr and content.value. (content is a union)
- * The meaning of type and the content fields is totally up to the user,
- * the corresponding fields are never read by the kernel.
- *
- */
-typedef struct {
-    kernel_pid_t sender_pid;    /**< PID of sending thread. Will be filled in
-                                     by msg_send. */
-    uint16_t type;              /**< Type field. */
-    union {
-        void *ptr;              /**< Pointer content field. */
-        uint32_t value;         /**< Value content field. */
-    } content;                  /**< Content of the message. */
-} msg_t;
 
 /**
  * @brief Send a message (blocking).

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -84,9 +84,10 @@
 #include <stddef.h>
 #include <inttypes.h>
 
+#include "clist.h"
+#include "core_types.h"
 #include "kernel_defines.h"
 #include "native_sched.h"
-#include "clist.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,11 +135,6 @@ extern "C" {
 #endif  /* DEVELHELP */
 
 /**
- * Unique process identifier
- */
-typedef int16_t kernel_pid_t;
-
-/**
  * @brief   Determine if the given pid is valid
  *
  * @param[in]   pid     The pid to check
@@ -149,34 +145,6 @@ static inline int pid_is_valid(kernel_pid_t pid)
 {
     return ((KERNEL_PID_FIRST <= pid) && (pid <= KERNEL_PID_LAST));
 }
-/**
- * @brief forward declaration for thread_t, defined in thread.h
- */
-typedef struct _thread thread_t;
-
-/**
- * @name Thread states supported by RIOT
- *
- *       Keep in sync with OpenOCD src/rtos/riot.c
- * @{
- */
-typedef enum {
-    STATUS_STOPPED,                 /**< has terminated                           */
-    STATUS_ZOMBIE,                  /**< has terminated & keeps thread's thread_t */
-    STATUS_SLEEPING,                /**< sleeping                                 */
-    STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex               */
-    STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                    */
-    STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered      */
-    STATUS_REPLY_BLOCKED,           /**< waiting for a message response           */
-    STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask      */
-    STATUS_FLAG_BLOCKED_ALL,        /**< waiting for all flags in flag_mask       */
-    STATUS_MBOX_BLOCKED,            /**< waiting for get/put on mbox              */
-    STATUS_COND_BLOCKED,            /**< waiting for a condition variable         */
-    STATUS_RUNNING,                 /**< currently running                        */
-    STATUS_PENDING,                 /**< waiting to be scheduled to run           */
-    STATUS_NUMOF                    /**< number of supported thread states        */
-} thread_status_t;
-/** @} */
 
 /**
  * @name Helpers to work with thread states

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -119,9 +119,9 @@
 #ifndef THREAD_H
 #define THREAD_H
 
-#include "clist.h"
 #include "cib.h"
-#include "msg.h"
+#include "clist.h"
+#include "core_types.h"
 #include "cpu_conf.h"
 #include "sched.h"
 #include "thread_config.h"
@@ -147,70 +147,6 @@ extern "C" {
 #else
 #define THREAD_MAYBE_INLINE
 #endif /* THREAD_API_INLINED */
-
-#if defined(DEVELHELP) && !defined(CONFIG_THREAD_NAMES)
-/**
- * @brief   This global macro enable storage of thread names to help developers.
- *
- *          To activate it set environment variable `THREAD_NAMES=1`, or use Kconfig.
- *          It is automatically enabled if `DEVELHELP` is.
- */
-#define CONFIG_THREAD_NAMES
-#endif
-
-/**
- * @brief Prototype for a thread entry function
- */
-typedef void *(*thread_task_func_t)(void *arg);
-
-/**
- * @brief @c thread_t holds thread's context data.
- */
-struct _thread {
-    char *sp;                       /**< thread's stack pointer         */
-    thread_status_t status;         /**< thread's status                */
-    uint8_t priority;               /**< thread's priority              */
-
-    kernel_pid_t pid;               /**< thread's process id            */
-
-#if defined(MODULE_CORE_THREAD_FLAGS) || defined(DOXYGEN)
-    thread_flags_t flags;           /**< currently set flags            */
-#endif
-
-    clist_node_t rq_entry;          /**< run queue entry                */
-
-#if defined(MODULE_CORE_MSG) || defined(MODULE_CORE_THREAD_FLAGS) \
-    || defined(MODULE_CORE_MBOX) || defined(DOXYGEN)
-    void *wait_data;                /**< used by msg, mbox and thread
-                                         flags                          */
-#endif
-#if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
-    list_node_t msg_waiters;        /**< threads waiting for their message
-                                         to be delivered to this thread
-                                         (i.e. all blocked sends)       */
-    cib_t msg_queue;                /**< index of this [thread's message queue]
-                                         (thread_t::msg_array), if any  */
-    msg_t *msg_array;               /**< memory holding messages sent
-                                         to this thread's message queue */
-#endif
-#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) \
-    || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)
-    char *stack_start;              /**< thread's stack start address   */
-#endif
-#if defined(CONFIG_THREAD_NAMES) || defined(DOXYGEN)
-    const char *name;               /**< thread's name                  */
-#endif
-#if defined(DEVELHELP) || defined(DOXYGEN)
-    int stack_size;                 /**< thread's stack size            */
-#endif
-/* enable TLS only when Picolibc is compiled with TLS enabled */
-#ifdef PICOLIBC_TLS
-    void *tls;                      /**< thread local storage ptr */
-#endif
-#ifdef HAVE_THREAD_ARCH_T
-    thread_arch_t arch;             /**< architecture dependent part    */
-#endif
-};
 
 /**
  * @name Optional flags for controlling a threads initial state
@@ -499,7 +435,7 @@ void thread_print_stack(void);
  * @return  `== 0`, if @p thread has no initialized message queue
  * @return  `!= 0`, if @p thread has its message queue initialized
  */
-static inline int thread_has_msg_queue(const volatile struct _thread *thread)
+static inline int thread_has_msg_queue(const volatile thread_t *thread)
 {
 #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
     return (thread->msg_array != NULL);

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -117,11 +117,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Type definition of thread_flags_t
- */
-typedef uint16_t thread_flags_t;
-
-/**
  * @brief Set thread flags, possibly waking it up
  *
  * @param[in]   thread     thread to work on

--- a/cpu/riscv_common/context_frame.c
+++ b/cpu/riscv_common/context_frame.c
@@ -76,7 +76,7 @@ static void check_context_switch_frame_alignment(void)
     /*
      * also check the SP offset in the _frame structure
      */
-    _Static_assert( offsetof(struct _thread, sp) == SP_OFFSET_IN_THREAD,
+    _Static_assert( offsetof(thread_t, sp) == SP_OFFSET_IN_THREAD,
                     "Offset of SP in _thread mismatch");
 
 }

--- a/examples/posix_sockets/udp.c
+++ b/examples/posix_sockets/udp.c
@@ -38,6 +38,7 @@
 #include "net/netif.h"         /* for resolving ipv6 scope */
 #endif /* SOCK_HAS_IPV6 */
 
+#include "msg.h"
 #include "thread.h"
 
 #define SERVER_MSG_QUEUE_SIZE   (8)

--- a/tests/msg_send_receive/main.c
+++ b/tests/msg_send_receive/main.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include "cpu_conf.h"
+#include "msg.h"
 #include "thread.h"
 
 #define THREAD1_STACKSIZE   (THREAD_STACKSIZE_MAIN)

--- a/tests/thread_cooperation/main.c
+++ b/tests/thread_cooperation/main.c
@@ -22,8 +22,9 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#include "thread.h"
+#include "msg.h"
 #include "mutex.h"
+#include "thread.h"
 
 #ifndef PROBLEM
 #define PROBLEM 12


### PR DESCRIPTION
### Contribution description

Dependency graph before:

```
     +-------------------------------------+
     |                                     |
     |                                     V
+----------+        +-------+         +---------+
| thread.h | -----> | msg.h | ------> | sched.h |
+----------+        +-------+         +---------+
     ^                                     |
     |                                     |
     +-------------------------------------+
```

Dependency graph after:

```
                 +--------------+
                 | core_types.h |
                 +--------------+
                    ^   ^   ^
                    |   |   |
      +-------------+   |   +--------------+
      |                 |                  |
+----------+            |             +---------+
| thread.h |            |             | sched.h |
+----------+            |             +---------+
                        |                  ^
                    +-------+              |
                    | msg.h |--------------+
                    +-------+
```

### Testing procedure

This PR doesn't change code. It only relocates it. Hence, binaries shouldn't change.

### Issues/PRs references

This circular dependency became an issue in https://github.com/RIOT-OS/RIOT/pull/16174