### PR TITLE
drivers/periph: define rtc_mem and implement it for sam0_common

### DIFF
--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -15,6 +15,7 @@ config CPU_COMMON_SAMD5X
     select HAS_PERIPH_DMA
     select HAS_PERIPH_GPIO_TAMPER_WAKE
     select HAS_PERIPH_HWRNG
+    select HAS_PERIPH_RTC_MEM
     select HAS_PERIPH_SPI_ON_QSPI
 
 config CPU_FAM_SAMD51

--- a/cpu/samd5x/Makefile.features
+++ b/cpu/samd5x/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += backup_ram
 FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_gpio_tamper_wake
+FEATURES_PROVIDED += periph_rtc_mem
 FEATURES_PROVIDED += periph_spi_on_qspi
 
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -13,6 +13,7 @@ config CPU_COMMON_SAML21
     select HAS_CPU_SAML21
     select HAS_PERIPH_DMA
     select HAS_PERIPH_GPIO_FAST_READ
+    select HAS_PERIPH_RTC_MEM
 
 config CPU_FAM_SAML21
     bool

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_gpio_fast_read
 # It can still be used in normal and standby mode, but code that relies on it
 # being availiable during deep sleep / backup mode will not be portable here.
 FEATURES_PROVIDED += backup_ram
+FEATURES_PROVIDED += periph_rtc_mem
 
 ifeq (,$(filter $(CPU_MODELS_WITHOUT_HWRNG),$(CPU_MODEL)))
   FEATURES_PROVIDED += periph_hwrng

--- a/drivers/include/periph/rtc_mem.h
+++ b/drivers/include/periph/rtc_mem.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_periph_rtc_mem Low-Power RTC Memory
+ * @ingroup     drivers_periph_rtc
+ * @brief       Low-level RTC Memory peripheral driver
+ *
+ * This API provides an interface to access low-power memory present on some RTCs.
+ * This memory is retained even when the rest of the system is powered off.
+ *
+ * @{
+ * @file
+ * @brief       Low-level RTC memory peripheral driver interface definitions
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef PERIPH_RTC_MEM_H
+#define PERIPH_RTC_MEM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Get the amount of RTC memory.
+ *
+ * @return  The usable amount of RTC memory in bytes
+ */
+size_t rtc_mem_size(void);
+
+/**
+ * @brief Read from RTC memory
+ *
+ * @note  Reading beyond @ref rtc_mem_size are illegal and trigger an
+ *        assertion / be discarded.
+ *
+ * @param[in]  offset   Offset to the start of RTC memory in bytes
+ * @param[out] data     Destination buffer
+ * @param[in]  len      Amount of bytes to read
+ */
+void rtc_mem_read(unsigned offset, void *data, size_t len);
+
+/**
+ * @brief Write to RTC memory
+ *
+ * @note  Writing beyond @ref rtc_mem_size are illegal and trigger an
+ *        assertion / be discarded.
+ *
+ * @param[in] offset    Offset to the start of RTC memory in bytes
+ * @param[in] data      Source buffer
+ * @param[in] len       Amount of bytes to write
+ */
+void rtc_mem_write(unsigned offset, const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_RTC_MEM_H */
+/** @} */

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -257,6 +257,11 @@ config HAS_PERIPH_RTC
     help
         Indicates that an RTC peripheral is present.
 
+config HAS_PERIPH_RTC_MEM
+    bool
+    help
+        Indicates that the RTC peripheral provides storage memory for deep sleep.
+
 config HAS_PERIPH_RTC_MS
     bool
     help

--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -2,6 +2,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_rtc
 FEATURES_OPTIONAL += periph_rtc_ms
+FEATURES_OPTIONAL += periph_rtc_mem
 
 DISABLE_MODULE += periph_init_rtc
 

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtt
 FEATURES_OPTIONAL += periph_rtt_set_counter
+FEATURES_OPTIONAL += periph_rtc_mem
 
 DISABLE_MODULE += periph_init_rtt
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The RTC often provides some memory that can be used to store data across reset / deep sleep.
Expose this memory with a proper API.

On SAM D5x/E5x general purpose registers are shared with the alarm registers.
Since the RTC/RTT interface only exposes a single alarm, we can only use the second pair of General Purpose Registers.

The data sheet for SAM L1x and SAM L2x do not mention such limitations, but according to the data sheet SAM L21 only has 2 General Purpose registers whereas the vendor files have definitions for 4. I didn't yet test if they do indeed all work. 

### Testing procedure

So far this only has been tested on `same54-xpro`. Both `tests/periph_rtc` and `tests/periph_rtt` have been adapted to make use of the feature and to ensure it does not interfere with normal RTC/RTT alarms.

 - [x] samd5x
 - [x] saml21
 - [ ] ~~saml1x~~ single set of shared Alarm / GP registers 


### Issues/PRs references

alternative to #16757 - @ant9000  does this work for your use-case? 
previously proposed in #11369
