### PR TITLE
gnrc_lorawan: fix gnrc_pktbuf_release_error (introduced by #16080)

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -300,9 +300,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
     mlme_request_t mlme_request;
     mlme_confirm_t mlme_confirm;
 
-    gnrc_pktsnip_t *head;
     uint8_t port;
     int res = -EINVAL;
+
+    assert(payload);
 
     if (IS_ACTIVE(CONFIG_GNRC_NETIF_LORAWAN_NETIF_HDR)) {
         gnrc_netif_hdr_t *netif_hdr;
@@ -318,11 +319,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
         }
 
         /* Remove the netif hdr snip and point to the MSDU */
-        head = gnrc_pktbuf_remove_snip(payload, payload);
+        payload = gnrc_pktbuf_remove_snip(payload, payload);
 
     }
     else {
-        head = payload;
         port = netif->lorawan.port;
     }
 
@@ -335,18 +335,18 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
     mcps_request_t req =
     { .type = netif->lorawan.ack_req ? MCPS_CONFIRMED : MCPS_UNCONFIRMED,
       .data =
-      { .pkt = (iolist_t *)head, .port = port,
+      { .pkt = (iolist_t *)payload, .port = port,
           .dr = netif->lorawan.datarate } };
     mcps_confirm_t conf;
 
     gnrc_lorawan_mcps_request(&netif->lorawan.mac, &req, &conf);
     res = conf.status;
 
-end:
     if (res < 0) {
         gnrc_pktbuf_release_error(payload, res);
     }
 
+end:
     return res;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes an issue introduced by #16080, in which the wrong pktsnip is released on TX errors.
I removed the `head` variable and asserted "payload" just to avoid this kind of mistakes in the future.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It's quite hard to test LoRAWAN right now if we don't have working setups with TTN, but I have a running instance of Chirpstack. I will post results ASAP.

If the transmissions fails (e.g the node didn't join), there's an assertion on master:
```
2021-07-06 13:59:26,331 # txtsnd 3 02 test
2021-07-06 13:59:26,338 # sys/net/gnrc/pktbuf/gnrc_pktbuf.c:94 => 0x8000165
2021-07-06 13:59:26,340 # *** RIOT kernel panic:
2021-07-06 13:59:26,341 # FAILED ASSERTION.
```

With this PR:
```
2021-07-06 14:28:20,569 # reboot
2021-07-06 14:28:20,613 # NETOPT_RX_END_IRQ not implemented by driver
2021-07-06 14:28:20,621 # main(): This is RIOT! (Version: 2021.07-devel-489-g13274-pr/gnrc_lorawan_fix_release)
2021-07-06 14:28:20,626 # Initialization successful - starting the shell now
> txtsnd 3 01 test
2021-07-06 14:28:25,992 # txtsnd 3 01 test
> txtsnd 3 01 test
2021-07-06 14:28:26,840 # txtsnd 3 01 test
2021-07-06 14:28:27,021 # txtsnd 3 01 test
2021-07-06 14:28:27,169 # txtsnd 3 01 test
2021-07-06 14:28:27,318 # txtsnd 3 01 test
2021-07-06 14:28:27,460 # txtsnd 3 01 test
2021-07-06 14:28:27,603 # txtsnd 3 01 test
2021-07-06 14:28:27,756 # txtsnd 3 01 test
2021-07-06 14:28:29,070 # txtsnd 3 01 test
> txtsnd 3 01 test
2021-07-06 14:28:30,244 # txtsnd 3 01 test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#16080
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
