### PR TITLE
ci: fix coccinelle warnings

### DIFF
--- a/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
@@ -18,7 +18,7 @@
  */
 #include <assert.h>
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #include "net/gnrc.h"

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng.c
@@ -19,7 +19,7 @@
 #include <errno.h>
 #include <string.h>
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 #include "kernel_defines.h"
 

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_communication.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_communication.c
@@ -24,7 +24,7 @@
 #include "nrf24l01p_ng_constants.h"
 #include "nrf24l01p_ng_communication.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #define SPI_BUS     (dev->params.spi)

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <assert.h>
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #include "kernel_defines.h"

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_states.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_states.c
@@ -19,7 +19,7 @@
 #include <assert.h>
 #include <string.h>
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #include "xtimer.h"

--- a/sys/arduino/wireport.cpp
+++ b/sys/arduino/wireport.cpp
@@ -32,7 +32,7 @@ extern "C" {
 #include "panic.h"
 #include "periph/i2c.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #define WIRE_PORT_OK                    (0)

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
@@ -24,7 +24,7 @@
 #include "log.h"
 #include "msg.h"
 #include "net/gnrc/netif/conf.h"
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #ifndef NRF24L01P_NG_EXTRA_STACKSIZE

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -28,7 +28,7 @@
 #include "net/gnrc/lorawan/region.h"
 #include "net/gnrc/netreg.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 #define MSG_TYPE_MLME_BACKOFF_EXPIRE (0x3458)           /**< Backoff timer expiration message type */

--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -24,7 +24,7 @@
 #include "usb/usbus/hid.h"
 #include "tsrb.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 static void _init(usbus_t *usbus, usbus_handler_t *handler);

--- a/sys/usb/usbus/hid/hid_io.c
+++ b/sys/usb/usbus/hid/hid_io.c
@@ -26,7 +26,7 @@
 #include "usb/usbus/hid.h"
 #include "usb/usbus/hid_io.h"
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 static usbus_hid_device_t hid;


### PR DESCRIPTION
### Contribution description

This PR makes a couple of trivial changes to `ENABLE_DEBUG` statements across the code base to fix the warnings that are currently raised by coccinelle in the CI.

### Testing procedure

All CI tests should pass with no warnings raised by coccinelle.

### Issues/PRs references
