### PR TITLE
cpu/rpx0xx: fix minor gpio warnings

### DIFF
--- a/cpu/rpx0xx/include/periph_cpu.h
+++ b/cpu/rpx0xx/include/periph_cpu.h
@@ -416,7 +416,8 @@ static inline volatile uint32_t * gpio_pad_register(uint8_t pin)
  */
 static inline void gpio_set_pad_config(uint8_t pin, gpio_pad_ctrl_t config)
 {
-    *(volatile gpio_pad_ctrl_t*)gpio_pad_register(pin) = config;
+    uint32_t *c = (uint32_t *)&config;
+    *gpio_pad_register(pin) = *c;
 }
 
 /**
@@ -433,7 +434,8 @@ static inline volatile uint32_t * gpio_io_register(uint8_t pin)
  */
 static inline void gpio_set_io_config(uint8_t pin, gpio_io_ctrl_t config)
 {
-    *(volatile gpio_io_ctrl_t*)gpio_io_register(pin) = config;
+    uint32_t *c = (uint32_t *)&config;
+    *gpio_io_register(pin) = *c;
 }
 
 /**

--- a/cpu/rpx0xx/include/periph_cpu.h
+++ b/cpu/rpx0xx/include/periph_cpu.h
@@ -235,7 +235,7 @@ extern "C" {
  * @note    The RPX0XX MCU family only has a single GPIO port. Still the API requires a
  *          port parameter, which is currently ignored.
  */
-#define GPIO_PIN(port, pin)     (pin)
+#define GPIO_PIN(port, pin)     ((((port) & 0)) | (pin))
 
 /**
  * @brief   Overwrite the default gpio_t type definition


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The PR fixes some minor warnings which Murdock discovered in #16627

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

The tests which failed to compile now work as expected.

`tests/pkg_flatbuffers`
```
2021-07-27 15:21:33,626 # Connect to serial port /dev/ttyUSB0
Welcome to pyterm!
Type '/exit' to exit.
s
2021-07-27 15:21:36,117 # START
2021-07-27 15:21:36,127 # main(): This is RIOT! (Version: 2021.10-devel-165-g0d740-cpu_rp2040_periph_timer)
2021-07-27 15:21:36,132 # The FlatBuffer was successfully created and verified!
```

`tests/periph_gpio`
```
2021-07-27 15:27:24,475 # auto_test 0 14 0 15
2021-07-27 15:27:24,475 # [START]
2021-07-27 15:27:24,482 # [SUCCESS]
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#16627