### PR TITLE
pkg/nimble/autoadv: make AD flag optionnal

### DIFF
--- a/pkg/nimble/autoadv/README.md
+++ b/pkg/nimble/autoadv/README.md
@@ -26,3 +26,18 @@ To specify a device name add the following line to your Makefile:
 ```
 CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"Riot OS device"'
 ```
+
+By the default, in the advertised packet, the module includes the advertising
+**Flags** data type. According to Bluetooth Core Specification Supplement (see
+[§1.3.1](https://www.bluetooth.com/specifications/specs/core-specification-supplement-9/))
+> The Flags data type shall be included when any of the Flag bits are non-zero
+and the advertising packet is connectable, otherwise the Flags data type may be
+omitted.
+
+If your application is not connectable (eg. a temperature sensor advertising
+its current value), you might want omit this flag by clearing the
+`NIMBLE_AUTOADV_FLAG_FIELD` when including this module:
+```
+CFLAGS += -DNIMBLE_AUTOADV_FLAG_FIELD=0
+```
+This will grant three extra bytes in the advertisement packet.

--- a/pkg/nimble/autoadv/include/nimble_autoadv.h
+++ b/pkg/nimble/autoadv/include/nimble_autoadv.h
@@ -57,6 +57,17 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Include the advetisement flag field. If this is not
+ *          defined, it will be defined as 1, resulting in including the field.
+ *          The Flags data type shall be included when any of the Flag bits
+ *          are non-zero and the advertising packet is connectable, otherwise
+ *          the Flags data type may be omitted.
+ */
+#ifndef NIMBLE_AUTOADV_FLAG_FIELD
+    #define NIMBLE_AUTOADV_FLAG_FIELD 1
+#endif
+
+/**
 * @brief    Initialize autoadv module.
 */
 void nimble_autoadv_init(void);

--- a/pkg/nimble/autoadv/nimble_autoadv.c
+++ b/pkg/nimble/autoadv/nimble_autoadv.c
@@ -160,8 +160,14 @@ void nimble_autoadv_reset(void)
     int rc = 0;
     (void) rc;
 
-    rc = bluetil_ad_init_with_flags(&_ad, buf, sizeof(buf), BLUETIL_AD_FLAGS_DEFAULT);
-    assert(rc == BLUETIL_AD_OK);
+    if (IS_ACTIVE(NIMBLE_AUTOADV_FLAG_FIELD) && BLUETIL_AD_FLAGS_DEFAULT) {
+        rc = bluetil_ad_init_with_flags(&_ad, buf, sizeof(buf),
+                                        BLUETIL_AD_FLAGS_DEFAULT);
+        assert(rc == BLUETIL_AD_OK);
+    }
+    else {
+        bluetil_ad_init(&_ad, buf, 0, sizeof(buf));
+    }
 
     if (NIMBLE_AUTOADV_DEVICE_NAME != NULL) {
         rc = bluetil_ad_add_name(&_ad, NIMBLE_AUTOADV_DEVICE_NAME);


### PR DESCRIPTION
### Contribution description

These fields can be omitted if all other FLAGS are 0 and the advertising
packets are not connectable, allowing for 3 extra bytes for advertisement
payload.

In an application I need every byte I can get out of the advertisement packet so It's useful/required to gain these 3 extra bytes.

### Testing procedure

Flash with and without the flag set the FLAGS are then omitted from the payload:

`CFLAGS=-DNIMBLE_AUTOADV_FLAG_FIELD=0 BOARD=nrf52840-mdk make -C examples/nimble_heart_rate_sensor/ flash term -j7`

![image](https://user-images.githubusercontent.com/23060007/128000996-c1e51ee2-0525-471a-90d6-0e5af652b3dd.png)
![image](https://user-images.githubusercontent.com/23060007/128001022-353b853c-d6b7-413d-891f-81e9e248476c.png)





