### PR TITLE
net/netif: add function to get interface by name from a buffer

### DIFF
--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -34,6 +34,7 @@
 #define NET_NETIF_H
 
 #include <stdint.h>
+#include <string.h>
 
 #include "list.h"
 #include "net/netopt.h"
@@ -114,6 +115,19 @@ int netif_get_name(netif_t *netif, char *name);
 int16_t netif_get_id(const netif_t *netif);
 
 /**
+ * @brief   Gets interface by name, from a buffer
+ *
+ * @pre `name != NULL`
+ *
+ * @param[in] name          The name of an interface as an array of chars. Must not be `NULL`.
+ * @param[in] name_len      Number of characters in @p name.
+ *
+ * @return  Pointer to the interface that matches the name
+ * @retval  NULL if no interface is named @p name.
+ */
+netif_t *netif_get_by_name_buffer(const char *name, size_t name_len);
+
+/**
  * @brief   Gets interface by name
  *
  * @pre `name != NULL`
@@ -125,7 +139,10 @@ int16_t netif_get_id(const netif_t *netif);
  * @return  The interface on success.
  * @return  NULL if no interface is named @p name.
  */
-netif_t *netif_get_by_name(const char *name);
+static inline netif_t *netif_get_by_name(const char *name)
+{
+    return netif_get_by_name_buffer(name, strlen(name));
+}
 
 /**
  * @brief   Gets interface by a numeric identifier.

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -56,16 +56,22 @@ __attribute__((weak)) int16_t netif_get_id(const netif_t *netif)
     return -1;
 }
 
-netif_t *netif_get_by_name(const char *name)
+netif_t *netif_get_by_name_buffer(const char *name, size_t name_len)
 {
     assert(name);
+
+    if (name_len > CONFIG_NETIF_NAMELENMAX) {
+        return NULL;
+    }
+
     list_node_t *node = netif_list.next;
 
     char tmp[CONFIG_NETIF_NAMELENMAX];
 
     while (node) {
        netif_get_name((netif_t *)node, tmp);
-       if (strncmp(name, tmp, CONFIG_NETIF_NAMELENMAX) == 0) {
+       size_t len = strlen(tmp);
+       if ((len == name_len) && (strncmp(name, tmp, name_len) == 0)) {
            return (netif_t *)node;
        }
        node = node->next;

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1308,6 +1308,18 @@ static void test_netif_get_by_name(void)
     TEST_ASSERT(netif == netif_get_by_name(name));
 }
 
+static void test_netif_get_by_name_buffer(void)
+{
+    char name[CONFIG_NETIF_NAMELENMAX] = "6nPRK28";
+    netif_t *netif = netif_iter(NULL);
+
+    TEST_ASSERT(netif_get_by_name_buffer(name, strlen(name)) == NULL);
+    /* there must be at least one interface */
+    TEST_ASSERT_NOT_NULL(netif);
+    TEST_ASSERT(netif_get_name(netif, name) > 0);
+    TEST_ASSERT(netif == netif_get_by_name_buffer(name, strlen(name)));
+}
+
 static void test_netif_get_opt(void)
 {
     /* just repeat one of the gnrc_netapi_get tests, just with netif_get_opt */
@@ -1758,6 +1770,7 @@ static Test *embunit_tests_gnrc_netif(void)
             new_TestFixture(test_netif_iter),
             new_TestFixture(test_netif_get_name),
             new_TestFixture(test_netif_get_by_name),
+            new_TestFixture(test_netif_get_by_name_buffer),
             new_TestFixture(test_netif_get_opt),
             new_TestFixture(test_netif_set_opt),
             /* only add tests not involving output here */


### PR DESCRIPTION
### Contribution description
This adds a function to `netif` that allows to search an interface by name, using a buffer and length (like the one provided by the [URI parser](http://doc.riot-os.org/group__sys__uri__parser.html)), instead a null-terminated string. `tests/gnrc_netif` has been extended accordingly.

### Testing procedure

`tests/gnrc_netif` should pass.

### Issues/PRs references
Split from #16233
