### PR TITLE
sys/net/gnrc/netif: Make aac_mode a flag field

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -27,9 +27,9 @@ extern "C" {
  * @anchor  net_gnrc_netif_aac
  */
 enum {
-    GNRC_NETIF_AAC_NONE = 0,    /**< no configuration */
-    GNRC_NETIF_AAC_AUTO,        /**< Use some automatic bootstrapping (e.g. SLAAC with IPv6) */
-    GNRC_NETIF_AAC_DHCP,        /**< Use DHCP(v6) */
+    GNRC_NETIF_AAC_NONE = 0x00, /**< no configuration */
+    GNRC_NETIF_AAC_AUTO = 0x01, /**< Use some automatic bootstrapping (e.g. SLAAC with IPv6) */
+    GNRC_NETIF_AAC_DHCP = 0x02, /**< Use DHCP(v6) */
     /* extend if needed */
 };
 
@@ -82,7 +82,7 @@ enum {
 #define GNRC_NETIF_FLAGS_IPV6_ADV_RETRANS_TIMER    (0x00000040U)
 
 /**
- * @brief   If gnrc_netif_t::ipv6::aac_mode == GNRC_NETIF_AAC_DHCP then this
+ * @brief   If gnrc_netif_t::ipv6::aac_mode & GNRC_NETIF_AAC_DHCP then this
  *          flag indicates that other configuration information is available via
  *          DHCPv6 (e.g. DNS-related information)
  *

--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -243,7 +243,7 @@ typedef struct {
 #endif /* MODULE_GNRC_IPV6_NIB */
 
     /**
-     * @brief   IPv6 auto-address configuration mode
+     * @brief   IPv6 auto-address configuration mode flags
      *
      * @note    Only available with module @ref net_gnrc_ipv6 "gnrc_ipv6"
      */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -163,7 +163,7 @@ void _remove_tentative_addr(gnrc_netif_t *netif, const ipv6_addr_t *addr)
          * not change hardware address to retry SLAAC => use purely
          * DHCPv6 instead */
         /* TODO: implement IA_NA for DHCPv6 */
-        /* then => tgt_netif->aac_mode = GNRC_NETIF_AAC_DHCP; */
+        /* then => tgt_netif->aac_mode |= GNRC_NETIF_AAC_DHCP; */
         DEBUG("nib: would set interface %i to DHCPv6, "
               "but is not implemented yet", netif->pid);
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -133,7 +133,7 @@ void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif)
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) || IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     /* TODO: set differently dependent on CONFIG_GNRC_IPV6_NIB_SLAAC if
      * alternatives exist */
-    netif->ipv6.aac_mode = GNRC_NETIF_AAC_AUTO;
+    netif->ipv6.aac_mode |= GNRC_NETIF_AAC_AUTO;
 #endif  /* CONFIG_GNRC_IPV6_NIB_SLAAC || CONFIG_GNRC_IPV6_NIB_6LN */
     _init_iface_router(netif);
     gnrc_netif_init_6ln(netif);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -69,7 +69,7 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
         (ipv6_addr_match_prefix(&netif->ipv6.addrs[idx], pfx) >= pfx_len)) {
         dst->flags |= _PFX_ON_LINK;
     }
-    if (netif->ipv6.aac_mode == GNRC_NETIF_AAC_AUTO) {
+    if (netif->ipv6.aac_mode & GNRC_NETIF_AAC_AUTO) {
         dst->flags |= _PFX_SLAAC;
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR) && IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -538,7 +538,7 @@ void gnrc_ndp_rtr_adv_send(gnrc_netif_t *netif, const ipv6_addr_t *src,
         if (!fin) {
             adv_ltime = netif->ipv6.rtr_ltime;
         }
-        if (netif->ipv6.aac_mode == GNRC_NETIF_AAC_DHCP) {
+        if (netif->ipv6.aac_mode & GNRC_NETIF_AAC_DHCP) {
             flags |= NDP_RTR_ADV_FLAGS_M;
             if (netif->flags & GNRC_NETIF_FLAGS_IPV6_ADV_O_FLAG) {
                 flags |= NDP_RTR_ADV_FLAGS_O;

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
+    stm32mp157c-dk2 \
     telosb \
     waspmote-pro \
     z1 \


### PR DESCRIPTION
### Contribution description

This PR is another spin-off from #16228. Its changes let the the `aac_mode` field of `gnrc_netif_ipv6_t` be treated as flag field.
The members of the `net_gnrc_netif_aac` enum are updated accordingly. This way, it is possible for a net interface to use (for instance) both SLAAC and DHCPv6 for auto-adress configuration.

### Testing procedure

As this is curently more or less a refactoring, you can use the existing `gnrc` and unit tests should which should still be passing.

### Issues/PRs references

