### PR TITLE
boards/nrf52: replace gnrc_netdev_default with netdev_default

### DIFF
--- a/boards/common/nrf52/Makefile.nimble.dep
+++ b/boards/common/nrf52/Makefile.nimble.dep
@@ -1,5 +1,7 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-  ifeq (,$(filter nrfmin nrf802154,$(USEMODULE)))
-    USEMODULE += nimble_netif
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  ifneq (,$(filter gnrc,$(USEMODULE)))
+    ifeq (,$(filter nrfmin nrf802154,$(USEMODULE)))
+      USEMODULE += nimble_netif
+    endif
   endif
 endif

--- a/boards/common/nrf52/Makefile.nrfmin.dep
+++ b/boards/common/nrf52/Makefile.nrfmin.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   ifeq (,$(filter nimble_% nrf802154,$(USEMODULE)))
     USEMODULE += nrfmin
   endif


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Only nimble depends on GNRC, but we want to replace gnrc_netdev_default with netdev_default, so check for gnrc instead.

### Testing procedure

`gnrc_netdev_default` selects `netdev_default` so binaries will stay the same.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
