### PR TITLE
drivers/mtd: Prevent potential heap overflow

### DIFF
--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -36,8 +36,8 @@ extern "C" {
  * @brief   MTD power states
  */
 enum mtd_power_state {
-    MTD_POWER_UP,    /**< Power up */
-    MTD_POWER_DOWN,  /**< Power down */
+    MTD_POWER_UP,       /**< Power up */
+    MTD_POWER_DOWN,     /**< Power down */
 };
 
 /**
@@ -56,12 +56,12 @@ typedef struct mtd_desc mtd_desc_t;
  * @brief   MTD device descriptor
  */
 typedef struct {
-    const mtd_desc_t *driver;  /**< MTD driver */
-    uint32_t sector_count;     /**< Number of sector in the MTD */
-    uint32_t pages_per_sector; /**< Number of pages by sector in the MTD */
-    uint32_t page_size;        /**< Size of the pages in the MTD */
+    const mtd_desc_t *driver;   /**< MTD driver */
+    uint32_t sector_count;      /**< Number of sector in the MTD */
+    uint32_t pages_per_sector;  /**< Number of pages by sector in the MTD */
+    uint32_t page_size;         /**< Size of the pages in the MTD */
 #if defined(MODULE_MTD_WRITE_PAGE) || DOXYGEN
-    void *work_area;           /**< sector-sized buffer */
+    void *work_area;            /**< sector-sized buffer */
 #endif
 } mtd_dev_t;
 

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -258,16 +258,16 @@ int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
  * @param[out] dest     the buffer to fill in
  * @param[in]  page     Page number to start reading from
  * @param[in]  offset   offset from the start of the page (in bytes)
- * @param[in]  size     the number of bytes to read
+ * @param[in]  count    the number of bytes to read
  *
  * @return 0 on success
  * @return < 0 if an error occurred
  * @return -ENODEV if @p mtd is not a valid device
  * @return -ENOTSUP if operation is not supported on @p mtd
- * @return -EOVERFLOW if @p addr or @p count are not valid, i.e. outside memory
+ * @return -EOVERFLOW if @p page or @p count are not valid, i.e. outside memory
  * @return -EIO if I/O error occurred
  */
-int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset, uint32_t size);
+int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset, uint32_t count);
 
 /**
  * @brief   Write data to a MTD device
@@ -306,7 +306,7 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
  * @param[in]  src      the buffer to write
  * @param[in]  page     Page number to start writing to
  * @param[in]  offset   byte offset from the start of the page
- * @param[in]  size     the number of bytes to write
+ * @param[in]  count    the number of bytes to write
  *
  * @return 0 on success
  * @return < 0 if an error occurred
@@ -317,7 +317,7 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
  * @return -EINVAL if parameters are invalid
  */
 int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page,
-                       uint32_t offset, uint32_t size);
+                       uint32_t offset, uint32_t count);
 
 /**
  * @brief   Write data to a MTD device with pagewise addressing
@@ -336,7 +336,7 @@ int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page,
  * @param[in]  src      the buffer to write
  * @param[in]  page     Page number to start writing to
  * @param[in]  offset   byte offset from the start of the page
- * @param[in]  size     the number of bytes to write
+ * @param[in]  count    the number of bytes to write
  *
  * @return 0 on success
  * @return < 0 if an error occurred
@@ -347,7 +347,7 @@ int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page,
  * @return -EINVAL if parameters are invalid
  */
 int mtd_write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
-                   uint32_t offset, uint32_t size);
+                   uint32_t offset, uint32_t count);
 
 /**
  * @brief   Erase sectors of a MTD device
@@ -372,7 +372,7 @@ int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count);
  *
  * @param      mtd    the device to erase
  * @param[in]  sector the first sector number to erase
- * @param[in]  num    the number of sectors to erase
+ * @param[in]  count  the number of sectors to erase
  *
  * @return 0 if erase successful
  * @return < 0 if an error occurred
@@ -381,7 +381,7 @@ int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count);
  * @return -EOVERFLOW if @p addr or @p sector are not valid, i.e. outside memory
  * @return -EIO if I/O error occurred
  */
-int mtd_erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t num);
+int mtd_erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t count);
 
 /**
  * @brief   Set power mode on a MTD device

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -80,7 +80,8 @@ int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset,
         /* TODO: remove when all backends implement read_page */
         if (mtd->driver->read) {
             return mtd->driver->read(mtd, dest, mtd->page_size * page + offset, count);
-        } else {
+        }
+        else {
             return -ENOTSUP;
         }
     }
@@ -94,7 +95,7 @@ int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset,
     const uint32_t page_shift = bitarithm_msb(mtd->page_size);
     const uint32_t page_mask = mtd->page_size - 1;
 
-    page  += offset >> page_shift;
+    page += offset >> page_shift;
     offset = offset & page_mask;
 
     char *_dst = dest;
@@ -112,9 +113,9 @@ int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset,
             break;
         }
 
-        _dst   += read_bytes;
-        page   += (offset + read_bytes) >> page_shift;
-        offset  = (offset + read_bytes) & page_mask;
+        _dst += read_bytes;
+        page += (offset + read_bytes) >> page_shift;
+        offset = (offset + read_bytes) & page_mask;
     }
 
     return 0;
@@ -191,7 +192,8 @@ int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t 
         /* TODO: remove when all backends implement write_page */
         if (mtd->driver->write) {
             return mtd->driver->write(mtd, src, mtd->page_size * page + offset, count);
-        } else {
+        }
+        else {
             return -ENOTSUP;
         }
     }
@@ -205,7 +207,7 @@ int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t 
     const uint32_t page_shift = bitarithm_msb(mtd->page_size);
     const uint32_t page_mask = mtd->page_size - 1;
 
-    page  += offset >> page_shift;
+    page += offset >> page_shift;
     offset = offset & page_mask;
 
     const char *_src = src;
@@ -223,9 +225,9 @@ int mtd_write_page_raw(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t 
             break;
         }
 
-        _src   += written;
-        page   += (offset + written) >> page_shift;
-        offset  = (offset + written) & page_mask;
+        _src += written;
+        page += (offset + written) >> page_shift;
+        offset = (offset + written) & page_mask;
     }
 
     return 0;
@@ -271,7 +273,8 @@ int mtd_erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t count)
             return mtd->driver->erase(mtd,
                                       sector * sector_size,
                                       count * sector_size);
-        } else {
+        }
+        else {
             return -ENOTSUP;
         }
     }

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -155,6 +155,11 @@ int mtd_write_page(mtd_dev_t *mtd, const void *data, uint32_t page,
     const uint32_t sector_page = sector * mtd->pages_per_sector;
     const uint32_t sector_size = mtd->pages_per_sector * mtd->page_size;
 
+    /* prevent heap overflow of work buffer */
+    if (len + (page - sector_page) * mtd->page_size + offset > sector_size) {
+        return -EOVERFLOW;
+    }
+
     /* copy sector to RAM */
     res = mtd_read_page(mtd, work, sector_page, 0, sector_size);
     if (res < 0) {

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -139,14 +139,14 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
 
 #ifdef MODULE_MTD_WRITE_PAGE
 int mtd_write_page(mtd_dev_t *mtd, const void *data, uint32_t page,
-                   uint32_t offset, uint32_t len)
+                   uint32_t offset, uint32_t count)
 {
     if (!mtd || !mtd->driver) {
         return -ENODEV;
     }
 
     if (mtd->work_area == NULL) {
-        return mtd_write_page_raw(mtd, data, page, offset, len);
+        return mtd_write_page_raw(mtd, data, page, offset, count);
     }
 
     int res;
@@ -156,7 +156,7 @@ int mtd_write_page(mtd_dev_t *mtd, const void *data, uint32_t page,
     const uint32_t sector_size = mtd->pages_per_sector * mtd->page_size;
 
     /* prevent heap overflow of work buffer */
-    if (len + (page - sector_page) * mtd->page_size + offset > sector_size) {
+    if (count + (page - sector_page) * mtd->page_size + offset > sector_size) {
         return -EOVERFLOW;
     }
 
@@ -173,7 +173,7 @@ int mtd_write_page(mtd_dev_t *mtd, const void *data, uint32_t page,
     }
 
     /* modify sector in RAM */
-    memcpy(work + (page - sector_page) * mtd->page_size + offset, data, len);
+    memcpy(work + (page - sector_page) * mtd->page_size + offset, data, count);
 
     /* write back modified sector copy */
     return mtd_write_page_raw(mtd, work, sector_page, 0, sector_size);

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "od.h"
 #include "mtd.h"
@@ -437,6 +438,10 @@ static int cmd_test(int argc, char **argv)
     assert(mtd_write_page(dev, test_str_2, page_0, offset, sizeof(test_str_2)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str_2)) == 0);
     assert(memcmp(test_str_2, buffer, sizeof(test_str_2)) == 0);
+
+    /* test error when overflow */
+    assert(mtd_write_page(dev, test_str_2, page_0, 0, dev->pages_per_sector
+                            * dev->page_size + 1) == -EOVERFLOW);
 
     puts("[SUCCESS]");
 

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -80,8 +80,8 @@ static mtd_dev_t *_get_dev(int argc, char **argv)
 static uint64_t _get_size(mtd_dev_t *dev)
 {
     return (uint64_t)dev->sector_count
-         * dev->pages_per_sector
-         * dev->page_size;
+           * dev->pages_per_sector
+           * dev->page_size;
 }
 
 static int cmd_read(int argc, char **argv)
@@ -95,9 +95,10 @@ static int cmd_read(int argc, char **argv)
     }
 
     addr = atoi(argv[2]);
-    len  = atoi(argv[3]);
+    len = atoi(argv[3]);
 
     void *buffer = malloc(len);
+
     if (buffer == NULL) {
         puts("out of memory");
         return -1;
@@ -129,11 +130,12 @@ static int cmd_read_page(int argc, char **argv)
         return -1;
     }
 
-    page   = atoi(argv[2]);
+    page = atoi(argv[2]);
     offset = atoi(argv[3]);
-    len    = atoi(argv[4]);
+    len = atoi(argv[4]);
 
     void *buffer = malloc(len);
+
     if (buffer == NULL) {
         puts("out of memory");
         return -1;
@@ -163,7 +165,7 @@ static int cmd_write(int argc, char **argv)
     }
 
     addr = atoi(argv[2]);
-    len  = strlen(argv[3]);
+    len = strlen(argv[3]);
 
     int res = mtd_write(dev, argv[3], addr, len);
 
@@ -184,9 +186,9 @@ static int cmd_write_page_raw(int argc, char **argv)
         return -1;
     }
 
-    page   = atoi(argv[2]);
+    page = atoi(argv[2]);
     offset = atoi(argv[3]);
-    len    = strlen(argv[4]);
+    len = strlen(argv[4]);
 
     int res = mtd_write_page_raw(dev, argv[4], page, offset, len);
 
@@ -207,9 +209,9 @@ static int cmd_write_page(int argc, char **argv)
         return -1;
     }
 
-    page   = atoi(argv[2]);
+    page = atoi(argv[2]);
     offset = atoi(argv[3]);
-    len    = strlen(argv[4]);
+    len = strlen(argv[4]);
 
     int res = mtd_write_page(dev, argv[4], page, offset, len);
 
@@ -232,7 +234,7 @@ static int cmd_erase(int argc, char **argv)
     }
 
     addr = atoi(argv[2]);
-    len  = atoi(argv[3]);
+    len = atoi(argv[3]);
 
     int res = mtd_erase(dev, addr, len);
 
@@ -276,7 +278,8 @@ static void _print_size(uint64_t size)
     if (size == 0) {
         len = 0;
         unit = "byte";
-    } else if ((size & (GiB(1) - 1)) == 0) {
+    }
+    else if ((size & (GiB(1) - 1)) == 0) {
         len = size / GiB(1);
         unit = "GiB";
     }
@@ -287,7 +290,8 @@ static void _print_size(uint64_t size)
     else if ((size & (KiB(1) - 1)) == 0) {
         len = size / KiB(1);
         unit = "kiB";
-    } else {
+    }
+    else {
         len = size;
         unit = "byte";
     }
@@ -297,9 +301,9 @@ static void _print_size(uint64_t size)
 
 static void _print_info(mtd_dev_t *dev)
 {
-    printf("sectors: %"PRIu32"\n", dev->sector_count);
-    printf("pages per sector: %"PRIu32"\n", dev->pages_per_sector);
-    printf("page size: %"PRIu32"\n", dev->page_size);
+    printf("sectors: %" PRIu32 "\n", dev->sector_count);
+    printf("pages per sector: %" PRIu32 "\n", dev->pages_per_sector);
+    printf("page size: %" PRIu32 "\n", dev->page_size);
     printf("total: ");
     _print_size(_get_size(dev));
     puts("");
@@ -345,9 +349,11 @@ static int cmd_power(int argc, char **argv)
 
     if (strcmp(argv[2], "off") == 0) {
         state = MTD_POWER_DOWN;
-    } else if (strcmp(argv[2], "on") == 0) {
+    }
+    else if (strcmp(argv[2], "on") == 0) {
         state = MTD_POWER_UP;
-    } else {
+    }
+    else {
         return _print_power_usage(argv[0]);
     }
 
@@ -383,7 +389,8 @@ static int cmd_test(int argc, char **argv)
 
     if (argc > 2) {
         sector = atoi(argv[2]);
-    } else {
+    }
+    else {
         sector = dev->sector_count - 2;
     }
 
@@ -415,6 +422,7 @@ static int cmd_test(int argc, char **argv)
     /* write test data & read it back */
     const char test_str[] = "0123456789";
     uint32_t offset = 5;
+
     assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
     assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
@@ -427,13 +435,14 @@ static int cmd_test(int argc, char **argv)
 
     /* write across sector boundary */
     offset = page_size - sizeof(test_str) / 2
-           + (dev->pages_per_sector - 1) * page_size;
+             + (dev->pages_per_sector - 1) * page_size;
     assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
     assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     /* overwrite first test string, rely on MTD for read-modify-write */
     const char test_str_2[] = "Hello World!";
+
     offset = 5;
     assert(mtd_write_page(dev, test_str_2, page_0, offset, sizeof(test_str_2)) == 0);
     assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str_2)) == 0);
@@ -441,7 +450,7 @@ static int cmd_test(int argc, char **argv)
 
     /* test error when overflow */
     assert(mtd_write_page(dev, test_str_2, page_0, 0, dev->pages_per_sector
-                            * dev->page_size + 1) == -EOVERFLOW);
+                          * dev->page_size + 1) == -EOVERFLOW);
 
     puts("[SUCCESS]");
 
@@ -454,7 +463,8 @@ static const shell_command_t shell_commands[] = {
     { "info", "Print properties of the MTD device", cmd_info },
     { "power", "Turn the MTD device on/off", cmd_power },
     { "read", "Read a region of memory on the MTD device", cmd_read },
-    { "read_page", "Read a region of memory on the MTD device (pagewise addressing)", cmd_read_page },
+    { "read_page", "Read a region of memory on the MTD device (pagewise addressing)",
+      cmd_read_page },
     { "write", "Write a region of memory on the MTD device", cmd_write },
     { "write_page_raw",
       "Write a region of memory on the MTD device (pagewise addressing)",
@@ -494,6 +504,7 @@ int main(void)
 
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
+
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a check to `drivers/mtd/mtd.c` to prevent  a heap overflow of the internal work buffer.
Additional it slightly improves the documentation in `mtd.h`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
A test was added to `tests/mtd_raw` to check if the potential heap overflow is handled correctly.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
