### PR TITLE
README.md: fix doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ https://www.riot-os.org
 
 
 [api-badge]: https://img.shields.io/badge/docs-API-informational.svg
-[api-link]: https://riot-os.org/api/
+[api-link]: https://doc.riot-os.org/
 [license-badge]: https://img.shields.io/github/license/RIOT-OS/RIOT
 [license-link]: https://github.com/RIOT-OS/RIOT/blob/master/LICENSE
 [master-ci-badge]: https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/badge.svg


### PR DESCRIPTION
### Contribution description

I noticed the doc link badge is broken, this should fix it. 

### Testing procedure

Test the link in master, follow the link in this PR (or open the file in markdown and click on the badge).


