### PR TITLE
sys/auto_init: new auto_init_storage

### DIFF
--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -17,13 +17,14 @@
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  * @}
  */
-
+#include "kernel_defines.h"
 #include "board.h"
 #include "periph/gpio.h"
 #include "mtd_spi_nor.h"
+#include "mtd_at24cxxx.h"
 #include "timex.h"
 
-#ifdef MODULE_MTD
+#if IS_USED(MODULE_MTD)
 /* N25Q256A */
 static const mtd_spi_nor_params_t _same54_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
@@ -51,7 +52,7 @@ static mtd_spi_nor_t same54_nor_dev = {
 };
 mtd_dev_t *mtd0 = (mtd_dev_t *)&same54_nor_dev;
 
-#include "mtd_at24cxxx.h"
+#if !IS_USED(MODULE_AUTO_INIT_STORAGE_AT24CXXX)
 #include "at24cxxx_params.h"
 static at24cxxx_t at24cxxx_dev;
 static mtd_at24cxxx_t at24mac_dev = {
@@ -62,6 +63,9 @@ static mtd_at24cxxx_t at24mac_dev = {
     .params = at24cxxx_params,
 };
 mtd_dev_t *mtd1 = (mtd_dev_t *)&at24mac_dev;
+#else
+mtd_dev_t *mtd1;
+#endif /* !IS_USED(MODULE_AUTO_INIT_STORAGE_AT24CXXX) */
 #endif /* MODULE_MTD */
 
 void board_init(void)
@@ -75,4 +79,9 @@ void board_init(void)
 
     /* initialize the CPU */
     cpu_init();
+
+#if IS_USED(MODULE_MTD) && \
+    IS_USED(MODULE_AUTO_INIT_STORAGE_AT24CXXX)
+    mtd1 = (mtd_dev_t *)mtd_at24cxxx_devs();
+#endif
 }

--- a/boards/same54-xpro/include/mtd_at24cxxx_params.h
+++ b/boards/same54-xpro/include/mtd_at24cxxx_params.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Otto-von-Guericke Universität
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mtd_at24cxxx
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for AT24CXXX MTD
+ *
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
+ */
+#ifndef MTD_AT24CXXX_PARAMS_H
+#define MTD_AT24CXXX_PARAMS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef MTD_AT24CXXX_NUMOF
+/**
+ * @brief   Number of at24cxxx MTD
+ */
+#define MTD_AT24CXXX_NUMOF        1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_AT24CXXX_PARAMS_H */
+/** @} */

--- a/drivers/at24cxxx/include/mtd_at24cxxx_params.h
+++ b/drivers/at24cxxx/include/mtd_at24cxxx_params.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Otto-von-Guericke Universität
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mtd_at24cxxx
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for AT24CXXX MTD
+ *
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
+ */
+#ifndef MTD_AT24CXXX_PARAMS_H
+#define MTD_AT24CXXX_PARAMS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef MTD_AT24CXXX_NUMOF
+/**
+ * @brief   Number of at24cxxx MTD
+ */
+#define MTD_AT24CXXX_NUMOF        0
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_AT24CXXX_PARAMS_H */
+/** @} */

--- a/drivers/include/at24cxxx.h
+++ b/drivers/include/at24cxxx.h
@@ -209,6 +209,31 @@ int at24cxxx_enable_write_protect(const at24cxxx_t *dev);
  */
 int at24cxxx_disable_write_protect(const at24cxxx_t *dev);
 
+#if IS_USED(MODULE_AUTO_INIT_STORAGE_AT24CXXX) || defined(DOXYGEN)
+/**
+ * @brief   Signed type to store a unique ID for each auto-initialized
+ *          at24cxxx device
+ */
+typedef int8_t at24cxxx_id_t;
+/**
+ * @brief   Maximum ID of an at24cxxx device
+ */
+#define AT24CXXX_ID_MAX \
+    ((((1LL << (sizeof(at24cxxx_id_t) * 8 - 2)) - 1) << 1) + 1)
+/**
+ * @brief   Get a pointer to all auto-initialized at24cxxx devices
+ *
+ * @return  Pointer to an array of all auto-initilized at24cxxx devices
+ */
+at24cxxx_t *at24cxxx_devs(void);
+/**
+ * @brief   Get the number of auto-initialized at24cxxx devices
+ *
+ * @return  Number of auto-initialized at24cxxx devices
+ */
+at24cxxx_id_t at24cxxx_numof(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/mtd_at24cxxx.h
+++ b/drivers/include/mtd_at24cxxx.h
@@ -59,6 +59,21 @@ typedef struct {
  */
 extern const mtd_desc_t mtd_at24cxxx_driver;
 
+#if IS_USED(MODULE_AUTO_INIT_STORAGE_AT24CXXX) || defined(DOXYGEN)
+/**
+ * @brief   Get a pointer to all auto-initialized at24cxxx MTD
+ *
+ * @return  Pointer to all auto-initialized at24cxxx MTD
+ */
+mtd_at24cxxx_t *mtd_at24cxxx_devs(void);
+/**
+ * @brief   Get the number of all auto-initialized at24cxxx MTD
+ *
+ * @return  Number of all auto-initialized at24cxxx MTD
+ */
+at24cxxx_id_t mtd_at24cxxx_numof(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -322,6 +322,7 @@ NO_PSEUDOMODULES += auto_init_can
 NO_PSEUDOMODULES += auto_init_loramac
 NO_PSEUDOMODULES += auto_init_multimedia
 NO_PSEUDOMODULES += auto_init_security
+NO_PSEUDOMODULES += auto_init_storage
 NO_PSEUDOMODULES += auto_init_usbus
 NO_PSEUDOMODULES += auto_init_screen
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -84,6 +84,10 @@ ifneq (,$(filter base64url,$(USEMODULE)))
   USEMODULE += base64
 endif
 
+ifneq (,$(filter auto_init_storage_%,$(USEMODULE)))
+  USEMODULE += auto_init_storage
+endif
+
 ifneq (,$(filter auto_init_saul,$(USEMODULE)))
   USEMODULE += saul_init_devs
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -88,6 +88,10 @@ ifneq (,$(filter auto_init_storage_%,$(USEMODULE)))
   USEMODULE += auto_init_storage
 endif
 
+ifneq (,$(filter auto_init_storage_at24cxxx,$(USEMODULE)))
+  USEMODULE += at24cxxx
+endif
+
 ifneq (,$(filter auto_init_saul,$(USEMODULE)))
   USEMODULE += saul_init_devs
 endif

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -26,6 +26,10 @@ ifneq (,$(filter auto_init_security,$(USEMODULE)))
   DIRS += security
 endif
 
+ifneq (,$(filter auto_init_storage,$(USEMODULE)))
+  DIRS += storage
+endif
+
 ifneq (,$(filter auto_init_screen,$(USEMODULE)))
   DIRS += screen
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -129,6 +129,11 @@ void auto_init(void)
         extern void gcoap_init(void);
         gcoap_init();
     }
+    if (IS_USED(MODULE_AUTO_INIT_STORAGE)) {
+        LOG_DEBUG("Auto init storage.\n");
+        extern void auto_init_storage(void);
+        auto_init_storage();
+    }
     if (IS_USED(MODULE_DEVFS)) {
         LOG_DEBUG("Mounting /dev.\n");
         extern void auto_init_devfs(void);

--- a/sys/auto_init/storage/Makefile
+++ b/sys/auto_init/storage/Makefile
@@ -1,0 +1,7 @@
+MODULE = auto_init_storage
+
+SRC := $(MODULE).c
+
+SUBMODULES := 1
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/storage/at24cxxx.c
+++ b/sys/auto_init/storage/at24cxxx.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+/**
+ * @ingroup     sys_auto_init_storage
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of at24cxxx devices
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
+ */
+#include <assert.h>
+#include "log.h"
+#include "kernel_defines.h"
+#include "at24cxxx.h"
+#include "at24cxxx_params.h"
+#include "mtd_at24cxxx.h"
+#include "mtd_at24cxxx_params.h"
+
+#define AT24CXXX_NUMOF  ARRAY_SIZE(at24cxxx_params)
+
+static at24cxxx_t _at24cxxx_devs[AT24CXXX_NUMOF];
+
+#if MTD_AT24CXXX_NUMOF > 0
+static mtd_at24cxxx_t _mtd_at24cxxx_devs[MTD_AT24CXXX_NUMOF];
+#else
+#define _mtd_at24cxxx_devs          ((mtd_at24cxxx_t *)NULL)
+#endif
+
+at24cxxx_t *at24cxxx_devs(void) {
+    return _at24cxxx_devs;
+}
+at24cxxx_id_t at24cxxx_numof(void) {
+    return AT24CXXX_NUMOF;
+}
+
+#if IS_USED(MODULE_MTD_AT24CXXX) || defined(DOXYGEN)
+mtd_at24cxxx_t *mtd_at24cxxx_devs(void) {
+    return _mtd_at24cxxx_devs;
+}
+at24cxxx_id_t mtd_at24cxxx_numof(void) {
+    return MTD_AT24CXXX_NUMOF;
+}
+
+static void _auto_init_mtd_at24cxxx(mtd_at24cxxx_t *mtd,
+                                    at24cxxx_t *devs,
+                                    const at24cxxx_params_t *params,
+                                    at24cxxx_id_t numof)
+{
+    for (at24cxxx_id_t i = 0; i < numof; i++) {
+        mtd[i].base.driver = &mtd_at24cxxx_driver;
+        mtd[i].at24cxxx_eeprom = &devs[i];
+        mtd[i].params = &params[i];
+    }
+}
+
+/**
+ * @internal    Additional setup at24cxxx MTD,
+ *              e.g. to be implemented by the board
+ *
+ * @note This function has __attribute__((weak)) so it can be overridden
+ *
+ * @param[in] at24cxxx      Pointer to at24cxxx device
+ * @param[in] numof         Number of at24cxxx devices
+ */
+void __attribute__((weak)) auto_init_mtd_at24cxxx(mtd_at24cxxx_t *at24cxxx,
+                                                  at24cxxx_id_t numof)
+{
+    (void)at24cxxx;
+    (void)numof;
+}
+#else
+#define _auto_init_mtd_at24cxxx(...)
+#define auto_init_mtd_at24cxxx(...)
+#endif
+
+static void _auto_init_at24cxxx(at24cxxx_t *devs,
+                                const at24cxxx_params_t *params,
+                                at24cxxx_id_t numof)
+{
+    for (at24cxxx_id_t i = 0; i < numof; i++) {
+        int init;
+        if (AT24CXXX_OK != (init = at24cxxx_init(&devs[i], &params[i]))) {
+            LOG_DEBUG("[auto_init_at24cxxx]: "
+                      "failed to initialize device %d due to reason %d",
+                      devs - _at24cxxx_devs, init);
+        }
+    }
+}
+
+void auto_init_at24cxxx(void)
+{
+    assert(AT24CXXX_ID_MAX >= AT24CXXX_NUMOF);
+    assert(MTD_AT24CXXX_NUMOF <= AT24CXXX_NUMOF);
+
+    const at24cxxx_params_t *params = at24cxxx_params;
+    at24cxxx_t *devs = _at24cxxx_devs;
+
+    _auto_init_mtd_at24cxxx(_mtd_at24cxxx_devs, devs, params, MTD_AT24CXXX_NUMOF);
+    _auto_init_at24cxxx(devs + MTD_AT24CXXX_NUMOF,
+                        params + MTD_AT24CXXX_NUMOF,
+                        AT24CXXX_NUMOF - MTD_AT24CXXX_NUMOF);
+
+    auto_init_mtd_at24cxxx(_mtd_at24cxxx_devs, MTD_AT24CXXX_NUMOF);
+}

--- a/sys/auto_init/storage/auto_init_storage.c
+++ b/sys/auto_init/storage/auto_init_storage.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup sys_auto_init_storage Auto-initialization of storage devices
+ * @ingroup  sys_auto_init
+ *
+ * @{
+ * @file
+ * @brief   Implementation of the auto initialization of storage devices
+ *
+ * @author  Fabian Hüßler <fabian.huessler@ovgu.de>
+ *
+ * @}
+ */
+
+void auto_init_storage(void)
+{
+}

--- a/sys/auto_init/storage/auto_init_storage.c
+++ b/sys/auto_init/storage/auto_init_storage.c
@@ -19,6 +19,14 @@
  * @}
  */
 
+#include "kernel_defines.h"
+#include "log.h"
+
 void auto_init_storage(void)
 {
+    if (IS_USED(MODULE_AUTO_INIT_STORAGE_AT24CXXX)) {
+        LOG_DEBUG("Auto init at24cxxx.\n");
+        extern void auto_init_at24cxxx(void);
+        auto_init_at24cxxx();
+    }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
- Add new module `auto_init_storage` to auto-initialize storage devices
- A storage device `<d>` shall be auto initialized if the pseudomodule `auto_init_storage_<d>` is pulled in
- If the storage device has an MTD layer, the `auto_init` module  shall setup the MTD device from device `params`
- A board that uses an MTD device for a dedicated purpose can implement a hook `auto_init_mtd_<d>`
- implement `auto_init_storage_at24cxxx` as an example

I´ll mark this as a draft because the implementation of the auto-initialization of the `at24cxxx` should probably be another PR.
This PR could be just the `auto_init_storage` module, if you agree with the code changes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes

-->

### Testing procedure
Board `sam54e-xpro` has an MTD `at24mac`.
Add to `boards/sam54e-xpro/board.c`:
```C
#include <stdio.h>
void auto_init_mtd_at24cxxx(mtd_at24cxxx_t *at24cxxx, at24cxxx_id_t numof)
{
    puts("auto init at24cxxx");
}
```
Try `USEMODULE="mtd auto_init_storage_at24cxxx" BOARD=sam54e-xpro make -C examples/gnrc_networking` and verify that it is called. The board does not use the MTD for a special purpose, so this is just an example.
A board that has to actually read or write something on auto-init must call `mtd_init()` and do whatever it needs to do.
I do not have that board but I have another board that is not in RIOT for which it works well.
 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references
Similar as #11871

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
