### PR TITLE
gnrc_dhcpv6_client_6lbr: choose downstream if as !upstream

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -257,10 +257,10 @@ void auto_init(void)
         dhcpv6_client_auto_init();
     }
 
-    if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_6LBR)) {
-        LOG_DEBUG("Auto init 6LoWPAN border router DHCPv6 client\n");
-        extern void gnrc_dhcpv6_client_6lbr_init(void);
-        gnrc_dhcpv6_client_6lbr_init();
+    if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_SIMPLE_PD)) {
+        LOG_DEBUG("Auto init DHCPv6 client for simple prefix delegation\n");
+        extern void gnrc_dhcpv6_client_simple_pd_init(void);
+        gnrc_dhcpv6_client_simple_pd_init();
     }
 
     if (IS_USED(MODULE_AUTO_INIT_MULTIMEDIA)) {

--- a/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
+++ b/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
@@ -7,9 +7,10 @@
  */
 
 /**
- * @defgroup    net_dhcpv6_client_6lbr  DHCPv6 client for 6LoWPAN border routers
+ * @defgroup    net_dhcpv6_client_6lbr  DHCPv6 client for simple prefix
+ *              delegation
  * @ingroup     net_dhcpv6_client
- * @brief       DHCPv6 client bootstrapping for 6LoWPAN border routers
+ * @brief       DHCPv6 client bootstrapping for routers & 6LoWPAN border routers
  * @{
  *
  * @file
@@ -17,8 +18,8 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NET_GNRC_DHCPV6_CLIENT_6LBR_H
-#define NET_GNRC_DHCPV6_CLIENT_6LBR_H
+#ifndef NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H
+#define NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,15 +61,15 @@ extern "C" {
 #endif
 
 /**
- * @brief   Initializes the DHCPv6 client for 6LoWPAN border router
+ * @brief   Initializes the DHCPv6 client for simple prefix delegation
  *
  * @note    Called by `auto_init` when included
  */
-void gnrc_dhcpv6_client_6lbr_init(void);
+void gnrc_dhcpv6_client_simple_pd_init(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* NET_GNRC_DHCPV6_CLIENT_6LBR_H */
+#endif /* NET_GNRC_DHCPV6_CLIENT_SIMPLE_PD_H */
 /** @} */

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -52,6 +52,10 @@ ifneq (,$(filter gnrc_dhcpv6_client,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_dhcpv6_client_6lbr,$(USEMODULE)))
+  USEMODULE += gnrc_dhcpv6_client_simple_pd
+endif
+
+ifneq (,$(filter gnrc_dhcpv6_client_simple_pd,$(USEMODULE)))
   USEMODULE += gnrc_dhcpv6_client
 endif
 

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -18,7 +18,7 @@
 #include "log.h"
 #include "net/arp.h"
 #include "net/dhcpv6.h"
-#include "net/gnrc/dhcpv6/client/6lbr.h"
+#include "net/gnrc/dhcpv6/client/simple_pd.h"
 #include "net/gnrc/ipv6/nib/pl.h"
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "net/gnrc/netif.h"


### PR DESCRIPTION
### Contribution description

The `gnrc_dhcpv6_client_6lbr` code only considers 6LoWPAN interfaces possible downstream interface candidates.
This needlessly excludes the use of DHCPv6 for non-6lo downstream networks.

Chose all non-upstream interfaces as downstream interfaces for DHCPv6 to allow using it together with e.g. SLIP, DOSE or ethos.


### Testing procedure

I tested this on `same54-xpro` which has an Ethernet interface that is used as uplink and which has a downlink device connected via SLIP.
For this to work with SLIP a second patch is needed to simulate a L2 address that is then used as an IPv6 IID.

I ran this with `examples/gnrc_networking` with the following modules added:

```Makefile
USEMODULE += ethos
USEMODULE += gnrc_dhcpv6_client_6lbr
CFLAGS += -DETHOS_UART=UART_DEV\(1\)
CFLAGS += -DETHOS_BAUDRATE=115200
CFLAGS += -DCONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM=6
```

#### master

No prefix for the non-6lo downstream interface

```
2021-06-06 23:56:51,753 # Iface  6  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-06 23:56:51,757 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2021-06-06 23:56:51,760 #           Source address length: 6
2021-06-06 23:56:51,763 #           Link type: wired
2021-06-06 23:56:51,769 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-06 23:56:51,776 #           inet6 addr: 2001:16b8:45fb:1d00:fec2:3dff:fe0d:2d1f  scope: global  VAL
2021-06-06 23:56:51,779 #           inet6 group: ff02::2
2021-06-06 23:56:51,781 #           inet6 group: ff02::1
2021-06-06 23:56:51,785 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-06 23:56:51,786 #           
2021-06-06 23:56:51,789 #           Statistics for Layer 2
2021-06-06 23:56:51,792 #             RX packets 43  bytes 10838
2021-06-06 23:56:51,796 #             TX packets 9 (Multicast: 9)  bytes 762
2021-06-06 23:56:51,800 #             TX succeeded 9 errors 0
2021-06-06 23:56:51,802 #           Statistics for IPv6
2021-06-06 23:56:51,806 #             RX packets 16  bytes 4722
2021-06-06 23:56:51,810 #             TX packets 9 (Multicast: 9)  bytes 636
2021-06-06 23:56:51,813 #             TX succeeded 9 errors 0
2021-06-06 23:56:51,813 # 
2021-06-06 23:56:51,817 # Iface  5  HWaddr: A6:ED:29:EC:C7:F3 
2021-06-06 23:56:51,821 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-06 23:56:51,823 #           RTR_ADV  
2021-06-06 23:56:51,826 #           Source address length: 6
2021-06-06 23:56:51,828 #           Link type: wired
2021-06-06 23:56:51,834 #           inet6 addr: fe80::a4ed:29ff:feec:c7f3  scope: link  VAL
2021-06-06 23:56:51,836 #           inet6 group: ff02::2
2021-06-06 23:56:51,839 #           inet6 group: ff02::1
2021-06-06 23:56:51,843 #           inet6 group: ff02::1:ffec:c7f3
2021-06-06 23:56:51,844 #           
2021-06-06 23:56:51,847 #           Statistics for Layer 2
2021-06-06 23:56:51,850 #             RX packets 0  bytes 0
2021-06-06 23:56:51,854 #             TX packets 1 (Multicast: 1)  bytes 78
2021-06-06 23:56:51,857 #             TX succeeded 0 errors 0
2021-06-06 23:56:51,860 #           Statistics for IPv6
2021-06-06 23:56:51,863 #             RX packets 0  bytes 0
2021-06-06 23:56:51,867 #             TX packets 1 (Multicast: 1)  bytes 64
2021-06-06 23:56:51,870 #             TX succeeded 1 errors 0
```

#### this PR

The downstream interface gets a prefix
```
2021-06-06 23:55:40,042 # Iface  6  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-06 23:55:40,046 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2021-06-06 23:55:40,050 #           Source address length: 6
2021-06-06 23:55:40,052 #           Link type: wired
2021-06-06 23:55:40,058 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-06 23:55:40,065 #           inet6 addr: 2001:16b8:45fb:1d00:fec2:3dff:fe0d:2d1f  scope: global  VAL
2021-06-06 23:55:40,068 #           inet6 group: ff02::2
2021-06-06 23:55:40,070 #           inet6 group: ff02::1
2021-06-06 23:55:40,074 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-06 23:55:40,075 #           
2021-06-06 23:55:40,078 #           Statistics for Layer 2
2021-06-06 23:55:40,081 #             RX packets 31  bytes 6684
2021-06-06 23:55:40,085 #             TX packets 8 (Multicast: 8)  bytes 734
2021-06-06 23:55:40,089 #             TX succeeded 8 errors 0
2021-06-06 23:55:40,091 #           Statistics for IPv6
2021-06-06 23:55:40,095 #             RX packets 16  bytes 3431
2021-06-06 23:55:40,099 #             TX packets 8 (Multicast: 8)  bytes 622
2021-06-06 23:55:40,102 #             TX succeeded 8 errors 0
2021-06-06 23:55:40,102 # 
2021-06-06 23:55:40,106 # Iface  5  HWaddr: A6:ED:29:EC:C7:F3 
2021-06-06 23:55:40,110 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2021-06-06 23:55:40,112 #           RTR_ADV  
2021-06-06 23:55:40,115 #           Source address length: 6
2021-06-06 23:55:40,117 #           Link type: wired
2021-06-06 23:55:40,123 #           inet6 addr: fe80::a4ed:29ff:feec:c7f3  scope: link  VAL
2021-06-06 23:55:40,130 #           inet6 addr: 2001:16b8:45fb:1df8:a4ed:29ff:feec:c7f3  scope: global  VAL
2021-06-06 23:55:40,133 #           inet6 group: ff02::2
2021-06-06 23:55:40,135 #           inet6 group: ff02::1
2021-06-06 23:55:40,139 #           inet6 group: ff02::1:ffec:c7f3
2021-06-06 23:55:40,142 #           inet6 group: ff02::1a
2021-06-06 23:55:40,143 #           
2021-06-06 23:55:40,146 #           Statistics for Layer 2
2021-06-06 23:55:40,149 #             RX packets 0  bytes 0
2021-06-06 23:55:40,153 #             TX packets 9 (Multicast: 9)  bytes 948
2021-06-06 23:55:40,156 #             TX succeeded 0 errors 0
2021-06-06 23:55:40,159 #           Statistics for IPv6
2021-06-06 23:55:40,162 #             RX packets 0  bytes 0
2021-06-06 23:55:40,166 #             TX packets 9 (Multicast: 9)  bytes 822
2021-06-06 23:55:40,169 #             TX succeeded 9 errors 0
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
