### PR TITLE
examples/lorawan: add missing sx126x descriptor

### DIFF
--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -52,7 +52,12 @@ static kernel_pid_t sender_pid;
 static char sender_stack[THREAD_STACKSIZE_MAIN / 2];
 
 static semtech_loramac_t loramac;
+#if IS_USED(MODULE_SX127X)
 static sx127x_t sx127x;
+#endif
+#if IS_USED(MODULE_SX126X)
+static sx126x_t sx126x;
+#endif
 
 static const char *message = "This is RIOT!";
 


### PR DESCRIPTION
## Contribution description

If `sx126x` is used the device descriptor is missing.

### Testing procedure

A compile test should be enough (didn't test more myself since I have other issues with the hardware).

### Issues/PRs references


