### PR TITLE
gcoap: fix socket type naming

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -782,16 +782,16 @@ typedef struct {
  * @brief   Coap socket types
  */
 typedef enum {
-    COAP_SOCKET_TYPE_UNDEF = 0,
-    COAP_SOCKET_TYPE_UDP,
-    COAP_SOCKET_TYPE_DTLS
-} coap_socket_type_t;
+    GCOAP_SOCKET_TYPE_UNDEF = 0,
+    GCOAP_SOCKET_TYPE_UDP,
+    GCOAP_SOCKET_TYPE_DTLS
+} gcoap_socket_type_t;
 
 /**
  * @brief   Coap socket to handle multiple transport types
  */
 typedef struct {
-    coap_socket_type_t type;                /**< Type of stored socket */
+    gcoap_socket_type_t type;                /**< Type of stored socket */
     union {
         sock_udp_t *udp;
 #if IS_USED(MODULE_GCOAP_DTLS) || defined(DOXYGEN)
@@ -803,7 +803,7 @@ typedef struct {
                                                  Used for exchanging a session between
                                                  functions. */
 #endif
-} coap_socket_t;
+} gcoap_socket_t;
 
 /**
  * @brief   Initializes the gcoap thread and device


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The `coap_socket_t` and `coap_socket_type_t` types are used by gCoAP only and the `coap_` prefix is usually used to namespace the `nanocoap` module's API. This makes it confusing to locate the types in question.

As these types were introduced in the current release cycle and those types are mostly used internally to `gcoap`, I do not think the usual deprecation process is required here.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/gcoap` and `example/gcoap_dtls` should still compile and work.

```
$ git grep "\<coap_socket"
```
should yield no results.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
