### PR TITLE
net/eui_provider: only use every provider once

### DIFF
--- a/sys/net/link_layer/eui_provider/eui_provider.c
+++ b/sys/net/link_layer/eui_provider/eui_provider.c
@@ -18,11 +18,26 @@
 #include "luid.h"
 #include "net/eui_provider.h"
 
+struct netdev_id {
+    uint8_t type;
+    uint8_t index;
+};
+
 void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
 {
+    __attribute__((unused))
+    static struct netdev_id used[EUI48_PROVIDER_NUMOF];
     unsigned i = EUI48_PROVIDER_NUMOF;
+
     while (i--) {
 #ifdef MODULE_NETDEV_REGISTER
+        /* EUI provider already used */
+        if (used[i].type  != NETDEV_ANY &&
+           (used[i].type  != netdev->type ||
+            used[i].index != netdev->index)) {
+            continue;
+        }
+
         if (eui48_conf[i].type != netdev->type &&
             eui48_conf[i].type != NETDEV_ANY) {
             continue;
@@ -36,6 +51,10 @@ void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
         (void) netdev;
 #endif
         if (eui48_conf[i].provider(i, addr) == 0) {
+#ifdef MODULE_NETDEV_REGISTER
+            used[i].type  = netdev->type;
+            used[i].index = netdev->index;
+#endif
             return;
         }
     }
@@ -45,9 +64,19 @@ void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
 
 void netdev_eui64_get(netdev_t *netdev, eui64_t *addr)
 {
+    __attribute__((unused))
+    static struct netdev_id used[EUI64_PROVIDER_NUMOF];
     unsigned i = EUI64_PROVIDER_NUMOF;
+
     while (i--) {
 #ifdef MODULE_NETDEV_REGISTER
+        /* EUI provider already used */
+        if (used[i].type  != NETDEV_ANY &&
+           (used[i].type  != netdev->type ||
+            used[i].index != netdev->index)) {
+            continue;
+        }
+
         if (eui64_conf[i].type != netdev->type &&
             eui64_conf[i].type != NETDEV_ANY) {
             continue;
@@ -61,6 +90,10 @@ void netdev_eui64_get(netdev_t *netdev, eui64_t *addr)
         (void) netdev;
 #endif
         if (eui64_conf[i].provider(i, addr) == 0) {
+#ifdef MODULE_NETDEV_REGISTER
+            used[i].type  = netdev->type;
+            used[i].index = netdev->index;
+#endif
             return;
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If an EUI provider is set to match ANY interface at ANY index, it will match multiple times if there are multiple interfaces.
Avoid this by introducing an array to keep track of which provider was used for which interface.

### Testing procedure

Add `USEMODULE += dose` to `examples/gnrc_networking` when building for `same54-xpro`.

#### before

Both DOSE and Ethernet interface use the same MAC address from the at24mac chip.

```
2021-06-02 13:54:52,130 # Iface  6  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-02 13:54:52,134 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 13:54:52,136 #           RTR_ADV  
2021-06-02 13:54:52,139 #           Source address length: 6
2021-06-02 13:54:52,141 #           Link type: wired
2021-06-02 13:54:52,147 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-02 13:54:52,150 #           inet6 group: ff02::2
2021-06-02 13:54:52,152 #           inet6 group: ff02::1
2021-06-02 13:54:52,156 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-02 13:54:52,157 #           
2021-06-02 13:54:52,160 #           Statistics for Layer 2
2021-06-02 13:54:52,163 #             RX packets 0  bytes 0
2021-06-02 13:54:52,167 #             TX packets 1 (Multicast: 1)  bytes 78
2021-06-02 13:54:52,170 #             TX succeeded 1 errors 0
2021-06-02 13:54:52,173 #           Statistics for IPv6
2021-06-02 13:54:52,176 #             RX packets 0  bytes 0
2021-06-02 13:54:52,180 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 13:54:52,183 #             TX succeeded 1 errors 0
2021-06-02 13:54:52,183 # 
2021-06-02 13:54:52,187 # Iface  5  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-02 13:54:52,191 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 13:54:52,193 #           RTR_ADV  
2021-06-02 13:54:52,196 #           Source address length: 6
2021-06-02 13:54:52,198 #           Link type: wired
2021-06-02 13:54:52,204 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  TNT[1]
2021-06-02 13:54:52,207 #           inet6 group: ff02::2
2021-06-02 13:54:52,210 #           inet6 group: ff02::1
2021-06-02 13:54:52,213 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-02 13:54:52,214 #           
2021-06-02 13:54:52,217 #           Statistics for Layer 2
2021-06-02 13:54:52,220 #             RX packets 0  bytes 0
2021-06-02 13:54:52,224 #             TX packets 1 (Multicast: 1)  bytes 0
2021-06-02 13:54:52,227 #             TX succeeded 0 errors 1
2021-06-02 13:54:52,230 #           Statistics for IPv6
2021-06-02 13:54:52,233 #             RX packets 0  bytes 0
2021-06-02 13:54:52,237 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 13:54:52,241 #             TX succeeded 1 errors 0
```

#### with this patch

The MAC address is only used once.

```
2021-06-02 14:03:50,929 # Iface  6  HWaddr: A6:ED:29:EC:CB:F3 
2021-06-02 14:03:50,933 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 14:03:50,935 #           RTR_ADV  
2021-06-02 14:03:50,938 #           Source address length: 6
2021-06-02 14:03:50,941 #           Link type: wired
2021-06-02 14:03:50,946 #           inet6 addr: fe80::a4ed:29ff:feec:cbf3  scope: link  VAL
2021-06-02 14:03:50,949 #           inet6 group: ff02::2
2021-06-02 14:03:50,952 #           inet6 group: ff02::1
2021-06-02 14:03:50,955 #           inet6 group: ff02::1:ffec:cbf3
2021-06-02 14:03:50,956 #           
2021-06-02 14:03:50,959 #           Statistics for Layer 2
2021-06-02 14:03:50,962 #             RX packets 0  bytes 0
2021-06-02 14:03:50,966 #             TX packets 1 (Multicast: 1)  bytes 78
2021-06-02 14:03:50,970 #             TX succeeded 1 errors 0
2021-06-02 14:03:50,972 #           Statistics for IPv6
2021-06-02 14:03:50,975 #             RX packets 0  bytes 0
2021-06-02 14:03:50,980 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 14:03:50,983 #             TX succeeded 1 errors 0
2021-06-02 14:03:50,983 # 
2021-06-02 14:03:50,986 # Iface  5  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-02 14:03:50,990 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 14:03:50,992 #           RTR_ADV  
2021-06-02 14:03:50,995 #           Source address length: 6
2021-06-02 14:03:50,998 #           Link type: wired
2021-06-02 14:03:51,003 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-02 14:03:51,006 #           inet6 group: ff02::2
2021-06-02 14:03:51,009 #           inet6 group: ff02::1
2021-06-02 14:03:51,012 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-02 14:03:51,013 #           
2021-06-02 14:03:51,016 #           Statistics for Layer 2
2021-06-02 14:03:51,019 #             RX packets 0  bytes 0
2021-06-02 14:03:51,023 #             TX packets 1 (Multicast: 1)  bytes 0
2021-06-02 14:03:51,027 #             TX succeeded 0 errors 1
2021-06-02 14:03:51,029 #           Statistics for IPv6
2021-06-02 14:03:51,032 #             RX packets 0  bytes 0
2021-06-02 14:03:51,037 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 14:03:51,040 #             TX succeeded 1 errors 0
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
