### PR TITLE
gnrc_ipv6_nib: consider all local interfaces when looking for address

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -331,11 +331,16 @@ void gnrc_ndp_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
     gnrc_netif_acquire(netif);
     do {    /* XXX: hidden goto */
         int tgt_idx;
+        gnrc_netif_t *tgt_netif = gnrc_netif_get_by_ipv6_addr(tgt);
 
-        if ((tgt_idx = gnrc_netif_ipv6_addr_idx(netif, tgt)) < 0) {
+        if (tgt_netif == NULL) {
             DEBUG("ndp: tgt not assigned to interface. Abort sending\n");
             break;
         }
+
+        tgt_idx = gnrc_netif_ipv6_addr_idx(tgt_netif, tgt);
+        assert(tgt_idx >= 0);
+
         if (gnrc_netif_is_rtr(netif) && gnrc_netif_is_rtr_adv(netif)) {
             adv_flags |= NDP_NBR_ADV_FLAGS_R;
         }
@@ -368,7 +373,7 @@ void gnrc_ndp_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
         }
         /* TODO: also check if the node provides proxy services for tgt */
         if ((pkt != NULL) &&
-            (netif->ipv6.addrs_flags[tgt_idx] &
+            (tgt_netif->ipv6.addrs_flags[tgt_idx] &
              GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST)) {
             /* TL2A is not supplied and tgt is not anycast */
             adv_flags |= NDP_NBR_ADV_FLAGS_O;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If a node has two interfaces A with `2001:16b8:45b5:9af8:5884:3bff:fe4f:a903` and B with `2001:16b8:45b5:9afa:5884:3bff:fe4f:a902` and receives a neighbor solicitation on A for an address configured on interface B, answer the neighbor solicitation instead of bailing out with

> Target address `2001:16b8:45b5:9afa:5884:3bff:fe4f:a902` is not assigned to the local interface

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

see https://github.com/RIOT-OS/RIOT/pull/8823#discussion_r651768593
