### PR TITLE
make: add capability to check config for `test-with-config`

### DIFF
--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -40,17 +40,36 @@ test-as-root/available:
 	$(Q)test -n "$(strip $(TESTS_AS_ROOT))"
 
 # Tests that require specific configuration
-.PHONY: test-with-config test-with-config/available
-TESTS_WITH_CONFIG ?= $(foreach file,$(wildcard $(APPDIR)/tests-with-config/*[^~]),\
-                        $(shell test -f $(file) -a -x $(file) && echo $(file)))
+.PHONY: test-with-config test-with-config/available test-with-config/check-config
+# Scripts for tests that require specific configuration (with automatic
+# configuration checks filtered out)
+TESTS_WITH_CONFIG ?= $(filter-out $(APPDIR)/tests-with-config/check-config%,\
+  $(foreach file,$(wildcard $(APPDIR)/tests-with-config/*[^~]),\
+     $(shell test -f $(file) -a -x $(file) && echo $(file)))\
+)
+# Scripts that provide an automatic configuration check
+# for tests with specific configuration
+CHECK_CONFIG ?= $(foreach file,$(wildcard $(APPDIR)/tests-with-config/check-config*[^~]),\
+                  $(shell test -f $(file) -a -x $(file) && echo $(file)))
 
-test-with-config: $(TEST_DEPS)
+test-with-config: test-with-config/check-config $(TEST_DEPS)
 	$(Q) for t in $(TESTS_WITH_CONFIG); do \
 		$$t || exit 1; \
 	done
 
-test-with-config/available:
-	$(Q)test -n "$(strip $(TESTS_WITH_CONFIG))"
+# run the automatic configuration check
+test-with-config/check-config:
+	$(Q)test -z "$(strip $(CHECK_CONFIG))" || \
+		${COLOR_ECHO} -n "${COLOR_RED}"; \
+		for t in $(CHECK_CONFIG) empty; do \
+			test $$t = "empty" && break; \
+			$$t || \
+			(echo "System configuration for" \
+			"tests is not available, check $${t#$${RIOTBASE}/} failed." \
+			"${COLOR_RESET}"; \
+				exit 1) || exit 1; \
+		done; \
+		${COLOR_ECHO} -n "${COLOR_RESET}"
 
 # this target only makes sense if an ELFFILE is actually created, thus guard by
 # RIOTNOLINK="".


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds another dependency for `test-with-config` that uses (optional) `check-config` scripts within the `tests-with-config` directory to check if the config required for the test is available. If the config is not available, the `make test-with-config` target will fail with an appropriate error message.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I will provide a config checker for `tests/gnrc_dhcpv6_client` as a follow-up (https://github.com/RIOT-OS/RIOT/pull/16797). With that, this PR will be testable.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
