### PR TITLE
pkg/lwip: Fix compilation without IPv6

### DIFF
--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -41,6 +41,7 @@ void lwip_netif_init_devs(void);
  */
 struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
 
+#if IS_USED(MODULE_LWIP_SIXLOWPAN)
 /**
  * @brief Adds a 6LoWPAN netif using the supplied netdev.
  *
@@ -50,6 +51,7 @@ struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
  * The netif will be set up using the `lwip_netdev_init` helper.
  */
 struct netif *lwip_add_6lowpan(struct netif *netif, netdev_t *state);
+#endif /* MODULE_LWIP_SIXLOWPAN */
 
 typedef void (*lwip_netif_setup_func_t)(void);
 

--- a/pkg/lwip/init_devs/init.c
+++ b/pkg/lwip/init_devs/init.c
@@ -60,9 +60,11 @@ struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state)
     return _if;
 }
 
+#if IS_USED(MODULE_LWIP_SIXLOWPAN)
 struct netif *lwip_add_6lowpan(struct netif *netif, netdev_t *state)
 {
     return netif_add_noaddr(netif, state, lwip_netdev_init, tcpip_6lowpan_input);
 }
+#endif /* MODULE_LWIP_SIXLOWPAN */
 
 /**@}*/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fixes build failure without IPv6:
```
RIOT/pkg/lwip/init_devs/init.c:65:61: error: 'tcpip_6lowpan_input' undeclared (first use in this function)
     return netif_add_noaddr(netif, state, lwip_netdev_init, tcpip_6lowpan_input);
                                                             ^
```

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Build `examples/paho-mqtt` with `LWIP_IPV4=1 LWIP_IPV6=0`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Build failure existed since #16162 