### PR TITLE
pkg/lvgl: remove internal thread

### DIFF
--- a/pkg/lvgl/include/lvgl_riot.h
+++ b/pkg/lvgl/include/lvgl_riot.h
@@ -33,9 +33,9 @@ extern "C" {
 void lvgl_init(screen_dev_t *screen_dev);
 
 /**
- * Start the lvgl task handler background thread
+ * Run the lvgl task handler
 */
-void lvgl_start(void);
+void lvgl_run(void);
 
 /**
  * @brief   Wakeup lvgl when inactive

--- a/pkg/lvgl/include/lvgl_riot.h
+++ b/pkg/lvgl/include/lvgl_riot.h
@@ -33,8 +33,14 @@ extern "C" {
 void lvgl_init(screen_dev_t *screen_dev);
 
 /**
- * Run the lvgl task handler
-*/
+ * @brief   Run the lvgl task handler
+ *
+ * In order to run the lvgl internal task handler in an endless loop, this
+ * function must be called manually either from the main thread or from a
+ * custom thread.
+ * In case of CONFIG_LVGL_INACTIVITY_PERIOD_MS ms of inactivity, the loop stops
+ * the thread running the lvgl task handler until @ref lvgl_wakeup is called.
+ */
 void lvgl_run(void);
 
 /**

--- a/tests/pkg_lvgl/main.c
+++ b/tests/pkg_lvgl/main.c
@@ -121,10 +121,10 @@ int main(void)
     /* Enable backlight */
     disp_dev_backlight_on();
 
-    lvgl_start();
-
     /* Create the system monitor widget */
     sysmon_create();
+
+    lvgl_run();
 
     return 0;
 }

--- a/tests/pkg_lvgl/main.c
+++ b/tests/pkg_lvgl/main.c
@@ -111,9 +111,8 @@ void sysmon_create(void)
     info_label = lv_label_create(win, NULL);
     lv_label_set_recolor(info_label, true);
 
-    /* Refresh the chart and label manually at first */
+    /* Create the task used to refresh the chart and label */
     refr_task = lv_task_create(sysmon_task, REFR_TIME, LV_TASK_PRIO_LOW, NULL);
-    sysmon_task(NULL);
 }
 
 int main(void)

--- a/tests/pkg_lvgl_touch/main.c
+++ b/tests/pkg_lvgl_touch/main.c
@@ -57,7 +57,7 @@ int main(void)
     lv_obj_t * label = lv_label_create(btn, NULL);
     lv_label_set_text(label, "Click me");
 
-    lvgl_start();
+    lvgl_run();
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a small refactoring of the lvgl integration into RIOT: the internal thread used to trigger the lvgl task handler is removed and `lvgl_start` is renamed `lvgl_run`. It's still possible to run lvgl in its own thread, but this becomes the responsibility of the user  to do that.

There's one call to `lv_task_handler();` that is moved from `lvgl_init` to the beginning of `lvgl_run`. I'm suspecting that this change might fix the issue reported in #16471.

Since there's one thread less in `tests/pkg_lvgl` and `tests/pkg_lvgl_touch`, this PR frees up 2K of RAM on both.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- `tests/pkg_lvgl` and `tests/pkg_lvgl_touch` are still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Might help with #16471 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
