### PR TITLE
makefiles/docker.inc.mk: use release docker image

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -1,4 +1,4 @@
-export DOCKER_IMAGE ?= riot/riotbuild:latest
+export DOCKER_IMAGE ?= riot/riotbuild:2021.01
 export DOCKER_BUILD_ROOT ?= /data/riotbuild
 DOCKER_RIOTBASE ?= $(DOCKER_BUILD_ROOT)/riotbase
 # List of Docker-enabled make goals


### PR DESCRIPTION
### Contribution description

Tag the release docker image. Not sure if we want to merge this right now or start doing it only with future releases...

### Testing procedure

- green murdock
- run release tests maybe?
