### PR TITLE
atmega_common/periph/spi: bugfix for CLOCK_CORECLOCK != 16MHz

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -110,30 +110,6 @@ typedef enum {
     SPI_MODE_3 = SPI_MODE_SEL(1, 1)     /**< mode 3 */
 } spi_mode_t;
 /** @} */
-
-/**
- * @brief   SPI speed selection macro
- *
- * We encode the speed in bits 2, 1, and 0, where bit0 and bit1 hold the SPCR
- * prescaler bits, while bit2 holds the SPI2X bit.
- */
-#define SPI_CLK_SEL(s2x, pr1, pr0)    ((s2x << 2) | (pr1 << 1) | pr0)
-
-/**
- * @name   Override SPI speed values
- *
- * We assume a master clock speed of 16MHz here.
- * @{
- */
-#define HAVE_SPI_CLK_T
-typedef enum {
-    SPI_CLK_100KHZ = SPI_CLK_SEL(0, 1, 1),      /**< 16/128 -> 125KHz */
-    SPI_CLK_400KHZ = SPI_CLK_SEL(1, 1, 0),      /**< 16/32  -> 500KHz */
-    SPI_CLK_1MHZ   = SPI_CLK_SEL(0, 0, 1),      /**< 16/16  -> 1MHz */
-    SPI_CLK_5MHZ   = SPI_CLK_SEL(0, 0, 0),      /**< 16/4   -> 4MHz */
-    SPI_CLK_10MHZ  = SPI_CLK_SEL(1, 0, 0)       /**< 16/2   -> 8MHz */
-} spi_clk_t;
-/** @} */
 #endif /* ifndef DOXYGEN */
 
 /**

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -59,7 +59,7 @@ static uint8_t spi2x[5], spr[5];
 static uint8_t _clk_shift(uint32_t clk)
 {
     /* Atmega datasheets give the following table:
-     * SPI2X    SPR1    SPR0    SCK Freqency
+     * SPI2X    SPR1    SPR0    SCK Frequency
      * 0        0       0       Fosc/4
      * 0        0       1       Fosc/16
      * 0        1       0       Fosc/64
@@ -94,7 +94,6 @@ static uint8_t _clk_shift(uint32_t clk)
 
 static void _init_clk(void)
 {
-    uint8_t shift;
     for (uint8_t i = 0; i < 5; i++) {
 
         DEBUG("[spi] spi_clk[%"PRIu8"]: %8"PRIu32" -> ", i, spi_clk[i]);
@@ -108,7 +107,7 @@ static void _init_clk(void)
         }
 
         /* Compute shift values */
-        shift = _clk_shift(spi_clk[i]);
+        uint8_t shift = _clk_shift(spi_clk[i]);
 
         /* Save registers bits */
         spi2x[i] = ~shift & 1;

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -31,7 +31,7 @@
 #include "periph/spi.h"
 #include "macros/units.h"
 
-#define ENABLE_DEBUG        1
+#define ENABLE_DEBUG        0
 #include "debug.h"
 
 static mutex_t lock = MUTEX_INIT;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In `atmega_common/include/periph_cpu_common.h` sti_clk_t enum was overridden with a kind of encoded register bits assuming a master clock speed of 16MHz.

This leads into a (CLOCK_CORECLOCK / 16MHz) ratio for SPI_CLK_* for boards boards like atmega1284p where CLOCK_CORECLOCK differ from 16MHz.

In addition, the first two values were greater than the named values which does not comply with the usual rule.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
With ENABLE_DEBUG set to 1, build tests/periph_spi for atmega1284p:
#### CLOCK_CORECLOCK     (8000000UL)
```
2021-09-03 22:28:45,903 # [spi] spi_clk[0]:   100000 ->    62500 (8000000 / 128)  SPI2X: 0  SPR1: 1  SPR0: 1
2021-09-03 22:28:45,989 # [spi] spi_clk[1]:   400000 ->   250000 (8000000 /  32)  SPI2X: 1  SPR1: 1  SPR0: 0
2021-09-03 22:28:46,075 # [spi] spi_clk[2]:  1000000 ->  1000000 (8000000 /   8)  SPI2X: 1  SPR1: 0  SPR0: 1
2021-09-03 22:28:46,162 # [spi] spi_clk[3]:  5000000 ->  4000000 (8000000 /   2)  SPI2X: 1  SPR1: 0  SPR0: 0
2021-09-03 22:28:46,249 # [spi] spi_clk[4]: 10000000 ->  4000000 (8000000 /   2)  SPI2X: 1  SPR1: 0  SPR0: 0
```
##### Measured period on SCK pin
- [x] spi_clk[0]: 16 µs
- [x] spi_clk[1]: 4 µs
- [x] spi_clk[2]: 1 µs
- [x] spi_clk[3]: 250 ns
- [x] spi_clk[4]: 250 ns

#### CLOCK_CORECLOCK     (10000000UL)
```
 #error Unsupported hardware timer frequency (XTIMER_HZ), missing XTIMER_SHIFT in board.h? See xtimer.h documentation for more info
```
#### CLOCK_CORECLOCK     (16000000UL)
I do not have a 16MHz crystal so the serial connection was made at 4800 bauds and the period measurements were divided by 2. 
```
2021-09-03 22:54:09,349 # [spi] spi_clk[0]:   100000 ->   125000 (16000000 / 128)  SPI2X: 0  SPR1: 1  SPR0: 1
2021-09-03 22:54:09,524 # [spi] spi_clk[1]:   400000 ->   250000 (16000000 /  64)  SPI2X: 0  SPR1: 1  SPR0: 0
2021-09-03 22:54:09,699 # [spi] spi_clk[2]:  1000000 ->  1000000 (16000000 /  16)  SPI2X: 0  SPR1: 0  SPR0: 1
2021-09-03 22:54:09,873 # [spi] spi_clk[3]:  5000000 ->  4000000 (16000000 /   4)  SPI2X: 0  SPR1: 0  SPR0: 0
2021-09-03 22:54:10,048 # [spi] spi_clk[4]: 10000000 ->  8000000 (16000000 /   2)  SPI2X: 1  SPR1: 0  SPR0: 0
```
##### Measured period on SCK pin
- [x] spi_clk[0]: 8 µs
- [x] spi_clk[1]: 4 µs
- [x] spi_clk[2]: 1 µs
- [x] spi_clk[3]: 250 ns
- [x] spi_clk[4]: 125 ns

#### CLOCK_CORECLOCK     (20000000UL)
```
 #error Unsupported hardware timer frequency (XTIMER_HZ), missing XTIMER_SHIFT in board.h? See xtimer.h documentation for more info
```
#### CLOCK_CORECLOCK     (32000000UL)
```
I do not have a 16MHz crystal so the serial connection was made at 2400 bauds and the period measurements were divided by 4.
2021-09-03 23:04:52,390 # [spi] spi_clk[0]:   100000 ->   250000 (32000000 / 128)  SPI2X: 0  SPR1: 1  SPR0: 1
2021-09-03 23:04:52,740 # [spi] spi_clk[1]:   400000 ->   250000 (32000000 / 128)  SPI2X: 0  SPR1: 1  SPR0: 1
2021-09-03 23:04:53,089 # [spi] spi_clk[2]:  1000000 ->  1000000 (32000000 /  32)  SPI2X: 1  SPR1: 1  SPR0: 0
2021-09-03 23:04:53,439 # [spi] spi_clk[3]:  5000000 ->  4000000 (32000000 /   8)  SPI2X: 1  SPR1: 0  SPR0: 1
2021-09-03 23:04:53,788 # [spi] spi_clk[4]: 10000000 ->  8000000 (32000000 /   4)  SPI2X: 0  SPR1: 0  SPR0: 0
```
##### Measured period on SCK pin
- [x] spi_clk[0]: 4 µs
- [x] spi_clk[1]: 4 µs
- [x] spi_clk[2]: 1 µs
- [x] spi_clk[3]: 250 ns
- [x] spi_clk[4]: 125 ns


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/16727#issuecomment-909846484
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
