### PR TITLE
pkg/nimble/scanner: add function to set scan duration 

### DIFF
--- a/examples/nimble_scanner/Makefile
+++ b/examples/nimble_scanner/Makefile
@@ -8,7 +8,6 @@ BOARD ?= nrf52dk
 RIOTBASE ?= $(CURDIR)/../..
 
 # We use the xtimer and the shell in this example
-USEMODULE += xtimer
 USEMODULE += shell
 
 # configure and use Nimble

--- a/examples/nimble_scanner/main.c
+++ b/examples/nimble_scanner/main.c
@@ -22,7 +22,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "shell.h"
 #include "shell_commands.h"
 
@@ -30,25 +31,25 @@
 #include "nimble_scanlist.h"
 
 /* default scan duration (1s) */
-#define DEFAULT_DURATION        (1000000U)
+#define DEFAULT_DURATION_MS        (1 * MS_PER_SEC)
 
 int _cmd_scan(int argc, char **argv)
 {
-    uint32_t timeout = DEFAULT_DURATION;
+    uint32_t timeout = DEFAULT_DURATION_MS;
 
     if ((argc == 2) && (memcmp(argv[1], "help", 4) == 0)) {
         printf("usage: %s [timeout in ms]\n", argv[0]);
         return 0;
     }
     if (argc >= 2) {
-        timeout = (uint32_t)(atoi(argv[1]) * 1000);
+        timeout = atoi(argv[1]);
     }
 
     nimble_scanlist_clear();
-    printf("Scanning for %ums now ...", (unsigned)(timeout / 1000));
+    printf("Scanning for %"PRIu32" ms now ...", timeout);
+    nimble_scanner_set_scan_duration(timeout);
     nimble_scanner_start();
-    xtimer_usleep(timeout);
-    nimble_scanner_stop();
+    ztimer_sleep(ZTIMER_MSEC, timeout);
     puts(" done\n\nResults:");
     nimble_scanlist_print();
     puts("");

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -68,6 +68,9 @@ int nimble_scanner_init(const struct ble_gap_disc_params *params,
 
 /**
  * @brief   Start scanning using timing parameters configured on initialization
+ *
+ * @note    Scanning will run for ever unless stopped or unless a different
+ *          scan duration is set with @ref nimble_scanner_set_scan_duration
  */
 int nimble_scanner_start(void);
 
@@ -83,6 +86,15 @@ void nimble_scanner_stop(void);
  * @return  NIMBLE_SCANNER_STOPPED if the scanner is stopped
  */
 int nimble_scanner_status(void);
+
+/**
+ * @brief   Set the duration for the scanning procedure.
+ *
+ *          If there is an active scanning process, it will be restarted.
+ *
+ * @param[in]  duration_ms  duration of scanning procedure in ms
+ */
+void nimble_scanner_set_scan_duration(int32_t duration_ms);
 
 #ifdef __cplusplus
 }

--- a/pkg/nimble/scanner/nimble_scanner.c
+++ b/pkg/nimble/scanner/nimble_scanner.c
@@ -32,12 +32,18 @@
 static nimble_scanner_cb _disc_cb = NULL;
 static struct ble_gap_disc_params _scan_params = { 0 };
 
+/* duration of the scanning procedure */
+static int32_t _scan_duration = BLE_HS_FOREVER;
+
 static int _on_scan_evt(struct ble_gap_event *event, void *arg)
 {
     /* only interested in the DISC event */
     if (event->type == BLE_GAP_EVENT_DISC) {
         _disc_cb(event->disc.event_type, &event->disc.addr, event->disc.rssi,
                  event->disc.data, (size_t)event->disc.length_data);
+    }
+    else if (event->type == BLE_GAP_EVENT_DISC_COMPLETE) {
+        DEBUG("[scanner] scan cycle completed\n");
     }
     else {
         /* this should never happen */
@@ -51,7 +57,7 @@ static int _on_scan_evt(struct ble_gap_event *event, void *arg)
 int nimble_scanner_start(void)
 {
     if (ble_gap_disc_active() == 0) {
-        int res = ble_gap_disc(nimble_riot_own_addr_type, BLE_HS_FOREVER,
+        int res = ble_gap_disc(nimble_riot_own_addr_type, _scan_duration,
                                &_scan_params, _on_scan_evt, NULL);
         if (res != 0) {
             DEBUG("[scanner] err: start failed (%i)\n", res);
@@ -77,6 +83,15 @@ int nimble_scanner_status(void)
     return (ble_gap_disc_active())
         ? NIMBLE_SCANNER_SCANNING
         : NIMBLE_SCANNER_STOPPED;
+}
+
+void nimble_scanner_set_scan_duration(int32_t duration_ms)
+{
+    _scan_duration = duration_ms;
+    if (ble_gap_disc_active()) {
+        nimble_scanner_stop();
+        nimble_scanner_start();
+    }
 }
 
 int nimble_scanner_init(const struct ble_gap_disc_params *params,


### PR DESCRIPTION
### Contribution description

This PR adds a function to enable setting the scan duration, similar to what is done for the autoadv module. By default it will run forever. The `nimble_scanner` example has been adapted accordingly.

### Testing procedure

`make -C examples/nimble_scanner/ flash term`

```
2021-08-03 12:00:47,058 # main(): This is RIOT! (Version: 2021.10-devel-270-g0202e2-pr_nimble_scanner_set_duration)
2021-08-03 12:00:47,059 # NimBLE Scanner Example Application
2021-08-03 12:00:47,059 # Type `scan help` for more information
> scan 1000
2021-08-03 12:01:21,922 # scan 1000
2021-08-03 12:01:22,925 # Scanning for 1000 ms now ... done
2021-08-03 12:01:22,926 # 
2021-08-03 12:01:22,926 # Results:
2021-08-03 12:01:22,935 # [ 0] e4:dd:e0:8f:73:65 (RANDOM) [IND] "RIOT-autoconn", adv_msg_cnt: 19, adv_int: 49093us, last_rssi: -55
2021-08-03 12:01:22,936 # 
> scan
2021-08-03 12:01:24,617 # scan
2021-08-03 12:01:25,620 # Scanning for 1000 ms now ... done
2021-08-03 12:01:25,621 # 
2021-08-03 12:01:25,621 # Results:
2021-08-03 12:01:25,630 # [ 0] e4:dd:e0:8f:73:65 (RANDOM) [IND] "RIOT-autoconn", adv_msg_cnt: 18, adv_int: 47056us, last_rssi: -55
2021-08-03 12:01:25,630 # 
```
