### PR TITLE
makefiles/boot/riotboot.mk: pass IOTLAB_NODE

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -76,12 +76,15 @@ riotboot: $(SLOT_RIOT_BINS)
 
 # riotboot bootloader compile target
 riotboot/flash-bootloader: riotboot/bootloader/flash
+# IOTLAB_NODE is passed so that FLASHFILE is also set in the recursive make call
+# when PROGRAMMER=iotlab
 # avoid circular dependency against clean
 riotboot/bootloader/%: $$(if $$(filter riotboot/bootloader/clean,$$@),,$$(BUILDDEPS) pkg-prepare)
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD)\
 		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID) \
+		IOTLAB_NODE=$(IOTLAB_NODE) \
 		PROGRAMMER=$(PROGRAMMER) PROGRAMMER_QUIET=$(PROGRAMMER_QUIET) \
 			$(MAKE) --no-print-directory -C $(RIOTBOOT_DIR) $*
 


### PR DESCRIPTION
### Contribution description

If flashing a riotboot application on iotlab, then `FLASHFILE` is not set on the submake since the `PROGRAMMER=iotlab`.  By passing IOTLAB_NODE this is fixed:

### Testing procedure

The following fails in master:

```
IOTLAB_NODE=auto BOARD=iotlab-m3 make -C tests/riotboot riotboot/flash-combined-slot0
Warning! EXTERNAL_MODULE_DIRS is a search folder since 2021.07-branch, see https://doc.riot-os.org/creating-modules.html#modules-outside-of-riotbase
3.2.1
/home/francisco/workspace/RIOT/bootloaders/riotboot/../..//Makefile.include:614: *** FLASHFILE is not defined for this board: .  Stop.
make: *** [/home/francisco/workspace/RIOT/makefiles/boot/riotboot.mk:81: riotboot/bootloader/binfile] Error 2
```

is fixed with this PR.

### Issues/PRs references

Exposed by #16047