### PR TITLE
drivers/sx126x : r/NETOPT_RX_TIMEOUT/NETOPT_RX_SYMBOL_TIMEOUT

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -21,6 +21,8 @@
 #ifndef SX126X_H
 #define SX126X_H
 
+#include <assert.h>
+
 #include "sx126x_driver.h"
 
 #include "net/netdev.h"
@@ -96,6 +98,23 @@ void sx126x_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index);
  * @return                  0 on success
  */
 int sx126x_init(sx126x_t *dev);
+
+/**
+ * @brief   Converts symbol value to time in milliseconds.
+ *
+ * @param[in] dev                      Device descriptor of the driver
+ * @param[in] symbols                  Symbols
+ *
+ * @return Time for symbol(s) in milliseconds
+ */
+static inline int sx126x_symbol_to_msec(sx126x_t *dev, uint16_t symbols)
+{
+    assert(dev && (dev->mod_params.bw <= SX126X_LORA_BW_500) && \
+           (dev->mod_params.bw >= SX126X_LORA_BW_125));
+
+    /* Refer section 6.1.4 LoRa Time-on-Air in SX1268 datasheet */
+    return (symbols * (1 << (dev->mod_params.sf + 7 - dev->mod_params.bw)) / 1000);
+}
 
 /**
  * @brief   Gets the channel RF frequency.

--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -77,7 +77,7 @@ typedef struct {
     sx126x_pkt_params_lora_t pkt_params;    /**< Lora packet parameters */
     sx126x_mod_params_lora_t mod_params;    /**< Lora modulation parameters */
     uint32_t channel;                       /**< Current channel frequency (in Hz) */
-    uint32_t rx_timeout;                    /**< RX timeout in ms */
+    uint8_t rx_timeout;                     /**< Rx Timeout in terms of symbols */
 } sx126x_t;
 
 /**

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -203,6 +203,9 @@ int sx126x_init(sx126x_t *dev)
         DEBUG("[sx126x] init: cmd status %d\n", radio_status.cmd_status);
     }
 
+    /* Radio Rx timeout timer stopped on preamble detection */
+    sx126x_stop_timer_on_preamble(dev, true);
+
     return res;
 }
 

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -288,8 +288,9 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
     case NETOPT_STATE_RX:
         DEBUG("[sx126x] netdev: set NETOPT_STATE_RX state\n");
         sx126x_cfg_rx_boosted(dev, true);
-        if (dev->rx_timeout != 0) {
-            sx126x_set_rx(dev, dev->rx_timeout);
+        int _timeout = (sx126x_symbol_to_msec(dev, dev->rx_timeout));
+        if (_timeout != 0) {
+            sx126x_set_rx(dev, _timeout);
         }
         else {
             sx126x_set_rx(dev, SX126X_RX_SINGLE_MODE);
@@ -386,10 +387,10 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         sx126x_set_lora_crc(dev, *((const netopt_enable_t *)val) ? true : false);
         return sizeof(netopt_enable_t);
 
-    case NETOPT_RX_TIMEOUT:
-        assert(len <= sizeof(uint32_t));
-        dev->rx_timeout = *(const uint32_t *)val;
-        return sizeof(uint32_t);
+    case NETOPT_RX_SYMBOL_TIMEOUT:
+        assert(len <= sizeof(uint8_t));
+        dev->rx_timeout = *(const uint8_t *)val;
+        return sizeof(uint8_t);
 
     case NETOPT_TX_POWER:
         assert(len <= sizeof(int16_t));


### PR DESCRIPTION
### Contribution description

This PR  adds `NETOPT_RX_SYMBOL_TIMEOUT` which is required by the sx126x radio and also removes `NETOPT_RX_TIMEOUT` which is no longer required. The PR has been made as per discussions in thread #16579 , which  would integrate a `periph` version of `sx1261` radio driver used in STMWL55JC SoC.

Forced Radio Rx timeout timer to stop on preamble detection, else it breaks the current stack.

### Testing procedure

The changes were already tested in #16579 using `Nucleo-WL55JC` and logs can be found in its description.

### Issues/PRs references
#16579
Depends on #16604