### PR TITLE
sys/ztimer: convert clock do not require pm

### DIFF
--- a/sys/ztimer/convert.c
+++ b/sys/ztimer/convert.c
@@ -46,6 +46,9 @@ void ztimer_convert_init(ztimer_convert_t *ztimer_convert,
             .arg = ztimer_convert,
         },
         .super.max_value = max_value,
+#  ifdef MODULE_PM_LAYERED
+        .super.block_pm_mode = ZTIMER_CLOCK_NO_REQUIRED_PM_MODE,
+#  endif
     };
 
     *ztimer_convert = tmp;

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -111,4 +111,7 @@ void ztimer_convert_frac_init(ztimer_convert_frac_t *self,
         self->round = freq_self / freq_lower;
         self->super.super.max_value = UINT32_MAX;
     }
+#ifdef MODULE_PM_LAYERED
+    self->super.super.block_pm_mode = ZTIMER_CLOCK_NO_REQUIRED_PM_MODE;
+#endif
 }


### PR DESCRIPTION
avoid blocking and unblocking of power mode 0 for convert clocks

@vincent-d identified in #15911 that pm should be done in base clock which was implemented in the huge ztimer auto init overhaul, but it was lacking the not blocking and not unblocking of #15911 for convert clocks which by default are set to 0 (un)blocking that pm

this removes that flaw

in contrast to my comment in #15911 `ztimer/convert_muldiv64.c` and `ztimer/convert_shift.c` do not need modification since they call the init of `ztimer/convert.c` 

### Contribution description

this add setting convert clocks to require no pm (the base clock should have the pm blocking setup correctly)

### Testing procedure

have hardware that operates with pm_mode 0 active, check the power consumption while you expect it sleeping, check if it wakes up when required. 

i don't have such a setup (stm loses most of their mem with pm 0), but would @vincent-d and maybe @jue89 to have.

while one may not be able to test the effect it should be possible to check what this does by:

build and flash `tests/ztimer_xsec` with `USEMODULE=pm_layered` to your favorite board and `make debug`

`(gdb) b main`

on a second console `make term` and start  `Help: Press s to start test, r to print it is ready` -> `[s] and [return]` 

back to the first console and see 
```
Breakpoint 1 at 0x80000f0: file ztimer_xsec/main.c, line 57.
(gdb) p ZTIMER_SEC->block_pm_mode
```
ante patch -> `$n = 0 '\000'`  means block an unblock pm 0 what ZTIMER_SEC should not do 
post patch -> `$n = 255 '\377'` means do not do any pm thing for ZTIMER_SEC :heavy_check_mark: 

### Issues/PRs references

fixes what is left of #15911

I think this should be added to the ztimer project 

