### PR TITLE
makefiles: Sort >/dev/null and 2>&1

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -327,12 +327,12 @@ APPLICATION := $(strip $(APPLICATION))
 
 ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
   ifeq (,$(WGET))
-    ifeq (0,$(shell which wget 2>&1 > /dev/null ; echo $$?))
+    ifeq (0,$(shell which wget > /dev/null 2>&1 ; echo $$?))
       WGET := $(shell which wget)
     endif
   endif
   ifeq (,$(CURL))
-    ifeq (0,$(shell which curl 2>&1 > /dev/null ; echo $$?))
+    ifeq (0,$(shell which curl > /dev/null 2>&1 ; echo $$?))
       CURL := $(shell which curl)
     endif
   endif
@@ -349,10 +349,10 @@ ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
 endif
 
 ifeq (,$(UNZIP_HERE))
-  ifeq (0,$(shell which unzip 2>&1 > /dev/null ; echo $$?))
+  ifeq (0,$(shell which unzip > /dev/null 2>&1 ; echo $$?))
     UNZIP_HERE := $(shell which unzip) -q
   else
-    ifeq (0,$(shell which 7z 2>&1 > /dev/null ; echo $$?))
+    ifeq (0,$(shell which 7z > /dev/null 2>&1 ; echo $$?))
       UNZIP_HERE := $(shell which 7z) x -bd
     else
       $(error Neither unzip nor 7z is installed.)
@@ -714,7 +714,7 @@ endef
 # This is not the case on MacOSX, so it must be built on the fly
 ifeq ($(OS),Darwin)
   ifneq (,$(filter debug, $(MAKECMDGOALS)))
-    ifneq (0,$(shell command -v setsid 2>&1 > /dev/null ; echo $$?))
+    ifneq (0,$(shell command -v setsid > /dev/null 2>&1 ; echo $$?))
       SETSID = $(RIOTTOOLS)/setsid/setsid
       $(call target-export-variables,debug,$(SETSID))
       DEBUGDEPS += $(SETSID)

--- a/makefiles/tools/gdb.inc.mk
+++ b/makefiles/tools/gdb.inc.mk
@@ -1,5 +1,5 @@
 # new versions of gdb will support all architectures in one binary
-ifeq ($(shell gdb-multiarch -v 2>&1 > /dev/null; echo $$?),0)
+ifeq ($(shell gdb-multiarch -v > /dev/null 2>&1; echo $$?),0)
 export GDB        ?= gdb-multiarch
 else
 export GDBPREFIX  ?= $(PREFIX)

--- a/makefiles/tools/riotgen.inc.mk
+++ b/makefiles/tools/riotgen.inc.mk
@@ -3,7 +3,7 @@
 -include makefiles/color.inc.mk
 
 riotgen-installed:
-	@command -v riotgen 2>&1 > /dev/null || \
+	@command -v riotgen > /dev/null 2>&1 || \
 	{ $(COLOR_ECHO) \
 	"$(COLOR_RED)'riotgen' command is not available \
 	please consider installing it from \

--- a/pkg/flatbuffers/Makefile.include
+++ b/pkg/flatbuffers/Makefile.include
@@ -2,7 +2,7 @@ INCLUDES += -I$(PKGDIRBASE)/flatbuffers/include
 
 FLATC ?= flatc
 
-ifneq (0,$(shell which flatc 2>&1 > /dev/null ; echo $$?))
+ifneq (0,$(shell which flatc > /dev/null 2>&1 ; echo $$?))
   FLATC = $(RIOTTOOLS)/flatc/flatc
   $(call target-export-variables,all,FLATC)
 endif


### PR DESCRIPTION
### Contribution description

Redirecting `2>&1 >/dev/null` moves stderr to stdout first and then
stdout to /dev/null; when checking for command existence or otherwise
silencing output, this is usually not desired (but only starts producing
errors when the actual command fails, which is often not tested).

In particular cases, the redirect made things even worse: while stderr would have gone to the user's screen otherwise, the `2>&1 >/dev/null` means that warnings raised now get mingled in the later `echo $?` and thus make the equality check for `0` fail -- tools are then not detected any more.

### Testing procedure

Try building anything on a recent Debian sid system; it will fail before with

```
.../Makefile.include:340: *** Neither wget nor curl is installed!.  Stop.
```
and now run through.

### Issues/PRs references

debianutils' which, in its [changelog](https://salsa.debian.org/debian/debianutils/-/blob/master/debian/NEWS), states:

```
  * The 'which' utility will be removed in the future.  Shell scripts
    often use it to check whether a command is available.  A more
    standard way to do this is with 'command -v'; for example:
      if command -v update-icon-caches >/dev/null; then
        update-icon-caches /usr/share/icons/...
      fi
    '2>/dev/null' is unnecessary when using 'command': POSIX says "no
    output shall be written" if the command isn't found.  It's also
    unnecessary for the debianutils version of 'which', and hides the
    deprecation warning.
```

Note that this PR does *not* change which to command, it just fixes the fallout of ill-sequenced redirects. That change is probably good to do, but right now this should be minimal enough to get merged quickly, and I don't want it held up in the question of whether everyone and their dog already implement POSIX `command`.