### PR TITLE
nanocoap & gcoap: allow path to be non-`\0`-terminated.

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -844,15 +844,43 @@ void gcoap_register_listener(gcoap_listener_t *listener);
  * @param[in] len       Length of the buffer
  * @param[in] code      Request code, one of COAP_METHOD_XXX or COAP_CODE_EMPTY
  *                      to ping
- * @param[in] path      Resource path, may be NULL
+ * @param[in] path      Resource path, may be NULL. @p path_len will be ignored
+ *                      in that case.
+ * @param[in] path_len  Length of @p path.
  *
  * @pre @p path must start with `/` if not NULL
  *
  * @return  0 on success
  * @return  < 0 on error
  */
-int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
-                   unsigned code, const char *path);
+int gcoap_req_init_path_buffer(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                               unsigned code, const char *path,
+                               size_t path_len);
+
+/**
+ * @brief   Initializes a CoAP request PDU on a buffer.
+ *
+ * If @p code is COAP_CODE_EMPTY, prepares a complete "CoAP ping" 4 byte empty
+ * message request, ready to send.
+ *
+ * @param[out] pdu      Request metadata
+ * @param[out] buf      Buffer containing the PDU
+ * @param[in] len       Length of the buffer
+ * @param[in] code      Request code, one of COAP_METHOD_XXX or COAP_CODE_EMPTY
+ *                      to ping
+ * @param[in] path      `\0`-terminated resource path, may be NULL
+ *
+ * @pre @p path must start with `/` if not NULL
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+static inline int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                                 unsigned code, const char *path)
+{
+    return gcoap_req_init_path_buffer(pdu, buf, len, code, path,
+                                      (path) ? strlen(path) : 0U);
+}
 
 /**
  * @brief   Writes a complete CoAP request PDU when there is not a payload

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1131,7 +1131,7 @@ static inline ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum,
  * @note Use this only for null-terminated strings.
  *
  * @param[in,out] pkt         Packet being built
- * @param[in]     path        Resource (sub)path
+ * @param[in]     path        `\0`-terminated resource (sub)path
  *
  * @pre     ((pkt != NULL) && (path != NULL))
  *
@@ -1142,6 +1142,28 @@ static inline ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum,
 static inline ssize_t coap_opt_add_uri_path(coap_pkt_t *pkt, const char *path)
 {
     return coap_opt_add_string(pkt, COAP_OPT_URI_PATH, path, '/');
+}
+
+/**
+ * @brief   Adds one or multiple Uri-Path options in the form '/path' into pkt
+ *
+ * @note Use this only for null-terminated strings.
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     path        Resource (sub)path
+ * @param[in]     path_len    Length of @p path
+ *
+ * @pre     ((pkt != NULL) && (path != NULL))
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
+ */
+static inline ssize_t coap_opt_add_uri_path_buffer(coap_pkt_t *pkt,
+                                                   const char *path,
+                                                   size_t path_len)
+{
+    return coap_opt_add_chars(pkt, COAP_OPT_URI_PATH, path, path_len, '/');
 }
 
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1023,8 +1023,8 @@ void gcoap_register_listener(gcoap_listener_t *listener)
     }
 }
 
-int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
-                   unsigned code, const char *path)
+int gcoap_req_init_path_buffer(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                               unsigned code, const char *path, size_t path_len)
 {
     assert((path == NULL) || (path[0] == '/'));
 
@@ -1055,8 +1055,8 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     }
 
     coap_pkt_init(pdu, buf, len, res);
-    if (path != NULL) {
-        res = coap_opt_add_uri_path(pdu, path);
+    if ((path != NULL) && (path_len > 0)) {
+        res = coap_opt_add_uri_path_buffer(pdu, path, path_len);
     }
     return (res > 0) ? 0 : res;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When working with modules such as `uri_parser`, where the path is not necessarily `\0`-terminated, this change greatly simplifies working with these modules.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/gcoap` should still be able to exchange messages, same for `tests/nanocoap_cli`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
