### PR TITLE
tests/gnrc_dhcpv6_client: honor configured $IFACE in Kea config

### DIFF
--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -41,6 +41,7 @@ include $(RIOTBASE)/Makefile.include
 
 .PHONY: dhcpv6_server
 
+dhcpv6_server: IFACE := ${IFACE}
 dhcpv6_server:
 	$(CURDIR)/dhcpv6_server.sh $(DHCPV6_SERVER_PORT) $(CURDIR)/kea-dhcp6.conf
 

--- a/tests/gnrc_dhcpv6_client/README.md
+++ b/tests/gnrc_dhcpv6_client/README.md
@@ -21,7 +21,9 @@ If you use any platform other than `native`, you need to use `ethos`, otherwise
 `netdev_tap` is chosen.
 
 An instance of Kea that configured via [kea-dhcp6.conf](kea-dhcp6.conf) is
-started in parallel to `make term`/`make test-with-config`.
+started in parallel to `make term`/`make test-with-config`. The
+`{{ env.IFACE }}` template variable will be replaced by the `dhcpv6_server.sh`
+script.
 
 Read the [Kea documentation] on the configuration file for more information.
 

--- a/tests/gnrc_dhcpv6_client/README.md
+++ b/tests/gnrc_dhcpv6_client/README.md
@@ -21,7 +21,7 @@ If you use any platform other than `native`, you need to use `ethos`, otherwise
 `netdev_tap` is chosen.
 
 An instance of Kea that configured via [kea-dhcp6.conf](kea-dhcp6.conf) is
-started in parallel to `make term`/`make test-as-root`.
+started in parallel to `make term`/`make test-with-config`.
 
 Read the [Kea documentation] on the configuration file for more information.
 

--- a/tests/gnrc_dhcpv6_client/kea-dhcp6.conf
+++ b/tests/gnrc_dhcpv6_client/kea-dhcp6.conf
@@ -2,7 +2,7 @@
   "Dhcp6":
   {
     "interfaces-config": {
-      "interfaces": [ "tapbr0" ]
+      "interfaces": [ "{{ env.IFACE }}" ]
     },
     "data-directory": ".",
     "lease-database": {
@@ -22,7 +22,7 @@
     "renew-timer": 1000,
     "rebind-timer": 2000,
     "subnet6": [
-    {    "interface": "tapbr0",
+    {    "interface": "{{ env.IFACE }}",
          "subnet": "2001:db8::/32",
          "pools": [ { "pool": "2001:db8:1::/64" } ],
          "pd-pools": [ { "prefix": "2001:db8:8000::",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently, Kea will only start in `tests/gnrc_dhcpv6_client` properly, when `IFACE` is set to `tapbr0`. With this change, the Kea config honors the value of the `IFACE` variable.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Create a bridge typically not used with RIOT e.g.

```sh
dist/tools/tapsetup/tapsetup -b tapbr1
```

and start the test with that interface

```sh
IFACE=tapbr1 make -C tests/gnrc_dhcpv6_client flash -j test-with-config
```

without this change the test will fail and Kea will complain, that `tapbr0` does not exist. With this change the test should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #16792.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
