### PR TITLE
add a systick interface for the ztimer

### DIFF
--- a/sys/include/ztimer/periph_systick.h
+++ b/sys/include/ztimer/periph_systick.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021   Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_ztimer_periph_systick  ztimer periph/systick backend
+ * @ingroup     sys_ztimer
+ * @brief       ztimer periph/systick backend
+ *
+ * This ztimer module implements a ztimer virtual clock on top of periph/systick.
+ *
+ * @{
+ *
+ * @file
+ * @brief       ztimer periph/systick backend API
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ */
+
+#ifndef ZTIMER_PERIPH_SYSTICK_H
+#define ZTIMER_PERIPH_SYSTICK_H
+
+#include "ztimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   ztimer periph/systick backend initialization function
+ *
+ * @param[in, out]  clock   ztimer_periph_systick_t object to initialize
+ */
+void ztimer_periph_systick_init(ztimer_clock_t *clock);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZTIMER_PERIPH_SYSTICK_H */
+/** @} */

--- a/sys/ztimer/periph_systick.c
+++ b/sys/ztimer/periph_systick.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021   Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup sys_ztimer_periph_systick
+ * @{
+ *
+ * @file
+ * @brief       ztimer periph/systick implementation
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ *
+ * @}
+ */
+#include "assert.h"
+#include "irq.h"
+#include "ztimer/periph_systick.h"
+#include "debug.h"
+
+#define ENABLE_DEBUG 0
+
+#define ENABLE_MASK     (SysTick_CTRL_CLKSOURCE_Msk | \
+                         SysTick_CTRL_ENABLE_Msk    | \
+                         SysTick_CTRL_TICKINT_Msk)
+
+/* full periods before alarm */
+static uint16_t alarm_ext;
+
+/* remaining time to alarm (last period length) */
+static uint32_t alarm_val;
+
+/* current time if the timer ran at freq Hz */
+static uint32_t now;
+
+static ztimer_clock_t *clock_timer;
+
+void isr_systick(void)
+{
+    ztimer_handler(clock_timer);
+}
+
+static void _ztimer_periph_systick_set(ztimer_clock_t *clock, uint32_t val)
+{
+    (void)clock;
+    unsigned state = irq_disable();
+
+    /*Stop the systick to prevent race condition*/
+    SysTick->CTRL = 0;
+
+    /*val divided by 2^24 to guarantee a suitable size*/
+    alarm_ext = val >> 24;
+    alarm_val = val & SysTick_LOAD_RELOAD_Msk;
+
+    /*Systick is counting backwards*/
+    now += SysTick->LOAD - SysTick->VAL;
+
+    /*If the value is greater than the maximum value the value is set to the maximum*/
+    if (alarm_ext) {
+        SysTick->LOAD = SysTick_LOAD_RELOAD_Msk;
+    }
+    else {
+        SysTick->LOAD = alarm_val;
+    }
+
+    /* force reload */
+    SysTick->VAL = 0;
+
+    /* start the timer again */
+    SysTick->CTRL = ENABLE_MASK;
+
+    irq_restore(state);
+}
+
+static uint32_t _ztimer_periph_systick_now(ztimer_clock_t *clock)
+{
+    (void)clock;
+    return (now + SysTick->LOAD - SysTick->VAL) & 0xFFFFFFU;
+}
+
+static void _ztimer_periph_systick_cancel(ztimer_clock_t *clock)
+{
+    (void)clock;
+    SysTick->LOAD = SysTick_LOAD_RELOAD_Msk;
+}
+
+static const ztimer_ops_t _ztimer_periph_systick_ops = {
+    .set = _ztimer_periph_systick_set,
+    .now = _ztimer_periph_systick_now,
+    .cancel = _ztimer_periph_systick_cancel,
+};
+
+void ztimer_periph_systick_init(ztimer_clock_t *clock)
+{
+    clock->ops = &_ztimer_periph_systick_ops;
+    clock->max_value = 0xFFFFFFU;
+    clock_timer = clock;
+
+    SysTick->VAL = 0;
+    SysTick->LOAD = SysTick_LOAD_RELOAD_Msk;
+    SysTick->CTRL = ENABLE_MASK;
+
+    NVIC_SetPriority(SysTick_IRQn, CPU_DEFAULT_IRQ_PRIO);
+    NVIC_EnableIRQ(SysTick_IRQn);
+}

--- a/tests/ztimer_systick/Makefile
+++ b/tests/ztimer_systick/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += ztimer_msec ztimer_usec ztimer_sec
+USEMODULE += ztimer_periph_systick
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_systick/main.c
+++ b/tests/ztimer_systick/main.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Franz Freitag, Justus Krebs, Nick Weiler
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       SysTick Ztimer test application
+ *
+ * @author      Franz Freitag <franz.freitag@st.ovgu.de>
+ * @author      Justus Krebs <justus.krebs@st.ovgu.de>
+ * @author      Nick Weiler <nick.weiler@st.ovgu.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "mutex.h"
+#include "ztimer.h"
+#include "ztimer/periph_systick.h"
+#include "periph_conf.h"
+#include "board.h"
+
+#define INTERVAL_SEC        2lu
+#define INTERVAL_LONG_SEC   30lu
+
+static void test_timer_set(unsigned period, unsigned iterations)
+{
+    while (iterations--) {
+        ztimer_sleep(ZTIMER_SEC, period);
+        printf("now: %lu\n", ztimer_now(ZTIMER_SEC));
+    }
+}
+
+int main(void)
+{
+    printf("Test setting %lu s intervals\n", INTERVAL_SEC);
+    test_timer_set(INTERVAL_SEC, 5);
+
+    printf("Test setting %lu s intervals\n", INTERVAL_LONG_SEC);
+    test_timer_set(INTERVAL_LONG_SEC, 5);
+    puts("Test passed");
+    return 0;
+}


### PR DESCRIPTION
### Contribution description 
This PR adds a systick interface to the ztimer in RIOT-OS. It is based on #14553.
This implementation does not work with the nrf boards due to an issue with the lower power mode. 
 
This pull request is a first implementation and can be improved in the future. Recommendations and improvements are welcome.

### Testing procedure
We added a test for the new feature. It can be found under `tests/ztimer_systick`.
It uses the ZTIMER_SEC interface to test various time periods.  

It was successfully tested on the `seeeduino_xiao` and the `nucleo-f767zi`.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14553