### PR TITLE
core/thread: add getters for thread_t

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -508,6 +508,17 @@ static inline thread_status_t thread_get_status(const thread_t *thread)
 }
 
 /**
+ * Get a thread's priority
+ *
+ * @param   thread   thread to work on
+ * @returns priority of thread
+ */
+static inline  uint8_t thread_get_priority(const thread_t *thread)
+{
+    return thread->priority;
+}
+
+/**
  * Returns if a thread is active (currently running or waiting to be scheduled)
  *
  * @param   thread   thread to work on
@@ -525,6 +536,81 @@ static inline bool thread_is_active(const thread_t *thread)
  * @returns ptr to string representation of thread state (or to "unknown")
  */
 const char *thread_state_to_string(thread_status_t state);
+
+/**
+ * Get start address (lowest) of a thread's stack.
+ *
+ * @param   thread thread to work on
+ * @returns current stack pointer, or NULL if not available
+ */
+static inline void *thread_get_stackstart(const thread_t *thread)
+{
+#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
+    || defined(MODULE_MPU_STACK_GUARD)
+    return thread->stack_start;
+#else
+    (void)thread;
+    return NULL;
+#endif
+}
+
+/**
+ * Get stored Stack Pointer of thread.
+ *
+ * *Only provides meaningful value if the thread is not currently running!*.
+ *
+ * @param   thread thread to work on
+ * @returns current stack pointer
+ */
+static inline void *thread_get_sp(const thread_t *thread)
+{
+    return thread->sp;
+}
+
+/**
+ * Get size of a thread's stack.
+ *
+ * @param   thread thread to work on
+ * @returns thread stack size, or 0 if not available
+ */
+static inline size_t thread_get_stacksize(const thread_t *thread)
+{
+#if defined(DEVELHELP)
+    return thread->stack_size;
+#else
+    (void)thread;
+    return 0;
+#endif
+}
+
+/**
+ * Get PID of thread.
+ *
+ * This is a simple getter for thread->pid.
+ *
+ * @param   thread thread to work on
+ * @returns thread pid
+ */
+static inline kernel_pid_t thread_getpid_of(const thread_t *thread)
+{
+    return thread->pid;
+}
+
+/**
+ * Get name of thread.
+ *
+ * @param   thread thread to work on
+ * @returns thread name or NULL if not available
+ */
+static inline const char *thread_get_name(const thread_t *thread)
+{
+#if defined(CONFIG_THREAD_NAMES)
+    return thread->name;
+#else
+    (void)thread;
+    return NULL;
+#endif
+}
 
 #ifdef __cplusplus
 }

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -95,9 +95,9 @@ void ps(void)
             const char *sname = thread_state_to_string(state);              /* get state name */
             const char *queued = thread_is_active(p) ? "Q" : "_";           /* get queued flag */
 #ifdef DEVELHELP
-            int stacksz = p->stack_size;                                    /* get stack size */
+            int stacksz = thread_get_stacksize(p);                          /* get stack size */
             overall_stacksz += stacksz;
-            int stack_free = thread_measure_stack_free(p->stack_start);
+            int stack_free = thread_measure_stack_free(thread_get_stackstart(p));
             stacksz -= stack_free;
             overall_used += stacksz;
 #endif
@@ -115,20 +115,20 @@ void ps(void)
 #endif
                    " | %-8s %.1s | %3i"
 #ifdef DEVELHELP
-                   " | %6i (%5i) (%5i) | %10p | %10p "
+                   " | %6" PRIu32 " (%5i) (%5i) | %10p | %10p "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    " | %2d.%03d%% |  %8u  | %10"PRIu32" "
 #endif
                    "\n",
-                   p->pid,
+                   thread_getpid_of(p),
 #ifdef CONFIG_THREAD_NAMES
-                   p->name,
+                   thread_get_name(p),
 #endif
-                   sname, queued, p->priority
+                   sname, queued, thread_get_priority(p)
 #ifdef DEVELHELP
-                   , p->stack_size, stacksz, stack_free,
-                   (void *)p->stack_start, (void *)p->sp
+                   , (uint32_t)thread_get_stacksize(p), stacksz, stack_free,
+                   thread_get_stackstart(p), thread_get_sp(p)
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    , runtime_major, runtime_minor, switches, xtimer_usec_from_ticks(xtimer_ticks)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR creates some getters for internal thread_t defines as used by ps().
Main reason is "cleanup", I also want to be able to have alternative core implementations.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Binaries should not change.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
