### PR TITLE
pkg/nimble/netif: fix and optimize NimBLE buffer sizes

### DIFF
--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -93,15 +93,27 @@ ifneq (,$(filter nimble_netif,$(USEMODULE)))
 
   # configure NimBLE's internals
   NIMBLE_MAX_CONN ?= 3
-  CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=264
   CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=$(NIMBLE_MAX_CONN)
   CFLAGS += -DMYNEWT_VAL_BLE_MAX_CONNECTIONS=$(NIMBLE_MAX_CONN)
-  # NimBLEs internal buffer need to hold one IPv6 MTU per connection
-  # for the internal MTU of 256 byte, we need 10 mbufs per connection...
+
+  # the maximum fragment size that we can receive. For maximum efficiency this
+  # should be equal to the maximum configured link layer packet size.
+  # WARNING: this value MUST never be larger than MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE
+  CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MPS=251
+
+  # in order to fit a 251 byte COC data segment into a single mbuf buffer, the
+  # used block size must be at least 297 byte (251 data + 48 overhead)
+  CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE="(MYNEWT_VAL_BLE_L2CAP_COC_MPS + 48)"
+
+  # in the worst case, NimBLEs internal buffer needs to hold two full IPv6 MTUs
+  # per connection (1 TX and 1 RX). But in practice this would be highly over-
+  # provisioned. Allocating 10 memory blocks per connection plus another 5
+  # for internal buffering has proven to be a generous default value.
   CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=35
 
   # optimize the NimBLE controller for IP traffic
   ifneq (,$(filter nimble_controller,$(USEMODULE)))
+    CFLAGS += -DMYNEWT_VAL_BLE_LL_MAX_PKT_SIZE=251
     CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1
   endif
 endif

--- a/tests/nimble_l2cap_server/nimble.inc.mk
+++ b/tests/nimble_l2cap_server/nimble.inc.mk
@@ -26,11 +26,21 @@ CFLAGS += -DAPP_CID=$(APP_CID)
 # configure NimBLE
 USEPKG += nimble
 MSYS_CNT ?= 40
-CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=1
-CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MPS=250
-CFLAGS += -DMYNEWT_VAL_BLE_MAX_CONNECTIONS=1
-CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=$(MSYS_CNT)
-CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=298
+# For this test we use the controllers link layer data length extension
 CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1
+CFLAGS += -DMYNEWT_VAL_BLE_LL_MAX_PKT_SIZE=251
+# Enable L2CAP connection oriented channels, 1 is sufficient for this test
+CFLAGS += -DMYNEWT_VAL_BLE_MAX_CONNECTIONS=1
+CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=1
+# For maximum efficiency, we set the maximum L2CAP fragment size to the same
+# value as the maximum link layer packet size.
+# WARNING: this value MUST never be larger than MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE
+CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MPS=MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE
+# To be able to handle large packets, we must increase the default packet buffer
+# used by NimBLE.
+# In order to store a full L2CAP fragment/link layer packet in a single block,
+# we need to cater for a 48 byte overhead per block.
+CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=$(MSYS_CNT)
+CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE="(MYNEWT_VAL_BLE_L2CAP_COC_MPS + 48)"
 
 INCLUDES += -I$(RIOTBASE)/tests/nimble_l2cap_server/include


### PR DESCRIPTION
### Contribution description
The current buffer size configuration for `nimble_netif` is broken: if the L2CAP COC MPS size (`MYNEWT_VAL_BLE_L2CAP_COC_MPS`) is set to a value larger than the maximum link layer packet size (`MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE`), it triggers faulty behavior where the link layer will simply cut off bytes at the end of the payload, leading to the receiving node being stuck waiting for those missing bytes.

Currently, nodes will run out of nimble buffers and get stuck when receiving IP packets larger than 251 bytes...

This PR cleans up and optimizes the NimBLE buffer sizes for the use with `nimble_netif`: 
- the faulty behavior as described above is fixed by setting `COC_MPS` equal to `LL_MAX_PKT_SIZE`
- the `MSYS_1_BLOCK_SIZE` is adapted, so that a full COC payload of 251 bytes fits into a single block

To verify the used parameters, I also set the buffer sizes for the `tests/nimble_l2cap` test application to the same values.

### Testing procedure
- run `gnrc_networking`, everything should work as expected.
- run `tests/nimble_l2cap` with two nodes, flooding and inctest should work as expected.

### Issues/PRs references
none