### PR TITLE
pkg/lwip: add auto-init for DOSE & at86rf215, cc2538_rf

### DIFF
--- a/pkg/lwip/init_devs/auto_init_at86rf215.c
+++ b/pkg/lwip/init_devs/auto_init_at86rf215.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for at86rf215 network interfaces
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "at86rf215.h"
+#include "at86rf215_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define USED_BANDS (IS_USED(MODULE_AT86RF215_SUBGHZ) + IS_USED(MODULE_AT86RF215_24GHZ))
+#define NETIF_AT86RF215_NUMOF   ARRAY_SIZE(at86rf215_params)
+
+static struct netif netif[NETIF_AT86RF215_NUMOF * USED_BANDS];
+static at86rf215_t at86rf215_devs[NETIF_AT86RF215_NUMOF * USED_BANDS];
+
+static void auto_init_at86rf215(void)
+{
+    unsigned i = 0;
+    for (unsigned j = 0; j < NETIF_AT86RF215_NUMOF;j++) {
+
+        at86rf215_t *dev_09 = NULL;
+        at86rf215_t *dev_24 = NULL;
+        struct netif *netif_09 = NULL;
+        struct netif *netif_24 = NULL;
+
+        if (IS_USED(MODULE_AT86RF215_SUBGHZ)) {
+            dev_09   = &at86rf215_devs[i];
+            netif_09 = &netif[i];
+            ++i;
+        }
+
+        if (IS_USED(MODULE_AT86RF215_24GHZ)) {
+            dev_24   = &at86rf215_devs[i];
+            netif_24 = &netif[i];
+            ++i;
+        }
+
+        at86rf215_setup(dev_09, dev_24, &at86rf215_params[j], j);
+
+        if (dev_09) {
+            if (lwip_add_6lowpan(netif_09, &dev_09->netdev.netdev) == NULL) {
+                DEBUG("Could not add sub-GHz at86rf215 device #%u\n", j);
+            }
+        }
+        if (dev_24) {
+            if (lwip_add_6lowpan(netif_24, &dev_24->netdev.netdev) == NULL) {
+                DEBUG("Could not add 2.4-GHz at86rf215 device #%u\n", j);
+            }
+        }
+    }
+}
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_at86rf215);
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_cc2538_rf.c
+++ b/pkg/lwip/init_devs/auto_init_cc2538_rf.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for cc2538 network interfaces
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "cc2538_rf.h"
+#include "net/netdev/ieee802154_submac.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+static struct netif netif;
+static netdev_ieee802154_submac_t cc2538_rf_netdev;
+
+static void auto_init_cc2538_rf(void)
+{
+    netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
+
+    cc2538_init();
+
+    if (lwip_add_6lowpan(&netif, &cc2538_rf_netdev.dev.netdev) == NULL) {
+       DEBUG("Could not add CC2538 device\n");
+    }
+}
+
+LWIP_INIT_6LOWPAN_NETIF(auto_init_cc2538_rf);
+/** @} */

--- a/pkg/lwip/init_devs/auto_init_dose.c
+++ b/pkg/lwip/init_devs/auto_init_dose.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_auto_init_lwip_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for DOSE network interfaces
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author  Erik Ekman <eekman@google.com>
+ */
+
+#include "dose.h"
+#include "dose_params.h"
+
+#include "lwip_init_devs.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#define NETIF_DOSE_NUMOF    ARRAY_SIZE(dose_params)
+
+static struct netif netif[NETIF_DOSE_NUMOF];
+static dose_t dose_devs[NETIF_DOSE_NUMOF];
+
+static void auto_init_dose(void)
+{
+    for (unsigned i = 0; i < NETIF_DOSE_NUMOF; i++) {
+        dose_setup(&dose_devs[i], &dose_params[i], i);
+        if (lwip_add_ethernet(&netif[i], &dose_devs[i].netdev) == NULL) {
+            DEBUG("Could not add DOSE device #%u\n", i);
+        }
+    }
+}
+
+LWIP_INIT_ETH_NETIF(auto_init_dose);
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adding new devices to LWIP is easy now, so add some more drivers.

### Testing procedure

#### same54-xpro with DOSE

```
2021-08-20 16:18:00,692 # ifconfig
2021-08-20 16:18:00,697 # Iface ET0 HWaddr: a6:ed:29:ec:c3:f3 Link: up State: up
2021-08-20 16:18:00,700 #         Link type: wired
2021-08-20 16:18:00,704 #         inet addr: 0.0.0.0 mask: 0.0.0.0 gw: 0.0.0.0
2021-08-20 16:18:00,719 #         inet6 addr: fe80:0:0:0:a4ed:29ff:feec:c3f3 scope: link
2021-08-20 16:18:00,724 # Iface ET1 HWaddr: a6:ed:29:ec:cb:f3 Link: up State: up
2021-08-20 16:18:00,726 #         Link type: wired
2021-08-20 16:18:00,730 #         inet addr: 0.0.0.0 mask: 0.0.0.0 gw: 0.0.0.0
2021-08-20 16:18:00,736 #         inet6 addr: fe80:0:0:0:a4ed:29ff:feec:cbf3 scope: link
2021-08-20 16:18:00,742 #         inet6 addr: 2001:16b8:45f3:100:a4ed:29ff:feec:cbf3 scope: global
```

#### openmote-b

```
2021-08-20 16:36:51,341 # ifconfig
2021-08-20 16:36:51,342 # Iface L60 HWaddr: ae:8d:fe:e1:60:41:91:f0 Link: up State: up
2021-08-20 16:36:51,343 #         Link type: wireless
2021-08-20 16:36:51,358 #         inet6 addr: fe80:0:0:0:ac8d:fee1:6041:91f0 scope: link
2021-08-20 16:36:51,374 # Iface L61 HWaddr: ae:8d:fe:e1:60:41:91:f1 Link: up State: up
2021-08-20 16:36:51,374 #         Link type: wireless
2021-08-20 16:36:51,375 #         inet6 addr: fe80:0:0:0:ac8d:fee1:6041:91f1 scope: link
```

with `cc2538_rf`

```
2021-08-20 16:45:45,830 # ifconfig
2021-08-20 16:45:45,847 # Iface L60 HWaddr: ae:8d:fe:e1:60:41:93:f0 Link: up State: up
2021-08-20 16:45:45,848 #         Link type: wireless
2021-08-20 16:45:45,849 #         inet6 addr: fe80:0:0:0:ac8d:fee1:6041:93f0 scope: link
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
