### PR TITLE
.github/labeler: match Kconfig files in subfolders

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,7 +45,7 @@
   - dist/tools/kconfiglib/**/*
   - makefiles/kconfig.mk
   - kconfigs/*
-  - Kconfig
+  - **/Kconfig
 
 "Area: LoRa":
   - drivers/llcc68/**/*


### PR DESCRIPTION
### Contribution description
The labeler seems to be missing changes on `Kconfig` files that occur in subdirectories of the tree (e.g. #16515). This tries to match those.

### Testing procedure
Not really sure if the labeler can be triggered before merging this. The glob pattern should match now all Kconfig files in the tree.

### Issues/PRs references
Example of issue in #16515