### PR TITLE
drivers/slipdev: report NETOPT_ADDRESS to simulate l2 address

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -321,6 +321,7 @@ typedef enum {
     NETDEV_SX126X,
     NETDEV_CC2420,
     NETDEV_ETHOS,
+    NETDEV_SLIPDEV,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -105,8 +105,10 @@ typedef struct {
  *
  * @param[in] dev       device descriptor
  * @param[in] params    parameters for device initialization
+ * @param[in] index     index of @p params in a global parameter struct array.
+ *                      If initialized manually, pass a unique identifier instead.
  */
-void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params);
+void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index);
 
 #ifdef __cplusplus
 }

--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -1,4 +1,5 @@
 USEMODULE += tsrb
+USEMODULE += eui_provider
 FEATURES_REQUIRED += periph_uart
 
 ifneq (,$(filter slipdev_stdio,$(USEMODULE)))

--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -1,5 +1,6 @@
 USEMODULE += tsrb
 USEMODULE += eui_provider
+USEMODULE += netdev_register
 FEATURES_REQUIRED += periph_uart
 
 ifneq (,$(filter slipdev_stdio,$(USEMODULE)))

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -252,12 +252,14 @@ static const netdev_driver_t slip_driver = {
     .set = netdev_set_notsup,
 };
 
-void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params)
+void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index)
 {
     /* set device descriptor fields */
     dev->config = *params;
     dev->state = 0;
     dev->netdev.driver = &slip_driver;
+
+    netdev_register(&dev->netdev, NETDEV_SLIPDEV, index);
 }
 
 /** @} */

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -21,6 +21,7 @@
 #include "log.h"
 #include "slipdev.h"
 #include "slipdev_internal.h"
+#include "net/eui_provider.h"
 
 /* XXX: BE CAREFUL ABOUT USING OUTPUT WITH MODULE_SLIPDEV_STDIO IN SENDING
  * FUNCTIONALITY! MIGHT CAUSE DEADLOCK!!!1!! */
@@ -231,6 +232,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_SLIP;
             return sizeof(uint16_t);
+#if IS_USED(MODULE_SLIPDEV_L2ADDR)
+        case NETOPT_ADDRESS_LONG:
+            assert(max_len == sizeof(eui64_t));
+            netdev_eui64_get(netdev, value);
+            return sizeof(eui64_t);
+#endif
         default:
             return -ENOTSUP;
     }

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -128,6 +128,7 @@ PSEUDOMODULES += sched_cb
 PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio
+PSEUDOMODULES += slipdev_l2addr
 PSEUDOMODULES += sock
 PSEUDOMODULES += sock_async
 PSEUDOMODULES += sock_aux_local

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -143,7 +143,7 @@ extern "C" {
  *       address types are included
  */
 #ifndef GNRC_NETIF_L2ADDR_MAXLEN
-#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE)
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) || defined(MODULE_SLIPDEV_L2ADDR)
 #define GNRC_NETIF_L2ADDR_MAXLEN   (IEEE802154_LONG_ADDRESS_LEN)
 #elif   MODULE_NETDEV_ETH
 #define GNRC_NETIF_L2ADDR_MAXLEN   (ETHERNET_ADDR_LEN)

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1364,8 +1364,13 @@ static void _test_options(gnrc_netif_t *netif)
             assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
             assert(netif->l2addr_len >= 3U && netif->l2addr_len <= 5U);
             break;
-        case NETDEV_TYPE_LORA: /* LoRa doesn't provide L2 ADDR */
         case NETDEV_TYPE_SLIP:
+#if IS_USED(MODULE_SLIPDEV_L2ADDR)
+            assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
+            assert(8U == netif->l2addr_len);
+            break;
+#endif /* IS_USED(MODULE_SLIPDEV_L2ADDR) */
+        case NETDEV_TYPE_LORA: /* LoRa doesn't provide L2 ADDR */
             assert(!(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR));
             assert(0U == netif->l2addr_len);
             /* don't check MTU here for now since I'm not sure the current

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -57,6 +57,11 @@ netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
             }
             break;
 #endif
+#if defined(MODULE_SLIPDEV_L2ADDR)
+        case NETDEV_TYPE_SLIP:
+            res = NETOPT_ADDRESS_LONG;
+            break;
+#endif
         default:
             break;
     }

--- a/sys/net/gnrc/netif/init_devs/auto_init_slipdev.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_slipdev.c
@@ -48,7 +48,7 @@ void auto_init_slipdev(void)
 
         LOG_DEBUG("[auto_init_netif] initializing slip #%u\n", i);
 
-        slipdev_setup(&slipdevs[i], p);
+        slipdev_setup(&slipdevs[i], p, i);
         gnrc_netif_raw_create(&_netif[i], _slipdev_stacks[i], SLIPDEV_STACKSIZE,
                               SLIPDEV_PRIO, "slipdev",
                               (netdev_t *)&slipdevs[i]);

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -123,6 +123,11 @@ int l2util_eui64_from_addr(int dev_type, const uint8_t *addr, size_t addr_len,
                 return -EINVAL;
             }
 #endif /* defined (MODULE_NRF24L01P_NG) */
+#if defined(MODULE_SLIPDEV_L2ADDR)
+        case NETDEV_TYPE_SLIP:
+            memcpy(eui64, addr, addr_len);
+            return sizeof(eui64_t);
+#endif /* defined(MODULE_SLIPDEV_L2ADDR) */
         default:
             (void)addr;
             (void)addr_len;
@@ -230,6 +235,11 @@ int l2util_ipv6_iid_to_addr(int dev_type, const eui64_t *iid, uint8_t *addr)
             memcpy(&addr[addr_len - 3], &iid->uint8[5], 3);
             return addr_len;
 #endif /* defined(MODULE_NRF24L01P_NG) */
+#if defined(MODULE_SLIPDEV_L2ADDR)
+        case NETDEV_TYPE_SLIP:
+            memcpy(addr, iid, sizeof(eui64_t));
+            return sizeof(eui64_t);
+#endif /* defined(MODULE_SLIP) */
         default:
             (void)iid;
             (void)addr;
@@ -288,6 +298,10 @@ int l2util_ndp_addr_len_from_l2ao(int dev_type,
             (void)opt;
             return 5; /* maximum length */
 #endif /* defined(MODULE_NRF24L01P_NG) */
+#if defined(MODULE_SLIPDEV_L2ADDR)
+        case NETDEV_TYPE_SLIP:
+            return sizeof(eui64_t);
+#endif /* defined(MODULE_SLIPDEV_L2ADDR) */
         default:
             (void)opt;
 #ifdef DEVELHELP


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A lot of things break if `GNRC_NETIF_FLAGS_HAS_L2ADDR` is not set (failed asserts, no IPv6 IID).
In order to handle router advertisements and auto-configuration, generate a faux l2 address based on the netdev ID.


### Testing procedure

In combination with #16530 SLIP can now be used as a downstream interface for board to board communication:

I ran this on `same54-xpro` with examples/gnrc_networking with the following modules added:


```Make
USEMODULE += slipdev_l2addr
USEMODULE += gnrc_dhcpv6_client_6lbr
CFLAGS += -DSLIPDEV_PARAM_UART=UART_DEV\(1\)
CFLAGS += -DCONFIG_GNRC_DHCPV6_CLIENT_6LBR_UPSTREAM=5
```

The SLIP interface now has a hardware address, which gives it a link-local address and the possibility to get a prefix via DHCPv6:

```
2021-06-07 00:13:08,232 # ifconfig
2021-06-07 00:13:08,233 # Iface  6 
2021-06-07 00:13:08,237 #           Long HWaddr: E6:EA:AF:F8:AF:5D:EB:E5 
2021-06-07 00:13:08,240 #           MTU:65535  HL:64  RTR  
2021-06-07 00:13:08,242 #           RTR_ADV  
2021-06-07 00:13:08,244 #           Link type: wired
2021-06-07 00:13:08,250 #           inet6 addr: fe80::e4ea:aff8:af5d:ebe5  scope: link  VAL
2021-06-07 00:13:08,257 #           inet6 addr: 2001:16b8:45fb:1dfc:e4ea:aff8:af5d:ebe5  scope: global  VAL
2021-06-07 00:13:08,260 #           inet6 group: ff02::2
2021-06-07 00:13:08,262 #           inet6 group: ff02::1
2021-06-07 00:13:08,266 #           inet6 group: ff02::1:ff5d:ebe5
2021-06-07 00:13:08,269 #           inet6 group: ff02::1a
2021-06-07 00:13:08,270 #           
2021-06-07 00:13:08,273 #           Statistics for Layer 2
2021-06-07 00:13:08,276 #             RX packets 1  bytes 64
2021-06-07 00:13:08,280 #             TX packets 11 (Multicast: 0)  bytes 1038
2021-06-07 00:13:08,284 #             TX succeeded 0 errors 0
2021-06-07 00:13:08,286 #           Statistics for IPv6
2021-06-07 00:13:08,289 #             RX packets 1  bytes 64
2021-06-07 00:13:08,294 #             TX packets 11 (Multicast: 11)  bytes 1038
2021-06-07 00:13:08,297 #             TX succeeded 11 errors 0
2021-06-07 00:13:08,297 # 
2021-06-07 00:13:08,301 # Iface  5  HWaddr: FC:C2:3D:0D:2D:1F 
2021-06-07 00:13:08,305 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2021-06-07 00:13:08,308 #           Source address length: 6
2021-06-07 00:13:08,310 #           Link type: wired
2021-06-07 00:13:08,316 #           inet6 addr: fe80::fec2:3dff:fe0d:2d1f  scope: link  VAL
2021-06-07 00:13:08,323 #           inet6 addr: 2001:16b8:45fb:1d00:fec2:3dff:fe0d:2d1f  scope: global  VAL
2021-06-07 00:13:08,326 #           inet6 group: ff02::2
2021-06-07 00:13:08,329 #           inet6 group: ff02::1
2021-06-07 00:13:08,332 #           inet6 group: ff02::1:ff0d:2d1f
2021-06-07 00:13:08,333 #           
2021-06-07 00:13:08,336 #           Statistics for Layer 2
2021-06-07 00:13:08,339 #             RX packets 43  bytes 9676
2021-06-07 00:13:08,344 #             TX packets 10 (Multicast: 8)  bytes 898
2021-06-07 00:13:08,347 #             TX succeeded 10 errors 0
2021-06-07 00:13:08,350 #           Statistics for IPv6
2021-06-07 00:13:08,353 #             RX packets 19  bytes 4459
2021-06-07 00:13:08,358 #             TX packets 10 (Multicast: 8)  bytes 758
2021-06-07 00:13:08,361 #             TX succeeded 10 errors 0
```

The node on the other side also gets a link-local and a global address:

```
2021-06-07 00:14:43,284 # Iface  5  HWaddr: 00:04:25:19:18:01:C9:05 
2021-06-07 00:14:43,288 #           MTU:65535  HL:64  RTR  
2021-06-07 00:14:43,289 #           
2021-06-07 00:14:43,291 #           Link type: wired
2021-06-07 00:14:43,297 #           inet6 addr: fe80::204:2519:1801:c905  scope: link  VAL
2021-06-07 00:14:43,304 #           inet6 addr: 2001:16b8:45fb:1dfc:204:2519:1801:c905  scope: global  VAL
2021-06-07 00:14:43,307 #           inet6 group: ff02::2
2021-06-07 00:14:43,310 #           inet6 group: ff02::1
2021-06-07 00:14:43,314 #           inet6 group: ff02::1:ff01:c905
2021-06-07 00:14:43,315 #           
2021-06-07 00:14:43,318 #           Statistics for Layer 2
2021-06-07 00:14:43,321 #             RX packets 1  bytes 104
2021-06-07 00:14:43,325 #             TX packets 6 (Multicast: 0)  bytes 392
2021-06-07 00:14:43,328 #             TX succeeded 0 errors 0
2021-06-07 00:14:43,331 #           Statistics for IPv6
2021-06-07 00:14:43,334 #             RX packets 1  bytes 104
2021-06-07 00:14:43,339 #             TX packets 6 (Multicast: 6)  bytes 392
2021-06-07 00:14:43,342 #             TX succeeded 6 errors 0
2021-06-07 00:14:43,342 # 
> ping 2600::
2021-06-07 00:14:48,175 # ping 2600::
2021-06-07 00:14:48,310 # 12 bytes from 2600::: icmp_seq=0 ttl=52 time=130.329 ms
2021-06-07 00:14:49,311 # 12 bytes from 2600::: icmp_seq=1 ttl=52 time=129.894 ms
2021-06-07 00:14:50,312 # 12 bytes from 2600::: icmp_seq=2 ttl=52 time=129.805 ms
2021-06-07 00:14:50,312 # 
2021-06-07 00:14:50,315 # --- 2600:: PING statistics ---
2021-06-07 00:14:50,320 # 3 packets transmitted, 3 packets received, 0% packet loss
2021-06-07 00:14:50,325 # round-trip min/avg/max = 129.805/130.009/130.329 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
