### PR TITLE
ieee802154: migrate `netdev_ieee802154_dst_filter` to a common ieee802154

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -492,8 +492,10 @@ void isr_radio(void)
                 /* only process packet if event callback is set and CRC is valid */
                 if ((nrf802154_dev->netdev.event_callback) &&
                     (NRF_RADIO->CRCSTATUS == 1) &&
-                    (netdev_ieee802154_dst_filter(nrf802154_dev,
-                                                  &rxbuf[1]) == 0)) {
+                    (ieee802154_dst_filter(&rxbuf[1],
+                                           nrf802154_dev->pan,
+                                           (network_uint16_t*) nrf802154_dev->short_addr,
+                                           nrf802154_dev->long_addr) == 0)) {
                     _state |= RX_COMPLETE;
                 }
                 else {

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -208,6 +208,9 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *va
  * this function is meant top be used by drivers that do not support address
  * filtering in hw
  *
+ * @deprecated  This function is currently deprecated and will be removed
+ * after Release 2022.01. Use @ref ieee802154_dst_filter instead.
+ *
  * @param[in] dev       network device descriptor
  * @param[in] mhr       mac header
  *

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -397,6 +397,25 @@ int ieee802154_get_src(const uint8_t *mhr, uint8_t *src, le_uint16_t *src_pan);
 int ieee802154_get_dst(const uint8_t *mhr, uint8_t *dst, le_uint16_t *dst_pan);
 
 /**
+ * @brief  Check whether a frame pass the IEEE 802.15.4 frame filter.
+ *
+ * A frame passes the frame filter only if:
+ * - The PAN ID matches the PAN ID of the frame filter or the broadcast PAN ID
+ * - Either the Short or Extended Address matches the frame filter OR the
+ *   Short Address is the broadcast address.
+ *
+ * @param[in] mhr           MAC header (PSDU)
+ * @param[in] pan           PAN ID of the frame filter.
+ * @param[in] short_addr    Short Address of the frame filter.
+ * @param[in] ext_addr      Extended Address of the frame filter.
+ *
+ * @return 0            if frame passes the frame filter.
+ * @return 1            if frame doesn't pass the frame filter.
+ */
+int ieee802154_dst_filter(const uint8_t *mhr, uint16_t pan,
+                          network_uint16_t short_addr, const eui64_t *ext_addr);
+
+/**
  * @brief   Gets sequence number from MAC header.
  *
  * @pre length of allocated space at @p mhr > 3

--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -241,4 +241,31 @@ int ieee802154_get_dst(const uint8_t *mhr, uint8_t *dst, le_uint16_t *dst_pan)
     return 0;
 }
 
+int ieee802154_dst_filter(const uint8_t *mhr, uint16_t pan,
+                          network_uint16_t short_addr, const eui64_t *ext_addr)
+{
+    uint8_t dst_addr[IEEE802154_LONG_ADDRESS_LEN];
+    le_uint16_t dst_pan;
+    uint8_t pan_bcast[] = IEEE802154_PANID_BCAST;
+
+    int addr_len = ieee802154_get_dst(mhr, dst_addr, &dst_pan);
+
+    /* filter PAN ID */
+    if ((memcmp(pan_bcast, dst_pan.u8, 2) != 0) &&
+        (memcmp(&pan, dst_pan.u8, 2) != 0)) {
+        return 1;
+    }
+
+    /* check destination address */
+    if (((addr_len == IEEE802154_SHORT_ADDRESS_LEN) &&
+          (memcmp(&short_addr.u8, dst_addr, addr_len) == 0 ||
+           memcmp(ieee802154_addr_bcast, dst_addr, addr_len) == 0)) ||
+        ((addr_len == IEEE802154_LONG_ADDRESS_LEN) &&
+          (memcmp(ext_addr->uint8, dst_addr, addr_len) == 0))) {
+        return 0;
+    }
+
+    return 1;
+}
+
 /** @} */

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -953,6 +953,128 @@ static void test_ieee802154_get_dst_dst8_pancomp(void)
     TEST_ASSERT_EQUAL_INT(exp_pan.u16, res_pan.u16);
 }
 
+static void test_ieee802154_dst_filter_pan_fail(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
+    const uint8_t mhr[] = { 0,
+                            IEEE802154_FCF_DST_ADDR_SHORT,
+                            TEST_UINT8,
+                            exp_pan.u8[0], exp_pan.u8[1],
+                            exp_addr.u8[1], exp_addr.u8[0] };
+    TEST_ASSERT_EQUAL_INT(1, ieee802154_dst_filter(mhr,
+                                                   exp_pan.u16 + 1,
+                                                   exp_addr,
+                                                   &long_addr));
+}
+
+static void test_ieee802154_dst_filter_short_addr_fail(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
+    const uint8_t mhr[] = { 0,
+                            IEEE802154_FCF_DST_ADDR_SHORT,
+                            TEST_UINT8,
+                            exp_pan.u8[0], exp_pan.u8[1],
+                            exp_addr.u8[1], exp_addr.u8[0] };
+    TEST_ASSERT_EQUAL_INT(1, ieee802154_dst_filter(mhr,
+                                                   exp_pan.u16,
+                                                   byteorder_htons(exp_addr.u16 + 1),
+                                                   &long_addr));
+}
+
+static void test_ieee802154_dst_filter_long_addr_fail(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
+    const eui64_t long_addr_fail =  {.uint64.u64 = TEST_UINT64 + 1};
+    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_DST_ADDR_LONG,
+                            TEST_UINT8,
+                            exp_pan.u8[0], exp_pan.u8[1],
+                            long_addr.uint8[7], long_addr.uint8[6],
+                            long_addr.uint8[5], long_addr.uint8[4],
+                            long_addr.uint8[3], long_addr.uint8[2],
+                            long_addr.uint8[1], long_addr.uint8[0] };
+    TEST_ASSERT_EQUAL_INT(1, ieee802154_dst_filter(mhr,
+                                                   exp_pan.u16,
+                                                   exp_addr,
+                                                   &long_addr_fail));
+}
+
+static void test_ieee802154_dst_filter_pan_short(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
+    const uint8_t mhr[] = { 0,
+                            IEEE802154_FCF_DST_ADDR_SHORT,
+                            TEST_UINT8,
+                            exp_pan.u8[0], exp_pan.u8[1],
+                            exp_addr.u8[1], exp_addr.u8[0] };
+    TEST_ASSERT_EQUAL_INT(0, ieee802154_dst_filter(mhr,
+                                                   exp_pan.u16,
+                                                   exp_addr,
+                                                   &long_addr));
+}
+
+static void test_ieee802154_dst_filter_bcast_short(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const uint8_t pan_bcast[] = IEEE802154_PANID_BCAST;
+    const uint8_t mhr[] = { 0,
+                            IEEE802154_FCF_DST_ADDR_SHORT,
+                            TEST_UINT8,
+                            pan_bcast[0], pan_bcast[1],
+                            exp_addr.u8[1], exp_addr.u8[0] };
+    TEST_ASSERT_EQUAL_INT(0, ieee802154_dst_filter(mhr,
+                                                   TEST_UINT16,
+                                                   exp_addr,
+                                                   &long_addr));
+}
+
+static void test_ieee802154_dst_filter_pan_long(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
+    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_DST_ADDR_LONG,
+                            TEST_UINT8,
+                            exp_pan.u8[0], exp_pan.u8[1],
+                            long_addr.uint8[7], long_addr.uint8[6],
+                            long_addr.uint8[5], long_addr.uint8[4],
+                            long_addr.uint8[3], long_addr.uint8[2],
+                            long_addr.uint8[1], long_addr.uint8[0] };
+    TEST_ASSERT_EQUAL_INT(0, ieee802154_dst_filter(mhr,
+                                                   exp_pan.u16,
+                                                   exp_addr,
+                                                   &long_addr));
+}
+
+static void test_ieee802154_dst_filter_bcast_long(void)
+{
+    const network_uint16_t exp_addr = byteorder_htons(TEST_UINT16);
+    const eui64_t long_addr = {.uint64.u64 = TEST_UINT64};
+    const uint8_t pan_bcast[] = IEEE802154_PANID_BCAST;
+    const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP,
+                            IEEE802154_FCF_DST_ADDR_LONG,
+                            TEST_UINT8,
+                            pan_bcast[0], pan_bcast[1],
+                            long_addr.uint8[7], long_addr.uint8[6],
+                            long_addr.uint8[5], long_addr.uint8[4],
+                            long_addr.uint8[3], long_addr.uint8[2],
+                            long_addr.uint8[1], long_addr.uint8[0] };
+    TEST_ASSERT_EQUAL_INT(0, ieee802154_dst_filter(mhr,
+                                                   TEST_UINT16,
+                                                   exp_addr,
+                                                   &long_addr));
+}
+
 static void test_ieee802154_get_seq(void)
 {
     const uint8_t mhr[] = { 0x00, 0x00, TEST_UINT8 };
@@ -1088,6 +1210,13 @@ Test *tests_ieee802154_tests(void)
         new_TestFixture(test_ieee802154_get_dst_dst2_pancomp),
         new_TestFixture(test_ieee802154_get_dst_dst8),
         new_TestFixture(test_ieee802154_get_dst_dst8_pancomp),
+        new_TestFixture(test_ieee802154_dst_filter_pan_fail),
+        new_TestFixture(test_ieee802154_dst_filter_short_addr_fail),
+        new_TestFixture(test_ieee802154_dst_filter_long_addr_fail),
+        new_TestFixture(test_ieee802154_dst_filter_pan_short),
+        new_TestFixture(test_ieee802154_dst_filter_bcast_short),
+        new_TestFixture(test_ieee802154_dst_filter_pan_long),
+        new_TestFixture(test_ieee802154_dst_filter_bcast_long),
         new_TestFixture(test_ieee802154_get_seq),
         new_TestFixture(test_ieee802154_get_iid_addr_len_0),
         new_TestFixture(test_ieee802154_get_iid_addr_len_SIZE_MAX),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR migrates `netdev_ieee802154_dst_filter` to `ieee802154_dst_filter`.
This not only makes it not dependent to netdev, but will help with Kconfig modelling since now `netdev_ieee802154` can be represented as a pure netdev layer. I will add a follow up PR that shows this in action.

`netdev_ieee802154_dst_filter` is marked as deprecated and will be removed after 2022.01.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check that `examples/gnrc_networking` compiles for e.g `nrf52840dk` (with `USEMODULE=`nrf802154_netdev_legacy`) and confirm that pinging still works.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
