### PR TITLE
net/gcoap: add helper functions

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -529,6 +529,7 @@ ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += sock_util
   USEMODULE += event_callback
   USEMODULE += event_timeout
+  USEMODULE += netutils
   ifneq (,$(filter openwsn%,$(USEMODULE)))
     USEMODULE += openwsn_sock_udp
   endif

--- a/sys/include/net/gcoap_helper.h
+++ b/sys/include/net/gcoap_helper.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gcoap_helper GCoAP helper functions
+ * @ingroup     net_gcoap
+ * @{
+ *
+ * @file
+ * @brief       Helper functions for GCoAP
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef NET_GCOAP_HELPER_H
+#define NET_GCOAP_HELPER_H
+
+#include "net/gcoap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Issue a blocking CoAP GET request
+ *
+ * @param[in]     host          The hostname or IP string of the CoAP server
+ * @param[in]     path          The CoAP request path
+ * @param[in]     confirmable   Whether the request should be confirmable
+ * @param[out]    response      Buffer for the response payload
+ * @param[in,out] response_size Size of the response buffer. Will contain the
+ *                              actual length of the response when finished.
+ *
+ * @return        CoAP response code or negative error
+ */
+int coap_get(const char *host, const char *path, bool confirmable,
+             void *response, size_t *response_size);
+
+/**
+ * @brief   Issue a blocking CoAP POST request
+ *
+ * @param[in]     host          The hostname or IP string of the CoAP server
+ * @param[in]     path          The CoAP request path
+ * @param[in]     confirmable   Whether the request should be confirmable
+ * @param[in]     payload       Payload for the POST request, may be NULL
+ * @param[in]     payload_size  Size of the payload buffer
+ * @param[out]    response      Buffer for the response payload
+ * @param[in,out] response_size Size of the response buffer. Will contain the
+ *                              actual length of the response when finished.
+ *
+ * @return        CoAP response code or negative error
+ */
+int coap_post(const char *host, const char *path, bool confirmable,
+              const void *payload, size_t payload_size,
+              void *response, size_t *response_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GCOAP_HELPER_H */
+/** @} */

--- a/sys/net/application_layer/gcoap/gcoap_helper.c
+++ b/sys/net/application_layer/gcoap/gcoap_helper.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gcoap_helper
+ * @{
+ *
+ * @file
+ * @brief       Helper functions for GCoAP
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "net/gcoap_helper.h"
+#include "net/utils.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#define COAP_REQ_CONFIRMABLE    (1 << 0)
+
+struct coap_request_ctx {
+    mutex_t lock;
+    const void *payload;
+    const size_t payload_len;
+    void *dst;
+    size_t dst_len;
+    const size_t dst_len_max;
+    const char *path;
+    int code;
+    uint8_t method;
+    uint8_t flags;
+};
+
+/*
+ * Response callback.
+ */
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                          const sock_udp_ep_t *remote)
+{
+    (void)remote;       /* not interested in the source currently */
+
+    struct coap_request_ctx *ctx = memo->context;
+
+    if (memo->state == GCOAP_MEMO_TIMEOUT) {
+        DEBUG("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
+        ctx->code = -ETIME;
+        goto out;
+    }
+    else if (memo->state == GCOAP_MEMO_ERR) {
+        DEBUG("gcoap: error in response\n");
+        ctx->code = -EBADMSG;
+        goto out;
+    }
+
+    coap_block1_t block;
+    char *class_str = (coap_get_code_class(pdu) == COAP_CLASS_SUCCESS)
+                            ? "Success" : "Error";
+    DEBUG("gcoap: response %s, code %1u.%02u\n", class_str,
+                                                 coap_get_code_class(pdu),
+                                                 coap_get_code_detail(pdu));
+    ctx->code = coap_get_code(pdu);
+
+    if (pdu->payload_len) {
+        if (ctx->dst_len + pdu->payload_len > ctx->dst_len_max) {
+            DEBUG("gcoap: not enough memory in destination buffer\n");
+            ctx->code = -ENOMEM;
+            goto out;
+        }
+        memcpy((uint8_t *)ctx->dst + ctx->dst_len, pdu->payload, pdu->payload_len);
+        ctx->dst_len += pdu->payload_len;
+    }
+
+    /* ask for next block if present */
+    if (coap_get_block2(pdu, &block)) {
+
+        if (block.blknum == 0) {
+            DEBUG("--- blockwise start ---\n");
+        }
+
+        if (block.more) {
+            unsigned msg_type = coap_get_type(pdu);
+
+            gcoap_req_init(pdu, (uint8_t *)pdu->hdr, CONFIG_GCOAP_PDU_BUF_SIZE,
+                           ctx->method, ctx->path);
+
+            if (msg_type == COAP_TYPE_ACK) {
+                coap_hdr_set_type(pdu->hdr, COAP_TYPE_CON);
+            }
+            block.blknum++;
+            coap_opt_add_block2_control(pdu, &block);
+
+            int len = coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
+            gcoap_req_send((uint8_t *)pdu->hdr, len, remote,
+                           _resp_handler, memo->context);
+        }
+        else {
+            DEBUG("--- blockwise complete ---\n");
+        }
+    }
+
+out:
+    mutex_unlock(&ctx->lock);
+}
+
+static void coap_request(const sock_udp_ep_t *remote, struct coap_request_ctx *ctx)
+{
+    size_t len;
+    coap_pkt_t pdu;
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
+
+    gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, ctx->method, ctx->path);
+
+    /* set confirmable / non-confirmable */
+    if (ctx->flags & COAP_REQ_CONFIRMABLE) {
+        coap_hdr_set_type(pdu.hdr, COAP_TYPE_CON);
+    } else {
+        coap_hdr_set_type(pdu.hdr, COAP_TYPE_NON);
+    }
+
+    /* options done */
+    if (ctx->payload_len == 0) {
+        len = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
+    } else {
+        len = coap_opt_finish(&pdu, COAP_OPT_FINISH_PAYLOAD);
+
+        if (pdu.payload_len < ctx->payload_len) {
+            ctx->code = -ENOMEM;
+            return;
+        }
+
+        memcpy(pdu.payload, ctx->payload, ctx->payload_len);
+        pdu.payload_len -= ctx->payload_len;
+        len += ctx->payload_len;
+    }
+
+    /* send COAP request */
+    gcoap_req_send(buf, len, remote, _resp_handler, ctx);
+
+    /* wait for response */
+    mutex_lock(&ctx->lock);
+}
+
+static int _fill_remote(const char *host, sock_udp_ep_t *remote)
+{
+    int res;
+    gnrc_netif_t *netif;
+
+    /* parse hostname */
+    res = netutils_get_ipv6((ipv6_addr_t *)&remote->addr, &netif, host);
+    if (res < 0) {
+        return res;
+    }
+
+    /* fill in CoAP server information */
+    remote->family = AF_INET6;
+    remote->netif  = netif ? netif->pid : SOCK_ADDR_ANY_NETIF;
+    remote->port   = COAP_PORT;
+
+    return 0;
+}
+
+int coap_get(const char *host, const char *path, bool confirmable,
+             void *response, size_t *response_len)
+{
+    sock_udp_ep_t remote;
+    struct coap_request_ctx ctx = {
+        .lock    = MUTEX_INIT_LOCKED,
+        .dst     = response,
+        .dst_len_max = *response_len,
+        .path    = path,
+        .method  = COAP_METHOD_GET,
+        .flags   = confirmable ? COAP_REQ_CONFIRMABLE : 0,
+    };
+
+    ctx.code = _fill_remote(host, &remote);
+    if (ctx.code) {
+        return ctx.code;
+    }
+
+    coap_request(&remote, &ctx);
+
+    *response_len = ctx.dst_len;
+    return ctx.code;
+}
+
+int coap_post(const char *host, const char *path, bool confirmable,
+              const void *payload, size_t payload_len,
+              void *response, size_t *response_len)
+{
+    sock_udp_ep_t remote;
+    struct coap_request_ctx ctx = {
+        .lock    = MUTEX_INIT_LOCKED,
+        .payload = payload,
+        .payload_len = payload_len,
+        .dst     = response,
+        .dst_len_max = *response_len,
+        .path    = path,
+        .method  = COAP_METHOD_POST,
+        .flags   = confirmable ? COAP_REQ_CONFIRMABLE : 0,
+    };
+
+    ctx.code = _fill_remote(host, &remote);
+    if (ctx.code) {
+        return ctx.code;
+    }
+
+    coap_request(&remote, &ctx);
+
+    *response_len = ctx.dst_len;
+    return ctx.code;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Doing a blocking CoAP request currently involves writing (or copying) lots of boilerplate code.

This adds the two helper functions

 - `coap_get()`
 - `coap_post()`

To issue a blocking GET or POST request with a single command.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

includes c599385 from #16634
