### PR TITLE
boards/rpi-pico: Use correct variable name in OpenOCD configuration

### DIFF
--- a/boards/rpi-pico/dist/openocd.cfg
+++ b/boards/rpi-pico/dist/openocd.cfg
@@ -1,3 +1,3 @@
 source [find target/rp2040-core0.cfg]
-$_TARGETNAME configure -rtos auto
+$_TARGETNAME_0 configure -rtos auto
 adapter speed 4000


### PR DESCRIPTION
The target name variable is defined as **$_TARGET_0** in ```target/rp2040-core0.cfg```. Hence, using **$_TARGETNAME** made flashing with OpenOCD fail.

### Contribution description

Flashing failed while trying to flash the board with, ```make BOARD=rpi-pico flash``` (using, OpenOCD + pico-debug-gimmecache.uf2):

```
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-g71510a77a-dirty (2021-07-17-14:49)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Info : Hardware thread awareness created
Info : RP2040 Flash Bank Command
/home/ishraq/git/iia/RIOT/boards/rpi-pico/dist/openocd.cfg:2: Error: can't read "_TARGETNAME": no such variable
in procedure 'script' 
at file "embedded:startup.tcl", line 26
at file "/home/ishraq/git/iia/RIOT/boards/rpi-pico/dist/openocd.cfg", line 2
make: *** [/home/ishraq/git/iia/RIOT/examples/hello-world/../../Makefile.include:776: flash] Error 1
```

After this fix flashing worked as expected:

```
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-g71510a77a-dirty (2021-07-17-14:49)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Info : Hardware thread awareness created
Info : RP2040 Flash Bank Command
adapter speed: 4000 kHz

Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 2.0.0
Info : CMSIS-DAP: Serial# = E660583883173439
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 0 SWDIO/TMS = 0 TDI = 0 TDO = 0 nTRST = 0 nRESET = 0
Info : CMSIS-DAP: Interface ready
Info : clock speed 4000 kHz
Info : SWD DPIDR 0x0bc12477
Info : SWD DLPIDR 0x00000001
Info : rp2040.core0: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for rp2040.core0 on 0
Info : Listening on port 41161 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* rp2040.core0       cortex_m   little rp2040.core0.cpu   unknown

target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x000000ee msp: 0x20041f00
Info : RP2040 B0 Flash Probe: 2097152 bytes @10000000, in 512 sectors

Info : Writing 16384 bytes starting at 0x0
auto erase enabled
wrote 16384 bytes from file /home/ishraq/git/iia/RIOT/examples/hello-world/bin/rpi-pico/hello-world.elf in 2.391082s (6.692 KiB/s)

verified 12708 bytes in 0.261018s (47.545 KiB/s)

shutdown command invoked
Done flashing
```