### PR TITLE
gnrc_ipv6_nib: get node from proper interface

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -228,6 +228,10 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                 /* release pre-assumed netif */
                 gnrc_netif_release(netif);
                 netif = _acquire_new_iface(iface);
+                /* get node from proper interface */
+                if (netif != NULL) {
+                    node = _nib_onl_get(dst, netif->pid);
+                }
             }
             if ((netif == NULL) ||
                 !_resolve_addr(dst, netif, pkt, nce, node)) {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If we switch the interface in `gnrc_ipv6_nib_get_next_hop_l2addr()` we must also re-get the nib entry from the 'proper' interface.
Otherwise we will always find the host unreachable on the 'wrong' interface.


### Testing procedure

You need a node with two interfaces of type `Ethernet` with both of them having a global address configured.
Now send a ping request to the global address of the second interface by a host connected to the first interface.

On `master` only the first request is answered and any subsequent communication to that host fails from the downstream interface address. Instead, the node will send a neighbor solicitation even though the host is already in the neighbor cache.

With this patch, the pings are answered as expected. 

### Issues/PRs references

fixes #16547
