### PR TITLE
ieee802154/submac: fix leftovers of #16746

### DIFF
--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -153,11 +153,21 @@ static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802
         }
         else {
             ieee802154_radio_read(&submac->dev, NULL, 0, NULL);
+
+            /* If the radio doesn't support RX Continuous, go to RX */
+            if (!ieee802154_radio_has_rx_continuous(&submac->dev)) {
+                _req_set_trx_state_wait_busy(&submac->dev, IEEE802154_TRX_STATE_RX_ON);
+            }
+
             /* Keep on current state */
             return IEEE802154_FSM_STATE_RX;
         }
     case IEEE802154_FSM_EV_CRC_ERROR:
         ieee802154_radio_read(&submac->dev, NULL, 0, NULL);
+        /* If the radio doesn't support RX Continuous, go to RX */
+        if (!ieee802154_radio_has_rx_continuous(&submac->dev)) {
+            _req_set_trx_state_wait_busy(&submac->dev, IEEE802154_TRX_STATE_RX_ON);
+        }
         /* Keep on current state */
         return IEEE802154_FSM_STATE_RX;
 


### PR DESCRIPTION
…y in RX

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
During the re-refactor of #16746 I missed one: if the radio indicates RX_DONE or CRC_FAIL, the SubMAC must manually trigger `request_set_trx_state(RX_ON)` if the SubMAC state is RX.
This PR fixes that.

It also fixes a concurrency issue, where `netdev_ieee802154_submac` in `tests/ieee802154_submac` was running distributed in 2 threads. I synchronize it with mutex.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Ping command is not enough because the SubMAC state goes back and forth between RX and TX.
For testing this one, send several frames to a `nrf52840` using the SubMAC. Without this PR, only the first frame will be received.

Test results for `nrf802154` and `cc2538_rf`:
```
2021-09-07 16:55:36,546 # Trying to register cc2538_rf.
2021-09-07 16:55:36,548 # Success
2021-09-07 16:55:36,552 # Initialization successful - starting the shell now
> print_addr
2021-09-07 16:55:47,794 # print_addr
2021-09-07 16:55:47,795 # ae8dfee1608937c4
> 2021-09-07 16:55:58,809 # 
2021-09-07 16:55:58,810 # DATA
2021-09-07 16:55:58,821 # Dest. PAN: 0x0023, Dest. addr.: ae:8d:fe:e1:60:89:37:c4
2021-09-07 16:55:58,827 # Src. PAN: 0x0023, Src. addr.: de:82:3e:96:37:07:21:33
2021-09-07 16:55:58,844 # Security: 0, Frame pend.: 0, ACK req.: 1, PAN comp.: 1
2021-09-07 16:55:58,845 # Version: 1, Seq.: 1
2021-09-07 16:55:58,850 # 00000000  4C  6F  72  65  6D  20  69  70  73  75  6D  20  64  6F  6C  6F
2021-09-07 16:55:58,853 # 00000010  72  20  73  69  74  20  61  6D  65  74  2C  20  63  6F  6E  73
2021-09-07 16:55:58,865 # 00000020  65  63  74  65  74  75  72  20  61  64  69  70  69  73  63  69
2021-09-07 16:55:58,867 # 00000030  6E  67  20  65  6C  69  74  2E  20  45  74  69  61  6D  20  6F
2021-09-07 16:55:58,869 # 00000040  72  6E  61  72  65  20  6C  61  63  69  6E  69  61  20  6D  69
2021-09-07 16:55:58,870 # 00000050  20  65  6C  65  6D  65  6E  74  75  6D  20  69  6E  74  65  72
2021-09-07 16:55:58,871 # 00000060  64  75  6D  20
2021-09-07 16:55:58,880 # txt: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ornare lacin
2021-09-07 16:55:58,881 #      ia mi elementum interdum 
2021-09-07 16:55:58,881 # RSSI: -46, LQI: 238
2021-09-07 16:55:58,881 # 
txtsnd de823e9637072133 10
2021-09-07 16:58:12,993 # txtsnd de823e9637072133 10
2021-09-07 16:58:12,998 # Tx complete
> txtsnd de823e9637072133 10
2021-09-07 16:58:13,633 # txtsnd de823e9637072133 10
2021-09-07 16:58:13,638 # Tx complete
```

```
print_addr
2021-09-07 16:55:37,511 # print_addr
2021-09-07 16:55:37,513 # de823e9637072133
txtsnd de823e9637072133 10
2021-09-07 16:55:39,063 # txtsnd de823e9637072133 10
2021-09-07 16:55:39,090 # No ACK
ae8dfee1608937c4
2021-09-07 16:55:53,047 # ae8dfee1608937c4
2021-09-07 16:55:53,051 # shell: command not found: ae8dfee1608937c4
txtsnd ae8dfee1608937c4 100
2021-09-07 16:55:58,803 # txtsnd ae8dfee1608937c4 100
2021-09-07 16:55:58,810 # Tx complete
> print_addr
2021-09-07 16:58:05,133 # print_addr
2021-09-07 16:58:05,134 # de823e9637072133
> 2021-09-07 16:58:12,997 # 
2021-09-07 16:58:12,998 # DATA
2021-09-07 16:58:13,003 # Dest. PAN: 0x0023, Dest. addr.: de:82:3e:96:37:07:21:33
2021-09-07 16:58:13,008 # Src. PAN: 0x0023, Src. addr.: ae:8d:fe:e1:60:89:37:c4
2021-09-07 16:58:13,012 # Security: 0, Frame pend.: 0, ACK req.: 1, PAN comp.: 1
2021-09-07 16:58:13,015 # Version: 1, Seq.: 0
2021-09-07 16:58:13,018 # 00000000  4C  6F  72  65  6D  20  69  70  73  75
2021-09-07 16:58:13,019 # txt: Lorem ipsu
2021-09-07 16:58:13,022 # RSSI: -168, LQI: 196
2021-09-07 16:58:13,022 # 
2021-09-07 16:58:13,637 # 
2021-09-07 16:58:13,638 # DATA
2021-09-07 16:58:13,643 # Dest. PAN: 0x0023, Dest. addr.: de:82:3e:96:37:07:21:33
2021-09-07 16:58:13,647 # Src. PAN: 0x0023, Src. addr.: ae:8d:fe:e1:60:89:37:c4
2021-09-07 16:58:13,652 # Security: 0, Frame pend.: 0, ACK req.: 1, PAN comp.: 1
2021-09-07 16:58:13,654 # Version: 1, Seq.: 1
2021-09-07 16:58:13,658 # 00000000  4C  6F  72  65  6D  20  69  70  73  75
2021-09-07 16:58:13,660 # txt: Lorem ipsu
2021-09-07 16:58:13,661 # RSSI: -168, LQI: 196
2021-09-07 16:58:13,662 # 
2021-09-07 17:00:32,898 # main(): This is RIOT! (Version: 2021.10-devel-585-g201c2e-pr/submac/fix_rx_continuous)
2021-09-07 17:00:32,901 # Trying to register nrf52840.
2021-09-07 17:00:32,902 # Success
2021-09-07 17:00:32,907 # Initialization successful - starting the shell now
> 
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#16746
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
