### PR TITLE
shell_commands/gnrc_netif: fix gnrc_netif_cmd_lora dependency

### DIFF
--- a/drivers/sx127x/Makefile.dep
+++ b/drivers/sx127x/Makefile.dep
@@ -7,8 +7,3 @@ USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec
 
 USEMODULE += lora
-
-ifneq (,$(filter gnrc,$(USEMODULE)))
-  # Pull in `ifconfig` support for LoRA
-  USEMODULE += gnrc_netif_cmd_lora
-endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -262,6 +262,10 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
     USEMODULE += netif
     USEMODULE += ipv6_addr
   endif
+
+  ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
+    USEMODULE += gnrc_netif_cmd_lora
+  endif
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This commit fixes the dependency resolution of `gnrc_netif_cmd_lora`.
As it was, this module was pulled by the driver if `gnrc` was used.
Besides pulling an extra dependency in applications that don't use
`shell_commands` or `gnrc_lorawan`, this hardcodes the module
resolution in the drivers.

This commit pulls `gnrc_netif_cmd_lora` if `shell_commands` and
`gnrc_lorawan` are present.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check that `gnrc_netif_cmd_lora` is pulled when using `examples/gnrc_lorawan`. (`make info-modules`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
