### PR TITLE
tests/gnrc_dhcpv6_client: kill potential previous Kea session

### DIFF
--- a/tests/gnrc_dhcpv6_client/dhcpv6_server.sh
+++ b/tests/gnrc_dhcpv6_client/dhcpv6_server.sh
@@ -6,7 +6,7 @@
 # Distributed under terms of the MIT license.
 #
 
-if ! command -v kea-dhcp6; then
+if ! command -v kea-dhcp6 > /dev/null; then
   echo -e "\033[31;1mCommand kea-dhcp6 required\033[0m" >&2
   exit 1
 fi

--- a/tests/gnrc_dhcpv6_client/dhcpv6_server.sh
+++ b/tests/gnrc_dhcpv6_client/dhcpv6_server.sh
@@ -30,6 +30,11 @@ _dhcpv6_server() {
     # only used `mktemp` with dry-run above to get temp directory name, so we
     # still need to create the directory
     mkdir -p "${TMPDIR}"
+
+    if [ -f "${TMPDIR}/kea-dhcp6.kea-dhcp6.pid" ]; then
+        # Kill Kea instance from potential previous run:w
+        kill "$(cat "${TMPDIR}/kea-dhcp6.kea-dhcp6.pid")"
+    fi
     sed "s/\"{{\s*env\.IFACE\s*}}\"/\"${IFACE}\"/" "$2" > "${CONFIG}"
     if ! _kea_version_lesser_1_7_10; then
         # Top-level "Logging" config is not supported by Kea >=1.7.10, so move
@@ -55,5 +60,4 @@ EOF
         kea-dhcp6 -p "$1" -c "$CONFIG" &
 }
 
-# no need to kill from external, kea handles double instances gracefully
 _dhcpv6_server "$1" "$2" &

--- a/tests/gnrc_dhcpv6_client/dhcpv6_server.sh
+++ b/tests/gnrc_dhcpv6_client/dhcpv6_server.sh
@@ -31,6 +31,7 @@ _dhcpv6_server() {
     # still need to create the directory
     mkdir -p "${TMPDIR}"
 
+    echo "Running kea-dhcpv6 in data directory ${TMPDIR}"
     if [ -f "${TMPDIR}/kea-dhcp6.kea-dhcp6.pid" ]; then
         # Kill Kea instance from potential previous run:w
         kill "$(cat "${TMPDIR}/kea-dhcp6.kea-dhcp6.pid")"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Polly needs to die ;-).

![](https://media.giphy.com/media/B8P2DKq8lKbuM/giphy.gif?cid=ecf05e47ke1kts22iti25t7f9lf3tj9zouavbf1g7ynk227i&rid=giphy.gif&ct=g)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Re-issuing `make -C tests/gnrc_dhcpv6_client` multiple times should now restart a new Kea session with the old one being killed (can be seen by a `DHCP6_SHUTDOWN server shutdown` in the output).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up for #16796 and #16797
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
