### PR TITLE
native/backtrace: improve its print capabilitys and test

### DIFF
--- a/cpu/native/backtrace/backtrace.c
+++ b/cpu/native/backtrace/backtrace.c
@@ -16,20 +16,44 @@
 #include <execinfo.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "backtrace.h"
 
 void backtrace_print(void)
 {
     void *array[BACKTRACE_SIZE + 1];
-    size_t size;
+    int size;
 
     size = backtrace(array, BACKTRACE_SIZE + 1);
 
     /* skip above line's return address and start with 1 */
-    for (size_t i = 1; i < size; i++) {
+    for (int i = 1; i < size; i++) {
         printf("%p\n", array[i]);
     }
+}
+
+void backtrace_print_symbols(void)
+{
+    void *array[BACKTRACE_SIZE + 1];
+    int size;
+
+    size = backtrace(array, BACKTRACE_SIZE + 1);
+
+    char ** symbols = backtrace_symbols(array, size);
+
+    /* skip above line's return address and start with 1 */
+    for (int i = 1; i < size; i++) {
+        printf("%s\n", symbols[i]);
+    }
+    free(symbols);
+}
+
+int backtrace_len(void)
+{
+    void *array[BACKTRACE_SIZE + 1];
+
+    return backtrace(array, BACKTRACE_SIZE + 1) - 1;
 }
 
 /** @} */

--- a/cpu/native/include/backtrace.h
+++ b/cpu/native/include/backtrace.h
@@ -36,10 +36,22 @@ extern "C" {
 #endif
 
 /**
- * @brief   Print the last @ref BACKTRACE_SIZE return addresses from call of this
+ * @brief   Print up to the last @ref BACKTRACE_SIZE return addresses from call of this
  *          function
  */
 void backtrace_print(void);
+
+/**
+ * @brief   Print up to the last @ref BACKTRACE_SIZE symbol_names from call of this
+ *          function
+ */
+void backtrace_print_symbols(void);
+
+/**
+ * @brief   get the number of stack frames that are printed by print or print_symbols
+ *
+ */
+int backtrace_len(void);
 
 #ifdef __cplusplus
 }

--- a/tests/cpu/native_backtrace/main.c
+++ b/tests/cpu/native_backtrace/main.c
@@ -24,7 +24,10 @@
 
 int main(void)
 {
-    printf("BACKTRACE_SIZE: %u\n", BACKTRACE_SIZE);
+    printf("BACKTRACE_SIZE: %d\n", backtrace_len());
+    printf("\n## backtrace_print: print addresses\n");
     backtrace_print();
+    printf("\n## backtrace_print_symbols: print symbol information\n");
+    backtrace_print_symbols();
     return 0;
 }

--- a/tests/cpu/native_backtrace/tests/01-run.py
+++ b/tests/cpu/native_backtrace/tests/01-run.py
@@ -13,8 +13,12 @@ from testrunner import run
 def testfunc(child):
     child.expect(r"BACKTRACE_SIZE: (\d+)\r\n")
     trace_size = int(child.match.group(1))
+    child.expect("backtrace_print:")
     for i in range(trace_size):
         child.expect(r"0x[0-9a-f]+")
+    child.expect("backtrace_print_symbols:")
+    for i in range(trace_size):
+        child.expect(r".*")
 
     print("All tests successful")
 


### PR DESCRIPTION
### Contribution description

this improve its print capabilities and test for the backtrace functionality of native 

adding symbol printing and depth information gathering making this a more complete package for using the GNU-libc execinfo.h

### Testing procedure

run the backtrace test  

~compile it with 'LINKERFLAGS=-no-pie' and it will no longer lie to you how many lines it will print~ #16186 does this

add some or all of of the functions to you own code (just Native) 

#### Testrun

```
machine:<RIOT>/tests/cpu/native_backtrace/ > make
<RIOT>/makefiles/arch/native.inc.mk:24: module backtrace is used, do not omit frame pointers
Building application "tests_native_backtrace" for "native" with CPU "native".

"make" -C <RIOT>/boards/common/init
"make" -C <RIOT>/boards/native
"make" -C <RIOT>/boards/native/drivers
"make" -C <RIOT>/core
"make" -C <RIOT>/core/lib
"make" -C <RIOT>/cpu/native
"make" -C <RIOT>/cpu/native/backtrace
"make" -C <RIOT>/cpu/native/periph
"make" -C <RIOT>/cpu/native/stdio_native
"make" -C <RIOT>/drivers
"make" -C <RIOT>/drivers/periph_common
"make" -C <RIOT>/sys
"make" -C <RIOT>/sys/auto_init
"make" -C <RIOT>/sys/isrpipe
"make" -C <RIOT>/sys/libc
"make" -C <RIOT>/sys/preprocessor
"make" -C <RIOT>/sys/test_utils/interactive_sync
"make" -C <RIOT>/sys/test_utils/print_stack_usage
"make" -C <RIOT>/sys/tsrb
   text    data     bss     dec     hex filename
  25784     564   47840   74188   121cc <RIOT>/tests/cpu/native_backtrace/bin/native/tests_native_backtrace.elf
machine:<RIOT>/tests/cpu/native_backtrace/ > make test                    
<RIOT>/makefiles/arch/native.inc.mk:24: module backtrace is used, do not omit frame pointers
r
<RIOT>/makefiles/arch/native.inc.mk:24: module backtrace is used, do not omit frame pointers
<RIOT>/tests/cpu/native_backtrace/bin/native/tests_native_backtrace.elf  tap0 
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2024.04-devel-475-gb654a0-p-backtrace-fix)
BACKTRACE_SIZE: 3

## backtrace_print: print addresses
0x8049656
0x80498e4
0xf5c4ac99

## backtrace_print_symbols: print symbol information
<RIOT>/tests/cpu/native_backtrace/bin/native/tests_native_backtrace.elf() [0x8049669]
<RIOT>/tests/cpu/native_backtrace/bin/native/tests_native_backtrace.elf() [0x80498e4]
/lib/i386-linux-gnu/libc.so.6(makecontext+0x109) [0xf5c4ac99]
All tests successful
```

### Issues/PRs references

#16186 fixed the no-pie thing

### Notes

https://www.gnu.org/software/libc/manual/html_node/Backtraces.html

https://github.com/libunwind/libunwind/