### PR TITLE
pkg/pkg.mk: avoid git fetch if commit is already there

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -113,7 +113,10 @@ $(PKG_PATCHED): $(PKG_PATCHED_PREREQUISITES)
 
 $(PKG_DOWNLOADED): $(MAKEFILE_LIST) | $(PKG_SOURCE_DIR)/.git
 	$(info [INFO] updating $(PKG_NAME) $(PKG_DOWNLOADED))
-	$(Q)$(GIT_IN_PKG) fetch $(GIT_QUIET) $(PKG_URL) $(PKG_VERSION)
+	$(Q)if ! $(GIT_IN_PKG) cat-file -e $(PKG_VERSION); then \
+		printf "[INFO] fetching new $(PKG_NAME) version "$(PKG_VERSION)"\n"; \
+		$(GIT_IN_PKG) fetch $(GIT_QUIET) "$(PKG_URL)" "$(PKG_VERSION)"; \
+	fi
 	echo $(PKG_VERSION) > $@
 
 $(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a take over of #11491 adapted to the new pkg.mk structure. This allows to build an application using a package even without network and if the package was already downloaded once (except for openthread and micropython).

I'm wondering if this will work on Murdock with tags given as package version. If this is problematic, failing package version will have to be updated to the commit hash.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check that git fetch is not called if not needed (no message printed):

<details>

- first call: no fetch

```
$ make -C tests/pkg_cayenne-lpp/
make: Entering directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
Building application "tests_pkg_cayenne-lpp" for "native" with MCU "native".

[INFO] updating cayenne-lpp /work/riot/RIOT/build/pkg/cayenne-lpp/.pkg-state.git-downloaded
echo 0.1.1 > /work/riot/RIOT/build/pkg/cayenne-lpp/.pkg-state.git-downloaded
[INFO] patch cayenne-lpp
"make" -C /work/riot/RIOT/pkg/cayenne-lpp
"make" -C /work/riot/RIOT/build/pkg/cayenne-lpp -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
/usr/bin/ld: /work/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
   text	   data	    bss	    dec	    hex	filename
  29455	    612	  47856	  77923	  13063	/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf
make: Leaving directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
```

- second with new version: the new version is not there so it's fetched

```
$ make -C tests/pkg_cayenne-lpp/
make: Entering directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
Building application "tests_pkg_cayenne-lpp" for "native" with MCU "native".

[INFO] updating cayenne-lpp /work/riot/RIOT/build/pkg/cayenne-lpp/.pkg-state.git-downloaded
[INFO] fetching new cayenne-lpp version 7c0539e8abd5c6d8adc14cff4563895129b98e71
echo 7c0539e8abd5c6d8adc14cff4563895129b98e71 > /work/riot/RIOT/build/pkg/cayenne-lpp/.pkg-state.git-downloaded
[INFO] patch cayenne-lpp
"make" -C /work/riot/RIOT/pkg/cayenne-lpp
"make" -C /work/riot/RIOT/build/pkg/cayenne-lpp -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
/usr/bin/ld: /work/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
   text	   data	    bss	    dec	    hex	filename
  29455	    612	  47856	  77923	  13063	/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf
make: Leaving directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
```

- third call: no fetch

```
$ make -C tests/pkg_cayenne-lpp/
make: Entering directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
Building application "tests_pkg_cayenne-lpp" for "native" with MCU "native".

"make" -C /work/riot/RIOT/pkg/cayenne-lpp
"make" -C /work/riot/RIOT/build/pkg/cayenne-lpp -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
/usr/bin/ld: /work/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
   text	   data	    bss	    dec	    hex	filename
  29455	    612	  47856	  77923	  13063	/work/riot/RIOT/tests/pkg_cayenne-lpp/bin/native/tests_pkg_cayenne-lpp.elf
make: Leaving directory '/work/riot/RIOT/tests/pkg_cayenne-lpp'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

closes #11491 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
