### PR TITLE
boards/feather-nrf52840: namespace board_init

### DIFF
--- a/boards/feather-nrf52840/board.c
+++ b/boards/feather-nrf52840/board.c
@@ -18,7 +18,7 @@
 
 #include "periph/gpio.h"
 
-void board_init(void)
+void board_feather_nrf52840_init(void)
 {
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
@@ -28,6 +28,11 @@ void board_init(void)
 
     /* initialize the CPU */
     cpu_init();
+}
+
+void __attribute__((weak)) board_init(void)
+{
+    board_feather_nrf52840_init();
 }
 
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR namespace the `feather-nrf52840` board init to allow overriding the `board_init` sequence when inheriting from this `BOARD` for external `BOARD`s

### Testing procedure

- Murdock should take care of this