### PR TITLE
sys/net/dhcpv6: Refactor DHCPv6 client

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -968,7 +968,9 @@ static bool _parse_reply(uint8_t *rep, size_t len)
                 }
                 break;
             case DHCPV6_OPT_IA_NA:
-                ia_na = (dhcpv6_opt_ia_na_t *)opt;
+                if (IS_USED(MODULE_DHCPV6_CLIENT_IA_NA)) {
+                    ia_na = (dhcpv6_opt_ia_na_t *)opt;
+                }
                 break;
             case DHCPV6_OPT_SMR:
                 smr = (dhcpv6_opt_smr_t *)opt;

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -887,7 +887,7 @@ static bool _parse_ia_na_option(dhcpv6_opt_ia_na_t *ia_na)
         unsigned na_t1, na_t2;
         uint32_t ia_id = byteorder_ntohl(ia_na->ia_id);
         size_t ia_na_len = byteorder_ntohs(ia_na->len) -
-                            (sizeof(dhcpv6_opt_ia_na_t) - sizeof(dhcpv6_opt_t));
+                           (sizeof(dhcpv6_opt_ia_na_t) - sizeof(dhcpv6_opt_t));
         size_t ia_na_orig_len = ia_na_len;
 
         if (lease->parent.ia_id.id != ia_id) {
@@ -895,12 +895,12 @@ static bool _parse_ia_na_option(dhcpv6_opt_ia_na_t *ia_na)
         }
         /* check for status */
         for (dhcpv6_opt_t *ia_na_opt = (dhcpv6_opt_t *)(ia_na + 1);
-                ia_na_len > 0;
-                ia_na_len -= _opt_len(ia_na_opt),
-                ia_na_opt = _opt_next(ia_na_opt)) {
+             ia_na_len > 0;
+             ia_na_len -= _opt_len(ia_na_opt),
+             ia_na_opt = _opt_next(ia_na_opt)) {
             if (ia_na_len > ia_na_orig_len) {
                 DEBUG("DHCPv6 client: IA_NA options overflow option "
-                        "boundaries\n");
+                      "boundaries\n");
                 return false;
             }
             switch (byteorder_ntohs(ia_na_opt->type)) {


### PR DESCRIPTION
### Contribution description

This PR makes a couple of changes to the DHCPv6 client implementation to increase maintainability and the possibility to add new features.

It mostly moves existing code to separate functions but also refactors the composition of messages by adding a new `_compose_message` function which eliminates some code duplication and makes it easier to see which options are used (or requested) with each message type. This should also make it easier to add additional features like information-requests to the client.

### Testing procedure

You can use the existing tests under `tests/gnrc_dhcpv6_client` and `tests/gnrc_dhcpv6_client_6lbr`. Despite the changes, these should still work.
