### PR TITLE
core/msg doc: Clarify; elaborating on interaction with queue

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -311,7 +311,13 @@ int msg_try_receive(msg_t *m);
  * @brief Send a message, block until reply received.
  *
  * This function sends a message to *target_pid* and then blocks until target
- * has sent a reply which is then stored in *reply*.
+ * has sent a reply which is then stored in *reply*. The responding thread must
+ * use @ref msg_reply().
+ *
+ * Any incoming messages other than the reply are put into the queue (if one is
+ * configured), block the sender (if sent with @ref msg_send from a thread), or
+ * rejected (if sent with @ref msg_try_send or from an interrupt) -- just like
+ * if the thread were blocked on anything different than message reception.
  *
  * @pre     @p target_pid is not the PID of the current thread.
  *


### PR DESCRIPTION
### Contribution description

When I worked through messages, I got once more confused by how msg_send_receive / msg_reply work -- what if I receive another message while waiting? Do I have to make sure that doesn't happen? Would the other message get dropped? What if there's already a message waiting in the queue?

This clarifies the behavior, which (from reading the code) I understand to be that the thread, for all other messages, behaves like it's not waiting for a message, and that only the msg_respond function understands that state and puts the message in -- responses never enter the queue.

### Testing procedure

* Read updated documentation and compare to your expectations.