### PR TITLE
ieee802154/submac: fix initialization code

### DIFF
--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -302,8 +302,24 @@ static int _init(netdev_t *netdev)
                                                              netdev_ieee802154_submac_t,
                                                              dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
+    netdev_ieee802154_setup(netdev_ieee802154);
+
     ieee802154_submac_init(submac, (network_uint16_t*) netdev_ieee802154->short_addr, (eui64_t*) netdev_ieee802154->long_addr);
 
+    /* This function already sets the PAN ID to the default one */
+    netdev_ieee802154_reset(netdev_ieee802154);
+
+    uint16_t chan = submac->channel_num;
+    int16_t tx_power = submac->tx_pow;
+    netopt_enable_t enable = NETOPT_ENABLE;
+
+    /* Initialise netdev_ieee802154_t struct */
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
+                          &chan, sizeof(chan));
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
+                          &enable, sizeof(enable));
+
+    netdev_submac->dev.txpower = tx_power;
     return 0;
 }
 
@@ -324,25 +340,6 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac,
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;
-
-    netdev_ieee802154_t *netdev_ieee802154 = &netdev_submac->dev;
-
-    /* This function already sets the PAN ID to the default one */
-    netdev_ieee802154_reset(netdev_ieee802154);
-
-    uint16_t chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
-    int16_t tx_power = CONFIG_IEEE802154_DEFAULT_TXPOWER;
-    netopt_enable_t enable = NETOPT_ENABLE;
-
-    netdev_ieee802154_setup(netdev_ieee802154);
-
-    /* Initialise netdev_ieee802154_t struct */
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
-                          &chan, sizeof(chan));
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
-                          &enable, sizeof(enable));
-
-    netdev_submac->dev.txpower = tx_power;
 
     return 0;
 }

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -304,7 +304,13 @@ static int _init(netdev_t *netdev)
     ieee802154_submac_t *submac = &netdev_submac->submac;
     netdev_ieee802154_setup(netdev_ieee802154);
 
-    ieee802154_submac_init(submac, (network_uint16_t*) netdev_ieee802154->short_addr, (eui64_t*) netdev_ieee802154->long_addr);
+    int res = ieee802154_submac_init(submac,
+                                     (network_uint16_t*) netdev_ieee802154->short_addr,
+                                     (eui64_t*) netdev_ieee802154->long_addr);
+
+    if (res < 0) {
+        return res;
+    }
 
     /* This function already sets the PAN ID to the default one */
     netdev_ieee802154_reset(netdev_ieee802154);

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -371,7 +371,7 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
     ieee802154_phy_conf_t conf =
     { .phy_mode = submac->phy_mode,
       .channel = CONFIG_IEEE802154_DEFAULT_CHANNEL,
-      .page = CONFIG_IEEE802154_DEFAULT_CHANNEL,
+      .page = CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE,
       .pow = CONFIG_IEEE802154_DEFAULT_TXPOWER };
 
     ieee802154_radio_config_phy(dev, &conf);

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -370,15 +370,16 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
     /* Configure PHY settings (mode, channel, TX power) */
     ieee802154_phy_conf_t conf =
     { .phy_mode = submac->phy_mode,
-      .channel = CONFIG_IEEE802154_DEFAULT_CHANNEL,
-      .page = CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE,
-      .pow = CONFIG_IEEE802154_DEFAULT_TXPOWER };
+      .channel = submac->channel_num,
+      .page = submac->channel_page,
+      .pow = submac->tx_pow };
 
     ieee802154_radio_config_phy(dev, &conf);
     assert(ieee802154_radio_set_cca_threshold(dev,
                                               CONFIG_IEEE802154_CCA_THRESH_DEFAULT) >= 0);
 
     ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_RX_ON);
+    while(ieee802154_radio_confirm_set_trx_state(dev) == -EAGAIN) {};
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR does essentially 3 things:
- Move some of the initialization code of netdev_ieee802154_submac from `netdev_submac_ieee802154_init` to the actual `_init` function of `netdev_driver_t`. This is required in order to make sure the device is initialized before setting netdev stuff.
- Fix the default SubGHz page
- Call `confirm_set_trx_state` after setting the state to RX_ON during initialization. In some cases, the radio was not ready to do a state transition because `request_set_trx_state` didn't finish.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Ensure hal dependent radios (cc2538, nrf52840) still work with `gnrc_networking` and `tests/ieee802154_hal`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
