### PR TITLE
[RFC] at86rf2xx: implement radio HAL

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -113,6 +113,7 @@ static const ieee802154_radio_cipher_ops_t _at86rf2xx_cipher_ops = {
 #endif /* IS_USED(MODULE_AT86RF2XX_AES_SPI) && \
           IS_USED(MODULE_IEEE802154_SECURITY) */
 
+#if 0
 void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t index)
 {
     netdev_t *netdev = &dev->netdev.netdev;
@@ -137,8 +138,9 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t
     /* set device address */
     netdev_ieee802154_setup(&dev->netdev);
 }
+#endif
 
-static void at86rf2xx_disable_clock_output(at86rf2xx_t *dev)
+void at86rf2xx_disable_clock_output(at86rf2xx_t *dev)
 {
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
     (void) dev;
@@ -151,7 +153,7 @@ static void at86rf2xx_disable_clock_output(at86rf2xx_t *dev)
 #endif
 }
 
-static void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
+void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
 {
 #if AT86RF2XX_SMART_IDLE_LISTENING
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_RPC);
@@ -167,6 +169,7 @@ static void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
 #endif
 }
 
+#if 0
 void at86rf2xx_reset(at86rf2xx_t *dev)
 {
     netdev_ieee802154_reset(&dev->netdev);
@@ -245,6 +248,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 
     DEBUG("at86rf2xx_reset(): reset complete.\n");
 }
+#endif
 
 size_t at86rf2xx_send(at86rf2xx_t *dev, const uint8_t *data, size_t len)
 {
@@ -281,7 +285,7 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
 
 void at86rf2xx_tx_exec(at86rf2xx_t *dev)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    //netdev_t *netdev = (netdev_t *)dev;
 
 #if AT86RF2XX_HAVE_RETRIES
     dev->tx_retries = -1;
@@ -292,10 +296,12 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
     /* trigger sending of pre-loaded frame */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE,
                         AT86RF2XX_TRX_STATE__TX_START);
+    /*
     if (netdev->event_callback &&
         (dev->flags & AT86RF2XX_OPT_TELL_TX_START)) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
     }
+    */
 }
 
 bool at86rf2xx_cca(at86rf2xx_t *dev)

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -164,6 +164,7 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
              && (dev->state != AT86RF2XX_STATE_P_ON));
 }
 
+#if 0
 void at86rf2xx_configure_phy(at86rf2xx_t *dev)
 {
     /* we must be in TRX_OFF before changing the PHY configuration */
@@ -219,6 +220,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
     /* Return to the state we had before reconfiguring */
     at86rf2xx_set_state(dev, prev_state);
 }
+#endif
 
 #if AT86RF2XX_RANDOM_NUMBER_GENERATOR
 void at86rf2xx_get_random(const at86rf2xx_t *dev, uint8_t *data, size_t len)

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -46,6 +46,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#if 0
 static int _send(netdev_t *netdev, const iolist_t *iolist);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
@@ -836,6 +837,7 @@ static void _isr(netdev_t *netdev)
         }
     }
 }
+#endif
 
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
 

--- a/drivers/at86rf2xx/at86rf2xx_radio_ops.c
+++ b/drivers/at86rf2xx/at86rf2xx_radio_ops.c
@@ -1,0 +1,633 @@
+#include "at86rf2xx.h"
+#include "at86rf2xx_internal.h"
+#include "at86rf2xx_registers.h"
+#include "net/ieee802154/radio.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+extern void at86rf2xx_irq_handler(void *arg);
+
+static const ieee802154_radio_ops_t at86rf2xx_ops;
+
+static int _write(ieee802154_dev_t *dev, const iolist_t *psdu)
+{
+    DEBUG("at86rf2xx_rf_ops: write\n");
+    size_t len = 0;
+
+    at86rf2xx_t *_dev = dev->priv;
+
+    _dev->tx_frame_len = IEEE802154_FCS_LEN;
+
+    /* load packet data into FIFO */
+    for (const iolist_t *iol = psdu; iol; iol = iol->iol_next) {
+        /* current packet data + FCS too long */
+        if ((len + iol->iol_len + 2) > AT86RF2XX_MAX_PKT_LENGTH) {
+            DEBUG("[at86rf2xx] error: packet too large (%u byte) to be send\n",
+                  (unsigned)len + 2);
+            return -EOVERFLOW;
+        }
+
+        if (iol->iol_len) {
+            len = at86rf2xx_tx_load(_dev, iol->iol_base, iol->iol_len, len);
+        }
+    }
+    return 0;
+}
+
+static int _request_transmit(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: request_transmit\n");
+    at86rf2xx_t *_dev = dev->priv;
+    at86rf2xx_tx_exec(_dev);
+    return 0;
+}
+
+static int _confirm_transmit(ieee802154_dev_t *dev, ieee802154_tx_info_t *info)
+{
+    DEBUG("at86rf2xx_rf_ops: confirm_transmit\n");
+    at86rf2xx_t *_dev = dev->priv;
+    uint8_t status = at86rf2xx_get_status(_dev);
+    if (status == AT86RF2XX_STATE_BUSY_TX_ARET || status == AT86RF2XX_STATE_BUSY_TX) {
+        return -EAGAIN;
+    }
+
+    if (info) {
+        uint8_t trac_status = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__TRX_STATE) & AT86RF2XX_TRX_STATE_MASK__TRAC;
+#if AT86RF2XX_HAVE_RETRIES && defined(AT86RF2XX_REG__XAH_CTRL_2)
+        info->retrans = (at86rf2xx_reg_read(_dev, AT86RF2XX_REG__XAH_CTRL_2)
+                       & AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK) >>
+                      AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;
+#endif
+        switch(trac_status) {
+            case AT86RF2XX_TRX_STATE__TRAC_SUCCESS:
+                info->status = TX_STATUS_SUCCESS;
+                break;
+            case AT86RF2XX_TRX_STATE__TRAC_SUCCESS_DATA_PENDING:
+                info->status = TX_STATUS_FRAME_PENDING;
+                break;
+            case AT86RF2XX_TRX_STATE__TRAC_CHANNEL_ACCESS_FAILURE:
+                info->status = TX_STATUS_MEDIUM_BUSY;
+                break;
+            case AT86RF2XX_TRX_STATE__TRAC_NO_ACK:
+                info->status = TX_STATUS_NO_ACK;
+                break;
+            default:
+                DEBUG("[at86rf2xx] Unhandled TRAC_STATUS: %d\n", trac_status >> 5);
+
+        }
+    }
+    return 0;
+}
+
+static int _len(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: len\n");
+    uint8_t phr;
+    at86rf2xx_t *_dev = dev->priv;
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    phr = TST_RX_LENGTH;
+#else
+    at86rf2xx_sram_read(_dev, 0, &phr, 1);
+#endif
+    return (phr & 0x7f) - 2;
+}
+
+/* The radio should be woken up */
+static int _read(ieee802154_dev_t *dev, void *buf, size_t max_size, ieee802154_rx_info_t *info)
+{
+    DEBUG("at86rf2xx_rf_ops: read\n");
+    uint8_t phr;
+    size_t pkt_len;
+
+    at86rf2xx_t *_dev = dev->priv;
+
+    /* start frame buffer access */
+    at86rf2xx_fb_start(_dev);
+
+    /* get the size of the received packet */
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    phr = TST_RX_LENGTH;
+#else
+    at86rf2xx_fb_read(_dev, &phr, 1);
+#endif
+
+    /* ignore MSB (refer p.80) and subtract length of FCS field */
+    pkt_len = (phr & 0x7f) - 2;
+
+    /* not enough space in buf */
+    if (pkt_len > max_size) {
+        at86rf2xx_fb_stop(_dev);
+        return -ENOBUFS;
+    }
+
+    if (!buf) {
+        at86rf2xx_fb_stop(_dev);
+        return 0;
+    }
+    /* copy payload */
+    at86rf2xx_fb_read(_dev, (uint8_t *)buf, pkt_len);
+
+    /* Ignore FCS but advance fb read - we must give a temporary buffer here,
+     * as we are not allowed to issue SPI transfers without any buffer */
+    uint8_t tmp[2];
+    at86rf2xx_fb_read(_dev, tmp, 2);
+    (void)tmp;
+
+    /* AT86RF212B RSSI_BASE_VAL + 1.03 * ED, base varies for diff. modulation and datarates
+     * AT86RF232  RSSI_BASE_VAL + ED, base -91dBm
+     * AT86RF233  RSSI_BASE_VAL + ED, base -94dBm
+     * AT86RF231  RSSI_BASE_VAL + ED, base -91dBm
+     * AT86RFA1   RSSI_BASE_VAL + ED, base -90dBm
+     * AT86RFR2   RSSI_BASE_VAL + ED, base -90dBm
+     *
+     * AT86RF231 MAN. p.92, 8.4.3 Data Interpretation
+     * AT86RF232 MAN. p.91, 8.4.3 Data Interpretation
+     * AT86RF233 MAN. p.102, 8.5.3 Data Interpretation
+     *
+     * for performance reasons we ignore the 1.03 scale factor on the 212B,
+     * which causes a slight error in the values, but the accuracy of the ED
+     * value is specified as +/- 5 dB, so it should not matter very much in real
+     * life.
+     */
+    if (info != NULL) {
+        uint8_t ed = 0;
+        at86rf2xx_fb_read(_dev, &(info->lqi), 1);
+
+#if defined(MODULE_AT86RF231) || defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+        /* AT86RF231 does not provide ED at the end of the frame buffer, read
+         * from separate register instead */
+        at86rf2xx_fb_stop(_dev);
+        ed = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__PHY_ED_LEVEL);
+#else
+        at86rf2xx_fb_read(_dev, &ed, 1);
+        at86rf2xx_fb_stop(_dev);
+#endif
+        info->rssi = RSSI_BASE_VAL + ed;
+        DEBUG("[at86rf2xx] LQI:%d high is good, RSSI:%d high is either good or"
+              "too much interference.\n", info->lqi, info->rssi);
+    }
+    else {
+        at86rf2xx_fb_stop(_dev);
+    }
+
+    return pkt_len;
+}
+
+static int _request_cca(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: request_cca\n");
+    at86rf2xx_t *_dev = dev->priv;
+    uint8_t reg;
+    /* TODO: Check basic mode */
+    at86rf2xx_set_state(_dev, AT86RF2XX_STATE_RX_ON);
+    /* Perform CCA */
+    reg = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__PHY_CC_CCA);
+    reg |= AT86RF2XX_PHY_CC_CCA_MASK__CCA_REQUEST;
+    at86rf2xx_reg_write(_dev, AT86RF2XX_REG__PHY_CC_CCA, reg);
+    return 0;
+}
+
+static int _confirm_cca(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: confirm_cca\n");
+    uint8_t reg;
+    at86rf2xx_t *_dev = dev->priv;
+    reg = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__TRX_STATUS);
+    if ((reg & AT86RF2XX_TRX_STATUS_MASK__CCA_DONE) == 0) {
+        return -EAGAIN;
+    }
+    at86rf2xx_set_state(_dev, AT86RF2XX_STATE_RX_AACK_ON);
+    return !!(reg & AT86RF2XX_TRX_STATUS_MASK__CCA_STATUS);
+}
+
+static int _set_cca_threshold(ieee802154_dev_t *dev, int8_t threshold)
+{
+    DEBUG("at86rf2xx_rf_ops: set_cca_threshold to %i\n", threshold);
+    at86rf2xx_t *_dev = dev->priv;
+    at86rf2xx_set_cca_threshold(_dev, threshold);
+    //phy_cc_cca |= (channel & AT86RF2XX_PHY_CC_CCA_MASK__CHANNEL);
+    //at86rf2xx_reg_write(_dev, AT86RF2XX_REG__PHY_CC_CCA, phy_cc_cca);
+    return 0;
+}
+
+int at86rf2xx_config_phy_alt(at86rf2xx_t *dev, uint8_t channel,
+        uint8_t page, int8_t txpower);
+
+static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+{
+    DEBUG("at86rf2xx_rf_ops: config_phy to page %i, channel %i and txpow %i\n", conf->page, conf->channel, conf->pow);
+    at86rf2xx_t *_dev = dev->priv;
+    return at86rf2xx_config_phy_alt(_dev, conf->channel, conf->page, conf->pow);
+}
+
+static int _request_set_trx_state(ieee802154_dev_t *dev, ieee802154_trx_state_t state)
+{
+    /* TODO: Fix transition between RX and TX!! */
+    /* TODO: Add basic mode support */
+    DEBUG("at86r2xx_rf_ops: request_set_trx_state to ");
+    at86rf2xx_t *_dev = dev->priv;
+
+    /* TODO: Implement for periph version */
+
+    /* Prevent issue described in https://github.com/RIOT-OS/RIOT/pull/11256 */
+    if ((at86rf2xx_get_status(_dev) == AT86RF2XX_PHY_STATE_RX_BUSY) || _dev->pending_irq) {
+        return -EBUSY;
+    }
+
+    int int_state;
+    switch(state) {
+        case IEEE802154_TRX_STATE_TRX_OFF:
+            int_state = AT86RF2XX_STATE_TRX_OFF;
+            DEBUG("TRX_OFF");
+            break;
+        case IEEE802154_TRX_STATE_RX_ON:
+            int_state = AT86RF2XX_STATE_RX_AACK_ON;
+            DEBUG("RX_ON");
+            /*TODO: Disable race condition */
+            break;
+        case IEEE802154_TRX_STATE_TX_ON:
+            DEBUG("TX_ON");
+            int_state = AT86RF2XX_STATE_TX_ARET_ON;
+            break;
+        default:
+            return -EINVAL;
+    }
+
+    DEBUG("\n");
+
+
+    /* This is also required to prevent https://github.com/RIOT-OS/RIOT/pull/11256.
+     * Disabling the RX path (RX_SYN) is not enough to prevent the race condition :/
+     * If getting the internal transceiver status and checking if there are
+     * pending IRQs doesn't 
+     */
+    if (state != IEEE802154_TRX_STATE_TRX_OFF) {
+        at86rf2xx_reg_write(_dev, AT86RF2XX_REG__TRX_STATE, AT86RF2XX_TRX_STATE__FORCE_PLL_ON);
+    }
+
+    at86rf2xx_reg_write(_dev, AT86RF2XX_REG__TRX_STATE, int_state);
+    return 0;
+}
+
+static int _confirm_set_trx_state(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: confirm_set_trx_state\n");
+    at86rf2xx_t *_dev = dev->priv;
+    assert(at86rf2xx_get_status(_dev) != AT86RF2XX_PHY_STATE_RX_BUSY);
+    if (at86rf2xx_get_status(_dev) == AT86RF2XX_STATE_IN_PROGRESS) {
+        return -EAGAIN;
+    }
+    return 0;
+}
+
+static int _set_hw_addr_filter(ieee802154_dev_t *dev, const network_uint16_t *short_addr, const eui64_t *ext_addr, const uint16_t *pan_id)
+{
+    DEBUG("at86rf2xx_rf_ops: set_hw_addr_filter. ");
+    at86rf2xx_t *_dev = dev->priv;
+    if (pan_id) {
+        le_uint16_t le_pan = byteorder_btols(byteorder_htons(*pan_id));
+        at86rf2xx_reg_write(_dev, AT86RF2XX_REG__PAN_ID_0, le_pan.u8[0]);
+        at86rf2xx_reg_write(_dev, AT86RF2XX_REG__PAN_ID_1, le_pan.u8[1]);
+        DEBUG("PANID: %04x ", *pan_id);
+
+    }
+
+    if (short_addr) {
+        at86rf2xx_reg_write(_dev, AT86RF2XX_REG__SHORT_ADDR_0,
+                            short_addr->u8[1]);
+        at86rf2xx_reg_write(_dev, AT86RF2XX_REG__SHORT_ADDR_1,
+                            short_addr->u8[0]);
+        DEBUG("SHORT_ADDR: %04x ", byteorder_ntohs(*short_addr));
+    }
+
+    if (ext_addr) {
+        DEBUG(" EXT_ADDR: ");
+        for (int i = 0; i < 8; i++) {
+            at86rf2xx_reg_write(_dev, (AT86RF2XX_REG__IEEE_ADDR_0 + i),
+                    ext_addr->uint8[IEEE802154_LONG_ADDRESS_LEN - 1 - i]);
+                DEBUG("%02x", ext_addr->uint8[i]);
+        }
+        DEBUG("\n");
+    }
+
+    return 0;
+}
+
+static int _set_frame_retrans(ieee802154_dev_t *dev, uint8_t retries)
+{
+    DEBUG("at86rf2xx_rf_ops: set_frame_retrans to %i\n", retries);
+    at86rf2xx_t *_dev = dev->priv;
+    uint8_t tmp = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__XAH_CTRL_0);
+
+    tmp &= ~(AT86RF2XX_XAH_CTRL_0__MAX_FRAME_RETRIES);
+    tmp |= ((retries > 7) ? 7 : retries) << 4;
+    at86rf2xx_reg_write(_dev, AT86RF2XX_REG__XAH_CTRL_0, tmp);
+    return 0;
+}
+
+static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd, int8_t retries)
+{
+    DEBUG("at86rf2xx_rf_ops: set_csma_params. ");
+    at86rf2xx_t *_dev = dev->priv;
+    retries = (retries > 5) ? 5 : retries;  /* valid values: 0-5 */
+    retries = (retries < 0) ? 7 : retries;  /* max < 0 => disable CSMA (set to 7) */
+    DEBUG("Retries: %i ", retries);
+    uint8_t tmp = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__XAH_CTRL_0);
+    tmp &= ~(AT86RF2XX_XAH_CTRL_0__MAX_CSMA_RETRIES);
+    tmp |= (retries << 1);
+    at86rf2xx_reg_write(_dev, AT86RF2XX_REG__XAH_CTRL_0, tmp);
+
+    if(bd) {
+        uint8_t max = bd->max;
+        uint8_t min = bd->min;
+        DEBUG("max: %i ", max);
+        DEBUG("min: %i ", min);
+        max = (max > 8) ? 8 : max;
+        min = (min > max) ? max : min;
+        at86rf2xx_reg_write(_dev, AT86RF2XX_REG__CSMA_BE, (max << 4) | (min));
+    }
+    DEBUG("\n");
+
+    return 0;
+}
+
+static int _off(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: off\n");
+    at86rf2xx_t *_dev = dev->priv;
+    at86rf2xx_reg_write(_dev, AT86RF2XX_REG__TRX_STATE, AT86RF2XX_STATE_FORCE_TRX_OFF);
+    /* TODO: Disable interrupts */
+    /* Discard all IRQ flags, framebuffer is lost anyway */
+    at86rf2xx_reg_read(_dev, AT86RF2XX_REG__IRQ_STATUS);
+    /* Go to SLEEP mode from TRX_OFF */
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    /* reset interrupts states in device */
+    _dev->irq_status = 0;
+    /* Setting SLPTR bit brings radio transceiver to sleep in in TRX_OFF*/
+    *AT86RF2XX_REG__TRXPR |= (AT86RF2XX_TRXPR_SLPTR);
+#else
+    gpio_set(_dev->params.sleep_pin);
+#endif
+    return 0;
+}
+
+int _request_on(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: request_on\n");
+    at86rf2xx_t *_dev = dev->priv;
+    gpio_irq_enable(_dev->params.int_pin);
+    /* enable interrupts */
+    at86rf2xx_reg_write(_dev, AT86RF2XX_REG__IRQ_MASK,
+                        AT86RF2XX_IRQ_STATUS_MASK__TRX_END | AT86RF2XX_IRQ_STATUS_MASK__RX_START);
+
+
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    /* Setting SLPTR bit in TRXPR to 0 returns the radio transceiver
+     * to the TRX_OFF state */
+    *AT86RF2XX_REG__TRXPR &= ~(AT86RF2XX_TRXPR_SLPTR);
+#else
+    gpio_clear(_dev->params.sleep_pin);
+#endif
+    return 0;
+}
+
+static int _confirm_on(ieee802154_dev_t *dev)
+{
+    DEBUG("at86rf2xx_rf_ops: confirm_on\n");
+    at86rf2xx_t *_dev = dev->priv;
+    int status = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__TRX_STATUS)
+                     & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+
+     if (status != AT86RF2XX_TRX_STATUS__TRX_OFF)
+     {
+         return -EAGAIN;
+
+     }
+    at86rf2xx_reg_read(_dev, AT86RF2XX_REG__IRQ_STATUS);
+    _dev->pending_irq = false;
+    return 0;
+}
+
+static int _set_cca_mode(ieee802154_dev_t *dev, ieee802154_cca_mode_t mode)
+{
+    (void) dev;
+    /* TODO: */
+    if (mode != IEEE802154_CCA_MODE_ED_THRESHOLD) {
+        DEBUG("at86rf2xx_rf_ops: CCA mode not supported\n");
+        return -ENOTSUP;
+     }
+    DEBUG("at86rf2xx_rf_ops: set_cca_mode to ED Threshold\n");
+    return 0;
+}
+
+static int _set_rx_mode(ieee802154_dev_t *dev, ieee802154_rx_mode_t mode)
+{
+    DEBUG("at86rf2xx_rf_ops: set_rx_mode to ");
+    at86rf2xx_t *_dev = dev->priv;
+    bool ack_pending = false;
+    bool auto_ack = false;
+    bool promisc = false;
+    switch(mode) {
+        case IEEE802154_RX_AACK_ENABLED:
+            DEBUG("IEEE802154_RX_AACK_ENABLED\n");
+            auto_ack = true;
+            break;
+        case IEEE802154_RX_AACK_FRAME_PENDING:
+            DEBUG("IEEE802154_RX_AACK_FRAME_PENDING\n");
+            auto_ack = true;
+            ack_pending = true;
+            break;
+        case IEEE802154_RX_PROMISC:
+            DEBUG("IEEE802154_RX_PROMISC\n");
+            promisc = true;
+            break;
+        case IEEE802154_RX_WAIT_FOR_ACK:
+            DEBUG("IEEE802154_RX_WAIT_FOR_ACK\n");
+            return -ENOTSUP;
+            break;
+        case IEEE802154_RX_AACK_DISABLED:
+            DEBUG("IEEE802154_RX_AACK_DISABLED\n");
+            break;
+    }
+
+    at86rf2xx_set_option(_dev, AT86RF2XX_OPT_AUTOACK, auto_ack);
+    at86rf2xx_set_option(_dev, AT86RF2XX_OPT_ACK_PENDING, ack_pending);
+    at86rf2xx_set_option(_dev, AT86RF2XX_OPT_PROMISCUOUS, promisc);
+    return 0;
+}
+
+void at86rf2xx_init_hal(at86rf2xx_t *dev, ieee802154_dev_t *hal)
+{
+    hal->driver = &at86rf2xx_ops;
+    hal->priv = dev;
+}
+
+/* TODO */
+int at86rf2xx_init(at86rf2xx_t *dev, const at86rf2xx_params_t *params, void *arg)
+{
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    (void) params;
+    /* set all interrupts off */
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK, 0x00);
+#else
+    /* initialize device descriptor */
+    dev->params = *params;
+#endif
+
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    at86rfmega_dev = dev;
+#else
+    /* initialize GPIOs */
+    spi_init_cs(dev->params.spi, dev->params.cs_pin);
+    gpio_init(dev->params.sleep_pin, GPIO_OUT);
+    gpio_clear(dev->params.sleep_pin);
+    gpio_init(dev->params.reset_pin, GPIO_OUT);
+    gpio_set(dev->params.reset_pin);
+    gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, at86rf2xx_irq_handler, arg);
+    gpio_irq_disable(dev->params.int_pin);
+    /* DEBUG PINS */
+    gpio_init(ISR_PIN, GPIO_OUT);
+    gpio_init(TX_PIN, GPIO_OUT);
+    gpio_init(RX_PIN, GPIO_OUT);
+    gpio_init(STATE_PIN, GPIO_OUT);
+
+    /* Intentionally check if bus can be acquired,
+       since getbus() drops the return value */
+    if (spi_acquire(dev->params.spi, dev->params.cs_pin, SPI_MODE_0,
+                                                dev->params.spi_clk) < 0) {
+        DEBUG("[at86rf2xx] error: unable to acquire SPI bus\n");
+        return -EIO;
+    }
+    spi_release(dev->params.spi);
+#endif
+
+    /* reset hardware into a defined state */
+    at86rf2xx_hardware_reset(dev);
+
+    /* test if the device is responding */
+    if (at86rf2xx_reg_read(dev, AT86RF2XX_REG__PART_NUM) != AT86RF2XX_PARTNUM) {
+        DEBUG("[at86rf2xx] error: unable to read correct part number\n");
+        return -ENOTSUP;
+    }
+
+    /* reset device to default values and put it into RX state */
+    //at86rf2xx_reset(dev);
+
+    /* enable safe mode (protect RX FIFO until reading data starts) */
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
+                        AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
+
+#if !defined(MODULE_AT86RFA1) && !defined(MODULE_AT86RFR2)
+    /* don't populate masked interrupt flags to IRQ_STATUS register */
+    uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);
+    tmp &= ~(AT86RF2XX_TRX_CTRL_1_MASK__IRQ_MASK_MODE);
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_1, tmp);
+#endif
+
+    /* configure smart idle listening feature */
+    at86rf2xx_enable_smart_idle(dev);
+
+    /* disable clock output to save power */
+    at86rf2xx_disable_clock_output(dev);
+
+    /* TODO!! */
+    at86rf2xx_set_state(dev, AT86RF2XX_STATE_FORCE_TRX_OFF);
+    /* TODO: ??? */
+    /* enable TX start interrupt for retry counter */
+#ifdef AT86RF2XX_REG__IRQ_MASK1
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK1,
+                             AT86RF2XX_IRQ_STATUS_MASK1__TX_START);
+#endif
+
+    /* TODO: ???? */
+#if IS_USED(MODULE_IEEE802154_SECURITY) && \
+    IS_USED(MODULE_AT86RF2XX_AES_SPI)
+    dev->netdev.sec_ctx.dev.cipher_ops = &_at86rf2xx_cipher_ops;
+    dev->netdev.sec_ctx.dev.ctx = dev;
+    /* All configurations of the security module, the SRAM content,
+       and keys are reset during DEEP_SLEEP or RESET state. */
+    at86rf2xx_aes_key_write_encrypt(dev,
+        dev->netdev.sec_ctx.cipher.context.context);
+#endif
+
+    return 0;
+}
+
+void at86rf2xx_task_handler(ieee802154_dev_t *dev)
+{
+    uint8_t irq_mask;
+    uint8_t state;
+
+    at86rf2xx_t *_dev = dev->priv;
+    /* If transceiver is sleeping register access is impossible and frames are
+     * lost anyway, so return immediately.
+     */
+    /* TODO: Clear flags on sleep... */
+    state = at86rf2xx_get_status(_dev);
+    if (state == AT86RF2XX_STATE_SLEEP) {
+        return;
+    }
+
+    /* read (consume) device status */
+#if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+    irq_mask = _dev->irq_status;
+    _dev->irq_status = 0;
+#else
+    irq_mask = at86rf2xx_reg_read(_dev, AT86RF2XX_REG__IRQ_STATUS);
+    _dev->pending_irq = false;
+#endif
+
+    if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__RX_START) {
+        DEBUG("[at86rf2xx] EVT - RX_START\n");
+        dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_START);
+    }
+
+    if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__TRX_END) {
+        /* TODO: */
+       if ((state == AT86RF2XX_PHY_STATE_RX)
+            || (state == AT86RF2XX_PHY_STATE_RX_BUSY)) {
+            DEBUG("[at86rf2xx] EVT - RX_END\n");
+            dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
+
+        }
+        else if (state == AT86RF2XX_PHY_STATE_TX) {
+            /* check for more pending TX calls and return to idle state if
+             * there are none */
+            DEBUG("[at86rf2xx] EVT - TX_END");
+            dev->cb(dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
+        }
+        else {
+        }
+    }
+}
+
+static const ieee802154_radio_ops_t at86rf2xx_ops = {
+    .caps =  IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_IRQ_RX_START
+          | IEEE802154_CAP_IRQ_TX_DONE
+          | IEEE802154_CAP_PHY_OQPSK
+          | IEEE802154_CAP_FRAME_RETRANS_INFO
+          | IEEE802154_CAP_REG_RETENTION
+          | IEEE802154_CAP_FRAME_RETRANS,
+
+    .write = _write,
+    .read = _read,
+    .request_transmit = _request_transmit,
+    .confirm_transmit = _confirm_transmit,
+    .len = _len,
+    .off = _off,
+    .request_on = _request_on,
+    .confirm_on = _confirm_on,
+    .request_set_trx_state = _request_set_trx_state,
+    .confirm_set_trx_state = _confirm_set_trx_state,
+    .request_cca = _request_cca,
+    .confirm_cca = _confirm_cca,
+    .set_cca_threshold = _set_cca_threshold,
+    .set_cca_mode = _set_cca_mode,
+    .config_phy = _config_phy,
+    .set_hw_addr_filter = _set_hw_addr_filter,
+    .set_csma_params = _set_csma_params,
+    .set_rx_mode = _set_rx_mode, /* OK! */
+    .set_frame_retrans = _set_frame_retrans,
+};

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -34,8 +34,10 @@
 
 #include "board.h"
 #include "kernel_defines.h"
-#include "net/netdev.h"
-#include "net/netdev/ieee802154.h"
+//#include "net/netdev.h"
+//#include "net/netdev/ieee802154.h"
+#include "net/netdev/ieee802154_submac.h"
+#include "net/ieee802154/radio.h"
 #include "net/gnrc/nettype.h"
 
 /* we need no peripherals for memory mapped radios */
@@ -238,13 +240,18 @@ typedef struct at86rf2xx_params {
 } at86rf2xx_params_t;
 #endif
 
+#define ISR_PIN GPIO_PIN(PB, 2)
+#define TX_PIN GPIO_PIN(PB, 3)
+#define RX_PIN GPIO_PIN(PA, 14)
+#define STATE_PIN GPIO_PIN(PA, 15)
+
 /**
  * @brief   Device descriptor for AT86RF2XX radio devices
  *
  * @extends netdev_ieee802154_t
  */
 typedef struct {
-    netdev_ieee802154_t netdev;             /**< netdev parent struct */
+    //netdev_ieee802154_t netdev;             /**< netdev parent struct */
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
     /* ATmega256rfr2 signals transceiver events with different interrupts
      * they have to be stored to mimic the same flow as external transceiver
@@ -257,6 +264,7 @@ typedef struct {
 #else
     /* device specific fields */
     at86rf2xx_params_t params;              /**< parameters for initialization */
+    bool pending_irq;
 #endif
     uint16_t flags;                         /**< Device specific flags */
     uint8_t state;                          /**< current state of the radio */
@@ -621,6 +629,13 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev);
  * @return                  false if channel is determined busy
  */
 bool at86rf2xx_cca(at86rf2xx_t *dev);
+
+int at86rf2xx_init(at86rf2xx_t *dev, const at86rf2xx_params_t *params, void *arg);
+void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev);
+void at86rf2xx_disable_clock_output(at86rf2xx_t *dev);
+void at86rf2xx_task_handler(ieee802154_dev_t *dev);
+void at86rf2xx_irq_handler(void *arg);
+void at86rf2xx_init_hal(at86rf2xx_t *dev, ieee802154_dev_t *hal);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -57,13 +57,12 @@ typedef struct {
  * @brief Init the IEEE 802.15.4 SubMAC netdev adoption.
  *
  * @param[in] netdev_submac pointer to the netdev submac descriptor.
- * @param[in] dev pointer to the device associated to @p netdev_submac.
  *
  * @return 0 on success.
  * @return negative errno on failure.
  */
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac,
-                                  ieee802154_dev_t *dev);
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac);
+                              
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -291,8 +291,24 @@ static int _init(netdev_t *netdev)
         (netdev_ieee802154_submac_t *)netdev;
     ieee802154_submac_t *submac = &netdev_submac->submac;
     netdev_ieee802154_t *netdev_ieee802154 = (netdev_ieee802154_t *)netdev;
+    netdev_ieee802154_setup(netdev_ieee802154);
+
     ieee802154_submac_init(submac, (network_uint16_t*) netdev_ieee802154->short_addr, (eui64_t*) netdev_ieee802154->long_addr);
 
+    /* This function already sets the PAN ID to the default one */
+    netdev_ieee802154_reset(netdev_ieee802154);
+
+    uint16_t chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
+    int16_t tx_power = CONFIG_IEEE802154_DEFAULT_TXPOWER;
+    netopt_enable_t enable = NETOPT_ENABLE;
+
+    /* Initialise netdev_ieee802154_t struct */
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
+                          &chan, sizeof(chan));
+    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
+                          &enable, sizeof(enable));
+
+    netdev_submac->dev.txpower = tx_power;
     return 0;
 }
 
@@ -313,25 +329,6 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac,
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;
-
-    netdev_ieee802154_t *netdev_ieee802154 = (netdev_ieee802154_t *)netdev;
-
-    /* This function already sets the PAN ID to the default one */
-    netdev_ieee802154_reset(netdev_ieee802154);
-
-    uint16_t chan = CONFIG_IEEE802154_DEFAULT_CHANNEL;
-    int16_t tx_power = CONFIG_IEEE802154_DEFAULT_TXPOWER;
-    netopt_enable_t enable = NETOPT_ENABLE;
-
-    netdev_ieee802154_setup(netdev_ieee802154);
-
-    /* Initialise netdev_ieee802154_t struct */
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_CHANNEL,
-                          &chan, sizeof(chan));
-    netdev_ieee802154_set(netdev_ieee802154, NETOPT_ACK_REQ,
-                          &enable, sizeof(enable));
-
-    netdev_submac->dev.txpower = tx_power;
 
     return 0;
 }

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -263,7 +263,7 @@ static const ieee802154_submac_cb_t _cb = {
 /* Event Notification callback */
 static void _hal_radio_cb(ieee802154_dev_t *dev, ieee802154_trx_ev_t status)
 {
-    ieee802154_submac_t *submac = dev->ctx;
+    ieee802154_submac_t *submac = container_of(dev, ieee802154_submac_t, dev);
     netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
                                                              netdev_ieee802154_submac_t,
                                                              submac);
@@ -312,20 +312,17 @@ static int _init(netdev_t *netdev)
     return 0;
 }
 
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac,
-                                  ieee802154_dev_t *dev)
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
 {
     netdev_t *netdev = (netdev_t *)netdev_submac;
 
     netdev->driver = &netdev_submac_driver;
     ieee802154_submac_t *submac = &netdev_submac->submac;
 
-    submac->dev = dev;
     submac->cb = &_cb;
-    submac->dev->ctx = submac;
 
     /* Set the Event Notification */
-    submac->dev->cb = _hal_radio_cb;
+    submac->dev.cb = _hal_radio_cb;
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -343,7 +343,8 @@ struct ieee802154_dev {
     /**
      * @brief pointer to the context of the device
      */
-    void *ctx;
+    //void *ctx;
+    void *priv;
     /**
      * @brief the event callback of the device
      */

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -104,9 +104,9 @@ typedef struct {
  * @brief IEEE 802.15.4 SubMAC descriptor
  */
 struct ieee802154_submac {
+    ieee802154_dev_t dev;              /**< pointer to the 802.15.4 HAL descriptor */
     eui64_t ext_addr;                   /**< IEEE 802.15.4 extended address */
     network_uint16_t short_addr;        /**< IEEE 802.15.4 short address */
-    ieee802154_dev_t *dev;              /**< pointer to the 802.15.4 HAL descriptor */
     const ieee802154_submac_cb_t *cb;   /**< pointer to the SubMAC callbacks */
     ieee802154_csma_be_t be;            /**< CSMA-CA backoff exponent params */
     bool wait_for_ack;                  /**< SubMAC is waiting for an ACK frame */
@@ -173,7 +173,7 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist);
 static inline int ieee802154_set_short_addr(ieee802154_submac_t *submac,
                                             const network_uint16_t *short_addr)
 {
-    int res = ieee802154_radio_set_hw_addr_filter(submac->dev, short_addr, NULL,
+    int res = ieee802154_radio_set_hw_addr_filter(&submac->dev, short_addr, NULL,
                                                   NULL);
 
     if (res >= 0) {
@@ -195,7 +195,7 @@ static inline int ieee802154_set_short_addr(ieee802154_submac_t *submac,
 static inline int ieee802154_set_ext_addr(ieee802154_submac_t *submac,
                                           const eui64_t *ext_addr)
 {
-    int res = ieee802154_radio_set_hw_addr_filter(submac->dev, NULL, ext_addr,
+    int res = ieee802154_radio_set_hw_addr_filter(&submac->dev, NULL, ext_addr,
                                                   NULL);
 
     if (res >= 0) {
@@ -216,7 +216,7 @@ static inline int ieee802154_set_ext_addr(ieee802154_submac_t *submac,
 static inline int ieee802154_set_panid(ieee802154_submac_t *submac,
                                        const uint16_t *panid)
 {
-    int res = ieee802154_radio_set_hw_addr_filter(submac->dev, NULL, NULL,
+    int res = ieee802154_radio_set_hw_addr_filter(&submac->dev, NULL, NULL,
                                                   panid);
 
     if (res >= 0) {
@@ -320,7 +320,7 @@ static inline int ieee802154_set_tx_power(ieee802154_submac_t *submac,
  */
 static inline int ieee802154_get_frame_length(ieee802154_submac_t *submac)
 {
-    return ieee802154_radio_len(submac->dev);
+    return ieee802154_radio_len(&submac->dev);
 }
 
 /**
@@ -339,7 +339,7 @@ static inline int ieee802154_get_frame_length(ieee802154_submac_t *submac)
 static inline int ieee802154_read_frame(ieee802154_submac_t *submac, void *buf,
                                         size_t len, ieee802154_rx_info_t *info)
 {
-    return ieee802154_radio_read(submac->dev, buf, len, info);
+    return ieee802154_radio_read(&submac->dev, buf, len, info);
 }
 
 /**

--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
@@ -44,30 +44,59 @@
 #define AT86RF2XX_NUM ARRAY_SIZE(at86rf2xx_params)
 
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
-static gnrc_netif_t _netif[AT86RF2XX_NUM];
+struct radio_container {
+    event_t event;
+    netdev_ieee802154_submac_t netdev_submac;
+    gnrc_netif_t netif;
+};
+
+struct radio_container at86rf2xx_container[AT86RF2XX_NUM];
 static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];
+
+static void at86rf2xx_handler(event_t *ev)
+{
+    struct radio_container *c = container_of(ev, struct radio_container, event);
+    at86rf2xx_task_handler(&c->netdev_submac.submac.dev);
+}
+
+void at86rf2xx_irq_handler(void *arg)
+{
+    struct radio_container *c = arg;
+    at86rf2xx_t *dev = c->netdev_submac.submac.dev.priv;
+    event_queue_t *evq = &c->netif.evq;
+    dev->pending_irq = true;
+    event_post(evq, &c->event);
+}
 
 void auto_init_at86rf2xx(void)
 {
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
         LOG_DEBUG("[auto_init_netif] initializing at86rf2xx #%u\n", i);
 
-        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
+        //at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
+        netdev_t *netdev = &at86rf2xx_container[i].netdev_submac.dev.netdev;
+        netdev_register(netdev, NETDEV_AT86RF2XX, i);
+        netdev_ieee802154_submac_init(&at86rf2xx_container[i].netdev_submac);
+        at86rf2xx_container[i].event.handler = at86rf2xx_handler;
+        at86rf2xx_init_hal(&at86rf2xx_devs[i], &at86rf2xx_container[i].netdev_submac.submac.dev);
+        at86rf2xx_init(&at86rf2xx_devs[i], &at86rf2xx_params[i], &at86rf2xx_container[i]);
+        gnrc_netif_t *netif = &at86rf2xx_container[i].netif;
+
 #if defined(MODULE_GNRC_GOMACH)
-        gnrc_netif_gomach_create(&_netif[i], _at86rf2xx_stacks[i],
+        gnrc_netif_gomach_create(netif, _at86rf2xx_stacks[i],
                                  AT86RF2XX_MAC_STACKSIZE,
                                  AT86RF2XX_MAC_PRIO, "at86rf2xx-gomach",
-                                 (netdev_t *)&at86rf2xx_devs[i]);
+                                 netdev);
 #elif defined(MODULE_GNRC_LWMAC)
-        gnrc_netif_lwmac_create(&_netif[i], _at86rf2xx_stacks[i],
+        gnrc_netif_lwmac_create(netif, _at86rf2xx_stacks[i],
                                 AT86RF2XX_MAC_STACKSIZE,
                                 AT86RF2XX_MAC_PRIO, "at86rf2xx-lwmac",
-                                (netdev_t *)&at86rf2xx_devs[i]);
+                                netdev);
 #else
-        gnrc_netif_ieee802154_create(&_netif[i], _at86rf2xx_stacks[i],
+        gnrc_netif_ieee802154_create(netif, _at86rf2xx_stacks[i],
                                      AT86RF2XX_MAC_STACKSIZE,
                                      AT86RF2XX_MAC_PRIO, "at86rf2xx",
-                                     (netdev_t *)&at86rf2xx_devs[i]);
+                                     netdev);
 #endif
     }
 }

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -32,7 +32,7 @@ static void _handle_tx_no_ack(ieee802154_submac_t *submac);
 static void _tx_end(ieee802154_submac_t *submac, int status,
                     ieee802154_tx_info_t *info)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     ieee802154_radio_request_set_trx_state(dev, submac->state == IEEE802154_STATE_LISTEN ? IEEE802154_TRX_STATE_RX_ON : IEEE802154_TRX_STATE_TRX_OFF);
 
@@ -50,7 +50,7 @@ static inline bool _does_handle_ack(ieee802154_dev_t *dev)
 
 static int _perform_csma_ca(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     if (submac->csma_retries_nb <= submac->csma_retries) {
         ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_TX_ON);
@@ -97,7 +97,7 @@ static int _perform_csma_ca(ieee802154_submac_t *submac)
  */
 int ieee802154_csma_ca_transmit(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     /* If radio has Auto CSMA-CA or Frame Retransmissions, simply send and wait for the transmit confirmation. */
     if (ieee802154_radio_has_auto_csma(dev) ||
@@ -127,7 +127,7 @@ static bool _has_retrans_left(ieee802154_submac_t *submac)
 
 static void _perform_retrans(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     if (_has_retrans_left(submac)) {
         submac->retrans++;
@@ -149,7 +149,7 @@ void ieee802154_submac_ack_timeout_fired(ieee802154_submac_t *submac)
 
 void ieee802154_submac_crc_error_cb(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
     /* switch back to RX_ON state */
     ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_RX_ON);
     while (ieee802154_radio_confirm_set_trx_state(dev) == -EAGAIN) {}
@@ -158,7 +158,7 @@ void ieee802154_submac_crc_error_cb(ieee802154_submac_t *submac)
 /* All callbacks run in the same context */
 void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     if (!_does_handle_ack(dev) && submac->wait_for_ack) {
         uint8_t ack[3];
@@ -169,13 +169,14 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
             ieee802154_tx_info_t tx_info;
             tx_info.retrans = submac->retrans;
             bool fp = (ack[0] & IEEE802154_FCF_FRAME_PEND);
-            ieee802154_radio_set_rx_mode(submac->dev,
+            ieee802154_radio_set_rx_mode(&submac->dev,
                                          IEEE802154_RX_AACK_ENABLED);
             _tx_end(submac, fp ? TX_STATUS_FRAME_PENDING : TX_STATUS_SUCCESS,
                     &tx_info);
         }
     }
     else {
+        assert(!submac->tx);
         submac->cb->rx_done(submac);
 
         /* Only set the radio to the SubMAC default state only if the upper
@@ -195,15 +196,15 @@ void ieee802154_submac_rx_done_cb(ieee802154_submac_t *submac)
          * sending ACK frames). In such case we need to wait until the radio is
          * not busy
          */
-        while (ieee802154_radio_request_set_trx_state(submac->dev, next_state) == -EBUSY);
-        while (ieee802154_radio_confirm_set_trx_state(submac->dev) == -EAGAIN) {}
+        while (ieee802154_radio_request_set_trx_state(&submac->dev, next_state) == -EBUSY);
+        while (ieee802154_radio_confirm_set_trx_state(&submac->dev) == -EAGAIN) {}
     }
 }
 
 static void _handle_tx_success(ieee802154_submac_t *submac,
                                ieee802154_tx_info_t *info)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_RX_ON);
     while (ieee802154_radio_confirm_set_trx_state(dev) == -EAGAIN) {}
@@ -225,7 +226,7 @@ static void _handle_tx_success(ieee802154_submac_t *submac,
 
 static void _handle_tx_medium_busy(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     if (ieee802154_radio_has_frame_retrans(dev) ||
         ieee802154_radio_has_auto_csma(dev)) {
@@ -240,7 +241,7 @@ static void _handle_tx_medium_busy(ieee802154_submac_t *submac)
 
 static void _handle_tx_no_ack(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     if (ieee802154_radio_has_frame_retrans(dev)) {
         ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_RX_ON);
@@ -254,7 +255,7 @@ static void _handle_tx_no_ack(ieee802154_submac_t *submac)
 
 void ieee802154_submac_tx_done_cb(ieee802154_submac_t *submac)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
     ieee802154_tx_info_t info;
 
     ieee802154_radio_confirm_transmit(dev, &info);
@@ -278,7 +279,7 @@ void ieee802154_submac_tx_done_cb(ieee802154_submac_t *submac)
 
 int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     uint8_t *buf = iolist->iol_base;
     bool cnf = buf[0] & IEEE802154_FCF_ACK_REQ;
@@ -308,7 +309,7 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
 int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *short_addr,
                            const eui64_t *ext_addr)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     submac->tx = false;
     submac->state = IEEE802154_STATE_LISTEN;
@@ -390,7 +391,7 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
 int ieee802154_set_phy_conf(ieee802154_submac_t *submac, uint16_t channel_num,
                             uint8_t channel_page, int8_t tx_pow)
 {
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
     const ieee802154_phy_conf_t conf =
     { .phy_mode = submac->phy_mode,
       .channel = channel_num,
@@ -425,7 +426,7 @@ int ieee802154_set_state(ieee802154_submac_t *submac, ieee802154_submac_state_t 
 {
     int res;
 
-    ieee802154_dev_t *dev = submac->dev;
+    ieee802154_dev_t *dev = &submac->dev;
 
     if (submac->tx) {
         return -EBUSY;

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -382,6 +382,7 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
                                               CONFIG_IEEE802154_CCA_THRESH_DEFAULT) >= 0);
 
     ieee802154_radio_request_set_trx_state(dev, IEEE802154_TRX_STATE_RX_ON);
+    while(ieee802154_radio_confirm_set_trx_state(dev) == -EAGAIN) {};
 
     return 0;
 }

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -374,7 +374,7 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
     ieee802154_phy_conf_t conf =
     { .phy_mode = submac->phy_mode,
       .channel = CONFIG_IEEE802154_DEFAULT_CHANNEL,
-      .page = CONFIG_IEEE802154_DEFAULT_CHANNEL,
+      .page = CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE,
       .pow = CONFIG_IEEE802154_DEFAULT_TXPOWER };
 
     ieee802154_radio_config_phy(dev, &conf);

--- a/tests/ieee802154_hal/Makefile
+++ b/tests/ieee802154_hal/Makefile
@@ -15,6 +15,7 @@ BOARD_WHITELIST :=  \
 					remote-pa \
 					remote-reva \
 					remote-revb \
+					samr21-xpro \
 					#
 
 DISABLE_MODULE += auto_init_at86rf2xx auto_init_nrf802154

--- a/tests/ieee802154_hal/init_devs.c
+++ b/tests/ieee802154_hal/init_devs.c
@@ -21,6 +21,8 @@
 #include "assert.h"
 #include "kernel_defines.h"
 #include "net/ieee802154/radio.h"
+#include "event.h"
+#include "event/thread.h"
 
 #ifdef MODULE_CC2538_RF
 #include "cc2538_rf.h"
@@ -28,6 +30,11 @@
 
 #ifdef MODULE_NRF802154
 #include "nrf802154.h"
+#endif
+
+#ifdef MODULE_AT86RF2XX
+#include "at86rf2xx.h"
+#include "at86rf2xx_params.h"
 #endif
 
 #ifdef MODULE_CC2538_RF
@@ -38,14 +45,38 @@ extern ieee802154_dev_t cc2538_rf_dev;
 extern ieee802154_dev_t nrf802154_hal_dev;
 #endif
 
+#ifdef MODULE_AT86RF2XX
+#define AT86RF2XX_NUM ARRAY_SIZE(at86rf2xx_params)
+static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
+
+#endif
+
+/* TODO: Fix */
 #define RADIOS_NUMOF IS_USED(MODULE_CC2538_RF) + \
-                     IS_USED(MODULE_NRF802154)
+                     IS_USED(MODULE_NRF802154) + \
+                     IS_USED(MODULE_AT86RF2XX)
 
 #if RADIOS_NUMOF == 0
 #error "Radio is not supported"
 #endif
 
-static ieee802154_dev_t *_radios[RADIOS_NUMOF];
+static ieee802154_dev_t _radios[RADIOS_NUMOF];
+static void at86rf2xx_handler(event_t *ev)
+{
+    (void) ev;
+   at86rf2xx_task_handler(&_radios[0]);
+}
+
+static event_t ev = {
+    .handler = at86rf2xx_handler,
+};
+
+void at86rf2xx_irq_handler(void *arg)
+{
+    (void) arg;
+    at86rf2xx_devs[0].pending_irq = true;
+    event_post(EVENT_PRIO_HIGHEST, &ev);
+}
 
 static void _register_radios(void)
 {
@@ -57,6 +88,12 @@ static void _register_radios(void)
 
 #ifdef MODULE_NRF802154
     _radios[i++] = &nrf802154_hal_dev;
+#endif
+
+    /* TODO: fix */
+#ifdef MODULE_AT86RF2XX
+    at86rf2xx_init_hal(&at86rf2xx_devs[0], &_radios[0]);
+    i++;
 #endif
 
     assert(i == RADIOS_NUMOF);
@@ -76,10 +113,14 @@ void ieee802154_hal_test_init_devs(void)
 #ifdef MODULE_NRF802154
     nrf802154_init();
 #endif
+
+#ifdef MODULE_AT86RF2XX
+    at86rf2xx_init(&at86rf2xx_devs[0], &at86rf2xx_params[0], NULL);
+#endif
 }
 
 ieee802154_dev_t *ieee802154_hal_test_get_dev(int id)
 {
     assert(id < RADIOS_NUMOF);
-    return _radios[id];
+    return &_radios[id];
 }

--- a/tests/ieee802154_submac/Makefile
+++ b/tests/ieee802154_submac/Makefile
@@ -15,6 +15,7 @@ BOARD_WHITELIST :=  \
 					remote-pa \
 					remote-reva \
 					remote-revb \
+					samr21-xpro \
 					#
 USEMODULE += od
 USEMODULE += shell


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This (draft) PR implements the Radio HAL interface for `at86rf2xx`. This is the first SPI radio that runs the Radio HAL, so I had to adapt some stuff that I would like to discuss with the community (see Discussion).

This port is resilient against https://github.com/RIOT-OS/RIOT/pull/11256. After many debugging hours, forcing the radio to PLL_ON before a transition from RX_ON to TX_ON seems to be the only way to prevent the bug described there, since there's a small gap which makes it impossible to detect if there are incoming frames even when:
a) The transceiver state is checked before `request_set_trx_state`
b) The function checks if there are pending interrupts for the radio
c) The SHR detection is disabled right before checking a) and b)

The port has been tested against other radio in stressful conditions and it seems to work. There are some pending stuff before it's mergeable: 

- [ ] Basic Mode support
- [ ] Periph implementation
- [ ] Some cleanup
- [ ] Adapt to gnrc_netif's thread_flag mechanism

And of course, it would nice to resolve the discussion presented above.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Discussion

Contrary to netdev, it was decided that the ISR offloading (a.k.a Bottom Half processing) would be independent of the upper layer, since not all radios require ISR processing or some might require a slightly different mechanism (e.g devices with 2 radios).

For radios that require ISR offloading, we need a Bottom Half Processing interface than can indicate there are pending IRQs and be able to process the events. I see 2 patterns that we might follow:

1. Implement a simple indication/response pattern that indicates the BH to call a driver specific "task handler" when an interrupt is triggered. This patterns was chosen for this draft and for this case 2 functions are defined:
    - `at86rf2xx_irq_handler`: To be implemented by the network stack. This function is called from ISR context and indicates the BH to process the radio events. The argument of this function (e.g pointer to the HAL) is assigned during `at86rf2xx_init`.
    - `at86rf2xx_task_handler`: This function process the pending IRQs and calls the Radio HAL CB functions.
2. Implement several mechanisms to process ISR functions with different mechanisms (event_thread, thread flags, msg_t, etc). This would require to implement functions like `at86rf2xx_init_evq` or similar to setup the BH.

The first approach has the advantage that it can be easily adapted to any network stack specific mechanism, with the cost of a BH implementation for every driver - network stack combination.
The second approach simplifies simplifies bootstrap code of the drivers. We could eventually decouple the initialization of the drivers from the initialization of the network stacks. The price to pay in this case is the fact he implementation of the drivers would be slightly more complex, since each driver has to implement variants of every mechanism. Also, the drivers would be hardcoded to a specific set of BH mechanisms

Opinions on this?
If there's a better way to process the events, please report it :)

### Testing procedure
Try `tests/ieee802154_hal` and `examples/gnrc_networking`.

I haven't configured the dependencies properly. Therefore it's required to manually include `gnrc_netif_events` and `netdev_ieee802154_submac` for `examples/gnrc_networking`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #16533 and #16534 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
