### PR TITLE
gcoap: multi-transport support

### DIFF
--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -75,6 +75,7 @@ static const char *_link_params[] = {
 static gcoap_listener_t _listener = {
     &_resources[0],
     ARRAY_SIZE(_resources),
+    GCOAP_SOCKET_TYPE_UNDEF,
     _encode_link,
     NULL,
     NULL

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -208,6 +208,13 @@ typedef struct {
     BITFIELD(opt_crit, CONFIG_NANOCOAP_NOPTS_MAX);    /**< unhandled critical option */
 #ifdef MODULE_GCOAP
     uint32_t observe_value;                           /**< observe value           */
+    /**
+     * @brief   transport the packet was received over
+     * @see     @ref gcoap_socket_type_t for values.
+     * @note    @ref gcoap_socket_type_t can not be used, as this would
+     *          cyclically include the @ref net_gcoap header.
+     */
+    uint32_t tl_type;
 #endif
 } coap_pkt_t;
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
https://github.com/RIOT-OS/RIOT/pull/15549 introduced DTLS support for CoAP, but did not make it possible to select the transport on request. Since switching between CoAP and CoAPS (CoAP-over-DTLS) as client is a valid use case (one might want to e.g. talk to one server over CoAP and to another over CoAPS), this change makes that possible.

This is only a draft for now.

TODOs:

- [ ] Testing.
- [x] Also make listeners configurable at run-time.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Untested for now.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/15549
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
