### PR TITLE
gnrc_tcp: Add GNRC_TCP_NO_TIMEOUT

### DIFF
--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -34,6 +34,16 @@
 extern "C" {
 #endif
 
+/* Note: This value if configurable for test purposes. Do not override it.
+ *       Changing this value may lead to errors that are hard to track down.
+ */
+#ifndef GNRC_TCP_NO_TIMEOUT
+/**
+ * @brief Special timeout value representing no timeout.
+ */
+#define GNRC_TCP_NO_TIMEOUT (UINT32_MAX)
+#endif
+
 /**
  * @brief Address information for a single TCP connection endpoint.
  * @extends sock_tcp_ep_t
@@ -172,7 +182,9 @@ int gnrc_tcp_listen(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t *tcbs, size_t tc
  *
  * @param[in]  queue                      Listening queue to accept connection from.
  * @param[out] tcb                        Pointer to TCB associated with a established connection.
- * @param[in]  user_timeout_duration_ms   User specified timeout in milliseconds.
+ * @param[in]  user_timeout_duration_ms   User specified timeout in milliseconds. If
+ *                                        GNRC_TCP_NO_TIMEOUT the function blocks until a
+ *                                        connection was established or an error occurred.
  *
  * @return 0 on success.
  * @return -ENOMEM if all connection in @p queue were already accepted.
@@ -182,7 +194,7 @@ int gnrc_tcp_listen(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t *tcbs, size_t tc
  *                    could be established.
  */
 int gnrc_tcp_accept(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t **tcb,
-                    uint32_t user_timeout_duration_ms);
+                    const uint32_t user_timeout_duration_ms);
 
 /**
  * @brief Transmit data to connected peer.
@@ -199,6 +211,9 @@ int gnrc_tcp_accept(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t **tcb,
  * @param[in]     user_timeout_duration_ms   If not zero and there was not data transmitted
  *                                           the function returns after user_timeout_duration_ms.
  *                                           If zero, no timeout will be triggered.
+ *                                           If GNRC_TCP_NO_TIMEOUT the timeout is disabled
+ *                                           causing the function to block until some data was
+ *                                           transmitted or and error occurred.
  *
  * @return   The number of successfully transmitted bytes.
  * @return   -ENOTCONN if connection is not established.
@@ -228,6 +243,9 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
  *                                           returns immediately. If not zero the function
  *                                           blocks until data is available or
  *                                           @p user_timeout_duration_ms milliseconds passed.
+ *                                           If GNRC_TCP_NO_TIMEOUT, causing the function to
+ *                                           block until some data was available or an error
+ *                                           occurred.
  *
  * @return   The number of bytes read into @p data.
  * @return   0, if the connection is closing and no further data can be read.

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -539,7 +539,7 @@ int gnrc_tcp_listen(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t *tcbs, size_t tc
 }
 
 int gnrc_tcp_accept(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t **tcb,
-                    uint32_t user_timeout_duration_ms)
+                    const uint32_t user_timeout_duration_ms)
 {
     TCP_DEBUG_ENTER;
     assert(queue != NULL);
@@ -612,8 +612,10 @@ int gnrc_tcp_accept(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t **tcb,
     }
 
     /* Setup User specified Timeout */
-    _sched_mbox(&event_user_timeout, user_timeout_duration_ms,
-                MSG_TYPE_USER_SPEC_TIMEOUT, &mbox);
+    if (user_timeout_duration_ms != GNRC_TCP_NO_TIMEOUT) {
+        _sched_mbox(&event_user_timeout, user_timeout_duration_ms,
+                    MSG_TYPE_USER_SPEC_TIMEOUT, &mbox);
+    }
 
     /* Wait until a connection was established */
     while (ret >= 0 && *tcb == NULL) {
@@ -692,7 +694,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
     /* Setup connection timeout */
     _sched_connection_timeout(&tcb->event_misc, &mbox);
 
-    if (timeout_duration_ms > 0) {
+    if ((0 < timeout_duration_ms) && (timeout_duration_ms != GNRC_TCP_NO_TIMEOUT)) {
         _sched_mbox(&event_user_timeout, timeout_duration_ms,
                     MSG_TYPE_USER_SPEC_TIMEOUT, &mbox);
     }
@@ -841,7 +843,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
     /* Setup connection timeout */
     _sched_connection_timeout(&tcb->event_misc, &mbox);
 
-    if (timeout_duration_ms > 0) {
+    if (timeout_duration_ms != GNRC_TCP_NO_TIMEOUT) {
         _sched_mbox(&event_user_timeout, timeout_duration_ms,
                     MSG_TYPE_USER_SPEC_TIMEOUT, &mbox);
     }

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -8,6 +8,9 @@ TAP ?= tap0
 MSL_MS ?= 1000
 TIMEOUT_MS ?= 3000
 
+# Set custom GNRC_TCP_NO_TIMEOUT constant for testing purposes
+CUSTOM_GNRC_TCP_NO_TIMEOUT ?= 1
+
 # This test depends on tap device setup (only allowed by root)
 # Suppress test execution to avoid CI errors
 TEST_ON_CI_BLACKLIST += all
@@ -56,4 +59,9 @@ endif
 # Set the shell echo configuration via CFLAGS if not being controlled via Kconfig
 ifndef CONFIG_KCONFIG_USEMODULE_SHELL
   CFLAGS += -DCONFIG_SHELL_NO_ECHO
+endif
+
+# Set GNRC_TCP_NO_TIMEOUT via CFLAGS
+ifndef GNRC_TCP_NO_TIMEOUT
+  CFLAGS += -DGNRC_TCP_NO_TIMEOUT=$(CUSTOM_GNRC_TCP_NO_TIMEOUT)
 endif


### PR DESCRIPTION
### Contribution description
This PR adds the constant GNRC_TCP_NO_TIMEOUT to disable user specified timeouts on the functions gnrc_tcp_accept, gnrc_tcp_send, gnrc_tcp_recv. 

### Testing procedure
This PR can be partially tested by executing the tests under tests/gnrc_tcp. Tests exist for gnrc_tcp_accept and gnrc_tcp_recv.
The function gnrc_tcp_send can't be tested because as soon as a connection was established the host system stores received data, therefore gnrc_tcp_send would be unblocked.

### Issues/PRs references
Adds missing functionality required by #16494