### PR TITLE
tests/ieee802154_hal: check error codes and improve error reporting

### DIFF
--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -423,7 +423,14 @@ int _cca(int argc, char **argv)
 static inline void _set_trx_state(int state, bool verbose)
 {
     xtimer_ticks32_t a;
-    int res = ieee802154_radio_request_set_trx_state(&_radio[0], state);
+    int res;
+
+    /* Under certain conditions (internal house-keeping or sending ACK frames
+     * back) the radio could indicate it's busy. Therefore, busy loop until
+     * the radio doesn't report BUSY
+     */
+    while((res = ieee802154_radio_request_set_trx_state(&_radio[0], state)) == -EBUSY) {}
+
     if (verbose) {
         a = xtimer_now();
         if(res != 0) {

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -216,9 +216,16 @@ static void _send(iolist_t *pkt)
     /* Block until the radio confirms the state change */
     while(ieee802154_radio_confirm_set_trx_state(&_radio[0]) == -EAGAIN);
 
-    /* Trigger the transmit and wait for the mutex unlock (TX_DONE event) */
+    /* Set the frame filter to receive ACKs */
     ieee802154_radio_set_frame_filter_mode(&_radio[0], IEEE802154_FILTER_ACK_ONLY);
-    ieee802154_radio_request_transmit(&_radio[0]);
+
+    /* Trigger the transmit and wait for the mutex unlock (TX_DONE event).
+     * Spin if the radio is busy before transmission (this indicates the
+     * transmission is requested before the end of the IFS).
+     * This won't be necessary anymore when the upper layers take care
+     * of the IFS.
+     */
+    while (ieee802154_radio_request_transmit(&_radio[0]) == -EBUSY) {}
     mutex_lock(&lock);
 
     event_post(EVENT_PRIO_HIGHEST, &_tx_finish_ev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR does essentially 2 things:
- Check error codes when requesting state transitions and transmission. In some cases radios were BUSY when requesting transmission or a new state (because of IFS or the hardware accelerator was finishing a task). This ended up with a situation where "confirm_xxx" functions were called without a successful request.

- Report errors when CCA failed or the transmission could not be performed.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I think https://github.com/RIOT-OS/RIOT/pull/15761 would be appropiate to test this. This issue was triggered when using the `txtspam` command (Radios simply stop receiving packets after one is successfully received).

@LarsKowoll could you give it a look? :)


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered by @LarsKowoll in https://github.com/RIOT-OS/RIOT/pull/15761
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
