### PR TITLE
drivers/flashpage: flashpage_page() takes a const argument

### DIFF
--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -329,7 +329,7 @@ size_t flashpage_size(unsigned page)
     }
 }
 
-unsigned flashpage_page(void *addr)
+unsigned flashpage_page(const void *addr)
 {
     /* Calculates the flashpage number based on the address for the
      * non-homogeneous flashpage stm32 series.

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -190,7 +190,7 @@ static inline void *flashpage_addr(unsigned page)
  *
  * @return              page containing the given address
  */
-static inline unsigned flashpage_page(void *addr)
+static inline unsigned flashpage_page(const void *addr)
 {
     return (((intptr_t)addr - CPU_FLASH_BASE) / FLASHPAGE_SIZE);
 }
@@ -200,7 +200,7 @@ static inline unsigned flashpage_page(void *addr)
 /* Bare prototypes for the above functions. See above for the documentation */
 size_t flashpage_size(unsigned page);
 void *flashpage_addr(unsigned page);
-unsigned flashpage_page(void *addr);
+unsigned flashpage_page(const void *addr);
 
 #endif
 
@@ -319,7 +319,7 @@ static inline void *flashpage_rwwee_addr(unsigned page)
  *
  * @return              RWWEE page containing the given address
  */
-static inline int flashpage_rwwee_page(void *addr)
+static inline int flashpage_rwwee_page(const void *addr)
 {
     return (int)(((int)addr - CPU_FLASH_RWWEE_BASE) / FLASHPAGE_SIZE);
 }

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -118,7 +118,7 @@ void *flashpage_addr(unsigned page)
 #endif /* PERIPH_FLASHPAGE_NEEDS_FLASHPAGE_ADDR */
 
 #ifdef PERIPH_FLASHPAGE_NEEDS_FLASHPAGE_PAGE
-unsigned flashpage_page(void *addr)
+unsigned flashpage_page(const void *addr)
 {
     unsigned page = 0;
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

All addresses to flashpage_page() must be in flash. Flash memory is `const`, therefore this function must also take `const` pointers.


### Testing procedure

Code should still compile.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
