### PR TITLE
sys/net/dhcpv6: include RIO after configuring downstream subnets

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -58,6 +58,7 @@ endif
 ifneq (,$(filter gnrc_dhcpv6_client_simple_pd,$(USEMODULE)))
   USEMODULE += gnrc_dhcpv6_client
   USEMODULE += dhcpv6_client_ia_pd
+  CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ADV_ROUTER=0
 endif
 
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -84,15 +84,6 @@ static void _configure_upstream_netif(gnrc_netif_t *upstream_netif)
         addr.u8[15] = 2;
         gnrc_netif_ipv6_addr_add(upstream_netif, &addr, 64, 0);
     }
-
-    /* Disable router advertisements on upstream interface. With this, the border
-     * router
-     * 1. Does not confuse the upstream router to add the border router to its
-     *    default router list and
-     * 2. Solicits upstream Router Advertisements quicker to auto-configure its
-     *    upstream global address.
-     */
-    gnrc_ipv6_nib_change_rtr_adv_iface(upstream_netif, false);
 }
 
 /**
@@ -111,6 +102,28 @@ static void _configure_dhcpv6_client(void)
             dhcpv6_client_req_ia_pd(netif->pid, 64U);
         }
     }
+}
+
+void dhcpv6_client_conf_done(unsigned iface)
+{
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+
+    /* Disable router advertisements on upstream interface. With this, the border
+     * router
+     * 1. Does not confuse the upstream router to add the border router to its
+     *    default router list and
+     * 2. Solicits upstream Router Advertisements quicker to auto-configure its
+     *    upstream global address.
+     */
+    gnrc_ipv6_nib_change_rtr_adv_iface(netif, false);
+}
+
+void dhcpv6_client_conf_prefix_done(unsigned iface)
+{
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+
+    /* start advertising subnet obtained via DHCPv6 */
+    gnrc_ipv6_nib_change_rtr_adv_iface(netif, true);
 }
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -56,6 +56,7 @@ config GNRC_IPV6_NIB_DNS
 
 config GNRC_IPV6_NIB_ADV_ROUTER
     bool "Activate router advertising at interface start-up"
+    default n if USEMODULE_GNRC_DHCPV6_CLIENT_SIMPLE_PD
     default y if GNRC_IPV6_NIB_ROUTER && (!GNRC_IPV6_NIB_6LR || GNRC_IPV6_NIB_6LBR)
 
 config GNRC_IPV6_NIB_DC


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If the upstream router manages a /56 and hands our DHCPv6 IA_PD enabled router a /62 for use in it's downstream network, hosts in the upstream network may still assume that hosts on the new subnet are on-link.

To fix this, we include the  route information option about the subnets routed via our router in the last router advertisement.

This means we must delay sending the last router advertisement until the downstream interface(s) have been configured.

To speed up configuration, start with RAs disabled and only enable sending them once we have received a valid configuration via DHCPv6.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

depends on #16568
