### PR TITLE
gnrc_ipv6_nib: provide functions to get offset of public timestamps

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/abr.h
+++ b/sys/include/net/gnrc/ipv6/nib/abr.h
@@ -23,6 +23,11 @@
 
 #include <kernel_defines.h>
 
+/* prevent cascading include error to xtimer if it is not compiled in or not
+ * supported by board */
+#if IS_USED(MODULE_EVTIMER)
+#include "evtimer.h"
+#endif
 #include "net/ipv6/addr.h"
 #include "net/gnrc/ipv6/nib/conf.h"
 
@@ -98,6 +103,22 @@ void gnrc_ipv6_nib_abr_del(const ipv6_addr_t *addr);
  *          the NIB.
  */
 bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *abr);
+
+#if IS_USED(MODULE_EVTIMER) || defined(DOXYGEN)
+/**
+ * @brief   Provides the time in minutes for which the authoritative border
+ *          router entry is valid
+ *
+ * @param[in] abr   An authoritative border router entry.
+ *
+ * @return  The time in minutes for which the authoritative border router entry
+ *          is valid.
+ */
+static inline uint32_t gnrc_ipv6_nib_abr_valid_offset(const gnrc_ipv6_nib_abr_t *abr)
+{
+    return abr->valid_until - evtimer_now_min();
+}
+#endif
 
 /**
  * @brief   Prints an authoritative border router list entry

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -22,6 +22,9 @@
 
 #include <stdint.h>
 
+#if IS_USED(MODULE_EVTIMER)
+#include "evtimer.h"
+#endif
 #include "net/ipv6/addr.h"
 
 #ifdef __cplusplus
@@ -121,6 +124,45 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
  */
 bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
                            gnrc_ipv6_nib_pl_t *ple);
+
+#if IS_USED(MODULE_EVTIMER) || defined(DOXYGEN)
+/**
+ * @brief   Provides the time in milliseconds for which the prefix list
+ *          entry is valid
+ *
+ * @param[in] ple   A prefix list entry.
+ *
+ * @return  The time in milliseconds for which the prefix list entry is valid.
+ *          UINT32_MAX if it is valid forever.
+ */
+static inline uint32_t gnrc_ipv6_nib_pl_valid_offset(const gnrc_ipv6_nib_pl_t *ple)
+{
+
+    return (ple->valid_until == UINT32_MAX)
+        ? UINT32_MAX
+        : (ple->valid_until - evtimer_now_msec());
+}
+
+/**
+ * @brief   Provides the time in milliseconds for which the prefix list
+ *          entry is preferred
+ *
+ * A prefix for which the preference expired is deprecated (see [RFC 4862]
+ * (https://tools.ietf.org/html/rfc4862))
+ *
+ * @param[in] ple   A prefix list entry.
+ *
+ * @return  The time in milliseconds for which the prefix list entry is
+ *          preferred. UINT32_MAX if it is preferred forever.
+ */
+static inline uint32_t gnrc_ipv6_nib_pl_pref_offset(const gnrc_ipv6_nib_pl_t *ple)
+{
+
+    return (ple->pref_until == UINT32_MAX)
+        ? UINT32_MAX
+        : (ple->pref_until - evtimer_now_msec());
+}
+#endif
 
 /**
  * @brief   Prints a prefix list entry


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`gnrc_ipv6_nib` provides for some of its view a time stamp until which an entry is valid. Since we now have multiple clocks that provide timestamps, getting the offset of the current time to said timestamp can be tricky, since it is not immediately clear what the timestamp was generated from. This aims to solve that by providing helper functions to the affected NIB views to calculate that offset for external use.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Did not bother to provide tests. The functions are simple enough so just read ;-).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Might be needed for #16536.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
