### PR TITLE
usb/acm: Blocking mode for USBUS CDC ACM STDIO

### DIFF
--- a/sys/usb/usbus/cdc/acm/Kconfig
+++ b/sys/usb/usbus/cdc/acm/Kconfig
@@ -43,4 +43,10 @@ config USBUS_CDC_ACM_BULK_EP_SIZE_64
 
 endchoice
 
+config USBUS_CDC_ACM_STDIO_BLOCKING
+    bool "USB CDC ACM blocking mode"
+    help
+        Configure if STDIO should block on input when pending bytes over
+        the USB connection cannot be immediately consumed.
+
 endif # KCONFIG_USEMODULE_USBUS_CDC_ACM


### PR DESCRIPTION
### Contribution description

I've modified USBUS CDC ACM STDIO to support blocking on pending characters from USB. The behaviour is controlled by CONFIG_USBUS_CDC_ACM_STDIO_BLOCKING variable, and can be configured via Kconfig.

### Testing procedure

I have tested it against my own [PoC](https://github.com/ant9000/test_usb_uart). With the default RIOT config, characters from USB are lost as soon as the STDIO buffer (defined by CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE) is overrun.
If I enable the new blocking mode, the sender application slows down and adapts to the receiver speed.

### Issues/PRs references

This PR implements feature #16500 .
