### PR TITLE
drivers/nrf802154: fix write return value and `__cplusplus` closing bracket.

### DIFF
--- a/cpu/nrf52/include/nrf802154.h
+++ b/cpu/nrf52/include/nrf802154.h
@@ -99,5 +99,9 @@ int nrf802154_init(void);
  */
 void nrf802154_setup(nrf802154_t *dev);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* NRF802154_H */
 /** @} */

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -174,7 +174,7 @@ static int _write(ieee802154_dev_t *dev, const iolist_t *iolist)
     /* specify the length of the package. */
     txbuf[0] = len + IEEE802154_FCS_LEN;
 
-    return len;
+    return 0;
 }
 
 static int _confirm_transmit(ieee802154_dev_t *dev, ieee802154_tx_info_t *info)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes 2 things:
1. The return value is not compliant with the radio HAL API. It should return either 0 or a negative errno, not the frame length
2. There was a missing:
```c
#ifdef __cplusplus
}
#endif
```
This was not detected because we usually don't include this header from C++ files.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I guess not so much. Just make sure it compiles and the fact including the header from a C++ files works.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered while porting OpenDSME
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
