### PR TITLE
lwip_tcp: fix build with DEVELHELP=0

### DIFF
--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -224,7 +224,6 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg,
     return res;
 }
 
-#ifdef DEVELHELP
 static kernel_pid_t lwip_tcpip_thread = KERNEL_PID_UNDEF;
 static kernel_pid_t lwip_lock_thread;
 
@@ -252,6 +251,5 @@ bool sys_check_core_locked(void) {
     }
     return true;
 }
-#endif
 
 /** @} */

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -116,7 +116,6 @@ static inline void sys_mbox_set_invalid(sys_mbox_t *mbox)
 
 typedef kernel_pid_t sys_thread_t;      /**< Platform specific thread type */
 
-#if DEVELHELP
 /**
  * @name    Functions for locking/unlocking core to assure thread safety.
  * @{
@@ -126,7 +125,6 @@ void sys_lock_tcpip_core(void);
 void sys_unlock_tcpip_core(void);
 #define UNLOCK_TCPIP_CORE()        sys_unlock_tcpip_core()
 /** @} */
-#endif
 
 #ifdef MODULE_RANDOM
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If DEVELHELP is not set `LOCK_TCPIP_CORE()`/`UNLOCK_TCPIP_CORE()` are not defined, leading to a build failure.

Defining them to no-op leads to a run-time segmentation fault, so better always use those functions.


### Testing procedure

Compile the TCP echo examples from #16739 with `LWIP=1 DEVELHELP=0`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
