### PR TITLE
tests/pkg_qr-code-generator: improve display speed in test application

### DIFF
--- a/tests/pkg_qr-code-generator/main.c
+++ b/tests/pkg_qr-code-generator/main.c
@@ -22,6 +22,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
 #include "qrcodegen.h"
 
 #ifdef MODULE_DISP_DEV
@@ -34,6 +35,11 @@
 
 static uint8_t qr0[qrcodegen_BUFFER_LEN_FOR_VERSION(2)];
 static uint8_t buffer[qrcodegen_BUFFER_LEN_FOR_VERSION(2)];
+
+#ifdef MODULE_DISP_DEV
+#define DISPLAY_BUFFER_MAX_SIZE (1024)
+static uint16_t display_buffer[DISPLAY_BUFFER_MAX_SIZE];
+#endif
 
 int main(void)
 {
@@ -56,30 +62,33 @@ int main(void)
     }
     disp_dev_backlight_on();
 
-    uint16_t white = UINT16_MAX;
-    uint16_t black = 0;
-    for (uint16_t y = 0; y < disp_dev_height(disp_dev->dev); y++) {
-        for (uint16_t x = 0; x <  disp_dev_width(disp_dev->dev); x++) {
-            disp_dev_map(disp_dev->dev, x, x, y, y, &black);
-        }
-    }
-
+    /* Compute scaling factor and height/width offsets */
     const uint8_t scale = disp_dev_height(disp_dev->dev) / size;
     const uint8_t w_offset = (disp_dev_width(disp_dev->dev) - (size * scale)) / 2;
     const uint8_t h_offset = (disp_dev_height(disp_dev->dev) - (size * scale)) / 2;
+
+    /* Clear the screen */
+    const uint8_t lines_group = (DISPLAY_BUFFER_MAX_SIZE / disp_dev_height(disp_dev->dev));
+    for (uint16_t y = 0; y < disp_dev_height(disp_dev->dev); y += lines_group) {
+        disp_dev_map(disp_dev->dev, 0, disp_dev_width(disp_dev->dev), y, y + lines_group, display_buffer);
+    }
+
+    /* Prepare a subset of the display buffer for white tiles */
+    for (int w = 0; w < scale; w++) {
+        for (int h = 0; h < scale; h++) {
+            display_buffer[w + h * scale] = UINT16_MAX;
+        }
+    }
 #endif
 
     for (int y = 0; y < size; y++) {
         for (int x = 0; x < size; x++) {
 #ifdef MODULE_DISP_DEV
-            for (int w = x * scale; w < (x + 1) * scale; w++) {
-                for (int h = y * scale; h < (y + 1) * scale; h++) {
-                    if (qrcodegen_getModule(qr0, x, y)) {
-                        disp_dev_map(disp_dev->dev,
-                                     w + w_offset, w + w_offset, h + h_offset, h + h_offset,
-                                     &white);
-                    }
-                }
+            if (qrcodegen_getModule(qr0, x, y)) {
+                disp_dev_map(disp_dev->dev,
+                             w_offset + (x * scale), w_offset + ((x + 1)* scale) - 1,
+                             h_offset + (y * scale), h_offset + ((y + 1)* scale) - 1,
+                             display_buffer);
             }
 #endif
             printf("%s", qrcodegen_getModule(qr0, x, y) ? "██" : "  ");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the display speed of the `tests/pkg_qr-code-generator` application (added #16462). In master, the QR code is sent to the display pixel by pixel, which is super slow.
This PR uses a buffer and chunks of pixel are sent to the display: the result is a super fast screen cleanup and display of the QR code. This of course comes with an extra RAM consumption but boards that provide a display usually have plenty so this is a good tradeoff IMHO.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
-  `tests/pkg_qr-code-generator` still works as expected and is much much faster

<details>

```
$ BUILD_IN_DOCKER=1 make -C tests/pkg_qr-code-generator BOARD=adafruit-clue flash test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=adafruit-clue'  -w '/data/riotbuild/riotbase/tests/pkg_qr-code-generator/' 'riot/riotbuild:latest' make 'BOARD=adafruit-clue'    
Building application "tests_pkg_qr-code-generator" for "adafruit-clue" with MCU "nrf52".

"make" -C /data/riotbuild/riotbase/pkg/qr-code-generator
"make" -C /data/riotbuild/riotbase/build/pkg/qr-code-generator/c -f /data/riotbuild/riotbase/pkg/qr-code-generator/qr-code-generator.mk
"make" -C /data/riotbuild/riotbase/boards/adafruit-clue
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/nrf52
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf52/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf52/vectors
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/disp_dev
"make" -C /data/riotbuild/riotbase/drivers/ili9341
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/auto_init/screen
"make" -C /data/riotbuild/riotbase/sys/auto_init/usb
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/event
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/usb/usbus
"make" -C /data/riotbuild/riotbase/sys/usb/usbus/cdc/acm
"make" -C /data/riotbuild/riotbase/sys/usb_board_reset
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  24948	    128	   7868	  32944	   80b0	/data/riotbuild/riotbase/tests/pkg_qr-code-generator/bin/adafruit-clue/tests_pkg_qr-code-generator.elf
adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application /work/riot/RIOT/tests/pkg_qr-code-generator/bin/adafruit-clue/tests_pkg_qr-code-generator.hex /work/riot/RIOT/tests/pkg_qr-code-generator/bin/adafruit-clue/tests_pkg_qr-code-generator.hex.zip
Zip created at /work/riot/RIOT/tests/pkg_qr-code-generator/bin/adafruit-clue/tests_pkg_qr-code-generator.hex.zip
adafruit-nrfutil dfu serial --port=/dev/ttyACM0 --baudrate=115200 --touch=1200 --package=/work/riot/RIOT/tests/pkg_qr-code-generator/bin/adafruit-clue/tests_pkg_qr-code-generator.hex.zip --singlebank
Upgrading target on /dev/ttyACM0 with DFU package /work/riot/RIOT/tests/pkg_qr-code-generator/bin/adafruit-clue/tests_pkg_qr-code-generator.hex.zip. Flow control is disabled, Single bank, Touch 1200
########################################
#########
Activating new firmware
Device programmed.
sleep 2
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.07-devel-205-g47042-pr/tests/qr-code-generator-opt)
██████████████  ██████████    ██    ██████████████
██          ██  ██    ██      ████  ██          ██
██  ██████  ██  ████    ██  ████    ██  ██████  ██
██  ██████  ██  ████        ██      ██  ██████  ██
██  ██████  ██  ██████████  ████    ██  ██████  ██
██          ██    ██  ██    ████    ██          ██
██████████████  ██  ██  ██  ██  ██  ██████████████
                ██      ██████  ██                
  ████  ██  ████    ██████  ██████  ██  ██████████
  ████    ██  ████████  ██        ████          ██
  ██  ████████  ██  ██  ████                ██████
██████  ██    ██    ██  ██            ██      ██  
          ████████  ██  ██        ██████  ██  ████
  ██          ████    ██  ██    ██████    ██    ██
██    ██    ██    ████████        ██  ██    ██████
  ██    ████  ████    ██        ██  ██  ██    ██  
██      ██  ██████          ████████████████      
                ██████    ██  ████      ████  ████
██████████████  ████████  ████████  ██  ████  ████
██          ██    ██  ██████    ██      ████    ██
██  ██████  ██  ██████████      ████████████    ██
██  ██████  ██    ████  ██  ██        ████████    
██  ██████  ██  ██  ████      ██  ██    ██      ██
██          ██  ████    ██████████      ████  ██  
██████████████          ██      ██  ████      ████

SUCCESS
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #16462 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
