### PR TITLE
sys/net/gcoap: allow seperate response

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -43,8 +43,8 @@ static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, vo
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
-    { "/riot/board", COAP_GET, _riot_board_handler, NULL },
+    { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, 0, NULL },
+    { "/riot/board", COAP_GET, _riot_board_handler, COAP_SEPERATE_RESPONSE, NULL },
 };
 
 static const char *_link_params[] = {

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -41,10 +41,11 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
-/* CoAP resources. Must be sorted by path (ASCII order). */
+/* CoAP resources. Must be sorted by path (ASCII order). 
+ * /riot/board serves as an example for sending a separate response.*/
 static const coap_resource_t _resources[] = {
     { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, 0, NULL },
-    { "/riot/board", COAP_GET, _riot_board_handler, COAP_SEPERATE_RESPONSE, NULL },
+    { "/riot/board", COAP_GET, _riot_board_handler, COAP_SEPARATE_RESPONSE, NULL },
 };
 
 static const char *_link_params[] = {

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -44,8 +44,8 @@ static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, vo
 /* CoAP resources. Must be sorted by path (ASCII order). 
  * /riot/board serves as an example for sending a separate response.*/
 static const coap_resource_t _resources[] = {
-    { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, 0, NULL },
-    { "/riot/board", COAP_GET, _riot_board_handler, COAP_SEPARATE_RESPONSE, NULL },
+    { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
+    { "/riot/board", COAP_SEPARATE_RESPONSE | COAP_GET, _riot_board_handler, NULL },
 };
 
 static const char *_link_params[] = {

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -589,9 +589,9 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Flag to send a seperate response for a resource in coap_resource_t::flags
+ * @brief Flag to send a separate response for a resource in coap_resource_t::flags
  */
-#define COAP_SEPERATE_RESPONSE      (1)
+#define COAP_SEPARATE_RESPONSE      (1)
 
 /**
  * @brief   Context information required to write a resource link

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -589,11 +589,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Flag to send a separate response for a resource in coap_resource_t::flags
- */
-#define COAP_SEPARATE_RESPONSE      (1)
-
-/**
  * @brief   Context information required to write a resource link
  */
 typedef struct {

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -589,6 +589,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief Flag to send a seperate response for a resource in coap_resource_t::flags
+ */
+#define COAP_SEPERATE_RESPONSE      (1)
+
+/**
  * @brief   Context information required to write a resource link
  */
 typedef struct {

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -224,6 +224,9 @@ typedef struct {
     const char *path;               /**< URI path of resource               */
     coap_method_flags_t methods;    /**< OR'ed methods this resource allows */
     coap_handler_t handler;         /**< ptr to resource handler            */
+#ifdef MODULE_GCOAP
+    uint8_t flags;                  /**< flags e.g. for seperate response   */
+#endif
     void *context;                  /**< ptr to user defined context data   */
 } coap_resource_t;
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -225,7 +225,7 @@ typedef struct {
     coap_method_flags_t methods;    /**< OR'ed methods this resource allows */
     coap_handler_t handler;         /**< ptr to resource handler            */
 #ifdef MODULE_GCOAP
-    uint8_t flags;                  /**< flags e.g. for seperate response   */
+    uint8_t flags;                  /**< flags e.g. for separate response   */
 #endif
     void *context;                  /**< ptr to user defined context data   */
 } coap_resource_t;

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -109,6 +109,7 @@ extern "C" {
 #define COAP_FETCH              (0x10)
 #define COAP_PATCH              (0x20)
 #define COAP_IPATCH             (0x40)
+#define COAP_SEPARATE_RESPONSE  (0x80)
 #define COAP_MATCH_SUBTREE      (0x8000) /**< Path is considered as a prefix
                                               when matching */
 /** @} */
@@ -224,9 +225,6 @@ typedef struct {
     const char *path;               /**< URI path of resource               */
     coap_method_flags_t methods;    /**< OR'ed methods this resource allows */
     coap_handler_t handler;         /**< ptr to resource handler            */
-#ifdef MODULE_GCOAP
-    uint8_t flags;                  /**< flags e.g. for separate response   */
-#endif
     void *context;                  /**< ptr to user defined context data   */
 } coap_resource_t;
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -69,7 +69,7 @@ static int _request_matcher_default(gcoap_listener_t *listener,
 
 /* Internal variables */
 const coap_resource_t _default_resources[] = {
-    { "/.well-known/core", COAP_GET, _well_known_core_handler, 0, NULL },
+    { "/.well-known/core", COAP_GET, _well_known_core_handler, NULL },
 };
 
 static gcoap_listener_t _default_listener = {
@@ -364,23 +364,20 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
             return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
             break;
     }
-    
-    if (resource->flags & COAP_SEPARATE_RESPONSE) {
-        coap_pkt_t pdu_sep;
-        uint8_t buf_sep[CONFIG_GCOAP_PDU_BUF_SIZE] = { 0 };
-        memcpy(buf_sep, buf, len);
-        ssize_t res = coap_parse(&pdu_sep, buf_sep, len);
-        if (res < 0) {
-            DEBUG("gcoap: parse failure: %d\n", (int)res);
-            /* If a response, can't clear memo, but it will timeout later. */
-            return -1;
-        }
 
-        coap_hdr_set_type(pdu_sep.hdr, COAP_TYPE_ACK);
-        coap_hdr_set_code(pdu_sep.hdr, COAP_CODE_EMPTY);
-        pdu_sep.hdr->ver_t_tkl &= 0xf0;
+    if ((coap_get_type(pdu) == COAP_TYPE_CON) && 
+        (resource->methods & COAP_SEPARATE_RESPONSE)) {
+        /* prepare empty ack message */
+        uint8_t buf_sep[GCOAP_HEADER_MAXLEN] = { 0 };        
+        memcpy(buf_sep, buf, GCOAP_HEADER_MAXLEN);
+        coap_hdr_t *hdr = (coap_hdr_t *)buf_sep;
 
-        ssize_t bytes = sock_udp_send(&_sock_udp, buf_sep, sizeof(pdu_sep.hdr), remote);
+        coap_hdr_set_type(hdr, COAP_TYPE_ACK);
+        coap_hdr_set_code(hdr, COAP_CODE_EMPTY);
+        hdr->ver_t_tkl &= 0xf0;
+
+        ssize_t bytes = sock_udp_send(&_sock_udp, buf_sep, 
+                                    sizeof(hdr), remote);
         if (bytes <= 0) {
             DEBUG("gcoap: send response failed: %d\n", (int)bytes);
         }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -365,7 +365,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
             break;
     }
     
-    if (resource->flags & COAP_SEPERATE_RESPONSE) {
+    if (resource->flags & COAP_SEPARATE_RESPONSE) {
         coap_pkt_t pdu_sep;
         uint8_t buf_sep[CONFIG_GCOAP_PDU_BUF_SIZE] = { 0 };
         memcpy(buf_sep, buf, len);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Gcoap doesn't allow sending separate responses on CON messages (see #14393). This can be useful if it is known ahead that computations on the server will take longer. Otherwise the client will retransmit the request and a timeout will occur.
This PR allows to choose separate responses instead of piggybacked responses for a resource. It does not allow to send separate responses per request by the handler itself (as suggested in #14395), but is done by gcoap in case this was selected for a resource.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Start a gcoap server and GET from a client `/riot/board` (as CON message). Observing it with Wireshark shows that an Empty response message is sent before the actual response is sent.

### Issues/PRs references
See also #14395, #14393
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
