### PR TITLE
pkg/nimble/netif: add nimble_netif_accept_direct()

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -254,6 +254,22 @@ int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
                         const struct ble_gap_adv_params *adv_params);
 
 /**
+ * @brief   Wait for an incoming connection from a specific peer, sending
+ *          directed advertisements (IND_DIR)
+ *
+ * @param[in] addr          BLE address of the target peer
+ * @param[in] timeout_ms    stop advertising after this time (in ms), set to
+ *                          BLE_HS_FOREVER to disable timeout
+ * @param[in] adv_params    advertising (timing) parameters to use
+ *
+ * @return  NIMBLE_NETIF_OK on success
+ * @return  NIMBLE_NETIF_BUSY if already advertising
+ * @return  NIMBLE_NETIF_NOMEM on insufficient connection memory
+ */
+int nimble_netif_accept_direct(const ble_addr_t *addr, uint32_t timeout_ms,
+                               const struct ble_gap_adv_params *adv_params);
+
+/**
  * @brief   Stop accepting incoming connections (stop advertising)
  * *
  * @return  NIMBLE_NETIF_OK on success

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -531,6 +531,11 @@ static int _on_gap_slave_evt(struct ble_gap_event *event, void *arg)
         case BLE_GAP_EVENT_CONN_UPDATE_REQ:
             /* nothing to do here */
             break;
+        case BLE_GAP_EVENT_ADV_COMPLETE: {
+            uint8_t addr[BLE_ADDR_LEN];
+            nimble_netif_conn_free(handle, addr);
+            _notify(handle, NIMBLE_NETIF_ACCEPT_STOP, addr);
+        }
         default:
             break;
     }
@@ -634,10 +639,10 @@ int nimble_netif_close(int handle)
     return NIMBLE_NETIF_OK;
 }
 
-int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
-                        const struct ble_gap_adv_params *adv_params)
+static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
+                   uint32_t timeout,
+                   const struct ble_gap_adv_params *adv_params)
 {
-    assert(ad);
     assert(adv_params);
 
     int handle;
@@ -651,16 +656,38 @@ int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
     }
 
     /* set advertisement data */
-    res = ble_gap_adv_set_data(ad, (int)ad_len);
-    assert(res == 0);
+    if (ad != NULL) {
+        res = ble_gap_adv_set_data(ad, (int)ad_len);
+        assert(res == 0);
+    }
+    /* remember address if applicable */
+    if (addr) {
+        nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
+        bluetil_addr_swapped_cp(addr->val, conn->addr);
+    }
+
     /* remember context and start advertising */
-    res = ble_gap_adv_start(nimble_riot_own_addr_type, NULL, BLE_HS_FOREVER,
+    res = ble_gap_adv_start(nimble_riot_own_addr_type, addr, timeout,
                             adv_params, _on_gap_slave_evt, (void *)handle);
     assert(res == 0);
 
     _notify(handle, NIMBLE_NETIF_ACCEPTING, _netif.l2addr);
 
     return NIMBLE_NETIF_OK;
+}
+
+int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
+                        const struct ble_gap_adv_params *adv_params)
+{
+    assert(ad != NULL);
+    assert(ad_len > 0);
+    return _accept(ad, ad_len, NULL, BLE_HS_FOREVER, adv_params);
+}
+
+int nimble_netif_accept_direct(const ble_addr_t *addr, uint32_t timeout,
+                              const struct ble_gap_adv_params *adv_params)
+{
+    return _accept(NULL, 0, addr, timeout, adv_params);
 }
 
 int nimble_netif_accept_stop(void)


### PR DESCRIPTION
### Contribution description
This PR extends `nimble_netif` to support connecting to other devices by sending directed advertising packets (`DIRECT_IND`). This is a special type of advertising packets has as payload only a target BLE address. These packets are ignored by all other nodes except the one directly addressed by this included address. 

Using these advertisements is useful for e.g. reconnecting to a specific node after a connection loss... I am using this in a more advanced BLE connection manager (PR will follow soon).

This PR also extends the `ble` shell command to expose this new functionality -> use `ble adv direct xx:xx:xx:xx:xx:xx` to trigger directed advertisements. But note: you won't be able to see them e.g. on the nrfConnect mobile app, if the given address does not match your scanning device...

### Testing procedure
- flash `gnrc_networking` to any two supported BLE devices, for `nrf52840`-based nodes make sure you enable `nimble_netif`...
- get the BLE address of node A -> `ble info`
- let node B send directed advertisements: `ble adv direct ADD_OF_NODE_A`
- start scanning with node A _> `ble scan`
-> you should see the directed advertising packets from node B, they should have type `DIRECT_IND_HD`

Example:
```
A:
2021-07-01 11:27:43,631 # ble info
2021-07-01 11:27:43,637 # Own Address: CE:57:7A:19:D7:37 -> [FE80::CE57:7AFF:FE19:D737]

B:
> ble adv direct CE:57:7A:19:D7:37
2021-07-01 11:28:06,211 # ble adv direct CE:57:7A:19:D7:37
2021-07-01 11:28:06,213 # DBG: direct adv
2021-07-01 11:28:06,217 # success: started to send directed advertisements

A:
> ble scan
2021-07-01 11:28:15,856 # ble scan
2021-07-01 11:28:15,858 # scanning (for 500ms) ...
2021-07-01 11:28:16,359 # done
...
2021-07-01 11:28:16,432 # [ 7] c9:88:95:ba:ec:98 (RANDOM) [DIRECT_IND_HD] "undefined", adv_msg_cnt: 3, adv_int: 103831us, last_rssi: -25
....
> ble connect 7
2021-07-01 11:28:47,693 # ble connect 7
2021-07-01 11:28:47,698 # initiated connection procedure with C9:88:95:BA:EC:98
> 2021-07-01 11:28:47,809 # event: handle 0 -> CONNECTED as MASTER (C9:88:95:BA:EC:98)

B:
> 2021-07-01 11:28:47,759 # event: handle 0 -> CONNECTED as SLAVE (CE:57:7A:19:D7:37)
```

### Issues/PRs references
None