### PR TITLE
boards/native: Document flashpage support

### DIFF
--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -12,7 +12,9 @@
 # Hardware
 - CPU: Host CPU
 - RAM: Host RAM
-- Flash: Host file system
+- Flash:
+    - for program execution: Host file system
+    - for the @ref drivers_periph_flashpage : emulated in RAM
 - Network: Tap Interface
 - UART: Runtime configurable - `/dev/tty*` are supported
 - Timers: Host timer


### PR DESCRIPTION
### Contribution description / commit message

This documents the additions of [15935].

[15935]: https://github.com/RIOT-OS/RIOT/pull/15935

### Rationale

The previous documentation content was, in light of the changes, misleading in that it could be assumed that flash reads/writes also go to the FS.

Writing to the FS may be an actual improvement -- but is not what happens right now. (I do however consider adding that; ).