### PR TITLE
core: forward declare msg_t in thread.h

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -168,7 +168,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "sched.h"
+#include "thread.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,7 +182,7 @@ extern "C" {
  * the corresponding fields are never read by the kernel.
  *
  */
-typedef struct {
+struct msg {
     kernel_pid_t sender_pid;    /**< PID of sending thread. Will be filled in
                                      by msg_send. */
     uint16_t type;              /**< Type field. */
@@ -190,7 +190,7 @@ typedef struct {
         void *ptr;              /**< Pointer content field. */
         uint32_t value;         /**< Value content field. */
     } content;                  /**< Content of the message. */
-} msg_t;
+};
 
 
 /**

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -121,7 +121,6 @@
 
 #include "clist.h"
 #include "cib.h"
-#include "msg.h"
 #include "cpu_conf.h"
 #include "sched.h"
 #include "thread_config.h"
@@ -162,6 +161,11 @@ extern "C" {
  * @brief Prototype for a thread entry function
  */
 typedef void *(*thread_task_func_t)(void *arg);
+
+/**
+ * @brief Forward declaration of msg_t
+ */
+typedef struct msg msg_t;
 
 /**
  * @brief @c thread_t holds thread's context data.

--- a/core/msg.c
+++ b/core/msg.c
@@ -23,11 +23,9 @@
 #include <stddef.h>
 #include <inttypes.h>
 #include <assert.h>
-#include "sched.h"
-#include "msg.h"
+#include "thread.h"
 #include "msg_bus.h"
 #include "list.h"
-#include "thread.h"
 #if MODULE_CORE_THREAD_FLAGS
 #include "thread_flags.h"
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Alternative to #16458.
This forward-declares msg_t in thread.h, and adapts thread.h, sched.h and msg.h accordingly.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
