### PR TITLE
.github: add automatic PR labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,154 @@
+"Area: arduino API":
+  - sys/arduino/**/*
+
+"Area: BLE":
+  - pkg/nimble/**/*
+  - sys/net/ble/**/*
+  - sys/include/net/bluetil/**/*
+  - sys/include/net/skald/**/*
+  - sys/include/net/skald.h
+
+"Area: boards":
+  - boards/**/*
+
+"Area: build system":
+  - Makefile.*
+  - makefiles/**/*
+  - ./**/*.mk
+
+"Area: CI":
+  - .circleci/**/*
+  - .github/**/*.yml
+  - .murdock
+
+"Area: CoAP":
+  - sys/net/application_layer/*coap/**/*
+  - sys/include/net/*coap*/**/*
+
+"Area: core":
+  - core/**/*
+
+"Area: cpu":
+  - cpu/**/*
+
+"Area: doc":
+  - doc/**/*
+  - ./*.md
+
+"Area: drivers":
+  - drivers/**/*
+
+"Area: examples":
+  - examples/**/*
+
+"Area: Kconfig":
+  - dist/tools/kconfiglib/**/*
+  - makefiles/kconfig.mk
+  - kconfigs/*
+  - Kconfig
+
+"Area: LoRa":
+  - drivers/llcc68/**/*
+  - drivers/sx126x/**/*
+  - drivers/sx127x/**/*
+  - drivers/include/llcc68.h
+  - drivers/include/sx126x.h
+  - drivers/include/sx127x.h
+  - pkg/semtech-loramac/**/*
+  - sys/net/lora/**/*
+  - sys/net/gnrc/link_layer/lorawan/**/*
+  - sys/include/net/lorawan/**/*
+  - sys/include/net/gnrc/lorawan/**/*
+  - sys/include/net/gnrc/lorawan.h
+  - sys/include/net/lora.h
+  - sys/include/net/loramac.h
+
+"Area: network":
+  - sys/net/**/*
+  - sys/include/net/**/*
+  - pkg/lwip/**/*
+  - pkg/openthread/**/*
+  - pkg/openwsn/**/*
+  - pkg/paho-mqtt/**/*
+
+"Area: OTA":
+  - sys/suit/**/*
+  - sys/include/suit/**/*
+  - sys/include/suit.h
+
+"Area: pkg":
+  - pkg/**/*
+
+"Area: SAUL":
+  - drivers/saul/**/*
+  - drivers/include/saul/**/*
+  - drivers/include/saul.h
+  - sys/saul_reg/**/*
+  - sys/include/saul_reg.h
+
+"Area: sys":
+  - sys/**/*
+
+"Area: tests":
+  - tests/**/*
+  - fuzzing/**/*
+  - dist/pythonlibs/**/*
+  - makefiles/tests/**/*
+
+"Area: timers":
+  - sys/*timer/**/*
+  - sys/include/*timer/**/*
+  - sys/include/*timer.h
+
+"Area: toolchain":
+  - makefiles/toolchain/**/*
+
+"Area: tools":
+  - dist/tools/**/*
+  - dist/testbed-support/**/*
+  - makefiles/tools/**/*
+
+"Area: USB":
+  - sys/usb/**/*
+  - sys/include/usb/**/*
+  - sys/include/usb.h
+
+"Platform: native":
+  - boards/native/**/*
+  - cpu/native/**/*
+
+"Platform: ARM":
+  - cpu/arm7_common/**/*
+  - cpu/cortexm_common/**/*
+  - cpu/cc2*/**/*
+  - cpu/efm32/**/*
+  - cpu/kinetis/**/*
+  - cpu/lm4f120/**/*
+  - cpu/lpc*/**/*
+  - cpu/nrf5*/**/*
+  - cpu/qn908x/**/*
+  - cpu/sam*/**/*
+  - cpu/stellaris_common/**/*
+  - cpu/stm32/**/*
+  - makefiles/arch/cortexm.inc.mk
+
+"Platform: AVR":
+  - cpu/atmega*/**/*
+  - cpu/avr8_common/**/*
+  - makefiles/arch/avr8.inc.mk
+
+"Platform: ESP":
+  - cpu/esp*/**/*
+
+"Platform: MIPS":
+  - cpu/mips*/**/*
+  - makefiles/arch/mips.inc.mk
+
+"Platform: MSP":
+  - cpu/msp*/**/*
+  - makefiles/arch/msp430.inc.mk
+
+"Platform: RISC-V":
+  - cpu/riscv_common/**/*
+  - cpu/fe310/**/*
+  - makefiles/arch/riscv.inc.mk

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: pr-labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a new github action to automatically assign `Area: *` labels to newly opened PRs. This is based on the [labeler action](https://github.com/actions/labeler).

Some rules are predefined for setting the most common `Area: *` labels but we can probably finely tune them, later.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

There are 3 `REMOVEME` commits that should automatically add `Area: boards`, `Area: cpu` and `Area: build system` labels.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Useful with https://github.com/RIOT-OS/RIOT-release-manager/pull/20 which relies on those labels being set to automatically and correctly generate the release notes.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
