### PR TITLE
dhcpv6_client: make IA_PD an optional module

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -25,6 +25,7 @@ PSEUDOMODULES += dbgpin
 PSEUDOMODULES += devfs_%
 PSEUDOMODULES += dhcpv6_%
 PSEUDOMODULES += dhcpv6_client_dns
+PSEUDOMODULES += dhcpv6_client_ia_pd
 PSEUDOMODULES += dhcpv6_client_mud_url
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += event_%

--- a/sys/include/net/dhcpv6/client.h
+++ b/sys/include/net/dhcpv6/client.h
@@ -122,7 +122,12 @@ void dhcpv6_client_start(void);
  * @brief   Configures the client to request prefix delegation for a network
  *          interface from a server
  *
+ * @pre Module `dhcpv6_client_ia_pd` is compiled in.
  * @pre `pfx_len <= 128`
+ *
+ * Without module `dhcpv6_client_ia_pd` and `NDEBUG` set this function is a NOP.
+ * Without module `dhcpv6_client_ia_pd` and `NDEBUG` unset this function will
+ * abort the running code on a failed assertion.
  *
  * @param[in] netif     The interface to request the prefix delegation for.
  * @param[in] pfx_len   The desired length of the prefix (note that the server

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -57,6 +57,7 @@ endif
 
 ifneq (,$(filter gnrc_dhcpv6_client_simple_pd,$(USEMODULE)))
   USEMODULE += gnrc_dhcpv6_client
+  USEMODULE += dhcpv6_client_ia_pd
 endif
 
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))

--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -8,6 +8,7 @@ RIOTBASE ?= $(CURDIR)/../..
 # boards don't support ethos
 BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker ruuvitag thingy52
 
+USEMODULE += dhcpv6_client_ia_pd
 USEMODULE += gnrc_dhcpv6_client
 USEMODULE += gnrc_ipv6_default
 USEMODULE += xtimer


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Prefix delegation used to be the only supported feature of our DHCPv6 client, but by now it also supports MUD, DNS recursive name servers and IA_NA is on the horizon. So it makes sense to make IA_PD an optional module like all those other features are as well.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Binary sizes of the `tests/gnrc_dhcpv6_*` test applications as well as the border router with `USE_DHCPV6=1` should stay the same with and without this fix (build with `RIOT_CI_BUILD=1`).

When removing the line
https://github.com/RIOT-OS/RIOT/blob/233249eae0e96c36ad6d34e1806a0679d6393ced/tests/gnrc_dhcpv6_client/Makefile#L11
the build size should decrease drastically. The test will fail (since it checks for working prefix delegation), but it should not crash during the run. Additionally, one may check if the proper DHCPv6 handshake of SOLICIT -> ADVERTISE -> REQUEST -> REPLY is completed, either by sniffing the traffic during the test or by enabling DEBUG here

https://github.com/RIOT-OS/RIOT/blob/233249eae0e96c36ad6d34e1806a0679d6393ced/sys/net/application_layer/dhcpv6/client.c#L29
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
