### PR TITLE
tests/touch_dev: improve genericity by using auto_init_screen module

### DIFF
--- a/tests/touch_dev/Makefile
+++ b/tests/touch_dev/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 DISABLE_MODULE += test_utils_interactive_sync
 
-USEMODULE += stmpe811
+USEMODULE += auto_init_screen
 USEMODULE += touch_dev
 USEMODULE += xtimer
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is similar to #16479 but applied to the `tests/touch_dev` application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- The test application is still functional. Tested on stm32f429i-disc1:

<details>

```
$ USE_PROGRAMMER_WRAPPER_SCRIPT=1 BUILD_IN_DOCKER=1 make -C tests/touch_dev flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/touch_dev/' 'riot/riotbuild:latest' make     
Building application "tests_touch_dev" for "stm32f429i-disc1" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/stm32f429i-disc1
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/stmpe811
"make" -C /data/riotbuild/riotbase/drivers/touch_dev
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/auto_init/screen
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  13580	    112	   2516	  16208	   3f50	/data/riotbuild/riotbase/tests/touch_dev/bin/stm32f429i-disc1/tests_touch_dev.elf
For full programmer output add PROGRAMMER_QUIET=0 or QUIET=0 to the make command line.
 ✓ Flashing done! (programmer: 'openocd' - duration: 2.01s)
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-05-19 11:34:53,361 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2021-05-19 11:34:55,828 # Event: pressed!
2021-05-19 11:34:55,829 # X: 201, Y:130
2021-05-19 11:34:55,840 # Event: X: 203, Y:132
2021-05-19 11:34:55,852 # X: 202, Y:132
2021-05-19 11:34:55,864 # X: 202, Y:132
2021-05-19 11:34:55,882 # X: 203, Y:131
2021-05-19 11:34:55,894 # X: 203, Y:131
2021-05-19 11:34:55,906 # X: 202, Y:131
2021-05-19 11:34:55,918 # Event: released!
2021-05-19 11:34:57,340 # Event: pressed!
2021-05-19 11:34:57,346 # X: 248, Y:173
2021-05-19 11:34:57,358 # X: 248, Y:174
2021-05-19 11:34:57,369 # X: 248, Y:173
2021-05-19 11:34:57,382 # X: 247, Y:173
2021-05-19 11:34:57,393 # X: 247, Y:172
2021-05-19 11:34:57,405 # X: 245, Y:171
2021-05-19 11:34:57,429 # Event: X: 243, Y:172
2021-05-19 11:34:57,435 # Event: released!
2021-05-19 11:34:57,447 # Event: pressed!
2021-05-19 11:34:57,448 # X: 211, Y:187
2021-05-19 11:34:57,459 # released!
2021-05-19 11:34:57,531 # Event: pressed!
2021-05-19 11:34:57,532 # X: 170, Y:189
2021-05-19 11:34:57,543 # X: 169, Y:189
2021-05-19 11:34:57,555 # X: 167, Y:189
2021-05-19 11:34:57,573 # X: 165, Y:188
2021-05-19 11:34:57,585 # X: 163, Y:182
2021-05-19 11:34:57,597 # Event: X: 162, Y:182
2021-05-19 11:34:57,609 # released!
2021-05-19 11:34:58,132 # Event: Event: pressed!
2021-05-19 11:34:58,133 # X: 168, Y:119
2021-05-19 11:34:58,144 # X: 168, Y:118
2021-05-19 11:34:58,155 # X: 167, Y:118
2021-05-19 11:34:58,173 # X: 167, Y:118
2021-05-19 11:34:58,186 # X: 166, Y:118
2021-05-19 11:34:58,197 # Event: released!
2021-05-19 11:34:58,672 # Event: Event: pressed!
2021-05-19 11:34:58,677 # X: 157, Y:127
2021-05-19 11:34:58,690 # X: 156, Y:128
2021-05-19 11:34:58,702 # X: 157, Y:127
2021-05-19 11:34:58,714 # X: 156, Y:127
2021-05-19 11:34:58,726 # X: 156, Y:127
2021-05-19 11:34:58,737 # X: 156, Y:127
2021-05-19 11:34:58,755 # X: 156, Y:127
2021-05-19 11:34:58,767 # Event: released!
2021-05-19 11:35:00,099 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
