### PR TITLE
boards/hifive1b: Fix uart dev1 pins

### DIFF
--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -51,8 +51,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .addr       = UART1_CTRL_ADDR,
-        .rx         = GPIO_PIN(0, 18),
-        .tx         = GPIO_PIN(0, 23),
+        .rx         = GPIO_PIN(0, 23),
+        .tx         = GPIO_PIN(0, 18),
         .isr_num    = INT_UART1_BASE,
     },
 };


### PR DESCRIPTION


### Contribution description

This fixes the tx and rx pins for the HiFive1 Rev B01 for uart device 1. These pins were in the wrong order.
See the FE310-G002 manual at page 81.
https://sifive.cdn.prismic.io/sifive/e36c0a2f-413f-49d4-85c1-51ee1ed243e5_fe310-g002-manual-v1p1.pdf


### Testing procedure



### Issues/PRs references

This change will be tested with RobotFW https://github.com/RIOT-OS/RobotFW-tests/pull/117
