### PR TITLE
boards/esp32-wrover-kit: add dependency to ILI9341

### DIFF
--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -1,1 +1,5 @@
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += ili9341
+endif
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep


### PR DESCRIPTION
### Contribution description

When `disp_dev` is present, pull the ili9341 driver to allow auto-initialization. Previously initialization of LVGL failed because no display was found.

### Testing procedure

- `make -C tests/pkg_lvgl BOARD=esp32-wrover-kit flash`. See the system monitor test 😉 

### Issues/PRs references

Fixes #16471 
