### PR TITLE
drivers/at24cxxx: rearrange AT24CXXX_PARAMS

### DIFF
--- a/drivers/at24cxxx/include/at24cxxx_params.h
+++ b/drivers/at24cxxx/include/at24cxxx_params.h
@@ -73,9 +73,9 @@ extern "C" {
  */
 #define AT24CXXX_PARAMS                {            \
     .i2c = AT24CXXX_PARAM_I2C,                      \
-    .dev_addr = AT24CXXX_PARAM_ADDR,                \
     .pin_wp = AT24CXXX_PARAM_PIN_WP,                \
     .eeprom_size = AT24CXXX_PARAM_EEPROM_SIZE,      \
+    .dev_addr = AT24CXXX_PARAM_ADDR,                \
     .page_size = AT24CXXX_PARAM_PAGE_SIZE,          \
     .max_polls = AT24CXXX_PARAM_MAX_POLLS           \
 }


### PR DESCRIPTION
Hello everyone. 

### Contribution description

This PR is related to issue #16589 (sorry it took so long). It fixes the compilation error in C++ of drivers/include/at24cxxx_params.h 

Members of at24cxxx_params were not initialized in the right order. 

### Testing procedure

Compile the driver. 
