### PR TITLE
drivers/sm_pwm_01c: remove checksum in Kconfig

### DIFF
--- a/drivers/sm_pwm_01c/Kconfig
+++ b/drivers/sm_pwm_01c/Kconfig
@@ -9,7 +9,6 @@ menuconfig MODULE_SM_PWM_01C
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
     depends on TEST_KCONFIG
-    select MODULE_CHECKSUM
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
     select MODULE_ZTIMER


### PR DESCRIPTION

### Contribution description

Removes a `checksum` module from the kconfig for the sm_pwm_01c.  It doesn't show up in the binary but the info-modules show a difference


### Testing procedure

Run this on master vs this pr.

```
cd tests/driver_sm_pwm_01c
make clean && make info-modules > /tmp/no-kconfig && make clean && TEST_KCONFIG=1 make info-modules > /tmp/kconfig && diff /tmp/no-kconfig /tmp/kconfig
```

### Issues/PRs references

