### PR TITLE
sys/event/timeout: add option to use ztimer as backend

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -25,6 +25,7 @@ PSEUDOMODULES += devfs_%
 PSEUDOMODULES += dhcpv6_%
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += event_%
+PSEUDOMODULES += event_timeout_ztimer
 PSEUDOMODULES += evtimer_mbox
 PSEUDOMODULES += evtimer_on_ztimer
 PSEUDOMODULES += fmt_%

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -474,8 +474,16 @@ ifneq (,$(filter event_thread_%,$(USEMODULE)))
   USEMODULE += event_thread
 endif
 
+ifneq (,$(filter event_timeout_ztimer,$(USEMODULE)))
+  USEMODULE += event_timeout
+endif
+
 ifneq (,$(filter event_timeout,$(USEMODULE)))
-  USEMODULE += xtimer
+  ifneq (,$(filter event_timeout_ztimer,$(USEMODULE)))
+    USEMODULE += ztimer_usec
+  else
+    USEMODULE += xtimer
+  endif
 endif
 
 ifneq (,$(filter event,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

This PR adds an option to use ztimer as the backend for an `event/timeout`. To keep the API compatible I added a `ztimer_clock_t` field to the `event_timeout_t` type. But this could also be passed in the function signature and maybe have static inlines to implement the current API.

### Testing procedure

- `USEMODULE+=event_timeout_ztimer make -C flash teset`

TODO: add a individual test.
