### PR TITLE
gnrc_dhcpv6_client / uhcp: delay router advertisements until prefix was received

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -57,6 +57,7 @@ endif
 ifneq (,$(filter gnrc_dhcpv6_client_simple_pd,$(USEMODULE)))
   USEMODULE += gnrc_dhcpv6_client
   USEMODULE += dhcpv6_client_ia_pd
+  CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ADV_ROUTER=0
 endif
 
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -65,6 +65,7 @@ ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   USEMODULE += uhcpc
   USEMODULE += gnrc_sock_udp
   USEMODULE += fmt
+  CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ADV_ROUTER=0
 endif
 
 ifneq (,$(filter gnrc_%,$(filter-out gnrc_lorawan gnrc_netapi gnrc_netreg gnrc_netif% gnrc_pkt%,$(USEMODULE))))

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -84,7 +84,10 @@ void dhcpv6_client_conf_prefix(unsigned iface, const ipv6_addr_t *pfx,
 {
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
     int idx = gnrc_netif_ipv6_add_prefix(netif, pfx, pfx_len, valid, pref);
-    if (idx >= 0) {
+    if ((idx >= 0) && (pfx_len != IPV6_ADDR_BIT_LEN)) {
+        /* start advertising subnet obtained via DHCPv6 */
+        gnrc_ipv6_nib_change_rtr_adv_iface(netif, true);
+        /* configure this router as RPL root */
         gnrc_rpl_configure_root(netif, &netif->ipv6.addrs[idx]);
     }
 }

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -84,15 +84,6 @@ static void _configure_upstream_netif(gnrc_netif_t *upstream_netif)
         addr.u8[15] = 2;
         gnrc_netif_ipv6_addr_add(upstream_netif, &addr, 64, 0);
     }
-
-    /* Disable router advertisements on upstream interface. With this, the border
-     * router
-     * 1. Does not confuse the upstream router to add the border router to its
-     *    default router list and
-     * 2. Solicits upstream Router Advertisements quicker to auto-configure its
-     *    upstream global address.
-     */
-    gnrc_ipv6_nib_change_rtr_adv_iface(upstream_netif, false);
 }
 
 /**

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -40,15 +40,6 @@ static void set_interface_roles(void)
                             sizeof(addr));
             ipv6_addr_from_str(&addr, "fe80::1");
             gnrc_ipv6_nib_ft_add(&defroute, IPV6_ADDR_BIT_LEN, &addr, dev, 0);
-
-            /* Disable router advertisements on upstream interface. With this,
-             * the border router
-             * 1. Does not confuse the upstream router to add the border router
-             *    to its default router list and
-             * 2. Solicits upstream Router Advertisements quicker to
-             *    auto-configure its upstream global address.
-             */
-            gnrc_ipv6_nib_change_rtr_adv_iface(netif, false);
         }
         else if ((!gnrc_wireless_interface) && (is_wired != 1)) {
             gnrc_wireless_interface = dev;
@@ -86,6 +77,9 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime,
     idx = gnrc_netif_ipv6_add_prefix(wireless, (ipv6_addr_t *)prefix, prefix_len,
                                      lifetime, lifetime);
     if (idx >= 0) {
+        /* start advertising subnet obtained via UHCP */
+        gnrc_ipv6_nib_change_rtr_adv_iface(wireless, true);
+        /* configure this router as RPL root */
         gnrc_rpl_configure_root(wireless, &wireless->ipv6.addrs[idx]);
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The border router does not send out router solicitations as it sends out router advertisements instead.
This delays the reception of router advertisements from upstream routers.

Instead, start with router advertisements disabled and only enable them when we received a global prefix via DHCPv6 or UHCP.

### Testing procedure

Run `examples/gnrc_border_router` both with `USE_DHCPV6=1` and without.
You should notice that now a configuration on the upstream interface is obtained much faster.

### Issues/PRs references

alternative to #16590
