### PR TITLE
uri_parser: constify result

### DIFF
--- a/sys/include/uri_parser.h
+++ b/sys/include/uri_parser.h
@@ -39,8 +39,8 @@ extern "C" {
  * @brief container that holds all results
  */
 typedef struct {
-    char *scheme;                   /**< scheme */
-    char *userinfo;                 /**< userinfo */
+    const char *scheme;             /**< scheme */
+    const char *userinfo;           /**< userinfo */
 
     /**
      * @brief host part
@@ -49,7 +49,7 @@ typedef struct {
      * '[' and ']' as well as the zoneid (with leading '%'), if
      * present.
      */
-    char *host;
+    const char *host;
 
     /**
      * @brief Pointer to the start of the address, if @ref host is an
@@ -58,18 +58,18 @@ typedef struct {
      * @note @ref ipv6addr does not include the brackets '[' and ']'
      * and the zoneid part.
      */
-    char *ipv6addr;
+    const char *ipv6addr;
 
     /**
      * @brief zoneid if @ref host is IPv6 address, NULL otherwise
      *
      * @see https://tools.ietf.org/html/rfc6874
      */
-    char *zoneid;
+    const char *zoneid;
 
-    char *port;                     /**< port */
-    char *path;                     /**< path */
-    char *query;                    /**< query */
+    const char *port;               /**< port */
+    const char *path;               /**< path */
+    const char *query;              /**< query */
     uint16_t scheme_len;            /**< length of @ref scheme */
     uint16_t userinfo_len;          /**< length of @ref userinfo */
     uint16_t host_len;              /**< length of @ref host */
@@ -84,8 +84,8 @@ typedef struct {
  * @brief   Container to represent a query parameter
  */
 typedef struct {
-    char *name;                     /**< name of the query parameter */
-    char *value;                    /**< value of the query parameter */
+    const char *name;               /**< name of the query parameter */
+    const char *value;              /**< value of the query parameter */
     uint16_t name_len;              /**< length of @ref name */
     uint16_t value_len;             /**< length of @ref value */
 } uri_parser_query_param_t;


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`uri_parser_process()` takes a `const char *` as input parameter but the result is a struct of `char *` to the original string.

This may lead a user to modifying the strings in `uri_parser_result_t` which will cause a crash if the original string resides in read-only memory (and violates the no-modifications promise of the const parameter in `uri_parser_process()`).

To fix this, make the resulting strings `const` as well, so nobody dares to touch them in a writing way.


### Testing procedure

    make -C tests/unittests tests-uri_parser term


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16695#discussion_r681820654
