### PR TITLE
sys/net/nanocoap: block_finish returns if more are expected

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -664,8 +664,11 @@ void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
  *
  * @param[in]     slicer      Preallocated slicer struct to use
  * @param[in]     option      option number (block1 or block2)
+ *
+ * @return      true if the `more` bit is set in the block option
+ * @return      false if the `more` bit is not set the block option
  */
-void coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
+bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
 
 /**
  * @brief Finish a block1 request
@@ -677,10 +680,13 @@ void coap_block_finish(coap_block_slicer_t *slicer, uint16_t option);
  * function overwrites bytes in the packet rather than adding new.
  *
  * @param[in]     slicer      Preallocated slicer struct to use
+ *
+ * @return      true if the `more` bit is set in the block option
+ * @return      false if the `more` bit is not set the block option
  */
-static inline void coap_block1_finish(coap_block_slicer_t *slicer)
+static inline bool coap_block1_finish(coap_block_slicer_t *slicer)
 {
-    coap_block_finish(slicer, COAP_OPT_BLOCK1);
+    return coap_block_finish(slicer, COAP_OPT_BLOCK1);
 }
 
 /**
@@ -693,10 +699,13 @@ static inline void coap_block1_finish(coap_block_slicer_t *slicer)
  * function overwrites bytes in the packet rather than adding new.
  *
  * @param[in]     slicer      Preallocated slicer struct to use
+ *
+ * @return      true if the `more` bit is set in the block option
+ * @return      false if the `more` bit is not set the block option
  */
-static inline void coap_block2_finish(coap_block_slicer_t *slicer)
+static inline bool coap_block2_finish(coap_block_slicer_t *slicer)
 {
-    coap_block_finish(slicer, COAP_OPT_BLOCK2);
+    return coap_block_finish(slicer, COAP_OPT_BLOCK2);
 }
 
 /**

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1022,7 +1022,7 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
     coap_block_slicer_init(slicer, blknum, coap_szx2size(szx));
 }
 
-void coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
+bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
 {
     assert(slicer->opt);
 
@@ -1032,10 +1032,12 @@ void coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
     uint8_t *pos = slicer->opt + 1;
     uint16_t delta = _decode_value(*slicer->opt >> 4, &pos, slicer->opt + 3);
 
-    uint32_t blkopt = _slicer2blkopt(slicer, slicer->cur > slicer->end);
+    bool more = slicer->cur > slicer->end;
+    uint32_t blkopt = _slicer2blkopt(slicer, more);
     size_t olen = _encode_uint(&blkopt);
 
     coap_put_option(slicer->opt, option - delta, option, (uint8_t *)&blkopt, olen);
+    return more;
 }
 
 ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,


### PR DESCRIPTION
### Contribution description

From a client-side when performing a POST it can be useful to know when the complete message has been transmitted. Since when using BLOCK payloads are relatively large if the resource is dynamic then upon sending out the last block then the resource can be freed checking the return status of `coap_block%_finish` can be a way of getting this information, so this PR has `coap_block_finish` return the value of the `more` field.

### Testing procedure

- Murdock: Everything should still be green
- Release tests regarding block transactions still pass

```
tox -- -k "spec09 and (task03 or task04)" --non-RC
test installed: aiocoap==0.4.1,attrs==21.2.0,beautifulsoup4==4.9.3,certifi==2021.5.30,cffi==1.14.6,charset-normalizer==2.0.4,coverage==5.5,Deprecated==1.2.12,idna==3.2,iniconfig==1.1.1,iotlabcli==3.2.1,jmespath==0.10.0,LinkHeader==0.4.3,packaging==21.0,paho-mqtt==1.5.1,pexpect==4.8.0,pluggy==0.13.1,psutil==5.8.0,ptyprocess==0.7.0,py==1.10.0,pycparser==2.20,PyGithub==1.55,PyJWT==2.1.0,PyNaCl==1.4.0,pyparsing==2.4.7,pytest==6.2.4,pytest-cov==2.12.1,pytest-rerunfailures==10.1,requests==2.26.0,riotctrl==0.4.1,scapy==2.4.5,six==1.16.0,soupsieve==2.2.1,toml==0.10.2,urllib3==1.26.6,wrapt==1.12.1
test run-test-pre: PYTHONHASHSEED='1608208642'
test run-test: commands[0] | pytest -k 'spec09 and (task03 or task04)' --non-RC
========================================================= test session starts ==========================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/francisco/workspace/Release-Specs/.tox/test/bin/python
cachedir: .tox/test/.pytest_cache
rootdir: /home/francisco/workspace/Release-Specs, configfile: setup.cfg
plugins: rerunfailures-10.1, cov-2.12.1
collected 117 items / 115 deselected / 2 selected

09-coap/test_spec09.py::test_task03[nodes0] PASSED                                                                               [ 50%]
09-coap/test_spec09.py::test_task04[nodes0] PASSED                                                                               [100%]

=========================================================== warnings summary ===========================================================
.tox/test/lib/python3.8/site-packages/iotlabcli/associations.py:58
  /home/francisco/workspace/Release-Specs/.tox/test/lib/python3.8/site-packages/iotlabcli/associations.py:58: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    collections.MutableMapping, dict):

-- Docs: https://docs.pytest.org/en/stable/warnings.html
----------------------------- generated xml file: /home/francisco/workspace/Release-Specs/test-report.xml ------------------------------
======================================= 2 passed, 115 deselected, 1 warning in 281.93s (0:04:41) =======================================
flake8 installed: flake8==3.9.2,mccabe==0.6.1,pycodestyle==2.7.0,pyflakes==2.3.1
flake8 run-test-pre: PYTHONHASHSEED='1608208642'
flake8 run-test: commands[0] | flake8
pylint installed: aiocoap==0.4.1,astroid==2.6.5,attrs==21.2.0,beautifulsoup4==4.9.3,certifi==2021.5.30,cffi==1.14.6,charset-normalizer==2.0.4,coverage==5.5,Deprecated==1.2.12,idna==3.2,iniconfig==1.1.1,iotlabcli==3.2.1,isort==5.9.3,jmespath==0.10.0,lazy-object-proxy==1.6.0,LinkHeader==0.4.3,mccabe==0.6.1,packaging==21.0,paho-mqtt==1.5.1,pexpect==4.8.0,pluggy==0.13.1,psutil==5.8.0,ptyprocess==0.7.0,py==1.10.0,pycparser==2.20,PyGithub==1.55,PyJWT==2.1.0,pylint==2.9.6,PyNaCl==1.4.0,pyparsing==2.4.7,pytest==6.2.4,pytest-cov==2.12.1,pytest-rerunfailures==10.1,requests==2.26.0,riotctrl==0.4.1,scapy==2.4.5,six==1.16.0,soupsieve==2.2.1,toml==0.10.2,urllib3==1.26.6,wrapt==1.12.1
pylint run-test-pre: PYTHONHASHSEED='1608208642'
pylint run-test: commands[0] | pylint conftest.py testutils/ 03-single-hop-ipv6-icmp/ 04-single-hop-6lowpan-icmp/ 05-single-hop-route/ 06-single-hop-udp/ 07-multi-hop/ 08-interop/ 09-coap/ 10-icmpv6-error/ 11-lorawan/

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

_______________________________________________________________ summary ________________________________________________________________
  test: commands succeeded
  flake8: commands succeeded
  pylint: commands succeeded
  congratulations :)
```

