### PR TITLE
net/cord doc: Usability fixes

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14280,7 +14280,6 @@ sys/include/net/coap\.h:[0-9]+: warning: Member COAP_TYPE_ACK \(macro definition
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_TYPE_CON \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_TYPE_NON \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_TYPE_RST \(macro definition\) of group net_coap is not documented\.
-sys/include/net/cord/config\.h:[0-9]+: warning: unbalanced grouping commands
 sys/include/net/dhcpv6/client\.h:[0-9]+: warning: unbalanced grouping commands
 sys/include/net/dhcpv6\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 sys/include/net/dns\.h:[0-9]+: warning: Member DNS_CLASS_IN \(macro definition\) of group net_dns is not documented\.

--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    net_cord_config CoRE RD Configuration
  * @ingroup     net_cord
+ * @ingroup     config
  * @brief       Configuration options for CoRE RD endpoints and lookup clients
  * @{
  *
@@ -27,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @defgroup net_cord_conf CoRE RD Client compile configurations
- * @ingroup config
- * @{
- */
-/**
  * @brief   Default lifetime in seconds (the default is 1 day)
  */
 #ifndef CONFIG_CORD_LT
@@ -44,7 +40,6 @@ extern "C" {
 #ifndef CONFIG_CORD_UPDATE_INTERVAL
 #define CONFIG_CORD_UPDATE_INTERVAL    ((CONFIG_CORD_LT / 4) * 3)
 #endif
-/** @} */
 
 /**
  * @brief   Delay until the RD client starts to try registering (in seconds)

--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -64,13 +64,10 @@ extern "C" {
 #ifndef CONFIG_CORD_EP
 #ifdef DOXYGEN
 /**
- * @ingroup net_cord_conf
  * @brief Endpoint ID definition
- * @{
  */
 #define CONFIG_CORD_EP "MyNewEpName"    //defined for doxygen documentation only
 #endif
-/** @} */
 
 /**
  * @brief   Number of generated hexadecimal characters added to the ep

--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_cord_config CoRE RD Endpoint and Lookup Client Configuration
+ * @defgroup    net_cord_config CoRE RD Configuration
  * @ingroup     net_cord
  * @brief       Configuration options for CoRE RD endpoints and lookup clients
  * @{

--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -86,7 +86,15 @@ extern "C" {
 /**
  * @brief   Extra query parameters added during registration
  *
- * Must be suitable for constructing a static array out of them.
+ * Must be suitable for constructing a static array out of them. Each item of
+ * the array is turned as a Uri-Query option. The [IANA RD Parameters subregistry]
+ * contains usable keys and their descriptions in entries that have an "R" in
+ * their "Use" column. Other keys can be used with known RD implementations.
+ *
+ * The `ep` and `lt` parameters are *not* to be set through this mechanism, but
+ * through @ref CONFIG_CORD_EP and @ref CONFIG_CORD_LT, respectively.
+ *
+ * [IANA RD Parameters subregistry]: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#rd-parameters
  *
  * Example:
  *

--- a/sys/include/net/cord/config.h
+++ b/sys/include/net/cord/config.h
@@ -105,7 +105,6 @@ extern "C" {
 #ifdef DOXYGEN
 #define CONFIG_CORD_EXTRAARGS
 #endif
-/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

The CoRD documentation had a few shortcomings, some of which doxygen already warned about, some from general usability, some because the text I added in #16113 was a bit too concise.

### Testing procedure

* Documentation builds without errors (even though some exclude patterns from #16779 were removed)
* All CoRD configuration macros are shown and searchable (for example, CONFIG_CORD_EP used to be shown but could not be found through the search;  CONFIG_CORD_EXTRAARGS was not shown before at all).