### PR TITLE
boards: Adding board support for the Seeeduino XIAO

### DIFF
--- a/boards/seeeduino_xiao/Kconfig
+++ b/boards/seeeduino_xiao/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "seeeduino_xiao" if BOARD_SEEEDUINO_XIAO
+
+config BOARD_SEEEDUINO_XIAO
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/seeeduino_xiao/Makefile
+++ b/boards/seeeduino_xiao/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/samdx1-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/seeeduino_xiao/Makefile.dep
+++ b/boards/seeeduino_xiao/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.dep

--- a/boards/seeeduino_xiao/Makefile.features
+++ b/boards/seeeduino_xiao/Makefile.features
@@ -1,0 +1,13 @@
+CPU = samd21
+CPU_MODEL = samd21g18a
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev

--- a/boards/seeeduino_xiao/Makefile.include
+++ b/boards/seeeduino_xiao/Makefile.include
@@ -1,0 +1,6 @@
+CFLAGS += -DBOOTLOADER_UF2
+
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
+# Include handling of serial and non-bossa programmers (if selected by user)
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/seeeduino_xiao/board.c
+++ b/boards/seeeduino_xiao/board.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C)    2021 Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeeduino_xiao
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Seeeduino XIAO board
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+#include "timex.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the on-board LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+
+    LED0_OFF;
+    LED1_OFF;
+    LED2_OFF;
+}

--- a/boards/seeeduino_xiao/doc.txt
+++ b/boards/seeeduino_xiao/doc.txt
@@ -1,0 +1,38 @@
+/**
+@defgroup    boards_seeeduino_xiao Seeeduino XIAO
+@ingroup     boards
+@brief       Support for the Seeeduino XIAO.
+
+### General information
+
+The Seeeduino XIAO is the smallest member of the Seeeduino family. It carries the powerful ATSAMD21G18A-MU which is a low-power microcontrollers. On the other hand, this little board has good performance in processing but needs less power. As a matter of fact, it is designed in a tiny size and can be used for wearable devices and small projects.
+
+Seeeduino XIAO has 14 GPIO PINs, which can be used for 11 digital interfaces, 11 mock interfaces, 10 PWM interfaces (d1-d10), 1 DAC output pin D0, 1 SWD pad interface, 1 I2C interface, 1 SPI interface, 1 UART interface, Serial communication indicator (T/R), Blink light (L). The colors of LEDs(Power,L,RX,TX) are green, yellow, blue and blue. Moreover, Seeeduino XIAO has a Type-C interface which can supply power and download code. There are two reset button, you can short connect them to reset the board.
+
+-- General description of the [wiki](https://wiki.seeedstudio.com/Seeeduino-XIAO/)
+
+### Pinout
+
+![XIAO pinout](https://files.seeedstudio.com/wiki/Seeeduino-XIAO/img/Seeeduino-XIAO-pinout.jpg)
+
+### Flash the board
+
+Use `BOARD=seeeduino_xiao` with the `make` command.<br/>
+
+Example with `default` application:
+```
+     make BOARD=seeeduino_xiao -C examples/default flash
+```
+
+RIOT will automatically trigger a reset to the bootloader, but this only works if RIOT is still
+running on the board.
+If your application has crashed or got erased, `make flash` will not be able to trigger a bootloader reset.
+
+To manually enter the bootloader, short the RST pins with a short line or tweezers
+You know you've successfully entered the bootloader when the orange LED flickers on and light up.
+
+![Reset Sequence](https://files.seeedstudio.com/wiki/Seeeduino-XIAO/img/XIAO-reset.gif)
+
+Sometimes flashing fails and the board gets stuck in the bootloader.
+In this case, just run `make flash` again when the device is not busy anymore.
+ */

--- a/boards/seeeduino_xiao/include/board.h
+++ b/boards/seeeduino_xiao/include/board.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C)    2021 Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeeduino_xiao
+ * @brief       Support for the Seeeduino XIAO board.
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Seeeduino XIAO
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED_PORT            PORT->Group[PA]
+
+#define LED0_PIN            GPIO_PIN(PA, 18)
+#define LED0_MASK           (1 << 18)
+#define LED0_NAME           "LED(BLUE_RX)"
+
+#define LED0_OFF            (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_ON             (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PA, 19)
+#define LED1_MASK           (1 << 19)
+#define LED1_NAME           "LED(BLUE_TX)"
+
+#define LED1_OFF            (LED_PORT.OUTSET.reg = LED1_MASK)
+#define LED1_ON             (LED_PORT.OUTCLR.reg = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT.OUTTGL.reg = LED1_MASK)
+
+#define LED2_PIN            GPIO_PIN(PA, 17)
+#define LED2_MASK           (1 << 17)
+#define LED2_NAME           "LED(YELLOW_USER)"
+
+#define LED2_OFF            (LED_PORT.OUTSET.reg = LED2_MASK)
+#define LED2_ON             (LED_PORT.OUTCLR.reg = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT.OUTTGL.reg = LED2_MASK)
+/** @} */
+
+/**
+ * @name USB configuration
+ * @{
+ */
+#define INTERNAL_PERIPHERAL_VID         (0x239A)
+#define INTERNAL_PERIPHERAL_PID         (0x0057)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/seeeduino_xiao/include/gpio_params.h
+++ b/boards/seeeduino_xiao/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C)  2021 Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeeduino_xiao
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = LED0_NAME,
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = LED1_NAME,
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = LED2_NAME,
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/seeeduino_xiao/include/periph_conf.h
+++ b/boards/seeeduino_xiao/include/periph_conf.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C)  2021  Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_seeeduino_xiao
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Serpente board
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC3,
+        .irq            = TC3_IRQn,
+        .pm_mask        = PM_APBCMASK_TC3,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = SAM0_GCLK_1MHZ,
+#else
+        .gclk_src       = SAM0_GCLK_MAIN,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT16,
+    },
+    {   /* Timer 1 */
+        .dev            = TC4,
+        .irq            = TC4_IRQn,
+        .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = SAM0_GCLK_1MHZ,
+#else
+        .gclk_src       = SAM0_GCLK_MAIN,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+#define TIMER_0_MAX_VALUE   0xffff
+
+/* interrupt function name mapping */
+#define TIMER_0_ISR         isr_tc3
+#define TIMER_1_ISR         isr_tc4
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB, 9),    /* D5 */
+        .tx_pin   = GPIO_PIN(PB, 8),    /* D4 */
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom4
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* D0 … D2 (user pins) */
+        .dev      = &SERCOM0->SPI,
+        .miso_pin = GPIO_PIN(PA, 5),    /* D9 */
+        .mosi_pin = GPIO_PIN(PA, 6),    /* D10 */
+        .clk_pin  = GPIO_PIN(PA, 7),    /* D8 */
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_1,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 9),    /* D5 */
+        .sda_pin  = GPIO_PIN(PA, 8),    /* D4 */
+        .mux      = GPIO_MUX_D,
+        .gclk_src = SAM0_GCLK_MAIN,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#endif
+/** @} */
+
+/**
+ * @name    ADC Default values
+ * @{
+ */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},
+    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},
+    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},
+    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},
+    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},
+    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},
+    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2},
+    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS_PIN3}
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -80,6 +80,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samr30-xpro \
     samr34-xpro \
     seeeduino_arch-pro \
+    seeeduino_xiao \
     sensebox_samd21 \
     serpente \
     slstk3400a \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -56,6 +56,7 @@ LOW_MEMORY_BOARDS += \
   opencm904 \
   saml10-xpro \
   saml11-xpro \
+  seeeduino_xiao \
   sensebox_samd21 \
   serpente \
   sodaq-autonomo \


### PR DESCRIPTION
### Contribution description

This pull request adds support for the Seeeduino XIAO board for RIOT OS. 
This implementation is based of the Serpente R2 board.
The feature PWM is not available in the current pull request.

### Testing procedure
The implementation passed all standard periphery tests. (UART, I2C, SPI etc.)