### PR TITLE
make: add -ffunction-sections -fdata-sections to LINKFLAGS if LTO=1

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -54,7 +54,7 @@ endif
 ifeq ($(LTO),1)
   $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto
-  LINKFLAGS += $(LTOFLAGS)
+  LINKFLAGS += $(LTOFLAGS) -ffunction-sections -fdata-sections
 endif
 
 # Forbid common symbols to prevent accidental aliasing.

--- a/sys/malloc_thread_safe/malloc_wrappers.c
+++ b/sys/malloc_thread_safe/malloc_wrappers.c
@@ -26,7 +26,7 @@ extern void *__real_realloc(void *ptr, size_t size);
 
 static mutex_t _lock;
 
-void *__wrap_malloc(size_t size)
+void __attribute__((used)) *__wrap_malloc(size_t size)
 {
     assert(!irq_is_in());
     mutex_lock(&_lock);
@@ -35,7 +35,7 @@ void *__wrap_malloc(size_t size)
     return ptr;
 }
 
-void __wrap_free(void *ptr)
+void __attribute__((used)) __wrap_free(void *ptr)
 {
     assert(!irq_is_in());
     mutex_lock(&_lock);
@@ -43,7 +43,7 @@ void __wrap_free(void *ptr)
     mutex_unlock(&_lock);
 }
 
-void *__wrap_calloc(size_t nmemb, size_t size)
+void * __attribute__((used)) __wrap_calloc(size_t nmemb, size_t size)
 {
     /* some c libs don't perform proper overflow check (e.g. newlib < 4.0.0). Hence, we
      * just implement calloc on top of malloc ourselves. In addition to ensuring proper
@@ -61,7 +61,7 @@ void *__wrap_calloc(size_t nmemb, size_t size)
     return res;
 }
 
-void *__wrap_realloc(void *ptr, size_t size)
+void * __attribute__((used))__wrap_realloc(void *ptr, size_t size)
 {
     assert(!irq_is_in());
     mutex_lock(&_lock);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

https://github.com/RIOT-OS/RIOT/pull/14754 broke LTO as it created significantly larger binaries (instead of smaller) with LTO enabled. Our micro benchmarks showed increased performance, so LTO still worked partially.
I tracked this down to `-ffunction-sections -fdata-sections` missing for the linker invocation.

This PR fixes that by adding those flags to LINKFLAGS if LTO is enabled.

binary (text) sizes for examples/hello-world on nrf52840dk:

|  | LTO=0 | LTO=1 |
| ----- | ----- | ----- |
| master | 8688 | 10188 |
 | PR | 8688| 7792 |



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

non-LTO binaries should be identical. lto binaries should be smaller and still work.

I did not enable "run tests" as no LTO tests are run on CI.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14754

fixes #16202
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
