### PR TITLE
pkg/lwip: Fix DHCP autostart

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -284,7 +284,7 @@ void lwip_bootstrap(void)
         struct netif *n = NULL;
         NETIF_FOREACH(n) {
             if (netif_is_flag_set(n, NETIF_FLAG_ETHERNET)) {
-                netifapi_dhcp_start(netif);
+                netifapi_dhcp_start(n);
             }
         }
     }

--- a/pkg/lwip/patches/0003-netif_is_flag_set-fix.patch
+++ b/pkg/lwip/patches/0003-netif_is_flag_set-fix.patch
@@ -1,0 +1,22 @@
+From 7a2923020f3686b030d38c3e604b1f3801ca2e43 Mon Sep 17 00:00:00 2001
+From: Thomas Mueller <tmueller@sysgo.com>
+Date: Mon, 8 Feb 2021 19:17:20 +0100
+Subject: [PATCH] Fix typo in definition of netif_is_flag_set() macro
+
+---
+ src/include/lwip/netif.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/include/lwip/netif.h b/src/include/lwip/netif.h
+index 5ecf8cdc8..6e04ce84b 100644
+--- a/src/include/lwip/netif.h
++++ b/src/include/lwip/netif.h
+@@ -469,7 +469,7 @@ void netif_set_gw(struct netif *netif, const ip4_addr_t *gw);
+ 
+ #define netif_set_flags(netif, set_flags)     do { (netif)->flags = (u8_t)((netif)->flags |  (set_flags)); } while(0)
+ #define netif_clear_flags(netif, clr_flags)   do { (netif)->flags = (u8_t)((netif)->flags & (u8_t)(~(clr_flags) & 0xff)); } while(0)
+-#define netif_is_flag_set(nefif, flag)        (((netif)->flags & (flag)) != 0)
++#define netif_is_flag_set(netif, flag)        (((netif)->flags & (flag)) != 0)
+ 
+ void netif_set_up(struct netif *netif);
+ void netif_set_down(struct netif *netif);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fix spelling error (nefif -> netif) in `netif_is_flag_set` macro. This did not cause compilation failures
as long as there is a variable called netif in scope - but in that case it did not check the flags on the correct interface. This fix comes from [lwIP upstream](https://git.savannah.nongnu.org/cgit/lwip.git/commit/?id=7a2923020f3686b030d38c3e604b1f3801ca2e43).

Also start DHCP on the interface that was checked, not the first one in the array.
### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Compilation of application using lwIP and IPv4 still works. \
DHCP now starts properly on all interfaces and not only the first one:

Before:
```
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f Link: up State: up
        Link type: wired
        inet addr: 10.4.4.81 mask: 255.255.254.0 gw: 10.4.4.1
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c Link: up State: up
        Link type: wireless
        inet addr: 0.0.0.0 mask: 0.0.0.0 gw: 0.0.0.0

```

After:
```
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f Link: up State: up
        Link type: wired
        inet addr: 10.4.4.81 mask: 255.255.254.0 gw: 10.4.4.1
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c Link: up State: up
        Link type: wireless
        inet addr: 10.4.4.86 mask: 255.255.254.0 gw: 10.4.4.1
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

DHCP for other interfaces than first broken since #16229.

I am trying to get rid of the single netif array in #16162.
