### PR TITLE
pkg/libcose: Update to latest master

### DIFF
--- a/pkg/libcose/Makefile
+++ b/pkg/libcose/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=libcose
 PKG_URL=https://github.com/bergzand/libcose
-PKG_VERSION=8b5f651c3203682a2d98121cd3e5c844cb2b4c36
+PKG_VERSION=3fdf1238987b6aeec113b1872e56307893feeae7
 PKG_LICENSE=LGPL
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libcose/Makefile.dep
+++ b/pkg/libcose/Makefile.dep
@@ -10,3 +10,6 @@ endif
 ifneq (,$(filter libcose_crypt_c25519,$(USEMODULE)))
   USEPKG += c25519
 endif
+ifneq (,$(filter libcose_crypt_tinycrypt,$(USEMODULE)))
+  USEPKG += tinycrypt
+endif

--- a/pkg/libcose/Makefile.include
+++ b/pkg/libcose/Makefile.include
@@ -7,6 +7,9 @@ endif
 ifneq (,$(filter libcose_crypt_c25519,$(USEMODULE)))
   CFLAGS += -DCRYPTO_C25519
 endif
+ifneq (,$(filter libcose_crypt_tinycrypt,$(USEMODULE)))
+  CFLAGS += -DCRYPTO_TINYCRYPT
+endif
 
 # Declare pseudomodules here to be selfcontained
 PSEUDOMODULES += libcose_crypt_%

--- a/pkg/libcose/patches/0001-RIOT-Use-RIOT-random_bytes-function-instead-of-rando.patch
+++ b/pkg/libcose/patches/0001-RIOT-Use-RIOT-random_bytes-function-instead-of-rando.patch
@@ -67,20 +67,19 @@ index c24d751..3bdcabf 100644
  }
  #endif /* CRYPTO_HACL_INCLUDE_CHACHAPOLY */
 diff --git a/src/crypt/monocypher.c b/src/crypt/monocypher.c
-index 9e4dcbc..d1fcac1 100644
+index f3186f7..fd27839 100644
 --- a/src/crypt/monocypher.c
 +++ b/src/crypt/monocypher.c
-@@ -17,8 +17,7 @@
- #include <monocypher.h>
+@@ -19,7 +19,7 @@
  #include "cose/crypto.h"
  #include "cose/crypto/selectors.h"
--
+ 
 -extern void randombytes(uint8_t *target, uint64_t n);
 +#include "random.h"
+ static const uint8_t zero[32] = { 0 };
  
  #ifdef CRYPTO_MONOCYPHER_INCLUDE_CHACHAPOLY
- static uint32_t load32_le(const uint8_t *u)
-@@ -105,7 +104,7 @@ COSE_ssize_t cose_crypto_keygen_chachapoly(uint8_t *sk, size_t len)
+@@ -109,7 +109,7 @@ COSE_ssize_t cose_crypto_keygen_chachapoly(uint8_t *sk, size_t len)
      if (len < 64) {
          return COSE_ERR_NOMEM;
      }
@@ -89,14 +88,14 @@ index 9e4dcbc..d1fcac1 100644
      return 64;
  }
  #endif /* CRYPTO_MONOCYPHER_INCLUDE_CHACHAPOLY */
-@@ -133,7 +132,7 @@ static void _ed25519_clamp(uint8_t *key)
+@@ -137,7 +137,7 @@ static void _ed25519_clamp(uint8_t *key)
  
  void cose_crypto_keypair_ed25519(cose_key_t *key)
  {
 -    randombytes(key->d, COSE_CRYPTO_SIGN_ED25519_SECRETKEYBYTES);
 +    random_bytes(key->d, COSE_CRYPTO_SIGN_ED25519_SECRETKEYBYTES);
      _ed25519_clamp(key->d);
-     crypto_sign_public_key(key->x, key->d);
+     crypto_ed25519_public_key(key->x, key->d);
  }
 -- 
 2.21.0

--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -5,5 +5,5 @@ PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all:
-	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/lib/source/ -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+all: Makefile.tinycrypt
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/lib/source/ -f $(CURDIR)/Makefile.tinycrypt -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/tinycrypt/Makefile.tinycrypt
+++ b/pkg/tinycrypt/Makefile.tinycrypt
@@ -1,0 +1,1 @@
+SRC = $(filter-out ecc_platform_specific.c,$(wildcard *.c))


### PR DESCRIPTION
### Contribution description

The latest libcose master adds support for AES-CCM through the added tinycrypt backend.

A tinycrypt opportunistic POSIX RNG dependency is patched out to allow the interaction -- as described in the commit, that would only have worked on native anyway, and it's better to consistently not pull in that function than give people surprise behavior when going away from native. (Also, the native function would have conflicted with the more generic implementation provided by libcose, which needs a RNG linked in there for key generation).

### Testing procedure

* `make -C tests/pkg_libcose all flash test`
* Same but with

```patch
diff --git a/tests/pkg_libcose/Makefile b/tests/pkg_libcose/Makefile
index 8206fe43b0..105b5a9aac 100644
--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -5,8 +5,9 @@ TEST_ON_CI_WHITELIST += native
 USEPKG += libcose
 # By default we use hacl as crypto backend, uncomment to use a different
 # crypto backend.
-USEMODULE += libcose_crypt_hacl
-# USEMODULE += libcose_crypt_c25519
+#USEMODULE += libcose_crypt_hacl
+USEMODULE += libcose_crypt_tinycrypt
+USEMODULE += libcose_crypt_c25519
 USEMODULE += memarray
 USEMODULE += embunit
```

to run on the new tinycrypt code paths.

Tested on native and microbit-v2; on the latter this takes some time, be patient.
