### PR TITLE
sys/random/fortuna: change interval ressed to ms

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -122,6 +122,7 @@ PSEUDOMODULES += posix_headers
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng
 PSEUDOMODULES += prng_%
+PSEUDOMODULES += fortuna_reseed
 PSEUDOMODULES += qmc5883l_int
 PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += rtt_cmd

--- a/sys/Kconfig
+++ b/sys/Kconfig
@@ -70,6 +70,10 @@ config MODULE_LIBSTDCPP
     depends on HAS_CPP
     select MODULE_CPP
 
+config MODULE_ATOMIC_UTILS
+    bool "Atomic access utility functions"
+    depends on TEST_KCONFIG
+
 config MODULE_SYS
     bool
     default y

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -419,7 +419,10 @@ ifneq (,$(filter random,$(USEMODULE)))
     USEMODULE += fortuna
     USEMODULE += hashes
     USEMODULE += crypto
-    USEMODULE += xtimer
+    ifneq (,$(filter fortuna_reseed,$(USEMODULE)))
+        USEMODULE += atomic_utils
+        USEMODULE += xtimer
+    endif
   endif
 
   ifneq (,$(filter prng_tinymt32,$(USEMODULE)))

--- a/sys/random/Kconfig
+++ b/sys/random/Kconfig
@@ -19,13 +19,20 @@ choice RANDOM_IMPLEMENTATION
     default MODULE_PRNG_HWRNG if HAS_PERIPH_HWRNG
     default MODULE_PRNG_TINYMT32
 
-config MODULE_PRNG_FORTUNA
+menuconfig MODULE_PRNG_FORTUNA
     bool "Fortuna"
     select MODULE_HASHES
-    select MODULE_XTIMER
     select MODULE_FORTUNA
     select MODULE_CRYPTO
     select MODULE_CRYPTO_AES_128
+
+if MODULE_PRNG_FORTUNA
+
+config MODULE_FORTUNA_RESEED
+    bool "Reseed prng according to FORTUNA_RESEED_INTERVAL_MS"
+    select MODULE_XTIMER
+    select MODULE_ATOMIC_UTILS
+endif
 
 config MODULE_PRNG_HWRNG
     bool "Hardware RNG"

--- a/sys/random/fortuna.c
+++ b/sys/random/fortuna.c
@@ -21,7 +21,6 @@
 
 #include "log.h"
 #include "mutex.h"
-
 #include "fortuna/fortuna.h"
 
 /**

--- a/sys/random/fortuna/fortuna.h
+++ b/sys/random/fortuna/fortuna.h
@@ -27,8 +27,14 @@
 #ifndef FORTUNA_H
 #define FORTUNA_H
 
-#include "xtimer.h"
 #include "mutex.h"
+#if FORTUNA_RESEED_INTERVAL_MS > 0 && IS_USED(MODULE_FORTUNA_RESEED)
+#if IS_USED(MODULE_ZTIMER_MSEC)
+#include "ztimer.h"
+#else
+#include "xtimer.h"
+#endif
+#endif
 
 #include "crypto/aes.h"
 #include "hashes/sha256.h"
@@ -63,13 +69,17 @@ extern "C" {
 #define FORTUNA_SEED_SIZE           (64U)
 #endif
 
+#if IS_USED(MODULE_FORTUNA_RESEED) || DOXYGEN
 /**
  * @brief Reseed interval in us. After this interval, the PRNG must be
  *        reseeded. Per section 9.5.5, the recommended value is 100ms. Set to
  *        zero to disable this security feature.
+ *
+ * @note Requires `fortuna_reseed` module.
  */
-#ifndef FORTUNA_RESEED_INTERVAL
-#define FORTUNA_RESEED_INTERVAL     (0)
+#ifndef FORTUNA_RESEED_INTERVAL_MS
+#define FORTUNA_RESEED_INTERVAL_MS  100
+#endif
 #endif
 
 /**
@@ -138,11 +148,16 @@ typedef struct {
     fortuna_generator_t gen;
     fortuna_pool_t pools[FORTUNA_POOLS];
     uint32_t reseeds;
-#if FORTUNA_RESEED_INTERVAL > 0
-    uint64_t last_reseed;
-#endif
 #if FORTUNA_LOCK
     mutex_t lock;
+#endif
+#if FORTUNA_RESEED_INTERVAL_MS > 0 && IS_USED(MODULE_FORTUNA_RESEED)
+#if IS_USED(MODULE_ZTIMER_MSEC)
+    ztimer_t reseed_timer;
+#else
+    xtimer_t reseed_timer;
+#endif
+    uint8_t needs_reseed;
 #endif
 } fortuna_state_t;
 

--- a/tests/bench_sys_atomic_utils/app.config.test
+++ b/tests/bench_sys_atomic_utils/app.config.test
@@ -1,0 +1,5 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_ATOMIC_UTILS=y
+CONFIG_MODULE_TEST_UTILS_INTERACTIVE_SYNC=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/sys_atomic_utils/app.config.test
+++ b/tests/sys_atomic_utils/app.config.test
@@ -1,0 +1,8 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_ATOMIC_UTILS=y
+CONFIG_MODULE_FMT=y
+CONFIG_MODULE_SHELL=y
+CONFIG_MODULE_RANDOM=y
+CONFIG_MODULE_PRNG_TINYMT32=y
+CONFIG_MODULE_XTIMER=y

--- a/tests/sys_atomic_utils_unittests/app.config.test
+++ b/tests/sys_atomic_utils_unittests/app.config.test
@@ -1,0 +1,7 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_EMBUNIT=y
+CONFIG_MODULE_ATOMIC_UTILS=y
+CONFIG_MODULE_RANDOM=y
+# Force tinymt32 to be selected
+CONFIG_MODULE_PRNG_TINYMT32=y


### PR DESCRIPTION
### Contribution description

`fortuna` suggests a 100ms reseed interval, therefore msec resolution should be enough for the reseed value which. This PR also uses a timer to set a flag when a reseed is necessary this allows using `ztimer` without the need of including `now64` and ticks an item off https://github.com/RIOT-OS/RIOT/issues/13667.

To do that I realized that Fortuna is actually relying on an xtimer call before the module is initialized, therefore I had to move timer initialization up, I'll split this part out.

### Testing procedure

I applied the following patch:

```diff
diff --git a/examples/hello-world/Makefile b/examples/hello-world/Makefile
index 258d8e9baf..f389bea7ca 100644
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -15,4 +15,11 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

+USEMODULE += xtimer
+USEMODULE += prng_fortuna
+USEMODULE += fortuna_reseed
+USEMODULE += random
+
+CFLAGS=-DFORTUNA_RESEED_INTERVAL_MS=1000
+
 include $(RIOTBASE)/Makefile.include
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..168cbdcfdc 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,8 @@
  */

 #include <stdio.h>
+#include "xtimer.h"
+#include "random.h"

 int main(void)
 {
@@ -28,5 +30,10 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);

+    while(1) {
+        printf("random number: %"PRIu32"\n", random_uint32());
+        xtimer_usleep(2000000);
+    }
+
     return 0;
 }
diff --git a/sys/random/fortuna/fortuna.c b/sys/random/fortuna/fortuna.c
index ac096eb360..5f9bcc2a58 100644
--- a/sys/random/fortuna/fortuna.c
+++ b/sys/random/fortuna/fortuna.c
@@ -199,8 +199,8 @@ int fortuna_random_data(fortuna_state_t *state, uint8_t *out, size_t bytes)

     /* reseed the generator if needed, before returning data */
 #if FORTUNA_RESEED_INTERVAL_MS > 0 && IS_USED(MODULE_FORTUNA_RESEED)
-    if (state->pools[0].len >= FORTUNA_MIN_POOL_SIZE &&
-        atomic_load_u8(&state->reseed)) {
+    if (state-atomic_load_u8(&state->needs_reseed)) {
+        puts("reseed");
 #else
     if (state->pools[0].len >= FORTUNA_MIN_POOL_SIZE) {
 #endif

```

- ` make -C examples/hello-world/ all term`

```
main(): This is RIOT! (Version: 2021.07-devel-485-g63b849-pr_sys_fortuna_reseed_ms)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
reseed
random number: 3113564991
reseed
random number: 984556921
reseed
random number: 44374394
reseed
random number: 4139781756
reseed
random number: 3529685450
reseed
random number: 2868101182

```

### Issues/PRs references

Ticks an item in https://github.com/RIOT-OS/RIOT/issues/13667
