### PR TITLE
cpu/esp_common: fix boot issue on ESP8266

### DIFF
--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -88,7 +88,7 @@ LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 ifeq (,$(filter esp_idf_heap,$(USEMODULE)))
   # use the wrapper functions for calloc to add correct overflow detection missing
   # in the newlib's version.
-  LINKFLAGS += -Wl,-wrap=calloc
+  LINKFLAGS += -Wl,-wrap=_calloc_r
 endif
 
 # LINKFLAGS += -Wl,--verbose

--- a/cpu/esp_common/syscalls.c
+++ b/cpu/esp_common/syscalls.c
@@ -289,7 +289,7 @@ void* IRAM_ATTR __wrap__calloc_r(struct _reent *r, size_t count, size_t size)
 
 #else /* MODULE_ESP_IDF_HEAP */
 
-void *__wrap_calloc(size_t nmemb, size_t size)
+void* IRAM_ATTR __wrap__calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
     /* The xtensa support has not yet upstreamed to newlib. Hence, the fixed
      * calloc implementation of newlib >= 4.0.0 is not available to the ESP
@@ -299,7 +299,7 @@ void *__wrap_calloc(size_t nmemb, size_t size)
         return NULL;
     }
 
-    void *res = malloc(total_size);
+    void *res = _malloc_r(r, total_size);
 
     if (res) {
         memset(res, 0, total_size);


### PR DESCRIPTION
### Contribution description

This fixes an issue that prevents ESP8266 from booting.

### Testing procedure

```
make BOARD=esp8266-esp-12x flash test BUILD_IN_DOCKER=1 -C tests/malloc_thread_safety
[...]
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2021.10-devel-139-ga53e1)
Test Application for multithreaded use of malloc()
==================================================

This test will run duelling threads allocating and freeing memory.
The running thread is interrupted every millisecond and the other
threads gets scheduled. Eventually, this should yield to memory
corruption unless proper guards are in place preventing them. After
ca. two seconds without crash, the test is considered as passing.

Testing: malloc()/free()
Testing: realloc()/free()
TEST PASSED
```

### Issues/PRs references

Bug introduced in https://github.com/RIOT-OS/RIOT/pull/16443 alternative to https://github.com/RIOT-OS/RIOT/pull/16638