### PR TITLE
cpu/sam0/i2c: Handle read with I2C_NOSTOP flag

### DIFF
--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -262,8 +262,14 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr,
         return ret;
     }
     /* Ensure all bytes has been read */
-    while ((bus(dev)->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk)
-           != BUSSTATE_IDLE) {}
+    if (flags & I2C_NOSTOP) {
+        while ((bus(dev)->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk)
+                != BUSSTATE_OWNER) {}
+    }
+    else {
+        while ((bus(dev)->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk)
+                != BUSSTATE_IDLE) {}
+    }
     /* return number of bytes sent */
     return 0;
 }


### PR DESCRIPTION

### Contribution description

When using the I2C_NOSTOP flag the bus should remain in control.
The current check assumes it must go to idle when reading.
This adds a condition checks if the nostop flag is active
and expects the bus status to be the owner of the bus.

### Testing procedure

Connect a driver to a sam* based i2c bus and run `tests/periph_i2c`

```
i2c_acquire 0
i2c_read_byte 0 <my_device_address> 4
```

On master this will lockup, with this PR it should give one byte back.  Please note that other reads that don't contain a `I2C_NOSTART` (0x08) may cause errors.

... or I can just post the result outputs.
### Issues/PRs references

This was an error on the [PHiLIP based HiL CI](https://hil.riot-os.org/results/nightly/latest/saml10-xpro/tests_periph_i2c/log#s1-s4-t1) for a long time, I finally have time to check it.