### PR TITLE
drivers/mrf24j40 : lower TX power on modules with PA/LNA enabled to s…

### DIFF
--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -62,6 +62,10 @@ void mrf24j40_enable_auto_pa_lna(mrf24j40_t *dev)
                                                          MRF24J40_TESTMODE_TESTMODE2 |
                                                          MRF24J40_TESTMODE_TESTMODE1 |
                                                          MRF24J40_TESTMODE_TESTMODE0));
+
+    /* Reduce TX power to stay in ISM band */
+    /* With PA/LNA enabled, -6.3dB is necessary to stay in ISM band on channel 26 */
+    mrf24j40_set_txpower(dev, 6);
 }
 
 void mrf24j40_disable_auto_pa_lna(mrf24j40_t *dev)
@@ -80,6 +84,9 @@ void mrf24j40_disable_auto_pa_lna(mrf24j40_t *dev)
                                                      MRF24J40_GPIO_1 |
                                                      MRF24J40_GPIO_2 |
                                                      MRF24J40_GPIO_3));
+
+    /* Reset TX power */
+    mrf24j40_set_txpower(dev, 0);
 }
 
 void mrf24j40_enable_lna(mrf24j40_t *dev)


### PR DESCRIPTION
…tay in ISM band

### Contribution description

One of my devices has a MRF24J40MD. As a part of CE certification process, I made measurements in a FAR (Full Anechoic Room). With default TX power configuration, the module emits on IEEE802.15.4 channel 26 slightly outside ISM band.

To stay in conformity, I had to lower the TX power (-6.3dB) so it stays in the limits defined by ISM band.

You can also check the MRF24J40 Linux driver. They do a similar thing. Based on the Linux driver, it seems to affect only modules with PA/LNA, that's why I simply added my code after PA/LNA activation.

NB : I made measurements only on channel 26. Maybe the module has the same issue on channel 11 but I didn't check (FAR are expensive :D ). So I chose the Linux river approach of lowering TX power on all channels.

### Testing procedure

I made measurements in the FAR with and without these modifications.

I tried also to compile with `default` example

### Issues/PRs references

n/a
