### PR TITLE
sx126x: add support for multiple simultaneous variants

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -33,6 +33,27 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Whether there's only one variant of this driver at compile time or
+ * not.
+ */
+#define SX126X_SINGLE ((            \
+                          IS_USED(MODULE_SX1261) \
+                        + IS_USED(MODULE_SX1262) \
+                        + IS_USED(MODULE_SX1268) \
+                        + IS_USED(MODULE_LLCC68) \
+                        ) == 1)
+
+/**
+ * @brief   Variant of the SX126x driver.
+ */
+typedef enum {
+    SX126X_TYPE_SX1261,
+    SX126X_TYPE_SX1262,
+    SX126X_TYPE_SX1268,
+    SX126X_TYPE_LLCC68,
+} sx126x_type_t;
+
+/**
  * @brief   Device initialization parameters
  */
 typedef struct {
@@ -42,6 +63,7 @@ typedef struct {
     gpio_t busy_pin;                    /**< Busy pin */
     gpio_t dio1_pin;                    /**< Dio1 pin */
     sx126x_reg_mod_t regulator;         /**< Power regulator mode */
+    sx126x_type_t type;                 /**< Variant of sx126x */
 } sx126x_params_t;
 
 /**

--- a/drivers/sx126x/Kconfig
+++ b/drivers/sx126x/Kconfig
@@ -1,14 +1,44 @@
 # Copyright (c) 2021 Inria
+# Copyright (c) 2021 HAW Hamburg
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
-#
+
+menu "Driver sx126x"
+    depends on TEST_KCONFIG
 
 config MODULE_SX126X
-    bool "SX126X LoRa Sub-GHz radio"
-    depends on HAS_PERIPH_GPIO_IRQ
-    depends on PACKAGE_DRIVER_SX126X
-    depends on TEST_KCONFIG
-    select MODULE_PERIPH_GPIO_IRQ
+    bool
+    select PACKAGE_DRIVER_SX126X
     select MODULE_IOLIST
+
+if HAS_PERIPH_SPI && HAS_PERIPH_GPIO_IRQ
+
+config MODULE_SX1261
+    bool "SX1261"
+    select MODULE_SX126X
+    select MODULE_PERIPH_GPIO
+    select MODULE_PERIPH_GPIO_IRQ
+
+config MODULE_SX1262
+    bool "SX1262"
+    select MODULE_SX126X
+    select MODULE_PERIPH_GPIO
+    select MODULE_PERIPH_GPIO_IRQ
+
+config MODULE_SX1268
+    bool "SX1268"
+    select MODULE_SX126X
+    select MODULE_PERIPH_GPIO
+    select MODULE_PERIPH_GPIO_IRQ
+
+config MODULE_LLCC68
+    bool "LLCC68"
+    select MODULE_SX126X
+    select MODULE_PERIPH_GPIO
+    select MODULE_PERIPH_GPIO_IRQ
+
+endif
+
+endmenu

--- a/drivers/sx126x/include/sx126x_internal.h
+++ b/drivers/sx126x/include/sx126x_internal.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_sx126x_internal SX1261/2/8 and LLCC68 internal functions
+ * @ingroup     drivers_sx126x
+ * @brief       Internal functions for the SX1261/2/8 and LLCC68
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      José I. Alamos <jose.alamos@haw-hamburg.de>
+ */
+#ifndef SX126X_INTERNAL_H
+#define SX126X_INTERNAL_H
+
+#include <assert.h>
+#include "sx126x.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Check whether the device model is sx1261
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ *
+ * @retval    true if the device is sx1261
+ * @retval    false otherwise
+ */
+static inline bool sx126x_is_sx1261(sx126x_t *dev)
+{
+    assert(dev);
+    if (SX126X_SINGLE) {
+        return IS_USED(MODULE_SX1261);
+    }
+    else {
+        return dev->params->type == SX126X_TYPE_SX1261;
+    }
+}
+
+/**
+ * @brief   Check whether the device model is sx1262
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ *
+ * @retval    true if the device is sx1262
+ * @retval    false otherwise
+ */
+static inline bool sx126x_is_sx1262(sx126x_t *dev)
+{
+    assert(dev);
+    if (SX126X_SINGLE) {
+        return IS_USED(MODULE_SX1262);
+    }
+    else {
+        return dev->params->type == SX126X_TYPE_SX1262;
+    }
+}
+
+/**
+ * @brief   Check whether the device model is llcc68
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ *
+ * @retval    true if the device is llcc68
+ * @retval    false otherwise
+ */
+static inline bool sx126x_is_llcc68(sx126x_t *dev)
+{
+    assert(dev);
+    if (SX126X_SINGLE) {
+        return IS_USED(MODULE_LLCC68);
+    }
+    else {
+        return dev->params->type == SX126X_TYPE_LLCC68;
+    }
+}
+
+/**
+ * @brief   Check whether the device model is sx1268
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ *
+ * @retval    true if the device is sx1268
+ * @retval    false otherwise
+ */
+static inline bool sx126x_is_sx1268(sx126x_t *dev)
+{
+    assert(dev);
+    if (SX126X_SINGLE) {
+        return IS_USED(MODULE_SX1268);
+    }
+    else {
+        return dev->params->type == SX126X_TYPE_SX1268;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SX126X_INTERNAL_H */
+/** @} */

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -57,11 +57,26 @@ extern "C" {
 #define SX126X_PARAM_REGULATOR              SX126X_REG_MODE_DCDC
 #endif
 
-#define SX126X_PARAMS             { .spi = SX126X_PARAM_SPI,      \
-                                    .nss_pin = SX126X_PARAM_SPI_NSS,  \
+#ifndef SX126X_PARAM_TYPE
+#    if IS_USED(MODULE_SX1261)
+#        define SX126X_PARAM_TYPE SX126X_TYPE_SX1261
+#    elif IS_USED(MODULE_SX1262)
+#        define SX126X_PARAM_TYPE SX126X_TYPE_SX1262
+#    elif IS_USED(MODULE_SX1268)
+#        define SX126X_PARAM_TYPE SX126X_TYPE_SX1268
+#    elif IS_USED(MODULE_LLCC68)
+#        define SX126X_PARAM_TYPE SX126X_TYPE_LLCC68
+#    else
+#        error "You should select at least one of the SX126x variants."
+#    endif
+#endif
+
+#define SX126X_PARAMS             { .spi = SX126X_PARAM_SPI,            \
+                                    .nss_pin = SX126X_PARAM_SPI_NSS,    \
                                     .reset_pin = SX126X_PARAM_RESET,    \
                                     .busy_pin = SX126X_PARAM_BUSY,      \
                                     .dio1_pin = SX126X_PARAM_DIO1,      \
+                                    .type     = SX126X_PARAM_TYPE,      \
                                     .regulator = SX126X_PARAM_REGULATOR }
 /**@}*/
 

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -48,6 +48,27 @@
 #define CONFIG_SX126X_RAMP_TIME_DEFAULT         (SX126X_RAMP_10_US)
 #endif
 
+const sx126x_pa_cfg_params_t sx1262_pa_cfg = {
+    .pa_duty_cycle = 0x02,
+    .hp_max = 0x02,
+    .device_sel = 0x00,
+    .pa_lut = 0x01
+};
+
+const sx126x_pa_cfg_params_t sx1268_pa_cfg = {
+    .pa_duty_cycle = 0x04,
+    .hp_max = 0x06,
+    .device_sel = 0x00,
+    .pa_lut = 0x01
+};
+
+const sx126x_pa_cfg_params_t sx1261_pa_cfg = {
+    .pa_duty_cycle = 0x04,
+    .hp_max = 0x00,
+    .device_sel = 0x01,
+    .pa_lut = 0x01
+};
+
 void sx126x_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index)
 {
     netdev_t *netdev = (netdev_t *)dev;
@@ -84,31 +105,13 @@ static void sx126x_init_default_config(sx126x_t *dev)
      * and are optimal for a TX output power of 14dBm.
      */
     if (IS_USED(MODULE_LLCC68) || IS_USED(MODULE_SX1262)) {
-        sx126x_pa_cfg_params_t pa_cfg = {
-            .pa_duty_cycle = 0x02,
-            .hp_max = 0x02,
-            .device_sel = 0x00,
-            .pa_lut = 0x01
-        };
-        sx126x_set_pa_cfg(dev, &pa_cfg);
+        sx126x_set_pa_cfg(dev, &sx1262_pa_cfg);
     }
     else if (IS_USED(MODULE_SX1268)) {
-        sx126x_pa_cfg_params_t pa_cfg = {
-            .pa_duty_cycle = 0x04,
-            .hp_max = 0x06,
-            .device_sel = 0x00,
-            .pa_lut = 0x01
-        };
-        sx126x_set_pa_cfg(dev, &pa_cfg);
+        sx126x_set_pa_cfg(dev, &sx1268_pa_cfg);
     }
     else { /* IS_USED(MODULE_SX1261) */
-        sx126x_pa_cfg_params_t pa_cfg = {
-            .pa_duty_cycle = 0x04,
-            .hp_max = 0x00,
-            .device_sel = 0x01,
-            .pa_lut = 0x01
-        };
-        sx126x_set_pa_cfg(dev, &pa_cfg);
+        sx126x_set_pa_cfg(dev, &sx1261_pa_cfg);
     }
     sx126x_set_tx_params(dev, CONFIG_SX126X_TX_POWER_DEFAULT, CONFIG_SX126X_RAMP_TIME_DEFAULT);
 

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -28,6 +28,7 @@
 #include "sx126x_driver.h"
 #include "sx126x.h"
 #include "sx126x_params.h"
+#include "sx126x_internal.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -104,13 +105,13 @@ static void sx126x_init_default_config(sx126x_t *dev)
      * Values used here comes from the datasheet, section 13.1.14 SetPaConfig
      * and are optimal for a TX output power of 14dBm.
      */
-    if (IS_USED(MODULE_LLCC68) || IS_USED(MODULE_SX1262)) {
+    if (sx126x_is_llcc68(dev) || sx126x_is_sx1262(dev)) {
         sx126x_set_pa_cfg(dev, &sx1262_pa_cfg);
     }
-    else if (IS_USED(MODULE_SX1268)) {
+    else if (sx126x_is_sx1268(dev)) {
         sx126x_set_pa_cfg(dev, &sx1268_pa_cfg);
     }
-    else { /* IS_USED(MODULE_SX1261) */
+    else { /* sx126x_is_sx1261(dev) */
         sx126x_set_pa_cfg(dev, &sx1261_pa_cfg);
     }
     sx126x_set_tx_params(dev, CONFIG_SX126X_TX_POWER_DEFAULT, CONFIG_SX126X_RAMP_TIME_DEFAULT);

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -29,15 +29,13 @@
 
 #include "sx126x.h"
 #include "sx126x_netdev.h"
+#include "sx126x_internal.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#if IS_USED(MODULE_LLCC68)
-#define SX126X_MAX_SF       LORA_SF11
-#else
-#define SX126X_MAX_SF       LORA_SF12
-#endif
+const uint8_t llcc68_max_sf = LORA_SF11;
+const uint8_t sx126x_max_sf = LORA_SF12;
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
@@ -357,7 +355,10 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     case NETOPT_SPREADING_FACTOR:
         assert(len <= sizeof(uint8_t));
         uint8_t sf = *((const uint8_t *)val);
-        if ((sf < LORA_SF6) || (sf > SX126X_MAX_SF)) {
+        const uint8_t max_sf = sx126x_is_llcc68(dev)
+                               ? llcc68_max_sf
+                               : sx126x_max_sf;
+        if ((sf < LORA_SF6) || (sf > max_sf)) {
             res = -EINVAL;
             break;
         }

--- a/tests/driver_sx126x/app.config.test
+++ b/tests/driver_sx126x/app.config.test
@@ -1,7 +1,6 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
-CONFIG_MODULE_SX126X=y
-CONFIG_PACKAGE_DRIVER_SX126X=y
+CONFIG_MODULE_SX1261=y
 
 CONFIG_MODULE_SHELL=y
 CONFIG_MODULE_SHELL_COMMANDS=y


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds support for multiple simultaneous sx126x variants running in the same binary, while at the same time keeping all compile time optimizations.

This idea can be used as a base for #16579, in which a periph version of the driver and an external might be used at the same time.

This PR reduces already ~12 bytes for sx1261 because the compile is not always able to put the pa_cfg structure in ROM (see https://github.com/RIOT-OS/RIOT/commit/f635a102f62cec0408cfb0b579b4e7414dad6fec). After the last commit, this remains unchanged.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The easiest way to test it is to select the corresponding driver version in periph_conf.h and compile it with an extra module. E.g
```
USEMODULE="sx1261 llcc68" make flash term
```
And make sure everything works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#16579
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
