### PR TITLE
tests/gnrc_dhcpv6_client: add script to check if $IFACE exists

### DIFF
--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -44,7 +44,7 @@ include $(RIOTBASE)/Makefile.include
 # export IFACE variable to environment of dhcpv6_server and
 # test-with-config/check-config rules
 # see: https://doc.riot-os.org/build-system-basics.html#variable-declaration-guidelines
-$(call target-export-variables,test-with-config/check-config,IFACE)
+$(call target-export-variables,dhcpv6_server test-with-config/check-config,IFACE)
 
 dhcpv6_server:
 dhcpv6_server:

--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -41,7 +41,12 @@ include $(RIOTBASE)/Makefile.include
 
 .PHONY: dhcpv6_server
 
-dhcpv6_server: IFACE := ${IFACE}
+# export IFACE variable to environment of dhcpv6_server and
+# test-with-config/check-config rules
+# see: https://doc.riot-os.org/build-system-basics.html#variable-declaration-guidelines
+$(call target-export-variables,test-with-config/check-config,IFACE)
+
+dhcpv6_server:
 dhcpv6_server:
 	$(CURDIR)/dhcpv6_server.sh $(DHCPV6_SERVER_PORT) $(CURDIR)/kea-dhcp6.conf
 

--- a/tests/gnrc_dhcpv6_client/tests-with-config/check-config.sh
+++ b/tests/gnrc_dhcpv6_client/tests-with-config/check-config.sh
@@ -1,0 +1,17 @@
+#! /bin/sh
+#
+# check_config.sh
+# Copyright (C) 2021 Martine Lenders <mail@martine-lenders.eu>
+#
+# Distributed under terms of the MIT license.
+#
+
+ip link show dev "${IFACE}" > /dev/null
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+    echo "You may be able to create \"${IFACE}\" by using e.g." \
+         "\`${RIOTTOOLS#${RIOTBASE}/}/tapsetup/tapsetup\`."
+fi
+
+exit $RESULT


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Adds a checker script if the required interface for `tests/gnrc_dhcpv6_client` exists.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `tests/gnrc_dhcpv6_client` with and without a TAP interface

```sh
sudo dist/tools/tapsetup/tapsetup
make -C tests/gnrc_dhcpv6_client flash -j test-with-config # should succeed
sudo dist/tools/tapsetup/tapsetup -d
make -C tests/gnrc_dhcpv6_client flash -j test-with-config # should fail with appropriate error message
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #16795 for the config check to work ~~and #16796 for the `$IFACE` export~~ (see https://github.com/RIOT-OS/RIOT/pull/16797#issuecomment-911714794).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
