### PR TITLE
net/gnrc_lorawan: fix pick channel

### DIFF
--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_region.c
@@ -100,10 +100,10 @@ uint32_t gnrc_lorawan_pick_channel(gnrc_lorawan_t *mac)
 {
     uint8_t index = 0;
 
-    uint8_t random_number = random_uint32_range(0, bitarithm_bits_set(mac->channel_mask));
+    uint8_t pos = random_uint32_range(0, bitarithm_bits_set(mac->channel_mask));
     unsigned state = mac->channel_mask;
 
-    for (int i = 0; i < random_number; i++) {
+    for (int i = 0; i < pos + 1; i++) {
         state = bitarithm_test_and_clear(state, &index);
     }
     return mac->channel[index];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

~This PR fixes the upper bound of `random_uint32_range` during channel selection. Since this function is defined as `a <= x < b`, the current implementation picks N-1 channels (instead of N).~

The function was actually right, but the for loop was not taking into consideration that the random number was the channel position in the bitmask.

If the channel mask is e.g `0x5` (`101`), this function should pick the either the first or the third channel (with indexes `0` and `2`).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Join a NS with ABP using `examples/gnrc_lorawan`. Send many unconfirmable uplinks. Make sure 3 channels are used.
@akshaim, coud you give it a look, since you have all the hardware?
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Discovered while reading the SDR results in https://github.com/RIOT-OS/RIOT/pull/15946#issuecomment-883370407
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
