### PR TITLE
sys/auto_init: move sock_dtls after network stack initialization

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -108,6 +108,11 @@ void auto_init(void)
         extern void lwip_bootstrap(void);
         lwip_bootstrap();
     }
+    if (IS_USED(MODULE_SOCK_DTLS)) {
+        LOG_DEBUG("Auto init sock_dtls.\n");
+        extern void sock_dtls_init(void);
+        sock_dtls_init();
+    }
     if (IS_USED(MODULE_OPENTHREAD)) {
         LOG_DEBUG("Bootstrapping openthread.\n");
         extern void openthread_bootstrap(void);
@@ -168,11 +173,6 @@ void auto_init(void)
         LOG_DEBUG("Auto init loramac.\n");
         extern void auto_init_loramac(void);
         auto_init_loramac();
-    }
-    if (IS_USED(MODULE_SOCK_DTLS)) {
-        LOG_DEBUG("Auto init sock_dtls.\n");
-        extern void sock_dtls_init(void);
-        sock_dtls_init();
     }
 
     /* initialize USB devices */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

(tinydtls context)
When DTLS is initialized after an application creates a DTLS socket, the memory access on the internal DTLS memory leads to a segfault. This PR moves the DTLS auto initialization right after the network stack initialization.

Happened for gcoap.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Tests should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
