### PR TITLE
boards/samr21-xpro: only configure antenna switch if radio is used

### DIFF
--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -41,12 +41,15 @@ void board_init(void)
     gpio_init(LED0_PIN, GPIO_OUT);
     LED0_OFF;
 
-    /* initialize the on-board antenna switch */
-    gpio_init(RFCTL1_PIN, GPIO_OUT);
-    gpio_init(RFCTL2_PIN, GPIO_OUT);
-    /* set default antenna switch configuration */
-    board_antenna_config(RFCTL_ANTENNA_DEFAULT);
-
     /* initialize the CPU */
     cpu_init();
+
+    /* initialize the on-board antenna switch */
+    if (IS_USED(MODULE_AT86RF233)) {
+        gpio_init(RFCTL1_PIN, GPIO_OUT);
+        gpio_init(RFCTL2_PIN, GPIO_OUT);
+
+        /* set default antenna switch configuration */
+        board_antenna_config(RFCTL_ANTENNA_DEFAULT);
+    }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If the radio module is not used, there is no need to configure the antenna switch.


### Testing procedure

Antenna should still be configured with `at86rf233` in use.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
