### PR TITLE
cpu/native: Add native mtd kconfig dep

### DIFF
--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -88,4 +88,5 @@ rsource "backtrace/Kconfig"
 
 endmenu # Native modules
 
+rsource "mtd/Kconfig"
 rsource "periph/Kconfig"

--- a/cpu/native/mtd/Kconfig
+++ b/cpu/native/mtd/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_MTD_NATIVE
+    bool
+    default y if MODULE_MTD
+    depends on NATIVE_OS_LINUX
+    depends on TEST_KCONFIG


### PR DESCRIPTION

### Contribution description

Implement the mtd module for native in Kconfig.

### Testing procedure

apply a patch to .murdock
```patch
diff --git a/.murdock b/.murdock
index e692d0eeb3..db34f895b9 100755
--- a/.murdock
+++ b/.murdock
@@ -29,6 +29,7 @@ tests/cb_mux*
 tests/congure_*
 tests/driver_ws281x
 tests/eepreg
+tests/mtd_flashpage
 tests/periph_*
 tests/pkg_c25519
 tests/pkg_cayenne-lpp

```

run:
```
/bin/bash -c "source .murdock; JOBS=4 compile tests/mtd_flashpage native:gnu"
```

in both master and this PR.

### Issues/PRs references
