### PR TITLE
Add FlockLab 2 specific configuration of nrf52840dongle

### DIFF
--- a/boards/nrf52840dongle-flocklab/Kconfig
+++ b/boards/nrf52840dongle-flocklab/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840dongle-flocklab" if BOARD_NRF52840DONGLE_FLOCKLAB
+
+config BOARD_NRF52840DONGLE_FLOCKLAB
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_VDD_LC_FILTER_REG0
+    select HAS_VDD_LC_FILTER_REG1
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840dongle-flocklab/Makefile
+++ b/boards/nrf52840dongle-flocklab/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf52840dongle-flocklab/Makefile.dep
+++ b/boards/nrf52840dongle-flocklab/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += saul_pwm
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52840dongle-flocklab/Makefile.features
+++ b/boards/nrf52840dongle-flocklab/Makefile.features
@@ -1,0 +1,17 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+FEATURES_PROVIDED += vdd_lc_filter_reg0
+FEATURES_PROVIDED += vdd_lc_filter_reg1
+
+# Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
+
+# Need to build with a bootloader in order for the application to run
+# See: https://gitlab.ethz.ch/tec/public/flocklab/wiki/-/wikis/Man/FAQ#why-do-i-not-get-any-serial-output-on-the-platform-nrf5
+FEATURES_REQUIRED += riotboot
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840dongle-flocklab/Makefile.include
+++ b/boards/nrf52840dongle-flocklab/Makefile.include
@@ -1,0 +1,17 @@
+# FlockLab 2 uses jlink to flash the device
+# See: https://gitlab.ethz.ch/tec/public/flocklab/observer/-/blob/master/testmanagement/tg_prog.py#L307
+PROGRAMMER = jlink
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include
+
+# FlockLab expects the nrf52840 to be given a firmware in elf format.
+# This firmware must contain both the bootloader and the application.
+# So we need to convert the bootloader and application (in slot0) in bin format to elf.
+
+.PHONY: flocklab
+
+flocklab: all $(BINDIR_APP).flocklab.elf
+	
+
+$(BINDIR_APP).flocklab.elf: $(RIOTBOOT_COMBINED_BIN)
+	$(Q)$(OBJCOPY) -I binary -O elf32-little $(RIOTBOOT_COMBINED_BIN) $(BINDIR_APP).flocklab.elf

--- a/boards/nrf52840dongle-flocklab/board.c
+++ b/boards/nrf52840dongle-flocklab/board.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle-flocklab
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the nRF52840-dongle
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the board's single LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+
+    /* initialize the board's RGB LED */
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+    gpio_init(LED3_PIN, GPIO_OUT);
+    gpio_set(LED3_PIN);
+
+    /* initialize the flocklab RGB LED */
+    gpio_init(FLOCKLAB_LED1_PIN, GPIO_OUT);
+    gpio_set(FLOCKLAB_LED1_PIN);
+    gpio_init(FLOCKLAB_LED2_PIN, GPIO_OUT);
+    gpio_set(FLOCKLAB_LED2_PIN);
+    gpio_init(FLOCKLAB_LED3_PIN, GPIO_OUT);
+    gpio_set(FLOCKLAB_LED3_PIN);
+
+    /* initialize the output pins flocklab monitors */
+    gpio_init(FLOCKLAB_INT1, GPIO_OUT);
+    gpio_clear(FLOCKLAB_INT1);
+    gpio_init(FLOCKLAB_INT2, GPIO_OUT);
+    gpio_clear(FLOCKLAB_INT2);
+
+    /* initialize the input pin flocklab can provide input to */
+    gpio_init(FLOCKLAB_SIG1, GPIO_IN);
+    gpio_init(FLOCKLAB_SIG2, GPIO_IN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf52840dongle-flocklab/doc.txt
+++ b/boards/nrf52840dongle-flocklab/doc.txt
@@ -1,0 +1,30 @@
+/**
+@defgroup    boards_nrf52840dongle-flocklab nRF52840-Dongle
+@ingroup     boards
+@brief       Support for the nRF52840-Dongle
+
+### General information
+
+The nRF52840-Dongle is a bare USB-stick shaped device that houses barely
+anything than the nRF52840 itself, which offers BLE and 802.15.4 and USB
+connectivity.
+
+Unlike similar sticks (like the @ref boards_nrf52840-mdk), it features no
+dedicated programmer hardware but relies on direct USB communication with a
+built-in bootloader.
+
+The board features two LEDs (LD1: green, LD2: RGB), a user (SW1) and a
+reset button as well as 15 configurable external pins.
+
+### Links
+
+- [nRF52840 web page](https://www.nordicsemi.com/?sc_itemid=%7BCDCCA013-FE4C-4655-B20C-1557AB6568C9%7D)
+- [documentation and hardware description](https://infocenter.nordicsemi.com/topic/ug_nrf52840_dongle/UG/nrf52840_Dongle/intro.html?cp=3_0_5)
+- [FlockLab 2 GPIO configurations](https://gitlab.ethz.ch/tec/public/flocklab/wiki/-/wikis/Man/GpioAssignmentTargetAdapter)
+
+### Flash the board
+
+FlockLab manages flashing the board. It performs a full erase before writing the new image.
+This means that the image provided to FlockLab contains a bootloader.
+
+ */

--- a/boards/nrf52840dongle-flocklab/include/board.h
+++ b/boards/nrf52840dongle-flocklab/include/board.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle-flocklab
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the nRF52840-Dongle
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+ /** @brief The LED labelled LD1 */
+#define LED0_PIN            GPIO_PIN(0, 6)
+
+ /** @brief The red channel of the LED labelled LD2 */
+#define LED1_PIN            GPIO_PIN(0, 8)
+ /** @brief The green channel of the LED labelled LD2 */
+#define LED2_PIN            GPIO_PIN(1, 9)
+ /** @brief The blue channel of the LED labelled LD2 */
+#define LED3_PIN            GPIO_PIN(0, 12)
+
+
+// For flocklab GPIO pins see:
+// https://gitlab.ethz.ch/tec/public/flocklab/wiki/-/wikis/Man/GpioAssignmentTargetAdapter
+
+ /** @brief The red channel of the LED labelled LD3 */
+#define FLOCKLAB_LED1_PIN            GPIO_PIN(0, 13)
+ /** @brief The green channel of the LED labelled LD3 */
+#define FLOCKLAB_LED2_PIN            GPIO_PIN(0, 15)
+ /** @brief The blue channel of the LED labelled LD3 */
+#define FLOCKLAB_LED3_PIN            GPIO_PIN(0, 17)
+
+/** @} */
+
+/**
+ * @name    LED access macros
+ * @{
+ */
+
+/** Enable LD1 */
+#define LED0_ON gpio_clear(LED0_PIN)
+/** Disable LD1 */
+#define LED0_OFF gpio_set(LED0_PIN)
+/** Toggle LD1 */
+#define LED0_TOGGLE gpio_toggle(LED0_PIN)
+
+/** Enable LD2's red channel */
+#define LED1_ON gpio_clear(LED1_PIN)
+/** Disable LD2's red channel */
+#define LED1_OFF gpio_set(LED1_PIN)
+/** Toggle LD2's red channel */
+#define LED1_TOGGLE gpio_toggle(LED1_PIN)
+
+/** Enable LD2's green channel */
+#define LED2_ON gpio_clear(LED2_PIN)
+/** Disable LD2's green channel */
+#define LED2_OFF gpio_set(LED2_PIN)
+/** Toggle LD2's green channel */
+#define LED2_TOGGLE gpio_toggle(LED2_PIN)
+
+/** Enable LD2's blue channel */
+#define LED3_ON gpio_clear(LED3_PIN)
+/** Disable LD2's blue channel */
+#define LED3_OFF gpio_set(LED3_PIN)
+/** Toggle LD2's blue channel */
+#define LED3_TOGGLE gpio_toggle(LED3_PIN)
+
+
+/** Enable LD3's red channel */
+#define FLOCKLAB_LED1_ON gpio_clear(FLOCKLAB_LED1_PIN)
+/** Disable LD3's red channel */
+#define FLOCKLAB_LED1_OFF gpio_set(FLOCKLAB_LED1_PIN)
+/** Toggle LD3's red channel */
+#define FLOCKLAB_LED1_TOGGLE gpio_toggle(FLOCKLAB_LED1_PIN)
+
+/** Enable LD3's green channel */
+#define FLOCKLAB_LED2_ON gpio_clear(FLOCKLAB_LED2_PIN)
+/** Disable LD3's green channel */
+#define FLOCKLAB_LED2_OFF gpio_set(FLOCKLAB_LED2_PIN)
+/** Toggle LD3's green channel */
+#define FLOCKLAB_LED2_TOGGLE gpio_toggle(FLOCKLAB_LED2_PIN)
+
+/** Enable LD3's blue channel */
+#define FLOCKLAB_LED3_ON gpio_clear(FLOCKLAB_LED3_PIN)
+/** Disable LD3's blue channel */
+#define FLOCKLAB_LED3_OFF gpio_set(FLOCKLAB_LED3_PIN)
+/** Toggle LD3's blue channel */
+#define FLOCKLAB_LED3_TOGGLE gpio_toggle(FLOCKLAB_LED3_PIN)
+
+/** @} */
+
+/**
+ * @name    FlockLab INT, SIG, EXT, NFC and SWO pins
+ * @{
+ */
+
+#define FLOCKLAB_INT1            GPIO_PIN(0, 20)
+#define FLOCKLAB_INT2            GPIO_PIN(0, 22)
+
+#define FLOCKLAB_SIG1            GPIO_PIN(0, 31)
+#define FLOCKLAB_SIG2            GPIO_PIN(0, 29)
+
+#define FLOCKLAB_EXT1            GPIO_PIN(0, 2)
+#define FLOCKLAB_EXT2            GPIO_PIN(1, 15)
+
+#define FLOCKLAB_NFC1            GPIO_PIN(0, 9)
+#define FLOCKLAB_NFC2            GPIO_PIN(0, 10)
+
+#define FLOCKLAB_SWO             GPIO_PIN(1, 0)
+
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+/** @brief The button labelled SW1 */
+#define BTN0_PIN            GPIO_PIN(1, 6)
+/** @brief The GPIO pin mode of the button labelled SW1 */
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/nrf52840dongle-flocklab/include/gpio_params.h
+++ b/boards/nrf52840dongle-flocklab/include/gpio_params.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle-flocklab
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED and button configuration for SAUL
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "SW 1",
+        .pin   = BTN0_PIN,
+        .mode  = GPIO_IN_PU,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/nrf52840dongle-flocklab/include/periph_conf.h
+++ b/boards/nrf52840dongle-flocklab/include/periph_conf.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
+ *               2021 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle-flocklab
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the nRF52840-Dongle
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ *
+ * Full details of the flocklab GPIO configuration can be found at
+ * https://gitlab.ethz.ch/tec/public/flocklab/wiki/-/wikis/Man/GpioAssignmentTargetAdapter
+ *
+ * @{
+ */
+
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 24),
+        .tx_pin     = GPIO_PIN(1, 10),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   PWM configuration
+ *
+ * For the nRF52840-Dongle board, the PWM0 module is set to drive the LEDs LD1
+ * and the channels LD2 red, green and blue in the four channels of PWM_DEV(0);
+ * other PWM outputs are not configured.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        NRF_PWM0,
+        {
+            GPIO_PIN(0, 6),
+            GPIO_PIN(0, 8),
+            GPIO_PIN(1, 9),
+            GPIO_PIN(0, 12),
+        },
+    },
+};
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/nrf52840dongle-flocklab/include/pwm_params.h
+++ b/boards/nrf52840dongle-flocklab/include/pwm_params.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle-flocklab
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped PWM channels
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#ifndef PWM_PARAMS_H
+#define PWM_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    The single LED exposed via SAUL
+ */
+static const saul_pwm_dimmer_params_t saul_pwm_dimmer_params[] =
+{
+    {
+        .name    = "LD 1",
+        .channel = { PWM_DEV(0), 0, SAUL_PWM_INVERTED },
+    }
+};
+
+static const saul_pwm_rgb_params_t saul_pwm_rgb_params[] =
+{
+    {
+        .name  = "LD 2",
+        .channels = {
+            { PWM_DEV(0), 1, SAUL_PWM_INVERTED },
+            { PWM_DEV(0), 2, SAUL_PWM_INVERTED },
+            { PWM_DEV(0), 3, SAUL_PWM_INVERTED }
+        }
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PWM_PARAMS_H */
+/** @} */

--- a/boards/nrf52840dongle-flocklab/reset.c
+++ b/boards/nrf52840dongle-flocklab/reset.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C)  2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle-flocklab
+ * @{
+ * @file
+ * @brief       Allows reboot into bootloader via hardware reset
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#include "periph/gpio.h"
+
+/* P0.19 is connected to the RESET line */
+#define BSP_SELF_PINRESET_PIN GPIO_PIN(0, 19)
+
+void usb_board_reset_in_bootloader(void)
+{
+    gpio_init(BSP_SELF_PINRESET_PIN, GPIO_OUT);
+    gpio_clear(BSP_SELF_PINRESET_PIN);
+}
+
+#endif /* MODULE_USB_BOARD_RESET */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

[FlockLab 2](https://gitlab.ethz.ch/tec/public/flocklab/wiki) is an IoT testbed with support for a variety of different hardware platforms. This PR adds a custom board definition that modifies the existing nrf52840dongle board to match how FlockLab 2 has set up their nrf52840dongle devices.

They key changes are:
 - Additional GPIO definitions have been added (such as additional LEDs)
 - The UART has been set to use the correct GPIO pins
 - SPI and I2C have been removed as FlockLab 2 does not connect any SPI or I2C devices
 - An additional compilation step has been added to support how FlockLab 2 [deploys images](https://gitlab.ethz.ch/tec/public/flocklab/observer/-/blob/master/testmanagement/tg_prog.py#L307) (in elf format) to the testbed. FlockLab performs a full wipe of flash and then writes the provided image. FlockLab 2 does not load a new image with support from a boot loader. So a new rule has been added to convert the combined bin generated by riotboot back into the supported elf format. Which can be invoked by:
```bash
make BOARD=nrf52840dongle-flocklab flocklab
```

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

1. Sign up for an account at https://user.flocklab.ethz.ch/
2. Build an example hello world
```bash
cd examples/hello-world
make BOARD=nrf52840dongle-flocklab flocklab
```
3. In `examples/hello-world/bin/nrf52840dongle-flocklab` there will be `hello-world.flocklab.elf` which can be deployed to the testbed on the nrf5 targets.
4. Deploy the image on the testbed. Note that the output may not occur due to the FlockLab logger starting up, so a short delay (e.g., 30 seconds) may need to be added to the beginning of the main function.

