### PR TITLE
gnrc_netreg: bail out if type is not registered

### DIFF
--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -95,7 +95,9 @@ static gnrc_netreg_entry_t *_netreg_lookup(gnrc_netreg_entry_t *from,
 
     if (from || !_INVALID_TYPE(type)) {
         gnrc_netreg_entry_t *head = (from) ? from->next : netreg[type];
-        LL_SEARCH_SCALAR(head, res, demux_ctx, demux_ctx);
+        if (head) {
+            LL_SEARCH_SCALAR(head, res, demux_ctx, demux_ctx);
+        }
     }
 
     return res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If no handler is registered for type or the type has been unregistered with `gnrc_netreg_unregister()`, return NULL instead of trying to dereference a NULL pointer.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
