### PR TITLE
unittests/tests-ipv?_addr: fix some uninitialized variable bugs [backport 2021.07]

### DIFF
--- a/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c
+++ b/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c
@@ -54,7 +54,7 @@ static void test_ipv4_addr_to_str__addr_NULL(void)
 
 static void test_ipv4_addr_to_str__result_NULL(void)
 {
-    ipv4_addr_t a;
+    ipv4_addr_t a = {0};
 
     TEST_ASSERT_NULL(ipv4_addr_to_str(NULL, &a, IPV4_ADDR_MAX_STR_LEN));
 }

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -826,7 +826,7 @@ static void test_ipv6_addr_to_str__addr_NULL(void)
 
 static void test_ipv6_addr_to_str__result_NULL(void)
 {
-    ipv6_addr_t a;
+    ipv6_addr_t a = {0};
 
     TEST_ASSERT_NULL(ipv6_addr_to_str(NULL, &a, IPV6_ADDR_MAX_STR_LEN));
 }


### PR DESCRIPTION
# Backport of #16614

### Contribution description

prevents gcc-11 error:

```
In file included from /home/kaspar/src/riot/sys/include/embUnit/embUnit.h:47,
                 from /home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:17:
/home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c: In function ‘test_ipv4_addr_to_str__result_NULL’:
/home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:59:22: error: ‘a’ may be used uninitialized [-Werror=maybe-uninitialized]
   59 |     TEST_ASSERT_NULL(ipv4_addr_to_str(NULL, &a, IPV4_ADDR_MAX_STR_LEN));
/home/kaspar/src/riot/sys/include/embUnit/AssertImpl.h:70:47: note: in definition of macro ‘TEST_ASSERT_NULL’
   70 |         __typeof__(pointer_) ____pointer__ = (pointer_); \
      |                                               ^~~~~~~~
In file included from /home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:20:
/home/kaspar/src/riot/sys/include/net/ipv4/addr.h:72:7: note: by argument 2 of type ‘const ipv4_addr_t *’ to ‘ipv4_addr_to_str’ declared here
   72 | char *ipv4_addr_to_str(char *result, const ipv4_addr_t *addr, uint8_t result_len);
      |       ^~~~~~~~~~~~~~~~
/home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:57:17: note: ‘a’ declared here
   57 |     ipv4_addr_t a;
      |                 ^
cc1: all warnings being treated as errors
In file included from /home/kaspar/src/riot/sys/include/embUnit/embUnit.h:47,
                 from /home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:17:
/home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c: In function ‘test_ipv4_addr_to_str__result_NULL’:
/home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:59:22: error: ‘a’ may be used uninitialized [-Werror=maybe-uninitialized]
   59 |     TEST_ASSERT_NULL(ipv4_addr_to_str(NULL, &a, IPV4_ADDR_MAX_STR_LEN));
/home/kaspar/src/riot/sys/include/embUnit/AssertImpl.h:70:47: note: in definition of macro ‘TEST_ASSERT_NULL’
   70 |         __typeof__(pointer_) ____pointer__ = (pointer_); \
      |                                               ^~~~~~~~
In file included from /home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:20:
/home/kaspar/src/riot/sys/include/net/ipv4/addr.h:72:7: note: by argument 2 of type ‘const ipv4_addr_t *’ to ‘ipv4_addr_to_str’ declared here
   72 | char *ipv4_addr_to_str(char *result, const ipv4_addr_t *addr, uint8_t result_len);
      |       ^~~~~~~~~~~~~~~~
/home/kaspar/src/riot/tests/unittests/tests-ipv4_addr/tests-ipv4_addr.c:57:17: note: ‘a’ declared here
   57 |     ipv4_addr_t a;
      |                 ^
cc1: all warnings being treated as errors
```
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
