### PR TITLE
SAM0 cpu: persist RTC GP registers across reset (see #16756)

### DIFF
--- a/cpu/sam0_common/periph/Kconfig
+++ b/cpu/sam0_common/periph/Kconfig
@@ -20,6 +20,13 @@ config MODULE_PERIPH_RTC_RTT
     bool
     default y if MODULE_PERIPH_RTT || MODULE_PERIPH_RTC
 
+config SAM0_PERIPH_RTT_RTC_PERSIST_GPR
+    bool
+    depends on MODULE_PERIPH_RTC_RTT
+    default n
+    help
+        Persist SAM0 RTC general purpose registers across RTC reset.
+
 config MODULE_PERIPH_UART_NONBLOCKING
     depends on HAS_PERIPH_UART_NONBLOCKING
     depends on MODULE_PERIPH_UART

--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -135,12 +135,24 @@ static inline void _rtc_set_enabled(bool on)
 
 static inline void _rtt_reset(void)
 {
+#if CONFIG_SAM0_PERIPH_RTT_RTC_PERSIST_GPR
+#ifdef RTC_GPR_NUM
+    uint32_t persist[RTC_GPR_NUM];
+    int i;
+    for (i = 0; i < RTC_GPR_NUM; i++) persist[i] = RTC->MODE0.GP[i].reg;
+#endif
+#endif
 #ifdef RTC_MODE0_CTRL_SWRST
     RTC->MODE0.CTRL.reg = RTC_MODE0_CTRL_SWRST;
     while (RTC->MODE0.CTRL.bit.SWRST) {}
 #else
     RTC->MODE0.CTRLA.reg = RTC_MODE2_CTRLA_SWRST;
     while (RTC->MODE0.CTRLA.bit.SWRST) {}
+#endif
+#if CONFIG_SAM0_PERIPH_RTT_RTC_PERSIST_GPR
+#ifdef RTC_GPR_NUM
+    for (i = 0; i < RTC_GPR_NUM; i++) RTC->MODE0.GP[i].reg = persist[i];
+#endif
 #endif
 }
 


### PR DESCRIPTION
As discussed in #16756 - a simple solution for persisting RTC general purpose registers across RTC reset.