### PR TITLE
pkg/nimble/netif: fix randomized conn intervals

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -42,6 +42,7 @@ extern "C" {
 typedef struct {
     struct ble_l2cap_chan *coc;     /**< l2cap context as exposed by NimBLE */
     uint16_t gaphandle;             /**< GAP handle exposed by NimBLE */
+    uint16_t itvl;                  /**< currently used connection interval */
     uint16_t state;                 /**< the current state of the context */
     uint8_t addr[BLE_ADDR_LEN];     /**< BLE address of connected peer
                                          (in network byte order) */
@@ -181,10 +182,10 @@ void nimble_netif_conn_free(int handle, uint8_t *addr);
  *
  * @param[in] handle        connection handle
  *
- * @return  used connection interval on success, multiples of 1.25ms
+ * @return  used connection interval in milliseconds on success
  * @return  0 if unable to get connection interval
  */
-uint16_t nimble_netif_conn_get_itvl(int handle);
+uint16_t nimble_netif_conn_get_itvl_ms(int handle);
 
 /**
  * @brief   Check if the given connection interval is used, taking the minimal
@@ -199,17 +200,6 @@ uint16_t nimble_netif_conn_get_itvl(int handle);
  * @return  false if given interval is not used
  */
 bool nimble_netif_conn_itvl_used(uint16_t itvl, int skip_handle);
-
-/**
- * @brief   Check if connection interval used by the given connection is valid
- *
- * @param[in] handle        connection to verify
- *
- * @return  true if the connection interval of the given connection collides
- *          with the connection interval of another BLE connection
- * @return  false if the connection interval of the given connection is valid
- */
-bool nimble_netif_conn_itvl_invalid(int handle);
 
 /**
  * @brief   Generate a pseudorandom connection interval from the given range


### PR DESCRIPTION
### Contribution description
This is a bug fix for the changes introduced in #16372.

It turns out, that once a node maintains multiple connections, its state can break after a GAP-slave node rejects a new incoming connection by closing it in the `GAP` event callback: 
- the master node opens a GAP connection
- the slave node triggers the `_on_gap_slave_evt` callback, Here it did check the connection interval and initiated a connection teardown if the iinterval was not spaced sufficiently
- in the mean time, the master node did not know about the connection teardown, yet, and creates the L2CAP channel
- this leads to the `_on_l2cap_server_evt()` event callback being triggered on the slave, despite the fact that it already triggered the connection to be closed
--> the slave node ends up with broken state and hangs

This PR fixes this behavior by checking the connection interval spacing only after the L2CAP channel was created. This keeps the slaves state consistent at all time.

Included in this fix is also a code optimization for `nimble_netif_conn`, where the connection interval is now simply buffered inside the `nimble_netif_conn_t` struct, saving significant lookup overhead and making the code better readable.

### Testing procedure
While building with `NIMBLE_NETIF_CONN_ITVL_SPACING >= 1`:
Build a network with at least 3 nodes, opening a BLE connection between two of them, and then connect a third node (as master) so that one of the other nodes is the connection slave. Close and reopen the latter connection until the new connection is rejected due to invalid connection spacing by the slave node. When repeating this multiple times, the slave node should not fail...

OR:

trust me that it works :-) Here is some evidence. I have been running multiple experiments including this fix with 15 IP over BLE 
nodes, encountering the above situation:

Here is one of these occurrences when node `nrf52dk-3` tries to connect to `nrf52dk-1` and the connection is rejected due to invalid connection interval spacing:
```
1625066387.467399;nrf52dk-3;[mc] INIT MASTER 0 nrf52dk-1
1625066388.270845;nrf52dk-1;[mc] INIT_SLAVE 2 nrf52dk-3
1625066388.275944;nrf52dk-1;netif: l2cap_slave_conn: itvl in use, closing now
1625066388.403657;nrf52dk-3;[mc] CONNECTED_MASTER 0 nrf52dk-1
1625066388.404199;nrf52dk-1;[mc] ABORT_SLAVE 2 nrf52dk-3
1625066388.420467;nrf52dk-3;[mc] CLOSED_MASTER 0 nrf52dk-1
```
At the same time I can veriify, that (a) the experiment finiished successful, without any node failing, and that (b) the connection interval spacing did function as expected:
```
Connection Interval Summary:
      nrf52dk-1 min spacing:  4 itvls:[65, 71, 75]
      nrf52dk-2 min spacing:  3 itvls:[60, 65, 68]
      nrf52dk-3 min spacing:  - itvls:[60]
      nrf52dk-4 min spacing:  - itvls:[77]
      nrf52dk-5 min spacing:  2 itvls:[65, 75, 77]
      nrf52dk-6 min spacing:  3 itvls:[65, 72, 75]
      nrf52dk-7 min spacing:  - itvls:[71]
      nrf52dk-8 min spacing:  - itvls:[60]
      nrf52dk-9 min spacing:  - itvls:[65]
     nrf52dk-10 min spacing:  - itvls:[68]
   nrf52840dk-6 min spacing:  - itvls:[63]
   nrf52840dk-7 min spacing:  2 itvls:[61, 63, 72]
   nrf52840dk-8 min spacing: 10 itvls:[61, 71]
   nrf52840dk-9 min spacing:  5 itvls:[60, 65, 75]
  nrf52840dk-10 min spacing:  - itvls:[71]
```

### Issues/PRs references
Fixes a bug introduces with #16372
