### PR TITLE
Kconfig: expose IEEE 802.15.4 Security to Kconfig

### DIFF
--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -101,17 +101,14 @@ struct ieee802154_sec_dev {
     void *ctx;
 };
 
-#if !defined(IEEE802154_SEC_DEFAULT_KEY) || defined(DOXYGEN)
+#if !defined(CONFIG_IEEE802154_SEC_DEFAULT_KEY) || defined(DOXYGEN)
 /**
- * @brief   AES key that is used in the test vectors from the specification
+ * @brief   AES default key
  *
  * @note    Predefine it yourself,
  *          if you want another key to be set up on initialization
  */
-#define IEEE802154_SEC_DEFAULT_KEY              { 0xc0, 0xc1, 0xc2, 0xc3,   \
-                                                  0xc4, 0xc5, 0xc6, 0xc7,   \
-                                                  0xc8, 0xc9, 0xca, 0xcb,   \
-                                                  0xcc, 0xcd, 0xce, 0xcf }
+#define CONFIG_IEEE802154_SEC_DEFAULT_KEY       "pizza_margherita"
 #endif
 
 /**

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -83,4 +83,15 @@ if KCONFIG_USEMODULE_IEEE802154
         int "IEEE802.15.4 default CSMA-CA maximum backoff exponent"
         default 5
 
+menuconfig KCONFIG_USEMODULE_IEEE802154_SECURITY
+    bool "Configure IEEE802.15.4 Security"
+    depends on USEMODULE_IEEE802154_SECURITY
+    help
+        Configure IEEE802.15.4 security module using Kconfig
+
+    config IEEE802154_SEC_DEFAULT_KEY
+        string "Default key to be used for encryption and decryption (>=16B)"
+        default "pizza_margherita"
+        depends on KCONFIG_USEMODULE_IEEE802154_SECURITY
+
 endif # KCONFIG_USEMODULE_IEEE802154

--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -401,7 +401,8 @@ void ieee802154_sec_init(ieee802154_sec_context_t *ctx)
     memset(ctx->key_source, 0, sizeof(ctx->key_source));
     ctx->key_index = 0;
     ctx->frame_counter = 0;
-    uint8_t key[] = IEEE802154_SEC_DEFAULT_KEY;
+    uint8_t key[] = CONFIG_IEEE802154_SEC_DEFAULT_KEY;
+    assert(sizeof(key) >= IEEE802154_SEC_KEY_LENGTH);
     assert(CIPHER_MAX_CONTEXT_SIZE >= IEEE802154_SEC_KEY_LENGTH);
     cipher_init(&ctx->cipher, CIPHER_AES, key, IEEE802154_SEC_KEY_LENGTH);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Makes IEEE 802.15.4 security module configurable with Kconfig.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`USEMODULE="ieee802154 ieee802154_security" BOARD=nucleo-f767zi make -C examples/gnrc_networking menuconfig`

![Screenshot_20210531_101355](https://user-images.githubusercontent.com/15147337/120169628-709c1d80-c200-11eb-9c9f-0752b53f175b.png)

![Screenshot_20210531_101435](https://user-images.githubusercontent.com/15147337/120169638-74c83b00-c200-11eb-9ed4-ecb24923dff5.png)

![Screenshot_20210531_101849](https://user-images.githubusercontent.com/15147337/120169655-77c32b80-c200-11eb-80fa-88d60b9065f3.png)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
