### PR TITLE
sys/net/dhcpv6: Refactor IA_NA implementation

### DIFF
--- a/sys/include/net/dhcpv6/client.h
+++ b/sys/include/net/dhcpv6/client.h
@@ -205,6 +205,20 @@ void dhcpv6_client_conf_prefix(unsigned netif, const ipv6_addr_t *pfx,
                                uint32_t pref);
 
 /**
+ * @brief   Configures a address lease that is provided by the server.
+ *
+ * @param[in] netif     Network interface the address was for.
+ * @param[in] addr      The assigned address.
+ * @param[in] valid     Valid lifetime of the address.
+ * @param[in] pref      Preferred lifetime of the address.
+ */
+static inline void dhcpv6_client_conf_addr(unsigned netif, const ipv6_addr_t *addr,
+                                           uint32_t valid, uint32_t pref)
+{
+    dhcpv6_client_conf_prefix(netif, addr, IPV6_ADDR_BIT_LEN, valid, pref);
+}
+
+/**
  * @brief   Checks if the given network interface is configured
  *          to use DHCPv6 IA_NA
  *
@@ -213,33 +227,6 @@ void dhcpv6_client_conf_prefix(unsigned netif, const ipv6_addr_t *pfx,
  * @return  true, if the network interface is set up for IA_NA.
  */
 bool dhcpv6_client_check_ia_na(unsigned netif);
-
-/**
- * @brief   Configures a address lease that is provided by the server.
- *
- * @param[in] netif     Network interface the address was for.
- * @param[in] addr      The assigned address.
- *
- * @return sizeof(ipv6_addr_t) on success.
- * @return <0 on error.
- */
-int dhcpv6_client_add_addr(unsigned netif, ipv6_addr_t *addr);
-
-/**
- * @brief   Deprecates an existing address from an address lease.
- *
- * @param[in] netif     Network interface the address was for.
- * @param[in] addr      The address to deprecate.
- */
-void dhcpv6_client_deprecate_addr(unsigned netif, const ipv6_addr_t *addr);
-
-/**
- * @brief   Removes an existing address that originated from an address lease.
- *
- * @param[in] netif     Network interface the address was for.
- * @param[in] addr      The address to remove.
- */
-void dhcpv6_client_remove_addr(unsigned netif, ipv6_addr_t *addr);
 
 /**
  * @brief   Determines how long the prefix delegation lease is still valid.
@@ -253,6 +240,21 @@ void dhcpv6_client_remove_addr(unsigned netif, ipv6_addr_t *addr);
 uint32_t dhcpv6_client_prefix_valid_until(unsigned netif,
                                           const ipv6_addr_t *pfx,
                                           unsigned pfx_len);
+
+/**
+ * @brief   Determines how long the address lease is still valid.
+ *
+ * @param[in] netif     Network interface the address was for.
+ * @param[in] addr      The assigned address.
+ *
+ * @return  Remaining valid lifetime of the address lease in seconds.
+ */
+static inline uint32_t dhcpv6_client_addr_valid_until(unsigned netif,
+                                                      const ipv6_addr_t *addr)
+{
+    return dhcpv6_client_prefix_valid_until(netif, addr, IPV6_ADDR_BIT_LEN);
+}
+
 /** @} */
 
 /**

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -96,36 +96,6 @@ bool dhcpv6_client_check_ia_na(unsigned iface)
     return netif->ipv6.aac_mode & GNRC_NETIF_AAC_DHCP;
 }
 
-int dhcpv6_client_add_addr(unsigned iface, ipv6_addr_t *addr)
-{
-    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
-
-    DEBUG("DHCPv6 client: ADD IP ADDRESS\n");
-
-    return gnrc_netif_ipv6_addr_add(netif, addr, 64, 0);
-}
-
-void dhcpv6_client_deprecate_addr(unsigned iface, const ipv6_addr_t *addr)
-{
-    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
-    int i;
-
-    gnrc_netif_acquire(netif);
-    i = gnrc_netif_ipv6_addr_idx(netif, addr);
-    if (i >= 0) {
-        netif->ipv6.addrs_flags[i] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
-        netif->ipv6.addrs_flags[i] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_DEPRECATED;
-    }
-    gnrc_netif_release(netif);
-}
-
-void dhcpv6_client_remove_addr(unsigned iface, ipv6_addr_t *addr)
-{
-    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
-
-    gnrc_netif_ipv6_addr_remove(netif, addr);
-}
-
 uint32_t dhcpv6_client_prefix_valid_until(unsigned netif,
                                           const ipv6_addr_t *pfx,
                                           unsigned pfx_len)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up to #16228 and removes introduced redundancy by re-using the already existing DHCPv6 prefix configuration functions.


### Testing procedure

You can use the existing test under `tests/gnrc_dhcpv6_client` to assert that the implementation is still working.


### Issues/PRs references

Depends on #16228 
