### PR TITLE
tools/testbed: use IOTLAB_NODE=auto instead of auto-ssh

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.boards.riot }}
     env:
-      IOTLAB_NODE: auto-ssh
+      IOTLAB_NODE: auto
       BUILD_IN_DOCKER: 1
       # Force .bin files generation because these files are used to flash on IoT-LAB and
       # because compile_and_test_for_board forces RIOT_CI_BUILD which skip .bin

--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -44,8 +44,14 @@ ifeq (,$(IOTLAB_NODE))
   $(warning    Example: m3-380.grenoble.iot-lab.info or a8-1.grenoble.iot-lab.info)
   $(warning  * <type>-<number> when run from iot-lab frontend)
   $(warning    Example: m3-380 or a8-1)
-  $(warning  * 'auto' or 'auto-ssh' to try auto-detecting the node from your experiment
+  $(warning  * 'auto' to try auto-detecting the node from your experiment
   $(error)
+endif
+
+ifeq (auto-ssh,$(IOTLAB_NODE))
+  $(info $(COLOR_YELLOW)IOTLAB_NODE=auto-ssh is deprecated and will be removed after \
+         2010.07 is released, use IOTLAB_NODE=auto instead$(COLOR_RESET))
+  override IOTLAB_NODE := auto
 endif
 
 IOTLAB_AUTH ?= $(HOME)/.iotlabrc
@@ -57,7 +63,7 @@ IOTLAB_EXP_ID ?=
 # Specify experiment-id option if provided
 _IOTLAB_EXP_ID := $(if $(IOTLAB_EXP_ID),--id $(IOTLAB_EXP_ID))
 
-# Number of the node to take from the list in 'auto' and 'auto-ssh' mode
+# Number of the node to take from the list in 'auto' mode
 # Default to 1 so the first one
 IOTLAB_NODE_AUTO_NUM ?= 1
 
@@ -109,18 +115,18 @@ endif
 #    * Check correctly deployed nodes with 'deploymentresults == "0"'
 #    * Select nodes by architucture using the board-archi mapping
 #    * Nodes for current server in 'auto'
-ifneq (,$(filter auto auto-ssh,$(IOTLAB_NODE)))
+ifeq (auto,$(IOTLAB_NODE))
   ifeq (,$(IOTLAB_ARCHI))
     $(error Could not find 'archi' for $(BOARD), update mapping in $(lastword $(MAKEFILE_LIST)))
   endif
 
-  ifeq (auto,$(IOTLAB_NODE))
-    _NODES_DEPLOYED := $(filter %.$(shell hostname).iot-lab.info, $(_NODES_DEPLOYED))
+  ifneq (,$(IOT_LAB_FRONTEND_FQDN))
+    _NODES_DEPLOYED := $(filter %.$(IOT_LAB_FRONTEND_FQDN), $(_NODES_DEPLOYED))
   endif
   _NODES_FOR_BOARD = $(shell iotlab-experiment --jmespath="items[?archi=='$(IOTLAB_ARCHI)'].network_address" --format='" ".join' get $(_IOTLAB_EXP_ID) $(_NODES_LIST_OPTION))
 
   _IOTLAB_NODE := $(word $(IOTLAB_NODE_AUTO_NUM),$(filter $(_NODES_DEPLOYED),$(_NODES_FOR_BOARD)))
-  ifeq (auto,$(IOTLAB_NODE))
+  ifneq (,$(IOT_LAB_FRONTEND_FQDN))
     override IOTLAB_NODE := $(firstword $(subst ., ,$(_IOTLAB_NODE)))
   else
     override IOTLAB_NODE := $(_IOTLAB_NODE)
@@ -129,24 +135,14 @@ ifneq (,$(filter auto auto-ssh,$(IOTLAB_NODE)))
   ifeq (,$(IOTLAB_NODE))
     $(error Could not automatically find a node for BOARD=$(BOARD))
   endif
-  override IOTLAB_NODE := $(patsubst node-%,%,$(IOTLAB_NODE))
 endif
 
-
-# If the IOTLAB_NODE format is:
-# * 'type-num.iot.lab.info' assume it is run from your computer
-# * 'type-num' assume it is run from iot-lab frontend
-ifneq (,$(filter %.iot-lab.info, $(IOTLAB_NODE)))
-  _IOTLAB_ON_FRONTEND =
-else
-  _IOTLAB_ON_FRONTEND = 1
-endif
 # Work with node url without 'node-'
 override IOTLAB_NODE := $(patsubst node-%,%,$(IOTLAB_NODE))
 
-
 # Create node list and optionally frontend url
-ifeq (,$(_IOTLAB_ON_FRONTEND))
+ifeq (,$(IOT_LAB_FRONTEND_FQDN))
+  # Running from a local computer
   # m3-380.grenoble.iot-lab.info    -> grenoble,m3,380
   # a8-1.grenoble.iot-lab.info      -> grenoble,a8,1
   _NODELIST_SED := 's/\([^.]*\)-\([^.]*\).\([^.]*\).*/\3,\1,\2/'
@@ -156,6 +152,7 @@ ifeq (,$(_IOTLAB_ON_FRONTEND))
   _IOTLAB_SERVER := $(shell echo '$(IOTLAB_NODE)' | sed 's/[^.]*.//')
   _IOTLAB_AUTHORITY = $(IOTLAB_USER)@$(_IOTLAB_SERVER)
 else
+  # Running from an IoT-LAB frontend
   # m3-380    -> $(hostname),m3,380
   # a8-1      -> $(hostname),a8,1
   _NODELIST_SED := 's/\([^.]*\)-\([^.]*\)/$(shell hostname),\1,\2/'
@@ -164,7 +161,7 @@ endif
 
 
 # Display value of IOTLAB_NODE, useful to get the value calculated when using
-# IOTLAB_NODE=auto or auto-ssh
+# IOTLAB_NODE=auto
 .PHONY: info-iotlab-node
 info-iotlab-node:
 	@echo $(IOTLAB_NODE)
@@ -181,7 +178,7 @@ ifneq (iotlab-a8-m3,$(BOARD))
   FFLAGS      = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) $(_NODES_FLASH_OPTION) $(FLASHFILE)
   RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) $(_IOTLAB_NODELIST) --reset
 
-  ifeq (,$(_IOTLAB_ON_FRONTEND))
+  ifeq (,$(IOT_LAB_FRONTEND_FQDN))
     TERMPROG  = ssh
     TERMFLAGS = -t $(_IOTLAB_AUTHORITY) 'socat - tcp:$(IOTLAB_NODE):20000'
   else
@@ -199,7 +196,7 @@ else
   RESET_FLAGS = $(_NODE_FMT) $(_IOTLAB_EXP_ID) reset-m3 $(_IOTLAB_NODELIST)
 
   TERMPROG  = ssh
-  ifeq (,$(_IOTLAB_ON_FRONTEND))
+  ifeq (,$(IOT_LAB_FRONTEND_FQDN))
     # Proxy ssh through the iot-lab frontend
     TERMFLAGS = -oProxyCommand='ssh $(_IOTLAB_AUTHORITY) -W %h:%p'
   else

--- a/examples/lorawan/README.md
+++ b/examples/lorawan/README.md
@@ -75,7 +75,7 @@ for that device.
 
 2. flash device, set appropriate keys and test
 
-    $ DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> IOTLAB_NODE=auto-ssh make -C examples/lorawan/ flash test
+    $ DEVEUI=<device eui> APPEUI=<application eui> APPKEY=<application key> IOTLAB_NODE=auto make -C examples/lorawan/ flash test
 
 3. stop the iotlab experiment:
 

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -256,7 +256,7 @@ for ABP. The test assumes that both devices have the same Application EUI.
 
 2. flash device with the appropriate keys and test
 
-    $ DEVEUI=<...> APPEUI=<...> APPKEY=<...> DEVADDR=<...> NWKSKEY=<...> APPSKEY=<...> RX2_DR=<...> IOTLAB_NODE=auto-ssh make -C tests/pkg_semtech-loramac flash test
+    $ DEVEUI=<...> APPEUI=<...> APPKEY=<...> DEVADDR=<...> NWKSKEY=<...> APPSKEY=<...> RX2_DR=<...> IOTLAB_NODE=auto make -C tests/pkg_semtech-loramac flash test
 
 3. stop the iotlab experiment:
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR ticks the item in #9694 which is about merging auto and auto-ssh possible values for IOTLAB_NODE. As said by @cladmi, since there's an IOT_LAB_FRONTEND_FQDN env variable on the frontend there's no need to distinguish between auto and auto-ssh.
This makes the usage of IOTLAB_NODE more simple as well as cleaning up the internal implementation.

This PR also adds a deprecation message when auto-ssh is uses.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on IoT-LAB with several iotlab-m3 and a8-m3:

```
$ iotlab-experiment submit -d 120 -l saclay,a8,110 -l grenoble,m3,20-31 -l saclay,m3,1-2
```

- Build and flash an application for the M3, use auto to select one automatically (the first one in grenoble is used):

<details>

```
$ BUILD_IN_DOCKER=1 make -C examples/default BOARD=iotlab-m3 IOTLAB_NODE=auto flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=iotlab-m3'  -w '/data/riotbuild/riotbase/examples/default/' 'riot/riotbuild:latest' make 'BOARD=iotlab-m3'    
Building application "default" for "iotlab-m3" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/iotlab-m3
"make" -C /data/riotbuild/riotbase/boards/common/iotlab
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/at86rf2xx
"make" -C /data/riotbuild/riotbase/drivers/isl29020
"make" -C /data/riotbuild/riotbase/drivers/l3g4200d
"make" -C /data/riotbuild/riotbase/drivers/lpsxxx
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/netdev
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/drivers/saul/init_devs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/net/gnrc
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netapi
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/hdr
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/ieee802154
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/init_devs
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netreg
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pkt
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktbuf
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktbuf_static
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktdump
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/eui_provider
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/ieee802154
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/l2util
"make" -C /data/riotbuild/riotbase/sys/net/netif
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/od
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  47292	    136	   6028	  53456	   d0d0	/data/riotbuild/riotbase/examples/default/bin/iotlab-m3/default.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list grenoble,m3,20 --flash /work/riot/RIOT/examples/default/bin/iotlab-m3/default.bin
ssh -t abadie@grenoble.iot-lab.info 'socat - tcp:m3-20.grenoble.iot-lab.info:20000' 
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
rtc                  control RTC peripheral interface
ifconfig             Configure network interfaces
txtsnd               Sends a custom string as is over the link layer
saul                 interact with sensors and actuators using SAUL
> reboot
reboot
[auto_init_saul] error initializing l3g4200d #0
[auto_init_saul] error initializing lps331ap #0
[auto_init_saul] error initializing lsm303dlhc #0
main(): This is RIOT! (Version: 2021.07-devel-246-g22dec-pr/tools/iotlab_deprecate_auto_ssh)
Welcome to RIOT!
> ^CConnection to grenoble.iot-lab.info closed.
```

</details>

- Build and flash an application for the M3, use the hostname to select one specifically in saclay:

<details>

```
$ BUILD_IN_DOCKER=1 make -C examples/default BOARD=iotlab-m3 IOTLAB_NODE=m3-1.saclay.iot-lab.info flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=iotlab-m3'  -w '/data/riotbuild/riotbase/examples/default/' 'riot/riotbuild:latest' make 'BOARD=iotlab-m3'    
Building application "default" for "iotlab-m3" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/iotlab-m3
"make" -C /data/riotbuild/riotbase/boards/common/iotlab
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/at86rf2xx
"make" -C /data/riotbuild/riotbase/drivers/isl29020
"make" -C /data/riotbuild/riotbase/drivers/l3g4200d
"make" -C /data/riotbuild/riotbase/drivers/lpsxxx
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/netdev
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/drivers/saul/init_devs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/net/gnrc
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netapi
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/hdr
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/ieee802154
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/init_devs
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netreg
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pkt
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktbuf
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktbuf_static
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktdump
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/eui_provider
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/ieee802154
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/l2util
"make" -C /data/riotbuild/riotbase/sys/net/netif
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/od
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  47292	    136	   6028	  53456	   d0d0	/data/riotbuild/riotbase/examples/default/bin/iotlab-m3/default.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,m3,1 --flash /work/riot/RIOT/examples/default/bin/iotlab-m3/default.bin
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-1.saclay.iot-lab.info:20000' 
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
rtc                  control RTC peripheral interface
ifconfig             Configure network interfaces
txtsnd               Sends a custom string as is over the link layer
saul                 interact with sensors and actuators using SAUL
> reboot
reboot
[auto_init_saul] error initializing l3g4200d #0
[auto_init_saul] error initializing lps331ap #0
[auto_init_saul] error initializing lsm303dlhc #0
main(): This is RIOT! (Version: 2021.07-devel-246-g22dec-pr/tools/iotlab_deprecate_auto_ssh)
Welcome to RIOT!
> ^CConnection to saclay.iot-lab.info closed.
```

</details>

- Build and flash an application for the A8-M3, use the auto to select one automatically in saclay (you need version 1.0.2 of iotlabsshcli for this one to work because of a bug, well missing feature, when flashing .bin firmwares in earlier versions):

<details>

```
$ BUILD_IN_DOCKER=1 make -C examples/default BOARD=iotlab-a8-m3 IOTLAB_NODE=auto flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=iotlab-a8-m3'  -w '/data/riotbuild/riotbase/examples/default/' 'riot/riotbuild:latest' make 'BOARD=iotlab-a8-m3'    
Building application "default" for "iotlab-a8-m3" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/iotlab-a8-m3
"make" -C /data/riotbuild/riotbase/boards/common/iotlab
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/at86rf2xx
"make" -C /data/riotbuild/riotbase/drivers/l3g4200d
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/netdev
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/saul
"make" -C /data/riotbuild/riotbase/drivers/saul/init_devs
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/net/gnrc
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netapi
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/hdr
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/ieee802154
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/init_devs
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netreg
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pkt
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktbuf
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktbuf_static
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/pktdump
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/eui_provider
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/ieee802154
"make" -C /data/riotbuild/riotbase/sys/net/link_layer/l2util
"make" -C /data/riotbuild/riotbase/sys/net/netif
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/od
"make" -C /data/riotbuild/riotbase/sys/phydat
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/saul_reg
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  45024	    136	   5956	  51116	   c7ac	/data/riotbuild/riotbase/examples/default/bin/iotlab-a8-m3/default.elf
iotlab-ssh --jmespath='keys(values(@)[0])[0]' --fmt='int'  flash-m3 --list saclay,a8,110 /work/riot/RIOT/examples/default/bin/iotlab-a8-m3/default.bin
sys:1: DeprecationWarning: flash-m3 command is deprecated and will be removed in next release. Please use flash instead.


0
ssh -oProxyCommand='ssh abadie@saclay.iot-lab.info -W %h:%p' -oStrictHostKeyChecking=no -t root@node-a8-110.saclay.iot-lab.info 'socat - open:/dev/ttyA8_M3,b500000,echo=0,raw' 
help
help
Command              Description
---------------------------------------
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
rtc                  control RTC peripheral interface
ifconfig             Configure network interfaces
txtsnd               Sends a custom string as is over the link layer
saul                 interact with sensors and actuators using SAUL
> reboot
reboot
main(): This is RIOT! (Version: 2021.07-devel-246-g22dec-pr/tools/iotlab_deprecate_auto_ssh)
Welcome to RIOT!
> ^CConnection to node-a8-110.saclay.iot-lab.info closed.
```

</details>

This PR also works when the commands above are launched from an IoT-LAB SSH frontend (except the one for A8-M3 because of the bug about .bin firmwares that is fixed in version 1.0.2 of iotlab-ssh but not released on the frontends).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #9694

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
