### PR TITLE
NanoCBOR: Bump version

### DIFF
--- a/pkg/nanocbor/Makefile
+++ b/pkg/nanocbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nanocbor
 PKG_URL     = https://github.com/bergzand/nanocbor
-PKG_VERSION = d3d88e2d8e8da53d278aabe448cb338dbf845f09
+PKG_VERSION = 7728af0633a8d9d119c9b36a5c5a441e11e75ff1
 PKG_LICENSE = CC-0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Upstream fixed a nasty bug when decoding an indefinite container inside a fixed
length container.

### Testing procedure

The test should work as before.

### Issues/PRs references

None