### PR TITLE
net/lorawan: Revert #16604 and fix NETOPT_RX_SYMBOL_TIMEOUT documentation

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -107,7 +107,7 @@ struct sx126x {
     sx126x_pkt_params_lora_t pkt_params;    /**< Lora packet parameters */
     sx126x_mod_params_lora_t mod_params;    /**< Lora modulation parameters */
     uint32_t channel;                       /**< Current channel frequency (in Hz) */
-    uint8_t rx_timeout;                     /**< Rx Timeout in terms of symbols */
+    uint16_t rx_timeout;                    /**< Rx Timeout in terms of symbols */
     bool radio_sleep;                       /**< Radio sleep status */
 };
 

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -637,7 +637,7 @@ void sx127x_set_preamble_length(sx127x_t *dev, uint16_t preamble);
  * @param[in] dev                      The sx127x device descriptor
  * @param[in] timeout                  The LoRa symbol timeout
  */
-void sx127x_set_symbol_timeout(sx127x_t *dev, uint8_t timeout);
+void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout);
 
 /**
  * @brief   Sets the SX127X RX timeout

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -425,9 +425,9 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         return sizeof(netopt_enable_t);
 
     case NETOPT_RX_SYMBOL_TIMEOUT:
-        assert(len <= sizeof(uint8_t));
-        dev->rx_timeout = *(const uint8_t *)val;
-        return sizeof(uint8_t);
+        assert(len <= sizeof(uint16_t));
+        dev->rx_timeout = *(const uint16_t *)val;
+        return sizeof(uint16_t);
 
     case NETOPT_TX_POWER:
         assert(len <= sizeof(int16_t));

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -866,16 +866,16 @@ void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout)
     dev->settings.lora.tx_timeout = timeout;
 }
 
-void sx127x_set_symbol_timeout(sx127x_t *dev, uint8_t timeout)
+void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout)
 {
     DEBUG("[sx127x] Set symbol timeout: %d\n", timeout);
 
     uint8_t config2_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG2);
 
     config2_reg &= SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
-    config2_reg |= timeout & ~SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
+    config2_reg |= (timeout >> 8) & ~SX127X_RF_LORA_MODEMCONFIG2_SYMBTIMEOUTMSB_MASK;
     sx127x_reg_write(dev, SX127X_REG_LR_MODEMCONFIG2, config2_reg);
-    sx127x_reg_write(dev, SX127X_REG_LR_SYMBTIMEOUTLSB, timeout);
+    sx127x_reg_write(dev, SX127X_REG_LR_SYMBTIMEOUTLSB, timeout & 0xFF);
 }
 
 bool sx127x_get_iq_invert(const sx127x_t *dev)

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -444,8 +444,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         return sizeof(netopt_enable_t);
 
     case NETOPT_RX_SYMBOL_TIMEOUT:
-        assert(len <= sizeof(uint8_t));
-        sx127x_set_symbol_timeout(dev, *((const uint8_t *)val));
+        assert(len <= sizeof(uint16_t));
+        sx127x_set_symbol_timeout(dev, *((const uint16_t *)val));
         return sizeof(uint16_t);
 
     case NETOPT_RX_TIMEOUT:

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -127,10 +127,7 @@ void SX127XSetRxConfig(RadioModems_t modem, uint32_t bandwidth,
     loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_CHANNEL_HOP_PERIOD, &hopPeriod, sizeof(uint8_t));
     netopt_enable_t iq_inverted = (iqInverted) ? NETOPT_ENABLE : NETOPT_DISABLE;
     loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_IQ_INVERT, &iq_inverted, sizeof(netopt_enable_t));
-    assert(symbTimeout <= UINT8_MAX);
-    uint8_t symbol_timeout = symbTimeout;
-    loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_RX_SYMBOL_TIMEOUT,
-                                    &symbol_timeout, sizeof(symbol_timeout));
+    loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_RX_SYMBOL_TIMEOUT, &symbTimeout, sizeof(uint16_t));
     netopt_enable_t single_rx = rxContinuous ? NETOPT_DISABLE : NETOPT_ENABLE;
     loramac_netdev_ptr->driver->set(loramac_netdev_ptr, NETOPT_SINGLE_RECEIVE, &single_rx, sizeof(netopt_enable_t));
 }

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -748,7 +748,7 @@ typedef enum {
     NETOPT_RANDOM,
 
     /**
-     * @brief (uint8_t) Get or set the number of PHY symbols before assuming there's no data
+     * @brief (uint16_t) Get or set the number of PHY symbols before assuming there's no data
      */
     NETOPT_RX_SYMBOL_TIMEOUT,
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -129,7 +129,7 @@ static void _config_radio(gnrc_lorawan_t *mac, uint32_t channel_freq,
         /* Switch to single listen mode */
         const netopt_enable_t single = true;
         dev->driver->set(dev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
-        const uint8_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
+        const uint16_t timeout = CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT;
         dev->driver->set(dev, NETOPT_RX_SYMBOL_TIMEOUT, &timeout,
                          sizeof(timeout));
     }

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -359,7 +359,7 @@ int rx_timeout_cmd(int argc, char **argv)
     }
 
     netdev_t *netdev = &sx127x.netdev;
-    uint8_t rx_timeout;
+    uint16_t rx_timeout;
 
     if (strstr(argv[1], "set") != NULL) {
         if (argc < 3) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
It turns out the SX127x DOES support 2 bytes symbol timeout. Therefore, #16604 makes no sense at all and the correct solution would be to change the NETOPT_RX_SYMBOL_TIMEOUT documentation to use `uint16_t` instead of `uint8_t`.

The worst thing is, #16604 also introduced a bug because the MSB was being written as the LSB. I guess I owe some beers...

This PR reverts such a disgrace and fixes the NETOPT documentation.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The Release tests are not enough to catch this bug. We should work on that.
The proper way to detect this bug is to follow a similar approach to https://github.com/RIOT-OS/RIOT/pull/16599#issuecomment-876300546.
I can provide a patch and test results.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#16604

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
