### PR TITLE
sys/bit: add bit_checkXX() functions

### DIFF
--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -197,6 +197,57 @@ static inline void bit_clear8(volatile uint8_t *ptr, uint8_t bit)
     *((volatile uint8_t *)bitband_addr(ptr, bit)) = 0;
 }
 
+/**
+ * @brief Checks if a single bit in the 32 bit word pointed to by @p ptr is set
+ *
+ * The effect is the same as for the following snippet:
+ *
+ * @code{c}
+ *   *ptr & (1 << bit);
+ * @endcode
+ *
+ * @param[in]  ptr pointer to target word
+ * @param[in]  bit bit number within the word
+ */
+static inline bool bit_check32(volatile uint32_t *ptr, uint8_t bit)
+{
+    return *((volatile uint32_t *)bitband_addr(ptr, bit));
+}
+
+/**
+ * @brief Checks if a single bit in the 16 bit word pointed to by @p ptr is set
+ *
+ * The effect is the same as for the following snippet:
+ *
+ * @code{c}
+ *   *ptr & (1 << bit);
+ * @endcode
+ *
+ * @param[in]  ptr pointer to target word
+ * @param[in]  bit bit number within the word
+ */
+static inline bool bit_check16(volatile uint16_t *ptr, uint8_t bit)
+{
+    return *((volatile uint16_t *)bitband_addr(ptr, bit));
+}
+
+/**
+ * @brief Checks if a single bit in the 8 bit byte pointed to by @p ptr is set
+ *
+ * The effect is the same as for the following snippet:
+ *
+ * @code{c}
+ *   *ptr & (1 << bit);
+ * @endcode
+ *
+ * @param[in]  ptr pointer to target byte
+ * @param[in]  bit bit number within the byte
+ */
+static inline bool bit_check8(volatile uint8_t *ptr, uint8_t bit)
+{
+    return *((volatile uint8_t *)bitband_addr(ptr, bit));
+}
+
 /** @} */
 
 #else /* CPU_HAS_BITBAND */
@@ -229,6 +280,21 @@ static inline void bit_clear16(volatile uint16_t *ptr, uint8_t bit)
 static inline void bit_clear8(volatile uint8_t *ptr, uint8_t bit)
 {
     *ptr &= ~(1 << (bit));
+}
+
+static inline bool bit_check32(volatile uint32_t *ptr, uint8_t bit)
+{
+    return *ptr & (1 << bit);
+}
+
+static inline bool bit_check16(volatile uint16_t *ptr, uint8_t bit)
+{
+    return *ptr & (1 << bit);
+}
+
+static inline bool bit_check8(volatile uint8_t *ptr, uint8_t bit)
+{
+    return *ptr & (1 << bit);
 }
 
 #endif /* CPU_HAS_BITBAND */


### PR DESCRIPTION
### Contribution description

There are functions to set and clear bits in a bit map, but no functions to check if a bit in a bit map is set.
Add those trivial functions for consistency. 


### Testing procedure

Read.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
