### PR TITLE
gnrc_tcp: rewrite passive open

### DIFF
--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -68,6 +68,7 @@ typedef struct _transmission_control_block {
     int32_t rto;           /**< Retransmission timeout duration */
     uint8_t retries;       /**< Number of retransmissions */
     evtimer_msg_event_t event_retransmit; /**< Retransmission event */
+    evtimer_msg_event_t event_timeout;    /**< Timeout event */
     evtimer_mbox_event_t event_misc;      /**< General purpose event */
     gnrc_pktsnip_t *pkt_retransmit;       /**< Pointer to packet in "retransmit queue" */
     mbox_t *mbox;            /**< TCB mbox for synchronization */
@@ -77,6 +78,20 @@ typedef struct _transmission_control_block {
     mutex_t function_lock;   /**< Mutex for function call synchronization */
     struct _transmission_control_block *next;   /**< Pointer next TCB */
 } gnrc_tcp_tcb_t;
+
+/**
+ * @brief Transmission control block queue.
+ */
+typedef struct _transmission_control_block_queue {
+    mutex_t lock;         /**< Mutex for access synchronization */
+    gnrc_tcp_tcb_t *tcbs; /**< Pointer to TCB sequence */
+    size_t tcbs_len;      /**< Number of TCBs behind member tcbs */
+} gnrc_tcp_tcb_queue_t;
+
+/**
+ * @brief Static initializer for type gnrc_tcp_tcb_queue_t
+ */
+#define GNRC_TCP_TCB_QUEUE_INIT   { MUTEX_INIT, NULL, 0 }
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/tcp.h
+++ b/sys/include/net/tcp.h
@@ -32,8 +32,8 @@ extern "C" {
  * @brief TCP offset value boundaries.
  * @{
  */
-#define TCP_HDR_OFFSET_MIN (0x05)
-#define TCP_HDR_OFFSET_MAX (0x0F)
+#define TCP_HDR_OFFSET_MIN (0x05) /**< Header offset minimum value */
+#define TCP_HDR_OFFSET_MAX (0x0F) /**< Header offset maximum value */
 /** @} */
 
 /**
@@ -49,7 +49,7 @@ extern "C" {
  * @brief TCP option "length"-field values.
  * @{
  */
-#define TCP_OPTION_LENGTH_MIN (2U)    /**< Minimum amount of bytes needed for an option with a length field */
+#define TCP_OPTION_LENGTH_MIN (2U)    /**< Minimum option field size in bytes */
 #define TCP_OPTION_LENGTH_MSS (0x04)  /**< MSS Option Size always 4 */
 /** @} */
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -330,6 +330,16 @@ static void *_eventloop(__attribute__((unused)) void *arg)
                               FSM_EVENT_TIMEOUT_TIMEWAIT, NULL, NULL, 0);
                 break;
 
+           /* A connection opening attempt from a TCB in listening mode failed.
+            * Clear retransmission and re-open for next attempt */
+            case MSG_TYPE_CONNECTION_TIMEOUT:
+                TCP_DEBUG_INFO("Received MSG_TYPE_CONNECTION_TIMEOUT.");
+                _gnrc_tcp_fsm((gnrc_tcp_tcb_t *)msg.content.ptr,
+                              FSM_EVENT_CLEAR_RETRANSMIT, NULL, NULL, 0);
+                _gnrc_tcp_fsm((gnrc_tcp_tcb_t *)msg.content.ptr,
+                              FSM_EVENT_CALL_OPEN, NULL, NULL, 0);
+                break;
+
             default:
                 TCP_DEBUG_ERROR("Received unexpected message.");
         }

--- a/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
+++ b/sys/net/gnrc/transport_layer/tcp/include/gnrc_tcp_common.h
@@ -42,9 +42,11 @@ extern "C" {
  * @brief TCB status flags
  * @{
  */
-#define STATUS_PASSIVE        (1 << 0)
+#define STATUS_LISTENING      (1 << 0)
 #define STATUS_ALLOW_ANY_ADDR (1 << 1)
 #define STATUS_NOTIFY_USER    (1 << 2)
+#define STATUS_ACCEPTED       (1 << 3)
+#define STATUS_LOCKED         (1 << 4)
 /** @} */
 
 /**

--- a/tests/gnrc_tcp/README.md
+++ b/tests/gnrc_tcp/README.md
@@ -30,6 +30,14 @@ in the tests directory.
 7) 07-endpoint_construction.py
     This test ensures the correctness of the endpoint construction.
 
+8) 08-return_codes.py
+    This test tries to trigger all documented return codes from GNRC_TCPs functions.
+
+9) 09-listen_accept_cycle.py
+    This test verifies that connection establishment via listen and accept can be repeated multiple
+    times.
+
+
 Setup
 ==========
 The test requires a tap-device setup. This can be achieved by running 'dist/tools/tapsetup/tapsetup'

--- a/tests/gnrc_tcp/tests-as-root/01-conn_lifecycle_as_client.py
+++ b/tests/gnrc_tcp/tests-as-root/01-conn_lifecycle_as_client.py
@@ -32,8 +32,9 @@ def testfunc(child):
 
     # Setup RIOT Node to connect to host systems TCP Server
     child.sendline('gnrc_tcp_tcb_init')
-    child.sendline('gnrc_tcp_open_active [{}]:{} 0'.format(target_addr, str(port)))
-    child.expect_exact('gnrc_tcp_open_active: returns 0')
+
+    child.sendline('gnrc_tcp_open [{}]:{} 0'.format(target_addr, str(port)))
+    child.expect_exact('gnrc_tcp_open: returns 0')
 
     # Close connection and verify that pktbuf is cleared
     shutdown_event.set()

--- a/tests/gnrc_tcp/tests-as-root/02-conn_lifecycle_as_server.py
+++ b/tests/gnrc_tcp/tests-as-root/02-conn_lifecycle_as_server.py
@@ -8,50 +8,35 @@
 
 import os
 import sys
-import socket
-import threading
 
-from testrunner import run
-from shared_func import generate_port_number, get_host_tap_device, get_riot_ll_addr, \
-                        verify_pktbuf_empty, sudo_guard
+from shared_func import Runner, RiotTcpServer, HostTcpClient, generate_port_number, \
+                        sudo_guard
 
 
-def tcp_client(addr, port, shutdown_event):
-    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-    addr_info = socket.getaddrinfo(addr + '%' + get_host_tap_device(), port, type=socket.SOCK_STREAM)
-
-    sock.connect(addr_info[0][-1])
-
-    shutdown_event.wait()
-
-    sock.close()
-
-
-def testfunc(child):
-    port = generate_port_number()
-    shutdown_event = threading.Event()
-
-    client_handle = threading.Thread(target=tcp_client, args=(get_riot_ll_addr(child), port, shutdown_event))
-
-    # Setup RIOT Node wait for incoming connections from host system
-    child.sendline('gnrc_tcp_tcb_init')
-    child.sendline('gnrc_tcp_open_passive [::]:{}'.format(str(port)))
-
-    client_handle.start()
-    child.expect_exact('gnrc_tcp_open_passive: returns 0')
-
-    # Close connection and verify that pktbuf is cleared
-    shutdown_event.set()
-    child.sendline('gnrc_tcp_close')
-    client_handle.join()
-
-    verify_pktbuf_empty(child)
-
-    print(os.path.basename(sys.argv[0]) + ': success')
+@Runner(timeout=10)
+def test_lifecycle_as_server(child):
+    """ Open/close a single connection as tcp server """
+    # Setup RIOT as server
+    with RiotTcpServer(child, generate_port_number()) as riot_srv:
+        # Setup Host as client
+        with HostTcpClient(riot_srv.addr, riot_srv.listen_port):
+            # Accept and close connection
+            riot_srv.accept(timeout_ms=1000)
+            riot_srv.close()
 
 
 if __name__ == '__main__':
     sudo_guard()
-    sys.exit(run(testfunc, timeout=7, echo=False, traceback=True))
+
+    # Read and run all test functions.
+    script = sys.modules[__name__]
+    tests = [getattr(script, t) for t in script.__dict__
+             if type(getattr(script, t)).__name__ == 'function'
+             and t.startswith('test_')]
+
+    for test in tests:
+        res = test()
+        if (res != 0):
+            sys.exit(res)
+
+    print(os.path.basename(sys.argv[0]) + ': success\n')

--- a/tests/gnrc_tcp/tests-as-root/03-send_data.py
+++ b/tests/gnrc_tcp/tests-as-root/03-send_data.py
@@ -40,8 +40,8 @@ def testfunc(child):
 
     # Setup RIOT Node to connect to host systems TCP Server
     child.sendline('gnrc_tcp_tcb_init')
-    child.sendline('gnrc_tcp_open_active [{}]:{} 0'.format(target_addr, str(port)))
-    child.expect_exact('gnrc_tcp_open_active: returns 0')
+    child.sendline('gnrc_tcp_open [{}]:{} 0'.format(target_addr, str(port)))
+    child.expect_exact('gnrc_tcp_open: returns 0')
 
     # Send data from RIOT Node to Linux
     write_data_to_internal_buffer(child, data)

--- a/tests/gnrc_tcp/tests-as-root/04-receive_data.py
+++ b/tests/gnrc_tcp/tests-as-root/04-receive_data.py
@@ -40,8 +40,8 @@ def testfunc(child):
 
     # Setup RIOT Node to connect to Hostsystems TCP Server
     child.sendline('gnrc_tcp_tcb_init')
-    child.sendline('gnrc_tcp_open_active [{}]:{} 0'.format(target_addr, str(port)))
-    child.expect_exact('gnrc_tcp_open_active: returns 0')
+    child.sendline('gnrc_tcp_open [{}]:{} 0'.format(target_addr, str(port)))
+    child.expect_exact('gnrc_tcp_open: returns 0')
 
     # Accept Data sent by the host system
     child.sendline('gnrc_tcp_recv 1000000 ' + str(data_len))

--- a/tests/gnrc_tcp/tests-as-root/06-receive_data_closed_conn.py
+++ b/tests/gnrc_tcp/tests-as-root/06-receive_data_closed_conn.py
@@ -42,8 +42,8 @@ def testfunc(child):
 
     # Setup RIOT Node to connect to Hostsystems TCP Server
     child.sendline('gnrc_tcp_tcb_init')
-    child.sendline('gnrc_tcp_open_active [{}]:{} 0'.format(target_addr, str(port)))
-    child.expect_exact('gnrc_tcp_open_active: returns 0')
+    child.sendline('gnrc_tcp_open [{}]:{} 0'.format(target_addr, str(port)))
+    child.expect_exact('gnrc_tcp_open: returns 0')
 
     # Initiate connection teardown from test host
     shutdown_event.set()

--- a/tests/gnrc_tcp/tests-as-root/07-endpoint_construction.py
+++ b/tests/gnrc_tcp/tests-as-root/07-endpoint_construction.py
@@ -132,13 +132,18 @@ def main(child):
              if type(getattr(script, t)).__name__ == "function"
              and t.startswith("test_")]
 
+    res = 0
+
     for test in tests:
         try:
             test(child)
             print('- {} SUCCESS'.format(test.__name__))
 
         except Exception:
+            res = -1
             print('- {} FAILED'.format(test.__name__))
+
+    return res
 
 
 if __name__ == '__main__':

--- a/tests/gnrc_tcp/tests-as-root/08-return_codes.py
+++ b/tests/gnrc_tcp/tests-as-root/08-return_codes.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021   Simon Brummer <simon.brummer@posteo.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import os
+
+from shared_func import Runner, RiotTcpServer, HostTcpClient, generate_port_number, \
+                        sudo_guard
+
+
+@Runner(timeout=0.5)
+def test_gnrc_tcp_accept_returns_EAGAIN(child):
+    """ gnrc_tcp_accept must return with -EAGAIN
+        if no connection is ready and timeout is 0
+    """
+    riot_srv = RiotTcpServer(child, generate_port_number())
+    riot_srv.listen()
+
+    child.sendline('gnrc_tcp_accept 0')
+    child.expect_exact('gnrc_tcp_accept: returns -EAGAIN')
+
+
+@Runner(timeout=1.5)
+def test_gnrc_tcp_accept_returns_ETIMEDOUT(child):
+    """ gnrc_tcp_accept must return with -ETIMEDOUT
+        if no connection is ready and timeout is not 0
+    """
+    riot_srv = RiotTcpServer(child, generate_port_number())
+    riot_srv.listen()
+
+    child.sendline('gnrc_tcp_accept 1000')
+    child.expect_exact('gnrc_tcp_accept: returns -ETIMEDOUT')
+
+
+@Runner(timeout=1)
+def test_gnrc_tcp_accept_returns_ENOMEM(child):
+    """ gnrc_tcp_accept must return with -ENOMEM
+        if all TCBs already handle a connection
+    """
+    with RiotTcpServer(child, generate_port_number()) as riot_srv:
+        # Establish connection to ensure that all TCBs are in use
+        with HostTcpClient(riot_srv.addr, riot_srv.listen_port):
+            riot_srv.accept(timeout_ms=0)
+
+            # Faulty accept should return immediately despite a huge timeout.
+            child.sendline('gnrc_tcp_accept 100000000')
+            child.expect_exact('gnrc_tcp_accept: returns -ENOMEM')
+
+
+if __name__ == '__main__':
+    sudo_guard()
+
+    # Read and run all test functions.
+    script = sys.modules[__name__]
+    tests = [getattr(script, t) for t in script.__dict__
+             if type(getattr(script, t)).__name__ == 'function'
+             and t.startswith('test_')]
+
+    for test in tests:
+        res = test()
+        if (res != 0):
+            sys.exit(res)
+
+    print(os.path.basename(sys.argv[0]) + ': success\n')

--- a/tests/gnrc_tcp/tests-as-root/09-listen_accept_cycle.py
+++ b/tests/gnrc_tcp/tests-as-root/09-listen_accept_cycle.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021   Simon Brummer <simon.brummer@posteo.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import os
+import random
+
+from shared_func import Runner, RiotTcpServer, HostTcpClient, generate_port_number, \
+                        sudo_guard
+
+
+@Runner(timeout=10)
+def test_listen_accept_cycle(child, iterations=10):
+    """ This test verifies gnrc_tcp in a typical server role by
+        accepting a connection, exchange data, teardown connection, handle the next one
+    """
+    # Setup RIOT Node as server
+    with RiotTcpServer(child, generate_port_number()) as riot_srv:
+        # Establish multiple connections iterativly
+        for i in range(iterations):
+            print('    Running iteration {}'.format(i))
+
+            with HostTcpClient(riot_srv.addr, riot_srv.listen_port) as host_cli:
+                # Accept connection from host system
+                riot_srv.accept(timeout_ms=0)
+
+                # Send data from host to RIOT
+                data = '0123456789'
+                host_cli.send(payload_to_send=data)
+                riot_srv.receive(timeout_ms=500, sent_payload=data)
+
+                # Send data from RIOT to host
+                riot_srv.send(timeout_ms=500, payload_to_send=data)
+                host_cli.receive(sent_payload=data)
+
+                # Randomize connection teardown: The connections
+                # can't be either closed or aborted from either
+                # side. Regardless type of the connection teardown
+                # riot_srv must be able to accept the next connection
+                # Note: python sockets don't offer abort...
+                dice_throw = random.randint(0, 3)
+                if dice_throw == 0:
+                    riot_srv.close()
+                    host_cli.close()
+
+                elif dice_throw == 1:
+                    riot_srv.abort()
+                    host_cli.close()
+
+                elif dice_throw == 2:
+                    host_cli.close()
+                    riot_srv.close()
+
+                elif dice_throw == 3:
+                    host_cli.close()
+                    riot_srv.abort()
+
+
+if __name__ == '__main__':
+    sudo_guard()
+
+    # Read and run all test functions.
+    script = sys.modules[__name__]
+    tests = [getattr(script, t) for t in script.__dict__
+             if type(getattr(script, t)).__name__ == 'function'
+             and t.startswith('test_')]
+
+    for test in tests:
+        res = test()
+        if (res != 0):
+            sys.exit(res)
+
+    print(os.path.basename(sys.argv[0]) + ': success\n')

--- a/tests/gnrc_tcp/tests-as-root/shared_func.py
+++ b/tests/gnrc_tcp/tests-as-root/shared_func.py
@@ -10,6 +10,31 @@ import os
 import re
 import socket
 import random
+import testrunner
+
+
+class Runner:
+    def __init__(self, timeout, echo=False, skip=False):
+        self.timeout = timeout
+        self.echo = echo
+        self.skip = skip
+
+    def __call__(self, fn):
+        if self.skip:
+            print('- Test "{}": SKIPPED'.format(fn.__name__))
+            return 0
+
+        res = -1
+        try:
+            res = testrunner.run(fn, self.timeout, self.echo)
+
+        finally:
+            if res == 0:
+                print('- Test "{}": SUCCESS'.format(fn.__name__))
+            else:
+                print('- Test "{}": FAILED'.format(fn.__name__))
+
+        return res
 
 
 class TcpServer:
@@ -35,6 +60,143 @@ class TcpServer:
 
     def recv(self, number_of_bytes):
         return self.conn.recv(number_of_bytes, socket.MSG_WAITALL).decode('utf-8')
+
+
+class HostTcpNode:
+    def __init__(self):
+        self.opened = False
+        self.sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.interface = get_host_tap_device()
+
+    def send(self, payload_to_send):
+        self.sock.send(payload_to_send.encode('utf-8'))
+
+    def receive(self, sent_payload):
+        total_bytes = len(sent_payload)
+        assert self.sock.recv(total_bytes, socket.MSG_WAITALL).decode('utf-8') == sent_payload
+
+    def close(self):
+        self.sock.close()
+        self.opened = False
+
+
+class HostTcpClient(HostTcpNode):
+    def __init__(self, target_addr, target_port):
+        super().__init__()
+        self.target_addr = target_addr
+        self.target_port = target_port
+
+    def __enter__(self):
+        if not self.opened:
+            self.open()
+        return self
+
+    def __exit__(self, _1, _2, _3):
+        if self.opened:
+            self.close()
+
+    def open(self):
+        addrinfo = socket.getaddrinfo(
+            self.target_addr + '%' + self.interface,
+            self.target_port,
+            type=socket.SOCK_STREAM
+        )
+        self.sock.connect(addrinfo[0][-1])
+        self.opened = True
+
+
+class RiotTcpNode:
+    def __init__(self, child):
+        self.child = child
+        self.opened = False
+
+        # Query local address of RIOT Node
+        self.addr = get_riot_ll_addr(self.child)
+
+    def tcb_init(self):
+        self.child.sendline('gnrc_tcp_tcb_init')
+        self.child.expect_exact('gnrc_tcp_tcb_init: returns')
+
+    def send(self, timeout_ms, payload_to_send):
+        total_bytes = len(payload_to_send)
+
+        # Verify that internal buffer can hold the given amount of data
+        assert setup_internal_buffer(self.child) >= total_bytes
+
+        # Write data to RIOT nodes internal buffer
+        write_data_to_internal_buffer(self.child, payload_to_send)
+
+        # Send buffer contents via tcp
+        self.child.sendline('gnrc_tcp_send {}'.format(str(timeout_ms)))
+        self.child.expect_exact('gnrc_tcp_send: sent {}'.format(str(total_bytes)))
+
+        # Verify that packet buffer is empty
+        verify_pktbuf_empty(self.child)
+
+    def receive(self, timeout_ms, sent_payload):
+        total_bytes = len(sent_payload)
+
+        # Verify that internal Buffer can hold the test data
+        assert setup_internal_buffer(self.child) >= total_bytes
+
+        # Receive Data
+        self.child.sendline('gnrc_tcp_recv {} {}'.format(timeout_ms, str(total_bytes)))
+        self.child.expect_exact('gnrc_tcp_recv: received ' + str(total_bytes), timeout=20)
+
+        # Readout internal buffer content of RIOT Note
+        assert read_data_from_internal_buffer(self.child, total_bytes) == sent_payload
+
+        # Verify that packet buffer is empty
+        verify_pktbuf_empty(self.child)
+
+    def close(self):
+        self.child.sendline('gnrc_tcp_close')
+        self.child.expect_exact('gnrc_tcp_close: returns')
+        verify_pktbuf_empty(self.child)
+        self.opened = False
+
+    def abort(self):
+        self.child.sendline('gnrc_tcp_abort')
+        self.child.expect_exact('gnrc_tcp_abort: returns')
+        verify_pktbuf_empty(self.child)
+        self.opened = False
+
+
+class RiotTcpServer(RiotTcpNode):
+    def __init__(self, child, listen_port, listen_addr='[::]'):
+        super().__init__(child)
+
+        self.listening = False
+        self.listen_port = str(listen_port)
+        self.listen_addr = str(listen_addr)
+
+        self.tcb_init()
+
+    def __enter__(self):
+        if not self.listening:
+            self.listen()
+            self.listening = True
+        return self
+
+    def __exit__(self, _1, _2, _3):
+        if self.listening:
+            self.stop_listen()
+            self.listening = False
+
+    def listen(self):
+        self.child.sendline('gnrc_tcp_listen {}:{}'.format(self.listen_addr, self.listen_port))
+        self.child.expect_exact('gnrc_tcp_listen: returns 0')
+
+    def accept(self, timeout_ms):
+        self.child.sendline('gnrc_tcp_accept {}'.format(str(timeout_ms)))
+        self.child.expect_exact('gnrc_tcp_accept: returns 0')
+        self.opened = True
+
+    def stop_listen(self):
+        self.child.sendline('gnrc_tcp_stop_listen')
+        self.child.expect_exact('gnrc_tcp_stop_listen: returns')
+        verify_pktbuf_empty(self.child)
 
 
 def generate_port_number():


### PR DESCRIPTION
### Contribution description
This PR rewrites the passive connection establishment mechanism of GNRC_TCP.
The new version aligns the GNRC_TCP interface with the SOCK_TCP interface with the goal to make a upcoming SOCK integration straight forward and trivial.

Since this is a large change, I've split the PR into three commits (api, implementation and tests) to help reviewing this.
The new tests are written in different style than existing tests, please ignore the difference in style for now, I plan to align the existing  test structure in a dedicated PR on after merging this. 

### Testing procedure
This PR is covered by the GNRC_TCP test suite.
To test this PR follow the instructions under tests/gnrc_tcp/Readme.md

### Issues/PRs references
Fixes #10664 - TCP Sockets can not be used / built
