### PR TITLE
cpu/stm32/periph/rtt_all: RTT peripheral support for CPU_FAM_STM32L5

### DIFF
--- a/cpu/stm32/periph/rtt_all.c
+++ b/cpu/stm32/periph/rtt_all.c
@@ -15,7 +15,7 @@
  * @brief       RTT implementation using LPTIM1
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- *
+ * @author      Andres Diaz    <andres.diaz@andeselectronics.cl>
  * @}
  */
 
@@ -59,6 +59,14 @@
 #else
 #define CLOCK_SRC_CFG       (RCC_DCKCFGR2_LPTIM1SEL_0)
 #endif
+#elif defined(CPU_FAM_STM32L5)
+#define CLOCK_SRC_REG       RCC->CCIPR1
+#define CLOCK_SRC_MASK      RCC_CCIPR1_LPTIM1SEL
+#if IS_ACTIVE(CONFIG_BOARD_HAS_LSE)
+#define CLOCK_SRC_CFG       (RCC_CCIPR1_LPTIM1SEL_1 | RCC_CCIPR1_LPTIM1SEL_0)
+#else
+#define CLOCK_SRC_CFG       (RCC_CCIPR1_LPTIM1SEL_0)
+#endif
 #else
 #define CLOCK_SRC_REG       RCC->CCIPR
 #define CLOCK_SRC_MASK      RCC_CCIPR_LPTIM1SEL
@@ -76,7 +84,7 @@ register. */
 #define EXTI_IMR2_IM32      (1 << 0)
 #endif
 
-#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB)
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32L5)
 #define IMR_REG             IMR2
 #define EXTI_IMR_BIT        EXTI_IMR2_IM32
 #elif defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32WL)
@@ -130,7 +138,8 @@ void rtt_init(void)
     EXTI->IMR_REG |= EXTI_IMR_BIT;
 #if !defined(CPU_FAM_STM32L4) && !defined(CPU_FAM_STM32L0) && \
     !defined(CPU_FAM_STM32WB) && !defined(CPU_FAM_STM32G4) && \
-    !defined(CPU_FAM_STM32G0) && !defined(CPU_FAM_STM32WL)
+    !defined(CPU_FAM_STM32G0) && !defined(CPU_FAM_STM32WL) && \
+    !defined(CPU_FAM_STM32L5)
     EXTI->FTSR_REG &= ~(EXTI_FTSR_BIT);
     EXTI->RTSR_REG |= EXTI_RTSR_BIT;
     EXTI->PR_REG = EXTI_PR_BIT;
@@ -241,7 +250,8 @@ void isr_lptim1(void)
     LPTIM1->ICR = (LPTIM_ICR_ARRMCF | LPTIM_ICR_CMPMCF);
 #if !defined(CPU_FAM_STM32L4) && !defined(CPU_FAM_STM32L0) && \
     !defined(CPU_FAM_STM32WB) && !defined(CPU_FAM_STM32G4) && \
-    !defined(CPU_FAM_STM32G0) && !defined(CPU_FAM_STM32WL)
+    !defined(CPU_FAM_STM32G0) && !defined(CPU_FAM_STM32WL) && \
+    !defined(CPU_FAM_STM32L5)
     EXTI->PR_REG = EXTI_PR_BIT; /* only clear the associated bit */
 #endif
 

--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -74,7 +74,7 @@ void stmclk_enable_lfclk(void)
 
     /* Set LSE system clock enable bit. This is required if LSE is to be used by
        USARTx, LPUARTx, LPTIMx, TIMx, RNG, system LSCO, MCO, MSI PLL mode */
-#if defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32WL) || defined (CPU_FAM_STM32L5)
         RCC->BDCR |= RCC_BDCR_LSESYSEN;
         while (!(RCC->BDCR & RCC_BDCR_LSESYSRDY)) {}
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
cpu/stm32/periph/rtt_all: 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->When testing peripherals on a CPU_FAM_STM32L5 based BOARD, tests/periph_rtt didn't work as expected. Implemented a case for CPU_FAM_STM32L5 for correct LPTIM1 register setup. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->Ran `tests/periph_rtt` on a STM32L5 CPU based BOARD, output as expected (bunch of Hellos). Wasn't working before since the registers for LPTIM1 setup weren't correct. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
--> Addition of periph_rtt to CPU_FAM_STM32L5
