### PR TITLE
picolibc: Reset color in error message if picolibc is not available

### DIFF
--- a/makefiles/libc/picolibc.mk
+++ b/makefiles/libc/picolibc.mk
@@ -17,7 +17,7 @@ _missing-picolibc:
 	@$(Q)echo "picolibc was selected to be build but no picolibc.spec could be found"
 	@$(Q)echo "you might want to install "picolibc" for "$(TARGET_ARCH)""
 	@$(Q)echo "or add "FEATURES_BLACKLIST += picolibc" to Makefile)"
-	@$(COLOR_ECHO) "$(COLOR_RED)check your installation or build configuration."
+	@$(COLOR_ECHO) "$(COLOR_RED)check your installation or build configuration.$(COLOR_RESET)"
 	@$(Q)exit 1
 
 ifeq (1,$(USE_PICOLIBC))


### PR DESCRIPTION
This is a regression which was introduced in #16114 (CC: @fjmolinas), without resetting
the color the red color will be used for all following text written to
the terminal and will also cause the shell prompt etc. pp. to be colored
in red which is undesirable. This commit fixes this regression by using
the ANSI escape sequences to reset the color after the error message has
been written.