### PR TITLE
examples/gnrc_networking: move udp command to shell commands

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -13,17 +13,14 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Activate ICMPv6 error messages
 USEMODULE += gnrc_icmpv6_error
-# Specify the mandatory networking modules for IPv6 and UDP
+# Specify the mandatory networking module for a IPv6 routing node
 USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_udp
 # Add a routing protocol
 USEMODULE += gnrc_rpl
 USEMODULE += auto_init_gnrc_rpl
-# This application dumps received packets to STDIO using the pktdump module
-USEMODULE += gnrc_pktdump
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
-USEMODULE += netutils
+USEMODULE += gnrc_udp_cmd
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/examples/gnrc_networking/main.c
+++ b/examples/gnrc_networking/main.c
@@ -26,13 +26,6 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern int udp_cmd(int argc, char **argv);
-
-static const shell_command_t shell_commands[] = {
-    { "udp", "send data over UDP and listen on UDP ports", udp_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* we need a message queue for the thread running the shell in order to
@@ -43,7 +36,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -66,6 +66,7 @@ PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_stats
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc
 PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
+PSEUDOMODULES += gnrc_udp_cmd
 PSEUDOMODULES += gnrc_sock_async
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -260,6 +260,10 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
     USEMODULE += netutils
   endif
 
+  ifneq (,$(gnrc_udp_cmd,$(USEMODULE)))
+    USEMODULE += netutils
+  endif
+
   ifneq (,$(filter nimble_netif,$(USEMODULE)))
     USEMODULE += nimble_scanner
     USEMODULE += nimble_scanlist

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -366,6 +366,11 @@ ifneq (,$(filter gnrc_udp,$(USEMODULE)))
   USEMODULE += udp
 endif
 
+ifneq (,$(filter gnrc_udp_cmd,$(USEMODULE)))
+  USEMODULE += gnrc_udp
+  USEMODULE += gnrc_pktdump
+endif
+
 ifneq (,$(filter gnrc_tcp,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_tcp
   USEMODULE += gnrc_nettype_tcp

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -35,6 +35,9 @@ endif
 ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   SRC += sc_gnrc_netif.c
 endif
+ifneq (,$(filter gnrc_udp_cmd,$(USEMODULE)))
+  SRC += sc_gnrc_udp.c
+endif
 ifneq (,$(filter netstats_neighbor,$(USEMODULE)))
   SRC += sc_netstats_nb.c
 endif

--- a/sys/shell/commands/sc_gnrc_udp.c
+++ b/sys/shell/commands/sc_gnrc_udp.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     examples
+ * @ingroup     sys_shell_commands
  * @{
  *
  * @file
@@ -41,7 +41,7 @@ static gnrc_netreg_entry_t server =
                         GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                    KERNEL_PID_UNDEF);
 
-static void send(char *addr_str, char *port_str, char *data, unsigned int num,
+static void send(char *addr_str, const char *port_str, const void *data, size_t num,
                  unsigned int delay)
 {
     netif_t *netif;
@@ -149,7 +149,7 @@ static void stop_server(void)
     puts("Success: stopped UDP server");
 }
 
-int udp_cmd(int argc, char **argv)
+int _gnrc_udp_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         printf("usage: %s [send|server]\n", argv[0]);

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -203,6 +203,10 @@ extern int _cryptoauth(int argc, char **argv);
 extern int _bootloader_handler(int argc, char **argv);
 #endif
 
+#ifdef MODULE_GNRC_UDP_CMD
+extern int _gnrc_udp_cmd(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
     {"version", "Prints current RIOT_VERSION", _version_handler},
@@ -295,6 +299,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_STATS
     {"6lo_frag", "6LoWPAN fragment statistics", _gnrc_6lo_frag_stats },
+#endif
+#ifdef MODULE_GNRC_UDP_CMD
+    { "udp", "send data over UDP and listen on UDP ports", _gnrc_udp_cmd },
 #endif
 #ifdef MODULE_SAUL_REG
     {"saul", "interact with sensors and actuators using SAUL", _saul },


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `udp` command is a valuable debugging tool that is also useful outside of the gnrc_networking example.

To enable easy sending of udp messages in other applications during development, move the `udp` command to the shell module and introduce the `gnrc_udp_cmd` pseudo-module to enable it.

### Testing procedure

The `udp` command is still present in the `gnrc_networking` example.

But it's now also possible to add

    USEMODULE += gnrc_udp_cmd

to e.g. `examples/gnrc_border_router` and have a simple test for one-way communication available there. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
