### PR TITLE
cpu/stm32: add support for STM32_PM_SHUTDOWN

### DIFF
--- a/cpu/stm32/include/periph/g4/periph_cpu.h
+++ b/cpu/stm32/include/periph/g4/periph_cpu.h
@@ -32,6 +32,9 @@ extern "C" {
  */
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
+#define PM_NUM_MODES          (3U)
+#define STM32_PM_SHUTDOWN     (2U)
+
 #endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/stm32/include/periph/g4/periph_cpu.h
+++ b/cpu/stm32/include/periph/g4/periph_cpu.h
@@ -33,7 +33,10 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
 #define PM_NUM_MODES          (3U)
-#define STM32_PM_SHUTDOWN     (2U)
+
+#define STM32_PM_STOP         (2U)
+#define STM32_PM_STANDBY      (1U)
+#define STM32_PM_SHUTDOWN     (0U)
 
 #endif /* ndef DOXYGEN */
 

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -63,6 +63,10 @@ typedef enum {
     ADC_RES_16BIT = (0x2)             /**< not applicable */
 } adc_res_t;
 /** @} */
+
+#define PM_NUM_MODES          (3U)
+#define STM32_PM_SHUTDOWN     (2U)
+
 #endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -65,7 +65,10 @@ typedef enum {
 /** @} */
 
 #define PM_NUM_MODES          (3U)
-#define STM32_PM_SHUTDOWN     (2U)
+
+#define STM32_PM_STOP         (2U)
+#define STM32_PM_STANDBY      (1U)
+#define STM32_PM_SHUTDOWN     (0U)
 
 #endif /* ndef DOXYGEN */
 

--- a/cpu/stm32/include/periph/wb/periph_cpu.h
+++ b/cpu/stm32/include/periph/wb/periph_cpu.h
@@ -32,6 +32,9 @@ extern "C" {
  */
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
+#define PM_NUM_MODES          (3U)
+#define STM32_PM_SHUTDOWN     (2U)
+
 #endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/stm32/include/periph/wb/periph_cpu.h
+++ b/cpu/stm32/include/periph/wb/periph_cpu.h
@@ -33,7 +33,10 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
 #define PM_NUM_MODES          (3U)
-#define STM32_PM_SHUTDOWN     (2U)
+
+#define STM32_PM_STOP         (2U)
+#define STM32_PM_STANDBY      (1U)
+#define STM32_PM_SHUTDOWN     (0U)
 
 #endif /* ndef DOXYGEN */
 

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -139,8 +139,10 @@ extern "C" {
  * @name    Power modes
  * @{
  */
+#ifndef STM32_PM_STOP
 #define STM32_PM_STOP         (1U)
 #define STM32_PM_STANDBY      (0U)
+#endif
 /** @} */
 
 #ifndef PM_EWUP_CONFIG

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -128,10 +128,12 @@ extern "C" {
  * @name    PM definitions
  * @{
  */
+#ifndef PM_NUM_MODES
 /**
  * @brief   Number of usable low power modes
  */
 #define PM_NUM_MODES    (2U)
+#endif
 
 /**
  * @name    Power modes


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This adds support for the STM32's Shutdown mode. Shutdown mode completely turns off the core, flash, ram, and peripherals. However, the RTC can still run and is capable of waking up the device, causing it to start executing the reset vector.

It should be noted that not all STM32s support the shutdown mode. Extra defines were added to supported MCUs in `cpu/stm32/include/periph/%/periph_cpu.h` to indicate to the pm peripheral that shutdown mode is supported.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Call `pm_set(STM32_PM_SHUTDOWN)` on a microcontroller that supports it. Notice the microcontroller shuts off. When triggering the reset pin, one of the wakeup pins, or the RTC it should come back online.