### PR TITLE
sys/shell/commands: gnrc_icmpv6_echo: use msg_avail()

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -132,7 +132,7 @@ finish:
     res = _finish(&data);
     gnrc_netreg_unregister(GNRC_NETTYPE_ICMPV6, &data.netreg);
     for (unsigned i = 0;
-         i < cib_avail(&thread_get_active()->msg_queue);
+         i < (unsigned)msg_avail();
          i++) {
         msg_t msg;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `gnrc_icmpv6_echo` implementation directly used a thread_t field where it could use public API.

Previously, it was calling `cib_avail(thread_get_active()->msg_queue)`. `msg_avail()` adds an extra check, which is always true when there actually is a msg_queue, which the previous code assumes. Under that assumption, `msg_avail()` casted to unsigned is equivalent to the previous call.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
