### PR TITLE
tree-wide: avoid explicit cast to netdev

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -214,7 +214,7 @@ void cc2538_setup(cc2538_rf_t *dev)
     (void) dev;
 #if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
     extern ieee802154_dev_t cc2538_rf_dev;
-    netdev_register((netdev_t* )dev, NETDEV_CC2538, 0);
+    netdev_register(&dev->netdev.dev.netdev, NETDEV_CC2538, 0);
     netdev_ieee802154_submac_init(&dev->netdev, &cc2538_rf_dev);
 #endif
     cc2538_init();

--- a/cpu/esp32/esp-eth/esp_eth_gnrc.c
+++ b/cpu/esp32/esp-eth/esp_eth_gnrc.c
@@ -37,7 +37,7 @@ void auto_init_esp_eth(void)
 {
     esp_eth_setup(&_esp_eth_dev);
     gnrc_netif_ethernet_create(&_netif, _esp_eth_stack, ESP_ETH_STACKSIZE, ESP_ETH_PRIO,
-                               "netif-esp-eth", (netdev_t *)&_esp_eth_dev);
+                               "netif-esp-eth", &_esp_eth_dev.netdev);
 }
 
 #else /* defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET) */

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -141,7 +141,7 @@ static int _esp_eth_init(netdev_t *netdev)
 {
     DEBUG("%s: netdev=%p\n", __func__, netdev);
 
-    esp_eth_netdev_t* dev = (esp_eth_netdev_t*)netdev;
+    esp_eth_netdev_t* dev = container_of(netdev, esp_eth_netdev_t, netdev);
 
     mutex_lock(&dev->dev_lock);
 
@@ -189,7 +189,7 @@ static int _esp_eth_send(netdev_t *netdev, const iolist_t *iolist)
     CHECK_PARAM_RET (netdev != NULL, -ENODEV);
     CHECK_PARAM_RET (iolist != NULL, -EINVAL);
 
-    esp_eth_netdev_t* dev = (esp_eth_netdev_t*)netdev;
+    esp_eth_netdev_t* dev = container_of(netdev, esp_eth_netdev_t, netdev);
 
     if (!_esp_eth_dev.link_up) {
         DEBUG("%s: link is down\n", __func__);
@@ -238,7 +238,7 @@ static int _esp_eth_recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     CHECK_PARAM_RET (netdev != NULL, -ENODEV);
 
-    esp_eth_netdev_t* dev = (esp_eth_netdev_t*)netdev;
+    esp_eth_netdev_t* dev = container_of(netdev, esp_eth_netdev_t, netdev);
 
     mutex_lock(&dev->dev_lock);
 
@@ -282,7 +282,7 @@ static int _esp_eth_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_le
     CHECK_PARAM_RET (netdev != NULL, -ENODEV);
     CHECK_PARAM_RET (val != NULL, -EINVAL);
 
-    esp_eth_netdev_t* dev = (esp_eth_netdev_t*)netdev;
+    esp_eth_netdev_t* dev = container_of(netdev, esp_eth_netdev_t, netdev);
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -323,7 +323,7 @@ static void _esp_eth_isr(netdev_t *netdev)
 
     CHECK_PARAM (netdev != NULL);
 
-    esp_eth_netdev_t *dev = (esp_eth_netdev_t *) netdev;
+    esp_eth_netdev_t* dev = container_of(netdev, esp_eth_netdev_t, netdev);
 
     switch (dev->event) {
         case SYSTEM_EVENT_ETH_RX_DONE:

--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -97,7 +97,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
-    esp_now_netdev_t *esp_now = (esp_now_netdev_t*)dev;
+    esp_now_netdev_t *esp_now = container_of(dev, esp_now_netdev_t, netdev);
 
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
     if (bytes_expected <= 0) {

--- a/cpu/esp_common/esp-wifi/esp_wifi_gnrc.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_gnrc.c
@@ -45,7 +45,7 @@ void auto_init_esp_wifi (void)
                                ESP_WIFI_PRIO,
 #endif
                                "netif-esp-wifi",
-                               (netdev_t *)&_esp_wifi_dev);
+                               &_esp_wifi_dev.netdev);
 }
 
 #else /* defined(MODULE_ESP_WIFI) && defined(MODULE_GNRC_NETIF_ETHERNET) */

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -562,7 +562,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
     }
     _esp_wifi_send_is_in = true;
 
-    esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
+    esp_wifi_netdev_t* dev = container_of(netdev, esp_wifi_netdev_t, netdev);
 
 #ifdef MODULE_ESP_WIFI_AP
     if (_esp_wifi_dev.sta_connected == 0) {
@@ -629,7 +629,7 @@ static int _esp_wifi_recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     assert(netdev != NULL);
 
-    esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
+    esp_wifi_netdev_t* dev = container_of(netdev, esp_wifi_netdev_t, netdev);
     uint16_t size;
 
     critical_enter();
@@ -688,7 +688,7 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
     assert(val != NULL);
 
 #ifndef MODULE_ESP_WIFI_AP
-    esp_wifi_netdev_t* dev = (esp_wifi_netdev_t*)netdev;
+    esp_wifi_netdev_t* dev = container_of(netdev, esp_wifi_netdev_t, netdev);
 #endif /* MODULE_ESP_WIFI_AP */
 
     switch (opt) {
@@ -748,7 +748,7 @@ static void _esp_wifi_isr(netdev_t *netdev)
 
     assert(netdev != NULL);
 
-    esp_wifi_netdev_t *dev = (esp_wifi_netdev_t *) netdev;
+    esp_wifi_netdev_t* dev = container_of(netdev, esp_wifi_netdev_t, netdev);
 
     while (dev->event_recv) {
         dev->event_recv--;

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -71,25 +71,25 @@ static int _recv(netdev_t *netdev, void *buf, size_t n, void *info);
 
 static inline void _get_mac_addr(netdev_t *netdev, uint8_t *dst)
 {
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
     memcpy(dst, dev->addr, ETHERNET_ADDR_LEN);
 }
 
 static inline void _set_mac_addr(netdev_t *netdev, const uint8_t *src)
 {
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
     memcpy(dev->addr, src, ETHERNET_ADDR_LEN);
 }
 
 static inline int _get_promiscuous(netdev_t *netdev)
 {
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
     return dev->promiscuous;
 }
 
 static inline int _set_promiscuous(netdev_t *netdev, int value)
 {
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
     dev->promiscuous = value;
     return value;
 }
@@ -206,7 +206,7 @@ static void _continue_reading(netdev_tap_t *dev)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
     (void)info;
 
     if (!buf) {
@@ -275,7 +275,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
 
     struct iovec iov[iolist_count(iolist)];
 
@@ -299,7 +299,8 @@ void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params) {
 static void _tap_isr(int fd, void *arg) {
     (void) fd;
 
-    netdev_t *netdev = (netdev_t *)arg;
+    netdev_tap_t *dev = arg;
+    netdev_t *netdev = &dev->netdev;
 
     if (netdev->event_callback) {
         netdev_trigger_event_isr(netdev);
@@ -313,7 +314,7 @@ static int _init(netdev_t *netdev)
 {
     DEBUG("%s:%s:%u\n", RIOT_FILE_RELATIVE, __func__, __LINE__);
 
-    netdev_tap_t *dev = (netdev_tap_t*)netdev;
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
 
     /* check device parametrs */
     if (dev == NULL) {

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -104,7 +104,8 @@ static size_t _prep_vector(socket_zep_t *dev, const iolist_t *iolist,
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    socket_zep_t *dev = (socket_zep_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    socket_zep_t *dev = container_of(netdev_ieee802154, socket_zep_t, netdev);
     unsigned n = iolist_count(iolist);
     struct iovec v[n + 2];
     int res;
@@ -179,7 +180,8 @@ static inline bool _dst_not_me(socket_zep_t *dev, const void *buf)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    socket_zep_t *dev = (socket_zep_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    socket_zep_t *dev = container_of(netdev_ieee802154, socket_zep_t, netdev);
     int size = 0;
 
     DEBUG("socket_zep::recv(%p, %p, %u, %p)\n", (void *)netdev, buf,
@@ -263,7 +265,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 static void _isr(netdev_t *netdev)
 {
     if (netdev->event_callback) {
-        socket_zep_t *dev = (socket_zep_t *)netdev;
+        netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+        socket_zep_t *dev = container_of(netdev_ieee802154, socket_zep_t, netdev);
 
         DEBUG("socket_zep::isr: firing %u\n", (unsigned)dev->last_event);
         netdev->event_callback(netdev, dev->last_event);
@@ -275,7 +278,7 @@ static void _socket_isr(int fd, void *arg)
 {
     (void)fd;
     (void)arg;
-    netdev_t *netdev = (netdev_t *)arg;
+    netdev_t *netdev = arg;
 
     DEBUG("socket_zep::_socket_isr: %d, %p (netdev == %p)\n",
           fd, arg, (void *)netdev);
@@ -283,7 +286,8 @@ static void _socket_isr(int fd, void *arg)
         return;
     }
     if (netdev->event_callback) {
-        socket_zep_t *dev = (socket_zep_t *)netdev;
+        netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+        socket_zep_t *dev = container_of(netdev_ieee802154, socket_zep_t, netdev);
 
         dev->last_event = NETDEV_EVENT_RX_COMPLETE;
         netdev_trigger_event_isr(netdev);
@@ -292,7 +296,8 @@ static void _socket_isr(int fd, void *arg)
 
 static int _init(netdev_t *netdev)
 {
-    socket_zep_t *dev = (socket_zep_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    socket_zep_t *dev = container_of(netdev_ieee802154, socket_zep_t, netdev);
 
     netdev_ieee802154_reset(&dev->netdev);
 
@@ -305,14 +310,15 @@ static int _init(netdev_t *netdev)
 static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
     assert(netdev != NULL);
-    return netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt, value, max_len);
+    return netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev),
+                                 opt, value, max_len);
 }
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *value,
                 size_t value_len)
 {
     assert(netdev != NULL);
-    return netdev_ieee802154_set((netdev_ieee802154_t *)netdev, opt,
+    return netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev), opt,
                                   value, value_len);
 }
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -784,7 +784,9 @@ void nrf802154_setup(nrf802154_t *dev)
 {
     (void) dev;
 #if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC)
-    netdev_t *netdev = (netdev_t*) dev;
+    netdev_ieee802154_submac_t *netdev_submac = &dev->netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = &netdev_submac->dev;
+    netdev_t *netdev = &netdev_ieee802154->netdev;
     netdev_register(netdev, NETDEV_NRF802154, 0);
     DEBUG("[nrf802154] init submac.\n")
     netdev_ieee802154_submac_init(&dev->netdev, &nrf802154_hal_dev);

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -184,5 +184,5 @@ void gnrc_nrfmin_init(void)
     /* setup the NRFMIN driver */
     nrfmin_setup();
     gnrc_netif_create(&_netif, stack, sizeof(stack), NRFMIN_GNRC_THREAD_PRIO, "nrfmin",
-                      (netdev_t *)&nrfmin_dev, &gnrc_nrfmin_ops);
+                      &nrfmin_dev, &gnrc_nrfmin_ops);
 }

--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -310,7 +310,7 @@ static int stm32_eth_get(netdev_t *dev, netopt_t opt,
 
 static void _timer_cb(void *arg)
 {
-    netdev_t *dev = (netdev_t *)arg;
+    netdev_t *dev = arg;
     uint8_t state = LINK_STATE_DOWN;
     if (_get_link_status()) {
         state = LINK_STATE_UP;

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -31,7 +31,7 @@
 
 static void _setup_interface(at86rf215_t *dev, const at86rf215_params_t *params, uint8_t index)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev.netdev;
 
     netdev->driver = &at86rf215_driver;
     dev->params = *params;
@@ -256,7 +256,7 @@ static void _block_while_busy(at86rf215_t *dev)
 
     do {
         if (gpio_read(dev->params.int_pin) || dev->timeout) {
-            at86rf215_driver.isr((netdev_t *) dev);
+            at86rf215_driver.isr(&dev->netdev.netdev);
         }
         /* allow the other interface to process events */
         thread_yield();

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -283,7 +283,7 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
 
 void at86rf2xx_tx_exec(at86rf2xx_t *dev)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev.netdev;
 
 #if AT86RF2XX_HAVE_RETRIES
     dev->tx_retries = -1;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -74,7 +74,9 @@ static void _irq_handler(void *arg)
 
 static int _init(netdev_t *netdev)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
 
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
     at86rfmega_dev = netdev;
@@ -114,7 +116,9 @@ static int _init(netdev_t *netdev)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     size_t len = 0;
 
     at86rf2xx_tx_prepare(dev);
@@ -143,7 +147,9 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     uint8_t phr;
     size_t pkt_len;
 
@@ -305,7 +311,9 @@ netopt_state_t _get_state(at86rf2xx_t *dev)
 
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
 
     if (netdev == NULL) {
         return -ENODEV;
@@ -378,8 +386,9 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     int res;
 
-    if (((res = netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt, val,
-                                      max_len)) >= 0) || (res != -ENOTSUP)) {
+    if (((res = netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      opt, val, max_len)) >= 0)
+        || (res != -ENOTSUP)) {
         return res;
     }
 
@@ -470,7 +479,9 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     if (dev == NULL) {
         return -ENODEV;
     }
@@ -640,7 +651,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     }
 
     if (res == -ENOTSUP) {
-        res = netdev_ieee802154_set((netdev_ieee802154_t *)netdev, opt, val, len);
+        res = netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev),
+                                    opt, val, len);
     }
 
     return res;
@@ -697,7 +709,9 @@ static void _isr_send_complete(at86rf2xx_t *dev, uint8_t trac_status)
 
 static inline void _isr_recv_complete(netdev_t *netdev)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     if (!netdev->event_callback) {
         return;
     }
@@ -719,7 +733,9 @@ static inline void _isr_recv_complete(netdev_t *netdev)
 
 static void _isr(netdev_t *netdev)
 {
-    at86rf2xx_t *dev = (at86rf2xx_t *) netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     uint8_t irq_mask;
     uint8_t state;
     uint8_t trac_status;
@@ -799,7 +815,9 @@ ISR(TRX24_TX_START_vect){
     /* __enter_isr(); is not necessary as there is nothing which causes a
      * thread_yield and the interrupt can not be interrupted by an other ISR */
 
-    at86rf2xx_t *dev = (at86rf2xx_t *) at86rfmega_dev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
 
     dev->tx_retries++;
 }
@@ -817,7 +835,10 @@ ISR(TRX24_PLL_LOCK_vect, ISR_BLOCK)
     avr8_enter_isr();
 
     DEBUG("TRX24_PLL_LOCK\n");
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__PLL_LOCK;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__PLL_LOCK;
 
     avr8_exit_isr();
 }
@@ -834,7 +855,10 @@ ISR(TRX24_PLL_UNLOCK_vect, ISR_BLOCK)
     avr8_enter_isr();
 
     DEBUG("TRX24_PLL_UNLOCK\n");
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__PLL_UNLOCK;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__PLL_UNLOCK;
 
     avr8_exit_isr();
 }
@@ -854,7 +878,10 @@ ISR(TRX24_RX_START_vect, ISR_BLOCK)
     uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
     DEBUG("TRX24_RX_START 0x%x\n", status);
 
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_START;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_START;
     /* Call upper layer to process valid PHR */
     netdev_trigger_event_isr(at86rfmega_dev);
 
@@ -876,7 +903,10 @@ ISR(TRX24_RX_END_vect, ISR_BLOCK)
     uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
     DEBUG("TRX24_RX_END 0x%x\n", status);
 
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_END;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_END;
     /* Call upper layer to process received data */
     netdev_trigger_event_isr(at86rfmega_dev);
 
@@ -895,7 +925,10 @@ ISR(TRX24_CCA_ED_DONE_vect, ISR_BLOCK)
     avr8_enter_isr();
 
     DEBUG("TRX24_CCA_ED_DONE\n");
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__CCA_ED_DONE;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__CCA_ED_DONE;
 
     avr8_exit_isr();
 }
@@ -913,7 +946,10 @@ ISR(TRX24_XAH_AMI_vect, ISR_BLOCK)
     avr8_enter_isr();
 
     DEBUG("TRX24_XAH_AMI\n");
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AMI;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AMI;
 
     avr8_exit_isr();
 }
@@ -929,7 +965,9 @@ ISR(TRX24_TX_END_vect, ISR_BLOCK)
 {
     avr8_enter_isr();
 
-    at86rf2xx_t *dev = (at86rf2xx_t *) at86rfmega_dev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
     uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
     DEBUG("TRX24_TX_END 0x%x\n", status);
 
@@ -959,7 +997,10 @@ ISR(TRX24_AWAKE_vect, ISR_BLOCK)
 
     DEBUG("TRX24_AWAKE\n");
 
-    ((at86rf2xx_t *)at86rfmega_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AWAKE;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(at86rfmega_dev,
+                          netdev_ieee802154_t, netdev);
+    at86rf2xx_t *dev = container_of(netdev_ieee802154, at86rf2xx_t, netdev);
+    dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AWAKE;
     /* Call upper layer to process transceiver wakeup finished */
     netdev_trigger_event_isr(at86rfmega_dev);
 

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -56,7 +56,7 @@ const netdev_driver_t cc2420_driver = {
 
 static void _irq_handler(void *arg)
 {
-    netdev_t *dev = (netdev_t *)arg;
+    netdev_t *dev = arg;
 
     netdev_trigger_event_isr(dev);
 }
@@ -96,7 +96,8 @@ static inline int opt_state(void *buf, bool cond)
 
 static int _init(netdev_t *netdev)
 {
-    cc2420_t *dev = (cc2420_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    cc2420_t *dev = container_of(netdev_ieee802154, cc2420_t, netdev);
 
     uint16_t reg;
 
@@ -135,7 +136,7 @@ static int _init(netdev_t *netdev)
         return -1;
     }
 
-    return cc2420_init((cc2420_t *)dev);
+    return cc2420_init(dev);
 }
 
 static void _isr(netdev_t *netdev)
@@ -145,13 +146,15 @@ static void _isr(netdev_t *netdev)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    cc2420_t *dev = (cc2420_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    cc2420_t *dev = container_of(netdev_ieee802154, cc2420_t, netdev);
     return (int)cc2420_send(dev, iolist);
 }
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    cc2420_t *dev = (cc2420_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    cc2420_t *dev = container_of(netdev_ieee802154, cc2420_t, netdev);
     return (int)cc2420_rx(dev, buf, len, info);
 }
 
@@ -161,7 +164,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
         return -ENODEV;
     }
 
-    cc2420_t *dev = (cc2420_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    cc2420_t *dev = container_of(netdev_ieee802154, cc2420_t, netdev);
 
     int ext = netdev_ieee802154_get(&dev->netdev, opt, val, max_len);
     if (ext > 0) {
@@ -230,7 +234,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t val_len)
         return -ENODEV;
     }
 
-    cc2420_t *dev = (cc2420_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    cc2420_t *dev = container_of(netdev_ieee802154, cc2420_t, netdev);
 
     int ext = netdev_ieee802154_set(&dev->netdev, opt, val, val_len);
 

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -92,13 +92,13 @@ void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params)
 
 static void encx24j600_isr(void *arg)
 {
-    encx24j600_t *dev = (encx24j600_t *) arg;
+    encx24j600_t *dev = arg;
 
     /* disable interrupt line */
     gpio_irq_disable(dev->int_pin);
 
     /* call netdev hook */
-    netdev_trigger_event_isr((netdev_t*) dev);
+    netdev_trigger_event_isr(&dev->netdev);
 }
 
 static void _isr(netdev_t *netdev)

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -118,7 +118,7 @@ static void _end_of_frame(ethos_t *dev)
             if (dev->framesize) {
                 assert(dev->last_framesize == 0);
                 dev->last_framesize = dev->framesize;
-                netdev_trigger_event_isr((netdev_t*) dev);
+                netdev_trigger_event_isr(&dev->netdev);
 
             }
             break;
@@ -187,14 +187,12 @@ static void ethos_isr(void *arg, uint8_t c)
 
 static void _isr(netdev_t *netdev)
 {
-    ethos_t *dev = (ethos_t *) netdev;
-    dev->netdev.event_callback((netdev_t*) dev, NETDEV_EVENT_RX_COMPLETE);
+    netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
 }
 
 static int _init(netdev_t *encdev)
 {
-    ethos_t *dev = (ethos_t *) encdev;
-    (void)dev;
+    (void)encdev;
     return 0;
 }
 

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -56,7 +56,7 @@ static void kw2xrf_set_address(kw2xrf_t *dev)
 
 void kw2xrf_setup(kw2xrf_t *dev, const kw2xrf_params_t *params)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev.netdev;
 
     netdev->driver = &kw2xrf_driver;
     /* initialize device descriptor */

--- a/drivers/kw41zrf/kw41zrf.c
+++ b/drivers/kw41zrf/kw41zrf.c
@@ -46,7 +46,7 @@ static void kw41zrf_set_address(kw41zrf_t *dev)
 
 void kw41zrf_setup(kw41zrf_t *dev, uint8_t index)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev.netdev;
 
     netdev->driver = &kw41zrf_driver;
 

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -66,7 +66,10 @@ static bool blocking_for_irq = false;
 static void kw41zrf_irq_handler(void *arg)
 {
     netdev_t *netdev = arg;
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
 
     KW41ZRF_LED_IRQ_ON;
     kw41zrf_mask_irqs();
@@ -85,7 +88,10 @@ static void kw41zrf_irq_handler(void *arg)
 
 static int kw41zrf_netdev_init(netdev_t *netdev)
 {
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
     dev->thread = thread_get_active();
 
     /* initialize hardware */
@@ -182,7 +188,7 @@ static void kw41zrf_wait_idle(kw41zrf_t *dev)
         /* Block until we get an IRQ */
         thread_flags_wait_any(KW41ZRF_THREAD_FLAG_ISR);
         /* Handle the IRQ */
-        kw41zrf_netdev_isr((netdev_t *)dev);
+        kw41zrf_netdev_isr(&dev->netdev.netdev);
         /* kw41zrf_netdev_isr() will switch the transceiver back to idle
          * after handling the sequence complete IRQ */
         if (kw41zrf_can_switch_to_idle(dev) && dev->backoff_delay == 0) {
@@ -216,7 +222,11 @@ int kw41zrf_cca(kw41zrf_t *dev)
 
 static int kw41zrf_netdev_send(netdev_t *netdev, const iolist_t *iolist)
 {
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
+
     size_t len = 0;
 
     kw41zrf_wait_idle(dev);
@@ -273,7 +283,10 @@ static inline void kw41zrf_unblock_rx(kw41zrf_t *dev)
 
 static int kw41zrf_netdev_recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
     if (kw41zrf_is_dsm()) {
         /* bring the device out of DSM, sleep will be restored before returning */
         kw41zrf_set_power_mode(dev, KW41ZRF_POWER_IDLE);
@@ -431,7 +444,10 @@ static netopt_state_t kw41zrf_netdev_get_state(kw41zrf_t *dev)
 
 int kw41zrf_netdev_get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
 {
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
 
     if (dev == NULL) {
         return -ENODEV;
@@ -615,14 +631,18 @@ int kw41zrf_netdev_get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
     }
 
     if (res == -ENOTSUP) {
-        res = netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt, value, len);
+        res = netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev),
+                                    opt, value, len);
     }
     return res;
 }
 
 static int kw41zrf_netdev_set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
 {
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
     int res = -ENOTSUP;
 
     if (dev == NULL) {
@@ -810,7 +830,8 @@ static int kw41zrf_netdev_set(netdev_t *netdev, netopt_t opt, const void *value,
     }
 
     if (res == -ENOTSUP) {
-        res = netdev_ieee802154_set((netdev_ieee802154_t *)netdev, opt, value, len);
+        res = netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev),
+                                    opt, value, len);
     }
 
     return res;
@@ -1132,7 +1153,10 @@ static uint32_t _isr_event_seq_ccca(kw41zrf_t *dev, uint32_t irqsts)
 
 static void kw41zrf_netdev_isr(netdev_t *netdev)
 {
-    kw41zrf_t *dev = (kw41zrf_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    kw41zrf_t *dev = container_of(netdev_ieee802154, kw41zrf_t, netdev);
 
     irq_is_queued = false;
     thread_flags_clear(KW41ZRF_THREAD_FLAG_ISR);

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -31,7 +31,7 @@
 
 void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params, uint8_t index)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev.netdev;
 
     netdev->driver = &mrf24j40_driver;
     /* initialize device descriptor */
@@ -136,8 +136,7 @@ size_t mrf24j40_tx_load(mrf24j40_t *dev, uint8_t *data, size_t len, size_t offse
 
 void mrf24j40_tx_exec(mrf24j40_t *dev)
 {
-    netdev_t *netdev = (netdev_t *)dev;
-
+    netdev_t *netdev = &dev->netdev.netdev;
 
     dev->tx_frame_len = dev->tx_frame_len - IEEE802154_FCS_LEN;
     /* write frame length field in FIFO */

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -39,16 +39,19 @@
 
 static void _irq_handler(void *arg)
 {
-    netdev_t *dev = (netdev_t *) arg;
+    netdev_t *dev = arg;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(dev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *mrf24j40 = container_of(netdev_ieee802154, mrf24j40_t, netdev);
 
     netdev_trigger_event_isr(dev);
 
-    ((mrf24j40_t *)arg)->irq_flag = 1;
+    mrf24j40->irq_flag = 1;
 }
 
 static int _init(netdev_t *netdev)
 {
-    mrf24j40_t *dev = (mrf24j40_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *dev = container_of(netdev_ieee802154, mrf24j40_t, netdev);
 
     /* initialize GPIOs */
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
@@ -66,7 +69,8 @@ static int _init(netdev_t *netdev)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    mrf24j40_t *dev = (mrf24j40_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *dev = container_of(netdev_ieee802154, mrf24j40_t, netdev);
     size_t len = 0;
 
     mrf24j40_tx_prepare(dev);
@@ -104,7 +108,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    mrf24j40_t *dev = (mrf24j40_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *dev = container_of(netdev_ieee802154, mrf24j40_t, netdev);
     uint8_t phr;
     size_t pkt_len;
     int res = -ENOBUFS;
@@ -161,7 +166,8 @@ static netopt_state_t _get_state(mrf24j40_t *dev)
 
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
-    mrf24j40_t *dev = (mrf24j40_t *) netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *dev = container_of(netdev_ieee802154, mrf24j40_t, netdev);
 
     if (netdev == NULL) {
         return -ENODEV;
@@ -330,8 +336,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
         default:
             /* try netdev settings */
-            res = netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt,
-                                         val, max_len);
+            res = netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev),
+                                        opt, val, max_len);
     }
     return res;
 }
@@ -361,7 +367,8 @@ static int _set_state(mrf24j40_t *dev, netopt_state_t state)
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
-    mrf24j40_t *dev = (mrf24j40_t *) netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *dev = container_of(netdev_ieee802154, mrf24j40_t, netdev);
     int res = -ENOTSUP;
 
     if (dev == NULL) {
@@ -513,15 +520,16 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     }
     /* try netdev building flags */
     if (res == -ENOTSUP) {
-        res = netdev_ieee802154_set((netdev_ieee802154_t *)netdev, opt,
-                                     val, len);
+        res = netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev),
+                                    opt, val, len);
     }
     return res;
 }
 
 static void _isr(netdev_t *netdev)
 {
-    mrf24j40_t *dev = (mrf24j40_t *) netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    mrf24j40_t *dev = container_of(netdev_ieee802154, mrf24j40_t, netdev);
     /* update pending bits */
     mrf24j40_update_tasks(dev);
     DEBUG("[mrf24j40] INTERRUPT (pending: %x),\n", dev->pending);

--- a/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
@@ -156,7 +156,7 @@ static int _nrf24l01p_ng_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     assert(pkt);
     assert(netif->dev);
 
-    netdev_t *netdev = (netdev_t *)netif->dev;
+    netdev_t *netdev = netif->dev;
     gnrc_netif_hdr_t *netif_hdr = (gnrc_netif_hdr_t *)pkt->data;
     if (!netif_hdr) {
         return -EBADMSG;
@@ -190,7 +190,7 @@ static int _nrf24l01p_ng_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     uint8_t src[1 + NRF24L01P_NG_ADDR_WIDTH];
     src[0] = NRF24L01P_NG_ADDR_WIDTH;
     memcpy(src + 1,
-           NRF24L01P_NG_ADDR_P1((nrf24l01p_ng_t *)netdev),
+           NRF24L01P_NG_ADDR_P1(container_of(netdev, nrf24l01p_ng_t, netdev)),
            NRF24L01P_NG_ADDR_WIDTH);
     iolist_t iolist_src_addr = {
         .iol_next = ((iolist_t *)pkt->next),

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -112,12 +112,12 @@ nrf24l01p_ng_state_t _state_from_netif(netopt_state_t state)
 
 static void _nrf24l01p_ng_irq_handler(void *_dev)
 {
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)_dev;
+    nrf24l01p_ng_t *dev = _dev;
     /* Once the IRQ pin has triggered,
        do not congest the thread´s
        message queue with IRQ events */
     gpio_irq_disable(dev->params.pin_irq);
-    netdev_trigger_event_isr((netdev_t *)dev);
+    netdev_trigger_event_isr(&dev->netdev);
 }
 
 static void _isr_max_rt(nrf24l01p_ng_t *dev)
@@ -162,7 +162,7 @@ static void _isr_tx_ds(nrf24l01p_ng_t *dev)
 
 static int _init(netdev_t *netdev)
 {
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)netdev;
+    nrf24l01p_ng_t *dev = container_of(netdev, nrf24l01p_ng_t, netdev);
     if (dev->params.config.cfg_data_rate >= NRF24L01P_NG_RF_DR_NUM_OF ||
         dev->params.config.cfg_crc == NRF24L01P_NG_CRC_0BYTE ||
         dev->params.config.cfg_channel >= NRF24L01P_NG_NUM_CHANNELS) {
@@ -299,7 +299,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         DEBUG_PUTS("[nrf24l01p_ng] Return upper frame estimation");
         return NRF24L01P_NG_ADDR_WIDTH + NRF24L01P_NG_MAX_PAYLOAD_WIDTH;
     }
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)netdev;
+    nrf24l01p_ng_t *dev = container_of(netdev, nrf24l01p_ng_t, netdev);
     uint8_t pl_width;
     uint8_t status = nrf24l01p_ng_read_rx_pl_width(dev, &pl_width);
     uint8_t pno = NRF24L01P_NG_VAL_RX_P_NO(status);
@@ -373,7 +373,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         DEBUG_PUTS("[nrf24l01p_ng] No Tx address or no payload");
         return -ENOTSUP;
     }
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)netdev;
+    nrf24l01p_ng_t *dev = container_of(netdev, nrf24l01p_ng_t, netdev);
     uint8_t pl_width = 0;
     const uint8_t bcast_addr[] = NRF24L01P_NG_BROADCAST_ADDR;
     uint8_t payload[NRF24L01P_NG_MAX_PAYLOAD_WIDTH];
@@ -457,7 +457,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
  */
 static void _isr(netdev_t *netdev)
 {
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)netdev;
+    nrf24l01p_ng_t *dev = container_of(netdev, nrf24l01p_ng_t, netdev);
 
     nrf24l01p_ng_acquire(dev);
     gpio_irq_enable(dev->params.pin_irq);
@@ -517,7 +517,7 @@ static void _isr(netdev_t *netdev)
  */
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)netdev;
+    nrf24l01p_ng_t *dev = container_of(netdev, nrf24l01p_ng_t, netdev);
 
     (void)max_len; /* only used in assert() */
     switch (opt) {
@@ -608,7 +608,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
  */
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
-    nrf24l01p_ng_t *dev = (nrf24l01p_ng_t *)netdev;
+    nrf24l01p_ng_t *dev = container_of(netdev, nrf24l01p_ng_t, netdev);
 
     switch (opt) {
         case NETOPT_ADDRESS: {

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -47,8 +47,8 @@
  */
 static void _rx_cb(void *arg, uint8_t c)
 {
-    rn2xx3_t *dev = (rn2xx3_t *)arg;
-    netdev_t *netdev = (netdev_t *)dev;
+    rn2xx3_t *dev = arg;
+    netdev_t *netdev = &dev->netdev;
 
     /* Avoid overflow of module response buffer */
     if (dev->resp_size >= RN2XX3_MAX_BUF) {
@@ -127,7 +127,7 @@ static void _rx_cb(void *arg, uint8_t c)
 static void _sleep_timer_cb(void *arg)
 {
     DEBUG("[rn2xx3] exit sleep\n");
-    rn2xx3_t *dev = (rn2xx3_t *)arg;
+    rn2xx3_t *dev = arg;
     dev->int_state = RN2XX3_INT_STATE_IDLE;
 }
 

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -67,7 +67,7 @@ static void _slip_rx_cb(void *arg, uint8_t byte)
 check_end:
     if (byte == SLIPDEV_END) {
         if (dev->state == SLIPDEV_STATE_NET) {
-            netdev_trigger_event_isr((netdev_t*) dev);
+            netdev_trigger_event_isr(&dev->netdev);
         }
         dev->state = SLIPDEV_STATE_NONE;
     }

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -72,7 +72,7 @@ const sx126x_pa_cfg_params_t sx1261_pa_cfg = {
 
 void sx126x_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev;
 
     netdev->driver = &sx126x_driver;
     dev->params = (sx126x_params_t *)params;
@@ -136,7 +136,7 @@ static void sx126x_init_default_config(sx126x_t *dev)
 
 static void _dio1_isr(void *arg)
 {
-    netdev_trigger_event_isr((netdev_t *)arg);
+    netdev_trigger_event_isr(arg);
 }
 
 int sx126x_init(sx126x_t *dev)

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -39,7 +39,7 @@ const uint8_t sx126x_max_sf = LORA_SF12;
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    sx126x_t *dev = (sx126x_t *)netdev;
+    sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
 
     netopt_state_t state;
 
@@ -78,10 +78,10 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
     DEBUG("[sx126x] netdev: read received data.\n");
 
-    sx126x_t *dev = (sx126x_t *)netdev;
+    sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
     uint8_t size = 0;
 
-    netdev_lora_rx_info_t *packet_info = (netdev_lora_rx_info_t *)info;
+    netdev_lora_rx_info_t *packet_info = info;
 
     if (packet_info) {
         sx126x_pkt_status_lora_t pkt_status;
@@ -111,7 +111,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _init(netdev_t *netdev)
 {
-    sx126x_t *dev = (sx126x_t *)netdev;
+    sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
 
     /* Launch initialization of driver and device */
     DEBUG("[sx126x] netdev: initializing driver...\n");
@@ -126,7 +126,7 @@ static int _init(netdev_t *netdev)
 
 static void _isr(netdev_t *netdev)
 {
-    sx126x_t *dev = (sx126x_t *)netdev;
+    sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
 
     sx126x_irq_mask_t irq_mask;
 
@@ -205,7 +205,7 @@ static int _get_state(sx126x_t *dev, void *val)
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
     (void)max_len; /* unused when compiled without debug, assert empty */
-    sx126x_t *dev = (sx126x_t *)netdev;
+    sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
 
     if (dev == NULL) {
         return -ENODEV;
@@ -316,7 +316,7 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
     (void)len; /* unused when compiled without debug, assert empty */
-    sx126x_t *dev = (sx126x_t *)netdev;
+    sx126x_t *dev = container_of(netdev, sx126x_t, netdev);
     int res = -ENOTSUP;
 
     if (dev == NULL) {

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -75,7 +75,7 @@ static void sx127x_on_dio3_isr(void *arg);
 
 void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params, uint8_t index)
 {
-    netdev_t *netdev = (netdev_t *)dev;
+    netdev_t *netdev = &dev->netdev;
 
     netdev->driver = &sx127x_driver;
     dev->params = *params;
@@ -234,27 +234,27 @@ void sx127x_isr(netdev_t *dev)
 static void sx127x_on_dio_isr(sx127x_t *dev, sx127x_flags_t flag)
 {
     dev->irq |= flag;
-    sx127x_isr((netdev_t *)dev);
+    sx127x_isr(&dev->netdev);
 }
 
 static void sx127x_on_dio0_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO0);
+    sx127x_on_dio_isr(arg, SX127X_IRQ_DIO0);
 }
 
 static void sx127x_on_dio1_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO1);
+    sx127x_on_dio_isr(arg, SX127X_IRQ_DIO1);
 }
 
 static void sx127x_on_dio2_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO2);
+    sx127x_on_dio_isr(arg, SX127X_IRQ_DIO2);
 }
 
 static void sx127x_on_dio3_isr(void *arg)
 {
-    sx127x_on_dio_isr((sx127x_t *)arg, SX127X_IRQ_DIO3);
+    sx127x_on_dio_isr(arg, SX127X_IRQ_DIO3);
 }
 
 /* Internal event handlers */
@@ -316,14 +316,14 @@ static int _init_gpios(sx127x_t *dev)
 
 static void _on_tx_timeout(void *arg)
 {
-    netdev_t *dev = (netdev_t *)arg;
+    netdev_t *dev = arg;
 
     dev->event_callback(dev, NETDEV_EVENT_TX_TIMEOUT);
 }
 
 static void _on_rx_timeout(void *arg)
 {
-    netdev_t *dev = (netdev_t *)arg;
+    netdev_t *dev = arg;
 
     dev->event_callback(dev, NETDEV_EVENT_RX_TIMEOUT);
 }

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -48,7 +48,7 @@ void _on_dio3_irq(void *arg);
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     DEBUG("[sx127x] Sending packet now.\n");
-    sx127x_t *dev = (sx127x_t *)netdev;
+    sx127x_t *dev = container_of(netdev, sx127x_t, netdev);
 
     if (sx127x_get_state(dev) == SX127X_RF_TX_RUNNING) {
         DEBUG("[sx127x] Cannot send packet: radio already in transmitting "
@@ -107,7 +107,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    sx127x_t *dev = (sx127x_t *)netdev;
+    sx127x_t *dev = container_of(netdev, sx127x_t, netdev);
     volatile uint8_t irq_flags = 0;
     uint8_t size = 0;
 
@@ -205,7 +205,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _init(netdev_t *netdev)
 {
-    sx127x_t *sx127x = (sx127x_t *)netdev;
+    sx127x_t *sx127x = container_of(netdev, sx127x_t, netdev);
 
     sx127x->irq = 0;
     sx127x_radio_settings_t settings;
@@ -234,7 +234,7 @@ static int _init(netdev_t *netdev)
 
 static void _isr(netdev_t *netdev)
 {
-    sx127x_t *dev = (sx127x_t *)netdev;
+    sx127x_t *dev = container_of(netdev, sx127x_t, netdev);
 
     uint8_t interruptReg = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
 
@@ -261,7 +261,7 @@ static void _isr(netdev_t *netdev)
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
     (void)max_len;   /* unused when compiled without debug, assert empty */
-    sx127x_t *dev = (sx127x_t *)netdev;
+    sx127x_t *dev = container_of(netdev, sx127x_t, netdev);
 
     if (dev == NULL) {
         return -ENODEV;
@@ -360,7 +360,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
     (void)len; /* unused when compiled without debug, assert empty */
 
-    sx127x_t *dev = (sx127x_t *)netdev;
+    sx127x_t *dev = container_of(netdev, sx127x_t, netdev);
     int res = -ENOTSUP;
 
     if (dev == NULL) {
@@ -577,8 +577,8 @@ static int _get_state(sx127x_t *dev, void *val)
 
 void _on_dio0_irq(void *arg)
 {
-    sx127x_t *dev = (sx127x_t *)arg;
-    netdev_t *netdev = (netdev_t *)&dev->netdev;
+    sx127x_t *dev = arg;
+    netdev_t *netdev = &dev->netdev;
 
     switch (dev->settings.state) {
     case SX127X_RF_RX_RUNNING:
@@ -612,8 +612,8 @@ void _on_dio0_irq(void *arg)
 void _on_dio1_irq(void *arg)
 {
     /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *)arg;
-    netdev_t *netdev = (netdev_t *)&dev->netdev;
+    sx127x_t *dev = arg;
+    netdev_t *netdev = &dev->netdev;
 
     switch (dev->settings.state) {
     case SX127X_RF_RX_RUNNING:
@@ -652,8 +652,8 @@ void _on_dio1_irq(void *arg)
 void _on_dio2_irq(void *arg)
 {
     /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *)arg;
-    netdev_t *netdev = (netdev_t *)dev;
+    sx127x_t *dev = arg;
+    netdev_t *netdev = &dev->netdev;
 
     switch (dev->settings.state) {
     case SX127X_RF_RX_RUNNING:
@@ -705,8 +705,8 @@ void _on_dio2_irq(void *arg)
 void _on_dio3_irq(void *arg)
 {
     /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *)arg;
-    netdev_t *netdev = (netdev_t *)dev;
+    sx127x_t *dev = arg;
+    netdev_t *netdev = &dev->netdev;
 
     switch (dev->settings.state) {
     case SX127X_RF_CAD:

--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -129,13 +129,13 @@ int main(void)
     /* Initialize the radio driver */
 #if IS_USED(MODULE_SX127X)
     sx127x_setup(&sx127x, &sx127x_params[0], 0);
-    loramac.netdev = (netdev_t *)&sx127x;
+    loramac.netdev = &sx127x.netdev;
     loramac.netdev->driver = &sx127x_driver;
 #endif
 
 #if IS_USED(MODULE_SX126X)
     sx126x_setup(&sx126x, &sx126x_params[0], 0);
-    loramac.netdev = (netdev_t *)&sx126x;
+    loramac.netdev = &sx126x.netdev;
     loramac.netdev->driver = &sx126x_driver;
 #endif
 

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -180,7 +180,7 @@ void lwip_bootstrap(void)
 #ifdef MODULE_NETDEV_TAP
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i]);
-        if (netif_add_noaddr(&netif[i], &netdev_taps[i], lwip_netdev_init,
+        if (netif_add_noaddr(&netif[i], &netdev_taps[i].netdev, lwip_netdev_init,
                              tcpip_input) == NULL) {
             DEBUG("Could not add netdev_tap device\n");
             return;
@@ -189,7 +189,7 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_MRF24J40)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
-        if (netif_add_noaddr(&netif[i], &mrf24j40_devs[i], lwip_netdev_init,
+        if (netif_add_noaddr(&netif[i], &mrf24j40_devs[i].netdev.netdev, lwip_netdev_init,
                              tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add mrf24j40 device\n");
             return;
@@ -198,7 +198,7 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_AT86RF2XX)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
-        if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i], lwip_netdev_init,
+        if (netif_add_noaddr(&netif[i], &at86rf2xx_devs[i].netdev.netdev, lwip_netdev_init,
                              tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add at86rf2xx device\n");
             return;
@@ -207,7 +207,7 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_ATWINC15X0)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
-        if (netif_add_noaddr(&netif[0], &atwinc15x0_devs[i], lwip_netdev_init,
+        if (netif_add_noaddr(&netif[0], &atwinc15x0_devs[i].netdev, lwip_netdev_init,
                              tcpip_input) == NULL) {
             DEBUG("Could not add atwinc15x0 device\n");
             return;
@@ -216,7 +216,7 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_ENC28J60)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i], i);
-        if (netif_add_noaddr(&netif[0], &enc28j60_devs[i], lwip_netdev_init,
+        if (netif_add_noaddr(&netif[0], &enc28j60_devs[i].netdev, lwip_netdev_init,
                              tcpip_input) == NULL) {
             DEBUG("Could not add enc28j60 device\n");
             return;
@@ -225,7 +225,7 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_SOCKET_ZEP)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i], i);
-        if (netif_add_noaddr(&netif[i], &socket_zep_devs[i], lwip_netdev_init,
+        if (netif_add_noaddr(&netif[i], &socket_zep_devs[i].netdev.netdev, lwip_netdev_init,
                              tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add socket_zep device\n");
             return;
@@ -234,7 +234,7 @@ void lwip_bootstrap(void)
 #elif (IS_USED(MODULE_ESP_ETH) || IS_USED(MODULE_ESP_WIFI))
 #if IS_USED(MODULE_ESP_ETH)
     esp_eth_setup(&_esp_eth_dev);
-    if (netif_add_noaddr(&netif[0], &_esp_eth_dev, lwip_netdev_init,
+    if (netif_add_noaddr(&netif[0], &_esp_eth_dev.netdev, lwip_netdev_init,
                          tcpip_input) == NULL) {
         DEBUG("Could not add esp_eth device\n");
         return;
@@ -242,7 +242,7 @@ void lwip_bootstrap(void)
 #endif
 #if IS_USED(MODULE_ESP_WIFI)
     esp_wifi_setup(&_esp_wifi_dev);
-    if (netif_add_noaddr(&netif[ESP_WIFI_INDEX], &_esp_wifi_dev, lwip_netdev_init,
+    if (netif_add_noaddr(&netif[ESP_WIFI_INDEX], &_esp_wifi_dev.netdev, lwip_netdev_init,
                          tcpip_input) == NULL) {
         DEBUG("Could not add esp_wifi device\n");
         return;
@@ -264,7 +264,7 @@ void lwip_bootstrap(void)
     }
 #elif defined(MODULE_NRF802154)
     nrf802154_setup(&nrf802154_dev);
-    if (netif_add_noaddr(&netif[0], &nrf802154_dev, lwip_netdev_init,
+    if (netif_add_noaddr(&netif[0], &nrf802154_dev.netdev.dev.netdev, lwip_netdev_init,
                          tcpip_6lowpan_input) == NULL) {
         DEBUG("Could not add nrf802154 device\n");
         return;

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -94,7 +94,7 @@ err_t lwip_netdev_init(struct netif *netif)
     }
 
     /* initialize netdev and netif */
-    netdev = (netdev_t *)netif->state;
+    netdev = netif->state;
     netdev->driver->init(netdev);
     _configure_netdev(netdev);
     netdev->event_callback = _event_cb;
@@ -203,7 +203,7 @@ err_t lwip_netdev_init(struct netif *netif)
 #ifdef MODULE_NETDEV_ETH
 static err_t _eth_link_output(struct netif *netif, struct pbuf *p)
 {
-    netdev_t *netdev = (netdev_t *)netif->state;
+    netdev_t *netdev = netif->state;
     struct pbuf *q;
     unsigned int count = 0;
 
@@ -236,7 +236,7 @@ static err_t _eth_link_output(struct netif *netif, struct pbuf *p)
 static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p)
 {
     LWIP_ASSERT("p->next == NULL", p->next == NULL);
-    netdev_t *netdev = (netdev_t *)netif->state;
+    netdev_t *netdev = netif->state;
     iolist_t pkt = {
         .iol_base = p->payload,
         .iol_len = (p->len - IEEE802154_FCS_LEN),   /* FCS is written by driver */

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -76,19 +76,19 @@ void openthread_bootstrap(void)
     /* setup netdev modules */
 #ifdef MODULE_AT86RF2XX
     at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0], 0);
-    netdev_t *netdev = (netdev_t *) &at86rf2xx_dev;
+    netdev_t *netdev = &at86rf2xx_dev.netdev.netdev;
 #endif
 #ifdef MODULE_KW41ZRF
     kw41zrf_setup(&kw41z_dev, 0);
-    netdev_t *netdev = (netdev_t *) &kw41z_dev;
+    netdev_t *netdev = &kw41z_dev.netdev.netdev;
 #endif
 #ifdef MODULE_CC2538_RF
     cc2538_setup(&cc2538_rf_dev);
-    netdev_t *netdev = (netdev_t*) &cc2538_rf_dev;
+    netdev_t *netdev = &cc2538_rf_dev.netdev.dev.netdev;
 #endif
 #ifdef MODULE_NRF802154
     nrf802154_setup(&nrf802154_dev);
-    netdev_t *netdev = (netdev_t*) &nrf802154_dev;
+    netdev_t *netdev = &nrf802154_dev.netdev.dev.netdev;
 #endif
 
     openthread_radio_init(netdev, tx_buf, rx_buf);

--- a/pkg/openwsn/contrib/radio_netdev.c
+++ b/pkg/openwsn/contrib/radio_netdev.c
@@ -79,7 +79,7 @@ static void _set_addr(void)
 int openwsn_radio_init(void *radio_dev)
 {
     assert(radio_dev);
-    netdev_t *netdev = (netdev_t *)radio_dev;
+    netdev_t *netdev = radio_dev;
 
     LOG_DEBUG("[openwsn/radio]: initialize riot-adaptation\n");
     openwsn_radio.dev = netdev;

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -569,16 +569,18 @@ static void _semtech_loramac_event_cb(netdev_t *dev, netdev_event_t event)
         case NETDEV_EVENT_FHSS_CHANGE_CHANNEL:
             DEBUG("[semtech-loramac] FHSS channel change\n");
             if(semtech_loramac_radio_events.FhssChangeChannel) {
-                semtech_loramac_radio_events.FhssChangeChannel((
-                            (sx127x_t *)dev)->_internal.last_channel);
+                sx127x_t *sx127x = container_of(dev, sx127x_t, netdev);
+                semtech_loramac_radio_events.FhssChangeChannel(
+                            sx127x->_internal.last_channel);
             }
             break;
 
         case NETDEV_EVENT_CAD_DONE:
             DEBUG("[semtech-loramac] test: CAD done\n");
+            sx127x_t *sx127x = container_of(dev, sx127x_t, netdev);
             if(semtech_loramac_radio_events.CadDone) {
-                semtech_loramac_radio_events.CadDone((
-                            (sx127x_t *)dev)->_internal.is_last_cad_success);
+                semtech_loramac_radio_events.CadDone(
+                            sx127x->_internal.is_last_cad_success);
             }
             break;
 #endif

--- a/sys/auto_init/loramac/auto_init_loramac.c
+++ b/sys/auto_init/loramac/auto_init_loramac.c
@@ -48,13 +48,13 @@ void auto_init_loramac(void)
 {
 #if IS_USED(MODULE_SX127X)
     sx127x_setup(&sx127x, &sx127x_params[0], 0);
-    loramac.netdev = (netdev_t *)&sx127x;
+    loramac.netdev = &sx127x.netdev;
     loramac.netdev->driver = &sx127x_driver;
 #endif
 
 #if IS_USED(MODULE_SX126X)
     sx126x_setup(&sx126x, &sx126x_params[0], 0);
-    loramac.netdev = (netdev_t *)&sx126x;
+    loramac.netdev = &sx126x.netdev;
     loramac.netdev->driver = &sx126x_driver;
 #endif
 

--- a/sys/fuzzing/netdev.c
+++ b/sys/fuzzing/netdev.c
@@ -45,7 +45,7 @@ int fuzzing_netdev(gnrc_netif_t *netif) {
     netdev_test_set_get_cb(&dev, NETOPT_DEVICE_TYPE, _dev_get_device_type);
 
     return gnrc_netif_raw_create(netif, _netif_stack, THREAD_STACKSIZE_DEFAULT,
-                                 GNRC_NETIF_PRIO, "dummy_netif", (netdev_t *)&dev);
+                                 GNRC_NETIF_PRIO, "dummy_netif", &dev.netdev.netdev);
 }
 
 void fuzzing_netdev_wait(void) {

--- a/sys/include/net/netdev_test.h
+++ b/sys/include/net/netdev_test.h
@@ -164,18 +164,14 @@ typedef int (*netdev_test_set_cb_t)(netdev_t *dev, const void *value,
 /**
  * @brief   Device descriptor for @ref sys_netdev_test devices
  *
- * @extends netdev_t
+ * @extends netdev_ieee802154_t
  */
 typedef struct {
     /**
      * @brief   netdev fields
      * @{
      */
-#ifdef  MODULE_NETDEV_IEEE802154
     netdev_ieee802154_t netdev;     /**< superclass */
-#else                               /* MODULE_NETDEV_IEEE802154 */
-    netdev_t netdev;                /**< superclass */
-#endif  /* MODULE_NETDEV_IEEE802154 */
     /** @} */
 
     /**

--- a/sys/include/net/netdev_test.h
+++ b/sys/include/net/netdev_test.h
@@ -46,7 +46,7 @@
  *     ipv6_addr_t dst = IPV6_ADDR_UNSPECIFIED;
  *
  *     netdev_test_setup(&dev, NULL);
- *     dev->driver->init((netdev_t *)&dev)
+ *     dev->driver->init(&dev->netdev->netdev)
  *     // initialize stack and connect `dev` to it
  *     // ...
  *     mutex_lock(&wait);
@@ -80,10 +80,7 @@
 
 #include "mutex.h"
 
-#ifdef MODULE_NETDEV_IEEE802154
 #include "net/netdev/ieee802154.h"
-#endif
-
 #include "net/netdev.h"
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -49,7 +49,7 @@
 int _gnrc_gomach_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = container_of(dev, netdev_ieee802154_t, netdev);
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;
@@ -159,7 +159,8 @@ static int _parse_packet(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt,
     assert(info != NULL);
     assert(pkt != NULL);
 
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_t *dev = netif->dev;
+    netdev_ieee802154_t *state = container_of(dev, netdev_ieee802154_t, netdev);
     /* Get the packet sequence number */
     info->seq = ieee802154_get_seq(pkt->next->data);
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -150,7 +150,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = container_of(dev, netdev_ieee802154_t, netdev);
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -36,7 +36,7 @@
 int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = container_of(dev, netdev_ieee802154_t, netdev);
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -185,8 +185,11 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
                 uint16_t payload_size = 0;
                 uint8_t *mic = NULL;
                 uint8_t mic_size = 0;
+                netdev_ieee802154_t *netdev_ieee802154 = container_of(dev,
+                                                                      netdev_ieee802154_t,
+                                                                      netdev);
                 if (mhr[0] & NETDEV_IEEE802154_SECURITY_EN) {
-                    if (ieee802154_sec_decrypt_frame(&((netdev_ieee802154_t *)dev)->sec_ctx,
+                    if (ieee802154_sec_decrypt_frame(&netdev_ieee802154->sec_ctx,
                                                      nread,
                                                      mhr, (uint8_t *)&mhr_len,
                                                      &payload, &payload_size,
@@ -248,7 +251,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = container_of(dev, netdev_ieee802154_t, netdev);
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;

--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
@@ -57,17 +57,17 @@ void auto_init_at86rf2xx(void)
         gnrc_netif_gomach_create(&_netif[i], _at86rf2xx_stacks[i],
                                  AT86RF2XX_MAC_STACKSIZE,
                                  AT86RF2XX_MAC_PRIO, "at86rf2xx-gomach",
-                                 (netdev_t *)&at86rf2xx_devs[i]);
+                                 &at86rf2xx_devs[i].netdev.netdev);
 #elif defined(MODULE_GNRC_LWMAC)
         gnrc_netif_lwmac_create(&_netif[i], _at86rf2xx_stacks[i],
                                 AT86RF2XX_MAC_STACKSIZE,
                                 AT86RF2XX_MAC_PRIO, "at86rf2xx-lwmac",
-                                (netdev_t *)&at86rf2xx_devs[i]);
+                                &at86rf2xx_devs[i].netdev.netdev);
 #else
         gnrc_netif_ieee802154_create(&_netif[i], _at86rf2xx_stacks[i],
                                      AT86RF2XX_MAC_STACKSIZE,
                                      AT86RF2XX_MAC_PRIO, "at86rf2xx",
-                                     (netdev_t *)&at86rf2xx_devs[i]);
+                                     &at86rf2xx_devs[i].netdev.netdev);
 #endif
     }
 }

--- a/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
@@ -63,7 +63,7 @@ void auto_init_atwinc15x0(void)
         gnrc_netif_ethernet_create(&_netif[i], stack[i],
                                    ATWINC15X0_MAC_STACKSIZE,
                                    ATWINC15X0_MAC_PRIO, "atwinc15x0",
-                                   (netdev_t *)&dev[i]);
+                                   &dev[i].netdev);
     }
 }
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
@@ -75,7 +75,7 @@ void auto_init_cc110x(void)
 
         cc110x_setup(&_cc110x_devs[i], &cc110x_params[i], i);
         gnrc_netif_cc1xxx_create(&_netif[i], stacks[i], CC110X_MAC_STACKSIZE, CC110X_MAC_PRIO,
-                                 "cc110x", (netdev_t *)&_cc110x_devs[i]);
+                                 "cc110x", &_cc110x_devs[i].netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2420.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2420.c
@@ -60,7 +60,7 @@ void auto_init_cc2420(void)
         cc2420_setup(&cc2420_devs[i], &cc2420_params[i], i);
         gnrc_netif_ieee802154_create(&_netif[i], _cc2420_stacks[i], CC2420_MAC_STACKSIZE,
                                      CC2420_MAC_PRIO, "cc2420",
-                                     (netdev_t *)&cc2420_devs[i]);
+                                     &cc2420_devs[i].netdev.netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
@@ -44,6 +44,6 @@ void auto_init_cc2538_rf(void)
     gnrc_netif_ieee802154_create(&_netif, _cc2538_rf_stack,
                                  CC2538_MAC_STACKSIZE,
                                  CC2538_MAC_PRIO, "cc2538_rf",
-                                 (netdev_t *)&cc2538_rf_dev);
+                                 &cc2538_rf_dev.netdev.dev.netdev);
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_dose.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_dose.c
@@ -46,7 +46,7 @@ void auto_init_dose(void)
 
         dose_setup(&dose[i], &dose_params[i], i);
         gnrc_netif_ethernet_create(&_netif[i], _netdev_eth_stack[i], DOSE_MAC_STACKSIZE,
-                                   DOSE_MAC_PRIO, "dose", (netdev_t *)&dose[i]);
+                                   DOSE_MAC_PRIO, "dose", &dose[i].netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_enc28j60.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_enc28j60.c
@@ -63,7 +63,7 @@ void auto_init_enc28j60(void)
         enc28j60_setup(&dev[i], &enc28j60_params[i], i);
         gnrc_netif_ethernet_create(&_netif[i], stack[i], ENC28J60_MAC_STACKSIZE,
                                    ENC28J60_MAC_PRIO, "enc28j60",
-                                   (netdev_t *)&dev[i]);
+                                   &dev[i].netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_encx24j600.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_encx24j600.c
@@ -53,6 +53,6 @@ void auto_init_encx24j600(void)
     /* initialize netdev<->gnrc adapter state */
     gnrc_netif_ethernet_create(&_netif, _netdev_eth_stack, ENCX24J600_MAC_STACKSIZE,
                                ENCX24J600_MAC_PRIO, "encx24j600",
-                               (netdev_t *)&encx24j600);
+                               &encx24j600.netdev);
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_ethos.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_ethos.c
@@ -59,7 +59,7 @@ void auto_init_ethos(void)
 
         /* initialize netdev<->gnrc adapter state */
         gnrc_netif_ethernet_create(&_netif[i], _netdev_eth_stack[i], ETHOS_MAC_STACKSIZE,
-                                   ETHOS_MAC_PRIO, "ethos", (netdev_t *)&ethos[i]);
+                                   ETHOS_MAC_PRIO, "ethos", &ethos[i].netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
@@ -54,7 +54,7 @@ void auto_init_kw2xrf(void)
         kw2xrf_setup(&kw2xrf_devs[i], (kw2xrf_params_t*) p);
         gnrc_netif_ieee802154_create(&_netif[i], _kw2xrf_stacks[i], KW2XRF_MAC_STACKSIZE,
                                      KW2XRF_MAC_PRIO, "kw2xrf",
-                                     (netdev_t *)&kw2xrf_devs[i]);
+                                     &kw2xrf_devs[i].netdev.netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw41zrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw41zrf.c
@@ -62,15 +62,15 @@ void auto_init_kw41zrf(void)
 #if defined(MODULE_GNRC_GOMACH)
         gnrc_netif_gomach_create(&_netif[i], _kw41zrf_stacks[i], KW41ZRF_NETIF_STACKSIZE,
                                  KW41ZRF_NETIF_PRIO, "kw41zrf-gomach",
-                                 (netdev_t *)&kw41zrf_devs[i]);
+                                 &kw41zrf_devs[i].netdev.netdev);
 #elif defined(MODULE_GNRC_LWMAC)
         gnrc_netif_lwmac_create(&_netif[i], _kw41zrf_stacks[i], KW41ZRF_NETIF_STACKSIZE,
                                 KW41ZRF_NETIF_PRIO, "kw41zrf-lwmac",
-                                (netdev_t *)&kw41zrf_devs[i]);
+                                &kw41zrf_devs[i].netdev.netdev);
 #else
         gnrc_netif_ieee802154_create(&_netif[i], _kw41zrf_stacks[i], KW41ZRF_NETIF_STACKSIZE,
                                      KW41ZRF_NETIF_PRIO, "kw41zrf",
-                                     (netdev_t *)&kw41zrf_devs[i]);
+                                     &kw41zrf_devs[i].netdev.netdev);
 #endif
     }
 }

--- a/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
@@ -51,7 +51,7 @@ void auto_init_mrf24j40(void)
         gnrc_netif_ieee802154_create(&_netif[i], _mrf24j40_stacks[i],
                                      MRF24J40_MAC_STACKSIZE, MRF24J40_MAC_PRIO,
                                      "mrf24j40",
-                                     (netdev_t *)&mrf24j40_devs[i]);
+                                     &mrf24j40_devs[i].netdev.netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
@@ -77,7 +77,7 @@ void auto_init_nrf24l01p_ng(void)
                                        NRF24L01P_NG_MAC_STACKSIZE,
                                        NRF24L01P_NG_MAC_PRIO,
                                        "nrf24l01p_ng",
-                                       (netdev_t *)&_nrf24l01p_ng_devs[i]);
+                                       &_nrf24l01p_ng_devs[i].netdev);
     }
 }
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
@@ -48,6 +48,6 @@ void auto_init_nrf802154(void)
     gnrc_netif_ieee802154_create(&_netif, _stack,
                                  NRF802154_MAC_STACKSIZE,
                                  NRF802154_MAC_PRIO, "nrf802154",
-                                 (netdev_t *)&nrf802154_dev);
+                                 &nrf802154_dev.netdev.dev.netdev);
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_slipdev.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_slipdev.c
@@ -51,7 +51,7 @@ void auto_init_slipdev(void)
         slipdev_setup(&slipdevs[i], p, i);
         gnrc_netif_raw_create(&_netif[i], _slipdev_stacks[i], SLIPDEV_STACKSIZE,
                               SLIPDEV_PRIO, "slipdev",
-                              (netdev_t *)&slipdevs[i]);
+                              &slipdevs[i].netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
@@ -50,7 +50,7 @@ void auto_init_socket_zep(void)
         gnrc_netif_ieee802154_create(&_netif[i], _socket_zep_stacks[i],
                                      SOCKET_ZEP_MAC_STACKSIZE,
                                      SOCKET_ZEP_MAC_PRIO, "socket_zep",
-                                     (netdev_t *)&_socket_zeps[i]);
+                                     &_socket_zeps[i].netdev.netdev);
     }
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
@@ -59,12 +59,12 @@ void auto_init_sx126x(void)
 
             gnrc_netif_lorawan_create(&_netif[i], sx126x_stacks[i],
                                       SX126X_STACKSIZE, SX126X_PRIO,
-                                      "sx126x", (netdev_t *)&sx126x_devs[i]);
+                                      "sx126x", &sx126x_devs[i].netdev);
         }
         else {
             gnrc_netif_raw_create(&_netif[i], sx126x_stacks[i],
                                   SX126X_STACKSIZE, SX126X_PRIO,
-                                  "sx126x", (netdev_t *)&sx126x_devs[i]);
+                                  "sx126x", &sx126x_devs[i].netdev);
         }
     }
 }

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
@@ -64,12 +64,12 @@ void auto_init_sx127x(void)
 
             gnrc_netif_lorawan_create(&_netif[i], sx127x_stacks[i],
                                       SX127X_STACKSIZE, SX127X_PRIO,
-                                      "sx127x", (netdev_t *)&sx127x_devs[i]);
+                                      "sx127x", &sx127x_devs[i].netdev);
         }
         else {
             gnrc_netif_raw_create(&_netif[i], sx127x_stacks[i],
                                   SX127X_STACKSIZE, SX127X_PRIO,
-                                  "sx127x", (netdev_t *)&sx127x_devs[i]);
+                                  "sx127x", &sx127x_devs[i].netdev);
         }
     }
 }

--- a/sys/net/gnrc/netif/init_devs/auto_init_w5100.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_w5100.c
@@ -59,7 +59,7 @@ void auto_init_w5100(void)
         w5100_setup(&dev[i], &w5100_params[i]);
         /* initialize netdev <-> gnrc adapter state */
         gnrc_netif_ethernet_create(&_netif[i], stack[i], MAC_STACKSIZE, MAC_PRIO, "w5100",
-                                   (netdev_t *)&dev[i]);
+                                   &dev[i].nd);
     }
 }
 /** @} */

--- a/sys/net/netdev_test/netdev_test.c
+++ b/sys/net/netdev_test/netdev_test.c
@@ -33,7 +33,8 @@ void netdev_test_reset(netdev_test_t *dev)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_test_t *dev = container_of(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      netdev_test_t, netdev);
     int res = -EINVAL;
 
     mutex_lock(&dev->mutex);
@@ -46,7 +47,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_test_t *dev = container_of(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      netdev_test_t, netdev);
     int res = (buf == NULL) ? 0 : len;  /* assume everything would be fine */
 
     mutex_lock(&dev->mutex);
@@ -63,7 +65,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _init(netdev_t *netdev)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_test_t *dev = container_of(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      netdev_test_t, netdev);
     int res = 0;        /* assume everything would be fine */
 
     mutex_lock(&dev->mutex);
@@ -76,7 +79,8 @@ static int _init(netdev_t *netdev)
 
 static void _isr(netdev_t *netdev)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_test_t *dev = container_of(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      netdev_test_t, netdev);
 
     mutex_lock(&dev->mutex);
     if (dev->isr_cb != NULL) {
@@ -90,7 +94,8 @@ static void _isr(netdev_t *netdev)
 
 static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_test_t *dev = container_of(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      netdev_test_t, netdev);
     int res = -ENOTSUP;     /* option assumed to be not supported */
 
     mutex_lock(&dev->mutex);
@@ -103,7 +108,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_test_t *dev = container_of(container_of(netdev, netdev_ieee802154_t, netdev),
+                                      netdev_test_t, netdev);
     int res = -ENOTSUP;     /* option assumed to be not supported */
 
     mutex_lock(&dev->mutex);
@@ -125,9 +131,7 @@ static const netdev_driver_t _driver = {
 
 void netdev_test_setup(netdev_test_t *dev, void *state)
 {
-    netdev_t *netdev = (netdev_t *)dev;
-
-    netdev->driver = &_driver;
+    dev->netdev.netdev.driver = &_driver;
     dev->state = state;
     mutex_init(&dev->mutex);
     netdev_test_reset(dev);

--- a/tests/driver_at86rf215/main.c
+++ b/tests/driver_at86rf215/main.c
@@ -98,7 +98,11 @@ static int cmd_set_trim(int argc, char **argv)
         return 1;
     }
 
-    at86rf215_t* dev = (at86rf215_t*)netif->dev;
+    netdev_t *netdev = netif->dev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     printf("setting trim to %u fF\n", 300U * trim);
     at86rf215_set_trim(dev, trim);
@@ -151,7 +155,11 @@ static int cmd_set_clock_out(int argc, char **argv)
         return 1;
     }
 
-    at86rf215_t *dev = (at86rf215_t *)netif->dev;
+    netdev_t *netdev = netif->dev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     printf("Clock output set to %s %s\n", keys[freq], freq ? "MHz" : "");
     at86rf215_set_clock_output(dev, AT86RF215_CLKO_4mA, freq);
@@ -183,7 +191,11 @@ static int cmd_get_random(int argc, char **argv)
         return 1;
     }
 
-    at86rf215_t *dev = (at86rf215_t *)netif->dev;
+    netdev_t *netdev = netif->dev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     at86rf215_get_random(dev, buffer, values);
 

--- a/tests/driver_at86rf2xx/cmd.c
+++ b/tests/driver_at86rf2xx/cmd.c
@@ -35,7 +35,7 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst_addr,
 int ifconfig_list(int idx)
 {
     int res;
-    netdev_ieee802154_t *dev = (netdev_ieee802154_t *)(&devs[idx]);
+    netdev_ieee802154_t *dev = &devs[idx].netdev;
 
     int (*get)(netdev_t *, netopt_t, void *, size_t) = dev->netdev.driver->get;
     netopt_enable_t enable_val;
@@ -47,21 +47,21 @@ int ifconfig_list(int idx)
     print_addr(dev->long_addr, IEEE802154_LONG_ADDRESS_LEN);
     printf(", PAN: 0x%04x", dev->pan);
 
-    res = get((netdev_t *)dev, NETOPT_ADDR_LEN, &u16_val, sizeof(u16_val));
+    res = get(&dev->netdev, NETOPT_ADDR_LEN, &u16_val, sizeof(u16_val));
     if (res < 0) {
         puts("(err)");
         return 1;
     }
     printf("\n           Address length: %u", (unsigned)u16_val);
 
-    res = get((netdev_t *)dev, NETOPT_SRC_LEN, &u16_val, sizeof(u16_val));
+    res = get(&dev->netdev, NETOPT_SRC_LEN, &u16_val, sizeof(u16_val));
     if (res < 0) {
         puts("(err)");
         return 1;
     }
     printf(", Source address length: %u", (unsigned)u16_val);
 
-    res = get((netdev_t *)dev, NETOPT_MAX_PDU_SIZE, &u16_val,
+    res = get(&dev->netdev, NETOPT_MAX_PDU_SIZE, &u16_val,
               sizeof(u16_val));
     if (res < 0) {
         puts("(err)");
@@ -70,20 +70,20 @@ int ifconfig_list(int idx)
     printf(", Max.Payload: %u", (unsigned)u16_val);
     printf("\n           Channel: %u", dev->chan);
 
-    res = get((netdev_t *)dev, NETOPT_CHANNEL_PAGE, &u16_val, sizeof(u16_val));
+    res = get(&dev->netdev, NETOPT_CHANNEL_PAGE, &u16_val, sizeof(u16_val));
     if (res < 0) {
         puts("(err)");
         return 1;
     }
     printf(", Ch.page: %u", (unsigned)u16_val);
 
-    res = get((netdev_t *)dev, NETOPT_TX_POWER, &u16_val, sizeof(u16_val));
+    res = get(&dev->netdev, NETOPT_TX_POWER, &u16_val, sizeof(u16_val));
     if (res < 0) {
         puts("(err)");
         return 1;
     }
     printf(", TXPower: %d dBm", (int)u16_val);
-    res = get((netdev_t *)dev, NETOPT_IS_WIRED, &u16_val, sizeof(u16_val));
+    res = get(&dev->netdev, NETOPT_IS_WIRED, &u16_val, sizeof(u16_val));
     if (res < 0) {
         puts(", wireless");
     }
@@ -92,27 +92,27 @@ int ifconfig_list(int idx)
     }
 
     printf("         ");
-    res = get((netdev_t *)dev, NETOPT_PRELOADING, &enable_val,
+    res = get(&dev->netdev, NETOPT_PRELOADING, &enable_val,
               sizeof(netopt_enable_t));
     if ((res > 0) && (enable_val == NETOPT_ENABLE)) {
         printf("  PRELOAD");
     }
-    res = get((netdev_t *)dev, NETOPT_AUTOACK, &enable_val,
+    res = get(&dev->netdev, NETOPT_AUTOACK, &enable_val,
               sizeof(netopt_enable_t));
     if ((res > 0) && (enable_val == NETOPT_ENABLE)) {
         printf("  AUTOACK");
     }
-    res = get((netdev_t *)dev, NETOPT_RAWMODE, &enable_val,
+    res = get(&dev->netdev, NETOPT_RAWMODE, &enable_val,
               sizeof(netopt_enable_t));
     if ((res > 0) && (enable_val == NETOPT_ENABLE)) {
         printf("  RAW");
     }
-    res = get((netdev_t *)dev, NETOPT_AUTOCCA, &enable_val,
+    res = get(&dev->netdev, NETOPT_AUTOCCA, &enable_val,
               sizeof(netopt_enable_t));
     if ((res > 0) && (enable_val == NETOPT_ENABLE)) {
         printf("  AUTOCCA");
     }
-    res = get((netdev_t *)dev, NETOPT_CSMA, &enable_val,
+    res = get(&dev->netdev, NETOPT_CSMA, &enable_val,
               sizeof(netopt_enable_t));
     if ((res > 0) && (enable_val == NETOPT_ENABLE)) {
         printf("  CSMA");
@@ -258,7 +258,7 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst, size_t dst_len,
         .iol_len = strlen(data)
     };
 
-    dev = (netdev_ieee802154_t *)&devs[iface];
+    dev = &devs[iface].netdev;
     flags = (uint8_t)(dev->flags & NETDEV_IEEE802154_SEND_MASK);
     flags |= IEEE802154_FCF_TYPE_DATA;
     src_pan = byteorder_btols(byteorder_htons(dev->pan));
@@ -288,7 +288,7 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst, size_t dst_len,
         .iol_len = (size_t)res
     };
 
-    res = dev->netdev.driver->send((netdev_t *)dev, &iol_hdr);
+    res = dev->netdev.driver->send(&dev->netdev, &iol_hdr);
     if (res < 0) {
         puts("txtsnd: Error on sending");
         return 1;

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -93,7 +93,7 @@ int main(void)
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
         netopt_enable_t en = NETOPT_ENABLE;
         const at86rf2xx_params_t *p = &at86rf2xx_params[i];
-        netdev_t *dev = (netdev_t *)(&devs[i]);
+        netdev_t *dev = &devs[i].netdev.netdev;
 
         printf("Initializing AT86RF2xx radio at SPI_%d\n", p->spi);
         at86rf2xx_setup(&devs[i], p, i);

--- a/tests/driver_sx126x/main.c
+++ b/tests/driver_sx126x/main.c
@@ -95,7 +95,7 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
 
 void *_recv_thread(void *arg)
 {
-    netdev_t *netdev = (netdev_t *)arg;
+    netdev_t *netdev = arg;
 
     static msg_t _msg_queue[SX126X_MSG_QUEUE];
 
@@ -295,7 +295,7 @@ int sx126x_cmd(int argc, char **argv)
         return -1;
     }
 
-    netdev_t *netdev = (netdev_t *)&sx126x;
+    netdev_t *netdev = &sx126x.netdev;
 
     if (!strcmp("get", argv[1])) {
         return sx126x_get_cmd(netdev, argc, argv);
@@ -321,7 +321,7 @@ static const shell_command_t shell_commands[] = {
 int main(void)
 {
     sx126x_setup(&sx126x, &sx126x_params[0], 0);
-    netdev_t *netdev = (netdev_t *)&sx126x;
+    netdev_t *netdev = &sx126x.netdev;
 
     netdev->driver = &sx126x_driver;
 

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -108,7 +108,7 @@ int lora_setup_cmd(int argc, char **argv)
     uint8_t lora_cr = (uint8_t)(cr - 4);
 
     /* Configure radio device */
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     netdev->driver->set(netdev, NETOPT_BANDWIDTH,
                         &lora_bw, sizeof(lora_bw));
@@ -127,7 +127,7 @@ int random_cmd(int argc, char **argv)
     (void)argc;
     (void)argv;
 
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
     uint32_t rand;
 
     netdev->driver->get(netdev, NETOPT_RANDOM, &rand, sizeof(rand));
@@ -135,7 +135,7 @@ int random_cmd(int argc, char **argv)
            (unsigned int)rand);
 
     /* reinit the transceiver to default values */
-    sx127x_init_radio_settings((sx127x_t *)netdev);
+    sx127x_init_radio_settings(&sx127x);
 
     return 0;
 }
@@ -249,7 +249,7 @@ int send_cmd(int argc, char **argv)
         .iol_len = (strlen(argv[1]) + 1)
     };
 
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     if (netdev->driver->send(netdev, &iolist) == -ENOTSUP) {
         puts("Cannot send: radio is still transmitting");
@@ -263,7 +263,7 @@ int listen_cmd(int argc, char **argv)
     (void)argc;
     (void)argv;
 
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
     /* Switch to continuous listen mode */
     const netopt_enable_t single = false;
 
@@ -289,7 +289,7 @@ int syncword_cmd(int argc, char **argv)
         return -1;
     }
 
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
     uint8_t syncword;
 
     if (strstr(argv[1], "get") != NULL) {
@@ -323,7 +323,7 @@ int channel_cmd(int argc, char **argv)
         return -1;
     }
 
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
     uint32_t chan;
 
     if (strstr(argv[1], "get") != NULL) {
@@ -358,7 +358,7 @@ int rx_timeout_cmd(int argc, char **argv)
         return -1;
     }
 
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
     uint8_t rx_timeout;
 
     if (strstr(argv[1], "set") != NULL) {
@@ -383,7 +383,7 @@ int reset_cmd(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     puts("resetting sx127x...");
     netopt_state_t state = NETOPT_STATE_RESET;
@@ -409,7 +409,7 @@ static void _set_opt(netdev_t *netdev, netopt_t opt, bool val, char *str_help)
 
 int crc_cmd(int argc, char **argv)
 {
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     if (argc < 3 || strcmp(argv[1], "set") != 0) {
         printf("usage: %s set <1|0>\n", argv[0]);
@@ -424,7 +424,7 @@ int crc_cmd(int argc, char **argv)
 
 int implicit_cmd(int argc, char **argv)
 {
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     if (argc < 3 || strcmp(argv[1], "set") != 0) {
         printf("usage: %s set <1|0>\n", argv[0]);
@@ -439,7 +439,7 @@ int implicit_cmd(int argc, char **argv)
 
 int payload_cmd(int argc, char **argv)
 {
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     if (argc < 3 || strcmp(argv[1], "set") != 0) {
         printf("usage: %s set <payload length>\n", argv[0]);
@@ -542,7 +542,7 @@ void *_recv_thread(void *arg)
 int main(void)
 {
     sx127x.params = sx127x_params[0];
-    netdev_t *netdev = (netdev_t *)&sx127x;
+    netdev_t *netdev = &sx127x.netdev;
 
     netdev->driver = &sx127x_driver;
 

--- a/tests/gnrc_ipv6_ext_frag/main.c
+++ b/tests/gnrc_ipv6_ext_frag/main.c
@@ -691,7 +691,7 @@ int main(void)
     int res = gnrc_netif_raw_create(&_netif, mock_netif_stack,
                                     sizeof(mock_netif_stack),
                                     GNRC_NETIF_PRIO, "mock_netif",
-                                    (netdev_t *)&mock_netdev);
+                                    &mock_netdev.netdev.netdev);
     mock_netif = &_netif;
     assert(res == 0);
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/gnrc_ipv6_fwd_w_sub/main.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/main.c
@@ -157,7 +157,13 @@ static int _run_test(int argc, char **argv)
         xtimer_usleep(200);
     }
     /* activate dumping of sent ethernet frames */
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154,
+                                              netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _dump_etherframe);
     /* first, test forwarding without subscription */
     subscribers = gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6,

--- a/tests/gnrc_ipv6_fwd_w_sub/mockup_netif.c
+++ b/tests/gnrc_ipv6_fwd_w_sub/mockup_netif.c
@@ -65,7 +65,7 @@ void _tests_init(void)
                            _get_address);
     int res = gnrc_netif_ethernet_create(&_netif,
            _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
-            "mockup_eth", &_mock_netdev.netdev
+            "mockup_eth", &_mock_netdev.netdev.netdev
         );
     _mock_netif = &_netif;
     expect(res == 0);

--- a/tests/gnrc_ipv6_nib/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib/mockup_netif.c
@@ -82,7 +82,7 @@ void _tests_init(void)
                            _get_address);
     int res = gnrc_netif_ethernet_create(&_netif,
            _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
-            "mockup_eth", &_mock_netdev.netdev
+            "mockup_eth", &_mock_netdev.netdev.netdev
         );
     _mock_netif = &_netif;
     expect(res == 0);

--- a/tests/gnrc_netif/common.c
+++ b/tests/gnrc_netif/common.c
@@ -27,8 +27,8 @@
 
 static netdev_test_t _devs[NETIF_NUMOF];
 
-netdev_t *ethernet_dev = (netdev_t *)&_devs[0];
-netdev_t *ieee802154_dev = (netdev_t *)&_devs[1];
+netdev_t *ethernet_dev = &_devs[DEV_ETHERNET].netdev.netdev;
+netdev_t *ieee802154_dev = &_devs[DEV_IEEE802154].netdev.netdev;
 netdev_t *devs[DEFAULT_DEVS_NUMOF];
 
 #define MSG_QUEUE_SIZE  (8)
@@ -116,7 +116,8 @@ static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len
     expect(max_len == sizeof(uint16_t));
     (void)max_len;
 
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    netdev_test_t *dev = container_of(netdev_ieee802154, netdev_test_t, netdev);
 
     if (dev->state == 0x0) {
         *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
@@ -143,7 +144,8 @@ static int _get_netdev_max_packet_size(netdev_t *netdev, void *value, size_t max
     expect(max_len == sizeof(uint16_t));
     (void)max_len;
 
-    netdev_test_t *dev = (netdev_test_t *)netdev;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
+    netdev_test_t *dev = container_of(netdev_ieee802154, netdev_test_t, netdev);
 
     if (dev->state == 0x0) {
         *((uint16_t *)value) = ETHERNET_DATA_LEN;
@@ -161,26 +163,26 @@ static int _get_netdev_max_packet_size(netdev_t *netdev, void *value, size_t max
 void _tests_init(void)
 {
     msg_init_queue(_main_msg_queue, MSG_QUEUE_SIZE);
-    netdev_test_setup((netdev_test_t *)ethernet_dev, 0);
-    netdev_test_set_send_cb((netdev_test_t *)ethernet_dev, _dump_send_packet);
-    netdev_test_set_recv_cb((netdev_test_t *)ethernet_dev, _netdev_recv);
-    netdev_test_set_isr_cb((netdev_test_t *)ethernet_dev, _netdev_isr);
-    netdev_test_set_get_cb((netdev_test_t *)ethernet_dev, NETOPT_DEVICE_TYPE,
+    netdev_test_setup(&_devs[DEV_ETHERNET], 0);
+    netdev_test_set_send_cb(&_devs[DEV_ETHERNET], _dump_send_packet);
+    netdev_test_set_recv_cb(&_devs[DEV_ETHERNET], _netdev_recv);
+    netdev_test_set_isr_cb(&_devs[DEV_ETHERNET], _netdev_isr);
+    netdev_test_set_get_cb(&_devs[DEV_ETHERNET], NETOPT_DEVICE_TYPE,
                            _get_netdev_device_type);
-    netdev_test_set_get_cb((netdev_test_t *)ethernet_dev, NETOPT_MAX_PDU_SIZE,
+    netdev_test_set_get_cb(&_devs[DEV_ETHERNET], NETOPT_MAX_PDU_SIZE,
                            _get_netdev_max_packet_size);
-    netdev_test_setup((netdev_test_t *)ieee802154_dev, (void *)1);
-    netdev_test_set_send_cb((netdev_test_t *)ieee802154_dev, _dump_send_packet);
-    netdev_test_set_recv_cb((netdev_test_t *)ieee802154_dev, _netdev_recv);
-    netdev_test_set_isr_cb((netdev_test_t *)ieee802154_dev, _netdev_isr);
-    netdev_test_set_get_cb((netdev_test_t *)ieee802154_dev, NETOPT_DEVICE_TYPE,
+    netdev_test_setup(&_devs[DEV_IEEE802154], (void *)1);
+    netdev_test_set_send_cb(&_devs[DEV_IEEE802154], _dump_send_packet);
+    netdev_test_set_recv_cb(&_devs[DEV_IEEE802154], _netdev_recv);
+    netdev_test_set_isr_cb(&_devs[DEV_IEEE802154], _netdev_isr);
+    netdev_test_set_get_cb(&_devs[DEV_IEEE802154], NETOPT_DEVICE_TYPE,
                            _get_netdev_device_type);
-    netdev_test_set_get_cb((netdev_test_t *)ieee802154_dev, NETOPT_PROTO,
+    netdev_test_set_get_cb(&_devs[DEV_IEEE802154], NETOPT_PROTO,
                            _get_netdev_proto);
-    netdev_test_set_get_cb((netdev_test_t *)ieee802154_dev,
+    netdev_test_set_get_cb(&_devs[DEV_IEEE802154],
                            NETOPT_MAX_PDU_SIZE, _get_netdev_max_packet_size);
     for (intptr_t i = SPECIAL_DEVS; i < NETIF_NUMOF; i++) {
-        devs[i - SPECIAL_DEVS] = (netdev_t *)&_devs[i];
+        devs[i - SPECIAL_DEVS] = &_devs[i].netdev.netdev;
         netdev_test_setup(&_devs[i], (void *)i);
         netdev_test_set_get_cb(&_devs[i], NETOPT_DEVICE_TYPE,
                                _get_netdev_device_type);

--- a/tests/gnrc_netif/common.h
+++ b/tests/gnrc_netif/common.h
@@ -29,6 +29,8 @@ extern "C" {
 #define NETIF_NUMOF         (4)
 #define SPECIAL_DEVS        (2)
 #define DEFAULT_DEVS_NUMOF  (NETIF_NUMOF - SPECIAL_DEVS)
+#define DEV_ETHERNET   0
+#define DEV_IEEE802154 1
 
 #define GP1 (0x20U)
 #define GP2 (0x01U)

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1770,27 +1770,37 @@ static Test *embunit_tests_gnrc_netif(void)
 int main(void)
 {
     _tests_init();
-    netdev_test_set_get_cb((netdev_test_t *)ethernet_dev, NETOPT_ADDRESS,
+    netdev_test_t *test_ethernet = container_of(
+            container_of(ethernet_dev, netdev_ieee802154_t, netdev),
+            netdev_test_t,
+            netdev
+            );
+    netdev_test_t *test_ieee802154 = container_of(
+            container_of(ieee802154_dev, netdev_ieee802154_t, netdev),
+            netdev_test_t,
+            netdev
+            );
+    netdev_test_set_get_cb(test_ethernet, NETOPT_ADDRESS,
             _get_netdev_address);
-    netdev_test_set_set_cb((netdev_test_t *)ethernet_dev, NETOPT_ADDRESS,
+    netdev_test_set_set_cb(test_ethernet, NETOPT_ADDRESS,
             _set_netdev_address);
-    netdev_test_set_get_cb((netdev_test_t *)ethernet_dev, NETOPT_L2_GROUP,
+    netdev_test_set_get_cb(test_ethernet, NETOPT_L2_GROUP,
             _get_netdev_l2_group);
-    netdev_test_set_set_cb((netdev_test_t *)ethernet_dev, NETOPT_L2_GROUP,
+    netdev_test_set_set_cb(test_ethernet, NETOPT_L2_GROUP,
             _set_netdev_l2_group);
-    netdev_test_set_set_cb((netdev_test_t *)ethernet_dev, NETOPT_L2_GROUP_LEAVE,
+    netdev_test_set_set_cb(test_ethernet, NETOPT_L2_GROUP_LEAVE,
             _set_netdev_l2_group_leave);
-    netdev_test_set_get_cb((netdev_test_t *)ieee802154_dev, NETOPT_ADDRESS,
+    netdev_test_set_get_cb(test_ieee802154, NETOPT_ADDRESS,
             _get_netdev_address);
-    netdev_test_set_set_cb((netdev_test_t *)ieee802154_dev, NETOPT_ADDRESS,
+    netdev_test_set_set_cb(test_ieee802154, NETOPT_ADDRESS,
             _set_netdev_address);
-    netdev_test_set_get_cb((netdev_test_t *)ieee802154_dev, NETOPT_ADDRESS_LONG,
+    netdev_test_set_get_cb(test_ieee802154, NETOPT_ADDRESS_LONG,
             _get_netdev_address_long);
-    netdev_test_set_set_cb((netdev_test_t *)ieee802154_dev, NETOPT_ADDRESS_LONG,
+    netdev_test_set_set_cb(test_ieee802154, NETOPT_ADDRESS_LONG,
             _set_netdev_address_long);
-    netdev_test_set_get_cb((netdev_test_t *)ieee802154_dev, NETOPT_SRC_LEN,
+    netdev_test_set_get_cb(test_ieee802154, NETOPT_SRC_LEN,
             _get_netdev_src_len);
-    netdev_test_set_set_cb((netdev_test_t *)ieee802154_dev, NETOPT_SRC_LEN,
+    netdev_test_set_set_cb(test_ieee802154, NETOPT_SRC_LEN,
             _set_netdev_src_len);
     TESTS_START();
     TESTS_RUN(embunit_tests_gnrc_netif());

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -111,7 +111,7 @@ static void _init_interface(void)
                            _get_netdev_addr_long);
     gnrc_netif_ieee802154_create(&_netif,
             _netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
-            "dummy_netif", (netdev_t *)&_ieee802154_dev);
+            "dummy_netif", &_ieee802154_dev.netdev.netdev);
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
 
     /* fd01::01 */

--- a/tests/gnrc_sixlowpan_frag_minfwd/main.c
+++ b/tests/gnrc_sixlowpan_frag_minfwd/main.c
@@ -318,7 +318,12 @@ static void _set_up(void)
 
 static void _tear_down(void)
 {
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev, NULL);
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test, NULL);
     mutex_unlock(&_target_buf_barrier);
     /* wait in case mutex in _mock_netdev_send was already entered */
     mutex_lock(&_target_buf_barrier);
@@ -455,7 +460,12 @@ static void test_minfwd_forward__success__1st_frag_sixlo(void)
     TEST_ASSERT_NOT_NULL((frag = gnrc_pktbuf_mark(pkt, sizeof(sixlowpan_frag_t),
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_minfwd_forward(pkt,
                                                                 frag->data,
@@ -490,7 +500,12 @@ static void test_minfwd_forward__success__1st_frag_iphc(void)
     TEST_ASSERT_NOT_NULL((frag = gnrc_pktbuf_mark(pkt, sizeof(sixlowpan_frag_t),
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_minfwd_forward(pkt,
                                                                 frag->data,
@@ -530,7 +545,12 @@ static void test_minfwd_forward__success__nth_frag_incomplete(void)
                                                   sizeof(sixlowpan_frag_n_t),
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_minfwd_forward(pkt,
                                                                 frag->data,
@@ -572,7 +592,12 @@ static void test_minfwd_forward__success__nth_frag_complete(void)
     LL_DELETE(pkt, frag);
     /* simulate current_size only missing the created fragment */
     vrbe->super.current_size = _vrbe_base.datagram_size;
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_minfwd_forward(pkt,
                                                                 frag->data,
@@ -613,7 +638,12 @@ static void test_minfwd_forward__ENOMEM__netif_hdr_build_fail(void)
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_sixlowpan_frag_minfwd_forward(pkt,
                                                                       frag->data,
@@ -637,7 +667,12 @@ static void test_minfwd_frag_iphc__success(void)
     fbuf->datagram_size = TEST_SEND_DATAGRAM_SIZE;
     fbuf->tag = TEST_SEND_DATAGRAM_TAG;
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(
             0, gnrc_sixlowpan_frag_minfwd_frag_iphc(pkt,
@@ -677,7 +712,12 @@ static void test_minfwd_frag_iphc__no_frag(void)
     fbuf->datagram_size = TEST_SEND_FRAG1_PAYLOAD_SIZE;
     fbuf->tag = TEST_SEND_DATAGRAM_TAG;
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(
             -1, gnrc_sixlowpan_frag_minfwd_frag_iphc(pkt,
@@ -716,7 +756,12 @@ static void test_minfwd_frag_iphc__ll_dst(void)
     fbuf->datagram_size = TEST_SEND_FRAG1_PAYLOAD_SIZE;
     fbuf->tag = TEST_SEND_DATAGRAM_TAG;
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(
             -1, gnrc_sixlowpan_frag_minfwd_frag_iphc(pkt,
@@ -744,7 +789,12 @@ static void test_sixlo_recv__1st_frag_uncomp(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -807,7 +857,12 @@ static void test_sixlo_recv__1st_frag_uncomp__after_nth_frag(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -856,7 +911,12 @@ static void test_sixlo_recv__1st_frag_comp(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -906,7 +966,12 @@ static void test_sixlo_recv__1st_frag_comp__only_iphc(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -946,7 +1011,12 @@ static void test_sixlo_recv__1st_frag_comp__only_iphc_no_nhc(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1084,7 +1154,12 @@ static void test_sixlo_recv__1st_frag_comp__after_nth_frag(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1135,7 +1210,12 @@ static void test_sixlo_recv__nth_frag(void)
                                                 _rem_l2, sizeof(_rem_l2)))
         );
     vrbe->super.arrival = xtimer_now_usec();
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1176,7 +1256,12 @@ static void test_sixlo_recv__nth_frag__datagram_complete(void)
     /* simulate current_size only missing the created fragment */
     vrbe->super.current_size = _vrbe_base.datagram_size - TEST_NTH_FRAG_SIZE;
     vrbe->super.arrival = xtimer_now_usec();
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1208,7 +1293,12 @@ static void test_sixlo_recv__nth_frag__no_vrbe(void)
     TEST_ASSERT_NOT_NULL(
             (frag = _create_recv_frag(_test_nth_frag, sizeof(_test_nth_frag)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1244,7 +1334,12 @@ static void test_sixlo_recv__nth_frag__duplicate(void)
                                                 _rem_l2, sizeof(_rem_l2)))
         );
     vrbe->super.arrival = xtimer_now_usec();
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1294,7 +1389,12 @@ static void test_sixlo_recv__nth_frag__overlap(void)
                                                 _rem_l2, sizeof(_rem_l2)))
         );
     vrbe->super.arrival = xtimer_now_usec();
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1334,7 +1434,12 @@ static void test_sixlo_send(void)
 
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,

--- a/tests/gnrc_sixlowpan_frag_sfr/main.c
+++ b/tests/gnrc_sixlowpan_frag_sfr/main.c
@@ -348,7 +348,13 @@ static void _set_up(void)
 
 static void _tear_down(void)
 {
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev, NULL);
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+
+    netdev_test_set_send_cb(netdev_test, NULL);
     mutex_unlock(&_target_buf_barrier);
     /* wait in case mutex in _mock_netdev_send was already entered */
     mutex_lock(&_target_buf_barrier);
@@ -373,7 +379,12 @@ static void test_sfr_forward__success__1st_frag_sixlo(void)
     TEST_ASSERT_NOT_NULL((frag = gnrc_pktbuf_mark(pkt, sizeof(sixlowpan_sfr_rfrag_t),
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_sfr_forward(pkt,
                                                                 frag->data,
@@ -407,7 +418,12 @@ static void test_sfr_forward__success__1st_frag_iphc(void)
     TEST_ASSERT_NOT_NULL((frag = gnrc_pktbuf_mark(pkt, sizeof(sixlowpan_sfr_rfrag_t),
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_sfr_forward(pkt,
                                                                 frag->data,
@@ -446,7 +462,12 @@ static void test_sfr_forward__success__nth_frag_incomplete(void)
                                                   sizeof(sixlowpan_sfr_rfrag_t),
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_sfr_forward(pkt,
                                                                 frag->data,
@@ -486,7 +507,12 @@ static void test_sfr_forward__success__nth_frag_complete(void)
     LL_DELETE(pkt, frag);
     /* simulate current_size only missing the created fragment */
     vrbe->super.current_size = _vrbe_base.datagram_size;
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(0, gnrc_sixlowpan_frag_sfr_forward(pkt,
                                                                 frag->data,
@@ -524,7 +550,12 @@ static void test_sfr_forward__ENOMEM__netif_hdr_build_fail(void)
                                                   GNRC_NETTYPE_SIXLOWPAN)));
     LL_DELETE(pkt, frag);
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_sixlowpan_frag_sfr_forward(pkt,
                                                                       frag->data,
@@ -548,7 +579,12 @@ static void test_sixlo_recv_fwd__1st_frag_uncomp(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -580,7 +616,12 @@ static void test_sixlo_recv_fwd__1st_frag_uncomp__req_ack(void)
     sixlowpan_sfr_rfrag_set_ack_req(frag->data);
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -613,7 +654,12 @@ static void test_sixlo_recv_fwd__1st_frag_uncomp__no_route(void)
             (frag = _create_recv_frag(_test_1st_frag_uncomp,
                                       sizeof(_test_1st_frag_uncomp)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -644,7 +690,12 @@ static void test_sixlo_recv_fwd__1st_frag_uncomp__after_nth_frag(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -693,7 +744,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -750,7 +806,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__resend(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -806,7 +867,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__only_iphc(void)
                                       sizeof(sixlowpan_sfr_rfrag_t));
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -846,7 +912,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__only_iphc_no_nhc(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -881,7 +952,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__no_route(void)
             (frag = _create_recv_frag(_test_1st_frag_comp_prev_hop,
                                       sizeof(_test_1st_frag_comp_prev_hop)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -910,7 +986,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__no_route_only_iphc(void)
             (frag = _create_recv_frag(_test_1st_frag_comp_prev_hop,
                                       TEST_1ST_FRAG_COMP_PREV_HOP_UDP_PAYLOAD_POS))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -946,7 +1027,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__no_refrag(void)
         reserved[i] = gnrc_sixlowpan_frag_fb_get();
         reserved[i]->pkt = frag;
     }
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -984,7 +1070,12 @@ static void test_sixlo_recv_fwd__1st_frag_comp__after_nth_frag(void)
         );
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1057,7 +1148,12 @@ static void test_sixlo_recv_fwd__1st_frag_abort(void)
         );
     vrbe->in_netif = _mock_netif;
     exp_tag = vrbe->out_tag & 0xff;
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1100,7 +1196,12 @@ static void test_sixlo_recv_fwd__1st_frag_nalp(void)
     data[sizeof(sixlowpan_sfr_rfrag_t)] &= ~(0xc0);
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1133,7 +1234,12 @@ static void test_sixlo_recv_fwd__1st_frag_nalp__req_ack(void)
     sixlowpan_sfr_rfrag_set_ack_req(frag->data);
     /* configure route to destination of IP header in frag */
     TEST_ASSERT_EQUAL_INT(0, _set_route_and_nce(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1166,7 +1272,12 @@ static void test_sixlo_recv_fwd__1st_frag_nalp__no_vrb(void)
     data = frag->data;
     /* mark dispatch after RFRAG header a non-6LoWPAN frame */
     data[sizeof(sixlowpan_sfr_rfrag_t)] &= ~(0xc0);
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1199,7 +1310,12 @@ static void test_sixlo_recv_fwd__nth_frag(void)
     vrbe->in_netif = _mock_netif;
     /* set offset_diff to test it in the outgoing RFRAG */
     vrbe->offset_diff = TEST_OFFSET_DIFF;
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1236,7 +1352,12 @@ static void test_sixlo_recv_fwd__nth_frag__no_vrbe(void)
     TEST_ASSERT_NOT_NULL(
             (frag = _create_recv_frag(_test_nth_frag, sizeof(_test_nth_frag)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1268,7 +1389,12 @@ static void test_sixlo_recv_fwd__nth_frag__duplicate(void)
             (vrbe = gnrc_sixlowpan_frag_vrb_add(&_vrbe_base, _mock_netif,
                                                 _rem_l2, sizeof(_rem_l2)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1313,7 +1439,12 @@ static void test_sixlo_recv_fwd__nth_frag__overlap(void)
             (vrbe = gnrc_sixlowpan_frag_vrb_add(&_vrbe_base, _mock_netif,
                                                 _rem_l2, sizeof(_rem_l2)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1358,7 +1489,12 @@ static void test_sixlo_recv_fwd__frag__too_short(void)
             (frag = _create_recv_frag(_test_1st_frag_comp,
                                       sizeof(sixlowpan_sfr_rfrag_t) - 1))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1392,7 +1528,12 @@ static void test_sixlo_recv_fwd__ack(void)
     vrbe->in_netif = _mock_netif;
     ack_hdr = ack->data;
     ack_hdr->base.tag = vrbe->out_tag;
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1428,7 +1569,12 @@ static void test_sixlo_recv_fwd__NULL_ack(void)
     ack_hdr->base.tag = vrbe->out_tag;
     /* set ACK bitmap to NULL */
     memset(ack_hdr->bitmap, 0, sizeof(ack_hdr->bitmap));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1466,7 +1612,12 @@ static void test_sixlo_recv_fwd__FULL_ack(void)
     ack_hdr->base.tag = vrbe->out_tag;
     /* set ACK bitmap to NULL */
     memcpy(ack_hdr->bitmap, full_bitmap, sizeof(ack_hdr->bitmap));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1490,7 +1641,12 @@ static void test_sixlo_recv_fwd__ack__no_vrbe(void)
     TEST_ASSERT_NOT_NULL(
             (ack = _create_recv_ack(_test_ack, sizeof(_test_ack)))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1519,7 +1675,12 @@ static void test_sixlo_recv_fwd__ack__too_short(void)
             (frag = _create_recv_frag(_test_ack,
                                       sizeof(sixlowpan_sfr_ack_t) - 1))
         );
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1548,7 +1709,12 @@ static void test_sixlo_recv_ep__1st_frag_uncomp(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1591,7 +1757,12 @@ static void test_sixlo_recv_ep__1st_frag_uncomp__req_ack(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1633,7 +1804,12 @@ static void test_sixlo_recv_ep__1st_frag_uncomp__after_nth_frag(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1691,7 +1867,12 @@ static void test_sixlo_recv_ep__1st_frag_comp(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1730,7 +1911,12 @@ static void test_sixlo_recv_ep__1st_frag_comp__after_nth_frag(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1788,7 +1974,12 @@ static void test_sixlo_recv_ep__1st_frag_abort(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1836,7 +2027,12 @@ static void test_sixlo_recv_ep__1st_frag_abort__req_ack(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_receive(GNRC_NETTYPE_SIXLOWPAN,
                                                  GNRC_NETREG_DEMUX_CTX_ALL,
@@ -1888,7 +2084,12 @@ static void test_sixlo_recv_ep__complete_datagram(void)
     /* configure interface to be endpoint of route */
     TEST_ASSERT_EQUAL_INT(sizeof(ipv6_addr_t),
                           _add_dst(&_rem_gb, REM_GB_PFX_LEN));
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     /* ==== FIRST FRAGMENT ==== */
     TEST_ASSERT_NOT_NULL(
@@ -2011,7 +2212,12 @@ static void test_sixlo_send(void)
     TEST_ASSERT(3 <= CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE);
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,
@@ -2071,7 +2277,12 @@ static void test_sixlo_send__first_ackd(void)
     TEST_ASSERT(3 <= CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE);
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,
@@ -2154,7 +2365,12 @@ static void test_sixlo_send__middle_ackd(void)
     TEST_ASSERT(3 <= CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE);
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,
@@ -2239,7 +2455,12 @@ static void test_sixlo_send__last_ackd(void)
     TEST_ASSERT(3 <= CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE);
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,
@@ -2324,7 +2545,12 @@ static void test_sixlo_send__all_ackd(void)
     TEST_ASSERT(3 <= CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE);
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,
@@ -2384,7 +2610,12 @@ static void test_sixlo_send__FULL_ack_recv(void)
     TEST_ASSERT(3 <= CONFIG_GNRC_SIXLOWPAN_SFR_OPT_WIN_SIZE);
     TEST_ASSERT_NOT_NULL((pkt = _create_send_datagram(false, true)));
 
-    netdev_test_set_send_cb((netdev_test_t *)_mock_netif->dev,
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(_mock_netif->dev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    netdev_test_t *netdev_test = container_of(netdev_ieee802154, netdev_test_t,
+                                              netdev);
+    netdev_test_set_send_cb(netdev_test,
                             _mock_netdev_send);
     TEST_ASSERT(0 < gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN,
                                               GNRC_NETREG_DEMUX_CTX_ALL,

--- a/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
+++ b/tests/gnrc_sixlowpan_iphc_w_vrb/main.c
@@ -311,7 +311,7 @@ static void _init_mock_netif(void)
                            _get_netdev_addr_long);
     gnrc_netif_ieee802154_create(&_netif, _mock_netif_stack,
                                  THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
-                                 "mock_netif", (netdev_t *)&_mock_dev);
+                                 "mock_netif", &_mock_dev.netdev.netdev);
     _mock_netif = &_netif;
     thread_yield_higher();
 }

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -65,7 +65,7 @@ extern const netdev_driver_t netdev_submac_driver;
 static void _netdev_isr_handler(event_t *event)
 {
     (void)event;
-    netdev_t *netdev = (netdev_t *)&netdev_submac;
+    netdev_t *netdev = &netdev_submac.dev.netdev;
 
     netdev->driver->isr(netdev);
 }
@@ -207,7 +207,7 @@ static int _init(void)
 {
     ieee802154_hal_test_init_devs();
 
-    netdev_t *dev = (netdev_t *)&netdev_submac;
+    netdev_t *dev = &netdev_submac.dev.netdev;
 
     dev->event_callback = _event_cb;
     netdev_ieee802154_submac_init(&netdev_submac,
@@ -254,7 +254,7 @@ static int send(uint8_t *dst, size_t dst_len,
     iol_hdr.iol_base = mhr;
     iol_hdr.iol_len = mhr_len;
 
-    netdev_t *dev = (netdev_t *)&netdev_submac;
+    netdev_t *dev = &netdev_submac.dev.netdev;
 
     dev->driver->send(dev, &iol_hdr);
     return 0;

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -155,7 +155,7 @@ void _net_init(void)
     netdev_test_set_recv_cb(&netdev, _netdev_recv);
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */
-    expect(netdev.netdev.driver);
+    expect(netdev.netdev.netdev.driver);
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
     local4.addr = _TEST_ADDR4_LOCAL;
@@ -232,7 +232,7 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint8_t proto, void *data,
     uint8_t *payload = (uint8_t *)(ip_hdr + 1);
     (void)netif;
 
-    _get_addr((netdev_t *)&netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
+    _get_addr(&netdev.netdev.netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
     eth_hdr->type = byteorder_htons(ETHERTYPE_IPV4);
     IPH_VHL_SET(ip_hdr, 4, 5);
     IPH_TOS_SET(ip_hdr, 0);
@@ -248,7 +248,7 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint8_t proto, void *data,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(struct ip_hdr) +
                           data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    netdev_trigger_event_isr((netdev_t *)&netdev);
+    netdev_trigger_event_isr(&netdev.netdev.netdev);
 
     return true;
 #else
@@ -267,7 +267,7 @@ bool _inject_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
     uint8_t *payload = (uint8_t *)(ipv6_hdr + 1);
     (void)netif;
 
-    _get_addr((netdev_t *)&netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
+    _get_addr(&netdev.netdev.netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
     eth_hdr->type = byteorder_htons(ETHERTYPE_IPV6);
     ipv6_hdr_set_version(ipv6_hdr);
     ipv6_hdr->len = byteorder_htons(data_len);
@@ -280,7 +280,7 @@ bool _inject_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(ipv6_hdr_t) +
                           data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    netdev_trigger_event_isr((netdev_t *)&netdev);
+    netdev_trigger_event_isr(&netdev.netdev.netdev);
 
     return true;
 #else

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -158,7 +158,7 @@ void _net_init(void)
     netdev_test_set_recv_cb(&netdev, _netdev_recv);
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */
-    expect(netdev.netdev.driver);
+    expect(netdev.netdev.netdev.driver);
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
     local4.addr = _TEST_ADDR4_LOCAL;
@@ -238,7 +238,7 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint16_t src_port,
     const uint16_t udp_len = (uint16_t)(sizeof(udp_hdr_t) + data_len);
     (void)netif;
 
-    _get_addr((netdev_t *)&netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
+    _get_addr(&netdev.netdev.netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
     eth_hdr->type = byteorder_htons(ETHERTYPE_IPV4);
     IPH_VHL_SET(ip_hdr, 4, 5);
     IPH_TOS_SET(ip_hdr, 0);
@@ -260,7 +260,7 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint16_t src_port,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(struct ip_hdr) +
                           sizeof(udp_hdr_t) + data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    netdev_trigger_event_isr((netdev_t *)&netdev);
+    netdev_trigger_event_isr(&netdev.netdev.netdev);
 
     return true;
 #else
@@ -284,7 +284,7 @@ bool _inject_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
     uint16_t csum = 0;
     (void)netif;
 
-    _get_addr((netdev_t *)&netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
+    _get_addr(&netdev.netdev.netdev, &eth_hdr->dst, sizeof(eth_hdr->dst));
     eth_hdr->type = byteorder_htons(ETHERTYPE_IPV6);
     ipv6_hdr_set_version(ipv6_hdr);
     ipv6_hdr->len = byteorder_htons(udp_len);
@@ -309,7 +309,7 @@ bool _inject_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
     _netdev_buffer_size = sizeof(ethernet_hdr_t) + sizeof(ipv6_hdr_t) +
                           sizeof(udp_hdr_t) + data_len;
     mutex_unlock(&_netdev_buffer_mutex);
-    netdev_trigger_event_isr((netdev_t *)&netdev);
+    netdev_trigger_event_isr(&netdev.netdev.netdev);
 
     return true;
 #else

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -138,7 +138,7 @@ static int test_receive(void)
                                                         thread_getpid());
     msg_t msg;
 
-    if (_dev.netdev.event_callback == NULL) {
+    if (_dev.netdev.netdev.event_callback == NULL) {
         puts("Device's event_callback not set");
         return 0;
     }
@@ -154,7 +154,7 @@ static int test_receive(void)
     /* register for GNRC_NETTYPE_UNDEF */
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &me);
     /* fire ISR event */
-    netdev_trigger_event_isr((netdev_t *)&_dev.netdev);
+    netdev_trigger_event_isr(&_dev.netdev.netdev);
     /* wait for packet from MAC layer*/
     msg_receive(&msg);
     /* check message */
@@ -261,7 +261,7 @@ int main(void)
     netdev_test_set_get_cb(&_dev, NETOPT_ADDRESS, _dev_get_addr);
     netdev_test_set_set_cb(&_dev, NETOPT_ADDRESS, _dev_set_addr);
     gnrc_netif_ethernet_create(&_netif, _mac_stack, _MAC_STACKSIZE, _MAC_PRIO,
-                                         "netdev_test", (netdev_t *)&_dev);
+                                         "netdev_test", &_dev.netdev.netdev);
     _mac_pid = _netif.pid;
 
     /* test execution */

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -48,7 +48,7 @@ static void _print_info(netdev_t *netdev);
 static void test_init(void)
 {
     const socket_zep_params_t *p = &socket_zep_params[0];
-    netdev_t *netdev = (netdev_t *)(&_dev);
+    netdev_t *netdev = &_dev.netdev.netdev;
 
     printf("Initializing socket ZEP with (local: [%s]:%s, remote: [%s]:%s)\n",
            p->local_addr, p->local_port, p->remote_addr, p->remote_port);
@@ -60,7 +60,7 @@ static void test_init(void)
 
 static void test_send__iolist_NULL(void)
 {
-    netdev_t *netdev = (netdev_t *)(&_dev);
+    netdev_t *netdev = &_dev.netdev.netdev;
 
     puts("Send zero-length packet");
     int res = netdev->driver->send(netdev, NULL);
@@ -77,7 +77,7 @@ static void test_send__iolist_not_NULL(void)
 
     iolist[0].iol_next = &iolist[1];
 
-    netdev_t *netdev = (netdev_t *)(&_dev);
+    netdev_t *netdev = &_dev.netdev.netdev;
 
     puts("Send 'Hello\\0World\\0'");
     int res =  netdev->driver->send(netdev, iolist);
@@ -91,7 +91,7 @@ static void test_recv(void)
 {
     puts("Waiting for an incoming message (use `make test`)");
     while (1) {
-        netdev_t *netdev = (netdev_t *)(&_dev);
+        netdev_t *netdev = &_dev.netdev.netdev;
         msg_t msg;
 
         msg_receive(&msg);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes all netdev<->driver dereferences and replace them with `container_of`.
This step is important to prevent wrong dereferences when migrating the IEEE 802.15.4 path to the Radio HAL/SubMAC.
Since I already touched several files, I decided to do it tree-wide since this also adds a layer of security.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This should be tested carefully, although I think a compile test should suffice. Wrong conversions will be pointed out by the compiler.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Related to #13943 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
