### PR TITLE
core/sched: add runq_callback hook and runq inspection functions

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -298,6 +298,62 @@ static inline void sched_runq_advance(uint8_t prio)
     clist_lpoprpush(&sched_runqueues[prio]);
 }
 
+#if (IS_USED(MODULE_SCHED_RUNQ_CALLBACK)) || defined(DOXYGEN)
+/**
+ * @brief   Scheduler runqueue (change) callback
+ *
+ * @details Function has to be provided by the user of this API.
+ *          It will be called:
+ *          - when the scheduler is run,
+ *          - when a thread enters the active queue or
+ *          - when the last thread leaves a queue
+ *
+ * @warning This API is not intended for out of tree users.
+ *          Breaking API changes will be done without notice and
+ *          without deprecation. Consider yourself warned!
+ *
+ * @param   prio      the priority of the runqueue that changed
+ *
+ */
+extern void sched_runq_callback(uint8_t prio);
+#endif
+
+/**
+ * @brief   Tell if the number of threads in a runqueue is 0
+ *
+ * @param[in]   prio      The priority of the runqueue to get information of
+ * @return      Truth value for that information
+ * @warning     This API is not intended for out of tree users.
+ */
+static inline int sched_runq_is_empty(uint8_t prio)
+{
+    return clist_is_empty(&sched_runqueues[prio]);
+}
+
+/**
+ * @brief   Tell if the number of threads in a runqueue is 1
+ *
+ * @param[in]   prio      The priority of the runqueue to get information of
+ * @return      Truth value for that information
+ * @warning     This API is not intended for out of tree users.
+ */
+static inline int sched_runq_is_one(uint8_t prio)
+{
+    return clist_exactly_one(&sched_runqueues[prio]);
+}
+
+/**
+ * @brief   Tell if the number of threads in a runqueue greater than 1
+ *
+ * @param[in]   prio      The priority of the runqueue to get information of
+ * @return      Truth value for that information
+ * @warning     This API is not intended for out of tree users.
+ */
+static inline int sched_runq_greater_one(uint8_t prio)
+{
+    return clist_more_than_one(&sched_runqueues[prio]);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -337,7 +337,7 @@ static inline int sched_runq_is_empty(uint8_t prio)
  * @return      Truth value for that information
  * @warning     This API is not intended for out of tree users.
  */
-static inline int sched_runq_is_one(uint8_t prio)
+static inline int sched_runq_exactly_one(uint8_t prio)
 {
     return clist_exactly_one(&sched_runqueues[prio]);
 }
@@ -349,7 +349,7 @@ static inline int sched_runq_is_one(uint8_t prio)
  * @return      Truth value for that information
  * @warning     This API is not intended for out of tree users.
  */
-static inline int sched_runq_greater_one(uint8_t prio)
+static inline int sched_runq_more_than_one(uint8_t prio)
 {
     return clist_more_than_one(&sched_runqueues[prio]);
 }

--- a/core/sched.c
+++ b/core/sched.c
@@ -75,8 +75,8 @@ clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
 static uint32_t runqueue_bitcache = 0;
 
 #ifdef MODULE_SCHED_CB
-static void (*sched_cb) (kernel_pid_t active_thread,
-                         kernel_pid_t next_thread) = NULL;
+static void (*sched_cb)(kernel_pid_t active_thread,
+                        kernel_pid_t next_thread) = NULL;
 #endif
 
 /* Depending on whether the CLZ instruction is available, the order of the

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -123,6 +123,7 @@ PSEUDOMODULES += saul_nrf_temperature
 PSEUDOMODULES += saul_pwm
 PSEUDOMODULES += scanf_float
 PSEUDOMODULES += sched_cb
+PSEUDOMODULES += sched_runq_callback
 PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio


### PR DESCRIPTION
### Contribution description

This adds a runqueue callback to core/sched that is called on changes to runqueue if they are active or their last thread is removed. (callbacks are issued when: a runqueue gets active, the active runqueue grows or a runqueue is emptied)

This also adds functions to gather informations about the length of runqueues. (empty, one thread, more than one thread)

Both features together may be used to implement schedulers that are able to adapt to demand (active if required, inactive if not)

### Testing procedure

none yet but testing #16126

### Issues/PRs references

#16311 added the required interface to change threads by advancing the runqueue

this is derived from #16126 which also adds a matching round robin scheduler
