### PR TITLE
cpu/atmega_common: move clock init to common code

### DIFF
--- a/boards/arduino-leonardo/board.c
+++ b/boards/arduino-leonardo/board.c
@@ -20,20 +20,11 @@
 
 #include "board.h"
 #include "cpu.h"
-#include "periph/gpio.h"
-
-#ifndef CPU_ATMEGA_CLK_SCALE_INIT
-#define CPU_ATMEGA_CLK_SCALE_INIT    CPU_ATMEGA_CLK_SCALE_DIV1
-#endif
 
 void led_init(void);
 
 void board_init(void)
 {
-    /* disable usb interrupt */
-    PRR1 |= 1<<PRUSB;
-
-    atmega_set_prescaler(CPU_ATMEGA_CLK_SCALE_INIT);
     avr8_stdio_init();
     cpu_init();
     led_init();

--- a/boards/common/atmega/board.c
+++ b/boards/common/atmega/board.c
@@ -22,21 +22,10 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 
-#ifndef CPU_ATMEGA_CLK_SCALE_INIT
-#define CPU_ATMEGA_CLK_SCALE_INIT    CPU_ATMEGA_CLK_SCALE_DIV1
-#endif
-
 void led_init(void);
 
 void __attribute__((weak)) board_init(void)
 {
-#ifdef CPU_ATMEGA32U4
-    /* disable usb interrupt on Atmega32U4 */
-    PRR1 |= 1<<PRUSB;
-#endif
-
-    atmega_set_prescaler(CPU_ATMEGA_CLK_SCALE_INIT);
-
     cpu_init();
 #ifdef LED0_ON
     led_init();

--- a/cpu/atmega_common/atmega_cpu.c
+++ b/cpu/atmega_common/atmega_cpu.c
@@ -28,11 +28,16 @@
 
 #include <avr/pgmspace.h>
 
+#include "board.h"
 #include "cpu.h"
 #include "panic.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+
+#ifndef CPU_ATMEGA_CLK_SCALE_INIT
+#define CPU_ATMEGA_CLK_SCALE_INIT    CPU_ATMEGA_CLK_SCALE_DIV1
+#endif
 
 extern uint8_t mcusr_mirror;
 extern uint8_t soft_rst;
@@ -60,6 +65,11 @@ void avr8_reset_cause(void)
         DEBUG("JTAG reset!\n");
     }
 #endif
+}
+
+void __attribute__((weak)) avr8_clk_init(void)
+{
+    atmega_set_prescaler(CPU_ATMEGA_CLK_SCALE_INIT);
 }
 
 /* This is a vector which is aliased to __vector_default,

--- a/cpu/atxmega/include/cpu_conf.h
+++ b/cpu/atxmega/include/cpu_conf.h
@@ -63,11 +63,6 @@ extern "C" {
  */
 #define IRQ_API_INLINED                 (1)
 
-/**
- * @brief   This arch require special clock initialization.
- */
-#define CPU_AVR8_HAS_CLOCK_INIT          1
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/avr8_common/avr8_cpu.c
+++ b/cpu/avr8_common/avr8_cpu.c
@@ -31,9 +31,7 @@
 #include <avr/pgmspace.h>
 
 #include "cpu.h"
-#ifdef CPU_AVR8_HAS_CLOCK_INIT
 #include "cpu_clock.h"
-#endif
 #include "board.h"
 #include "irq.h"
 #include "periph/init.h"
@@ -91,14 +89,17 @@ void get_mcusr(void)
 
 void cpu_init(void)
 {
+#ifdef PRUSB
+    /* disable usb interrupt */
+    PRR1 |= 1<<PRUSB;
+#endif
+
     avr8_reset_cause();
 
     wdt_reset();   /* should not be nececessary as done in bootloader */
     wdt_disable(); /* but when used without bootloader this is needed */
 
-#ifdef CPU_AVR8_HAS_CLOCK_INIT
     avr8_clk_init();
-#endif
 
     /* Initialize stdio before periph_init() to allow use of DEBUG() there */
 #ifdef MODULE_AVR_LIBC_EXTRA


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This code should not be in the realm of the board config, but in common arch code.



### Testing procedure

No change in functionality is expeted on ATMega boards.


### Issues/PRs references

split off #16055
