### PR TITLE
cpu/cc2538/periph/spi: move assert to spi_acquire

### DIFF
--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -96,6 +96,7 @@ void spi_init_pins(spi_t bus)
 
 void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
+    assert((unsigned)bus < SPI_NUMOF);
     DEBUG("%s: bus=%u\n", __FUNCTION__, bus);
     (void)cs;
     /* lock the bus */
@@ -131,7 +132,6 @@ static uint8_t _trx(cc2538_ssi_t *dev, uint8_t in)
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                         const void *out, void *in, size_t len)
 {
-    assert((unsigned)bus < SPI_NUMOF);
     DEBUG("%s: bus=%u, len=%u\n", __FUNCTION__, bus, (unsigned)len);
 
     const uint8_t *out_buf = out;


### PR DESCRIPTION
### Contribution description

Fixes a copy-paste error introduced in https://github.com/RIOT-OS/RIOT/pull/15902

### Testing procedure

Green Murdock and code review should be sufficient for this.

### Issues/PRs references

See https://github.com/RIOT-OS/RIOT/pull/15902#discussion_r702210076