### PR TITLE
gnrc_sock: imply end-point netif only if unset [backport 2021.07]

### DIFF
--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -125,7 +125,7 @@ static inline void gnrc_ep_set(sock_ip_ep_t *out, const sock_ip_ep_t *in,
                                size_t in_size)
 {
     memcpy(out, in, in_size);
-    if (gnrc_netif_highlander()) {
+    if (gnrc_netif_highlander() && (out->netif == 0)) {
         /* set interface implicitly */
         gnrc_netif_t *netif = gnrc_netif_iter(NULL);
 


### PR DESCRIPTION
# Backport of #16643

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Found this while testing https://github.com/RIOT-OS/RIOT/pull/16606: When using the `gnrc_netif_single` optimization module `gnrc_sock` basically accepts any `netif` value in the `gnrc_sock*_ep_t` structs, as it is just overwritten with the ID only existing network interface. While this seems like a nice extra from a shell user perspective, I wouldn't call this behavior valid and it also might cause some faulty behavior if e.g. invalid interface IDs are received from the network (as might be the case with DHCPv6's [Interface ID option]() https://github.com/RIOT-OS/RIOT/pull/16606).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following tests should still pass:
- `tests/gnrc_sock_udp`
- `tests/gnrc_sock_ip`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
