### PR TITLE
dist/Kconfiglib: fix autoconf header

### DIFF
--- a/dist/tools/kconfiglib/riot_kconfig.py
+++ b/dist/tools/kconfiglib/riot_kconfig.py
@@ -18,7 +18,7 @@ class RiotKconfig(Kconfig):
         for marker in doxygen_markers:
             node.help = node.help.replace(marker, "")
 
-    def write_autoconf(self, filename=None, header=None):
+    def write_autoconf(self, filename=None, header="/* RIOT Configuration File */\n"):
         """ Override to convert - to _ when writing autoconf.h """
         tmp_unique_defined_syms = self.unique_defined_syms.copy()
         for sym in self.unique_defined_syms:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This commit fixes the generation of autoconf headers.
The `write_autoconf` function in the RIOT wrapper was overriding
the default value of the `header` arg to None in Kconfiglib's `write_autoconf`.
It's now set to the default header.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I was not able to reproduce it in other environments, but at least it should be possible to see that Kconfig's `write_autoconf` will never receive `header=None`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
