### PR TITLE
pkg/nimble: configure BLE_LL_INIT_SLOT_SIZE to 1

### DIFF
--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -114,6 +114,7 @@ ifneq (,$(filter nimble_netif,$(USEMODULE)))
   # optimize the NimBLE controller for IP traffic
   ifneq (,$(filter nimble_controller,$(USEMODULE)))
     CFLAGS += -DMYNEWT_VAL_BLE_LL_MAX_PKT_SIZE=251
+    CFLAGS += -DMYNEWT_VAL_BLE_LL_CONN_INIT_SLOTS=1
     CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1
   endif
 endif


### PR DESCRIPTION
### Contribution description
NimBLE offers the option to configure a minimum slotsize that is used when scheduling connection events. I means that a minimum of `SLOT_SIZE * 1,25ms` slot will be reserved for every connection event in the controller, even if the event itself will take less time. The default value for NimBLE is `4`, making the controller block a 5ms for every connection event. Now when running multiple connections in parallel, the connection events will more likely overloap and be skipped, the larger this slot size is. Setting this value to its minimum value of `1` does greatly improve link layer performance for multi-hop (multiple connections per node) scenarios:

The impacts on the link layer are quite drastic, below plotted is the link layer packet delivery radio (PDR) for two runs of the same experiment (15 nodes, 1 to 3 hops in a tree topo, 14 nodes sending CoAP packets every 1s). For the first `BLE_LL_INIT_SLOTS` was configured to `1`, for the second run I configured it to its default value of `4`:
![non_fig_ll_pdr_slotsize](https://user-images.githubusercontent.com/620834/124092963-afb7cb80-da57-11eb-8617-4b9b2a3250fb.png)

Reducing the slot size to `1` increases the link layer reliability by more than 5%!

Looking at the link layer PDR per channel, this improvement can also be observed:

`BLE_LL_INIT_SLOTS := 4`:
![em6_putnon_meshconn-rpl_1s1h39b_i90r110_20210701-085259_ll_pdr_pc](https://user-images.githubusercontent.com/620834/124093693-6156fc80-da58-11eb-99fb-86dd02943265.png)

`BLE_LL_INIT_SLOTS := 1`:
![em6_putnon_meshconn-rpl_1s1h39b_i90r110_20210630-171804_ll_pdr_pc](https://user-images.githubusercontent.com/620834/124093763-6fa51880-da58-11eb-9546-a022d66bc3e0.png)


### Testing procedure
Quickly verifying `gnrc_networking` with at least two BLE nodes would certainly not hurt, everything should still work as expected.

### Issues/PRs references
none
