### PR TITLE
pkg/nanocbor: bump version

### DIFF
--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nanocbor
 PKG_URL     = https://github.com/bergzand/nanocbor
-PKG_VERSION = 97e8cbe943388dda0087ab703034fec268c7c12d
+PKG_VERSION = d3d88e2d8e8da53d278aabe448cb338dbf845f09
 PKG_LICENSE = CC-0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

 - add support for decimal fractions
 - fix underflow in nanocbor_leave_container()
 - make return values consistent with documentation


### Testing procedure

`tests/pkg_nanocbor` and `tests/suit_manifest` should still work. (tested by Murdock)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
