### PR TITLE
drivers/sx126x: fix netdev send and recv function

### DIFF
--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -51,22 +51,23 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         return -ENOTSUP;
     }
 
-    uint8_t size = iolist_size(iolist);
-
-    /* Ignore send if packet size is 0 */
-    if (!size) {
-        return 0;
-    }
-
-    DEBUG("[sx126x] netdev: sending packet now (size: %d).\n", size);
+    size_t pos = 0;
     /* Write payload buffer */
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
         if (iol->iol_len > 0) {
-            sx126x_set_lora_payload_length(dev, iol->iol_len);
-            sx126x_write_buffer(dev, 0, iol->iol_base, iol->iol_len);
+            sx126x_write_buffer(dev, pos, iol->iol_base, iol->iol_len);
             DEBUG("[sx126x] netdev: send: wrote data to payload buffer.\n");
+            pos += iol->iol_len;
         }
     }
+
+    /* Ignore send if packet size is 0 */
+    if (!pos) {
+        return 0;
+    }
+
+    DEBUG("[sx126x] netdev: sending packet now (size: %d).\n", pos);
+    sx126x_set_lora_payload_length(dev, pos);
 
     state = NETOPT_STATE_TX;
     netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(uint8_t));

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -108,7 +108,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     sx126x_read_buffer(dev, rx_buffer_status.buffer_start_pointer, buf, size);
 
-    return 0;
+    return size;
 }
 
 static int _init(netdev_t *netdev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This commit fixes the send function of sx126x. The loop that reads the
iolist was not considering the offset. Therefore each iolist snippet was
being written into the first position.

The loop was also setting the payload length to the size of the iolist
snippet. Then the payload was also wrong.

With this commit an iolist is copied sequentially into the framebuffer
and the payload length is set to `iolist_size`.

EDIT: This PR also fixes the return value of `_recv`. According to the `netdev_driver_t` API, the `recv` function must return the number of read bytes. The current version in master was returning 0. This was causing issues in GNRC LoRaWAN.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Trigger a Join Request using GNRC LoRaWAN. Neither `tests/driver_sx126x` nor Semtech LoRaMAC use an iolist with more than one snippet, so they won't show this issue.
- Trigger a downlink from the NS using GNRC LoRaWAN. The device should be able to receive the packet.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
