### PR TITLE
dhcpv6_client: refactor to use `event_timeout` for non-sock timeouts

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -99,8 +99,8 @@ endif
 
 ifneq (,$(filter dhcpv6_client,$(USEMODULE)))
   USEMODULE += event
+  USEMODULE += event_timeout
   USEMODULE += random
-  USEMODULE += xtimer
   ifneq (,$(filter sock_dns,$(USEMODULE)))
     USEMODULE += dhcpv6_client_dns
   endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -100,6 +100,10 @@ endif
 ifneq (,$(filter dhcpv6_client,$(USEMODULE)))
   USEMODULE += event
   USEMODULE += event_timeout
+  ifneq (,$(filter ztimer,$(USEMODULE)))
+    USEMODULE += event_timeout_ztimer
+    USEMODULE += ztimer_msec ztimer_sec
+  endif
   USEMODULE += random
   ifneq (,$(filter sock_dns,$(USEMODULE)))
     USEMODULE += dhcpv6_client_dns

--- a/sys/include/net/dhcpv6/client.h
+++ b/sys/include/net/dhcpv6/client.h
@@ -108,8 +108,11 @@ void dhcpv6_client_init(event_queue_t *event_queue, uint16_t netif);
 /**
  * @brief   Let the server start listening
  *
+ * @pre @ref dhcpv6_client_init() was called (i.e. the internal event queue of
+ *      he client was set).
+ *
  * This needs to be called *after* all desired [configuration functions]
- * (@ref net_dhcpv6_client_conf) where called.
+ * (@ref net_dhcpv6_client_conf) and @ref dhcpv6_client_init() were called.
  */
 void dhcpv6_client_start(void);
 

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -59,6 +59,11 @@ extern "C" {
 #define US_PER_CS  (10000U)
 
 /**
+ * @brief The number of milliseconds per centisecond
+ */
+#define MS_PER_CS  (10U)
+
+/**
  * @brief The number of nanoseconds per microsecond
  */
 #define NS_PER_US           (1000LU)

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 
 #include "event.h"
+#include "event/timeout.h"
 #include "log.h"
 #include "kernel_defines.h"
 #include "net/dhcpv6/client.h"
@@ -72,7 +73,7 @@ static uint8_t best_adv[DHCPV6_CLIENT_BUFLEN];
 static uint8_t duid[DHCPV6_CLIENT_DUID_LEN];
 static pfx_lease_t pfx_leases[CONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX];
 static server_t server;
-static xtimer_t timer, rebind_timer;
+static event_timeout_t solicit_renew_timeout, rebind_timeout;
 static event_queue_t *event_queue;
 static sock_udp_t sock;
 static sock_udp_ep_t local = { .family = AF_INET6, .port = DHCPV6_CLIENT_PORT };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Not sure, why I did not do that in the first place (maybe `event_timeout` did not exist back then, I seemed to basically have mirrored its behavior). As an added bonus, this makes the migration to `ztimer` really easy, which I also did in this PR.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make -C tests/gnrc_dhcpv6_client flash -j test` still passes, with and without `USEMODULE=ztimer`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~~Requires https://github.com/RIOT-OS/RIOT/pull/16667 for the test to pass with `ztimer`.~~ (merged)

#16661 conflicts with this PR, but IMHO #16661 should be merged first, to have the issue fixed in master.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
