### PR TITLE
gnrc_netif: use event loops by default to process ISR

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -86,7 +86,6 @@ PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_bus
-PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_netif_timestamp
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -139,7 +139,6 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS) || defined(DOXYGEN)
     /**
      * @brief   Event queue for asynchronous events
      */
@@ -148,7 +147,6 @@ typedef struct {
      * @brief   ISR event for the network device
      */
     event_t event_isr;
-#endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0) || DOXYGEN
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -41,11 +41,6 @@ extern "C" {
 #define GNRC_NETIF_PKTQ_DEQUEUE_MSG     (0x1233)
 
 /**
- * @brief   Message type for @ref netdev_event_t "netdev events"
- */
-#define NETDEV_MSG_TYPE_EVENT           (0x1234)
-
-/**
  * @brief   Acquires exclusive access to the interface
  *
  * @param[in] netif the network interface

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -163,11 +163,6 @@ ifneq (,$(filter gnrc_netif_bus,$(USEMODULE)))
   USEMODULE += core_msg_bus
 endif
 
-ifneq (,$(filter gnrc_netif_events,$(USEMODULE)))
-  USEMODULE += core_thread_flags
-  USEMODULE += event
-endif
-
 ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan
@@ -466,6 +461,8 @@ endif
 
 ifneq (,$(filter gnrc_netif_%,$(USEMODULE)))
   USEMODULE += gnrc_netif
+  USEMODULE += core_thread_flags
+  USEMODULE += event
 endif
 
 ifneq (,$(filter gnrc_netif_pktq,$(USEMODULE)))

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "event.h"
 #include "random.h"
 #include "timex.h"
 #include "periph/rtt.h"
@@ -2031,14 +2032,7 @@ static void _gomach_event_cb(netdev_t *dev, netdev_event_t event)
     gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
 
     if (event == NETDEV_EVENT_ISR) {
-        msg_t msg;
-
-        msg.type = NETDEV_MSG_TYPE_EVENT;
-        msg.content.ptr = (void *) netif;
-
-        if (msg_send(&msg, netif->pid) <= 0) {
-            DEBUG("[GOMACH] gnrc_netdev: possibly lost interrupt.\n");
-        }
+        event_post(&netif->evq, &netif->event_isr);
     }
     else {
         DEBUG("gnrc_netdev: event triggered -> %i\n", event);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "event.h"
 #include "od.h"
 #include "timex.h"
 #include "random.h"
@@ -796,14 +797,7 @@ static void _lwmac_event_cb(netdev_t *dev, netdev_event_t event)
     gnrc_netif_t *netif = (gnrc_netif_t *) dev->context;
 
     if (event == NETDEV_EVENT_ISR) {
-        msg_t msg;
-
-        msg.type = NETDEV_MSG_TYPE_EVENT;
-        msg.content.ptr = (void *) netif;
-
-        if (msg_send(&msg, netif->pid) <= 0) {
-            LOG_WARNING("WARNING: [LWMAC] gnrc_netdev: possibly lost interrupt.\n");
-        }
+        event_post(&netif->evq, &netif->event_isr);
     }
     else {
         DEBUG("gnrc_netdev: event triggered -> %i\n", event);

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -200,12 +200,7 @@ static void _driver_cb(netdev_t *dev, netdev_event_t event)
     gnrc_lorawan_t *mac = &netif->lorawan.mac;
 
     if (event == NETDEV_EVENT_ISR) {
-        msg_t msg = { .type = NETDEV_MSG_TYPE_EVENT,
-                      .content = { .ptr = netif } };
-
-        if (msg_send(&msg, netif->pid) <= 0) {
-            DEBUG("gnrc_netif: possibly lost interrupt.\n");
-        }
+        event_post(&netif->evq, &netif->event_isr);
     }
     else {
         DEBUG("gnrc_netif: event triggered -> %i\n", event);

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1298,7 +1298,7 @@ static void test_netif_get_name(void)
     TEST_ASSERT_NOT_NULL(netif);
 
     res = netif_get_name(netif, name);
-    sprintf(exp_name, "%d", (int) ((gnrc_netif_t *)netif)->pid);
+    sprintf(exp_name, "%d", netif_get_id(netif));
     TEST_ASSERT_EQUAL_INT(strlen(exp_name), res);
     TEST_ASSERT_EQUAL_STRING(&exp_name[0], &name[0]);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the NETDEV_MSG_TYPE_EVENT and forces GNRC Netif to do the Bottom Half processing (ISR offload) using event loops instead of msg queues.

Msg queues are not safe for processing ISR because they might be lost. Indeed this might happen often if the device is under stress (e.g Border Router). Losing these events tend to have catastrophic consequences such as:
- Radios might stop receiving frames if the FB is lock and nobody cares to read the framebuffer
- The IEEE 802.15.4 SubMAC might be go to the wrong state if one of the radio events get lost.

I suspect some of the BR freezes might be related to this.

This PR also removes the `gnrc_netif_events` since it's not optional anymore. We should adapt it in the future to use `thread_flags` directly though (I know @maribu already did this in one of the `confirm_send` PRs).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure GNRC netif works properly.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #16747, otherwise that radio won't work anymore.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
