### PR TITLE
event_timeout: check clock before removing ztimer on clear 

### DIFF
--- a/sys/event/timeout.c
+++ b/sys/event/timeout.c
@@ -60,7 +60,9 @@ void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout)
 void event_timeout_clear(event_timeout_t *event_timeout)
 {
 #if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
-    ztimer_remove(event_timeout->clock, &event_timeout->timer);
+    if (event_timeout->clock) {
+        ztimer_remove(event_timeout->clock, &event_timeout->timer);
+    }
 #else
     xtimer_remove(&event_timeout->timer);
 #endif

--- a/tests/event_ztimer/main.c
+++ b/tests/event_ztimer/main.c
@@ -108,6 +108,7 @@ int main(void)
     puts("waiting for periodic callback to be triggered 4 times");
     mutex_lock(&lock);
     puts("posting timed callback with timeout 0.5sec, clear right after");
+    event_timeout_clear(&event_timeout_cleared);
     event_timeout_ztimer_init(&event_timeout_cleared, ZTIMER_USEC,
                               EVENT_PRIO_MEDIUM, &event_never.super);
     event_timeout_set(&event_timeout_cleared, EVENT_TIMEOUT_TIME / 2);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently, `event_timeout_clear()` crashes when used with `ztimer` and when the timeout is uninitialized. This isn't the same behavior as with `xtimer`. As such, check the clock variable (which when set to `NULL` causes the crash) before clearing the timer.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/event` should pass. When the fix is reverted, it crashes.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
