### PR TITLE
tests/disp_dev: improve genericity of application + optimize screen refresh

### DIFF
--- a/tests/disp_dev/Makefile
+++ b/tests/disp_dev/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 DISABLE_MODULE += test_utils_interactive_sync
 
-USEMODULE += ili9341
+USEMODULE += auto_init_screen
 USEMODULE += disp_dev
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/disp_dev/main.c
+++ b/tests/disp_dev/main.c
@@ -22,40 +22,44 @@
 
 #include "disp_dev.h"
 
-#include "ili9341.h"
-#include "ili9341_params.h"
-#include "ili9341_disp_dev.h"
-
 #include "riot_logo.h"
 
 #include "test_utils/expect.h"
 
-static ili9341_t ili9341;
+#if IS_USED(MODULE_ILI9341)
+#include "ili9341.h"
+#endif
 
 int main(void)
 {
-    ili9341_init(&ili9341, &ili9341_params[0]);
+    /* Use the first screen */
+    disp_dev_reg_t *disp_dev = disp_dev_reg_find_screen(0);
+    if (!disp_dev) {
+        puts("No screen found!");
+        return -1;
+    }
 
-    disp_dev_t *dev = (disp_dev_t *)&ili9341;
-    dev->driver = &ili9341_disp_dev_driver;
-
-    disp_dev_set_invert(dev, true);
+    disp_dev_set_invert(disp_dev->dev, true);
     disp_dev_backlight_on();
 
-    uint16_t max_width = disp_dev_width(dev);
-    uint16_t max_height = disp_dev_height(dev);
+    uint16_t max_width = disp_dev_width(disp_dev->dev);
+    uint16_t max_height = disp_dev_height(disp_dev->dev);
 
-    expect(max_width == ili9341.params->lines);
+#if IS_USED(MODULE_ILI9341)
+    ili9341_t *ili9341 = (ili9341_t *)disp_dev->dev;
+    expect(ili9341);
+    expect(max_width == ili9341->params->lines);
     expect(max_height == 240);
+#endif
 
     uint16_t color = 0;
     for (uint16_t y = 0; y < max_height; ++y) {
         for (uint16_t x = 0; x < max_width; ++x) {
-            disp_dev_map(dev, x, x, y, y, &color);
+            disp_dev_map(disp_dev->dev, x, x, y, y, &color);
         }
     }
 
-    disp_dev_map(dev, 95, 222, 85, 153, (const uint16_t *)picture);
+    disp_dev_map(disp_dev->dev, 95, 222, 85, 153, (const uint16_t *)picture);
 
     puts("SUCCESS");
 

--- a/tests/disp_dev/main.c
+++ b/tests/disp_dev/main.c
@@ -30,6 +30,9 @@
 #include "ili9341.h"
 #endif
 
+#define DISPLAY_BUFFER_MAX_SIZE (320)
+static uint16_t display_buffer[DISPLAY_BUFFER_MAX_SIZE] = { 0 };
+
 int main(void)
 {
     /* Use the first screen */
@@ -52,11 +55,8 @@ int main(void)
     expect(max_height == 240);
 #endif
 
-    uint16_t color = 0;
     for (uint16_t y = 0; y < max_height; ++y) {
-        for (uint16_t x = 0; x < max_width; ++x) {
-            disp_dev_map(disp_dev->dev, x, x, y, y, &color);
-        }
+        disp_dev_map(disp_dev->dev, 0, max_width - 1, y, y, display_buffer);
     }
 
     disp_dev_map(disp_dev->dev, 95, 222, 85, 153, (const uint16_t *)picture);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the `tests/disp_dev` test application in order to remove the explicit dependency to the ili9341 module by using `auto_init_screen` and the related API.

There's also a small optimization of the screen refresh: apply the null pixel by lines instead of pixel by pixel. This is much faster but needs a buffer (so increase memory usage).

I'm also wondering if `auto_init_screen` shouldn't be made a default module when disp_dev is used. This would simplify the application Makefile again but would enforce all display device with a `disp_dev` adaption layer to provide an `auto_init` function. Thoughts ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Tested on adafruit-clue and the RIOT logo is displayed as expected (but faster)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Thought of it after reviewing #12509 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
