### PR TITLE
pkg/nimble: have RIOT always initialize nimble timers

### DIFF
--- a/pkg/mynewt-core/contrib/core.c
+++ b/pkg/mynewt-core/contrib/core.c
@@ -25,10 +25,17 @@
 void mynewt_core_init(void)
 {
 #if (MYNEWT_VAL_OS_CPUTIME_TIMER_NUM >= 0) && (defined(CPU_NRF51) || defined(CPU_NRF52))
-    int rc = hal_timer_init(5, NULL);
+    /* in mynewt-nimble and uwb-core OS_CPUTIMER_TIMER_NUM == 5 is NRF_RTC0,
+       for nimble this must be used for the BLE stack and must go through
+       mynewt timer initialization for it to work properly. The RTC frequency
+       should be set to the highest possible value, so 32768Hz */
+    assert(MYNEWT_VAL_OS_CPUTIME_TIMER_NUM == 5);
+    assert(MYNEWT_VAL_OS_CPUTIME_FREQ == 32768);
+    int rc = hal_timer_init(MYNEWT_VAL_OS_CPUTIME_TIMER_NUM, NULL);
     assert(rc == 0);
-    rc = os_cputime_init(MYNEWT_VAL_OS_CPUTIME_FREQ);
+    rc = hal_timer_config(MYNEWT_VAL_OS_CPUTIME_TIMER_NUM,
+                          MYNEWT_VAL_OS_CPUTIME_FREQ);
     assert(rc == 0);
-    (void) rc;
+    (void)rc;
 #endif
 }

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -105,6 +105,21 @@ void nimble_riot_init(void)
     int res;
     (void)res;
 
+#if !IS_USED(MODULE_MYNEWT_CORE) && IS_ACTIVE(NIMBLE_CFG_CONTROLLER)
+    /* in mynewt-nimble and uwb-core OS_CPUTIMER_TIMER_NUM == 5 is NRF_RTC0,
+       for nimble this must be used for the BLE stack and must go through
+       mynewt timer initialization for it to work properly. The RTC frequency
+       should be set to the highest possible value so, 32768Hz */
+    assert(MYNEWT_VAL_OS_CPUTIME_TIMER_NUM == 5);
+    assert(MYNEWT_VAL_OS_CPUTIME_FREQ == 32768);
+    int rc = hal_timer_init(MYNEWT_VAL_OS_CPUTIME_TIMER_NUM, NULL);
+    assert(rc == 0);
+    rc = hal_timer_config(MYNEWT_VAL_OS_CPUTIME_TIMER_NUM,
+                          MYNEWT_VAL_OS_CPUTIME_FREQ);
+    assert(rc == 0);
+    (void)rc;
+#endif
+
     /* and finally initialize and run the host */
     thread_create(_stack_host, sizeof(_stack_host),
                   NIMBLE_HOST_PRIO,

--- a/pkg/nimble/patches/0001-porting-nimble-src-nimble_port-riot-initializes-time.patch
+++ b/pkg/nimble/patches/0001-porting-nimble-src-nimble_port-riot-initializes-time.patch
@@ -1,21 +1,21 @@
-From 395209627ba495309098459173d40d490f680b8b Mon Sep 17 00:00:00 2001
+From e9728411aeed6c614b1f27bccd8f2c70bef9f560 Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Mon, 19 Apr 2021 15:47:49 +0200
-Subject: [PATCH] porting/nimble/src/nimble_port: riot initializes timers
+Subject: [PATCH 1/2] porting/nimble/src/nimble_port: riot initializes timers
 
 ---
  porting/nimble/src/nimble_port.c | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/porting/nimble/src/nimble_port.c b/porting/nimble/src/nimble_port.c
-index 484e3799..139179e1 100644
+index 484e3799..d4824d0b 100644
 --- a/porting/nimble/src/nimble_port.c
 +++ b/porting/nimble/src/nimble_port.c
 @@ -45,8 +45,10 @@ nimble_port_init(void)
  
  #if NIMBLE_CFG_CONTROLLER
      ble_hci_ram_init();
-+#ifndef MODULE_MYNEWT_CORE
++#ifndef RIOT_VERSION
      hal_timer_init(5, NULL);
      os_cputime_init(32768);
 +#endif

--- a/pkg/nimble/patches/0002-porting-npl-riot-add-namespaced-syscfg-symlink.patch
+++ b/pkg/nimble/patches/0002-porting-npl-riot-add-namespaced-syscfg-symlink.patch
@@ -1,4 +1,4 @@
-From 40012b6fad9772cb38547abff42149b7ce1ca8d1 Mon Sep 17 00:00:00 2001
+From 679179258e4e505d065dd64c9130ee1e3369f0c4 Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Mon, 5 Jul 2021 14:38:12 +0200
 Subject: [PATCH 2/2] porting/npl/riot: add namespaced syscfg symlink


### PR DESCRIPTION

### Contribution description

This PR implements suggestions in https://github.com/RIOT-OS/RIOT/pull/16348#discussion_r665160617, the upstream PR has been adapted accordingly https://github.com/apache/mynewt-nimble/pull/996. The patch can be removed once that Pr is merged and upstream commit updated.

### Testing procedure

It can be tested with a simple compile test verifying that its not called when using `uwb-core` and that it is when not (e.g.: adding a #error)

- note called ` CFLAGS=-fms-extensions USEPKG="uwb-dw1000 uwb-core" make -C examples/nimble_gatt/ all -j3`

- called ` make -C examples/nimble_gatt/ all -j3`

```
/home/francisco/workspace/RIOT/pkg/nimble/contrib/nimble_riot.c: In function 'nimble_riot_init':
/home/francisco/workspace/RIOT/pkg/nimble/contrib/nimble_riot.c:109:6: error: #error
  109 |     #11852 
```
