### PR TITLE
gnrc/nib: gnrc_ipv6_nib_get_next_hop_l2addr(): only assume neighbor cache entries to always be on-link

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -93,7 +93,7 @@ void _handle_sl2ao(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                    const icmpv6_hdr_t *icmpv6, const ndp_opt_t *sl2ao)
 {
     assert(netif != NULL);
-    _nib_onl_entry_t *nce = _nib_onl_get(&ipv6->src, netif->pid);
+    _nib_onl_entry_t *nce = _nib_onl_nc_get(&ipv6->src, netif->pid);
     int l2addr_len;
 
     l2addr_len = gnrc_netif_ndp_addr_len_from_l2ao(netif, sl2ao);
@@ -102,7 +102,7 @@ void _handle_sl2ao(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         return;
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ARSM)
-    if ((nce != NULL) && (nce->mode & _NC) &&
+    if ((nce != NULL) &&
         ((nce->l2addr_len != l2addr_len) ||
          (memcmp(nce->l2addr, sl2ao + 1, nce->l2addr_len) != 0)) &&
         /* a 6LR MUST NOT modify an existing NCE based on an SL2AO in an RS
@@ -113,7 +113,7 @@ void _handle_sl2ao(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         _set_nud_state(netif, nce, GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE);
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_ARSM */
-    if ((nce == NULL) || !(nce->mode & _NC)) {
+    if (nce == NULL) {
         DEBUG("nib: Creating NCE for (ipv6 = %s, iface = %u, nud_state = STALE)\n",
               ipv6_addr_to_str(addr_str, &ipv6->src, sizeof(addr_str)),
               netif->pid);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -351,6 +351,26 @@ _nib_onl_entry_t *_nib_onl_iter(const _nib_onl_entry_t *last);
 _nib_onl_entry_t *_nib_onl_get(const ipv6_addr_t *addr, unsigned iface);
 
 /**
+ * @brief   Gets a node by IPv6 address and interface from the neighbor cache
+ *
+ * @pre     `(addr != NULL)`
+ *
+ * @param[in] addr  The address of a node. Must not be NULL.
+ * @param[in] iface The interface to the node. May be 0 for any interface.
+ *
+ * @return  The Neighbor Cache entry for node with @p addr and @p iface on success.
+ * @return  NULL, if there is no such entry.
+ */
+static inline _nib_onl_entry_t *_nib_onl_nc_get(const ipv6_addr_t *addr, unsigned iface)
+{
+    _nib_onl_entry_t *nce = _nib_onl_get(addr, iface);
+    if (nce && (nce->mode & _NC)) {
+        return nce;
+    }
+    return NULL;
+}
+
+/**
  * @brief   Creates or gets an existing node from the neighbor cache by address
  *
  * @pre     `((cstate & GNRC_IPV6_NIB_NC_INFO_NUD_STATE_MASK) !=

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -221,8 +221,9 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
         unsigned iface = (node == NULL) ? 0 : _nib_onl_get_if(node);
 
         if ((node != NULL) || _on_link(dst, &iface)) {
-            DEBUG("nib: %s is on-link or in NC, start address resolution\n",
-                  ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)));
+            DEBUG("nib: %s is %s, start address resolution\n",
+                  ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)),
+                  node ? "in NC" : "on-link");
             /* on-link prefixes return their interface */
             if (!ipv6_addr_is_link_local(dst) && (iface != 0)) {
                 /* release pre-assumed netif */

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -220,7 +220,7 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
         /* consider neighbor cache entries first */
         unsigned iface = (node == NULL) ? 0 : _nib_onl_get_if(node);
 
-        if ((node != NULL) || _on_link(dst, &iface)) {
+        if ((node != NULL) && (node->mode & _NC)) || _on_link(dst, &iface)) {
             DEBUG("nib: %s is %s, start address resolution\n",
                   ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)),
                   node ? "in NC" : "on-link");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Consider the following: A node tries to forward a packet to another host for which it does not know the route yet. It assumes it to be on-link and starts a neighbor solicitation, putting the node address in the destination cache.

Later the route is known (via a second hop) but the host is still in the NIB.

The result is that `gnrc_ipv6_nib_get_next_hop_l2addr()` ends up in the [`"nib: %s is in NC or on-link, start address resolution"`](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/network_layer/ipv6/nib/nib.c#L223) case and does not attempt to resolve the route.

This results in the host remaining unreachable even though now a route is present.

The fix should make sense since only neighbor cache entries are guaranteed to be on-link. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
