### PR TITLE
README: use dynamic badge for the hil-ci-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ https://www.riot-os.org
 [wiki-badge]: https://img.shields.io/badge/docs-Wiki-informational.svg
 [wiki-link]: https://github.com/RIOT-OS/RIOT/wiki
 [hil-ci-link]: https://hil.riot-os.org/results/nightly/latest/overview
-[hil-ci-badge]: https://img.shields.io/badge/CI-HiL-blue
+[hil-ci-badge]: https://shields.io/endpoint?url=https://hil.riot-os.org/api/v1/nightly/latest/badge.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,20 @@ It executes without error if tests run by 'make test' are present.
     make test/available
 
 
+Using the HiL (Hardware in the Loop) CI for automated testing
+-------------------------------------------------------------
+
+Some maintainers have access to a growing
+[number of boards](https://hil.riot-os.org/jenkins/labelsdashboard/) to run
+automated tests via the [HiL CI](https://hil.riot-os.org/jenkins/).
+This allows both on-target testing described above as well as
+[Robot Framework based tests](https://github.com/RIOT-OS/RobotFW-tests) with an
+external reference device for peripheral testing,
+[PHiLIP](https://github.com/riot-appstore/PHiLIP).
+To limit time spent on the HiL CI, maintainers select the appropriate
+tests/boards required.
+
+
 Automated Tests Guidelines
 --------------------------
 


### PR DESCRIPTION


### Contribution description

As promised, the badge not shows the results from the nightly.  Note that the tests passed/failed indicats test suites not the test cases.  It will go green if all tests pass, this hasn't happened (as some tests just cannot due to features not being supported).  I will be improving the test in the short term to hopefully get some reliable passes.

This should still be a nice window into the current state though and we should be able to see if something is going really wrong. I think also showing that we are running on 24 different boards is pretty nice (and that number will continue to go up).

Note that this information is being generated from the [nightly](https://ci.riot-os.org/hil/job/nightly/) job script.  Those who have access can change and adapt it.  This should also become a bit easier as I try to simplify the jenkins job script deployment.

### Testing procedure

Go to the [link](https://shields.io/endpoint?url=https://hil.riot-os.org/api/v1/nightly/latest/badge.json) and it should read something like `HiL | 153 pass / 7 fail / 24 boards`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
