### PR TITLE
docs: Remove references to Freenode from the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,12 @@ of this document using the following links:
 * [Working with Git][working with git]
 
 If you have questions, please write a post over at our [forum] or chat on
-`#riot-os` on [IRC] or [Matrix].
+`#riot-os:matrix.org` on [Matrix].
 
 As a reminder, all contributors are expected to follow our
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
 [forum]: https://forum.riot-os.org
-[IRC]: http://webchat.freenode.net?channels=riot-os
 [Matrix]: https://matrix.to/#/#riot-os:matrix.org
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Merge chance][merge-chance-badge]][merge-chance-link]
 [![Stack Overflow questions][stackoverflow-badge]][stackoverflow-link]
 [![Twitter][twitter-badge]][twitter-link]
-[![IRC][irc-badge]][irc-link]
 [![Matrix][matrix-badge]][matrix-link]
 
                           ZZZZZZ
@@ -143,8 +142,6 @@ https://www.riot-os.org
 
 [api-badge]: https://img.shields.io/badge/docs-API-informational.svg
 [api-link]: https://riot-os.org/api/
-[irc-badge]: https://img.shields.io/badge/chat-IRC-brightgreen.svg
-[irc-link]: https://webchat.freenode.net?channels=%23riot-os
 [license-badge]: https://img.shields.io/github/license/RIOT-OS/RIOT
 [license-link]: https://github.com/RIOT-OS/RIOT/blob/master/LICENSE
 [master-ci-badge]: https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/badge.svg

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -43,8 +43,8 @@ RIOT is developed by an open community that anyone is welcome to join:
  - Regarding critical vulnerabilities we would appreciate if you give us a
    90-days head-start by reporting to security@riot-os.org, before making your
    information publicly available
- - Contact us on IRC for live support and discussions:
-   [irc.freenode.org \#riot-os](irc://irc.freenode.org/riot-os)
+ - Contact us on Matrix for live support and discussions:
+   [riot-os:matrix.org](https://matrix.to/#/#riot-os:matrix.org)
 
 
 The quickest start                                        {#the-quickest-start}


### PR DESCRIPTION
### Contribution description

Freenode migrated to a different IRC network and we lost control of the #riot-os room there. As we no longer own this room the references to this room should be removed from the documentation and be replaced with a reference to the matrix room where applicable.

### Testing procedure

- Check that the IRC shield is gone from the README.
- The main page of doxygen now refers to the Matrix room for live chat and support
- There are no remaining references to IRC in the source (except for previous release notes)

### Issues/PRs references

See the forum [here](https://forum.riot-os.org/t/riot-irc-channel-and-the-freenode-turmoil) and [here](https://forum.riot-os.org/t/riot-irc-and-even-more-freenode-turmoil)