### PR TITLE
net/gcoap: add functions to read and set the next message id

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -817,6 +817,24 @@ typedef struct {
 kernel_pid_t gcoap_init(void);
 
 /**
+ * @brief   Reads and returns the current set next message ID out of the
+ *          internal structure of gcoap.
+ *
+ * @return  Value of the next message ID
+ */
+uint16_t gcoap_read_next_message_id(void);
+
+/**
+ * @brief   Sets the next message ID with a given value
+ *
+ * @param[in] next_message_id Number of the next message ID
+ *
+ * @note    By default, the next message ID is set automatically with a random
+ *          value while initialization. Only set manually when needed.
+ */
+void gcoap_set_next_message_id(uint16_t next_message_id);
+
+/**
  * @brief   Starts listening for resource paths
  *
  * @pre @p listener is a valid pointer to a single listener (that is,

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1005,6 +1005,16 @@ kernel_pid_t gcoap_init(void)
     return _pid;
 }
 
+uint16_t gcoap_read_next_message_id(void)
+{
+    return (uint16_t)atomic_load(&_coap_state.next_message_id);
+}
+
+void gcoap_set_next_message_id(uint16_t next_message_id)
+{
+    atomic_init(&_coap_state.next_message_id, next_message_id);
+}
+
 void gcoap_register_listener(gcoap_listener_t *listener)
 {
     /* That item will be overridden, ensure that the user expecting different


### PR DESCRIPTION
### Contribution description

This PR adds two new functions to gcoap, which allow to read the next message ID and to set it to a given value.
Currently, the next message ID is randomly generated while init, but that is not always wanted. I need to set it manually.

I intentionally named the function "read" to make it indirectly clear that this is not part of the regular use-case of gcoap. Well, I hope it does that with this naming :D
### Testing procedure
Apply this small patch for the gcoap example:
```
diff --git a/examples/gcoap/gcoap_cli.c b/examples/gcoap/gcoap_cli.c
index f089a65c7b..ab3080b947 100644
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -328,6 +328,7 @@ int gcoap_cli_cmd(int argc, char **argv)
 #endif
         printf(" CLI requests sent: %u\n", req_count);
         printf("CoAP open requests: %u\n", open_reqs);
+        printf("Next message ID: %u\n", gcoap_read_next_message_id());
         printf("Configured Proxy: ");
         if (_proxied) {
             char addrstr[IPV6_ADDR_MAX_STR_LEN];
@@ -488,6 +489,6 @@ void gcoap_cli_init(void)
         printf("gcoap: cannot add credential to DTLS sock: %d\n", res);
     }
 #endif
-
+    gcoap_set_next_message_id(10);
     gcoap_register_listener(&_listener);
 }
 ```
 
 1) `coap info` shows the next message ID. It is set to 10 by default with this patch.
 2) Send a request to a server (request does not need to succeed)
 3) Next message ID should be 11

### Issues/PRs references