### PR TITLE
drivers/dose: calculate timeout based on symbol rate

### DIFF
--- a/drivers/dose/Kconfig
+++ b/drivers/dose/Kconfig
@@ -13,11 +13,11 @@ menuconfig KCONFIG_USEMODULE_DOSE
 
 if KCONFIG_USEMODULE_DOSE
 
-config DOSE_TIMEOUT_USEC
-    int "Transaction timeout in microseconds [us]"
-    default 5000
+config DOSE_TIMEOUT_BYTES
+    int "Transaction timeout in bytes"
+    default 50
     help
-        Timeout, in microseconds, to bring the driver back into idle state if
+        Timeout, in bytes at the set baudrate, to bring the driver back into idle state if
         the remote side died within a transaction.
 
 endif # KCONFIG_USEMODULE_DOSE

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -599,10 +599,11 @@ void dose_setup(dose_t *ctx, const dose_params_t *params, uint8_t index)
      * We have to ensure it is above the XTIMER_BACKOFF. Otherwise state
      * transitions are triggered from another state transition setting up the
      * timeout. */
-    ctx->timeout_base = CONFIG_DOSE_TIMEOUT_USEC;
+    ctx->timeout_base = CONFIG_DOSE_TIMEOUT_BYTES * 10UL * US_PER_SEC / params->baudrate;
     if (ctx->timeout_base < xtimer_usec_from_ticks(min_timeout)) {
         ctx->timeout_base = xtimer_usec_from_ticks(min_timeout);
     }
+    DEBUG("dose timeout set to %" PRIu32 " µs\n", ctx->timeout_base);
     ctx->timeout.callback = _isr_xtimer;
     ctx->timeout.arg = ctx;
 }

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -128,12 +128,12 @@ typedef enum {
  * @{
  */
 /**
- * @brief Timeout that brings the driver back into idle state.
+ * @brief Timeout that brings the driver back into idle state expressed as bytes.
  *
  *  Fallback to idle if the remote side died within a transaction.
  */
-#ifndef CONFIG_DOSE_TIMEOUT_USEC
-#define CONFIG_DOSE_TIMEOUT_USEC        (5000)
+#ifndef CONFIG_DOSE_TIMEOUT_BYTES
+#define CONFIG_DOSE_TIMEOUT_BYTES       (50)
 #endif
 /** @} */
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A fixed timeout is either too long for high symbol rates or too short for low symbol rates.

To fix this, calculate the timeout based on the symbol rate.

For this, the old 5ms timeout is equivalent to 58 bytes being transmitted at 115200 baud (8 data bit + start & stop bit).

I rounded this to 50 bytes which should yield 4340 µs.


### Testing procedure

```
2021-08-23 13:30:48,954 # main(): This is RIOT! (Version: 2021.10-devel-406-gdbd4d5-drivers/dose-timeout_bytes)
2021-08-23 13:33:21,675 # dose dose_setup(): mac addr a6:ed:29:ec:c3:f3
2021-08-23 13:33:21,678 # dose timeout set to 4340 µs
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
