### PR TITLE
drivers/w5100/w5100.c: fix TX_WR register's value

### DIFF
--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -201,7 +201,8 @@ static int send(netdev_t *netdev, const iolist_t *iolist)
     /* get access to the SPI bus for the duration of this function */
     spi_acquire(dev->p.spi, dev->p.cs, SPI_CONF, dev->p.clk);
 
-    uint16_t pos = raddr(dev, S0_TX_WR0, S0_TX_WR1);
+    uint16_t tx_wr = raddr(dev, S0_TX_WR0, S0_TX_WR1);
+    uint16_t pos = (tx_wr & S0_MASK) + S0_TX_BASE;
 
     /* the register is only set correctly after the first send pkt, so we need
      * this fix here */
@@ -215,7 +216,7 @@ static int send(netdev_t *netdev, const iolist_t *iolist)
         sum += len;
     }
 
-    waddr(dev, S0_TX_WR0, S0_TX_WR1, pos);
+    waddr(dev, S0_TX_WR0, S0_TX_WR1, tx_wr + sum);
 
     /* trigger the sending process */
     wreg(dev, S0_CR, CR_SEND_MAC);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
drivers/w5100/w5100.c
fix w5100's TX_WR register's value. Let the value exceed 0x2000.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #16417