### PR TITLE
drivers/{disp_dev,touch_dev}: add auto_init_screen as default module when used

### DIFF
--- a/drivers/disp_dev/Kconfig
+++ b/drivers/disp_dev/Kconfig
@@ -8,3 +8,4 @@
 config MODULE_DISP_DEV
     bool "Display device generic API"
     depends on TEST_KCONFIG
+    imply MODULE_AUTO_INIT_SCREEN

--- a/drivers/disp_dev/Makefile.dep
+++ b/drivers/disp_dev/Makefile.dep
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += auto_init_screen

--- a/drivers/touch_dev/Kconfig
+++ b/drivers/touch_dev/Kconfig
@@ -8,5 +8,6 @@
 config MODULE_TOUCH_DEV
     bool "Touch device generic API"
     depends on TEST_KCONFIG
+    imply MODULE_AUTO_INIT_SCREEN
     help
         This API is experimental and in an early state - expect changes!

--- a/drivers/touch_dev/Makefile.dep
+++ b/drivers/touch_dev/Makefile.dep
@@ -1,0 +1,1 @@
+DEFAULT_MODULE += auto_init_screen

--- a/pkg/lvgl/Makefile.dep
+++ b/pkg/lvgl/Makefile.dep
@@ -17,8 +17,6 @@ ifneq (,$(filter lvgl_contrib_touch,$(USEMODULE)))
   USEMODULE += touch_dev
 endif
 
-DEFAULT_MODULE += auto_init_screen
-
 # lvgl is not compatible with non 32bit platforms
 # Building lv_misc triggers the error:
 # "left shift count >= width of type [-Werror=shift-count-overflow]"

--- a/tests/disp_dev/Makefile
+++ b/tests/disp_dev/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 
 DISABLE_MODULE += test_utils_interactive_sync
 
-USEMODULE += auto_init_screen
 USEMODULE += disp_dev
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_qr-code-generator/Kconfig
+++ b/tests/pkg_qr-code-generator/Kconfig
@@ -1,7 +1,6 @@
 config APPLICATION
     bool
     default y
-    imply MODULE_AUTO_INIT_SCREEN if BOARD_HAS_DISPLAY
     imply MODULE_DISP_DEV if BOARD_HAS_DISPLAY
     depends on TEST_KCONFIG
 

--- a/tests/pkg_qr-code-generator/Makefile.board.dep
+++ b/tests/pkg_qr-code-generator/Makefile.board.dep
@@ -1,5 +1,4 @@
 # Boards with a screen can use disp_dev
 ifneq (,$(filter stm32f429i-disc% pinetime adafruit-clue esp32-wrover-kit,$(BOARD)))
-  USEMODULE += auto_init_screen
   USEMODULE += disp_dev
 endif

--- a/tests/touch_dev/Makefile
+++ b/tests/touch_dev/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 
 DISABLE_MODULE += test_utils_interactive_sync
 
-USEMODULE += auto_init_screen
 USEMODULE += touch_dev
 USEMODULE += xtimer
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR simplifies a bit the dependency resolution around the disp_dev and touch_dev modules. Now that #16479 and #16480 are merged it's possible to automatically set auto_init_screen as a default module when disp_dev and touch_dev modules are used.

As a result, by default,  it enforces any device providing a disp_dev/touch_dev interface to provide an auto_init function (since auto_init is used by default as well). But one can disable this using `DISABLE_MODULE += auto_init_screen` from an application that manually initialize the specific device driver.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- `tests/disp_dev`, `tests/touch_dev`, `tests/pkg_qr-code-generator`, `tests/pkg_lvgl` and `tests/pkg_lvgl_touch` are still working

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #16479 and #16480

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
