### PR TITLE
boards: lock EUI provider to interface type

### DIFF
--- a/boards/native/include/eui_provider_params.h
+++ b/boards/native/include/eui_provider_params.h
@@ -30,7 +30,9 @@ extern "C" {
  * @{
  */
 #define EUI64_PROVIDER_FUNC   native_cli_get_eui64
-#define EUI64_PROVIDER_TYPE   NETDEV_ANY
+#ifndef EUI64_PROVIDER_TYPE
+#define EUI64_PROVIDER_TYPE   NETDEV_SOCKET_ZEP
+#endif
 #define EUI64_PROVIDER_INDEX  NETDEV_INDEX_ANY
 /** @} */
 

--- a/boards/same54-xpro/include/eui_provider_params.h
+++ b/boards/same54-xpro/include/eui_provider_params.h
@@ -38,6 +38,9 @@ static inline int _at24mac_get_eui48(uint8_t index, eui48_t *addr)
  * @{
  */
 #define EUI48_PROVIDER_FUNC   _at24mac_get_eui48
+#ifndef EUI48_PROVIDER_TYPE
+#define EUI48_PROVIDER_TYPE   NETDEV_SAM0_ETH
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/sys/include/net/eui_provider.h
+++ b/sys/include/net/eui_provider.h
@@ -75,10 +75,13 @@
  * Recommendations
  * ===============
  *
- * While it is possible to match EUIs with any netdev in a first come, first serve
- * fashion (`NETDEV_ANY`, `NETDEV_INDEX_ANY`) it is recommended to fix the EUI
- * providers to a device and interface to avoid them being used for 'virtual'
- * interfaces.
+ * Do not use `NETDEV_ANY` as EUI device type. Otherwise if you have two
+ * interfaces both will match the same EUI.
+ *
+ * It is however possible to use `NETDEV_INDEX_ANY` if you have multiple
+ * interfaces of the same type and your EUI provider function takes the index
+ * into account (or returns error if the index is out of bounds with the
+ * available ids).
  *
  * Fixed addresses are only guaranteed if the network devices are also fixed.
  * E.g. if you usually have two netdevs and disable the first one at compile-time
@@ -132,7 +135,7 @@ typedef int (*netdev_get_eui64_cb_t)(uint8_t index, eui64_t *addr);
  */
 typedef struct {
     netdev_get_eui48_cb_t provider; /**< function to provide an EUI-48                  */
-    netdev_type_t type;             /**< device type to match or `NETDEV_ANY`           */
+    netdev_type_t type;             /**< device type to match                           */
     uint8_t index;                  /**< device index to match or `NETDEV_INDEX_ANY`    */
 } eui48_conf_t;
 
@@ -141,7 +144,7 @@ typedef struct {
  */
 typedef struct {
     netdev_get_eui64_cb_t provider; /**< function to provide an EUI-64                  */
-    netdev_type_t type;             /**< device type to match or `NETDEV_ANY`           */
+    netdev_type_t type;             /**< device type to match                           */
     uint8_t index;                  /**< device index to match or `NETDEV_INDEX_ANY`    */
 } eui64_conf_t;
 

--- a/sys/net/link_layer/eui_provider/eui_provider.c
+++ b/sys/net/link_layer/eui_provider/eui_provider.c
@@ -13,6 +13,7 @@
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
 
+#include "assert.h"
 #include "eui48_provider_params.h"
 #include "eui64_provider_params.h"
 #include "luid.h"
@@ -23,8 +24,13 @@ void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
     unsigned i = EUI48_PROVIDER_NUMOF;
     while (i--) {
 #ifdef MODULE_NETDEV_REGISTER
-        if (eui48_conf[i].type != netdev->type &&
-            eui48_conf[i].type != NETDEV_ANY) {
+        /* using NETDEV_ANY causes conflicts if there is another interface
+         * of a different type. Require EUI  providers to be locked to an
+         * interface type for uniqueness.
+         */
+        assert(eui48_conf[i].type != NETDEV_ANY);
+
+        if (eui48_conf[i].type != netdev->type) {
             continue;
         }
 
@@ -48,8 +54,13 @@ void netdev_eui64_get(netdev_t *netdev, eui64_t *addr)
     unsigned i = EUI64_PROVIDER_NUMOF;
     while (i--) {
 #ifdef MODULE_NETDEV_REGISTER
-        if (eui64_conf[i].type != netdev->type &&
-            eui64_conf[i].type != NETDEV_ANY) {
+        /* using NETDEV_ANY causes conflicts if there is another interface
+         * of a different type. Require EUI  providers to be locked to an
+         * interface type for uniqueness.
+         */
+        assert(eui64_conf[i].type != NETDEV_ANY);
+
+        if (eui64_conf[i].type != netdev->type) {
             continue;
         }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Otherwise the provider can be used for multiple interfaces but only return a single MAC address for all of them.


### Testing procedure

Add `USEMODULE += dose` to `examples/gnrc_networking` when building for `same54-xpro`.

#### before

Both DOSE and Ethernet interface use the same MAC address from the at24mac chip.

```
2021-06-02 13:54:52,130 # Iface  6  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-02 13:54:52,134 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 13:54:52,136 #           RTR_ADV  
2021-06-02 13:54:52,139 #           Source address length: 6
2021-06-02 13:54:52,141 #           Link type: wired
2021-06-02 13:54:52,147 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-02 13:54:52,150 #           inet6 group: ff02::2
2021-06-02 13:54:52,152 #           inet6 group: ff02::1
2021-06-02 13:54:52,156 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-02 13:54:52,157 #           
2021-06-02 13:54:52,160 #           Statistics for Layer 2
2021-06-02 13:54:52,163 #             RX packets 0  bytes 0
2021-06-02 13:54:52,167 #             TX packets 1 (Multicast: 1)  bytes 78
2021-06-02 13:54:52,170 #             TX succeeded 1 errors 0
2021-06-02 13:54:52,173 #           Statistics for IPv6
2021-06-02 13:54:52,176 #             RX packets 0  bytes 0
2021-06-02 13:54:52,180 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 13:54:52,183 #             TX succeeded 1 errors 0
2021-06-02 13:54:52,183 # 
2021-06-02 13:54:52,187 # Iface  5  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-02 13:54:52,191 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 13:54:52,193 #           RTR_ADV  
2021-06-02 13:54:52,196 #           Source address length: 6
2021-06-02 13:54:52,198 #           Link type: wired
2021-06-02 13:54:52,204 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  TNT[1]
2021-06-02 13:54:52,207 #           inet6 group: ff02::2
2021-06-02 13:54:52,210 #           inet6 group: ff02::1
2021-06-02 13:54:52,213 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-02 13:54:52,214 #           
2021-06-02 13:54:52,217 #           Statistics for Layer 2
2021-06-02 13:54:52,220 #             RX packets 0  bytes 0
2021-06-02 13:54:52,224 #             TX packets 1 (Multicast: 1)  bytes 0
2021-06-02 13:54:52,227 #             TX succeeded 0 errors 1
2021-06-02 13:54:52,230 #           Statistics for IPv6
2021-06-02 13:54:52,233 #             RX packets 0  bytes 0
2021-06-02 13:54:52,237 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 13:54:52,241 #             TX succeeded 1 errors 0
```

#### with this patch

The MAC address is only used once.

```
2021-06-02 14:03:50,929 # Iface  6  HWaddr: A6:ED:29:EC:CB:F3 
2021-06-02 14:03:50,933 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 14:03:50,935 #           RTR_ADV  
2021-06-02 14:03:50,938 #           Source address length: 6
2021-06-02 14:03:50,941 #           Link type: wired
2021-06-02 14:03:50,946 #           inet6 addr: fe80::a4ed:29ff:feec:cbf3  scope: link  VAL
2021-06-02 14:03:50,949 #           inet6 group: ff02::2
2021-06-02 14:03:50,952 #           inet6 group: ff02::1
2021-06-02 14:03:50,955 #           inet6 group: ff02::1:ffec:cbf3
2021-06-02 14:03:50,956 #           
2021-06-02 14:03:50,959 #           Statistics for Layer 2
2021-06-02 14:03:50,962 #             RX packets 0  bytes 0
2021-06-02 14:03:50,966 #             TX packets 1 (Multicast: 1)  bytes 78
2021-06-02 14:03:50,970 #             TX succeeded 1 errors 0
2021-06-02 14:03:50,972 #           Statistics for IPv6
2021-06-02 14:03:50,975 #             RX packets 0  bytes 0
2021-06-02 14:03:50,980 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 14:03:50,983 #             TX succeeded 1 errors 0
2021-06-02 14:03:50,983 # 
2021-06-02 14:03:50,986 # Iface  5  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-02 14:03:50,990 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-02 14:03:50,992 #           RTR_ADV  
2021-06-02 14:03:50,995 #           Source address length: 6
2021-06-02 14:03:50,998 #           Link type: wired
2021-06-02 14:03:51,003 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-02 14:03:51,006 #           inet6 group: ff02::2
2021-06-02 14:03:51,009 #           inet6 group: ff02::1
2021-06-02 14:03:51,012 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-02 14:03:51,013 #           
2021-06-02 14:03:51,016 #           Statistics for Layer 2
2021-06-02 14:03:51,019 #             RX packets 0  bytes 0
2021-06-02 14:03:51,023 #             TX packets 1 (Multicast: 1)  bytes 0
2021-06-02 14:03:51,027 #             TX succeeded 0 errors 1
2021-06-02 14:03:51,029 #           Statistics for IPv6
2021-06-02 14:03:51,032 #             RX packets 0  bytes 0
2021-06-02 14:03:51,037 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-02 14:03:51,040 #             TX succeeded 1 errors 0
```


### Issues/PRs references

alternative to #16521
