### PR TITLE
examples/gcoap: add support for socket ZEP

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -35,6 +35,21 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+# Instead of simulating an Ethernet connection, we can also simulate
+# an IEEE 802.15.4 radio using ZEP
+USE_ZEP ?= 0
+
+# set the ZEP port for native
+ZEP_PORT_BASE ?= 17754
+ifeq (1,$(USE_ZEP))
+  TERMFLAGS += -z [::1]:$(ZEP_PORT_BASE)
+  USEMODULE += socket_zep
+
+  ifneq (,$(ZEP_MAC))
+    TERMFLAGS += --eui64=$(ZEP_MAC)
+  endif
+endif
+
 include $(RIOTBASE)/Makefile.include
 
 # For now this goes after the inclusion of Makefile.include so Kconfig symbols


### PR DESCRIPTION
### Contribution description

To simulate gcoap on a 802.15.4 node we can use the `socket_zep` network interface for `native`.
This adds a convenient make variable to enable this with a single command line option.

### Testing procedure

 - create tap interface

        sudo dist/tools/tapsetup/tapsetup

  - start ZEP border router

        make -C examples/gnrc_border_router BOARD=native all term

 - run gcoap example with a simulated 802.15.4 interface with custom MAC address
 
        make -C examples/gcoap BOARD=native USE_ZEP=1 ZEP_MAC=\"E6:CB:21:BF:9B:F8:72:62\" all term

```
main(): This is RIOT! (Version: 2021.07-devel-225-gc21097)
gcoap example app
All up, running the shell now
> ifconfig
ifconfig
Iface  7  HWaddr: 72:62  Channel: 26  NID: 0x23 
          Long HWaddr: E6:CB:21:BF:9B:F8:72:62 
          L2-PDU:102  MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::e4cb:21bf:9bf8:7262  scope: link  VAL
          inet6 addr: 2001:db8::e4cb:21bf:9bf8:7262  scope: global  VAL
          inet6 group: ff02::1
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
