### PR TITLE
core/msg.c: possibly yield after thread_flags_wake() in queue_msg()

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -56,7 +56,9 @@ static int queue_msg(thread_t *target, const msg_t *m)
     *dest = *m;
 #if MODULE_CORE_THREAD_FLAGS
     target->flags |= THREAD_FLAG_MSG_WAITING;
-    thread_flags_wake(target);
+    if (thread_flags_wake(target)) {
+        thread_yield_higher();
+    }
 #endif
     return 1;
 }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Without this fix, it is possible that a thread got set to "PENDING"
after being woken up by a message flag, but no scheduling gets
triggered. So do that if a thread got woken up.

Spotted by @jia200x.

The proposed fix triggers a redundant "thread_yield_higher()" if msg_send_reply() is used *and* the receiving thread is waiting for the message flag. That should only hurt minimally performance wise.

The fix also assumes that calling thread_yield_higher() is safe from ISR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Not sure we have a test case for this.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
