### PR TITLE
uri_parser: provide function to split query

### DIFF
--- a/sys/include/uri_parser.h
+++ b/sys/include/uri_parser.h
@@ -81,6 +81,16 @@ typedef struct {
 } uri_parser_result_t;
 
 /**
+ * @brief   Container to represent a query parameter
+ */
+typedef struct {
+    char *name;                     /**< name of the query parameter */
+    char *value;                    /**< value of the query parameter */
+    uint16_t name_len;              /**< length of @ref name */
+    uint16_t value_len;             /**< length of @ref value */
+} uri_parser_query_param_t;
+
+/**
  * @brief Checks whether @p uri is in absolute form
  *
  * @param[in]   uri       URI reference to check. Must not be `NULL`
@@ -132,6 +142,36 @@ int uri_parser_process(uri_parser_result_t *result, const char *uri,
  * @return      -1        on parsing error
  */
 int uri_parser_process_string(uri_parser_result_t *result, const char *uri);
+
+/**
+ * @brief   Provides a list of URI query parameters from a given URI parser
+ *          result.
+ *
+ * @note    The function **DOES NOT** check for duplicate query parameters.
+ *
+ * @pre `uri_parsed != NULL`
+ * @pre `params != NULL` and all its elements are set to zero.
+ *
+ * @param[in] uri_parsed   A parsed URI result. Must not be NULL.
+ * @param[out] params      An array of @ref uri_parser_query_param_t.
+ *                         Must not be NULL and all zero-valued on call. Will be
+ *                         filled with the name-value-pairs in
+ *                         uri_parser_result_t::query of @p uri_parsed. If the
+ *                         number of query parameters in @p uri_parsed exceeds
+ *                         @p params_len, the list will be truncated and the
+ *                         function returns -2.
+ * @param[in] params_len   The length of @p params
+ *
+ * @return  number of filled entries in @p params on success. Might be 0 if
+ *          uri_parser_result_t::query is NULL.
+ * @return  -1 on parsing error.
+ * @return  -2 when the number of query parameters exceeds @p params_len.
+ *          In that case, the array is filled with the first @p params_len
+ *          name-value-pairs in uri_parser_result_t::query of @p uri_parsed.
+ */
+int uri_parser_split_query(const uri_parser_result_t *uri_parsed,
+                           uri_parser_query_param_t *params,
+                           size_t params_len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides a function to `uri_parser` to split the query part of a given URI parsing result into its components.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/unittests` were amended for the new function, so
```sh
make -C tests/unittests/ tests-uri_parser test
```
should succeed for a board of choice.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
