### PR TITLE
usbus/hid_io: add missing header file, add RX callback function

### DIFF
--- a/sys/include/usb/hid.h
+++ b/sys/include/usb/hid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Nils Ollrogge
+ * Copyright (C) 2021 Nils Ollrogge
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for
@@ -16,7 +16,7 @@
  * @file
  * @brief       Definition for USB HID interfaces
  *
- * @author      Nils Ollrogge <nils-ollrogge@outlook.de>
+ * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
 
 #ifndef USB_HID_H

--- a/sys/include/usb/usbus/hid.h
+++ b/sys/include/usb/usbus/hid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Nils Ollrogge
+ * Copyright (C) 2021 Nils Ollrogge
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for
@@ -21,7 +21,7 @@
  *              specific handling. A different module is required to provide
  *              functional handling of the data e.g. UART or STDIO integration.
  *
- * @author      Nils Ollrogge <nils-ollrogge@outlook.de>
+ * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  */
 
 #ifndef USB_USBUS_HID_H

--- a/sys/include/usb/usbus/hid_io.h
+++ b/sys/include/usb/usbus/hid_io.h
@@ -34,7 +34,7 @@ extern "C" {
 /**
  * @brief USBUS HID IO RX callback function
  */
-typedef void (*usb_hid_io_cb_t)(void*);
+typedef void (*usb_hid_io_cb_t)(void *);
 
 /**
  * @brief Set USBUS HID IO RX callback

--- a/sys/include/usb/usbus/hid_io.h
+++ b/sys/include/usb/usbus/hid_io.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Nils Ollrogge
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    usbus_hid_io USBUS HID IO
+ * @ingroup     usb_hid
+ * @brief       USBUS HID IO interface module
+ *
+ * @{
+ *
+ * @file
+ * @brief       USB HID callback and read/write functions
+ *
+ * @author      Nils Ollrogge <nils.ollrogge@fu-berlin.de>
+ */
+
+#ifndef USB_USBUS_HID_IO_H
+#define USB_USBUS_HID_IO_H
+
+#include <string.h>
+#include <stdint.h>
+
+#include "usb/usbus.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief USBUS HID IO RX callback function
+ */
+typedef void (*usb_hid_io_cb_t)(void*);
+
+/**
+ * @brief Set USBUS HID IO RX callback
+ *
+ * @param[in]   cb  callback function to use
+ * @param[in]   arg argument that will be passed to @p cb
+ */
+void usb_hid_io_set_rx_cb(usb_hid_io_cb_t cb, void *arg);
+
+/**
+ * @brief Write data to USB HID IN endpoint buffer
+ *
+ * @pre `buffer != NULL`
+ *
+ * @param[in]   buffer  buffer containing data to write
+ * @param[in]   len     length of buffer
+ */
+void usb_hid_io_write(const void *buffer, size_t len);
+
+/**
+ * @brief Read data from USB HID OUT endpoint (blocking)
+ *
+ * Wrapper for @ref isrpipe_read
+ *
+ * @pre `buffer != NULL`
+ *
+ * @param[out]      buffer  buffer to read data into
+ * @param[in]       len     length of buffer
+ *
+ * @return Number of bytes read
+ */
+int usb_hid_io_read(void *buffer, size_t len);
+
+/**
+ * @brief Read data from USB HID OUT endpoint (with timeout, blocking)
+ *
+ * Wrapper for @ref isrpipe_read_timeout
+ *
+ * @pre `buffer != NULL`
+ *
+ * @param[out]      buffer  buffer to read data into
+ * @param[in]       len     length of buffer
+ * @param[in]       timeout timeout in microseconds
+ *
+ * @return Number of bytes read
+ */
+int usb_hid_io_read_timeout(void *buffer, size_t len, uint32_t timeout);
+
+/**
+ * @brief Initialize an USB HID IO interface
+ *
+ * @param[in]   usbus               USBUS context
+ * @param[in]   report_desc         USB_HID report descriptor
+ * @param[in]   report_desc_size    size of USB_HID report descriptor
+ */
+void usb_hid_io_init(usbus_t *usbus, const uint8_t *report_desc, size_t report_desc_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_USBUS_HID_IO_H */
+/** @} */

--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -107,9 +107,9 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     hid->hid_descr.arg = hid;
 
     /*
-    Configure Interface as USB_HID interface, choosing NONE for subclass and
-    protocol in order to represent a generic I/O device
-    */
+       Configure Interface as USB_HID interface, choosing NONE for subclass and
+       protocol in order to represent a generic I/O device
+     */
     hid->iface.class = USB_CLASS_HID;
     hid->iface.subclass = USB_HID_SUBCLASS_NONE;
     hid->iface.protocol = USB_HID_PROTOCOL_NONE;
@@ -118,9 +118,9 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
 
     /* IN endpoint to send data to host */
     hid->ep_in = usbus_add_endpoint(usbus, &hid->iface,
-                                              USB_EP_TYPE_INTERRUPT,
-                                              USB_EP_DIR_IN,
-                                            CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
+                                    USB_EP_TYPE_INTERRUPT,
+                                    USB_EP_DIR_IN,
+                                    CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
 
     /* interrupt endpoint polling rate in ms */
     hid->ep_in->interval = 0x05;
@@ -129,8 +129,8 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
 
     /* OUT endpoint to receive data from host */
     hid->ep_out = usbus_add_endpoint(usbus, &hid->iface,
-                            USB_EP_TYPE_INTERRUPT, USB_EP_DIR_OUT,
-                            CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
+                                     USB_EP_TYPE_INTERRUPT, USB_EP_DIR_OUT,
+                                     CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
 
     /* interrupt endpoint polling rate in ms */
     hid->ep_out->interval = 0x05;
@@ -150,9 +150,9 @@ static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,
     (void)handler;
 
     switch (event) {
-        default:
-            DEBUG("USB HID unhandled event: 0x%x\n", event);
-            break;
+    default:
+        DEBUG("USB HID unhandled event: 0x%x\n", event);
+        break;
     }
 }
 
@@ -167,39 +167,39 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
 
     /* Requests defined in USB HID 1.11 spec section 7 */
     switch (setup->request) {
-        case USB_SETUP_REQ_GET_DESCRIPTOR: {
-            uint8_t desc_type = setup->value >> 8;
-            if (desc_type == USB_HID_DESCR_REPORT) {
-                usbus_control_slicer_put_bytes(usbus, hid->report_desc,
-                                               hid->report_desc_size);
-            }
-            else if (desc_type == USB_HID_DESCR_HID) {
-                _gen_hid_descriptor(usbus, NULL);
-            }
-            break;
+    case USB_SETUP_REQ_GET_DESCRIPTOR: {
+        uint8_t desc_type = setup->value >> 8;
+        if (desc_type == USB_HID_DESCR_REPORT) {
+            usbus_control_slicer_put_bytes(usbus, hid->report_desc,
+                                           hid->report_desc_size);
         }
-        case USB_HID_REQUEST_GET_REPORT:
-            break;
-        case USB_HID_REQUEST_GET_IDLE:
-            break;
-        case USB_HID_REQUEST_GET_PROTOCOL:
-            break;
-        case USB_HID_REQUEST_SET_REPORT:
-            if ((state == USBUS_CONTROL_REQUEST_STATE_OUTDATA)) {
-                size_t size = 0;
-                uint8_t *data = usbus_control_get_out_data(usbus, &size);
-                if (size > 0) {
-                    hid->cb(hid, data, size);
-                }
+        else if (desc_type == USB_HID_DESCR_HID) {
+            _gen_hid_descriptor(usbus, NULL);
+        }
+        break;
+    }
+    case USB_HID_REQUEST_GET_REPORT:
+        break;
+    case USB_HID_REQUEST_GET_IDLE:
+        break;
+    case USB_HID_REQUEST_GET_PROTOCOL:
+        break;
+    case USB_HID_REQUEST_SET_REPORT:
+        if ((state == USBUS_CONTROL_REQUEST_STATE_OUTDATA)) {
+            size_t size = 0;
+            uint8_t *data = usbus_control_get_out_data(usbus, &size);
+            if (size > 0) {
+                hid->cb(hid, data, size);
             }
-            break;
-        case USB_HID_REQUEST_SET_IDLE:
-            break;
-        case USB_HID_REQUEST_SET_PROTOCOL:
-            break;
-        default:
-            DEBUG("USB_HID: unknown request %d \n", setup->request);
-            return -1;
+        }
+        break;
+    case USB_HID_REQUEST_SET_IDLE:
+        break;
+    case USB_HID_REQUEST_SET_PROTOCOL:
+        break;
+    default:
+        DEBUG("USB_HID: unknown request %d \n", setup->request);
+        return -1;
     }
     return 1;
 }

--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -11,7 +11,7 @@
  * @{
  * @file
  *
- * @author  Nils Ollrogge <nils-ollrogge@outlook.de>
+ * @author  Nils Ollrogge <nils.ollrogge@fu-berlin.de>
  * @}
  */
 

--- a/tests/usbus_hid/main.c
+++ b/tests/usbus_hid/main.c
@@ -52,8 +52,9 @@ static usbus_t usbus;
 static char _stack[USBUS_STACKSIZE];
 static char test_arg[] = { "Test argument" };
 
-static void rx_cb(void* arg) {
-    printf("USB_HID rx_cb: %s \n", (char*)arg);
+static void rx_cb(void *arg)
+{
+    printf("USB_HID rx_cb: %s \n", (char *)arg);
 }
 
 static void init(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a header file for `sys/usb/usbus/hid/hid.io.c` which was missing before. Furthermore it adds the possibility to add a RX callback function which will be called whenever data has been received from the USB HID endpoint. This is supposed to enable the usage of the `hid_io` interface in an async context (e.g. trigger an event when data has been received).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I have extended `test/usbus_hid` to also test the functionality of the RX callback function.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
