### PR TITLE
sys/ztimer: use highest frequency for nrf51 as well

### DIFF
--- a/sys/ztimer/Makefile.include
+++ b/sys/ztimer/Makefile.include
@@ -8,7 +8,7 @@ endif
 # might not be the most optimized for conversion guarantees that ztimer_periph_rtt
 # will have a capable backend.
 ifneq (,$(filter ztimer_periph_rtt,$(USEMODULE)))
-  ifneq (,$(filter stm32 nrf52 sam% kinetis efm32,$(CPU)))
+  ifneq (,$(filter stm32 nrf5% sam% kinetis efm32,$(CPU)))
     RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
     CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
   endif


### PR DESCRIPTION
### Contribution description

In #16553 nrf51 was neglected by mistake in frequency configuration, this adds it for cases where the default frequency might be insufficient.

### Testing procedure

`IOTLAB_NODE=auto BOARD=nrf51dk make -C tests/ztimer_periodic/ flash test -j3`

```
main(): This is RIOT! (Version: 2021.07-devel-441-gbeee6f-pr_ztimer_rtt_nrf51)
Testing clock: ZTIMER_MSEC
i: 0 time: 3123 offset: 0
i: 1 time: 3223 offset: 0
i: 2 time: 3323 offset: 0
i: 3 time: 3423 offset: 0
i: 4 time: 3524 offset: 1
Testing clock: ZTIMER_USEC
i: 0 time: 3522502 offset: 50
i: 1 time: 3532510 offset: 8
i: 2 time: 3542510 offset: 0
i: 3 time: 3552510 offset: 0
i: 4 time: 3562510 offset: 0
Test successful.
```