### PR TITLE
gnrc_tcp: align with sock tcp

### DIFF
--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -102,6 +102,14 @@ int gnrc_tcp_init(void);
 void gnrc_tcp_tcb_init(gnrc_tcp_tcb_t *tcb);
 
 /**
+ * @brief Initialize Transmission Control Block (TCB) queue
+ * @pre @p queue must not be NULL.
+ *
+ * @param[in,out] queue   TCB queue to initialize.
+ */
+void gnrc_tcp_tcb_queue_init(gnrc_tcp_tcb_queue_t *queue);
+
+/**
  * @brief Opens a connection.
  *
  * @pre gnrc_tcp_tcb_init() must have been successfully called.
@@ -168,6 +176,7 @@ int gnrc_tcp_listen(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t *tcbs, size_t tc
  *
  * @return 0 on success.
  * @return -ENOMEM if all connection in @p queue were already accepted.
+ * @return -EINVAL if listen was never called on queue.
  * @return -EAGAIN if @p user_timeout_duration_ms was 0 and no connection is ready to accept.
  * @return -ETIMEDOUT if @p user_timeout_duration_ms was not 0 and no connection
  *                    could be established.
@@ -262,6 +271,48 @@ void gnrc_tcp_abort(gnrc_tcp_tcb_t *tcb);
  * @param[in,out] queue   TCB queue to stop listening
  */
 void gnrc_tcp_stop_listen(gnrc_tcp_tcb_queue_t *queue);
+
+/**
+ * @brief Get the local end point of a connected TCB
+ *
+ * @pre tcb must not be NULL
+ * @pre ep must not be NULL
+ *
+ * @param[in] tcb   TCB holding the connection information.
+ * @param[out] ep   The local end point.
+ *
+ * @return  0 on success.
+ * @return  -EADDRNOTAVAIL, when @p tcb in not in a connected state.
+ */
+int gnrc_tcp_get_local(gnrc_tcp_tcb_t *tcb, gnrc_tcp_ep_t *ep);
+
+/**
+ * @brief Get the remote end point of a connected TCB
+ *
+ * @pre tcb must not be NULL
+ * @pre ep must not be NULL
+ *
+ * @param[in] tcb   TCB holding the connection information.
+ * @param[out] ep   The remote end point.
+ *
+ * @return  0 on success.
+ * @return  -ENOTCONN, when @p tcb in not in a connected state.
+ */
+int gnrc_tcp_get_remote(gnrc_tcp_tcb_t *tcb, gnrc_tcp_ep_t *ep);
+
+/**
+ * @brief Gets the local end point of a TCB queue
+ *
+ * @pre queue must not be NULL
+ * @pre ep must not be NULL
+ *
+ * @param[in] queue   TCB queue to stop listening
+ * @param[out] ep     The local end point.
+ *
+ * @return  0 on success.
+ * @return  -EADDRNOTAVAIL, when @p queue has no local end point.
+ */
+int gnrc_tcp_queue_get_local(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_ep_t *ep);
 
 /**
  * @brief Calculate and set checksum in TCP header.

--- a/tests/gnrc_tcp/main.c
+++ b/tests/gnrc_tcp/main.c
@@ -217,6 +217,10 @@ int gnrc_tcp_accept_cmd(int argc, char **argv)
     int timeout = atol(argv[1]);
     int err = gnrc_tcp_accept(&queue, &tmp, timeout);
     switch (err) {
+        case -EINVAL:
+            printf("%s: returns -EINVAL\n", argv[0]);
+            break;
+
         case -EAGAIN:
             printf("%s: returns -EAGAIN\n", argv[0]);
             break;
@@ -341,6 +345,78 @@ int gnrc_tcp_stop_listen_cmd(int argc, char **argv)
     return 0;
 }
 
+int gnrc_tcp_get_local_cmd(int argc, char **argv)
+{
+    dump_args(argc, argv);
+    gnrc_tcp_ep_t ep;
+
+    int err = gnrc_tcp_get_local(tcb, &ep);
+    switch (err) {
+        case 0:
+            printf("%s: returns 0\n", argv[0]);
+            printf("Endpoint: addr.ipv6=");
+            ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+            printf(" netif=%u port=%u\n", ep.netif, ep.port);
+            break;
+
+        case -EADDRNOTAVAIL:
+            printf("%s: returns -EADDRNOTAVAIL\n", argv[0]);
+            break;
+
+        default:
+            printf("%s: returns %d\n", argv[0], err);
+    }
+    return 0;
+}
+
+int gnrc_tcp_get_remote_cmd(int argc, char **argv)
+{
+    dump_args(argc, argv);
+    gnrc_tcp_ep_t ep;
+
+    int err = gnrc_tcp_get_remote(tcb, &ep);
+    switch (err) {
+        case 0:
+            printf("%s: returns 0\n", argv[0]);
+            printf("Endpoint: addr.ipv6=");
+            ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+            printf(" netif=%u port=%u\n", ep.netif, ep.port);
+            break;
+
+        case -ENOTCONN:
+            printf("%s: returns -ENOTCONN\n", argv[0]);
+            break;
+
+        default:
+            printf("%s: returns %d\n", argv[0], err);
+    }
+    return 0;
+}
+
+int gnrc_tcp_queue_get_local_cmd(int argc, char **argv)
+{
+    dump_args(argc, argv);
+    gnrc_tcp_ep_t ep;
+
+    int err = gnrc_tcp_queue_get_local(&queue, &ep);
+    switch (err) {
+        case 0:
+            printf("%s: returns 0\n", argv[0]);
+            printf("Endpoint: addr.ipv6=");
+            ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+            printf(" netif=%u port=%u\n", ep.netif, ep.port);
+            break;
+
+        case -EADDRNOTAVAIL:
+            printf("%s: returns -EADDRNOTAVAIL\n", argv[0]);
+            break;
+
+        default:
+            printf("%s: returns %d\n", argv[0], err);
+    }
+    return 0;
+}
+
 /* Exporting GNRC TCP Api to for shell usage */
 static const shell_command_t shell_commands[] = {
     { "gnrc_tcp_ep_from_str", "Build endpoint from string",
@@ -363,6 +439,12 @@ static const shell_command_t shell_commands[] = {
       gnrc_tcp_abort_cmd },
     { "gnrc_tcp_stop_listen", "gnrc_tcp: stop listening",
       gnrc_tcp_stop_listen_cmd },
+    { "gnrc_tcp_get_local", "gnrc_tcp: get local",
+      gnrc_tcp_get_local_cmd },
+    { "gnrc_tcp_get_remote", "gnrc_tcp: get remote",
+      gnrc_tcp_get_remote_cmd },
+    { "gnrc_tcp_queue_get_local", "gnrc_tcp: get queue local",
+      gnrc_tcp_queue_get_local_cmd },
     { "buffer_init", "init internal buffer",
       buffer_init_cmd },
     { "buffer_get_max_size", "get max size of internal buffer",


### PR DESCRIPTION
### Contribution description
This PR implements all missing functions and API changes for SOCK_TCP integration to GNRC_TCP. 

### Testing procedure
All new functions and return codes are tested within the GNRC_TCP suite.
Just execute the tests under tests/gnrc_tcp

### Issues/PRs references
Depends on PR #16459
Depends on PR #16461
Fixes #10664 - TCP Sockets can not be used / built
