### PR TITLE
drivers/at86rf215: remove msg queue dependency

### DIFF
--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -347,7 +347,6 @@ typedef struct at86rf215 {
     const at86rf215_RF_regs_t  *RF;         /**< Radio Frontend Registers */
     const at86rf215_BBC_regs_t *BBC;        /**< Baseband Registers */
     xtimer_t timer;                         /**< timer for ACK & CSMA timeout */
-    msg_t timer_msg;                        /**< message for timeout timer */
     uint32_t ack_timeout_usec;              /**< time to wait before retransmission in µs */
     uint32_t csma_backoff_period;           /**< CSMA Backoff period */
     uint16_t flags;                         /**< Device specific flags */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes a hardcoded dependency to the GNRC msg queue in `at86rf215`.
The driver needs to do ISR offloading (Bottom Half processing) in order to execute ACK timer and CSMA-CA logic. However, it assumes the upper layer is running GNRC (it posts `NETDEV_MSG_TYPE_EVENT`).

This PR makes it generic using `netdev->event_callback(netdev, NETDEV_EVENT_ISR)`. This way, the driver can be still used with not only msg queues, but also event loops or even thread flags.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure `at87rf215` still works as expected. I unfortunately don't have the hardware to test.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
