### PR TITLE
tests/congure-turo: reset before opening terminal

### DIFF
--- a/tests/congure_test/tests/01-run.py
+++ b/tests/congure_test/tests/01-run.py
@@ -24,10 +24,10 @@ class TestCongUREBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
+        cls.ctrl.reset()
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout
-        cls.ctrl.reset()
         cls.shell = ShellInteraction(cls.ctrl)
         cls.json_parser = RapidJSONShellInteractionParser()
         cls.json_parser.set_parser_args(

--- a/tests/turo/tests/01-run.py
+++ b/tests/turo/tests/01-run.py
@@ -21,10 +21,10 @@ class TestTuroBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ctrl = RIOTCtrl()
+        cls.ctrl.reset()
         cls.ctrl.start_term()
         if cls.DEBUG:
             cls.ctrl.term.logfile = sys.stdout
-        cls.ctrl.reset()
         cls.shell = ShellInteraction(cls.ctrl)
         cls.json_parser = RapidJSONShellInteractionParser()
         cls.logger = logging.getLogger(cls.__name__)


### PR DESCRIPTION
### Contribution description

Some BOARD terminal is slow to start so if the BOARD is reset after
opening the terminal this can lead to off-by-one error when parsing
the output.

So instead do as testrunner and reset before opening the terminal.
Note that no interactive_sync is needed since a similar mechanism
happens in ShellInteraction.

### Testing procedure

- Murdock should now be green

- Ran the tests on a list of [BOARD's](https://ci.inria.fr/ci-riot-tribe/job/build-pipeline.jk/271/artifact/), (atmega based boards failures are unrelated to this PR, and `ek-lm4f120xl` failed to flash, and `z1` fails to boot the firmware on master as well)

### Realted issues

fixes  #16415