### PR TITLE
dhcpv6_client: add DNS recursive name server option handling

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -24,6 +24,7 @@ PSEUDOMODULES += cpu_check_address
 PSEUDOMODULES += dbgpin
 PSEUDOMODULES += devfs_%
 PSEUDOMODULES += dhcpv6_%
+PSEUDOMODULES += dhcpv6_client_dns
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += event_%
 PSEUDOMODULES += event_timeout_ztimer

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -102,6 +102,9 @@ ifneq (,$(filter dhcpv6_client,$(USEMODULE)))
   USEMODULE += event
   USEMODULE += random
   USEMODULE += xtimer
+  ifneq (,$(filter sock_dns,$(USEMODULE)))
+    USEMODULE += dhcpv6_client_dns
+  endif
 endif
 
 ifneq (,$(filter fuzzing,$(USEMODULE)))

--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -65,6 +65,7 @@ extern "C" {
 #define DHCPV6_OPT_PREF             (7U)    /**< preference option */
 #define DHCPV6_OPT_ELAPSED_TIME     (8U)    /**< elapsed time option */
 #define DHCPV6_OPT_STATUS           (13U)   /**< status code option */
+#define DHCPV6_OPT_DNS_RNS          (23U)   /**< DNS recursive name server option */
 #define DHCPV6_OPT_IA_PD            (25U)   /**< identity association for prefix
                                              *   delegation (IA_PD) option */
 #define DHCPV6_OPT_IAPFX            (26U)   /**< IA prefix option */

--- a/sys/net/application_layer/dhcpv6/_dhcpv6.h
+++ b/sys/net/application_layer/dhcpv6/_dhcpv6.h
@@ -173,6 +173,19 @@ typedef struct __attribute__((packed)) {
 } dhcpv6_opt_status_t;
 
 /**
+ * @brief   DHCPv6 DNS recursive name server option
+ * @see [RFC 3646, section 3]
+ *      (https://datatracker.ietf.org/doc/html/rfc3646#section-3)
+ * @note    Only parsed with `dhcpv6_client_dns` module compiled in.
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t type;          /**< @ref DHCPV6_OPT_DNS_RNS */
+    network_uint16_t len;           /**< length of dhcpv6_opt_status_t::dns_rns in byte */
+    ipv6_addr_t dns_rns[];          /**< addresses of DNS recursive name servers
+                                     *   in order of preference */
+} dhcpv6_opt_dns_rns_t;
+
+/**
  * @brief   DHCPv6 identity association for prefix delegation option (IA_PD)
  *          format
  * @see [RFC 8415, section 21.21]
@@ -223,6 +236,17 @@ typedef struct __attribute__((packed)) {
     network_uint16_t len;   /**< length of the mud_string in octets. */
     char mud_string[];       /**< MUD URL using the "https" scheme */
 } dhcpv6_opt_mud_url_t;
+
+/**
+ * @brief   Configures a DNS recursive name server provided by the server.
+ *
+ * @note    Only available with module `dhcpv6_client_dns`.
+ *
+ * @param[in] opt       A legal DNS recursive name option.
+ * @param[in] netif     Network interface the message carrying @p opt came in.
+ */
+void dhcpv6_client_dns_rns_conf(const dhcpv6_opt_dns_rns_t *opt,
+                                uint16_t netif);
 
 #ifdef __cplusplus
 }

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -636,6 +636,12 @@ static bool _parse_reply(uint8_t *rep, size_t len)
     for (dhcpv6_opt_t *opt = (dhcpv6_opt_t *)(&rep[sizeof(dhcpv6_msg_t)]);
          len > 0; len -= _opt_len(opt), opt = _opt_next(opt)) {
         switch (byteorder_ntohs(opt->type)) {
+#if IS_USED(MODULE_DHCPV6_CLIENT_DNS)
+            case DHCPV6_OPT_DNS_RNS:
+                dhcpv6_client_dns_rns_conf((dhcpv6_opt_dns_rns_t *)opt,
+                                           remote.netif);
+                break;
+#endif  /* IS_USED(MODULE_DHCPV6_CLIENT_DNS) */
             case DHCPV6_OPT_IA_PD:
                 for (unsigned i = 0; i < CONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX; i++) {
                     dhcpv6_opt_iapfx_t *iapfx = NULL;

--- a/sys/net/application_layer/dhcpv6/client_dns.c
+++ b/sys/net/application_layer/dhcpv6/client_dns.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "net/dhcpv6/client.h"
+#if IS_USED(MODULE_SOCK_DNS)
+#include "net/sock/dns.h"
+#endif
+
+#include "_dhcpv6.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
+
+void dhcpv6_client_dns_rns_conf(const dhcpv6_opt_dns_rns_t *opt, uint16_t netif)
+{
+    if (byteorder_ntohs(opt->len) < sizeof(ipv6_addr_t)) {
+        DEBUG("dhcpv6_client_dns: no DNS recursive name server provided.\n");
+        return;
+    }
+#if IS_USED(MODULE_SOCK_DNS) && IS_ACTIVE(SOCK_HAS_IPV6)
+    DEBUG("Overriding sock_dns_server with %s\n",
+          ipv6_addr_to_str(addr_str, opt->dns_rns, sizeof(addr_str)));
+    sock_dns_server.port = SOCK_DNS_PORT;
+    sock_dns_server.family = AF_INET6;
+    sock_dns_server.netif = netif;
+    memcpy(sock_dns_server.addr.ipv6, opt->dns_rns,
+           sizeof(sock_dns_server.addr.ipv6));
+    return;
+#endif
+}
+
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Now that I finally have IPv6 at home, I started playing around with configuring my OpenWRT as a 6LoWPAN border router, using an nrf52840dongle with `cdc-ecm` as the actual border router.

It took me a while to remember that I also can get the DNS server information from the WRT's router advertisements using the `gnrc_ipv6_nib_dns`, so I added this optional feature to the DHCPv6 client.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile the border router example with DHCPv6 with `dhcpv6_client_dns` and `sock_dns`, flash it, and wait until the DHCPv6 initialization is completed (you can check by looking at the 6LoWPAN interface; when it has a global address the procedure is complete). Given that you have your DHCPv6 server and firewall configured properly, you should now be able to ping a host name from the border router (did not test from downstream nodes as there are currently other problems in my network preventing that... but that would be unrelated from this PR anyway since that config would not come via DHCPv6).

Here is the excerpt from my home setup:

```console
$ UPLINK=cdc-ecm BOARD=nrf52840dongle USEMODULE="sock_dns" USE_DHCPV6=1 QUIETER=1 make -C examples/gnrc_border_router/ flash -j
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router'
Building application "gnrc_border_router" for "nrf52840dongle" with MCU "nrf52".

stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
   text	   data	    bss	    dec	    hex	filename
  87916	    240	  25868	 114024	  1bd68	/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/nrf52840dongle/gnrc_border_router.elf
nrfutil pkg generate --hw-version 52 --sd-req 0x00 --application-version 1 --application /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/nrf52840dongle/gnrc_border_router.hex /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/nrf52840dongle/gnrc_border_router.hex.zip

|===============================================================|
|##      ##    ###    ########  ##    ## #### ##    ##  ######  |
|##  ##  ##   ## ##   ##     ## ###   ##  ##  ###   ## ##    ## |
|##  ##  ##  ##   ##  ##     ## ####  ##  ##  ####  ## ##       |
|##  ##  ## ##     ## ########  ## ## ##  ##  ## ## ## ##   ####|
|##  ##  ## ######### ##   ##   ##  ####  ##  ##  #### ##    ## |
|##  ##  ## ##     ## ##    ##  ##   ###  ##  ##   ### ##    ## |
| ###  ###  ##     ## ##     ## ##    ## #### ##    ##  ######  |
|===============================================================|
|You are not providing a signature key, which means the DFU     |
|files will not be signed, and are vulnerable to tampering.     |
|This is only compatible with a signature-less bootloader and is|
|not suitable for production environments.                      |
|===============================================================|

Zip created at /home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/nrf52840dongle/gnrc_border_router.hex.zip
nrfutil dfu usb-serial --port=/dev/ttyACM0 --package=/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/bin/nrf52840dongle/gnrc_border_router.hex.zip
  [####################################]  100%          
Device programmed.
make: Leaving directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router'
```

Unplug dongle and plug it to OpenWRT router

```
$ ssh "<openwrt_router>"
# dmesg
[…]
[163858.252830] cdc_acm 1-1.2:1.0: ttyACM0: USB ACM device
[163858.270239] cdc_ether 1-1.2:1.2 usb0: register 'cdc_ether' at usb-1b000000.usb-1.2, CDC Ethernet Device, XX:XX:XX:XX:XX:XX
[…]
# ip link show dev usb0
83: usb0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether XX:XX:XX:XX:XX:XX brd ff:ff:ff:ff:ff:ff
# picocom --nolock --imap lfcrlf --baud 115200 /dev/ttyACM0
picocom v3.1

port is        : /dev/ttyACM0
flowcontrol    : none
baudrate is    : 115200
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
hangup is      : no
nolock is      : yes
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : lfcrlf,
omap is        : 
emap is        : crcrlf,delbs,
logfile is     : none
initstring     : none
exit_after is  : not set
exit is        : no

Type [C-a] [C-h] to see available commands
Terminal ready
ifconfig
Iface  7  HWaddr: 57:64  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: BA:F0:25:3A:6F:23:57:64 
           State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::b8f0:253a:6f23:5764  scope: link  VAL
          inet6 addr: 2a01:5241:28c:1f14:b8f0:253a:6f23:5764  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff23:5764
          
Iface  6  HWaddr: 7A:10:C2:67:B2:24 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::7810:c2ff:fe67:b224  scope: link  VAL
          inet6 addr: 2a01:5241:28c:1f10:7810:c2ff:fe67:b224  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff67:b224
          
> ping riot-os.org
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=0 ttl=57 time=30.069 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=1 ttl=57 time=24.455 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=2 ttl=57 time=26.435 ms

--- riot-os.org PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 24.455/26.986/30.069 ms
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
&mdash;
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
