### PR TITLE
cpu/saml21: uart: use arithmetic baud rate mode

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -38,7 +38,12 @@
 
 /* default to fractional baud rate calculation */
 #if !defined(CONFIG_SAM0_UART_BAUD_FRAC) && defined(SERCOM_USART_BAUD_FRAC_BAUD)
+/* SAML21 has no fractional baud rate on SERCOM5 */
+#if defined(CPU_SAML21)
+#define CONFIG_SAM0_UART_BAUD_FRAC  0
+#else
 #define CONFIG_SAM0_UART_BAUD_FRAC  1
+#endif
 #endif
 
 /* SAMD20 defines no generic macro */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

SERCOM5 on SAM L21 does not support fractional baud rate mode.
Instead of special-casing it, just use arithmetic baud rate mode in general on this CPU, as I'm not sure what the advantages of fractional baud rate mode are.




### Testing procedure

- configure SERCOM5 as UART on a board where the appropriate pins are exposed
- connect the uart to a different UART capable device
- run `tests/periph_uart`and try to communicate with different baud rates

### Issues/PRs references

fixes #16692
