### PR TITLE
boards/lora-e5-dev: initial support

### DIFF
--- a/boards/lora-e5-dev/Kconfig
+++ b/boards/lora-e5-dev/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "lora-e5-dev" if BOARD_LORA_E5_DEV
+
+config BOARD_LORA_E5_DEV
+    bool
+    default y
+    select CPU_MODEL_STM32WLE5JC
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/lora-e5-dev/Makefile
+++ b/boards/lora-e5-dev/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/lora-e5-dev/Makefile.dep
+++ b/boards/lora-e5-dev/Makefile.dep
@@ -1,0 +1,9 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx126x_stm32wl
+endif
+ifneq (,$(filter sx126x_stm32wl,$(USEMODULE)))
+  USEMODULE += sx126x_rf_switch
+endif
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/lora-e5-dev/Makefile.features
+++ b/boards/lora-e5-dev/Makefile.features
@@ -1,0 +1,13 @@
+CPU = stm32
+CPU_MODEL = stm32wle5jc
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_lpuart
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot

--- a/boards/lora-e5-dev/Makefile.include
+++ b/boards/lora-e5-dev/Makefile.include
@@ -1,0 +1,9 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/lora-e5-dev/board.c
+++ b/boards/lora-e5-dev/board.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lora-e5-dev
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the LoRa-E5 Development Board - STM32WLE5JC board
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria/fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+#if IS_USED(MODULE_SX126X_STM32WL)
+#include "sx126x.h"
+#endif
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+    /* initialization of on-board LEDs */
+#ifdef AUTO_INIT_LED0
+    gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
+#endif
+
+    if (IS_USED(MODULE_SX126X_STM32WL)) {
+        /* Initialize the GPIO control for RF 3-port switch (SP3T) */
+        gpio_init(FE_CTRL1, GPIO_OUT);
+        gpio_init(FE_CTRL2, GPIO_OUT);
+    }
+}
+
+#if IS_USED(MODULE_SX126X_STM32WL)
+/**
+ * @brief Callback to set RF switch mode
+ *
+ * This function sets the GPIO's wired to the SP3T RF Switch. LoRa-E5-dev
+ * supports two modes of operation.
+ */
+void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mode)
+{
+    (void) dev;
+    switch (rf_mode) {
+    case SX126X_RF_MODE_RX:
+        gpio_set(FE_CTRL1);
+        gpio_clear(FE_CTRL2);
+        break;
+    case SX126X_RF_MODE_TX_HPA:
+        gpio_clear(FE_CTRL1);
+        gpio_set(FE_CTRL2);
+        break;
+    default:
+        break;
+    }
+}
+#endif

--- a/boards/lora-e5-dev/dist/openocd.cfg
+++ b/boards/lora-e5-dev/dist/openocd.cfg
@@ -1,0 +1,3 @@
+source [find target/stm32wlx.cfg]
+reset_config trst_only
+$_TARGETNAME configure -rtos auto

--- a/boards/lora-e5-dev/doc.txt
+++ b/boards/lora-e5-dev/doc.txt
@@ -1,0 +1,64 @@
+/**
+ * @defgroup    boards_lora-e5-dev LoRa-E5 Development Board - STM32WLE5JC
+ * @ingroup     boards
+ * @brief       Support for the LoRa-E5 Development Board - STM32WLE5JC board.
+ *
+ *
+ *  ### MCU
+ *
+ * | MCU        |   STM32WL5EJC                                             |
+ * |:---------- |:--------------------------------------------------------- |
+ * | Family     | ARM Cortex-M4                                             |
+ * | Vendor     | ST Microelectronics                                       |
+ * | RAM        | 64KiB                                                     |
+ * | Flash      | 256KiB                                                    |
+ * | Frequency  | up to 48MHz                                               |
+ * | FPU        | no                                                        |
+ * | Vcc        | 1.8 V - 3.6V                                              |
+ * | Datasheet  | [Datasheet](https://files.seeedstudio.com/products/317990687/res/STM32WLE5JC%20Datasheet.pdf) |
+ * | Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0461-stm32wlex-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf) |
+ * | Board Manual   | [Board Manual](https://www.st.com/resource/en/data_brief/nucleo-wl55jc.pdf) |
+ * | Board Schematic | [Board Schematic](https://files.seeedstudio.com/products/113990934/LoRa-E5%20Dev%20Board%20v1.0.pdf) |
+ * | LoRa-E5 STM32WL5EJC Module wiki | https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module/#2-develop-with-stm32cube-mcu-package |
+ *
+ *
+ * ### Pinout
+ *
+ * ![lora-e5-dev](https://files.seeedstudio.com/wiki/LoRa-E5_Development_Kit/hardware%20overview/4071615359366_.pic_hd.jpg)
+ *
+ * ### User Interface
+ *
+ * 3 Buttons:
+ *
+ * | NAME   | BOOT     | D0        | RESET |
+ * |:------ |:---------|:--------- |:----- |
+ * | Pin    | PA0 (IN) | PB13 (IN) | NRST  |
+ *
+ * 1 LED:
+ *
+ * | NAME   | D5    |
+ * | -----  | ----- |
+ * | Color  | red   |
+ * | Pin    | PB5   |
+ *
+ * ### Flash the board
+ *
+ * The BOARD comes pre-flashed with a Factory AT Firmware with RDP (Read Protection)
+ * level 1, this needs to be removed to enable subsequent flashing. The easiest
+ * way is with STM32CubeProgramer as described in [seedstudio wiki](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module/#2-develop-with-stm32cube-mcu-package).
+ *
+ * Once read protection is removed subsequent flashing can be performed with and
+ * attached ST-LINK on the SWD pins (do not connect RST but only GND, SWCLK and SWDIO).
+ *
+ * ```
+ * BOARD=lora-e5-dev make flash
+ * ```
+ *
+ * The default used programmer is OpenOCD.
+ *
+ * ### Serial connection
+ *
+ * The default serial connection is through the USB-C port mapping to PB7 (RX) and
+ * PB6 (TX) UART pins (a second UART and an LPUART interface is also exposed).
+ *
+ */

--- a/boards/lora-e5-dev/include/board.h
+++ b/boards/lora-e5-dev/include/board.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lora-e5-dev
+ * @{
+ *
+ * @file
+ * @brief       Pin definitions and board configuration options for
+ *              LoRa-E5 Development Board
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.yyfr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "kernel_defines.h"
+#if IS_USED(MODULE_SX126X_STM32WL)
+#include "sx126x.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Sub-GHz radio (LoRa) configuration
+ * @{
+ */
+#define SX126X_PARAM_SPI                    (SPI_DEV(0))
+#if IS_USED(MODULE_SX126X_STM32WL)
+extern void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mode);
+#define SX126X_PARAM_SET_RF_MODE_CB         lora_e5_dev_sx126x_set_rf_mode
+#define SX126X_PARAM_TYPE                   SX126X_TYPE_STM32WL
+#endif
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PORT           GPIOB
+#define LED0_PIN            GPIO_PIN(PORT_B, 5)
+#define LED0_MASK           (1 << 5)
+#define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 5))
+#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief   Lora-E5-Dev always use LED0, as there is no dual use of its pin
+ * @{
+ */
+#ifndef AUTO_INIT_LED0
+#define AUTO_INIT_LED0
+#endif
+/** @} */
+
+/**
+ * @name    User button
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_B, 13)
+#define BTN0_MODE           GPIO_IN_PU
+#define BTN1_PIN            GPIO_PIN(PORT_A, 0)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    RF 3-port switch (SP3T) control
+ *
+ * Refer Section 6.6.3 RF Overview in User Manual (UM2592)
+ * @{
+ */
+#define FE_CTRL1            GPIO_PIN(PORT_A, 4)
+#define FE_CTRL2            GPIO_PIN(PORT_A, 5)
+/** @} */
+
+/**
+ * @brief   Board level initialization
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/lora-e5-dev/include/gpio_params.h
+++ b/boards/lora-e5-dev/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lora-e5-dev
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+#ifdef AUTO_INIT_LED0
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+#endif
+    {
+        .name = "Button(B1 Boot)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Button(B2 D0)",
+        .pin  = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/lora-e5-dev/include/periph_conf.h
+++ b/boards/lora-e5-dev/include/periph_conf.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lora-e5-dev
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the LoRa-E5 Development Board
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            1
+#endif
+
+/* This board provides a 32MHz HSE oscillator  */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE            1
+#endif
+
+#define CLOCK_HSE                       MHZ(32)
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_tim2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+   {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 7),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR1_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+    {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR2_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 1),
+        .tx_pin     = GPIO_PIN(PORT_C, 0),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB12,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+};
+
+#define UART_0_ISR          isr_usart1
+#define UART_1_ISR          isr_usart2
+#define UART_2_ISR          isr_lpuart1
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SUBGHZSPI, /* Internally connected to Sub-GHz radio Modem  */
+        .mosi_pin = GPIO_UNDEF,
+        .miso_pin = GPIO_UNDEF,
+        .sclk_pin = GPIO_UNDEF,
+        .cs_pin   = GPIO_UNDEF,
+        .mosi_af  = GPIO_AF_UNDEF,
+        .miso_af  = GPIO_AF_UNDEF,
+        .sclk_af  = GPIO_AF_UNDEF,
+        .cs_af    = GPIO_AF_UNDEF,
+        .rccmask  = RCC_APB3ENR_SUBGHZSPIEN,
+        .apbbus   = APB3,
+    },
+/* SUBGHZ DEBUG PINS use the SPI1 pins */
+#if !IS_ACTIVE(CONFIG_STM32_WLX5XX)
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_A, 10),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_UNDEF,
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB1ENR1_SPI2EN,
+        .apbbus   = APB1,
+    }
+#endif
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 15),
+        .sda_pin        = GPIO_PIN(PORT_A, 15),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR1_I2C2EN,
+        .irqn           = I2C2_ER_IRQn,
+    }
+};
+
+#define I2C_1_ISR           isr_i2c2_er
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/nucleo-wl55jc/include/periph_conf.h
+++ b/boards/nucleo-wl55jc/include/periph_conf.h
@@ -78,6 +78,7 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
+
 /**
  * @name    SPI configuration
  * @{
@@ -95,10 +96,10 @@ static const spi_conf_t spi_config[] = {
         .cs_af    = GPIO_AF_UNDEF,
         .rccmask  = RCC_APB3ENR_SUBGHZSPIEN,
         .apbbus   = APB3,
-    }
+    },
 /* SUBGHZ DEBUG PINS use the SPI1 pins */
-#if !IS_ACTIVE(CONFIG_STM32_WL55JC_SUBGHZ_DEBUG)
-    ,{
+#if !IS_ACTIVE(CONFIG_STM32_WLX5XX_SUBGHZ_DEBUG)
+    {
         .dev      = SPI1,
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),

--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -13,13 +13,20 @@ ROM_LEN_K := $(shell echo $(ROM_LEN) | sed 's/K//')
 RAM_LEN_K := $(shell echo $(RAM_LEN) | sed 's/K//')
 
 ifneq (,$(filter w%,$(CPU_FAM)))
-  # adjust RAM_LEN and ROM_LEN according to CPU2 RAM_LEN and ROM_LEN
-  CPU2_RAM_LEN_K := $(shell echo $(CPU2_RAM_LEN) | sed 's/K//')
-  RAM_LEN := $(shell echo $$(( ($(RAM_LEN_K) - $(CPU2_RAM_LEN_K) ) * $(KB) )))
-
-  CPU2_ROM_LEN_K := $(shell echo $(CPU2_ROM_LEN) | sed 's/K//')
-  FLASHSIZE := $(shell echo $$(( ($(ROM_LEN_K) - $(CPU2_ROM_LEN_K) )* $(KB) )) )
-  ROM_LEN := $(shell echo $$(( ($(ROM_LEN_K) - $(CPU2_ROM_LEN_K) ) ))K)
+  ifneq (,$(CPU2_RAM_LEN))
+    # adjust RAM_LEN and ROM_LEN according to CPU2 RAM_LEN and ROM_LEN
+    CPU2_RAM_LEN_K := $(shell echo $(CPU2_RAM_LEN) | sed 's/K//')
+    RAM_LEN := $(shell echo $$(( ($(RAM_LEN_K) - $(CPU2_RAM_LEN_K) ) * $(KB) )))
+  else
+    RAM_LEN := $(shell echo $$(( $(RAM_LEN_K) * $(KB) )) )
+  endif
+  ifneq (,$(CPU2_ROM_LEN))
+    CPU2_ROM_LEN_K := $(shell echo $(CPU2_ROM_LEN) | sed 's/K//')
+    FLASHSIZE := $(shell echo $$(( ($(ROM_LEN_K) - $(CPU2_ROM_LEN_K) )* $(KB) )) )
+    ROM_LEN := $(shell echo $$(( ($(ROM_LEN_K) - $(CPU2_ROM_LEN_K) ) ))K)
+  else
+    FLASHSIZE := $(shell echo $$(( $(ROM_LEN_K) * $(KB) )) )
+  endif
 else
   FLASHSIZE := $(shell echo $$(( $(ROM_LEN_K) * $(KB) )) )
   RAM_LEN := $(shell echo $$(( $(RAM_LEN_K) * $(KB) )) )

--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -155,9 +155,9 @@ static void _gpio_init_ain(void)
 /**
  * @brief   Initialize HW debug pins for Sub-GHz Radio
  */
-void _wl55jc_init_subghz_debug_pins(void)
+void _wlx5xx_init_subghz_debug_pins(void)
 {
-#if IS_ACTIVE(CONFIG_STM32_WL55JC_SUBGHZ_DEBUG)
+#if IS_ACTIVE(CONFIG_STM32_WLX5XX_SUBGHZ_DEBUG)
     /* SUBGHZSPI Debug */
     gpio_init(CPU_STM32WL_SUBGHZSPI_DEBUG_MOSIOUT, GPIO_OUT);
     gpio_init_af(CPU_STM32WL_SUBGHZSPI_DEBUG_MOSIOUT,
@@ -232,7 +232,7 @@ void cpu_init(void)
     /* trigger static peripheral initialization */
     periph_init();
 
-    if (IS_ACTIVE(CONFIG_STM32_WL55JC_SUBGHZ_DEBUG)) {
-        _wl55jc_init_subghz_debug_pins();
+    if (IS_ACTIVE(CONFIG_STM32_WLX5XX_SUBGHZ_DEBUG)) {
+        _wlx5xx_init_subghz_debug_pins();
     }
 }

--- a/cpu/stm32/include/periph/wl/periph_cpu.h
+++ b/cpu/stm32/include/periph/wl/periph_cpu.h
@@ -119,7 +119,7 @@ extern "C" {
  * @brief Set this to 1 to enable hardware debugging.
  */
 #ifdef DOXYGEN
-#define CONFIG_STM32_WL55JC_SUBGHZ_DEBUG
+#define CONFIG_STM32_WLX5XX_SUBGHZ_DEBUG
 #endif
 /** @} */
 

--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -190,7 +190,8 @@ void flashpage_erase(unsigned page)
     assert(page < (int)FLASHPAGE_NUMOF);
 
     /* ensure there is no attempt to write to CPU2 protected area */
-#if defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32WB) || (defined(CPU_FAM_STM32WL) && \
+                                 !defined(CPU_LINE_STM32WLE5xx))
     assert(page < (int)(FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 

--- a/cpu/stm32/stm32_info.mk
+++ b/cpu/stm32/stm32_info.mk
@@ -12,15 +12,20 @@ STM32_INFO     := $(shell echo $(CPU_MODEL_UPPERCASE) | sed -E -e 's/^STM32(F|L|
 STM32_TYPE     = $(word 1, $(STM32_INFO))
 STM32_FAMILY   = $(word 2, $(STM32_INFO))
 STM32_MODEL    = $(word 3, $(STM32_INFO))
-ifneq (MP, $(STM32_TYPE))
+ifneq (,$(filter W,$(STM32_TYPE)))
+  STM32_MODEL2   = $(word 4, $(STM32_INFO))
+  STM32_MODEL3   = $(word 5, $(STM32_INFO))
+  STM32_PINCOUNT = $(word 6, $(STM32_INFO))
+  STM32_ROMSIZE  = $(word 7, $(STM32_INFO))
+else ifneq (,$(filter MP,$(STM32_TYPE)))
+  STM32_MODEL2   = $(word 6, $(STM32_INFO))
+  STM32_PINCOUNT = $(word 7, $(STM32_INFO))$(word 8, $(STM32_INFO))
+else
   STM32_MODEL2   = $(word 4, $(STM32_INFO))
   STM32_MODEL3   = $(word 5, $(STM32_INFO))
   STM32_PINCOUNT = $(word 6, $(STM32_INFO))
   STM32_ROMSIZE  = $(word 7, $(STM32_INFO))
   STM32_RAMMOD   = $(word 8, $(STM32_INFO))
-else
-  STM32_MODEL2   = $(word 6, $(STM32_INFO))
-  STM32_PINCOUNT = $(word 7, $(STM32_INFO))$(word 8, $(STM32_INFO))
 endif
 
 CPU_FAM = $(call lowercase,$(STM32_TYPE)$(STM32_FAMILY))

--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -274,7 +274,17 @@ else ifeq ($(STM32_TYPE), W)
       endif
     endif
   else ifeq ($(STM32_FAMILY), L)
-    RAM_LEN = 64K
+    ifeq ($(STM32_MODEL), L55)
+      RAM_LEN = 64K
+    else ifneq (, $(filter LE5 LE4, $(STM32_MODEL)))
+      ifeq ($(STM32_ROMSIZE), 8)
+        RAM_LEN = 20K
+      else ifeq ($(STM32_ROMSIZE), B)
+        RAM_LEN = 48K
+      else
+        RAM_LEN = 64K
+      endif
+    endif
   endif
 else ifeq ($(STM32_TYPE), MP)
   ifeq ($(STM32_FAMILY), 1)
@@ -350,7 +360,11 @@ else ifeq ($(STM32_PINCOUNT), H)
 else ifeq ($(STM32_PINCOUNT), I)
   STM32_PIN = 176
 else ifeq ($(STM32_PINCOUNT), J)
-  STM32_PIN = 72
+  ifeq ($(STM32_TYPE), W)
+    STM32_PIN = 73
+  else
+    STM32_PIN = 72
+  endif
 else ifeq ($(STM32_PINCOUNT), K)
   STM32_PIN = 32
 else ifeq ($(STM32_PINCOUNT), M)

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -33,7 +33,8 @@ void flashpage_read(unsigned page, void *data)
 {
     assert(page < FLASHPAGE_NUMOF);
 
-#if defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32WB) || (defined(CPU_FAM_STM32WL) && \
+                                 !defined(CPU_LINE_STM32WLE5xx))
     assert(page < (FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 
@@ -44,7 +45,8 @@ int flashpage_verify(unsigned page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 
-#if defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32WB) || (defined(CPU_FAM_STM32WL) && \
+                                 !defined(CPU_LINE_STM32WLE5xx))
     assert(page < (int)(FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -46,6 +46,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     im880b \
     limifrog-v1 \
     lobaro-lorabox \
+    lora-e5-dev \
     lsn50 \
     maple-mini \
     mcb2388 \


### PR DESCRIPTION

### Contribution description

This PR adds support for [LoRa-E5 Development Board](https://www.google.com/search?channel=fs&client=ubuntu&q=seedstudio+lora-e5). 

Missing form this PR:
- [ ] support for the integrated temperature sensor
- [ ] support for the integrated spi-flash (no documentation available AFAIKT)

There seems to be an issue with I2C but I experienced the same issue with `nucleo-wl55jc`, so I think its unrelated to this PR and I'm confident on the pin mapping, so I kept the support. Maybe @MrKevinWeiss can use HIL to verify that `stm32wl` i2c is not broken?

### Testing procedure

Tested main functionalities:

- spi ( bme280_spi)

```
2021-07-20 13:46:27,385 # main(): This is RIOT! (Version: 2021.10-devel-170-g05efb-wip/lora_e5)
2021-07-20 13:46:27,386 # BMX280 test application
2021-07-20 13:46:27,386 #
2021-07-20 13:46:27,393 # +------------Initializing------------+
2021-07-20 13:46:27,393 # Initialization successful
2021-07-20 13:46:27,394 #
2021-07-20 13:46:27,398 # +------------Calibration Data------------+
2021-07-20 13:46:27,399 # dig_T1: 28497
2021-07-20 13:46:27,399 # dig_T2: 26274
2021-07-20 13:46:27,400 # dig_T3: 50
2021-07-20 13:46:27,404 # dig_P1: 37174
2021-07-20 13:46:27,404 # dig_P2: -10773
2021-07-20 13:46:27,405 # dig_P3: 3024
2021-07-20 13:46:27,405 # dig_P4: 9121
2021-07-20 13:46:27,406 # dig_P5: -67
2021-07-20 13:46:27,410 # dig_P6: -7
2021-07-20 13:46:27,410 # dig_P7: 12300
2021-07-20 13:46:27,410 # dig_P8: -12000
2021-07-20 13:46:27,411 # dig_P9: 5000
2021-07-20 13:46:27,411 # dig_H1: 75
2021-07-20 13:46:27,415 # dig_H2: 334
2021-07-20 13:46:27,415 # dig_H3: 0
2021-07-20 13:46:27,416 # dig_H4: 393
2021-07-20 13:46:27,416 # dig_H5: 50
2021-07-20 13:46:27,416 # dig_H6: 30
2021-07-20 13:46:27,416 #
2021-07-20 13:46:27,421 # +--------Starting Measurements--------+
2021-07-20 13:46:27,424 # [bmx280] _do_measurement: measurement data ready
2021-07-20 13:46:27,439 # [bmx280] _do_measurement: measurement data ready
2021-07-20 13:46:27,445 # [bmx280] _do_measurement: measurement data ready
2021-07-20 13:46:27,445 # Temperature [°C]: 26.14
2021-07-20 13:46:27,450 #    Pressure [Pa]: 99053
2021-07-20 13:46:27,451 #   Humidity [%rH]: 52.67
2021-07-20 13:46:27,451 #
2021-07-20 13:46:27,454 # +-------------------------------------+
2021-07-20 13:46:27,454 #
2021-07-20 13:46:29,459 # [bmx280] _do_measurement: measurement data ready
2021-07-20 13:46:29,467 # [bmx280] _do_measurement: measurement data ready
2021-07-20 13:46:29,475 # [bmx280] _do_measurement: measurement data ready
2021-07-20 13:46:29,480 # Temperature [°C]: 26.16
2021-07-20 13:46:29,480 #    Pressure [Pa]: 99076
2021-07-20 13:46:29,481 #   Humidity [%rH]: 52.62
2021-07-20 13:46:29,481 #
2021-07-20 13:46:29,485 # +-------------------------------------+
```

- rtt
```
2021-07-20 09:11:05,949 # main(): This is RIOT! (Version: 2021.10-devel-170-g43cad-wip/lora_e5)
2021-07-20 09:11:05,949 #
2021-07-20 09:11:05,951 # RIOT RTT low-level driver test
2021-07-20 09:11:05,952 # RTT configuration:
2021-07-20 09:11:05,955 # RTT_MAX_VALUE: 0x0000ffff
2021-07-20 09:11:05,956 # RTT_FREQUENCY: 1024
2021-07-20 09:11:05,956 #
2021-07-20 09:11:05,960 # Testing the tick conversion
2021-07-20 09:11:05,961 # Trying to convert 1 to seconds and back
2021-07-20 09:11:05,965 # Trying to convert 256 to seconds and back
2021-07-20 09:11:05,971 # Trying to convert 65536 to seconds and back
2021-07-20 09:11:05,971 # Trying to convert 16777216 to seconds and back
2021-07-20 09:11:05,978 # Trying to convert 2147483648 to seconds and back
2021-07-20 09:11:05,978 # All ok
2021-07-20 09:11:05,978 #
2021-07-20 09:11:05,979 # Initializing the RTT driver
2021-07-20 09:11:06,139 # This test will now display 'Hello' every 5 seconds
2021-07-20 09:11:06,140 #
2021-07-20 09:11:06,140 # RTT now: 1
2021-07-20 09:11:06,144 # Setting initial alarm to now + 5 s (5121)
2021-07-20 09:11:06,150 # rtt_get_alarm() PASSED
2021-07-20 09:11:06,151 # Done setting up the RTT, wait for many Hellos
2021-07-20 09:11:11,141 # Hello
2021-07-20 09:11:16,140 # Hello
2021-07-20 09:11:21,139 # Hello
2021-07-20 09:11:26,139 # Hello
2021-07-20 09:11:31,138 # Hello
```
- loramac

```
2021-07-20 10:13:08,853 # All up, running the shell now
: loramac set deveui 00D23F63A8D87785
2021-07-20 10:13:12,822 # loramac set deveui 00D23F63A8D87785
: loramac set appeui 70B3D57ED00204EC
2021-07-20 10:13:15,817 # loramac set appeui 70B3D57ED00204EC
: loramac set appkey 916145C2F84B9B30584164B8625B50EE
2021-07-20 10:13:18,962 # loramac set appkey 916145C2F84B9B30584164B8625B50EE
: loramac join otaa
2021-07-20 10:13:20,813 # loramac join otaa
2021-07-20 10:13:29,141 # Join procedure succeeded!
loramac tx "hi"
2021-07-20 10:13:42,814 # loramac tx "hi"
2021-07-20 10:13:50,162 # Received ACK from network
2021-07-20 10:13:50,163 # Message sent with success
```