### PR TITLE
cpu/stm32: Generate the irqs in a reproducible manner

### DIFF
--- a/cpu/stm32/dist/irqs/gen_irqs.py
+++ b/cpu/stm32/dist/irqs/gen_irqs.py
@@ -58,7 +58,7 @@ def list_cpu_lines(cpu_fam):
         headers.remove("partition_stm32l5xx.h")
     headers.remove("stm32{}xx.h".format(cpu_fam))
     headers.remove("system_stm32{}xx.h".format(cpu_fam))
-    return [header.split(".")[0] for header in headers]
+    return sorted([header.split(".")[0] for header in headers])
 
 
 def irq_numof(cpu_fam, cpu_line):


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Sort the output of `sort_cpu_lines` which relies on the output of `os.listdir` whose order is not deterministic.
