### PR TITLE
pkg/libcose: bump version

### DIFF
--- a/pkg/libcose/Makefile
+++ b/pkg/libcose/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=libcose
 PKG_URL=https://github.com/bergzand/libcose
-PKG_VERSION=3fdf1238987b6aeec113b1872e56307893feeae7
+PKG_VERSION=2929fdce7affbd5bb9db201370d95d8f7cf680f9
 PKG_LICENSE=LGPL
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libcose/doc.txt
+++ b/pkg/libcose/doc.txt
@@ -35,11 +35,15 @@
  * USEMODULE += libcose_crypt_hacl
  * USEMODULE += libcose_crypt_monocypher
  * USEMODULE += libcose_crypt_c25519
+ * USEMODULE += libcose_crypt_tinycrypt
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * The selection of pseudomodules determines the available algorithms:
  *
  * * @ref pkg_hacl "HACL" and @ref pkg_monocypher "Monocypher" both provide ChaCha20-Poly1305 and Ed25519.
  * * @ref pkg_c25519 "C25519" only provides the Ed25519 algorithm.
+ * * @ref pkg_tinycrypt "TINYCRYPT" provides AES-CCM-16-64-128, AES-CCM-16-128-128
+ *   ECDSA and ES256 as well as EC NIST P-256 curve support.
  *
+ * Some backend may conflict, others might be complementary.
  */


### PR DESCRIPTION
### Contribution description

Bumps the pkg version.


### Testing procedure

- `tests/pkg_libcose` still works
```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2021.07-devel-333-gcfb10d-HEAD)
...
OK (3 tests)
```
- green murdock
