### PR TITLE
drivers/cc2538_rf: fix deadlock when receiving too fast.

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -110,6 +110,8 @@ extern "C" {
 #define CC2538_STATE_SFD_WAIT_RANGE_MAX  (0x06U)  /**< max range value of SFD wait state */
 #define CC2538_FRMCTRL1_PENDING_OR_MASK  (0x04)   /**< mask for enabling or disabling the
                                                        frame pending bit */
+#define CC2538_FRMCTRL0_RX_MODE_DIS      (0xC)    /**< mask for disabling RX Chain during
+                                                       CCA */
 
 #define RFCORE_ASSERT(expr) (void)( (expr) || RFCORE_ASSERT_failure(#expr, __FUNCTION__, __LINE__) )
 

--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -36,6 +36,9 @@ ieee802154_dev_t cc2538_rf_dev = {
     .driver = &cc2538_rf_ops,
 };
 
+static bool cc2538_tx_busy;     /**< used to indicate TX chain is busy */
+static bool cc2538_rx_busy;     /**< used to indicate RX chain is busy */
+
 static uint8_t cc2538_min_be = CONFIG_IEEE802154_DEFAULT_CSMA_CA_MIN_BE;
 static uint8_t cc2538_max_be = CONFIG_IEEE802154_DEFAULT_CSMA_CA_MAX_BE;
 static int cc2538_csma_ca_retries = CONFIG_IEEE802154_DEFAULT_CSMA_CA_RETRIES;
@@ -44,8 +47,6 @@ static bool cc2538_cca_status;  /**< status of the last CCA request */
 static bool cc2538_cca;         /**< used to check whether the last CCA result
                                      corresponds to a CCA request or send with
                                      CSMA-CA */
-static bool cc2538_sfd_listen;  /**< used to check whether we should ignore
-                                     the SFD flag */
 
 static int _write(ieee802154_dev_t *dev, const iolist_t *iolist)
 {
@@ -91,6 +92,7 @@ static int _request_transmit(ieee802154_dev_t *dev)
 {
     (void) dev;
 
+    cc2538_tx_busy = true;
     if (cc2538_csma_ca_retries < 0) {
         RFCORE_SFR_RFST = ISTXON;
         /* The CPU Ctrl mask is used here to indicate whether the radio is being
@@ -220,7 +222,6 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t size, ieee802154_rx_in
         res = 0;
     }
 
-
     return res;
 }
 
@@ -297,12 +298,7 @@ static int _request_set_trx_state(ieee802154_dev_t *dev, ieee802154_trx_state_t 
 {
 
     (void) dev;
-    bool wait_sfd =
-        RFCORE->XREG_FSMSTAT0bits.FSM_FFCTRL_STATE >= CC2538_STATE_SFD_WAIT_RANGE_MIN
-        && RFCORE->XREG_FSMSTAT0bits.FSM_FFCTRL_STATE <= CC2538_STATE_SFD_WAIT_RANGE_MAX;
-
-    if ((RFCORE->XREG_FSMSTAT1bits.RX_ACTIVE && !wait_sfd) ||
-         RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE) {
+    if (cc2538_tx_busy || cc2538_rx_busy) {
         return -EBUSY;
     }
 
@@ -333,20 +329,24 @@ void cc2538_irq_handler(void)
     RFCORE_SFR_RFIRQF0 = 0;
     RFCORE_SFR_RFIRQF1 = 0;
 
-    if ((flags_f0 & SFD) && cc2538_sfd_listen) {
-        if (RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE) {
+    if ((flags_f0 & SFD)) {
+        /* If the radio already transmitted, this SFD is the TX_START event */
+        if (cc2538_tx_busy) {
             cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_INDICATION_TX_START);
+        }
+        /* If the RX chain was not busy, the detected SFD corresponds to a new
+         * incoming frame. Note the automatic ACK frame also triggers this event.
+         * Therefore, we use this variable to distinguish them. */
+        else if (!cc2538_rx_busy){
+            cc2538_rx_busy = true;
+            cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_INDICATION_RX_START);
         }
     }
 
     if (flags_f1 & TXDONE) {
+        /* TXDONE marks the end of the TX chain. The radio is not busy anymore */
+        cc2538_tx_busy = false;
         cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
-    }
-
-    if ((flags_f0 & SFD) && cc2538_sfd_listen) {
-        if (RFCORE->XREG_FSMSTAT1bits.RX_ACTIVE) {
-            cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_INDICATION_RX_START);
-        }
     }
 
     if (flags_f0 & RXPKTDONE) {
@@ -355,25 +355,28 @@ void cc2538_irq_handler(void)
         if (rfcore_peek_rx_fifo(pkt_len) & CC2538_CRC_BIT_MASK) {
             /* Disable RX while the frame has not been processed */
             RFCORE_XREG_RXMASKCLR = 0xFF;
-            /* If AUTOACK is enabled and the ACK request bit is set */
-            if (!IS_ACTIVE(CONFIG_IEEE802154_AUTO_ACK_DISABLE) &&
-                (rfcore_peek_rx_fifo(1) & IEEE802154_FCF_ACK_REQ)) {
-                /* The next SFD will be the ACK's, ignore it */
-                cc2538_sfd_listen = false;
+            /* If AUTOACK is disabled or the ACK request bit is not set */
+            if (IS_ACTIVE(CONFIG_IEEE802154_AUTO_ACK_DISABLE) ||
+                (!(rfcore_peek_rx_fifo(1) & IEEE802154_FCF_ACK_REQ))) {
+                /* The radio won't send an ACK. Therefore the RX chain is not
+                 * busy anymore
+                 */
+                cc2538_rx_busy = false;
             }
             cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_INDICATION_RX_DONE);
         }
         else {
             /* Disable RX while the frame has not been processed */
             RFCORE_XREG_RXMASKCLR = 0xFF;
-            /* CRC failed; discard packet */
+            /* CRC failed; discard packet. The RX chain is not busy anymore */
+            cc2538_rx_busy = false;
             cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_INDICATION_CRC_ERROR);
         }
     }
 
-    /* Re-Enable SFD ISR after ACK is received */
+    /* The RX chain is not busy anymore on TXACKDONE event */
     if (flags_f1 & TXACKDONE) {
-        cc2538_sfd_listen = true;
+        cc2538_rx_busy = false;
     }
 
     /* Check if the interrupt was triggered because the CSP finished its routine
@@ -387,6 +390,8 @@ void cc2538_irq_handler(void)
                 RFCORE_SFR_RFST = ISTXON;
             }
             else {
+                /* In case of CCA failure the TX chain is not busy anymore */
+                cc2538_tx_busy = false;
                 cc2538_rf_dev.cb(&cc2538_rf_dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
             }
         }
@@ -463,8 +468,6 @@ static int _request_on(ieee802154_dev_t *dev)
 {
     (void) dev;
     /* TODO */
-    /* when turned on listen for SFD interrupts */
-    cc2538_sfd_listen = true;
     return 0;
 }
 

--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -104,6 +104,8 @@ static int _request_transmit(ieee802154_dev_t *dev)
     else {
         cc2538_cca = false;
 
+        /* Disable RX Chain for CCA (see CC2538 RM, Section 29.9.5.3) */
+        RFCORE_XREG_FRMCTRL0 |= CC2538_FRMCTRL0_RX_MODE_DIS;
         RFCORE_SFR_RFST = ISRXON;
         /* Clear last program */
         RFCORE_SFR_RFST = ISCLEAR;
@@ -314,6 +316,8 @@ static int _request_set_trx_state(ieee802154_dev_t *dev, ieee802154_trx_state_t 
         case IEEE802154_TRX_STATE_RX_ON:
             RFCORE_XREG_RFIRQM0 |= RXPKTDONE;
             RFCORE_SFR_RFST = ISFLUSHRX;
+            /* Enable RX Chain */
+            RFCORE_XREG_FRMCTRL0 &= ~CC2538_FRMCTRL0_RX_MODE_DIS;
             RFCORE_SFR_RFST = ISRXON;
             break;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes a deadlock in `cc2538_rf` caused by frames being received too fast.
The reasons for this deadlock are:
1. While sending with CCA the RX chain should be disabled, which was not the case. When frames were received during CCA, there was a wrong state transition in the `submac` that ended with `submac->tx`  being not released. Therefore, the `submac` would always return `-EBUSY`.
2. The driver logic was always following the internal FSM states, although the Reference Manual (Section 23.11) explicitly says to not do that:

> Although it is possible to read the state of the FSM, do not use this information to control the program flow
in the application software

I was able to trigger cases were the FSM state was not defined but the radio was still fully functional. Therefore, I think we should follow the datasheet here.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It's very hard to reproduce, but here's a way: Take a RIOT BR, a `cc2538_rf` and another node (I used a `nrf52840dk`). When all nodes get prefix, ping from the CC2538 to the other non-BR node (use 1024 kB and short intervals such as 200 ms). Every now and then reset the target node. At some point, the `cc2538_rf` won't be able to send more frames and the TX counter will be increasing non-stop, although no frames get out of the radio. The pktbuf will be full of garbage frames.

With this PR, it's not possible to reproduce this scenario.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
