### PR TITLE
gnrc/nib: fix starting with router advertisements disabled, enabling them at run-time

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
@@ -118,12 +118,6 @@ gnrc_pktsnip_t *_copy_and_handle_aro(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6
                                      const sixlowpan_nd_opt_ar_t *aro,
                                      const ndp_opt_t *sl2ao);
 
-/**
- * @brief   Sets the @ref GNRC_NETIF_FLAGS_IPV6_RTR_ADV flags of an interface
- *
- * @param[in] netif The interface.
- */
-void _set_rtr_adv(gnrc_netif_t *netif);
 #else   /* CONFIG_GNRC_IPV6_NIB_6LR || defined(DOXYGEN) */
 #define _rtr_sol_on_6lr(netif, icmpv6)  (false)
 #define _get_ar_state(nbr)              (_ADDR_REG_STATUS_IGNORE)
@@ -133,7 +127,6 @@ void _set_rtr_adv(gnrc_netif_t *netif);
  */
 #define _copy_and_handle_aro(netif, ipv6, icmpv6, aro, sl2ao) \
                                         (NULL)
-#define _set_rtr_adv(netif)             (void)netif
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LR || defined(DOXYGEN) */
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
@@ -46,8 +46,7 @@ static inline void _init_iface_router(gnrc_netif_t *netif)
     netif->ipv6.ra_sent = 0;
     netif->flags |= GNRC_NETIF_FLAGS_IPV6_FORWARDING;
 
-    if (!IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LR) ||
-        IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR)) {
+    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ADV_ROUTER)) {
         netif->flags |= GNRC_NETIF_FLAGS_IPV6_RTR_ADV;
     }
 


### PR DESCRIPTION
### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Set the `CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ADV_ROUTER=0` option to start RIOT with router advertisements disabled.

Then selectively enable router advertisements by running `ifconfig <if> rtr_adv`.

The first step was not possible on master as the config option was ignored.

The second step was not possible on a non-6lo node as `_nib-6lr.h` turned it into a no-op.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
