### PR TITLE
event/timeout.h: fix typos in doc

### DIFF
--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -91,14 +91,14 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
  * @brief   Set a timeout
  *
  * This will make the event as configured in @p event_timeout be triggered
- * after @p timeout microseconds (if using @ref xtimer) or the the @ref
+ * after @p timeout microseconds (if using @ref xtimer) or the @ref
  * ztimer_clock_t ticks.
  *
  * @note: the used event_timeout struct must stay valid until after the timeout
  *        event has been processed!
  *
  * @param[in]   event_timeout   event_timout context object to use
- * @param[in]   timeout         timeout in microseconds ot the ztimer_clock_t
+ * @param[in]   timeout         timeout in microseconds or the ztimer_clock_t
  *                              ticks units
  */
 void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Just fixing some typos ;-)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read. Maybe the static tests also will reveal some more typos :-).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
