### PR TITLE
makefiles/clang-tidy: initial support

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -833,6 +833,8 @@ objdump:
 	$(call check_cmd,$(OBJDUMP),Objdump program)
 	$(OBJDUMP) $(OBJDUMPFLAGS) $(ELFFILE) | less
 
+# inlcude clang-tidy
+include $(RIOTMAKE)/clang_tidy.inc.mk
 # Support Eclipse IDE.
 include $(RIOTMAKE)/eclipse.inc.mk
 

--- a/makefiles/clang_tidy.inc.mk
+++ b/makefiles/clang_tidy.inc.mk
@@ -1,0 +1,18 @@
+.PHONY: clang-tidy
+
+ifneq (, $(filter clang-tidy,$(MAKECMDGOALS)))
+ifneq (llvm,$(TOOLCHAIN))
+  $(error clang-tidy must be ran with TOOLCHAIN=llvm)
+endif
+endif
+
+FILE_REFEX = '.([CcHh]|[ch]pp)$$'
+DIFF_FILTER ?= 'ACMR'
+BASE_BRANCH ?= master
+
+CLANG_TIDY_CHECKS ?= *
+CLANG_TIDY_SRCS ?= $(shell git diff --diff-filter=$(DIFF_FILTER) --name-only $(BASE_BRANCH) | grep -E $(FILE_REFEX))
+
+clang-tidy:
+	$(Q)cd $(RIOTBASE); \
+	clang-tidy -checks=$(CLANG_TIDY_CHECKS) $(CLANG_TIDY_SRCS) -- $(CFLAGS) $(INCLUDES)


### PR DESCRIPTION
### Contribution description

This PR adds a make target to run clang-tidy. By default the considered source files will those that have been changed regarding to `BASE_BRANCH` set to master by default.

### Testing procedure

On a branch different than master run `TOOLCHAIN=llvm make -C tests/event_timeout_ztimer/ clang-tidy`

```
BASE_BRANCH=upstream/master TOOLCHAIN=llvm make -C tests/event_timeout_ztimer/ clang-tidy
64 warnings generated.
127 warnings generated.
192 warnings generated.
328 warnings generated.
404 warnings generated.
/home/francisco/workspace/RIOT/sys/event/periodic_timeout.c:9:1: warning: #includes are not sorted properly [llvm-include-order]
#include "kernel_defines.h"
^        ~~~~~~~~~~~~~~~~~~
         "event/timeout.h"
/home/francisco/workspace/RIOT/sys/include/event/timeout.h:157:20: warning: unused function 'event_periodic_timeout_start' [clang-diagnostic-unused-function]
static inline void event_periodic_timeout_start(event_periodic_timeout_t *event_timeout,
                   ^
/home/francisco/workspace/RIOT/sys/include/event/timeout.h:174:20: warning: unused function 'event_periodic_timeout_stop' [clang-diagnostic-unused-function]
static inline void event_periodic_timeout_stop(event_periodic_timeout_t *event_timeout)
                   ^
/home/francisco/workspace/RIOT/tests/event_timeout_ztimer/main.c:26:1: warning: #includes are not sorted properly [llvm-include-order]
#include "test_utils/expect.h"
^        ~~~~~~~~~~~~~~~~~~~~~
         "event.h"
/home/francisco/workspace/RIOT/tests/events/main.c:25:1: warning: #includes are not sorted properly [llvm-include-order]
#include "test_utils/expect.h"
^        ~~~~~~~~~~~~~~~~~~~~~
         "event.h"
/home/francisco/workspace/RIOT/tests/events/main.c:201:48: warning: 500 is a magic number; consider replacing it with a named constant [cppcoreguidelines-avoid-magic-numbers]
    event_timeout_set(&event_timeout_canceled, 500 * US_PER_MS);
                                               ^
/home/francisco/workspace/RIOT/tests/events/main.c:201:48: warning: 500 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
Suppressed 397 warnings (397 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
