### PR TITLE
gnrc_netif: properly initialize address in gnrc_netif_ipv6_add_prefix()

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1243,7 +1243,7 @@ int gnrc_netif_ipv6_add_prefix(gnrc_netif_t *netif,
 {
     int res;
     eui64_t iid;
-    ipv6_addr_t addr;
+    ipv6_addr_t addr = {0};
 
     assert(netif != NULL);
     DEBUG("gnrc_netif: (re-)configure prefix %s/%d\n",


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Initialize `addr` with 0 first.
Otherwise if prefix is < 64 there will be random bits of stack memory in the bits of the address that are neither touched by `ipv6_addr_set_aiid()` nor `ipv6_addr_init_prefix()`.


### Testing procedure

I was wondering why I was randomly getting addresses like

    inet6 addr: 2001:db8:0:e:dcdb:4fff:fe0c:523d  scope: global  VAL

with

    2001:db8:0:c::/62 dev #7

This fixes it and the address configured with this prefix is now

    inet6 addr: 2001:db8:0:c:dcdb:4fff:fe0c:523d  scope: global  VAL

as expected. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
