### PR TITLE
feather-nrf52840: several fixes to documentation

### DIFF
--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -35,12 +35,14 @@ use an external Segger J-Link Programmer connected to the [SWD Connector].
 #### Flashing the uf2 bootloader
 
 To flash the uf2 bootloader (if its no longer present on your BOARD) then with
-a jlink attached to your BOARD and `nrf52prog` installed:
+a jlink attached to your BOARD and [`nrfjprog`][nrfjprog] installed:
 
 $ git clone git@github.com:adafruit/Adafruit_nRF52_Bootloader.git
 $ cd Adafruit_nRF52_Bootloader
 $ make BOARD=feather_nrf52840_express all
 $ make BOARD=feather_nrf52840_express flash
+
+[nrfjprog]: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools
 
 ### Terminal
 To connect a terminal to the Feather, RIOT chooses Segger RTT per default.

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -40,6 +40,12 @@ a jlink attached to your BOARD and [`nrfjprog`][nrfjprog] installed:
 ~~~~~~~~~~~~~{.sh}
 git clone git@github.com:adafruit/Adafruit_nRF52_Bootloader.git
 cd Adafruit_nRF52_Bootloader
+# only download what is needed, use
+#     `git submodule update --init --recursive`
+# to download everything
+git submodule update --init
+git -C lib/tinyusb submodule update --init hw/mcu/nordic/nrfx/
+pip3 install --user adafruit-nrfutil
 make BOARD=feather_nrf52840_express all
 make BOARD=feather_nrf52840_express flash
 ~~~~~~~~~~~~

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -48,14 +48,13 @@ git -C lib/tinyusb submodule update --init hw/mcu/nordic/nrfx/
 pip3 install --user adafruit-nrfutil
 make BOARD=feather_nrf52840_express all
 make BOARD=feather_nrf52840_express flash
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 [nrfjprog]: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools
 
 ### Terminal
-To connect a terminal to the Feather, RIOT chooses Segger RTT per default.
-This lets you use the Segger J-Link Programmer as a serial interface to the
-device.
+To connect a terminal to the Feather, RIOT chooses `stdio_cdc_acm` per default.
+This lets you access the Feather directly over USB.
 
 You have several alternative possibilities to connect to the board.
 
@@ -67,7 +66,7 @@ You have several alternative possibilities to connect to the board.
    UART-based terminals to connect to the feather
 2. With
    ~~~~~~~~~~~~~~~~~~~~~ {.mk}
-   USEMODULE += stdio_cdc_acm
+   USEMODULE += stdio_rtt
    ~~~~~~~~~~~~~~~~~~~~~
-   you can access the Feather with a terminal directly over USB.
+   you can use the Segger J-Link Programmer as a serial interface to the device.
 */

--- a/boards/feather-nrf52840/doc.txt
+++ b/boards/feather-nrf52840/doc.txt
@@ -37,10 +37,12 @@ use an external Segger J-Link Programmer connected to the [SWD Connector].
 To flash the uf2 bootloader (if its no longer present on your BOARD) then with
 a jlink attached to your BOARD and [`nrfjprog`][nrfjprog] installed:
 
-$ git clone git@github.com:adafruit/Adafruit_nRF52_Bootloader.git
-$ cd Adafruit_nRF52_Bootloader
-$ make BOARD=feather_nrf52840_express all
-$ make BOARD=feather_nrf52840_express flash
+~~~~~~~~~~~~~{.sh}
+git clone git@github.com:adafruit/Adafruit_nRF52_Bootloader.git
+cd Adafruit_nRF52_Bootloader
+make BOARD=feather_nrf52840_express all
+make BOARD=feather_nrf52840_express flash
+~~~~~~~~~~~~
 
 [nrfjprog]: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This fixes several issues with the documentation of the `feather-nrf52840` documentation:

- malformed formatting of the shell commands
- typo in requirements and missing info where to find them
- missing commands in shell commands to let them run out of the box
- out-dated doc on terminal

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile documentation with `make doc`. The output should now look much nicer and contain much more information compared to the current doc.riot-os.org. Also try out the instructions. The `feather-nrf52840` should mount as a disk drive afterwards (for Arch and Fedora I needed to patch `dist/tools/uf2/uf2conv.py` to be able to flash:

```diff
--- build/pkg/UF2/utils/uf2conv.py	2021-08-24 16:37:10.613961049 +0200
+++ dist/tools/uf2/uf2conv.py	2021-08-24 17:57:43.061182395 +0200
@@ -200,9 +200,13 @@
         if sys.platform == "darwin":
             rootpath = "/Volumes"
         elif sys.platform == "linux":
-            tmp = rootpath + "/" + os.environ["USER"]
+            tmp = os.path.join(rootpath, os.environ["USER"])
             if os.path.isdir(tmp):
                 rootpath = tmp
+            else:
+                tmp = os.path.join("/run/media", os.environ["USER"])
+                if os.path.isdir(tmp):
+                    rootpath = tmp
         for d in os.listdir(rootpath):
             drives.append(os.path.join(rootpath, d))
 
```

((question is: does it make sense to push this patch upstream... the tool does not look like it was written by someone with a whole lot of knowledge about Linux...)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/16276
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
