### PR TITLE
net/ieee802154/submac: calculate aUnitbackoffPeriod at runtime

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -27,6 +27,7 @@
 #include "byteorder.h"
 #include "net/eui64.h"
 #include "kernel_defines.h"
+#include "timex.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -24,7 +24,6 @@
 #include "errno.h"
 #include <assert.h>
 
-#define CSMA_SENDER_BACKOFF_PERIOD_UNIT_MS  (320U)
 #define ACK_TIMEOUT_US                      (864U)
 
 static void _handle_tx_no_ack(ieee802154_submac_t *submac);

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -24,8 +24,6 @@
 #include "errno.h"
 #include <assert.h>
 
-#define ACK_TIMEOUT_US                      (864U)
-
 static void _handle_tx_no_ack(ieee802154_submac_t *submac);
 
 static uint32_t _symbol_duration(ieee802154_submac_t *submac)
@@ -244,7 +242,7 @@ static void _handle_tx_success(ieee802154_submac_t *submac,
         ieee802154_radio_set_rx_mode(dev, IEEE802154_RX_WAIT_FOR_ACK);
 
         /* Handle ACK reception */
-        ieee802154_submac_ack_timer_set(submac, ACK_TIMEOUT_US);
+        ieee802154_submac_ack_timer_set(submac, ieee802154_get_ack_wait_duration(submac));
     }
 }
 

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -28,26 +28,25 @@
 
 static void _handle_tx_no_ack(ieee802154_submac_t *submac);
 
-static inline bool _is_on_channel_range(ieee802154_submac_t *submac,
-                                        uint8_t page, uint16_t start,
-                                        uint16_t end)
-{
-    return submac->channel_page == page && submac->channel_num >= start &&
-           submac->channel_num <= end;
-}
-
 static uint32_t _symbol_duration(ieee802154_submac_t *submac)
 {
     /* Rule applies to (62.5 ksymbol/s):
      * - page 0, channels 11-26 on 2.4 GHz O-QPSK PHY,
      * - page 2, channels 1-10 on 915 MHz O-QPSK PHY */
-    if (_is_on_channel_range(submac, 0, 11, 26) ||
-        _is_on_channel_range(submac, 2, 1, 10)) {
+    if ((submac->channel_page == 0 && submac->channel_num >= 11 && submac->channel_num <= 26) ||
+        (submac->channel_page == 2 && submac->channel_num >= 1 && submac->channel_num <= 10)) {
         return 16; /* 62.5 ksymbol/s */
+    }
+    /* - page 0, channel 0,  on 868 MHz BPSK PHY */
+    else if (submac->channel_page == 0 && submac->channel_num == 0) {
+        return 50; /* 20 ksymbol/s */
+    }
+    else if (submac->channel_page == 0 && submac->channel_num >= 1 && submac->channel_num <= 10) {
+        return 25; /* 40 ksymbol/s */
     }
     /* Rules applies to (25 ksymbol/s):
      * - page 2, channel 0 on 868 MHz O-QPSK PHY */
-    else if (_is_on_channel_range(submac, 2, 0, 0)) {
+    else if (submac->channel_page == 2 && submac->channel_num == 0) {
         return 40; /* 25 ksymbol/s */
     }
 

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -361,6 +361,8 @@ int constants(int argc, char **argv)
            ieee802154_get_cca_time(submac));
     printf("Unit backoff period: %"PRIu32" us\n",
            ieee802154_get_unit_backoff_period(submac));
+    printf("ACK wait duration: %"PRIu32" us\n",
+           ieee802154_get_ack_wait_duration(submac));
 
     return 0;
 }
@@ -368,7 +370,7 @@ int constants(int argc, char **argv)
 static const shell_command_t shell_commands[] = {
     { "print_addr", "Print IEEE802.15.4 addresses", print_addr },
     { "txtsnd", "Send IEEE 802.15.4 packet", txtsnd },
-    { "constants", "Print summary of IEEE 802.15.4 PHY/MAC constants", constants },
+    { "constants", "Print summary of IEEE 802.15.4 PHY/MAC constants and attributes", constants },
     { NULL, NULL, NULL }
 };
 

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -346,9 +346,29 @@ int txtsnd(int argc, char **argv)
     return send(addr, res, len);
 }
 
+int constants(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    const ieee802154_submac_t *submac = &netdev_submac.submac;
+
+    printf("Symbol duration: %"PRIu16" us\n",
+           ieee802154_get_symbol_duration(submac));
+    printf("Turn-around time: %"PRIu32" us\n",
+           ieee802154_get_turnaround_time(submac));
+    printf("CCA time: %"PRIu32" us\n",
+           ieee802154_get_cca_time(submac));
+    printf("Unit backoff period: %"PRIu32" us\n",
+           ieee802154_get_unit_backoff_period(submac));
+
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
     { "print_addr", "Print IEEE802.15.4 addresses", print_addr },
     { "txtsnd", "Send IEEE 802.15.4 packet", txtsnd },
+    { "constants", "Print summary of IEEE 802.15.4 PHY/MAC constants", constants },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
### Contribution description

Now aUnitBackoffPeriod is calculated at runtime from the current symbol duration and the value of the _aTurnaroundTime_ and _aCcaTime_ constants. This allows to add other PHYs that don't have fixed values for this constant and depend on the PHY configuration (symbol duration mostly).

Transceivers using the submac should work as usual since nrf52 and cc2538 use the same back-off period (320 us) and the added functions yield the same results. For other transceivers such as AT86RF212B (when ported to the HAL) may get a back-off period of either 320 us or 800 us depending on the band used.

### Testing procedure

- `make -C tests/ieee802154_submac BOARD=<board> term`

And send the `constants` command.

### Issues/PRs references

N/A