### PR TITLE
boards/z1: add CONFIG_ZTIMER_USEC_ADJUST_% values

### DIFF
--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -51,6 +51,14 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    ztimer configuration values
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET     (96)
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (97)
+/** @} */
+
+/**
  * @name    CPU core configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description

Without tunning most BOARD's behave OK, but some behave very bad as shown by https://github.com/RIOT-OS/RIOT/pull/16254. This PR adds the configuration adjust values for the spotted BOARDS.

### Testing procedure

- rebase on #16254 and run ` make -C tests/ztimer_periodic/ flash test`

- z1

```
2021-06-15 16:35:05,351 # main(): This is RIOT! (Version: 2021.07-devel-382-g391315-pr-16254)
2021-06-15 16:35:05,354 # Testing clock: ZTIMER_MSEC
2021-06-15 16:35:05,857 # i: 0 time: 3834 offset: 0
2021-06-15 16:35:05,859 # i: 1 time: 3934 offset: 0
2021-06-15 16:35:05,862 # i: 2 time: 4035 offset: 1
2021-06-15 16:35:05,864 # i: 3 time: 4134 offset: 1
2021-06-15 16:35:05,866 # i: 4 time: 4235 offset: 1
2021-06-15 16:35:05,869 # Testing clock: ZTIMER_USEC
2021-06-15 16:35:05,922 # i: 0 time: 4259368 offset: 28
2021-06-15 16:35:05,924 # i: 1 time: 4269392 offset: 24
2021-06-15 16:35:05,927 # i: 2 time: 4279392 offset: 0
2021-06-15 16:35:05,930 # i: 3 time: 4289392 offset: 0
2021-06-15 16:35:05,932 # i: 4 time: 4299392 offset: 0
2021-06-15 16:35:05,934 # Test successful.
```

Run `USEMODULE=ztimer_xtimer_compat make -C tests/xtimer_usleep/ flash test -j3`, it should have little offset.

```
2021-06-15 16:49:56,403 # Slept for 10013 us (expected: 10000 us) Offset: 13 us
2021-06-15 16:49:56,458 # Slept for 50001 us (expected: 50000 us) Offset: 1 us
2021-06-15 16:49:56,474 # Slept for 10247 us (expected: 10234 us) Offset: 13 us
2021-06-15 16:49:56,535 # Slept for 56781 us (expected: 56780 us) Offset: 1 us
2021-06-15 16:49:56,553 # Slept for 12134 us (expected: 12122 us) Offset: 12 us
2021-06-15 16:49:56,655 # Slept for 98766 us (expected: 98765 us) Offset: 1 us
2021-06-15 16:49:56,734 # Slept for 75002 us (expected: 75000 us) Offset: 2 us
2021-06-15 16:49:56,749 # Slept for 10012 us (expected: 10000 us) Offset: 12 us
2021-06-15 16:49:56,804 # Slept for 50003 us (expected: 50000 us) Offset: 3 us
2021-06-15 16:49:56,820 # Slept for 10246 us (expected: 10234 us) Offset: 12 us
2021-06-15 16:49:56,881 # Slept for 56781 us (expected: 56780 us) Offset: 1 us
2021-06-15 16:49:56,899 # Slept for 12135 us (expected: 12122 us) Offset: 13 us
2021-06-15 16:49:57,001 # Slept for 98766 us (expected: 98765 us) Offset: 1 us
2021-06-15 16:49:57,080 # Slept for 75002 us (expected: 75000 us) Offset: 2 us
2021-06-15 16:49:57,096 # Slept for 10013 us (expected: 10000 us) Offset: 13 us
2021-06-15 16:49:57,150 # Slept for 50001 us (expected: 50000 us) Offset: 1 us
2021-06-15 16:49:57,166 # Slept for 10246 us (expected: 10234 us) Offset: 12 us
2021-06-15 16:49:57,227 # Slept for 56783 us (expected: 56780 us) Offset: 3 us
2021-06-15 16:49:57,245 # Slept for 12134 us (expected: 12122 us) Offset: 12 us
2021-06-15 16:49:57,347 # Slept for 98767 us (expected: 98765 us) Offset: 2 us
2021-06-15 16:49:57,426 # Slept for 75000 us (expected: 75000 us) Offset: 0 us
2021-06-15 16:49:57,442 # Slept for 10011 us (expected: 10000 us) Offset: 11 us
2021-06-15 16:49:57,497 # Slept for 50003 us (expected: 50000 us) Offset: 3 us
2021-06-15 16:49:57,513 # Slept for 10247 us (expected: 10234 us) Offset: 13 us
2021-06-15 16:49:57,574 # Slept for 56780 us (expected: 56780 us) Offset: 0 us
2021-06-15 16:49:57,592 # Slept for 12134 us (expected: 12122 us) Offset: 12 us
2021-06-15 16:49:57,694 # Slept for 98766 us (expected: 98765 us) Offset: 1 us
2021-06-15 16:49:57,773 # Slept for 75002 us (expected: 75000 us) Offset: 2 us
2021-06-15 16:49:57,788 # Slept for 10013 us (expected: 10000 us) Offset: 13 us
2021-06-15 16:49:57,843 # Slept for 50001 us (expected: 50000 us) Offset: 1 us
2021-06-15 16:49:57,859 # Slept for 10246 us (expected: 10234 us) Offset: 12 us
2021-06-15 16:49:57,920 # Slept for 56783 us (expected: 56780 us) Offset: 3 us
2021-06-15 16:49:57,938 # Slept for 12134 us (expected: 12122 us) Offset: 12 us
2021-06-15 16:49:58,040 # Slept for 98767 us (expected: 98765 us) Offset: 2 us
2021-06-15 16:49:58,119 # Slept for 75000 us (expected: 75000 us) Offset: 0 us
2021-06-15 16:49:58,121 # Test ran for 1785390 us

```

### Issues/PRs references

Fixes issues in https://github.com/RIOT-OS/RIOT/pull/16254
Relates to https://github.com/RIOT-OS/RIOT/pull/14936
