### PR TITLE
sys/auto_init: init ztimer/xtimer before random

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -28,12 +28,7 @@
 
 void auto_init(void)
 {
-    if (IS_USED(MODULE_AUTO_INIT_RANDOM)) {
-        LOG_DEBUG("Auto init random.\n");
-        extern void auto_init_random(void);
-        auto_init_random();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_ZTIMER)) {
+   if (IS_USED(MODULE_AUTO_INIT_ZTIMER)) {
         LOG_DEBUG("Auto init ztimer.\n");
         void ztimer_init(void);
         ztimer_init();
@@ -43,6 +38,11 @@ void auto_init(void)
         LOG_DEBUG("Auto init xtimer.\n");
         extern void xtimer_init(void);
         xtimer_init();
+    }
+   if (IS_USED(MODULE_AUTO_INIT_RANDOM)) {
+        LOG_DEBUG("Auto init random.\n");
+        extern void auto_init_random(void);
+        auto_init_random();
     }
     if (IS_USED(MODULE_SCHEDSTATISTICS)) {
         LOG_DEBUG("Auto init schedstatistics.\n");


### PR DESCRIPTION

### Contribution description

While looking at `fortuna` I realized it makes a call to `xtimer_now64` before the module is initialized, and I started wondering if it did not make more sense to initialize timers before `random`, unless someone is aware of a dependency between in the other direction.

### Testing procedure

- Murdock, run tests on multiple BOARDS to be safe
