### PR TITLE
tests/ieee802154_hal: extend radio hal test 

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/ieee802154.py
+++ b/dist/pythonlibs/riotctrl_shell/ieee802154.py
@@ -1,0 +1,128 @@
+import re
+
+from riotctrl.shell import ShellInteraction
+
+# ==== ShellInteractions ====
+
+class IEEE802154Phy(ShellInteraction):
+    def ieee802154_config_phy(self, phy_mode, channel, tx_pow, timeout=None, async_=False):
+        cmd = "config_phy {phy_mode} {channel} {tx_pow}" \
+              .format(phy_mode=phy_mode, channel=channel, tx_pow=tx_pow)
+        
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+        except Exception as e:
+            print("Error:", e)
+        
+        if "Success" not in res:
+            raise RuntimeError(res)
+
+        if str(channel) not in res:
+            raise RuntimeError(res)
+
+    def ieee802154_print_info(self, timeout=None, async_=False):
+        cmd = "get_info" \
+              .format()
+
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+        except Exception as e:
+            print("Error:", e)
+
+        address_regex = re.compile(r"Address: (.*)$")
+        channel_regex = re.compile(r"Channel: (.*)$")
+        for line in res.splitlines():
+            address_group = re.match(address_regex, line)
+            channel_group = re.match(channel_regex, line)
+            if (address_group):
+                addr = address_group.groups()[0]
+            elif (channel_group):
+                channel = channel_group.groups()[0]
+                break
+
+        return addr, channel
+
+    def ieee802154_tx_mode(self, command, timeout=None, async_=False):
+        cmd = "tx_mode {command}" \
+                .format(command=command)
+
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+        except Exception as e:
+            print("Error:", e)
+
+        if "Ok" not in res:
+            raise RuntimeError(res)
+
+    def ieee802154_check_last_packet(self, long_addr, channel, timeout=None, async_=False):
+        cmd = "check_last_packet {long_addr} {channel}" \
+                .format(long_addr=long_addr, channel=channel)
+
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+        except Exception as e:
+            print("Error:", e)
+
+        if "Success" not in res:
+            raise RuntimeError(res)
+    
+    def ieee802154_reply_mode_cmd(self, reply_mode, timeout=None, async_=False):
+        cmd = "reply {reply_mode} " \
+                .format(reply_mode=reply_mode)
+
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+        except Exception as e:
+            print("Error:", e)
+
+        if "Success" not in res:
+            raise RuntimeError(res)
+
+    def ieee802154_txtsnd(self, long_addr, length, timeout=None, async_=False):
+        cmd = "txtsnd {long_addr} {length} " \
+              .format(long_addr=long_addr, length=length)
+
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+        except Exception as e:
+            print("Error:", e)
+
+    def ieee802154_txtspam(self, long_addr, length, number_of_packets, time_betweeen_packets, async_=False):
+        timeout = (number_of_packets * time_betweeen_packets) / 1000 + 1
+        cmd = "txtspam {long_addr} {length} {number_of_packets} {time_betweeen_packets} " \
+              .format(long_addr=long_addr, length=length, number_of_packets=number_of_packets,
+              time_betweeen_packets=time_betweeen_packets)
+
+        try:
+            res = self.cmd(cmd, timeout=timeout, async_=async_)
+            percentages = []
+            number_ack_packets = None
+            percentage_ack = None
+            for line in res.splitlines():
+                regex_summary = re.match("-------Summary of the test-------", line)
+                regex_send_packets = re.match("Send Packets: (.*)$", line)
+                regex_ack_packets = re.match("Acknowledged Packets: (.*)$", line)
+                regex_received_packets = re.match("Received Packets: (.*)$", line)
+                regex_percentage = re.match(".*Percentage: ([\d]+)\%$", line)
+                if (regex_summary):
+                    continue
+                elif (regex_send_packets):
+                    number_send_packets = int(regex_send_packets.groups()[0])
+                elif (regex_ack_packets):
+                    number_ack_packets = int(regex_ack_packets.groups()[0])
+                elif (regex_percentage):
+                    percentages.append(int(regex_percentage.groups()[0]))
+                elif (regex_received_packets):
+                    number_received_packets = int(regex_received_packets.groups()[0])
+
+        except Exception as e:
+            print("Error:", e)
+
+        if len(percentages) == 2:
+            percentage_ack = percentages[0]
+            percentage_received = percentages[1]
+        else:
+            percentage_received = percentages[0]
+
+        return {"tx_packets": number_send_packets, "ack_packets": number_ack_packets, "percentage_ack": percentage_ack,
+        "num_rx": number_received_packets, "percentage_rx": percentage_received}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

Refers to https://github.com/RIOT-OS/RIOT/pull/15761, because it was hard to rebase

### Contribution description

- spam:  Sends as fast and as many packets as specified in the parameters
- reply: The receiver sends the package back as soon as possible
- enable_prints: Prints interesting stuff. e.g. received packet. May have to be disabled due to timer issues caused by the printing
- test_channel: Sends and receive on different channels
- check_last_packet: Checks if the last packet matches to the expect sender

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
There is a automated test in riotctrl. https://github.com/RIOT-OS/Release-Specs/pull/222
It can be called in Release-Specs via `tox -- -k "spec12" --non-RC --local`

Currently there a three test:

1. The first test checks whether the radios on channels 11 to 26 can receive and transmit packets.
2. On the second test 20 packets send with a high frequency. It is checked whether all packets have been acknowledged.
3. The last test checks if the receiver can send back a packet immediately.

All tests pass.

For manual testing you need two boards and flash it with tests/ieee802154_hal

Usage of the function spam:
Call spam on board with the parameters
```
spam <address_board2> <length_of_the_payload> <number_of_packets> <delay>
```

If you call spam with the parameters `spam <address_board2> 5 3 1`
The device will send a packet to device2 every 1 ms with a payload of 3 Chars in total 5 packets will be send. 

You can set device2 in reply mode, means it will sends every packet back he receives, by calling the function reply. Just make sure to be easy on the delay otherwise the radio won't be able to handle this.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
