### PR TITLE
tests/unittests/tests-ipv6_hdr: fix too short ipv6_hdr_t allocations

### DIFF
--- a/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
+++ b/tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c
@@ -41,7 +41,7 @@
 
 static void test_ipv6_hdr_set_version(void)
 {
-    uint8_t val[] = { TEST_UINT8 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8 };
 
     ipv6_hdr_set_version((ipv6_hdr_t *)val);
 
@@ -58,7 +58,7 @@ static void test_ipv6_hdr_set_version(void)
 
 static void test_ipv6_hdr_get_version(void)
 {
-    uint8_t val[] = { TEST_UINT8 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8 };
 
     /*
      * Header format:
@@ -79,7 +79,7 @@ static void test_ipv6_hdr_is_ipv6_hdr__false(void)
      * |  6 |
      * +----+----
      */
-    uint8_t val[] = { 0 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { 0 };
 
     TEST_ASSERT(!ipv6_hdr_is((ipv6_hdr_t *)val));
 }
@@ -93,14 +93,14 @@ static void test_ipv6_hdr_is_ipv6_hdr__true(void)
      * |  6 |
      * +----+----
      */
-    uint8_t val[] = { 0x60 | (TEST_UINT8 & 0x0f) };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { 0x60 | (TEST_UINT8 & 0x0f) };
 
     TEST_ASSERT(ipv6_hdr_is((ipv6_hdr_t *)val));
 }
 
 static void test_ipv6_hdr_set_tc(void)
 {
-    uint8_t val[] = { TEST_UINT8, 0 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8, 0 };
 
     ipv6_hdr_set_tc((ipv6_hdr_t *)val, OTHER_BYTE);
 
@@ -117,7 +117,7 @@ static void test_ipv6_hdr_set_tc(void)
 
 static void test_ipv6_hdr_set_tc_ecn(void)
 {
-    uint8_t val[] = { TEST_UINT8 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8 };
 
     ipv6_hdr_set_tc_ecn((ipv6_hdr_t *)val, OTHER_BYTE);
 
@@ -138,7 +138,7 @@ static void test_ipv6_hdr_set_tc_ecn(void)
 
 static void test_ipv6_hdr_set_tc_dscp(void)
 {
-    uint8_t val[] = { TEST_UINT8, 0 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8, 0 };
 
     ipv6_hdr_set_tc_dscp((ipv6_hdr_t *)val, OTHER_BYTE);
 
@@ -160,7 +160,7 @@ static void test_ipv6_hdr_set_tc_dscp(void)
 
 static void test_ipv6_hdr_get_tc(void)
 {
-    uint8_t val[] = { TEST_UINT8, OTHER_BYTE };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8, OTHER_BYTE };
 
     /*
      * Header format:
@@ -175,7 +175,7 @@ static void test_ipv6_hdr_get_tc(void)
 
 static void test_ipv6_hdr_get_tc_ecn(void)
 {
-    uint8_t val[] = { TEST_UINT8 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8 };
 
     /*
      * Header format:
@@ -194,7 +194,7 @@ static void test_ipv6_hdr_get_tc_ecn(void)
 
 static void test_ipv6_hdr_get_tc_dscp(void)
 {
-    uint8_t val[] = { TEST_UINT8, OTHER_BYTE };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8, OTHER_BYTE };
 
     /*
      * Header format:
@@ -214,7 +214,7 @@ static void test_ipv6_hdr_get_tc_dscp(void)
 
 static void test_ipv6_hdr_set_fl(void)
 {
-    uint8_t val[] = { 0, TEST_UINT8, 0, 0 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { 0, TEST_UINT8, 0, 0 };
 
     ipv6_hdr_set_fl((ipv6_hdr_t *)val, TEST_UINT32);
 
@@ -235,7 +235,7 @@ static void test_ipv6_hdr_set_fl(void)
 
 static void test_ipv6_hdr_get_fl(void)
 {
-    uint8_t val[] = { TEST_UINT8, OTHER_BYTE, 0, 0 };
+    uint8_t val[sizeof(ipv6_hdr_t)] = { TEST_UINT8, OTHER_BYTE, 0, 0 };
 
     /*
      * Header format:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes some array bounds warnings:

```
In file included from tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c:21:                                                                          
tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c: In function ‘test_ipv6_hdr_set_version’:                                                          
./sys/include/net/ipv6/hdr.h:104:24: error: array subscript ‘ipv6_hdr_t[0]’ is partly outside array bounds of ‘uint8_t[1]’ {aka ‘unsigned char[1]’}
 [-Werror=array-bounds]                                                  
  104 |     hdr->v_tc_fl.u8[0] |= 0x60;                                                                                                            
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~                                                                                                             
tests/unittests/tests-ipv6_hdr/tests-ipv6_hdr.c:44:13: note: while referencing ‘val’
   44 |     uint8_t val[] = { TEST_UINT8 };                              
      |             ^~~                                                                                                                            
```

The code is "technically" correct, the tests casts a uint8_t[1] (val) to ipv6_hdr_t*, but then only calls e.g., `ipv6_hdr_set_version((ipv6_hdr_t *)val);` which should only access the first byte. seems like newer gcc doesn't like that still.

TBH, I cannot reproduce this warning/error on master. It only pops up when I build an my experimental laze branch. I tried matching the cflags (the laze branch is a bit outdated, doesn't do `-fwrapv`, `-U_FORTIFY_SOURCE`, `-std=gnu11` and some other minor differences). Still, the warning seems legit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
