### PR TITLE
cpu/atxmega: Fix features config

### DIFF
--- a/boards/atxmega-a1u-xpro/Kconfig
+++ b/boards/atxmega-a1u-xpro/Kconfig
@@ -12,15 +12,9 @@ config BOARD_ATXMEGA_A1U_XPRO
     bool
     default y
     select CPU_MODEL_XMEGA128A1U
-    select HAS_PERIPH_CPUID
-    select HAS_PERIPH_GPIO
-    select HAS_PERIPH_GPIO_IRQ
+
     select HAS_PERIPH_I2C
-    select HAS_PERIPH_NVM
-    select HAS_PERIPH_PM
     select HAS_PERIPH_SPI
-    select HAS_PERIPH_TIMER
-    select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_UART
 
     select HAVE_SAUL_GPIO

--- a/boards/atxmega-a1u-xpro/Makefile.features
+++ b/boards/atxmega-a1u-xpro/Makefile.features
@@ -1,3 +1,7 @@
 CPU_MODEL = atxmega128a1u
 
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
 include $(RIOTBOARD)/common/atxmega/Makefile.features

--- a/boards/atxmega-a3bu-xplained/Kconfig
+++ b/boards/atxmega-a3bu-xplained/Kconfig
@@ -12,15 +12,9 @@ config BOARD_ATXMEGA_A3BU_XPLAINED
     bool
     default y
     select CPU_MODEL_XMEGA256A3BU
-    select HAS_PERIPH_CPUID
-    select HAS_PERIPH_GPIO
-    select HAS_PERIPH_GPIO_IRQ
+
     select HAS_PERIPH_I2C
-    select HAS_PERIPH_NVM
-    select HAS_PERIPH_PM
     select HAS_PERIPH_SPI
-    select HAS_PERIPH_TIMER
-    select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_UART
 
     select HAVE_SAUL_GPIO

--- a/boards/atxmega-a3bu-xplained/Makefile.features
+++ b/boards/atxmega-a3bu-xplained/Makefile.features
@@ -1,3 +1,7 @@
 CPU_MODEL = atxmega256a3bu
 
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
 include $(RIOTBOARD)/common/atxmega/Makefile.features

--- a/cpu/atxmega/Kconfig
+++ b/cpu/atxmega/Kconfig
@@ -22,7 +22,6 @@ config CPU_COMMON_ATXMEGA
     select HAS_PERIPH_PM
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_TIMER_PERIODIC
-    select HAS_PERIPH_UART
 
 config CPU_CORE_ATXMEGA_A1
     bool

--- a/cpu/atxmega/Makefile.features
+++ b/cpu/atxmega/Makefile.features
@@ -6,9 +6,6 @@ include $(RIOTCPU)/avr8_common/Makefile.features
 FEATURES_PROVIDED += cpu_core_atxmega
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
-FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_nvm
 FEATURES_PROVIDED += periph_pm
-FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer periph_timer_periodic
-FEATURES_PROVIDED += periph_uart


### PR DESCRIPTION
### Contribution description

Update features definitions and configurations.  Now atxmega define features that only are full available on all variations and do not require any definition at periph_conf.h file.

### Testing procedure

The test was conducted using `tests/kconfig_features` .

### Issues/PRs references

This is a split from #16288

CC: @maribu