### PR TITLE
treewide: Address uncrustify suggestions

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -49,6 +49,7 @@ static inline __attribute__((always_inline)) void _block(mutex_t *mutex,
                                                          unsigned irq_state)
 {
     thread_t *me = thread_get_active();
+
     /* Fail visibly even if a blocking action is called from somewhere where
      * it's subtly not allowed, eg. board_init */
     assert(me != NULL);

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -60,10 +60,10 @@ typedef uint8_t gpio_t;
  * @brief   Structure for UART configuration data
  */
 typedef struct {
-    uint32_t addr;            /**< UART control register address */
-    gpio_t   rx;              /**< RX pin */
-    gpio_t   tx;              /**< TX pin */
-    irqn_t   isr_num;         /**< ISR source number */
+    uint32_t addr;              /**< UART control register address */
+    gpio_t rx;                  /**< RX pin */
+    gpio_t tx;                  /**< TX pin */
+    irqn_t isr_num;             /**< ISR source number */
 } uart_conf_t;
 
 /**

--- a/cpu/riscv_common/include/atomic_utils_arch.h
+++ b/cpu/riscv_common/include/atomic_utils_arch.h
@@ -18,13 +18,14 @@
 
 #ifndef ATOMIC_UTILS_ARCH_H
 #define ATOMIC_UTILS_ARCH_H
-#ifndef DOXYGEN
 
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef DOXYGEN
 
 /* clang provides no built-in atomic access to regular variables */
 #ifndef __clang__
@@ -65,12 +66,13 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val)
     __atomic_store_4(dest, val, __ATOMIC_SEQ_CST);
 }
 
-#endif /* __clang__ */
+#endif  /* __clang__ */
+
+#endif  /* DOXYGEN */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* DOXYGEN */
 #endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/riscv_common/include/clic.h
+++ b/cpu/riscv_common/include/clic.h
@@ -38,10 +38,10 @@ typedef void (*clic_isr_cb_t)(unsigned irq);
  * @brief RISC-V CLIC per interrupt configuration registers
  */
 typedef struct __attribute((packed)) {
-    volatile uint8_t ip;     /**< Interrupt pending */
-    volatile uint8_t ie;     /**< Interrupt enable */
-    volatile uint8_t attr;   /**< Interrupt attributes */
-    volatile uint8_t ctl;    /**< Interrupt control */
+    volatile uint8_t ip;        /**< Interrupt pending */
+    volatile uint8_t ie;        /**< Interrupt enable */
+    volatile uint8_t attr;      /**< Interrupt attributes */
+    volatile uint8_t ctl;       /**< Interrupt control */
 } clic_clicint_t;
 
 /**

--- a/cpu/riscv_common/include/irq_arch.h
+++ b/cpu/riscv_common/include/irq_arch.h
@@ -33,8 +33,8 @@ extern "C" {
 #endif
 
 /**
-￼ * @brief   Bit mask for the MCAUSE register
-￼ */
+ * @brief   Bit mask for the MCAUSE register
+ */
 #define CPU_CSR_MCAUSE_CAUSE_MSK        (0x0fffu)
 
 extern volatile int riscv_in_isr;
@@ -100,6 +100,7 @@ static inline __attribute__((always_inline)) int irq_is_in(void)
 static inline __attribute__((always_inline)) int irq_is_enabled(void)
 {
     unsigned state;
+
     __asm__ volatile (
         "csrr %[dest], mstatus"
         :[dest]    "=r" (state)

--- a/cpu/riscv_common/include/thread_arch.h
+++ b/cpu/riscv_common/include/thread_arch.h
@@ -38,7 +38,7 @@ static inline void _ecall_dispatch(uint32_t num, void *ctx)
         "add a1, x0, %[ctx] \n"
         "ECALL\n"
         : /* No outputs */
-        : [num] "r" (num), [ctx] "r" (ctx)
+        :[num] "r" (num), [ctx] "r" (ctx)
         : "memory", "a0", "a1"
         );
 }

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -82,13 +82,15 @@ void riscv_irq_init(void)
 /**
  * @brief Global trap and interrupt handler
  */
-static void __attribute((used)) handle_trap(uint32_t mcause)
+__attribute((used))
+static void handle_trap(uint32_t mcause)
 {
     /*  Tell RIOT to set sched_context_switch_request instead of
      *  calling thread_yield(). */
     riscv_in_isr = 1;
 
     uint32_t trap = mcause & CPU_CSR_MCAUSE_CAUSE_MSK;
+
     /* Check for INT or TRAP */
     if ((mcause & MCAUSE_INT) == MCAUSE_INT) {
         /* Cause is an interrupt - determine type */
@@ -149,7 +151,8 @@ static void __attribute((used)) handle_trap(uint32_t mcause)
 /* Marking this as interrupt to ensure an mret at the end, provided by the
  * compiler. Aligned to 64-byte boundary as per RISC-V spec and required by some
  * of the supported platforms (gd32)*/
-static void __attribute((aligned(64))) __attribute__((interrupt)) trap_entry(void)
+__attribute((aligned(64)))
+static void __attribute__((interrupt)) trap_entry(void)
 {
     __asm__ volatile (
         "addi sp, sp, -"XTSTR (CONTEXT_FRAME_SIZE)"          \n"

--- a/cpu/riscv_common/periph/plic.c
+++ b/cpu/riscv_common/periph/plic.c
@@ -30,8 +30,12 @@
 #include "plic.h"
 
 /* Local macros to calculate register offsets */
-#define _REG32(p, i) 			(*(volatile uint32_t *) ((p) + (i)))
-#define PLIC_REG(offset) 		_REG32(PLIC_CTRL_ADDR, offset)
+#ifndef _REG32
+#define _REG32(p, i)            (*(volatile uint32_t *)((p) + (i)))
+#endif
+#ifndef PLIC_REG
+#define PLIC_REG(offset)        _REG32(PLIC_CTRL_ADDR, offset)
+#endif
 
 /* PLIC external ISR function list */
 static plic_isr_cb_t _ext_isrs[PLIC_NUM_INTERRUPTS];

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -190,6 +190,7 @@ int riotboot_flashwrite_invalidate(int slot)
        write the whole header to avoid running in memory alignment issues
        with FLASHPAGE_WRITE_BLOCK_SIZE */
     riotboot_hdr_t tmp_hdr;
+
     memset(&tmp_hdr, (~FLASHPAGE_ERASE_STATE), sizeof(riotboot_hdr_t));
 
     flashpage_write((void *)riotboot_slot_get_hdr(slot), &tmp_hdr,

--- a/sys/riotboot/hdr.c
+++ b/sys/riotboot/hdr.c
@@ -59,6 +59,7 @@ int riotboot_hdr_validate(const riotboot_hdr_t *riotboot_hdr)
 
     int res = riotboot_hdr_checksum(riotboot_hdr) ==
               riotboot_hdr->chksum ? 0 : -1;
+
     if (res) {
         LOG_INFO("%s: riotboot_hdr checksum invalid\n", __func__);
     }

--- a/sys/riotboot/serial.c
+++ b/sys/riotboot/serial.c
@@ -182,6 +182,7 @@ static void _get_page(uintptr_t addr)
 {
     uart_write_byte(RIOTBOOT_UART_DEV, RIOTBOOT_STAT_OK);
     uint32_t page = flashpage_page((void *)addr);
+
     uart_write(RIOTBOOT_UART_DEV, (void *)&page, sizeof(page));
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR makes a couple of minor changes to get rid of the uncrustify suggestions made in the CI.

The changes in `sys/include/ztimer.h` are the result of false positives and can probably be dropped. Maybe there is a way to adjust the config to get rid of warnings like these?

### Testing procedure

All static tests should pass without suggestions/warnings while the CI stays green as well.

### Issues/PRs references

The false postives for `sys/include/ztimer.h` have been mentioned in #15802 before.