### PR TITLE
rtt_rtc: add rtt_rtc_settimeofday() & rtt_rtc_gettimeofday()

### DIFF
--- a/drivers/include/rtt_rtc.h
+++ b/drivers/include/rtt_rtc.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_rtt_rtc     RTC emulation on top of a RTT
+ * @ingroup     drivers_periph_rtc
+ *
+ * @{
+ *
+ * @file
+ * @brief       Additional functions provided in addition to the normal RTC API.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef RTT_RTC_H
+#define RTT_RTC_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set the time as epoch with sub-second precision
+ *        This feature is an extension provided by the `rtt_rtc` module.
+ *
+ * @note The actual µs precision depends on the underlying hardware.
+ *       The smallest time step will be 1 / @ref RTT_FREQUENCY.
+ *
+ * @param[in] s     The new epoch timestamp
+ * @param[in] us    Sub-Seconds
+ */
+void rtt_rtc_settimeofday(uint32_t s, uint32_t us);
+
+/**
+ * @brief Get the current epoch with sub-second precision
+ *        This feature is an extension provided by the `rtt_rtc` module.
+ *
+ * @note The actual µs precision depends on the underlying hardware.
+ *       The smallest time step will be 1 / @ref RTT_FREQUENCY.
+ *
+ * @param[out] s    The current epoch timestamp
+ * @param[out] us   Sub-Seconds
+ */
+void rtt_rtc_gettimeofday(uint32_t *s, uint32_t *us);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RTT_RTC_H */
+/** @} */

--- a/drivers/rtt_rtc/rtt_rtc.c
+++ b/drivers/rtt_rtc/rtt_rtc.c
@@ -138,16 +138,17 @@ int rtc_set_time(struct tm *time)
 
 int rtc_get_time_ms(struct tm *time, uint16_t *ms)
 {
-    uint32_t prev = rtc_now;
+    uint32_t tmp, prev = rtc_now;
 
     /* repeat calculation if an alarm triggered in between */
     do {
         uint32_t now = rtt_get_counter();
-        uint32_t tmp = _rtc_now(now);
+        tmp = _rtc_now(now);
 
-        rtc_localtime(tmp, time);
-        *ms = (SUBSECONDS(now) * MS_PER_SEC) / RTT_SECOND;
+        *ms = (SUBSECONDS(now - last_alarm) * MS_PER_SEC) / RTT_SECOND;
     } while (prev != rtc_now);
+
+    rtc_localtime(tmp, time);
 
     return 0;
 }

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega256rfr2-xpro \
     atmega328p \
     atmega328p-xplained-mini \
+    avsextrem \
     b-l072z-lrwan1 \
     blackpill \
     blackpill-128kib \

--- a/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c
+++ b/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c
@@ -17,6 +17,8 @@
 #include "embUnit.h"
 #include "periph/rtc.h"
 #include "periph/rtt.h"
+#include "timex.h"
+#include "rtt_rtc.h"
 
 void rtt_add_ticks(uint64_t ticks);
 
@@ -203,6 +205,29 @@ static void test_set_alarm_set_time(void)
     TEST_ASSERT_EQUAL_INT(2, alarm.tm_isdst);
 }
 
+static void test_rtt_rtc_settimeofday(void)
+{
+    uint32_t s = 10, sec;
+    uint32_t us = US_PER_SEC / 8, micro_sec;
+
+    rtt_rtc_settimeofday(s, us);
+    rtt_rtc_gettimeofday(&sec, &micro_sec);
+
+    TEST_ASSERT_EQUAL_INT(s, sec);
+    TEST_ASSERT_EQUAL_INT(us, micro_sec);
+
+    rtt_add_ticks(1LU * RTT_FREQUENCY);
+    s++;
+    rtt_rtc_gettimeofday(&sec, &micro_sec);
+    TEST_ASSERT_EQUAL_INT(s, sec);
+
+    rtt_add_ticks(RTT_FREQUENCY / 4);
+    us += US_PER_SEC / 4;
+    rtt_rtc_gettimeofday(&sec, &micro_sec);
+    TEST_ASSERT_EQUAL_INT(s, sec);
+    TEST_ASSERT_EQUAL_INT(us, micro_sec);
+}
+
 Test *tests_rtt_rtt_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -210,6 +235,7 @@ Test *tests_rtt_rtt_tests(void)
         new_TestFixture(test_set_alarm),
         new_TestFixture(test_set_alarm_short),
         new_TestFixture(test_set_alarm_set_time),
+        new_TestFixture(test_rtt_rtc_settimeofday),
     };
 
     EMB_UNIT_TESTCALLER(rtt_rtc_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

The `rtt_rtc` module provided a RTC based on a RTT.
For some applications (e.g. NTP) it can be handy to set / get the epoch timestamp directly while still retaining the calendar alarm functionality.

This PR adds two functions `rtc_settimeofday()` and `rtc_gettimeofday()` to set/get the RTT timestamp with µs precision (rounded to the closest multiple of `1 /  RTT_FREQUENCY`).

### Testing procedure

The unit test in `unittests/tests-rtt_rtc` was extended to cover the new functionality. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
