### PR TITLE
makefiles: add info-kconfig-boards-supported target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -227,17 +227,23 @@ include $(RIOTMAKE)/cargo-settings.inc.mk
 
 GLOBAL_GOALS += buildtest \
                 buildtest-indocker \
+                create-Makefile.ci \
                 info-boards-features-blacklisted \
                 info-boards-features-conflicting \
                 info-boards-features-missing \
                 info-boards-supported \
                 info-buildsizes info-buildsizes-diff \
-                create-Makefile.ci \
+                info-kconfig-boards-supported \
+                info-kconfig-board-supported-% \
                 #
 
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
-  include $(RIOTMAKE)/info-global.inc.mk
-  include $(RIOTMAKE)/buildtests.inc.mk
+  ifneq (, $(TEST_KCONFIG))
+    include $(RIOTMAKE)/info-kconfig.inc.mk
+  else
+    include $(RIOTMAKE)/buildtests.inc.mk
+    include $(RIOTMAKE)/info-global.inc.mk
+  endif
 else
 
 all: link

--- a/Makefile.include
+++ b/Makefile.include
@@ -238,12 +238,9 @@ GLOBAL_GOALS += buildtest \
                 #
 
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
-  ifneq (, $(TEST_KCONFIG))
     include $(RIOTMAKE)/info-kconfig.inc.mk
-  else
     include $(RIOTMAKE)/buildtests.inc.mk
     include $(RIOTMAKE)/info-global.inc.mk
-  endif
 else
 
 all: link

--- a/makefiles/info-kconfig.inc.mk
+++ b/makefiles/info-kconfig.inc.mk
@@ -1,5 +1,15 @@
 .PHONY: info-kconfig-board-supported-% info-kconfig-boards-supported
 
+ifneq (1,$(TEST_KCONFIG))
+
+info-kconfig-boards-supported:
+	@echo "To run $@ please set TEST_KCONFIG=1"
+
+info-kconfig-board-supported-%:
+	@echo "To run $@ please set TEST_KCONFIG=1"
+
+else
+
 # This is the root Kconfig
 KCONFIG ?= $(RIOTBASE)/Kconfig
 
@@ -85,3 +95,5 @@ info-kconfig-board-supported-%:
 	  --kconfig-filename $(KCONFIG) $(if $(Q),,--debug )\
 	  --config-sources $($*_CONFIG_SOURCES) $(if $(Q),2> /dev/null) && \
 	  printf "%s " $* || true
+
+endif # TEST_KCONFIG

--- a/makefiles/info-kconfig.inc.mk
+++ b/makefiles/info-kconfig.inc.mk
@@ -20,7 +20,9 @@ include $(RIOTMAKE)/tools/kconfiglib.inc.mk
 export KCONFIG_GENERATED_DEPENDENCIES
 
 # This file will contain external module configurations
-export KCONFIG_EXTERNAL_CONFIGS
+export KCONFIG_EXTERNAL_MODULE_CONFIGS
+# This file will contain external package configurations
+export KCONFIG_EXTERNAL_PKG_CONFIGS
 
 # replicate the QUIET logic as in Makefile.include
 QUIET ?= 1

--- a/makefiles/info-kconfig.inc.mk
+++ b/makefiles/info-kconfig.inc.mk
@@ -1,0 +1,87 @@
+.PHONY: info-kconfig-board-supported-% info-kconfig-boards-supported
+
+# This is the root Kconfig
+KCONFIG ?= $(RIOTBASE)/Kconfig
+
+# Include tools targets
+include $(RIOTMAKE)/tools/kconfiglib.inc.mk
+
+# This file will contain the calculated dependencies formated in Kconfig
+export KCONFIG_GENERATED_DEPENDENCIES
+
+# This file will contain external module configurations
+export KCONFIG_EXTERNAL_CONFIGS
+
+# replicate the QUIET logic as in Makefile.include
+QUIET ?= 1
+QQ=
+ifeq ($(QUIET),1)
+  Q=@
+else
+  Q=
+endif
+
+# Known configuration sources
+KCONFIG_APP_CONFIG = $(APPDIR)/app.config
+KCONFIG_USER_CONFIG = $(APPDIR)/user.config
+
+# Similarly to `info-global.inc.mk` we gather certain variables of all riot boards, needed to run
+# the kconfig script in `info-kconfig-board-supported-%`. Namely:
+# - CPU
+# - Configuration sources (.config files)
+# - BOARDDIR
+#
+define gather_board_variables
+  BOARD := $(1)
+
+  # Undefine variables that must not be defined when starting.
+  # Some are sometime set as `?=`
+  undefine CPU
+  undefine CPU_MODEL
+  undefine CPU_CORE
+  undefine CPU_FAM
+  undefine CPU_ARCH
+  undefine KCONFIG_ADD_CONFIG
+
+  # Find matching board folder
+  BOARDDIR := $$(word 1,$$(foreach dir,$$(BOARDSDIRS),$$(wildcard $$(dir)/$$(BOARD)/.)))
+
+  include $(RIOTBASE)/Makefile.features
+
+  $$(BOARD)_CONFIG_SOURCES := $$(KCONFIG_ADD_CONFIG)
+  $$(BOARD)_CONFIG_SOURCES += $$(wildcard $(KCONFIG_APP_CONFIG))
+  $$(BOARD)_CONFIG_SOURCES += $$(wildcard $(KCONFIG_APP_CONFIG).$$(BOARD))
+  $$(BOARD)_CONFIG_SOURCES += $$(wildcard $(KCONFIG_USER_CONFIG))
+  $$(BOARD)_CPU := $$(CPU)
+  $$(BOARD)_BOARDDIR := $$(BOARDDIR)
+
+endef
+
+# Only gather all boards variables if `info-kconfig-boards-supported` is called, otherwise just get
+# the variables of the requested boards
+ifneq (,$(filter info-kconfig-boards-supported,$(MAKECMDGOALS)))
+  $(foreach board, $(BOARDS), $(eval $(call gather_board_variables,$(board))))
+else
+  _QUERIES := $(foreach q, $(filter info-kconfig-board-supported-%,$(MAKECMDGOALS)), $(q))
+  _QUERIED_BOARDS := $(patsubst info-kconfig-board-supported-%,%,$(_QUERIES))
+  $(foreach board, $(_QUERIED_BOARDS), $(eval $(call gather_board_variables,$(board))))
+endif
+
+info-kconfig-boards-supported: $(foreach board, $(BOARDS), info-kconfig-board-supported-$(board))
+
+# Determines if a board is supported for the current application, given the application dependencies
+# and/or configurations.
+# Firstly we check if the board exists in the board list. Then we call the Kconfig script with the
+# application directory, board and configuration sources that should be merged. The script will
+# check if the configurations could be applied.
+#
+# If the board is supported the board's name is printed, otherwise there is no output.
+#
+info-kconfig-board-supported-%:
+	$(Q)$(if $(filter $*,$(BOARDS)), true, false) && \
+	  BOARD=$* CPU=$($*_CPU) APPDIR=$(APPDIR) BOARDDIR=$($*_BOARDDIR) RIOTBOARD=$(RIOTBOARD) \
+	  RIOTCPU=$(RIOTCPU) KCONFIG_GENERATED_DEPENDENCIES="none" KCONFIG_EXTERNAL_CONFIGS="none" \
+	  $(GENCONFIG) \
+	  --kconfig-filename $(KCONFIG) $(if $(Q),,--debug )\
+	  --config-sources $($*_CONFIG_SOURCES) $(if $(Q),2> /dev/null) && \
+	  printf "%s " $* || true


### PR DESCRIPTION
### Contribution description
This adds a logic to check which boards are supported for the current application given a certain configuration. It is based on the `genconfig.py` script.

- `info-kconfig-boards-supported`: returns a list of all supported boards
- `info-kconfig-board-supported-<BOARD>`: returns <BOARD> if it is supported

`info-kconfig-boards-supported` is slower than `info-boards-supported`, as the python script needs to be executed for every board, and Kconfig checks not only modules but that all configurations could be applied correctly.
As there is one target per board to determine if that board is supported, calling make with `-j` speeds things up a lot.

### Testing procedure
- run the targets in some application (e.g. `hello-world`), you should get the same output as `info-boards-supported`
- An interesting check to see that this is working is `tests/driver_edbg_eui` which only supports `samr21-xpro`

### Issues/PRs references
None so far
