### PR TITLE
drivers/dose: return -EBUSY if medium is busy

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -449,7 +449,7 @@ collision:
     DEBUG("dose _send(): collision!\n");
     if (--retries < 0) {
         ctx->netdev.event_callback((netdev_t *) ctx, NETDEV_EVENT_TX_MEDIUM_BUSY);
-        return 0;
+        return -EBUSY;
     }
     goto send;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If there was a collision, return -EBUSY so the frame can be put into the packet queue and we can attempt to send it again.



### Testing procedure

Add `USEMODULE += gnrc_netif_pktq` to your project and see if the packet loss goes down if you are sending lots of packets on a busy link.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
