### PR TITLE
dhcpv6_client: mrd calculation fixed

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -839,7 +839,7 @@ static void _request_renew_rebind(uint8_t type)
         case DHCPV6_RENEW:
             irt = DHCPV6_REN_TIMEOUT;
             mrt = DHCPV6_REN_MAX_RT;
-            mrd = rebind_time - t2;
+            mrd = rebind_time - _now_sec();
             break;
         case DHCPV6_REBIND: {
             irt = DHCPV6_REB_TIMEOUT;
@@ -858,7 +858,7 @@ static void _request_renew_rebind(uint8_t type)
                     mrd = valid_until;
                 }
             }
-            if (mrd > 0) {
+            if (mrd == 0) {
                 /* all leases already expired, don't try to rebind and
                  * solicit immediately */
                 _post_solicit_servers();

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -25,6 +25,7 @@
 #include "net/gnrc/rpl.h"
 #include "net/sock.h"
 #include "timex.h"
+#include "evtimer.h"
 
 #include "net/dhcpv6/client.h"
 
@@ -183,13 +184,14 @@ uint32_t dhcpv6_client_prefix_valid_until(unsigned netif,
     gnrc_ipv6_nib_pl_t ple;
     void *state = NULL;
     uint32_t max_valid = 0;
+    uint32_t now = evtimer_now_msec();
 
     while (gnrc_ipv6_nib_pl_iter(netif, &state, &ple)) {
         if ((ple.pfx_len == pfx_len) &&
-            ((ple.valid_until / MS_PER_SEC) > max_valid) &&
+            (((ple.valid_until - now) / MS_PER_SEC) > max_valid) &&
             (ipv6_addr_match_prefix(&ple.pfx,
                                     pfx) >= ple.pfx_len)) {
-            max_valid = ple.valid_until / MS_PER_SEC;
+            max_valid = (ple.valid_until - now) / MS_PER_SEC;
         }
     }
     return max_valid;


### PR DESCRIPTION
mrd calculation for dhcp-rebind and renew was wrong this fixes it
see issue  #16677

### Contribution description

fixes mrd calculation

### Testing procedure

run the "tests/gnrc_dhcpv6_client" but to see the effect you have to put some extra prints too

```
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -854,6 +854,7 @@ static void _request_renew_rebind(uint8_t type)
                         lease->parent.ia_id.info.netif,
                         &lease->pfx, lease->pfx_len
                     );
+                printf("valid_until %"PRIu32"\n",valid_until);
                 if (valid_until > mrd) {
                     mrd = valid_until;
                 }
@@ -887,6 +888,7 @@ static void _request_renew_rebind(uint8_t type)
     msg_len += _add_ia_pd_from_config(&send_buf[msg_len], sizeof(send_buf) - msg_len);
     _flush_stale_replies(&sock);
     while (sock_udp_send(&sock, send_buf, msg_len, &remote) <= 0) {}
+    printf("DHCPv6 client: mrd %"PRIu32" , etime %"PRIi16"\n", mrd, _get_elapsed_time() );
     while (((res = sock_udp_recv(&sock, recv_buf, sizeof(recv_buf),
                                  retrans_timeout * US_PER_MS, NULL)) <= 0) ||
            ((res > 0) && (recv_buf[0] != DHCPV6_REPLY))) {

```

you also want to shorten the lease-time kea-dhcp6.conf

```
+    "preferred-lifetime": 60,
+    "valid-lifetime": 80,
+     "renew-timer": 20,
+    "rebind-timer": 40,
```

and 
you may want to disable the renew schedule in `_schedule_t1_t2()` temporarily to see a rebind happen

(maybe you can use network fiters to achive the same thing)



### Issues/PRs references

Fixes #16677

this started in #16668

