### PR TITLE
sys/evtimer: use ztimer_sec instead of ztimer_now64 now_min

### DIFF
--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -141,7 +141,7 @@ static inline uint32_t evtimer_now_msec(void)
 static inline uint32_t evtimer_now_min(void)
 {
 #if IS_USED(MODULE_EVTIMER_ON_ZTIMER)
-    return ztimer_now(ZTIMER_MSEC) / (MS_PER_SEC * SEC_PER_MIN);
+    return ztimer_now(ZTIMER_SEC) / (SEC_PER_MIN);
 #else
     return xtimer_now_usec64() / (US_PER_SEC * SEC_PER_MIN);
 #endif

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -43,7 +43,7 @@ endif
 # make evtimer use ztimer_msec as low level timer
 ifneq (,$(filter evtimer_on_ztimer,$(USEMODULE)))
   USEMODULE += ztimer_msec
-  USEMODULE += ztimer_now64
+  USEMODULE += ztimer_sec
 endif
 
 # "ztimer_xtimer_compat" is a wrapper of the xtimer API on ztimer_used


### PR DESCRIPTION

### Contribution description

Since all timers are extended, using ZTIMER_SEC for evtimer_now_min
gives enough resolution(+3000years, or ~+2000 years since current
epoch) without the need of carrying a 64bit timestamp for all
'ztimer_now_t' types.

Whenever I pull in GNRC I end up having ztimer_now64 pulled in which transforms all my `ztimer_now_t` into 64bits timestamps, this seems quite wasteful when the only function really needing this resolution is `evtimer_now_min`. If used as system time or as an epoch (since 1900), this gives enough resolution for +3000/+2000 years, which seems enough by a longshot.

Since GNRC is the only module using this maybe @miri64 should take a look? I might be overlooking something important.

### Testing procedure

All `tests/evtimer*` pass, maybe @miri64 can suggest more testing?

```
./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications="tests/evtimer*"
INFO:native:Saving toolchain
INFO:native.tests/evtimer_mbox:Board supported: True
INFO:native.tests/evtimer_mbox:Board has enough memory: True
INFO:native.tests/evtimer_mbox:Application has test: True
INFO:native.tests/evtimer_mbox:Run compilation
INFO:native.tests/evtimer_mbox:Run test
INFO:native.tests/evtimer_mbox:Run test.flash
INFO:native.tests/evtimer_mbox:Success
INFO:native.tests/evtimer_msg:Board supported: True
INFO:native.tests/evtimer_msg:Board has enough memory: True
INFO:native.tests/evtimer_msg:Application has test: True
INFO:native.tests/evtimer_msg:Run compilation
INFO:native.tests/evtimer_msg:Run test
INFO:native.tests/evtimer_msg:Run test.flash
INFO:native.tests/evtimer_msg:Success
INFO:native.tests/evtimer_underflow:Board supported: True
INFO:native.tests/evtimer_underflow:Board has enough memory: True
INFO:native.tests/evtimer_underflow:Application has test: True
INFO:native.tests/evtimer_underflow:Run compilation
INFO:native.tests/evtimer_underflow:Run test
INFO:native.tests/evtimer_underflow:Run test.flash
INFO:native.tests/evtimer_underflow:Success
INFO:native:Tests successful
```

