### PR TITLE
stm32/spi : Add check for GPIO_UNDEF

### DIFF
--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -130,16 +130,33 @@ void spi_init(spi_t bus)
 void spi_init_pins(spi_t bus)
 {
 #ifdef CPU_FAM_STM32F1
-    gpio_init_af(spi_config[bus].sclk_pin, GPIO_AF_OUT_PP);
-    gpio_init_af(spi_config[bus].mosi_pin, GPIO_AF_OUT_PP);
-    gpio_init(spi_config[bus].miso_pin, GPIO_IN);
+
+    if (gpio_is_valid(spi_config[bus].sclk_pin)) {
+        gpio_init_af(spi_config[bus].sclk_pin, GPIO_AF_OUT_PP);
+    }
+
+    if (gpio_is_valid(spi_config[bus].mosi_pin)) {
+        gpio_init_af(spi_config[bus].mosi_pin, GPIO_AF_OUT_PP);
+    }
+
+    if (gpio_is_valid(spi_config[bus].miso_pin)) {
+        gpio_init(spi_config[bus].miso_pin, GPIO_IN);
+    }
 #else
-    gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
-    gpio_init(spi_config[bus].miso_pin, GPIO_IN);
-    gpio_init(spi_config[bus].sclk_pin, GPIO_OUT);
-    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].mosi_af);
-    gpio_init_af(spi_config[bus].miso_pin, spi_config[bus].miso_af);
-    gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].sclk_af);
+    if (gpio_is_valid(spi_config[bus].mosi_pin)) {
+        gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
+        gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].mosi_af);
+    }
+
+    if (gpio_is_valid(spi_config[bus].miso_pin)) {
+        gpio_init(spi_config[bus].miso_pin, GPIO_IN);
+        gpio_init_af(spi_config[bus].miso_pin, spi_config[bus].miso_af);
+    }
+
+    if (gpio_is_valid(spi_config[bus].sclk_pin)) {
+        gpio_init(spi_config[bus].sclk_pin, GPIO_OUT);
+        gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].sclk_af);
+    }
 #endif
 }
 
@@ -183,12 +200,20 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode)
     /* This has no effect on STM32F1 */
     return ret;
 #else
-    ret += gpio_init(spi_config[bus].mosi_pin, mode.mosi);
-    ret += gpio_init(spi_config[bus].miso_pin, mode.miso);
-    ret += gpio_init(spi_config[bus].sclk_pin, mode.sclk);
-    gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].mosi_af);
-    gpio_init_af(spi_config[bus].miso_pin, spi_config[bus].miso_af);
-    gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].sclk_af);
+    if (gpio_is_valid(spi_config[bus].mosi_pin)) {
+        ret += gpio_init(spi_config[bus].mosi_pin, mode.mosi);
+        gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].mosi_af);
+    }
+
+    if (gpio_is_valid(spi_config[bus].miso_pin)) {
+        ret += gpio_init(spi_config[bus].miso_pin, mode.miso);
+        gpio_init_af(spi_config[bus].miso_pin, spi_config[bus].miso_af);
+    }
+
+    if (gpio_is_valid(spi_config[bus].sclk_pin)) {
+        ret += gpio_init(spi_config[bus].sclk_pin, mode.sclk);
+        gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].sclk_af);
+    }
     return ret;
 #endif
 }


### PR DESCRIPTION

### Contribution description

This PR address issue first discovered in #16579 .  STM32WL55JC use a memory mapped SPI interface instead of a GPIO. The change would init the `pins` only if it's not `GPIO_UNDEF`

### Testing procedure

Tested using #16579. Works!

### Issues/PRs references

#16579