### PR TITLE
gnrc_netif/lorawan: drop netif header on send

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -311,12 +311,15 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
         dst = gnrc_netif_hdr_get_dst_addr(netif_hdr);
 
         assert(payload->type == GNRC_NETTYPE_NETIF);
-        head = payload->next;
         port = dst[0];
 
         if (netif_hdr->dst_l2addr_len != sizeof(port)) {
             goto end;
         }
+
+        /* Remove the netif hdr snip and point to the MSDU */
+        head = gnrc_pktbuf_remove_snip(payload, payload);
+
     }
     else {
         head = payload;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes a memory leak introduced by #16080. The netif hdr was not being released on send.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
On current master:
```
ifconfig 3 up
2021-06-24 15:24:51,325 # ifconfig 3 up
> ifconfig
2021-06-24 15:25:06,809 # ifconfig
2021-06-24 15:25:06,820 # Iface  3  HWaddr: 26:01:44:AF  Frequency: 869524963Hz  RSSI: 99  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2021-06-24 15:25:06,827 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2021-06-24 15:25:06,829 #           IQ_INVERT  
2021-06-24 15:25:06,833 #           RX_SINGLE  OTAA  L2-PDU:767  
2021-06-24 15:25:06,834 #           
txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:26:25,320 # txtsnd 3 01 "THIS IS RIOT!"
> txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:26:29,540 # txtsnd 3 01 "THIS IS RIOT!"
> pktbuf
2021-06-24 15:26:32,857 # pktbuf
2021-06-24 15:26:32,864 # packet buffer: first byte: 0x2000119c, last byte: 0x2000139c (size: 512)
2021-06-24 15:26:32,866 #   position of last byte used: 120
2021-06-24 15:26:32,872 # =========== chunk   0 (0x2000119c size:  120) ===========
2021-06-24 15:26:32,879 # 00000000  00  00  00  00  B4  11  00  20  0D  00  00  00  01  00  00  00
2021-06-24 15:26:32,885 # 00000010  00  00  00  00  00  00  00  00  70  7C  9F  54  84  06  8F  42
2021-06-24 15:26:32,892 # 00000020  BD  69  C1  24  3B  18  4F  84  9C  11  00  20  DC  11  00  20
2021-06-24 15:26:32,899 # 00000030  09  00  00  00  01  00  00  00  FF  00  00  00  00  00  00  00
2021-06-24 15:26:32,905 # 00000040  00  01  00  00  00  00  00  80  01  00  00  00  00  00  00  00
2021-06-24 15:26:32,912 # 00000050  9C  11  00  20  04  12  00  20  09  00  00  00  01  00  00  00
2021-06-24 15:26:32,919 # 00000060  FF  00  00  00  00  00  00  00  00  01  00  00  00  00  00  80
2021-06-24 15:26:32,922 # 00000070  01  00  00  00  00  00  00  00
2021-06-24 15:26:32,927 # ~ unused: 0x20001214 (next: (nil), size:  392) ~
```

With this PR:
```
2021-06-24 15:22:42,977 # ifconfig 3 up
> ifconfig
2021-06-24 15:22:53,247 # ifconfig
2021-06-24 15:22:53,258 # Iface  3  HWaddr: 26:01:4F:A0  Frequency: 869524963Hz  RSSI: 99  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2021-06-24 15:22:53,265 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2021-06-24 15:22:53,267 #           IQ_INVERT  
2021-06-24 15:22:53,271 #           RX_SINGLE  OTAA  L2-PDU:767  
2021-06-24 15:22:53,272 #           
txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:22:58,717 # txtsnd 3 01 "THIS IS RIOT!"
ifconfig 3 set dr 5
2021-06-24 15:23:14,571 # ifconfig 3 set dr 5
2021-06-24 15:23:14,576 # success: set datarate on interface 3 to 5
txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:23:16,002 # txtsnd 3 01 "THIS IS RIOT!"
> txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:23:23,133 # txtsnd 3 01 "THIS IS RIOT!"
> txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:23:36,768 # txtsnd 3 01 "THIS IS RIOT!"
> 2021-06-24 15:23:37,889 # PKTDUMP: data received:
2021-06-24 15:23:37,894 # ~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
2021-06-24 15:23:37,897 # 00000000  DE  AD  BE  EF
2021-06-24 15:23:37,901 # ~~ SNIP  1 - size:   9 byte, type: NETTYPE_NETIF (-1)
2021-06-24 15:23:37,905 # if_pid: 3  rssi: -32768  lqi: 0
2021-06-24 15:23:37,905 # flags: 0x0
2021-06-24 15:23:37,907 # src_l2addr: (nil)
2021-06-24 15:23:37,908 # dst_l2addr: 01
2021-06-24 15:23:37,912 # ~~ PKT    -  2 snips, total size:  13 byte
pktbuf
2021-06-24 15:23:44,918 # pktbuf
2021-06-24 15:23:44,924 # packet buffer: first byte: 0x2000119c, last byte: 0x2000139c (size: 512)
2021-06-24 15:23:44,928 #   position of last byte used: 128
2021-06-24 15:23:44,933 # ~ unused: 0x2000119c (next: (nil), size:  512) ~

```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#16080
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
