### PR TITLE
cpu/cortexm: ldscripts: bkup-ram -> bkup_ram

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -40,7 +40,7 @@ _backup_ram_len = DEFINED( _backup_ram_len ) ? _backup_ram_len : 0x0 ;
 /* not all Cortex-M platforms use cortexm.ld yet */
 MEMORY
 {
-    bkup-ram (w!rx) : ORIGIN = _backup_ram_start_addr, LENGTH = _backup_ram_len
+    bkup_ram (w!rx) : ORIGIN = _backup_ram_start_addr, LENGTH = _backup_ram_len
 }
 
 /* Section Definitions */
@@ -214,7 +214,7 @@ SECTIONS
         _ebackup_data = .;
         /* Round size so that we can use 4 byte copy in init */
         . = ALIGN(4);
-    } > bkup-ram AT> rom
+    } > bkup_ram AT> rom
 
     .backup.bss (NOLOAD) : ALIGN(4) {
         _sbackup_bss = .;
@@ -222,10 +222,10 @@ SECTIONS
         _ebackup_bss = .;
         /* Round size so that we can use 4 byte copy in init */
         . = ALIGN(4);
-    } > bkup-ram
+    } > bkup_ram
 
     .heap3 (NOLOAD) : ALIGN(4) {
         _sheap1 = . ;
-        _eheap1 = ORIGIN(bkup-ram) + LENGTH(bkup-ram);
-    } > bkup-ram
+        _eheap1 = ORIGIN(bkup_ram) + LENGTH(bkup_ram);
+    } > bkup_ram
 }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes this error with binutils 2.37 (the current one on Arch Linux):

```
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld:cortexm_base.ld:217: warning: memory region `bkup' not declared
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld:cortexm_base.ld:217: syntax error
```

Seems like newer binutils trip over the minus in the region name. This PR renames the memory region to "bkup_ram" (underline),
which is also more in line with the related variable names.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I'm not aware of any in-tree user. With my binutils, this broke every compilation for affected boards.
IMO, successful CI should be fine!

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

`bkup-ram` was introduced in #11486.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
