### PR TITLE
dhcpv6_client: fix scaling of get_rand_us_factor

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -322,7 +322,7 @@ static inline size_t _add_ia_pd_from_config(uint8_t *buf, size_t len_max)
 static inline int32_t get_rand_us_factor(void)
 {
     int32_t res = ((int32_t)random_uint32_range(0, 200 * US_PER_MS));
-    res -= 100 * US_PER_SEC;
+    res -= 100 * US_PER_MS;
     return res;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
From what I can tell, this is a bug. The [RFC defines RAND "a random number chosen with a uniform distribution between -0.1 and +0.1."](https://datatracker.ietf.org/doc/html/rfc8415#section-15), so we want to first take a number between 0μs and 200000μs and then subtract 100000μs from it to get the desired range, not take a number between 0μs and 200000μs and then subtract 100000000μs like it is the case in the current code.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Since I found this bug only through code review, I'm not sure how to test this. I think the retransmission times of the DHCPv6 should now be far less erratic.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
