### PR TITLE
pkg/wakaama: remove gnrc dependency

### DIFF
--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -169,8 +169,11 @@ static void *_lwm2m_client_run(void *arg)
                 break;
         }
 
-        DEBUG("Waiting for UDP packet on port: %d\n", _client_data->sock.local.port);
-        rcv_len = sock_udp_recv(&_client_data->sock, &rcv_buf, sizeof(rcv_buf),
+        sock_udp_ep_t local;
+        int res = sock_udp_get_local(&_client_data->sock, &local);
+        assert(res >= 0);
+        DEBUG("Waiting for UDP packet on port: %d\n", local.port);
+        rcv_len = sock_udp_recv(&_client_data->sock, rcv_buf, sizeof(rcv_buf),
                                 tv * US_PER_SEC, &remote);
         DEBUG("sock_udp_recv()\n");
         if (rcv_len > 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the only dependency to GNRC that was present in the Wakaama example, since https://github.com/RIOT-OS/RIOT/pull/12738 was already merged some time ago.

With this change it should be possible to run Wakaama with other network stacks (e.g LWIP ~and soon OpenThread~)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `examples/wakaama`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/12738
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
