### PR TITLE
avr_libc_extra: implement strerror()

### DIFF
--- a/cpu/avr8_common/avr_libc_extra/posix_unistd.c
+++ b/cpu/avr8_common/avr_libc_extra/posix_unistd.c
@@ -177,4 +177,80 @@ ssize_t write(int fd, const void *src, size_t count)
 #endif
 }
 
+const char *strerror(int errnum)
+{
+    if (errnum < 0) {
+        errnum = -errnum;
+    }
+
+    switch (errnum) {
+        case 0: return "OK";
+        case EDOM: return "EDOM";
+        case ERANGE: return "ERANGE";
+        case ENOSYS: return "ENOSYS";
+        case EINTR: return "EINTR";
+        case E2BIG: return "E2BIG";
+        case EACCES: return "EACCES";
+        case EADDRINUSE: return "EADDRINUSE";
+        case EADDRNOTAVAIL: return "EADDRNOTAVAIL";
+        case EAFNOSUPPORT: return "EAFNOSUPPORT";
+        case EAGAIN: return "EAGAIN";
+        case EALREADY: return "EALREADY";
+        case EBADF: return "EBADF";
+        case EBUSY: return "EBUSY";
+        case ECHILD: return "ECHILD";
+        case ECONNABORTED: return "ECONNABORTED";
+        case ECONNREFUSED: return "ECONNREFUSED";
+        case ECONNRESET: return "ECONNRESET";
+        case EDEADLK: return "EDEADLK";
+        case EDESTADDRREQ: return "EDESTADDRREQ";
+        case EEXIST: return "EEXIST";
+        case EFAULT: return "EFAULT";
+        case EFBIG: return "EFBIG";
+        case EHOSTUNREACH: return "EHOSTUNREACH";
+        case EILSEQ: return "EILSEQ";
+        case EINPROGRESS: return "EINPROGRESS";
+        case EINVAL: return "EINVAL";
+        case EIO: return "EIO";
+        case EISCONN: return "EISCONN";
+        case EISDIR: return "EISDIR";
+        case ELOOP: return "ELOOP";
+        case EMFILE: return "EMFILE";
+        case EMLINK: return "EMLINK";
+        case EMSGSIZE: return "EMSGSIZE";
+        case ENAMETOOLONG: return "ENAMETOOLONG";
+        case ENETDOWN: return "ENETDOWN";
+        case ENETRESET: return "ENETRESET";
+        case ENETUNREACH: return "ENETUNREACH";
+        case ENFILE: return "ENFILE";
+        case ENOBUFS: return "ENOBUFS";
+        case ENODEV: return "ENODEV";
+        case ENOENT: return "ENOENT";
+        case ENOEXEC: return "ENOEXEC";
+        case ENOLCK: return "ENOLCK";
+        case ENOMEM: return "ENOMEM";
+        case ENOMSG: return "ENOMSG";
+        case ENOPROTOOPT: return "ENOPROTOOPT";
+        case ENOSPC: return "ENOSPC";
+        case ENOTCONN: return "ENOTCONN";
+        case ENOTDIR: return "ENOTDIR";
+        case ENOTEMPTY: return "ENOTEMPTY";
+        case ENOTSOCK: return "ENOTSOCK";
+        case ENOTTY: return "ENOTTY";
+        case ENXIO: return "ENXIO";
+        case EOPNOTSUPP: return "EOPNOTSUPP";
+        case EPERM: return "EPERM";
+        case EPIPE: return "EPIPE";
+        case EPROTONOSUPPORT: return "EPROTONOSUPPORT";
+        case EPROTOTYPE: return "EPROTOTYPE";
+        case EROFS: return "EROFS";
+        case ESPIPE: return "ESPIPE";
+        case ESRCH: return "ESRCH";
+        case ETIMEDOUT: return "ETIMEDOUT";
+        case EWOULDBLOCK: return "EWOULDBLOCK";
+        case EXDEV: return "EXDEV";
+        default: return "unknown";
+    }
+}
+
 /** @} */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a minimal implementation of `strerror()`.
All other targets use either newlib or picolibc and provide this function, add it to AVR so we can rely on it in common code.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16494#discussion_r684194520
