### PR TITLE
gnrc_dhcpv6_client_simple_pd: fix old doc and names

### DIFF
--- a/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
+++ b/sys/include/net/gnrc/dhcpv6/client/simple_pd.h
@@ -7,14 +7,15 @@
  */
 
 /**
- * @defgroup    net_dhcpv6_client_6lbr  DHCPv6 client for simple prefix
- *              delegation
+ * @defgroup    net_dhcpv6_client_simple_pd     DHCPv6 client for simple prefix
+ *                                              delegation
  * @ingroup     net_dhcpv6_client
- * @brief       DHCPv6 client bootstrapping for routers & 6LoWPAN border routers
+ * @brief       DHCPv6 client bootstrapping for prefix deligation with routers &
+ *              6LoWPAN border routers
  * @{
  *
  * @file
- * @brief   DHCPv6 client on 6LoWPAN border router definitions
+ * @brief   DHCPv6 client for simple prefix delegation definitions
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -25,7 +25,7 @@
 #include "net/gnrc/dhcpv6/client/simple_pd.h"
 
 #if IS_USED(MODULE_AUTO_INIT_DHCPV6_CLIENT)
-#error "Module `gnrc_dhcpv6_client_6lbr` is mutually exclusive to \
+#error "Module `gnrc_dhcpv6_client_simple_pd` is mutually exclusive to \
 `auto_init_dhcpv6_client`"
 #endif
 
@@ -116,7 +116,7 @@ static void _configure_dhcpv6_client(void)
 /**
  * @brief   The DHCPv6 client thread
  */
-static void *_dhcpv6_cl_6lbr_thread(void *args)
+static void *_dhcpv6_cl_simple_pd_thread(void *args)
 {
     event_queue_t event_queue;
     gnrc_netif_t *upstream_netif = _find_upstream_netif();
@@ -146,7 +146,7 @@ void gnrc_dhcpv6_client_simple_pd_init(void)
     thread_create(_stack, DHCPV6_CLIENT_STACK_SIZE,
                   DHCPV6_CLIENT_PRIORITY,
                   THREAD_CREATE_STACKTEST,
-                  _dhcpv6_cl_6lbr_thread, NULL, "dhcpv6-client");
+                  _dhcpv6_cl_simple_pd_thread, NULL, "dhcpv6-client");
 }
 
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In https://github.com/RIOT-OS/RIOT/pull/16530 the module to bootstrap prefix delegation on border routers was renamed, but some of the rename is not reflected in the documentation and some of the function names, making both code and documentation somewhat confusing to read, if you do not know the history.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still compile and the doc should now show `simple_pd` instead of `6lbr` wherever it applies.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/16530
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
