### PR TITLE
tests/periph_uart_mode: Drop dep to periph_timer

### DIFF
--- a/tests/periph_uart_mode/Makefile
+++ b/tests/periph_uart_mode/Makefile
@@ -2,8 +2,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_uart
 FEATURES_REQUIRED += periph_uart_modecfg
-
-USEMODULE += xtimer
+FEATURES_OPTIONAL += periph_timer
 
 # Set this to prevent welcome message from printing and confusing output
 CFLAGS+=-DLOG_LEVEL=LOG_NONE

--- a/tests/periph_uart_mode/Makefile.board.dep
+++ b/tests/periph_uart_mode/Makefile.board.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter periph_timer,$(FEATURES_USED)))
+  USEMODULE += xtimer
+endif


### PR DESCRIPTION
### Contribution description

Use `xtimer` only optionally (when `periph_timer`is available) for the test. This makes this test applicable to freshly ported boards that do not yet have a peripheral timer driver.

### Testing procedure

1. Binaries shouldn't change for any upstream board (they all have a timer available)
2. It should still compile when the `periph_timer` feature is disabled via `export FEATURES_BLACKLIST=periph_timer` and work with an approximate timeout between test data from the UART instead of the precise one.

### Issues/PRs references

Used to test https://github.com/RIOT-OS/RIOT/pull/16609