### PR TITLE
makefiles/suit*: use $(Q) to silence output

### DIFF
--- a/dist/tools/suit/suit-manifest-generator/suit_tool/create.py
+++ b/dist/tools/suit/suit-manifest-generator/suit_tool/create.py
@@ -27,7 +27,6 @@ def main(options):
     m = json.loads(options.input_file.read(), object_pairs_hook=OrderedDict)
 
     nm = compile_manifest(options, m)
-    print('create done. Serializing')
     if m.get('severable') or (hasattr(options, 'severable') and options.severable):
         nm = nm.to_severable('sha256')
     output = {

--- a/makefiles/suit.base.inc.mk
+++ b/makefiles/suit.base.inc.mk
@@ -25,16 +25,16 @@ CFLAGS += -I$(SUIT_PUB_HDR_DIR)
 BUILDDEPS += $(SUIT_PUB_HDR)
 
 $(SUIT_SEC): $(CLEAN)
-	@echo suit: generating key in $(SUIT_KEY_DIR)
-	@mkdir -p $(SUIT_KEY_DIR)
-	@$(RIOTBASE)/dist/tools/suit/gen_key.py $(SUIT_SEC)
+	$(Q)echo suit: generating key in $(SUIT_KEY_DIR)
+	$(Q)mkdir -p $(SUIT_KEY_DIR)
+	$(Q)$(RIOTBASE)/dist/tools/suit/gen_key.py $(SUIT_SEC)
 
 # set FORCE so switching between keys using "SUIT_KEY=foo make ..."
 # triggers a rebuild even if the new key would otherwise not (because the other
 # key's mtime is too far back).
 $(SUIT_PUB_HDR): $(SUIT_SEC) FORCE | $(CLEAN)
-	@mkdir -p $(SUIT_PUB_HDR_DIR)
-	@$(SUIT_TOOL) pubkey -f header -k $(SUIT_SEC) \
+	$(Q)mkdir -p $(SUIT_PUB_HDR_DIR)
+	$(Q)$(SUIT_TOOL) pubkey -f header -k $(SUIT_SEC) \
 	  | '$(LAZYSPONGE)' $(LAZYSPONGE_FLAGS) '$@'
 
 suit/genkey: $(SUIT_SEC)

--- a/makefiles/suit.inc.mk
+++ b/makefiles/suit.inc.mk
@@ -27,7 +27,7 @@ SUIT_CLASS ?= $(BOARD)
 
 #
 $(SUIT_MANIFEST): $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
-	$(RIOTBASE)/dist/tools/suit/gen_manifest.py \
+	$(Q)$(RIOTBASE)/dist/tools/suit/gen_manifest.py \
 	  --urlroot $(SUIT_COAP_ROOT) \
 	  --seqnr $(SUIT_SEQNR) \
 	  --uuid-vendor $(SUIT_VENDOR) \
@@ -36,19 +36,19 @@ $(SUIT_MANIFEST): $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
 	  $(SLOT0_RIOT_BIN):$(SLOT0_OFFSET) \
 	  $(SLOT1_RIOT_BIN):$(SLOT1_OFFSET)
 
-	$(SUIT_TOOL) create -f suit -i $@.tmp -o $@
+	$(Q)$(SUIT_TOOL) create -f suit -i $@.tmp -o $@
 
-	rm -f $@.tmp
+	$(Q)rm -f $@.tmp
 
 
 $(SUIT_MANIFEST_SIGNED): $(SUIT_MANIFEST) $(SUIT_SEC)
-	$(SUIT_TOOL) sign -k $(SUIT_SEC) -m $(SUIT_MANIFEST) -o $@
+	$(Q)$(SUIT_TOOL) sign -k $(SUIT_SEC) -m $(SUIT_MANIFEST) -o $@
 
 $(SUIT_MANIFEST_LATEST): $(SUIT_MANIFEST)
-	@ln -f -s $< $@
+	$(Q)ln -f -s $< $@
 
 $(SUIT_MANIFEST_SIGNED_LATEST): $(SUIT_MANIFEST_SIGNED)
-	@ln -f -s $< $@
+	$(Q)ln -f -s $< $@
 
 SUIT_MANIFESTS := $(SUIT_MANIFEST) \
                   $(SUIT_MANIFEST_LATEST) \
@@ -58,15 +58,15 @@ SUIT_MANIFESTS := $(SUIT_MANIFEST) \
 suit/manifest: $(SUIT_MANIFESTS)
 
 suit/publish: $(SUIT_MANIFESTS) $(SLOT0_RIOT_BIN) $(SLOT1_RIOT_BIN)
-	@mkdir -p $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH)
-	@cp $^ $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH)
-	@for file in $^; do \
+	$(Q)mkdir -p $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH)
+	$(Q)cp $^ $(SUIT_COAP_FSROOT)/$(SUIT_COAP_BASEPATH)
+	$(Q)for file in $^; do \
 		echo "published \"$$file\""; \
 		echo "       as \"$(SUIT_COAP_ROOT)/$$(basename $$file)\""; \
 	done
 
 suit/notify: | $(filter suit/publish, $(MAKECMDGOALS))
-	@test -n "$(SUIT_CLIENT)" || { echo "error: SUIT_CLIENT unset!"; false; }
+	$(Q)test -n "$(SUIT_CLIENT)" || { echo "error: SUIT_CLIENT unset!"; false; }
 	aiocoap-client -m POST "coap://$(SUIT_CLIENT)/suit/trigger" \
 		--payload "$(SUIT_COAP_ROOT)/$(SUIT_NOTIFY_MANIFEST)" && \
 		echo "Triggered $(SUIT_CLIENT) to update."


### PR DESCRIPTION
### Contribution description

No change other than using `$(Q)` instead of `@` for silencing output. Some extra things are silenced now.

### Testing procedure

Run the suit workflow and look at the output from `MAKE`, main changes in `suit/publish`

` make suit/publish`

PR:

```
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1629727397.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1629727397.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727397.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit.1629727397.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1629727397.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit_signed.1629727397.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1629727397.riot.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-slot0.1629727397.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1629727397.riot.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-slot1.1629727397.riot.bin"
```

master:

```
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1629727322.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1629727322.riot.bin...
/home/francisco/workspace/RIOT/dist/tools/suit/gen_manifest.py \
  --urlroot coap://localhost/fw/samr21-xpro \
  --seqnr 1629727322 \
  --uuid-vendor "riot-os.org" \
  --uuid-class samr21-xpro \
  -o /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727322.bin.tmp \
  /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1629727322.riot.bin:0x1000 \
  /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1629727322.riot.bin:133120
/home/francisco/workspace/RIOT/dist/tools/suit/suit-manifest-generator/bin/suit-tool create -f suit -i /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727322.bin.tmp -o /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727322.bin
create done. Serializing
rm -f /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727322.bin.tmp
/home/francisco/workspace/RIOT/dist/tools/suit/suit-manifest-generator/bin/suit-tool sign -k /home/francisco/workspace/RIOT/keys/default.pem -m /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727322.bin -o /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1629727322.bin
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1629727322.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit.1629727322.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1629727322.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit_signed.1629727322.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1629727322.riot.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-slot0.1629727322.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1629727322.riot.bin"
       as "coap://localhost/fw/samr21-xpro/suit_update-slot1.1629727322.riot.bin"
```

Just in case, the `suit_update` example is still passing:

<details><summary>examples/suit_update <b>TEST PASSED</b></summary>

```
BOARD=nrf52840-mdk make -C examples/suit_update/ flash -j7
Building application "suit_update" for "nrf52840-mdk" with MCU "nrf52".

compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make[1]: Nothing to be done for 'prepare'.
make: Nothing to be done for 'all'.
make -C ethos
make -C uhcpd
make -C sliptty
cc -O3 -Wall ethos.c -o ethos
make -C zep_dispatch
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
"make" -C /home/francisco/workspace/RIOT/pkg/c25519
"make" -C /home/francisco/workspace/RIOT/pkg/libcose
"make" -C /home/francisco/workspace/RIOT/pkg/nanocbor
"make" -C /home/francisco/workspace/RIOT/build/pkg/c25519/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=c25519
"make" -C /home/francisco/workspace/RIOT/build/pkg/libcose/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=libcose
"make" -C /home/francisco/workspace/RIOT/build/pkg/nanocbor/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=nanocbor
"make" -C /home/francisco/workspace/RIOT/build/pkg/libcose/src/crypt -f /home/francisco/workspace/RIOT/pkg/libcose/Makefile.libcose_crypt
"make" -C /home/francisco/workspace/RIOT/boards/nrf52840-mdk
"make" -C /home/francisco/workspace/RIOT/boards/nrf52840-mdk
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/drivers/ethos
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/drivers/netdev
"make" -C /home/francisco/workspace/RIOT/sys/checksum
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys/crypto
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/evtimer
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/hashes
"make" -C /home/francisco/workspace/RIOT/sys/iolist
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/luid
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/vectors
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT/sys/net/application_layer/nanocoap
"make" -C /home/francisco/workspace/RIOT/sys/net/application_layer/uhcp
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT/sys/net/crosslayer/inet_csum
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netapi
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/application_layer/uhcpc
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/ethernet
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/hdr
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netreg
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/icmpv6
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/netif/init_devs
"make" -C /home/francisco/workspace/RIOT/sys/net/link_layer/eui_provider
"make" -C /home/francisco/workspace/RIOT/sys/net/link_layer/l2util
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/icmpv6/echo
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6
"make" -C /home/francisco/workspace/RIOT/sys/net/netif
"make" -C /home/francisco/workspace/RIOT/sys/net/netutils
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/icmpv6
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/network_layer/ipv6/hdr
"make" -C /home/francisco/workspace/RIOT/sys/net/sock
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/vectors
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ipv6/nib
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/ndp
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT/sys/net/transport_layer/udp
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/posix/inet
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pkt
"make" -C /home/francisco/workspace/RIOT/sys/progress_bar
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pktbuf
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys/random
"make" -C /home/francisco/workspace/RIOT/sys/random/tinymt32
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/pktbuf_static
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/sock
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/sock/udp
"make" -C /home/francisco/workspace/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /home/francisco/workspace/RIOT/sys/riotboot
"make" -C /home/francisco/workspace/RIOT/sys/shell
"make" -C /home/francisco/workspace/RIOT/sys/shell/commands
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/suit
"make" -C /home/francisco/workspace/RIOT/sys/suit/storage
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/sys/uuid
"make" -C /home/francisco/workspace/RIOT/sys/xtimer
"make" -C /home/francisco/workspace/RIOT/sys/suit/transport
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/checksum
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/riotboot
"make" -C /home/francisco/workspace/RIOT/sys/stdio_null
   text	   data	    bss	    dec	    hex	filename
  76076	    220	  21244	  97540	  17d04	/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update.elf
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727529.riot.bin...
/home/francisco/workspace/RIOT/dist/tools/pyocd/pyocd.sh flash /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0-extended.bin
### Flashing Target ###
[====================] 100%
0041315:INFO:loader:Erased 167936 bytes (41 sectors), programmed 167936 bytes (41 pages), skipped 364544 bytes (89 pages) at 12.99 kB/s
Done flashing
```

`BOARD=nrf52840-mdk make -C examples/suit_update/ test-with-config`

```
make -C ethos
make[2]: Nothing to be done for 'all'.
make -C uhcpd
make[2]: Nothing to be done for 'all'.
make -C sliptty
make[2]: Nothing to be done for 'all'.
make -C zep_dispatch
make[2]: Nothing to be done for 'all'.


/usr/bin/make -C ethos
make[3]: Nothing to be done for 'all'.
/usr/bin/make -C uhcpd
make[3]: Nothing to be done for 'all'.
/usr/bin/make -C sliptty
make[3]: Nothing to be done for 'all'.
/usr/bin/make -C zep_dispatch
make[3]: Nothing to be done for 'all'.
/home/francisco/workspace/RIOT/dist/tools/ethos/ethos riot0 /dev/riot/tty-nrf52840-mdk 
----> ethos: sending hello.
----> ethos: activating serial pass through.
----> ethos: hello reply received
----> ethos: hello reply received


riotboot-hdr

> 
> 
> 
> riotboot-hdr
Image magic_number: 0x544f4952
Image Version: 0x6123ab29
Image start address: 0x00002400
Header chksum: 0x758bcdee

> ifconfig
ifconfig
Iface  4  HWaddr: 5E:0D:18:57:DA:F3 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::5c0d:18ff:fe57:daf3  scope: link  VAL
pinging node...
PING fe80::5c0d:18ff:fe57:daf3%riot0(fe80::5c0d:18ff:fe57:daf3%riot0) 56 data bytes

--- fe80::5c0d:18ff:fe57:daf3%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 31.767/31.767/31.767/0.000 ms
pinging node succeeded.
suit
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff57:daf3
          inet6 group: ff02::1:ff00:2
          
> suit
Usage: suit <manifest url>
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727530.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727530.riot.bin...
suit: generating key in /home/francisco/workspace/RIOT/keys
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.1629727530.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.1629727530.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727530.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot0.1629727530.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727530.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot1.1629727530.riot.bin"
aiocoap-client -m POST "coap://[fe80::5c0d:18ff:fe57:daf3%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin" && \
	echo "Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update."
Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update.
> suit: received URL: "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
suit_coap: got manifest with size 509
suit: verifying manifest signature
Unable to validate signature: -2
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727528.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727528.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.1629727528.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.1629727528.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.1629727528.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727528.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727528.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot0.1629727528.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727528.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot1.1629727528.riot.bin"
aiocoap-client -m POST "coap://[fe80::5c0d:18ff:fe57:daf3%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727528.bin" && \
	echo "Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update."
Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update.
suit_parse() failed. res=-6
suit: received URL: "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727528.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727528.bin"
suit_coap: got manifest with size 509
suit: verifying manifest signature
suit: validated manifest version
)riotboot_hdr_validate: riotboot_hdr magic number invalid
Manifest seq_no: 1629727528, highest available: 1629727529
seq_nr <= running image
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727530.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727530.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.1629727530.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.1629727530.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727530.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot0.1629727530.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727530.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot1.1629727530.riot.bin"
aiocoap-client -m POST "coap://[fe80::5c0d:18ff:fe57:daf3%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin" && \
	echo "Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update."
Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update.
)suit_parse() failed. res=-5
suit: received URL: "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727530.bin"
suit_coap: got manifest with size 509
suit: verifying manifest signature
suit: validated manifest version
)riotboot_hdr_validate: riotboot_hdr magic number invalid
Manifest seq_no: 1629727530, highest available: 1629727529
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 2000 with other slot offset
Comparing manifest offset 81000 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 48f08ace-5a26-548b-8bec-23396ac6bd23 to 48f08ace-5a26-548b-8bec-23396ac6bd23 from manifest
validating class id: OK
Comparing manifest offset 2000 with other slot offset
Comparing manifest offset 81000 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x6123ab2a
Image start address: 0x00081400
Header chksum: 0x5597bdf7

suit_coap: rebooting...


----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2021.10-devel-282-g1b46f-pr_suit_use_Q_for_silencing)
RIOT SUIT update example application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x6123ab2a
Image start address: 0x00081400
Header chksum: 0x5597bdf7

suit_coap: started.
current-slot
Starting the shell
> 
> 
> current-slot
Running from slot 1
> ifconfig
ifconfig
Iface  4  HWaddr: 5E:0D:18:57:DA:F3 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::5c0d:18ff:fe57:daf3  scope: link  VAL
pinging node...
PING fe80::5c0d:18ff:fe57:daf3%riot0(fe80::5c0d:18ff:fe57:daf3%riot0) 56 data bytes

--- fe80::5c0d:18ff:fe57:daf3%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 40.692/40.692/40.692/0.000 ms
pinging node succeeded.
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727531.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727531.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.1629727531.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.1629727531.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.1629727531.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727531.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot0.1629727531.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot0.1629727531.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/nrf52840-mdk/suit_update-slot1.1629727531.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-slot1.1629727531.riot.bin"
aiocoap-client -m POST "coap://[fe80::5c0d:18ff:fe57:daf3%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727531.bin" && \
	echo "Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update."
Triggered [fe80::5c0d:18ff:fe57:daf3%riot0] to update.
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff57:daf3
          inet6 group: ff02::1:ff00:2
          
> suit: received URL: "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727531.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/nrf52840-mdk/suit_update-riot.suit_signed.1629727531.bin"
suit_coap: got manifest with size 509
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1629727531, highest available: 1629727530
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 2000 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 48f08ace-5a26-548b-8bec-23396ac6bd23 to 48f08ace-5a26-548b-8bec-23396ac6bd23 from manifest
validating class id: OK
Comparing manifest offset 2000 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 0
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x6123ab2b
Image start address: 0x00002400
Header chksum: 0x7593cdf0

suit_coap: rebooting...


----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2021.10-devel-282-g1b46f-pr_suit_use_Q_for_silencing)
RIOT SUIT update example application
Running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x6123ab2b
Image start address: 0x00002400
Header chksum: 0x7593cdf0

suit_coap: started.
current-slot
Starting the shell
> 
> 
> current-slot
Running from slot 0
> ifconfig
ifconfig
Iface  4  HWaddr: 5E:0D:18:57:DA:F3 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::5c0d:18ff:fe57:daf3  scope: link  VAL
pinging node...
PING fe80::5c0d:18ff:fe57:daf3%riot0(fe80::5c0d:18ff:fe57:daf3%riot0) 56 data bytes

--- fe80::5c0d:18ff:fe57:daf3%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 39.473/39.473/39.473/0.000 ms
pinging node succeeded.
TEST PASSED
```

</details>