### PR TITLE
pkg/semtech-loramac: don't force ztimer rtt backend

### DIFF
--- a/pkg/semtech-loramac/Makefile.dep
+++ b/pkg/semtech-loramac/Makefile.dep
@@ -9,7 +9,6 @@ USEMODULE += semtech_loramac_crypto
 USEMODULE += semtech_loramac_arch
 
 USEMODULE += ztimer_msec
-USEMODULE += ztimer_periph_rtt
 
 # The build fails on MSP430 because the toolchain doesn't provide
 # EXIT_SUCCESS/EXIT_FAILURE macros

--- a/tests/pkg_semtech-loramac/Makefile.ci
+++ b/tests/pkg_semtech-loramac/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
+    atxmega-a1u-xpro \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes the hard dependency of ztimer RTT backend used by semtech-loramac package. AFAIU, with #16553, the RTT backend is only used when the periph_rtt is provided by the board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- Semtech-loramac package based applications are still functional
- Check that ztimer RTT backend is used with b-l072z-lrwan1 board (which is the default for semtech-loramac applications)
- Check that examples/lorawan and tests/pkg_semtech-loramac can be built with im880b (no RTT provided so cannot be used in current master)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #16553

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
