### PR TITLE
gnrc_netif: add gnrc_netif_ipv6_add_prefix() & helper functions

### DIFF
--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -716,6 +716,26 @@ static inline int gnrc_netif_ipv6_group_to_l2_group(gnrc_netif_t *netif,
     return l2util_ipv6_group_to_l2_group(netif->device_type, ipv6_group,
                                          l2_group);
 }
+
+/**
+ * @brief   Configures a prefix on a network interface.
+ *
+ *          If the interface is a 6LoWPAN interface, this will also
+ *          take care of setting up a compression context.
+ *
+ * @param[in] netif     Network interface the prefix should be added to
+ * @param[in] pfx       Prefix to configure
+ * @param[in] pfx_len   Length of @p pfx in bits
+ * @param[in] valid     Valid lifetime of the prefix in seconds
+ * @param[in] pref      Preferred lifetime of the prefix in seconds
+ *
+ * @return  >= 0, on success
+ * @return  -ENOMEM, when no space for new addresses (or its solicited nodes
+ *          multicast address) is left on the interface
+ */
+int gnrc_netif_ipv6_add_prefix(gnrc_netif_t *netif,
+                               const ipv6_addr_t *pfx, uint8_t pfx_len,
+                               uint32_t valid, uint32_t pref);
 #else   /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 #define gnrc_netif_ipv6_init_mtu(netif)                             (void)netif
 #define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid)   (-ENOTSUP)

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -583,7 +583,7 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid);
  * @return  Pointer to the new RPL Instance, on success.
  * @return  NULL, otherwise.
  */
-gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_id,
+gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, const ipv6_addr_t *dodag_id,
                                         bool gen_inst_id, bool local_inst_id);
 
 /**
@@ -695,7 +695,7 @@ void gnrc_rpl_long_delay_dao(gnrc_rpl_dodag_t *dodag);
  * @return  Pointer to the new RPL instance, on success.
  * @return  NULL, otherwise.
  */
-gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, ipv6_addr_t *dodag_id,
+gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, const ipv6_addr_t *dodag_id,
                                                  uint8_t mop);
 
 /**

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -736,6 +736,18 @@ static inline void gnrc_rpl_config_pio(gnrc_rpl_dodag_t *dodag, bool status)
     }
 }
 
+#if IS_USED(MODULE_GNRC_RPL) || DOXYGEN
+/**
+ * @brief Convenience function to start a RPL root using the default configuration.
+ *
+ * @param[in] netif             Network interface to use as RPL root
+ * @param[in] dodag_id          Id of the DODAG
+ */
+void gnrc_rpl_configure_root(gnrc_netif_t *netif, const ipv6_addr_t *dodag_id);
+#else
+#define gnrc_rpl_configure_root(netif, dodag_id)  ((void)netif)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -107,7 +107,8 @@ gnrc_rpl_instance_t *gnrc_rpl_instance_get(uint8_t instance_id);
  * @return  true, if DODAG could be created.
  * @return  false, if DODAG could not be created or exists already.
  */
-bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface);
+bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, const ipv6_addr_t *dodag_id,
+                         kernel_pid_t iface);
 
 /**
  * @brief   Remove all parents from the @p dodag.

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -12,12 +12,7 @@
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
-#ifdef MODULE_GNRC_RPL
 #include "net/gnrc/rpl.h"
-#endif
-#ifdef MODULE_GNRC_SIXLOWPAN_CTX
-#include "net/gnrc/sixlowpan/ctx.h"
-#endif
 #include "net/ipv6/addr.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
@@ -26,7 +21,6 @@
 #include "log.h"
 #include "fmt.h"
 
-static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 static kernel_pid_t gnrc_border_interface;
 static kernel_pid_t gnrc_wireless_interface;
 
@@ -69,58 +63,13 @@ static void set_interface_roles(void)
              "interface.\n", gnrc_border_interface, gnrc_wireless_interface);
 }
 
-static ipv6_addr_t _prefix;
-static uint8_t _prefix_len;
-
-#ifdef MODULE_GNRC_SIXLOWPAN_CTX
-#define SIXLO_CTX_LTIME_MIN (60U)   /**< context lifetime in minutes */
-
-static bool _ctx_match(const gnrc_sixlowpan_ctx_t *ctx,
-                       const ipv6_addr_t *prefix, uint8_t prefix_len)
-{
-    return (ctx != NULL) &&
-           (ctx->prefix_len == prefix_len) &&
-           (ipv6_addr_match_prefix(&ctx->prefix, prefix) >= prefix_len);
-}
-
-static void _update_6ctx(const ipv6_addr_t *prefix, uint8_t prefix_len)
-{
-    gnrc_sixlowpan_ctx_t *ctx = gnrc_sixlowpan_ctx_lookup_addr(prefix);
-    uint8_t cid = 0;
-
-    if (!_ctx_match(ctx, prefix, prefix_len)) {
-        /* While the context is a prefix match, the defined prefix within the
-         * context does not match => use new context */
-        ctx = NULL;
-    }
-    else {
-        cid = ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK;
-    }
-    /* find first free context ID */
-    if (ctx == NULL) {
-        while (((ctx = gnrc_sixlowpan_ctx_lookup_id(cid)) != NULL) &&
-               !_ctx_match(ctx, prefix, prefix_len)) {
-            cid++;
-        }
-    }
-    if (cid < GNRC_SIXLOWPAN_CTX_SIZE) {
-        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): add compression context "
-                 "%u for prefix %s/%u\n", cid,
-                 ipv6_addr_to_str(addr_str, prefix, sizeof(addr_str)),
-                 prefix_len);
-        gnrc_sixlowpan_ctx_update(cid, (ipv6_addr_t *)prefix, prefix_len,
-                                  SIXLO_CTX_LTIME_MIN, true);
-    }
-}
-#endif
-
 void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime,
                         uint8_t *src, uhcp_iface_t iface)
 {
-    (void)lifetime;
+    int idx;
+    gnrc_netif_t *wireless;
     (void)src;
 
-    eui64_t iid;
     if (!gnrc_wireless_interface) {
         LOG_WARNING("gnrc_uhcpc: uhcp_handle_prefix(): received prefix, but "
                     "don't know any wireless interface\n");
@@ -133,71 +82,12 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime,
         return;
     }
 
-    if (gnrc_netapi_get(gnrc_wireless_interface, NETOPT_IPV6_IID, 0, &iid,
-                        sizeof(eui64_t)) >= 0) {
-        ipv6_addr_set_aiid((ipv6_addr_t*)prefix, iid.uint8);
+    wireless = gnrc_netif_get_by_pid(gnrc_wireless_interface);
+    idx = gnrc_netif_ipv6_add_prefix(wireless, (ipv6_addr_t *)prefix, prefix_len,
+                                     lifetime, lifetime);
+    if (idx >= 0) {
+        gnrc_rpl_configure_root(wireless, &wireless->ipv6.addrs[idx]);
     }
-    else {
-        LOG_WARNING("gnrc_uhcpc: uhcp_handle_prefix(): cannot get IID of "
-                    "wireless interface\n");
-        return;
-    }
-
-    if ((_prefix_len == prefix_len) &&
-        (ipv6_addr_match_prefix(&_prefix,
-                                (ipv6_addr_t *)prefix) >= prefix_len)) {
-        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): got same prefix "
-                 "again\n");
-#ifdef MODULE_GNRC_SIXLOWPAN_CTX
-        if (gnrc_netif_is_6ln(gnrc_netif_get_by_pid(gnrc_wireless_interface))) {
-            /* always update 6LoWPAN compression context so it does not time
-             * out, we can't just remove it anyway according to the RFC */
-            _update_6ctx((ipv6_addr_t *)prefix, prefix_len);
-        }
-#endif
-        return;
-    }
-    else if (!ipv6_addr_is_unspecified(&_prefix)) {
-        gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
-                        &_prefix, sizeof(_prefix));
-#if defined(MODULE_GNRC_IPV6_NIB) && IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR) && \
-    IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
-        gnrc_ipv6_nib_abr_del(&_prefix);
-#endif
-        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): removed old prefix %s/%u\n",
-                 ipv6_addr_to_str(addr_str, &_prefix, sizeof(addr_str)),
-                 prefix_len);
-    }
-    memcpy(&_prefix, prefix, sizeof(_prefix));
-    _prefix_len = prefix_len;
-    gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR,
-                    (prefix_len << 8), prefix, sizeof(ipv6_addr_t));
-    /* only configure 6Lo-ND features when wireless interface uses
-     * 6Lo-ND */
-    if (gnrc_netif_is_6ln(gnrc_netif_get_by_pid(gnrc_wireless_interface))) {
-#ifdef MODULE_GNRC_SIXLOWPAN_CTX
-        /* add compression before ABR to add it automatically to its context
-         * list */
-        _update_6ctx((ipv6_addr_t *)prefix, prefix_len);
-#endif
-#if defined(MODULE_GNRC_IPV6_NIB) && IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR) && \
-        IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
-        gnrc_ipv6_nib_abr_add((ipv6_addr_t *)prefix);
-#endif
-    }
-#ifdef MODULE_GNRC_RPL
-    gnrc_rpl_init(gnrc_wireless_interface);
-    gnrc_rpl_instance_t *inst = gnrc_rpl_instance_get(
-                                    CONFIG_GNRC_RPL_DEFAULT_INSTANCE);
-    if (inst) {
-        gnrc_rpl_instance_remove(inst);
-    }
-    gnrc_rpl_root_init(CONFIG_GNRC_RPL_DEFAULT_INSTANCE, (ipv6_addr_t*)prefix, false,
-                       false);
-#endif
-    LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix %s/%u\n",
-             ipv6_addr_to_str(addr_str, (ipv6_addr_t *)prefix,
-             sizeof(addr_str)), prefix_len);
 }
 
 extern void uhcp_client(uhcp_iface_t iface);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -128,7 +128,7 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
     return gnrc_rpl_pid;
 }
 
-gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_id,
+gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, const ipv6_addr_t *dodag_id,
                                         bool gen_inst_id, bool local_inst_id)
 {
     if (gen_inst_id) {

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -419,6 +419,18 @@ uint8_t gnrc_rpl_gen_instance_id(bool local)
     return instance_id;
 }
 
+void gnrc_rpl_configure_root(gnrc_netif_t *netif, const ipv6_addr_t *dodag_id)
+{
+    gnrc_rpl_init(netif->pid);
+    gnrc_rpl_instance_t *inst = gnrc_rpl_instance_get(
+            CONFIG_GNRC_RPL_DEFAULT_INSTANCE
+        );
+    if (inst) {
+        gnrc_rpl_instance_remove(inst);
+    }
+    gnrc_rpl_root_init(CONFIG_GNRC_RPL_DEFAULT_INSTANCE, dodag_id, false, false);
+}
+
 /**
  * @}
  */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -144,7 +144,8 @@ gnrc_rpl_instance_t *gnrc_rpl_instance_get(uint8_t instance_id)
     return NULL;
 }
 
-bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, kernel_pid_t iface)
+bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, const ipv6_addr_t *dodag_id,
+                         kernel_pid_t iface)
 {
     assert(instance && (instance->state > 0));
 
@@ -370,7 +371,7 @@ static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *doda
     return dodag->parents;
 }
 
-gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, ipv6_addr_t *dodag_id,
+gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, const ipv6_addr_t *dodag_id,
                                                  uint8_t mop)
 {
     if (gnrc_rpl_pid == KERNEL_PID_UNDEF) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Code from `dhcpv6_client_conf_prefix()` can be useful in other situations where we want to configure a prefix on an interface.
Move it to a common place and also use it for  uhcp.

### Testing procedure

`examples/gnrc_border_router` still gets a valid prefix

##### via UHCP

```
Iface  6  HWaddr: AE:8D:C2:75:23:DE 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::ac8d:c2ff:fe75:23de  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff75:23de
          inet6 group: ff02::1:ff00:2
          
Iface  5  HWaddr: 49:05  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
          
          Long HWaddr: 00:04:25:19:18:01:C9:05 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::204:2519:1801:c905  scope: link  VAL
          inet6 addr: 2001:db8::204:2519:1801:c905  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff01:c905
```


### Issues/PRs references

split off #16536
