### PR TITLE
boards/samr21-xpro: namespace board_init

### DIFF
--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -35,7 +35,7 @@ void board_antenna_config(uint8_t antenna)
     }
 }
 
-void board_init(void)
+void board_samr21_xpro_init(void)
 {
     /* initialize the on-board LED */
     gpio_init(LED0_PIN, GPIO_OUT);
@@ -49,4 +49,9 @@ void board_init(void)
 
     /* initialize the CPU */
     cpu_init();
+}
+
+void __attribute__((weak)) board_init(void)
+{
+    board_samr21_xpro_init();
 }


### PR DESCRIPTION

### Contribution description

This PR namespace the `samr21-xpro` board init to allow overriding the `board_init` sequence when inheriting from this `BOARD` for external `BOARD`s

### Testing procedure

- Murdock should take care of this