### PR TITLE
pkg/edhoc-c: remove nimble blacklist 

### DIFF
--- a/pkg/edhoc-c/Makefile.dep
+++ b/pkg/edhoc-c/Makefile.dep
@@ -11,9 +11,6 @@ endif
 
 ifneq (,$(filter edhoc-c_crypto_tinycrypt,$(USEMODULE)))
   USEPKG += tinycrypt
-  # Blacklist platforms using nimble, mynewt-nimble has an in-tree copy
-  # of tinycrypt that conflicts with the remote one
-  FEATURES_BLACKLIST += ble_nimble
   USEPKG += c25519
 endif
 

--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-newline-eof
+
 all: Makefile.tinycrypt
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/lib/source/ -f $(CURDIR)/Makefile.tinycrypt -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)


### PR DESCRIPTION
### Contribution description

With https://github.com/RIOT-OS/RIOT/pull/16540 the blacklist can be reverted.

### Testing procedure

A compile test is enough...

```
USEPKG="edhoc-c" USEMODULE="edhoc-c_cbor_nanocbor edhoc-c_crypto_tinycrypt" make -C examples/nimble_gatt/
Building application "nimble_gatt" for "nrf52dk" with MCU "nrf52".

make[1]: Nothing to be done for 'prepare'.
[INFO] updating nanocbor /home/francisco/workspace/RIOT2/build/pkg/nanocbor/.pkg-state.git-downloaded
echo 7728af0633a8d9d119c9b36a5c5a441e11e75ff1 > /home/francisco/workspace/RIOT2/build/pkg/nanocbor/.pkg-state.git-downloaded
[INFO] patch nanocbor
"make" -C /home/francisco/workspace/RIOT2/pkg/c25519
"make" -C /home/francisco/workspace/RIOT2/build/pkg/c25519/src -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=c25519
"make" -C /home/francisco/workspace/RIOT2/pkg/edhoc-c
"make" -C /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src/cbor -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=edhoc-c_cbor_nanocbor SRC=nanocbor.c
"make" -C /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src/crypto -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=edhoc-c_crypto_tinycrypt SRC=tinycrypt.c
"make" -C /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=edhoc-c
"make" -C /home/francisco/workspace/RIOT2/pkg/nanocbor
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nanocbor/src -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nanocbor
"make" -C /home/francisco/workspace/RIOT2/pkg/nimble
"make" -C /home/francisco/workspace/RIOT2/pkg/nimble/autoadv
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/controller/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_controller
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/drivers/nrf52/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_drivers_nrf5x
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/host/src/ -f /home/francisco/workspace/RIOT2/pkg/nimble/nimble.host.mk
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/host/store/ram/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_host_store_ram
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/host/util/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_host_util
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/porting/npl/riot/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_npl_riot
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/porting/nimble/src/ -f /home/francisco/workspace/RIOT2/pkg/nimble/nimble.porting.mk MODULE=nimble_porting_nimble
"make" -C /home/francisco/workspace/RIOT2/pkg/nimble/contrib/
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/host/services/gap/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_svc_gap
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/host/services/gatt/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_svc_gatt
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nimble/nimble/transport/ram/src/ -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nimble_transport_ram
"make" -C /home/francisco/workspace/RIOT2/pkg/tinycrypt
"make" -C /home/francisco/workspace/RIOT2/build/pkg/tinycrypt/lib/source/ -f /home/francisco/workspace/RIOT2/pkg/tinycrypt/Makefile.tinycrypt -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=tinycrypt
"make" -C /home/francisco/workspace/RIOT2/boards/nrf52dk
"make" -C /home/francisco/workspace/RIOT2/boards/common/nrf52xxxdk
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/nrf52/vectors
"make" -C /home/francisco/workspace/RIOT2/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT2/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/auto_init
"make" -C /home/francisco/workspace/RIOT2/sys/event
"make" -C /home/francisco/workspace/RIOT2/sys/frac
"make" -C /home/francisco/workspace/RIOT2/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT2/sys/net/ble/bluetil
"make" -C /home/francisco/workspace/RIOT2/sys/net/ble/bluetil/bluetil_ad
"make" -C /home/francisco/workspace/RIOT2/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT2/sys/sema
"make" -C /home/francisco/workspace/RIOT2/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT2/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  77076	    588	  10712	  88376	  15938	/home/francisco/workspace/RIOT2/examples/nimble_gatt/bin/nrf52dk/nimble_gatt.elf

```

### Issues/PRs references
