### PR TITLE
boards/nucleo-wl55jc: add SX126X_PARAM_TYPE to board.h

### DIFF
--- a/boards/nucleo-wl55jc/include/board.h
+++ b/boards/nucleo-wl55jc/include/board.h
@@ -40,6 +40,7 @@ extern "C" {
 #if IS_USED(MODULE_SX126X_STM32WL)
 extern void nucleo_wl55jc_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mode);
 #define SX126X_PARAM_SET_RF_MODE_CB         nucleo_wl55jc_sx126x_set_rf_mode
+#define SX126X_PARAM_TYPE                   SX126X_TYPE_STM32WL
 #endif
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR set the SX126X_PARAM_TYPE in `boards/nucleo-wl55jc` to `SX126X_TYPE_STM32WL`, in order to reflect the correct board when more than one SX126x is being used (see #16597).

As is it, it compiles with the default value (`SX126X_TYPE_SX1261`). This makes LoRaWAN applications running on `nucleo-wl55jc` crash if the default settings are used.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Pull more `sx126x` variants and make sure `nucleo-wl55jc` runs as expected.

Test results for `examples/gnrc_lorawan/> BOARD=nucleo-wl55jc USEMODULE="sx1262 sx1262 llcc68" PORT=/dev/ttyACM2 SHOULD_RUN_KCONFIG=y make flash term`:

```
help
2021-07-14 14:06:31,262 # help
2021-07-14 14:06:31,265 # Command              Description
2021-07-14 14:06:31,268 # ---------------------------------------
2021-07-14 14:06:31,272 # reboot               Reboot the node
2021-07-14 14:06:31,276 # version              Prints current RIOT_VERSION
2021-07-14 14:06:31,281 # pm                   interact with layered PM subsystem
2021-07-14 14:06:31,285 # random_init          initializes the PRNG
2021-07-14 14:06:31,290 # random_get           returns 32 bit of pseudo randomness
2021-07-14 14:06:31,294 # ifconfig             Configure network interfaces
2021-07-14 14:06:31,300 # txtsnd               Sends a custom string as is over the link layer
> ifconfig 3 up
2021-07-14 14:06:35,472 # ifconfig 3 up
> ifconfig
2021-07-14 14:07:30,248 # ifconfig
2021-07-14 14:07:30,258 # Iface  3  HWaddr: 00:D7:2A:C6  Frequency: 868300000Hz  RSSI: -128  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2021-07-14 14:07:30,263 #            State: STANDBY  Demod margin.: 0  Num gateways.: 0 
2021-07-14 14:07:30,266 #           IQ_INVERT  
2021-07-14 14:07:30,267 #           OTAA  
2021-07-14 14:07:30,268 #           
ifconfig 3 link_check
2021-07-14 14:07:48,378 # ifconfig 3 link_check
2021-07-14 14:07:48,380 # success: set option
> txtsnd 3 01 RIOT
2021-07-14 14:07:52,801 # txtsnd 3 01 RIOT
> ifconfig
2021-07-14 14:07:57,706 # ifconfig
2021-07-14 14:07:57,716 # Iface  3  HWaddr: 00:D7:2A:C6  Frequency: 867700000Hz  RSSI: -128  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2021-07-14 14:07:57,722 #            State: STANDBY  Demod margin.: 27  Num gateways.: 1 
2021-07-14 14:07:57,724 #           IQ_INVERT  
2021-07-14 14:07:57,726 #           OTAA  
2021-07-14 14:07:57,727 #           
> 
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#16597 #16579 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
