### PR TITLE
netutils: get interface by name rather than ID

### DIFF
--- a/sys/net/netutils/util.c
+++ b/sys/net/netutils/util.c
@@ -56,7 +56,7 @@ int netutils_get_ipv6(ipv6_addr_t *addr, netif_t **netif, const char *hostname)
     size_t len = strlen(hostname);
     char *iface = strchr(hostname, '%');
     if (iface) {
-        *netif = netif_get_by_id(atoi(iface + 1));
+        *netif = netif_get_by_name(iface + 1);
         len -= strlen(iface);
 
         if (*netif == NULL) {


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The zone ID part in a host part is the name of the network interface (which by chance is the string representation of the ID with GNRC), not the ID.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/netutils` should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Somehow slipped through the initial review. See https://github.com/RIOT-OS/RIOT/pull/16634#issuecomment-878475883.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
