### PR TITLE
ztimer: pull ztimer_periph_rtt for ZTIMER_MSEC if available

### DIFF
--- a/drivers/sx127x/Makefile.dep
+++ b/drivers/sx127x/Makefile.dep
@@ -6,12 +6,6 @@ USEMODULE += iolist
 USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec
 
-# If RTT feature is available use the RTT backend of ztimer
-FEATURES_OPTIONAL += periph_rtt
-ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-  USEMODULE += ztimer_periph_rtt
-endif
-
 USEMODULE += lora
 
 ifneq (,$(filter gnrc,$(USEMODULE)))

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -2,10 +2,6 @@
 USEMODULE += sema
 USEMODULE += event_callback
 USEMODULE += ztimer_msec
-# all nRF CPUs support hardware RTT, so we use it
-ifneq (,$(filter nrf5%,$(CPU_FAM)))
-  USEMODULE += ztimer_periph_rtt
-endif
 
 # Requires nimble feature
 FEATURES_REQUIRED += ble_nimble

--- a/pkg/openwsn/Makefile.dep
+++ b/pkg/openwsn/Makefile.dep
@@ -74,10 +74,6 @@ endif
 ifneq (,$(filter openwsn_sctimer_ztimer,$(USEMODULE)))
   USEMODULE += ztimer_usec
   USEMODULE += ztimer_msec
-  FEATURES_OPTIONAL += periph_rtt
-  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-    USEMODULE += ztimer_periph_rtt
-  endif
 endif
 
 ifneq (,$(filter openwsn_sctimer_rtt,$(USEMODULE)))

--- a/pkg/openwsn/Makefile.include
+++ b/pkg/openwsn/Makefile.include
@@ -72,13 +72,5 @@ ifneq (,$(filter at86rf2xx,$(USEMODULE)))
   CFLAGS += -DAT86RF2XX_BASIC_MODE
 endif
 
-# We want the highest possible frequency set for periph_rtt, but not all
-# platforms can configure this value. use highest possible RTT_FREQUENCY
-# for platforms that allow it
-ifneq (,$(filter stm32 nrf52 sam%,$(CPU)))
-  RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
-  CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
-endif
-
 # LLVM ARM shows issues with missing definitions for stdatomic
 TOOLCHAINS_BLACKLIST += llvm

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -269,9 +269,6 @@ endif
 
 ifneq (,$(filter posix_sleep,$(USEMODULE)))
   USEMODULE += ztimer_msec
-  ifneq (,$(filter periph_rtt,$(USEMODULE)))
-    USEMODULE += ztimer_periph_rtt
-  endif
   USEMODULE += ztimer_usec
   USEMODULE += posix_headers
 endif
@@ -539,9 +536,6 @@ ifneq (,$(filter skald,$(USEMODULE)))
   USEMODULE += nrfble
   USEMODULE += random
   USEMODULE += ztimer_msec
-   ifneq (,$(filter periph_rtt,$(USEMODULE)))
-    USEMODULE += ztimer_periph_rtt
-  endif
 endif
 
 ifneq (,$(filter bluetil_addr,$(USEMODULE)))

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -133,10 +133,8 @@ ifneq (,$(filter test_utils_result_output,$(USEMODULE)))
   include $(RIOTBASE)/sys/test_utils/result_output/Makefile.include
 endif
 
-# Convert xtimer into a pseudo module if its API is already implemented by
-# ztimer's compatibility wrapper
-ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-  PSEUDOMODULES += xtimer
+ifneq (,$(filter ztimer,$(USEMODULE)))
+  include $(RIOTBASE)/sys/ztimer/Makefile.include
 endif
 
 ifneq (,$(filter prng,$(USEMODULE)))

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -15,7 +15,11 @@ menuconfig MODULE_ZTIMER
 
 if MODULE_ZTIMER
 
+config ZTIMER_CUSTOM_BACKEND_CONFIGURATION
+    bool "Override default backend selection"
+
 menu "Backends"
+    visible if ZTIMER_CUSTOM_BACKEND_CONFIGURATION
 
 config MODULE_ZTIMER_PERIPH_RTC
     bool "RTC peripheral"
@@ -26,7 +30,6 @@ config MODULE_ZTIMER_PERIPH_RTT
     bool "RTT peripheral"
     depends on HAS_PERIPH_RTT
     select MODULE_PERIPH_RTT
-    default y if !MODULE_ZTIMER_PERIPH_TIMER
 
 config MODULE_ZTIMER_PERIPH_PTP
     bool "PTP peripheral"
@@ -37,7 +40,6 @@ config MODULE_ZTIMER_PERIPH_TIMER
     bool "Timer peripheral"
     depends on HAS_PERIPH_TIMER
     select MODULE_PERIPH_TIMER
-    default y
 
 endmenu # Backends
 
@@ -45,18 +47,56 @@ menu "Clocks"
 
 config MODULE_ZTIMER_USEC
     bool "Microseconds"
-    depends on MODULE_ZTIMER_PERIPH_TIMER
+    select MODULE_ZTIMER_PERIPH_TIMER
 
 config MODULE_ZTIMER_MSEC
     bool "Milliseconds"
-    depends on MODULE_ZTIMER_PERIPH_TIMER || MODULE_ZTIMER_PERIPH_RTT
+
+choice
+    bool "Backend"
+    depends on MODULE_ZTIMER_MSEC
+    default ZTIMER_MSEC_BACKEND_RTT
+
+config ZTIMER_MSEC_BACKEND_TIMER
+    bool "Timer"
+    select MODULE_ZTIMER_PERIPH_TIMER
+
+config ZTIMER_MSEC_BACKEND_RTT
+    bool "RTT"
+    depends on HAS_PERIPH_RTT
+    select MODULE_ZTIMER_PERIPH_RTT
+
+endchoice
 
 config MODULE_ZTIMER_SEC
     bool "Seconds"
-    depends on MODULE_ZTIMER_PERIPH_TIMER || MODULE_ZTIMER_PERIPH_RTT || MODULE_ZTIMER_PERIPH_RTC
+
+choice
+    bool "Backend"
+    depends on MODULE_ZTIMER_SEC
+    default ZTIMER_SEC_BACKEND_RTC if !BOARD_NATIVE && \
+                                      !CPU_COMMON_SAM0 && \
+                                      !CPU_COMMON_EFM32 && \
+                                      !CPU_COMMON_STM32F1
+    default ZTIMER_SEC_BACKEND_RTT
+
+config ZTIMER_SEC_BACKEND_TIMER
+    bool "Timer"
+    select MODULE_ZTIMER_PERIPH_TIMER
+
+config ZTIMER_SEC_BACKEND_RTT
+    bool "RTT"
+    depends on HAS_PERIPH_RTT
+    select MODULE_ZTIMER_PERIPH_RTT
+
+config ZTIMER_SEC_BACKEND_RTC
+    bool "RTC"
+    depends on HAS_PERIPH_RTC
+    select MODULE_ZTIMER_PERIPH_RTC
+
+endchoice
 
 endmenu # Clocks
-
 
 menu "Frequency conversion"
 

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -89,4 +89,22 @@ endif
 
 ifneq (,$(filter ztimer_msec,$(USEMODULE)))
   USEMODULE += ztimer
+  FEATURES_OPTIONAL += periph_rtt
+  # HACK: periph_rtt will get used only in the next iteration but an updated
+  # state for FEATURES_USED is needed here so include `features_check.inc.mk`
+  # here instead.
+  # An other option would be to check FEATURES_PROVIDED this would avoid the
+  # order of inclusion problem but it would no take into account possible conflicts
+  # and is also currently not allowed in the build system.
+  # An other alternative would be to delay to the next loop, but this produce a
+  # case where another loop is not executed and the conditional not evaluated
+  # If these kind of usecases pop up before Kconfig migration is completed
+  # then another alternative would be introduce a variable to require an extra
+  # loop independent of USEMODULE, FEATURES_REQUIRED and USEPKG
+  include $(RIOTMAKE)/features_check.inc.mk
+  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
+    USEMODULE += ztimer_periph_rtt
+  else
+    USEMODULE += ztimer_periph_timer
+  endif
 endif

--- a/sys/ztimer/Makefile.include
+++ b/sys/ztimer/Makefile.include
@@ -1,0 +1,15 @@
+# Convert xtimer into a pseudo module if its API is already implemented by
+# ztimer's compatibility wrapper
+ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  PSEUDOMODULES += xtimer
+endif
+
+# By defaul use highest possible RTT_FREQUENCY for platforms that allow it. This
+# might not be the most optimized for conversion guarantees that ztimer_periph_rtt
+# will have a capable backend.
+ifneq (,$(filter ztimer_periph_rtt,$(USEMODULE)))
+  ifneq (,$(filter stm32 nrf52 sam% kinetis efm32,$(CPU)))
+    RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
+    CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+  endif
+endif

--- a/tests/pkg_umorse/Makefile.ci
+++ b/tests/pkg_umorse/Makefile.ci
@@ -1,0 +1,2 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \

--- a/tests/ztimer_periodic/Makefile.ci
+++ b/tests/ztimer_periodic/Makefile.ci
@@ -1,0 +1,2 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \


### PR DESCRIPTION
### Contribution description

With #16546 `ztimer_periph_rtt` can always be included since all rtt are capable of supplying a msec timer, so this PR includes it by default.

I'm not sure how the Kconfig dependency should be adapted, I gave it a go but maybe @leandrolanzieri could take a second look.

### Testing procedure

Included modules should be the same for the affected pkgs, `rtt` is included when possible otherwise `ztimer_msec` fallbacks to `periph_timer`,


### Issues/PRs references

Takeover of #16334 