### PR TITLE
ieee802154/submac: reimplement using FSM

### DIFF
--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -41,6 +41,7 @@ extern "C" {
 #define NETDEV_SUBMAC_FLAGS_TX_DONE     (1 << 1)    /**< Flag for TX Done event */
 #define NETDEV_SUBMAC_FLAGS_RX_DONE     (1 << 2)    /**< Flag for RX Done event */
 #define NETDEV_SUBMAC_FLAGS_CRC_ERROR   (1 << 3)    /**< Flag for CRC ERROR event */
+#define NETDEV_SUBMAC_FLAGS_BH_REQUEST  (1 << 4)    /**< Flag for Bottom Half request event */
 
 /**
  * @brief IEEE 802.15.4 SubMAC netdev descriptor
@@ -51,6 +52,8 @@ typedef struct {
     xtimer_t ack_timer;                 /**< xtimer descriptor for the ACK timeout timer */
     int isr_flags;                      /**< netdev submac @ref NETDEV_EVENT_ISR flags */
     int8_t retrans;                     /**< number of frame retransmissions of the last TX */
+    bool dispatch;                      /**< whether an event should be dispatched or not */
+    netdev_event_t ev;                  /**< event to be dispatched */
 } netdev_ieee802154_submac_t;
 
 /**

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -22,7 +22,6 @@ static const netdev_driver_t netdev_submac_driver;
 
 static void _ack_timeout(void *arg)
 {
-    (void)arg;
     netdev_ieee802154_submac_t *netdev_submac = arg;
     netdev_t *netdev = arg;
 
@@ -33,23 +32,12 @@ static void _ack_timeout(void *arg)
 
 static netopt_state_t _get_submac_state(ieee802154_submac_t *submac)
 {
-    ieee802154_submac_state_t state = ieee802154_get_state(submac);
-
-    netopt_state_t netopt_state;
-    switch (state) {
-        case IEEE802154_STATE_OFF:
-            netopt_state = NETOPT_STATE_SLEEP;
-            break;
-        case IEEE802154_STATE_IDLE:
-            netopt_state = NETOPT_STATE_STANDBY;
-            break;
-        case IEEE802154_STATE_LISTEN:
-        default:
-            netopt_state = NETOPT_STATE_IDLE;
-            break;
+    if (ieee802154_submac_state_is_idle(submac)) {
+        return NETOPT_STATE_SLEEP;
     }
-
-    return netopt_state;
+    else {
+        return NETOPT_STATE_IDLE;
+    }
 }
 
 static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
@@ -82,12 +70,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 static int _set_submac_state(ieee802154_submac_t *submac, netopt_state_t state)
 {
     switch (state) {
-        case NETOPT_STATE_STANDBY:
-            return ieee802154_set_state(submac, IEEE802154_STATE_IDLE);
         case NETOPT_STATE_SLEEP:
-            return ieee802154_set_state(submac, IEEE802154_STATE_OFF);
+            return ieee802154_set_idle(submac);
+            break;
         case NETOPT_STATE_IDLE:
-            return ieee802154_set_state(submac, IEEE802154_STATE_LISTEN);
+            return ieee802154_set_rx(submac);
+            break;
         default:
             return -ENOTSUP;
     }
@@ -135,6 +123,18 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
                                  opt, value, value_len);
 }
 
+void ieee802154_submac_bh_request(ieee802154_submac_t *submac)
+{
+    netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
+                                                             netdev_ieee802154_submac_t,
+                                                             submac);
+
+    netdev_t *netdev = &netdev_submac->dev.netdev;
+    netdev_submac->isr_flags |= NETDEV_SUBMAC_FLAGS_BH_REQUEST;
+
+    netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+}
+
 void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac, uint16_t us)
 {
     netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
@@ -161,7 +161,13 @@ static int _send(netdev_t *netdev, const iolist_t *pkt)
                                                              dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
 
-    return ieee802154_send(submac, pkt);
+    int res = ieee802154_send(submac, pkt);
+    if (res >= 0) {
+        /* HACK: Used to mark a transmission when called
+         * inside the TX Done callback */
+        netdev_submac->ev = NETDEV_EVENT_TX_STARTED;
+    }
+    return res;
 }
 
 static void _isr(netdev_t *netdev)
@@ -172,11 +178,16 @@ static void _isr(netdev_t *netdev)
                                                              dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
 
+    bool can_dispatch = true;
     do {
         irq_disable();
         int flags = netdev_submac->isr_flags;
         netdev_submac->isr_flags = 0;
         irq_enable();
+
+        if (flags & NETDEV_SUBMAC_FLAGS_BH_REQUEST) {
+            ieee802154_submac_bh_process(submac);
+        }
 
         if (flags & NETDEV_SUBMAC_FLAGS_ACK_TIMEOUT) {
             ieee802154_submac_ack_timeout_fired(&netdev_submac->submac);
@@ -193,7 +204,33 @@ static void _isr(netdev_t *netdev)
         if (flags & NETDEV_SUBMAC_FLAGS_CRC_ERROR) {
             ieee802154_submac_crc_error_cb(submac);
         }
+
+        if (flags) {
+            can_dispatch = false;
+        }
+
     } while (netdev_submac->isr_flags != 0);
+
+    if (netdev_submac->dispatch) {
+        /* The SubMAC will not generate further events after calling TX Done
+         * or RX Done, but there might be pending ISR events that might not be
+         * caught by the previous loop.
+         * This should be safe to make sure that all events are cached */
+        if (!can_dispatch) {
+            netdev->event_callback(netdev, NETDEV_EVENT_ISR);
+            return;
+        }
+        netdev_submac->dispatch = false;
+        /* TODO: Prevent race condition when state goes to PREPARE */
+        netdev->event_callback(netdev, netdev_submac->ev);
+        /* HACK: the TX_STARTED event is used to indicate a frame was
+         * sent during the event callback.
+         * If no frame was sent go back to RX */
+        if (netdev_submac->ev != NETDEV_EVENT_TX_STARTED) {
+            ieee802154_set_rx(submac);
+        }
+    }
+
 }
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
@@ -231,24 +268,24 @@ static void submac_tx_done(ieee802154_submac_t *submac, int status,
     netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
                                                              netdev_ieee802154_submac_t,
                                                              submac);
-    netdev_t *netdev = &netdev_submac->dev.netdev;
-
     if (info) {
         netdev_submac->retrans = info->retrans;
     }
 
+    netdev_submac->dispatch = true;
+
     switch (status) {
     case TX_STATUS_SUCCESS:
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
+        netdev_submac->ev = NETDEV_EVENT_TX_COMPLETE;
         break;
     case TX_STATUS_FRAME_PENDING:
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE_DATA_PENDING);
+        netdev_submac->ev = NETDEV_EVENT_TX_COMPLETE_DATA_PENDING;
         break;
     case TX_STATUS_MEDIUM_BUSY:
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_MEDIUM_BUSY);
+        netdev_submac->ev = NETDEV_EVENT_TX_MEDIUM_BUSY;
         break;
     case TX_STATUS_NO_ACK:
-        netdev->event_callback(netdev, NETDEV_EVENT_TX_NOACK);
+        netdev_submac->ev = NETDEV_EVENT_TX_NOACK;
         break;
     default:
         break;
@@ -260,9 +297,8 @@ static void submac_rx_done(ieee802154_submac_t *submac)
     netdev_ieee802154_submac_t *netdev_submac = container_of(submac,
                                                              netdev_ieee802154_submac_t,
                                                              submac);
-    netdev_t *netdev = &netdev_submac->dev.netdev;
-
-    netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+    netdev_submac->dispatch = true;
+    netdev_submac->ev = NETDEV_EVENT_RX_COMPLETE;
 }
 
 static const ieee802154_submac_cb_t _cb = {

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -157,6 +157,18 @@ typedef enum {
      * set if the source address matches one from the table.
      */
     IEEE802154_CAP_SRC_ADDR_MATCH       = BIT18,
+    /**
+     * @brief the device stays in RX_ON on @ref
+     * IEEE802154_RADIO_INDICATION_RX_DONE or @ref
+     * IEEE802154_RADIO_INDICATION_CRC_ERROR
+     *
+     * Radios that provide this feature don't need to call @ref
+     * ieee802154_radio_request_set_trx_state on after receiving a frame, in
+     * case more frames are expected. This does not affect Framebuffer
+     * protection (e.g a radio might still be listening but its framebuffer is
+     * locked because the upper layer didn't call @ref ieee802154_radio_read)
+     */
+    IEEE802154_CAP_RX_CONTINUOUS        = BIT19,
 } ieee802154_rf_caps_t;
 
 /**
@@ -1408,6 +1420,22 @@ static inline bool ieee802154_radio_has_phy_mr_fsk(ieee802154_dev_t *dev)
 static inline uint32_t ieee802154_radio_get_phy_modes(ieee802154_dev_t *dev)
 {
     return (dev->driver->caps & IEEE802154_RF_CAPS_PHY_MASK);
+}
+
+/**
+ * @brief Check whether the radio stays in RX_ON after @ref
+ *        IEEE802154_RADIO_INDICATION_RX_DONE or @ref
+ *        IEEE802154_RADIO_INDICATION_CRC_ERROR events (see @ref
+ *        IEEE802154_CAP_RX_CONTINUOUS)
+ *
+ * @param[in] dev IEEE802.15.4 device descriptor
+ *
+ * @return true if the device stays in RX_ON state
+ * @return false otherwise
+ */
+static inline bool ieee802154_radio_has_rx_continuous(ieee802154_dev_t *dev)
+{
+    return (dev->driver->caps & IEEE802154_CAP_RX_CONTINUOUS);
 }
 
 /**

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -284,11 +284,10 @@ typedef enum {
      * The transceiver or driver MUST handle the ACK reply if the Ack Request
      * bit is set in the received frame and promiscuous mode is disabled.
      *
-     * The transceiver will be in a "FB Lock" state where no more frames are
+     * The transceiver might be in a "FB Lock" state where no more frames are
      * received. This is done in order to avoid overwriting the Frame Buffer
      * with new frame arrivals.  In order to leave this state, the upper layer
-     * must set the transceiver state (@ref
-     * ieee802154_radio_ops::request_set_trx_state).
+     * must call @ref ieee802154_radio_ops::read.
      */
     IEEE802154_RADIO_INDICATION_RX_DONE,
 
@@ -573,11 +572,13 @@ struct ieee802154_radio_ops {
      * This function reads the received frame from the internal framebuffer.
      * It should try to copy the received PSDU frame into @p buf. The FCS
      * field will **not** be copied and its size **not** be taken into account
-     * for the return value.
+     * for the return value. If the radio provides any kind of framebuffer protection,
+     * this function should release it.
      *
-     * @post It's not safe to call this function again before setting the
-     *       transceiver state to @ref IEEE802154_TRX_STATE_RX_ON (thus flushing
-     *       the RX FIFO).
+     * @post Don't call this function if there was no reception event
+     * (either @ref IEEE802154_RADIO_INDICATION_RX_DONE or @ref
+     * IEEE802154_RADIO_INDICATION_CRC_ERROR). Otherwise there's risk of RX
+     * underflow.
      *
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[out] buf buffer to write the received PSDU frame into.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR re-implements the IEEE802.15.4 SubMAC using a Mealy FSM. There are many advantages of using this method:
1. The SubMAC is more robust to hicups such as race condition or slow Bottom Half Processor (e.g SPI radios that process their internal events using the same thread as the SubMAC)
2. It's way easier to debug the SubMAC since the transitions are well known.
3. It's also easier to expand the functionalities of the SubMAC.
4. Automated testing should be way easier as well.
5. Last but not least, this helps to point out implementation issues in radios (this PR piggyback a fix for the CC2538)

Given this PR, the SubMAC seems to be way more stable and tolerant to radio quirks:
E.g:
```
2021-08-13 13:40:24,533 # 
2021-08-13 13:40:24,536 # --- fe80::204:2519:1801:bddb PING statistics ---
2021-08-13 13:40:24,539 # 1000 packets transmitted, 1000 packets received, 0% packet loss
2021-08-13 13:40:24,541 # round-trip min/avg/max = 134.533/145.050/169.359 ms
```
```
2021-08-13 21:06:24,808 # --- fe80::204:2519:1801:bddb PING statistics ---
2021-08-13 21:06:24,814 # 50000 packets transmitted, 49954 packets received, 0% packet loss
2021-08-13 21:06:24,819 # round-trip min/avg/max = 131.011/154.245/216.047 ms
```

Current master:
```
2021-08-12 10:27:16,869 # --- fe80::204:2519:1801:bddb PING statistics ---
2021-08-12 10:27:16,873 # 100 packets transmitted, 100 packets received, 0% packet loss
2021-08-12 10:27:16,876 # round-trip min/avg/max = 135.781/146.318/162.909 ms
```

This PR:
```
2021-08-12 10:26:14,348 # --- fe80::204:2519:1801:bddb PING statistics ---
2021-08-12 10:26:14,355 # 100 packets transmitted, 91 packets received, 9% packet loss
2021-08-12 10:26:14,357 # round-trip min/avg/max = 130.403/143.866/152.149 ms
```

This PR also changes the Radio HAL with a variant of the proposal described [here](https://github.com/RIOT-OS/RIOT/pull/13943#issuecomment-895276277). The RX_LEAVE mechanism was replaced by the RX Continuous cap.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try the following procedures using 2 SubMAC radios (e.g nrf802154 or cc2538)
- Regular ping (12 bytes, 1 second interval)
- Ping with many fragments and short interval (`-s 1024 -c 1000 -i 200)
- Same as before, but with a really short interval (`-s 1024, -c 1000, -i 20)
None of this tests should freeze the SubMAC nor create pktbuf leaks.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~Depends on #16745~
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
