### PR TITLE
gnrc_netif: use link-local source address if destination is link-local

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1015,6 +1015,10 @@ static int _create_candidate_set(const gnrc_netif_t *netif,
 {
     int res = -1;
 
+    if (ipv6_addr_is_link_local(dst)) {
+        ll_only = true;
+    }
+
     DEBUG("gathering source address candidates\n");
     /* currently this implementation supports only addresses as source address
      * candidates assigned to this interface. Thus we assume all addresses to be


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

So while debugging some strange behavior in GNRC I noticed that sometimes a packet would be send to a link-local address with a global address as the source if the source address is left unspecified.

Is this the intended behavior? From my naive understanding I would expect to only use link-local addresses when targeting another on-link host, but I might be wrong. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
