### PR TITLE
netdev/lora: fix size of NETOPT_RX_SYMBOL_TIMEOUT [backport 2021.07]

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -637,7 +637,7 @@ void sx127x_set_preamble_length(sx127x_t *dev, uint16_t preamble);
  * @param[in] dev                      The sx127x device descriptor
  * @param[in] timeout                  The LoRa symbol timeout
  */
-void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout);
+void sx127x_set_symbol_timeout(sx127x_t *dev, uint8_t timeout);
 
 /**
  * @brief   Sets the SX127X RX timeout

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -866,16 +866,16 @@ void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout)
     dev->settings.lora.tx_timeout = timeout;
 }
 
-void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout)
+void sx127x_set_symbol_timeout(sx127x_t *dev, uint8_t timeout)
 {
     DEBUG("[sx127x] Set symbol timeout: %d\n", timeout);
 
     uint8_t config2_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG2);
 
     config2_reg &= SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
-    config2_reg |= (timeout >> 8) & ~SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
+    config2_reg |= timeout & ~SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
     sx127x_reg_write(dev, SX127X_REG_LR_MODEMCONFIG2, config2_reg);
-    sx127x_reg_write(dev, SX127X_REG_LR_SYMBTIMEOUTLSB, timeout & 0xFF);
+    sx127x_reg_write(dev, SX127X_REG_LR_SYMBTIMEOUTLSB, timeout);
 }
 
 bool sx127x_get_iq_invert(const sx127x_t *dev)

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -444,8 +444,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         return sizeof(netopt_enable_t);
 
     case NETOPT_RX_SYMBOL_TIMEOUT:
-        assert(len <= sizeof(uint16_t));
-        sx127x_set_symbol_timeout(dev, *((const uint16_t *)val));
+        assert(len <= sizeof(uint8_t));
+        sx127x_set_symbol_timeout(dev, *((const uint8_t *)val));
         return sizeof(uint16_t);
 
     case NETOPT_RX_TIMEOUT:

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -127,7 +127,10 @@ void SX127XSetRxConfig(RadioModems_t modem, uint32_t bandwidth,
     loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_CHANNEL_HOP_PERIOD, &hopPeriod, sizeof(uint8_t));
     netopt_enable_t iq_inverted = (iqInverted) ? NETOPT_ENABLE : NETOPT_DISABLE;
     loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_IQ_INVERT, &iq_inverted, sizeof(netopt_enable_t));
-    loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_RX_SYMBOL_TIMEOUT, &symbTimeout, sizeof(uint16_t));
+    assert(symbTimeout <= UINT8_MAX);
+    uint8_t symbol_timeout = symbTimeout;
+    loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_RX_SYMBOL_TIMEOUT,
+                                    &symbol_timeout, sizeof(symbol_timeout));
     netopt_enable_t single_rx = rxContinuous ? NETOPT_DISABLE : NETOPT_ENABLE;
     loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_SINGLE_RECEIVE, &single_rx, sizeof(netopt_enable_t));
 }

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -129,7 +129,7 @@ static void _config_radio(gnrc_lorawan_t *mac, uint32_t channel_freq,
         /* Switch to single listen mode */
         const netopt_enable_t single = true;
         dev->driver->set(dev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
-        const uint16_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
+        const uint8_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
         dev->driver->set(dev, NETOPT_RX_SYMBOL_TIMEOUT, &timeout,
                          sizeof(timeout));
     }

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -359,7 +359,7 @@ int rx_timeout_cmd(int argc, char **argv)
     }
 
     netdev_t *netdev = (netdev_t *)&sx127x;
-    uint16_t rx_timeout;
+    uint8_t rx_timeout;
 
     if (strstr(argv[1], "set") != NULL) {
         if (argc < 3) {


### PR DESCRIPTION

### Contribution description

Backport of #16604


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

From #16604
