### PR TITLE
gnrc_lorawan: fix undefined state when PSDU is NULL

### DIFF
--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -237,8 +237,9 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
  *        To be called on radio RX done event.
  *
  * @param[in] mac pointer to the MAC descriptor
- * @param[in] data pointer to the psdu. Pass NULL if the packet was wrong (or
- * allocation failed)
+ * @param[in] data pointer to the psdu. Must not be NULL. Use
+ *            @ref gnrc_lorawan_radio_rx_error_cb instead if the reception was
+ *            not successful.
  * @param[in] size size of the PSDU
  */
 void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *data,

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -177,6 +177,17 @@ void gnrc_lorawan_radio_rx_timeout_cb(gnrc_lorawan_t *mac);
 void gnrc_lorawan_radio_tx_done_cb(gnrc_lorawan_t *mac);
 
 /**
+ * @brief Indicate the MAC layer reception of a frame went wrong.
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ */
+static inline void gnrc_lorawan_radio_rx_error_cb(gnrc_lorawan_t *mac)
+{
+    /* The failed reception is seen by the MAC layer as an RX timeout */
+    gnrc_lorawan_radio_rx_timeout_cb(mac);
+}
+
+/**
  * @brief Indicate the MAC layer that the timer was fired
  *
  * @param[in] mac pointer to the MAC descriptor

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -242,10 +242,8 @@ void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, iolist_t *psdu, uint8_t dr)
 void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *psdu,
                                    size_t size)
 {
+    assert(psdu);
     _sleep_radio(mac);
-    if (psdu == NULL) {
-        return;
-    }
     mac->state = LORAWAN_STATE_IDLE;
     gnrc_lorawan_remove_timer(mac);
 

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -180,13 +180,13 @@ static void _rx_done(gnrc_lorawan_t *mac)
         DEBUG("_recv_lorawan: cannot allocate pktsnip.\n");
         /* Discard packet on netdev device */
         dev->driver->recv(dev, NULL, bytes_expected, NULL);
-        gnrc_lorawan_radio_rx_done_cb(mac, NULL, 0);
+        gnrc_lorawan_radio_rx_error_cb(mac);
         return;
     }
     nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
     if (nread <= 0) {
         gnrc_pktbuf_release(pkt);
-        gnrc_lorawan_radio_rx_done_cb(mac, NULL, 0);
+        gnrc_lorawan_radio_rx_error_cb(mac);
         return;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes and undefined state when the PSDU is NULL (because `dev->driver->recv(...) return 0 or an error).
On current master, the MAC layer misses an event if `gnrc_lorawan_radio_rx_done_cb` is called with NULL. This either hangs the MAC layer or gets it stuck in a loop.

Since receiving a wrong packet is equivalent to an rx_timeout, I added a `gnrc_lorawan_radio_rx_error_cb` wrapper that maps to `gnrc_lorawan_radio_rx_timeout_cb`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Without this PR, if this patch is applied:
```diff
diff --git a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
index 51b06f2ac3..c9aa3f5cb4 100644
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -183,7 +183,8 @@ static void _rx_done(gnrc_lorawan_t *mac)
         gnrc_lorawan_radio_rx_done_cb(mac, NULL, 0);
         return;
     }
-    nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
+    dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
+    nread = 0;
     if (nread <= 0) {
         gnrc_pktbuf_release(pkt);
         gnrc_lorawan_radio_rx_done_cb(mac, NULL, 0);

```
And GNRC LoRaWAN debug is enabled, only one RX window is triggered during join or send and the MAC gets stuck:
```
2021-06-24 15:47:45,174 # ifconfig 3 up
> 2021-06-24 15:47:45,303 # gnrc_lorawan: Channel: 868100000Hz 
2021-06-24 15:47:52,776 # gnrc_lorawan: RX1 timeout.
ifconfig
2021-06-24 15:48:11,661 # ifconfig
2021-06-24 15:48:11,672 # Iface  3  HWaddr: 00:00:00:00  Frequency: 869524963Hz  RSSI: 99  BW: 125kHz  SF: 12  CR: 4/5  Link: down 
2021-06-24 15:48:11,679 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2021-06-24 15:48:11,681 #           IQ_INVERT  
2021-06-24 15:48:11,685 #           RX_SINGLE  OTAA  L2-PDU:767  
2021-06-24 15:48:11,686 #           
> ifconfig 3 up
2021-06-24 15:48:12,788 # ifconfig 3 up
> ifconfig 3 up
2021-06-24 15:48:30,667 # ifconfig 3 up
> 
```

With this PR (and the patch suggested above), both reception windows are triggered:
```
> ifconfig 3 up
2021-06-24 14:26:20,993 # ifconfig 3 up
> 2021-06-24 14:26:22,869 # gnrc_lorawan: Channel: 868300000Hz 
2021-06-24 14:26:30,341 # gnrc_lorawan: RX1 timeout.
2021-06-24 14:26:32,196 # gnrc_lorawan: RX2 timeout.
```

The MAC layer is still working as expected with this PR:
```
2021-06-24 15:43:07,134 # ifconfig 3 up
> ifconfig
2021-06-24 15:44:07,672 # ifconfig
2021-06-24 15:44:07,682 # Iface  3  HWaddr: 26:01:6D:7D  Frequency: 869524963Hz  RSSI: 99  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2021-06-24 15:44:07,690 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2021-06-24 15:44:07,692 #           IQ_INVERT  
2021-06-24 15:44:07,697 #           RX_SINGLE  OTAA  L2-PDU:767  
2021-06-24 15:44:07,698 #           
> ifconfig 3 set dr 5
2021-06-24 15:44:11,624 # ifconfig 3 set dr 5
2021-06-24 15:44:11,628 # success: set datarate on interface 3 to 5
txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:44:17,624 # txtsnd 3 01 "THIS IS RIOT!"
> txtsnd 3 01 "THIS IS RIOT!"
2021-06-24 15:44:26,328 # txtsnd 3 01 "THIS IS RIOT!"
> 2021-06-24 15:44:27,450 # PKTDUMP: data received:
2021-06-24 15:44:27,455 # ~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF (0)
2021-06-24 15:44:27,457 # 00000000  DE  AD  BE  ED
2021-06-24 15:44:27,462 # ~~ SNIP  1 - size:   9 byte, type: NETTYPE_NETIF (-1)
2021-06-24 15:44:27,465 # if_pid: 3  rssi: -32768  lqi: 0
2021-06-24 15:44:27,466 # flags: 0x0
2021-06-24 15:44:27,467 # src_l2addr: (nil)
2021-06-24 15:44:27,469 # dst_l2addr: 01
2021-06-24 15:44:27,473 # ~~ PKT    -  2 snips, total size:  13 byte

```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Found when working on #16570 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
