### PR TITLE
.gitignore: add .clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ keys/
 
 # clangd language server
 .clangd/
+
+# custom clang-tidy flags, also used when using clangd language server
+.clang-tidy


### PR DESCRIPTION
### Contribution description

As the title says. I use this to locally to fine-tune what clangd warns me about.

### Testing procedure

Create a `.clang-tidy` file. In `master` that file will show up in `git status`, with this PR it won't.

### Issues/PRs references

None