### PR TITLE
cortexm_common: remove hyphen from region name

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -40,7 +40,7 @@ _backup_ram_len = DEFINED( _backup_ram_len ) ? _backup_ram_len : 0x0 ;
 /* not all Cortex-M platforms use cortexm.ld yet */
 MEMORY
 {
-    bkup-ram (w!rx) : ORIGIN = _backup_ram_start_addr, LENGTH = _backup_ram_len
+    bkupram (w!rx) : ORIGIN = _backup_ram_start_addr, LENGTH = _backup_ram_len
 }
 
 /* Section Definitions */
@@ -214,7 +214,7 @@ SECTIONS
         _ebackup_data = .;
         /* Round size so that we can use 4 byte copy in init */
         . = ALIGN(4);
-    } > bkup-ram AT> rom
+    } > bkupram AT> rom
 
     .backup.bss (NOLOAD) : ALIGN(4) {
         _sbackup_bss = .;
@@ -222,10 +222,10 @@ SECTIONS
         _ebackup_bss = .;
         /* Round size so that we can use 4 byte copy in init */
         . = ALIGN(4);
-    } > bkup-ram
+    } > bkupram
 
     .heap3 (NOLOAD) : ALIGN(4) {
         _sheap1 = . ;
-        _eheap1 = ORIGIN(bkup-ram) + LENGTH(bkup-ram);
-    } > bkup-ram
+        _eheap1 = ORIGIN(bkupram) + LENGTH(bkupram);
+    } > bkupram
 }


### PR DESCRIPTION
### Contribution description
With binutils 2.37, I cannot link for arm cortex based boards:

```
[cgundogan@trantor] RIOT/examples/gnrc_networking % BOARD=iotlab-m3 make clean all
Building application "gnrc_networking" for "iotlab-m3" with MCU "stm32".
...
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld:cortexm_base.ld:217: warning: memory region `bkup' not declared
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld:cortexm_base.ld:217: syntax error
collect2: error: ld returned 1 exit status
make: *** [RIOT/examples/gnrc_networking/../../Makefile.include:666: RIOT/examples/gnrc_networking/bin/iotlab-m3/gnrc_networking.elf] Error 1
```

When I remove the hyphen from the `bkup-ram` region name, then linking works again.  But I am not sure, if this has other implications.  Did the ld syntax or naming conventions for regions change lately?

### Testing procedure
Build any example application for any cortex board, e.g, `iotlab-m3`.


### Issues/PRs references
