### PR TITLE
gnrc_netif: provide implementation for netif_get_by_name()

### DIFF
--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -44,6 +44,11 @@ netif_t *netif_get_by_id(int16_t id)
     return &gnrc_netif_get_by_pid((kernel_pid_t)id)->netif;
 }
 
+netif_t *netif_get_by_name(const char *name)
+{
+    return &gnrc_netif_get_by_pid((kernel_pid_t)atoi(name))->netif;
+}
+
 int netif_get_opt(netif_t *netif, netopt_t opt, uint16_t context,
                   void *value, size_t max_len)
 {

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -56,7 +56,7 @@ __attribute__((weak)) int16_t netif_get_id(const netif_t *netif)
     return -1;
 }
 
-netif_t *netif_get_by_name(const char *name)
+__attribute__((weak)) netif_t *netif_get_by_name(const char *name)
 {
     assert(name);
     list_node_t *node = netif_list.next;


### PR DESCRIPTION
### Contribution description

Provide a simpler implementation for `netif_get_by_name()` for GNRC.


### Testing procedure

#### master

```
   text	   data	    bss	    dec	    hex	filename
 206177	   1328	 102900	 310405	  4bc85	examples/gnrc_networking/bin/native/gnrc_networking.elf
```

#### this patch

```
   text	   data	    bss	    dec	    hex	filename
 206007	   1324	 102900	 310231	  4bbd7	examples/gnrc_networking/bin/native/gnrc_networking.elf
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
