### PR TITLE
Revert "cpu/esp_common: add overflow detection to calloc"

### DIFF
--- a/cpu/esp32/vendor/esp-idf/heap/heap_trace.c
+++ b/cpu/esp32/vendor/esp-idf/heap/heap_trace.c
@@ -407,13 +407,10 @@ IRAM_ATTR void *__wrap_realloc(void *p, size_t size)
 
 IRAM_ATTR void *__wrap_calloc(size_t nmemb, size_t size)
 {
-    size_t total_size;
-    if (__builtin_mul_overflow(nmemb, size, &total_size)) {
-        return NULL;
-    }
-    void *result = trace_malloc(total_size, 0, TRACE_MALLOC_DEFAULT);
+    size = size * nmemb;
+    void *result = trace_malloc(size, 0, TRACE_MALLOC_DEFAULT);
     if (result != NULL) {
-        memset(result, 0, total_size);
+        memset(result, 0, size);
     }
     return result;
 }

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -85,12 +85,6 @@ LINKFLAGS += -L$(ESP_SDK_DIR)/components/$(CPU)
 LINKFLAGS += -L$(ESP_SDK_DIR)/components/$(CPU)/lib
 LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 
-ifeq (,$(filter esp_idf_heap,$(USEMODULE)))
-  # use the wrapper functions for calloc to add correct overflow detection missing
-  # in the newlib's version.
-  LINKFLAGS += -Wl,-wrap=calloc
-endif
-
 # LINKFLAGS += -Wl,--verbose
 # LINKFLAGS += -Wl,--print-gc-sections
 

--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -289,25 +289,6 @@ void* IRAM_ATTR __wrap__calloc_r(struct _reent *r, size_t count, size_t size)
 
 #else /* MODULE_ESP_IDF_HEAP */
 
-void *__wrap_calloc(size_t nmemb, size_t size)
-{
-    /* The xtensa support has not yet upstreamed to newlib. Hence, the fixed
-     * calloc implementation of newlib >= 4.0.0 is not available to the ESP
-     * platform. We fix this by implementing calloc on top of malloc ourselves */
-    size_t total_size;
-    if (__builtin_mul_overflow(nmemb, size, &total_size)) {
-        return NULL;
-    }
-
-    void *res = malloc(total_size);
-
-    if (res) {
-        memset(res, 0, total_size);
-    }
-
-    return res;
-}
-
 /* for compatibility with ESP-IDF heap functions */
 
 void* _heap_caps_malloc(size_t size, uint32_t caps, const char *file, size_t line)


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This reverts commit a9dea12eb8d60bc531c69887edaef535635b920d to fix the issue that esp8266 would immediately crash at boot.


### Testing procedure

Flash any application on a esp8266 based board.
On `master` you will get no output and the CPU gets noticeably hot.

Reverting this commit restores it to a working condition.


### Issues/PRs references

Hopefully a better fix comes along before the release :wink: 