### PR TITLE
makefiles: Reject `2>&1 >/dev/null`, and weed out remaining offenders

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -51,7 +51,7 @@ endif
 IOTLAB_AUTH ?= $(HOME)/.iotlabrc
 IOTLAB_USER ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
 
-ifneq (0,$(shell command -v iotlab-experiment -h 2>&1 > /dev/null ; echo $$?))
+ifneq (0,$(shell command -v iotlab-experiment -h > /dev/null 2>&1; echo $$?))
   $(info $(COLOR_RED)'iotlab-experiment' command is not available \
 	        please consider installing it from \
 	        https://pypi.python.org/pypi/iotlabcli$(COLOR_RESET))
@@ -60,7 +60,7 @@ endif
 
 ifeq (iotlab-a8-m3,$(BOARD))
   ifneq (,$(filter flash% reset,$(MAKECMDGOALS)))
-    ifneq (0,$(shell command -v iotlab-ssh -h 2>&1 > /dev/null ; echo $$?))
+    ifneq (0,$(shell command -v iotlab-ssh -h > /dev/null 2>&1; echo $$?))
       $(info $(COLOR_RED)'iotlab-ssh' command is not available \
 	          please consider installing it from \
 	          https://pypi.python.org/pypi/iotlabsshcli$(COLOR_RESET))

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -349,6 +349,19 @@ check_no_riot_config() {
         | error_with_message "Don't push RIOT_CONFIG_* definitions upstream. Rather define configuration via Kconfig"
 }
 
+check_stderr_null() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e '2>[[:blank:]]*&1[[:blank:]]*>[[:blank:]]*/dev/null')
+
+    pathspec+=('Makefile*')
+    pathspec+=('**/Makefile*')
+    pathspec+=('**/*.mk')
+    git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message "Redirecting stderr and stdout to /dev/null is \`>/dev/null 2>&1\`; the other way round puts the old stderr to the new stdout."
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -369,6 +382,7 @@ all_checks() {
     check_no_usemodules_in_makefile_include
     check_no_pkg_source_local
     check_no_riot_config
+    check_stderr_null
 }
 
 main() {


### PR DESCRIPTION
### Contribution description

Shell redirects in the form of `2>&1 >/dev/null` do not, as one might think, redirect both stdout and err to /dev/null, but put stdout to /dev/null and redirect stderr to the process's standard output.

This adds an automated test for such redirects, and removes two more redirects that were spotted with its help.

### Testing procedure

* CI says Go
* Adding Makefile code with `2>&1 >/dev/null` trips up the static checks.

### Issues/PRs references

This is a follow-up on https://github.com/RIOT-OS/RIOT/pull/16775 with the unproblematic parts of https://github.com/RIOT-OS/RIOT/pull/16776 (which had to be reverted; the problematic parts come up in a different PR with more caution this time).