### PR TITLE
sys/random: default to prng_hwrng if available

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -40,9 +40,15 @@ ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
 endif
 
 ifneq (,$(filter random,$(USEMODULE)))
-  # select default prng if no prng is selected
-  ifeq (,$(filter prng_%,$(USEMODULE)))
-    USEMODULE += prng_tinymt32
+  ifeq (,$(filter prng_%,$(filter-out $(_DEFAULT_RNG),$(USEMODULE))))
+    # select default prng if no prng is selected
+    ifneq (,$(filter periph_hwrng,$(USEMODULE)))
+      USEMODULE += prng_hwrng
+      USEMODULE := $(filter-out $(_DEFAULT_RNG),$(USEMODULE))
+    else
+      USEMODULE += prng_tinymt32
+      _DEFAULT_RNG = prng_tinymt32 tinymt32
+    endif
   endif
 endif
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -435,10 +435,7 @@ ifneq (,$(filter random,$(USEMODULE)))
     FEATURES_REQUIRED += periph_hwrng
   endif
 
-  ifeq (,$(filter puf_sram,$(USEMODULE)))
-    FEATURES_OPTIONAL += periph_hwrng
-  endif
-
+  FEATURES_OPTIONAL += periph_hwrng
   USEMODULE += luid
 endif
 

--- a/sys/random/Kconfig
+++ b/sys/random/Kconfig
@@ -17,7 +17,7 @@ choice RANDOM_IMPLEMENTATION
     bool "PRNG Implementation"
     depends on TEST_KCONFIG
     default MODULE_PRNG_HWRNG if HAS_PERIPH_HWRNG
-    default MODULE_PRNG_TINYMT32
+    default MODULE_PRNG_TINYMT32 if !HAS_PERIPH_HWRNG
 
 config MODULE_PRNG_FORTUNA
     bool "Fortuna"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If a hardware random number generator is available we should always prefer that over tinymt32.



### Testing procedure

Run `tests/rng` on a board with a HWRNG:

#### master

```
2021-08-13 19:24:40,507 # > speed
2021-08-13 19:24:40,513 # Running speed test, with seed 0 using Tiny Mersenne Twister PRNG.
2021-08-13 19:24:40,513 # 
2021-08-13 19:24:40,516 # Running speed test for 10 seconds
2021-08-13 19:24:50,522 # Collected 15584410 samples in 10.000013 seconds (6087 KiB/s).
```

#### this PR

```
2021-08-13 19:23:26,869 # > speed
2021-08-13 19:23:26,873 # Running speed test, with seed 0 using Hardware RNG.
2021-08-13 19:23:26,873 # 
2021-08-13 19:23:26,876 # Running speed test for 10 seconds
2021-08-13 19:23:36,882 # Collected 9677416 samples in 10.000014 seconds (3780 KiB/s).
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
