### PR TITLE
Makefile.include: only warn if not curl, wget, unzip, 7z

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -328,34 +328,34 @@ APPLICATION := $(strip $(APPLICATION))
 ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
   ifeq (,$(WGET))
     ifeq (0,$(shell which wget > /dev/null 2>&1 ; echo $$?))
-      WGET := $(shell which wget)
+      WGET = $(call memoized,WGET,$(shell which wget))
     endif
   endif
   ifeq (,$(CURL))
     ifeq (0,$(shell which curl > /dev/null 2>&1 ; echo $$?))
-      CURL := $(shell which curl)
+      CURL = $(call memoized,CURL,$(shell which curl))
     endif
   endif
   ifeq (,$(WGET)$(CURL))
-    $(error Neither wget nor curl is installed!)
+    $(warning Neither wget nor curl is installed!)
   endif
 
   ifeq (,$(DOWNLOAD_TO_STDOUT))
-    DOWNLOAD_TO_STDOUT := $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
+    DOWNLOAD_TO_STDOUT ?= $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
   endif
   ifeq (,$(DOWNLOAD_TO_FILE))
-    DOWNLOAD_TO_FILE := $(if $(WGET),$(WGET) -nv -c -O,$(CURL) -s -o)
+    DOWNLOAD_TO_FILE ?= $(if $(WGET),$(WGET) -nv -c -O,$(CURL) -s -o)
   endif
 endif
 
 ifeq (,$(UNZIP_HERE))
   ifeq (0,$(shell which unzip > /dev/null 2>&1 ; echo $$?))
-    UNZIP_HERE := $(shell which unzip) -q
+    UNZIP_HERE = $(call memoized,UNZIP_HERE,$(shell which unzip) -q)
   else
     ifeq (0,$(shell which 7z > /dev/null 2>&1 ; echo $$?))
-      UNZIP_HERE := $(shell which 7z) x -bd
+      UNZIP_HERE = $(call memoized,UNZIP_HERE,$(shell which 7z) x -bd)
     else
-      $(error Neither unzip nor 7z is installed.)
+      $(warning Neither unzip nor 7z is installed.)
     endif
   endif
 endif


### PR DESCRIPTION
### Contribution description

Currently `Makefile.include` errors if these tools are absent, but they are actually rarely used, so as all other tools used by only some packages don't error, but keep the warning.

```
$ git grep \$\(CURL\)
Makefile.include:  ifeq (,$(CURL))
Makefile.include:  ifeq (,$(WGET)$(CURL))
Makefile.include:    DOWNLOAD_TO_STDOUT ?= $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
Makefile.include:    DOWNLOAD_TO_FILE ?= $(if $(WGET),$(WGET) -nv -c -O,$(CURL) -s -o)

$ git grep \$\(WGET\)
Makefile.include:  ifeq (,$(WGET))
Makefile.include:  ifeq (,$(WGET)$(CURL))
Makefile.include:    DOWNLOAD_TO_STDOUT ?= $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
Makefile.include:    DOWNLOAD_TO_FILE ?= $(if $(WGET),$(WGET) -nv -c -O,$(CURL) -s -o)

$ git grep \$\(DOWNLOAD_TO_STDOUT\)
Makefile.include:ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
Makefile.include:  ifeq (,$(DOWNLOAD_TO_STDOUT))
makefiles/info.inc.mk:  @echo 'DOWNLOAD_TO_STDOUT: $(DOWNLOAD_TO_STDOUT)'
makefiles/vars.inc.mk:export DOWNLOAD_TO_STDOUT    # Use `$(DOWNLOAD_TO_STDOUT) $(URL)` to download `$(URL)` output `$(URL)` to stdout, e.g. to be piped into `tar xz`.

$ git grep \$\(DOWNLOAD_TO_FILE\)
Makefile.include:ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
Makefile.include:  ifeq (,$(DOWNLOAD_TO_FILE))
makefiles/info.inc.mk:  @echo 'DOWNLOAD_TO_FILE:   $(DOWNLOAD_TO_FILE)'
makefiles/vars.inc.mk:export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL)` to download `$(URL)` to `$(DESTINATION)`.
pkg/Makefile.http:      $(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
pkg/c25519/Makefile:    $(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)

$ git grep \$\(UNZIP_HERE\)
Makefile.include:ifeq (,$(UNZIP_HERE))
makefiles/info.inc.mk:  @echo 'UNZIP_HERE:         $(UNZIP_HERE)'
makefiles/vars.inc.mk:export UNZIP_HERE            # Use `cd $(SOME_FOLDER) && $(UNZIP_HERE) $(SOME_FILE)` to extract the contents of the zip file `$(SOME_FILE)` into `$(SOME_FOLDER)`.
pkg/Makefile.http:      $(Q)$(UNZIP_HERE) $<
pkg/c25519/Makefile:    $(Q)$(UNZIP_HERE) -D -d $(PKGDIRBASE) $<
```

It also uses memoized do not call the shell functions if not needed, but still works if they are required:

### Testing procedure

- green murdock

```
make -C tests/pkg_c25519/ distclean clean all
rm -rf /home/francisco/workspace/RIOT/build/pkg/c25519 /home/francisco/workspace/RIOT/build/pkg/c25519-2017-10-05.zip
# Reset package to checkout state.
rm -rf /home/francisco/workspace/RIOT/build/pkg/c25519
Building application "tests_pkg_c25519" for "native" with MCU "native".

mkdir -p /home/francisco/workspace/RIOT/build/pkg
2021-08-28 11:39:47 URL:https://www.dlbeer.co.nz/downloads/c25519-2017-10-05.zip [68419/68419] -> "/home/francisco/workspace/RIOT/build/pkg/c25519-2017-10-05.zip" [1]
test "dbfb4285837ab2ea3d99c448b22877cc7a139ccbaebb1de367e2bec1fd562fe629b389d86603915448078b8fd7e631c8fc9a7d126eb889a1ba0c17611369b190  /home/francisco/workspace/RIOT/build/pkg/c25519-2017-10-05.zip" =  "$(sha512sum "/home/francisco/workspace/RIOT/build/pkg/c25519-2017-10-05.zip")"
"make" -C /home/francisco/workspace/RIOT/pkg/c25519
"make" -C /home/francisco/workspace/RIOT/build/pkg/c25519/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=c25519
"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/embunit
"make" -C /home/francisco/workspace/RIOT/sys/luid
"make" -C /home/francisco/workspace/RIOT/sys/random
"make" -C /home/francisco/workspace/RIOT/sys/random/tinymt32
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
   text	   data	    bss	    dec	    hex	filename
  51078	    716	  64364	 116158	  1c5be	/home/francisco/workspace/RIOT/tests/pkg_c25519/bin/native/tests_pkg_c25519.elf
```

### Issues/PRs references


Follow up to https://github.com/RIOT-OS/RIOT/pull/16776
