### PR TITLE
pkg/nimble/autoconn: stop scan/adv on NETIF_ABORT_SLAVE

### DIFF
--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -215,7 +215,7 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
             break;
         case NIMBLE_NETIF_ABORT_SLAVE:
             _evt_dbg("ABORT slave", handle, addr);
-            _state = STATE_IDLE;
+            _deactivate();
             break;
         case NIMBLE_NETIF_CONN_UPDATED:
             _evt_dbg("UPDATED", handle, addr);


### PR DESCRIPTION
### Contribution description

When a connection is aborted and the node in question is a slave
then it can be advertising/scanning at the time. The incoming
event triggers the state to be changed to IDLE but ongoing adv/scan
which will cause 'nimble_netif_conn_start_adv' to fail to allocate
a handle as the netif will still be busy. Therefore when
stop scan/stop before switching the state.

### Testing procedure

Use `nimble_autoconn` on two nimble capable devices, either on slave or master close the connection (can also be done by rebooting the master node), an assertion will blow on `pkg/nimble/autoconn/nimble_autoconn.c:81 => 0x611`:

`CFLAGS=-DDEBUG_ASSERT_VERBOSE USEMODULE=nimble_autoconn_ipsp BOARD=nrf52840-mdk make -C examples/gnrc_networking flash term`

```
> 2021-08-03 09:15:00,783 # ble info
2021-08-03 09:15:00,788 # Own Address: E4:DD:E0:8F:73:65 -> [FE80::E4DD:E0FF:FE8F:7365]
2021-08-03 09:15:00,790 #  Free slots: 1/3
2021-08-03 09:15:00,791 # Advertising: yes
2021-08-03 09:15:00,793 # Connections: 1
2021-08-03 09:15:00,799 # [ 0] D8:2A:B8:E0:AB:50 [FE80::D82A:B8FF:FEE0:AB50] (S,75ms,2500ms,0)
2021-08-03 09:15:00,804 #      (role, conn itvl, superv. timeout, slave latency)
2021-08-03 09:15:00,804 # Slots:
2021-08-03 09:15:00,808 # [ 0] state: 0x0022 - GAP-slave L2CAP-server
2021-08-03 09:15:00,811 # [ 1] state: 0x0100 - advertising
2021-08-03 09:15:00,813 # [ 2] state: 0x8000 - unused
2021-08-03 09:15:00,813 #
> ble close 0
2021-08-03 09:15:04,352 # ble close 0
2021-08-03 09:15:04,355 # success: connection tear down initiated
> 2021-08-03 09:15:04,439 # pkg/nimble/autoconn/nimble_autoconn.c:81 => 0x611
2021-08-03 09:15:04,441 # *** RIOT kernel panic:
2021-08-03 09:15:04,443 # FAILED ASSERTION.
2021-08-03 09:15:04,443 #
2021-08-03 09:15:04,452 #       pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current
2021-08-03 09:15:04,460 #         - | isr_stack            | -        - |   - |    512 (  368) (  144) | 0x20000000 | 0x200001c8
2021-08-03 09:15:04,469 #         1 | main                 | bl mutex _ |   7 |   1536 (  784) (  752) | 0x200003a0 | 0x20000764
2021-08-03 09:15:04,478 #         2 | pktdump              | bl rx    _ |   6 |   1536 (  244) ( 1292) | 0x20002ae0 | 0x20002fec
2021-08-03 09:15:04,487 #         3 | 6lo                  | bl rx    _ |   3 |   1024 (  420) (  604) | 0x200038b0 | 0x20003b24
2021-08-03 09:15:04,495 #         4 | ipv6                 | bl rx    _ |   4 |   1024 (  372) (  652) | 0x20000a9c | 0x20000d94
2021-08-03 09:15:04,504 #         5 | udp                  | bl rx    _ |   5 |   1024 (  252) (  772) | 0x20003cb0 | 0x20003fb4
2021-08-03 09:15:04,513 #         6 | nimble_host          | running  Q |   1 |   1024 (  648) (  376) | 0x20008bf0 | 0x20008f24
2021-08-03 09:15:04,521 #         7 | nimble_ctrl          | bl anyfl _ |   0 |   1024 (  272) (  752) | 0x200087f0 | 0x20008b3c
2021-08-03 09:15:04,530 #         8 | nimble_netif         | bl rx    _ |   2 |   1024 (  592) (  432) | 0x20005a88 | 0x20005d4c
2021-08-03 09:15:04,536 #           | SUM                  |            |     |   9728 ( 3952) ( 5776)
2021-08-03 09:15:04,537 #
2021-08-03 09:15:04,537 # *** halted.
2021-08-03 09:15:04,537 #
2021-08-03 09:15:04,537 #
2021-08-03 09:15:04,540 # Context before hardfault:
2021-08-03 09:15:04,542 #    r0: 0x0000000d
2021-08-03 09:15:04,543 #    r1: 0x00000000
2021-08-03 09:15:04,545 #    r2: 0x22400000
2021-08-03 09:15:04,547 #    r3: 0x00000000
2021-08-03 09:15:04,548 #   r12: 0x0000000a
2021-08-03 09:15:04,549 #    lr: 0x00000bfb
2021-08-03 09:15:04,551 #    pc: 0x00001120
2021-08-03 09:15:04,553 #   psr: 0x21000000
2021-08-03 09:15:04,553 #
2021-08-03 09:15:04,554 # FSR/FAR:
2021-08-03 09:15:04,555 #  CFSR: 0x00000000
2021-08-03 09:15:04,557 #  HFSR: 0x80000000
2021-08-03 09:15:04,558 #  DFSR: 0x00000002
2021-08-03 09:15:04,560 #  AFSR: 0x00000000
2021-08-03 09:15:04,560 # Misc
2021-08-03 09:15:04,562 # EXC_RET: 0xfffffffd
2021-08-03 09:15:04,565 # Active thread: 6 "nimble_host"
2021-08-03 09:15:04,569 # Attempting to reconstruct state for debugging...
2021-08-03 09:15:04,570 # In GDB:
2021-08-03 09:15:04,571 #   set $pc=0x1120
2021-08-03 09:15:04,572 #   frame 0
2021-08-03 09:15:04,573 #   bt
2021-08-03 09:15:04,573 #
2021-08-03 09:15:04,576 # ISR stack overflowed by at least 16 bytes.
2021-08-03 09:15:04,835 # NETOPT_RX_END_IRQ not implemented by driver
2021-08-03 09:15:04,839 # NETOPT_TX_END_IRQ not implemented by driver
2021-08-03 09:15:04,845 # main(): This is RIOT! (Version: 2021.10-devel-268-g54a76-HEAD)
2021-08-03 09:15:04,848 # RIOT network stack example application
2021-08-03 09:15:04,851 # All up, running the shell now
> 2021-08-03 09:15:30,518 # pkg/nimble/autoconn/nimble_autoconn.c:81 => 0x611
2021-08-03 09:15:30,520 # *** RIOT kernel panic:
2021-08-03 09:15:30,522 # FAILED ASSERTION.
2021-08-03 09:15:30,522 #
2021-08-03 09:15:30,530 #       pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current
2021-08-03 09:15:30,539 #         - | isr_stack            | -        - |   - |    512 (  368) (  144) | 0x20000000 | 0x200001c8
2021-08-03 09:15:30,548 #         1 | main                 | bl mutex _ |   7 |   1536 (  572) (  964) | 0x200003a0 | 0x20000764
2021-08-03 09:15:30,557 #         2 | pktdump              | bl rx    _ |   6 |   1536 (  244) ( 1292) | 0x20002ae0 | 0x20002fec
2021-08-03 09:15:30,565 #         3 | 6lo                  | bl rx    _ |   3 |   1024 (  424) (  600) | 0x200038b0 | 0x20003b24
2021-08-03 09:15:30,574 #         4 | ipv6                 | bl rx    _ |   4 |   1024 (  372) (  652) | 0x20000a9c | 0x20000d94
2021-08-03 09:15:30,583 #         5 | udp                  | bl rx    _ |   5 |   1024 (  252) (  772) | 0x20003cb0 | 0x20003fb4
2021-08-03 09:15:30,592 #         6 | nimble_host          | running  Q |   1 |   1024 (  748) (  276) | 0x20008bf0 | 0x20008d04
2021-08-03 09:15:30,600 #         7 | nimble_ctrl          | bl anyfl _ |   0 |   1024 (  272) (  752) | 0x200087f0 | 0x20008b3c
2021-08-03 09:15:30,609 #         8 | nimble_netif         | bl rx    _ |   2 |   1024 (  592) (  432) | 0x20005a88 | 0x20005d4c
2021-08-03 09:15:30,615 #           | SUM                  |            |     |   9728 ( 3844) ( 5884)
2021-08-03 09:15:30,615 #
2021-08-03 09:15:30,616 # *** halted.
2021-08-03 09:15:30,617 #
2021-08-03 09:15:30,617 #
2021-08-03 09:15:30,619 # Context before hardfault:
2021-08-03 09:15:30,620 #    r0: 0x0000000d
2021-08-03 09:15:30,622 #    r1: 0x00000000
2021-08-03 09:15:30,623 #    r2: 0x22400000
2021-08-03 09:15:30,625 #    r3: 0x00000000
2021-08-03 09:15:30,627 #   r12: 0x0000000a
2021-08-03 09:15:30,628 #    lr: 0x00000bfb
2021-08-03 09:15:30,630 #    pc: 0x00001120
2021-08-03 09:15:30,631 #   psr: 0x21000000
2021-08-03 09:15:30,632 #
2021-08-03 09:15:30,632 # FSR/FAR:
2021-08-03 09:15:30,634 #  CFSR: 0x00000000
2021-08-03 09:15:30,635 #  HFSR: 0x80000000
2021-08-03 09:15:30,637 #  DFSR: 0x00000002
2021-08-03 09:15:30,638 #  AFSR: 0x00000000
2021-08-03 09:15:30,639 # Misc
2021-08-03 09:15:30,641 # EXC_RET: 0xfffffffd
2021-08-03 09:15:30,643 # Active thread: 6 "nimble_host"
2021-08-03 09:15:30,648 # Attempting to reconstruct state for debugging...
2021-08-03 09:15:30,648 # In GDB:
2021-08-03 09:15:30,649 #   set $pc=0x1120
2021-08-03 09:15:30,651 #   frame 0
2021-08-03 09:15:30,651 #   bt
2021-08-03 09:15:30,651 #
2021-08-03 09:15:30,655 # ISR stack overflowed by at least 16 bytes.
2021-08-03 09:15:30,914 # NETOPT_RX_END_IRQ not implemented by driver
2021-08-03 09:15:30,918 # NETOPT_TX_END_IRQ not implemented by driver
```

With this PR the assertion does not blow as scan/adv is stopped before re-enabling:

```
2021-08-03 09:18:08,408 # ble info
2021-08-03 09:18:08,413 # Own Address: D8:2A:B8:E0:AB:50 -> [FE80::D82A:B8FF:FEE0:AB50]
2021-08-03 09:18:08,415 #  Free slots: 2/3
2021-08-03 09:18:08,416 # Advertising: no
2021-08-03 09:18:08,417 # Connections: 1
2021-08-03 09:18:08,423 # [ 0] E4:DD:E0:8F:73:65 [FE80::E4DD:E0FF:FE8F:7365] (S,75ms,2500ms,0)
2021-08-03 09:18:08,428 #      (role, conn itvl, superv. timeout, slave latency)
2021-08-03 09:18:08,429 # Slots:
2021-08-03 09:18:08,432 # [ 0] state: 0x0022 - GAP-slave L2CAP-server
2021-08-03 09:18:08,435 # [ 1] state: 0x8000 - unused
2021-08-03 09:18:08,438 # [ 2] state: 0x8000 - unused
2021-08-03 09:18:08,438 #
> ble close 0
2021-08-03 09:18:12,016 # ble close 0
2021-08-03 09:18:12,019 # success: connection tear down initiated
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
