### PR TITLE
tests/ieee802154_submac: remove netdev dependency

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -189,6 +189,7 @@ endif
 
 ifneq (,$(filter ieee802154_submac,$(USEMODULE)))
   USEMODULE += xtimer
+  USEMODULE += random
 endif
 
 ifneq (,$(filter l2util,$(USEMODULE)))

--- a/tests/ieee802154_submac/Makefile
+++ b/tests/ieee802154_submac/Makefile
@@ -18,11 +18,18 @@ BOARD_WHITELIST :=  \
 					#
 USEMODULE += od
 USEMODULE += shell
+USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += event_thread_highest
-USEMODULE += netdev_ieee802154_submac
+USEMODULE += event_thread
 USEMODULE += netdev_default
+USEMODULE += luid
+USEMODULE += l2util
+USEMODULE += eui_provider
+USEMODULE += ieee802154
+USEMODULE += ieee802154_submac
+USEMODULE += ztimer_usec
 
-CFLAGS += -DEVENT_THREAD_HIGHEST_STACKSIZE=1024
+CFLAGS += -DEVENT_THREAD_MEDIUM_STACKSIZE=1024
 
 include $(RIOTBASE)/Makefile.include
+include $(RIOTMAKE)/default-radio-settings.inc.mk

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -37,8 +37,6 @@
 
 #define MAX_LINE    (80)
 
-/* Only the first radio is supported so far */
-#define RADIO_DEFAULT_ID (0U)
 
 netdev_ieee802154_submac_t netdev_submac;
 mutex_t lock;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR removes the netdev dependency from `tests/ieee802154_submac`. From now on, there's no dependency to `netdev` from the submac. 

I also cleaned the code a bit and replaced xtimer by ztimer.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Sending and receiving frames with `tests/ieee802154_submac` should work. Here are my tests results:

```
2021-09-08 17:52:20,032 # txt: Lorem ipsu
2021-09-08 17:52:20,034 # RSSI: 134, LQI: 164
2021-09-08 17:52:20,035 # 
2021-09-08 17:52:20,151 # 
2021-09-08 17:52:20,152 # DATA
2021-09-08 17:52:20,157 # Dest. PAN: 0x0023, Dest. addr.: de:82:3e:96:37:07:21:33
2021-09-08 17:52:20,162 # Src. PAN: 0x0023, Src. addr.: ae:8d:fe:e1:60:89:37:c4
2021-09-08 17:52:20,167 # Security: 0, Frame pend.: 0, ACK req.: 1, PAN comp.: 1
2021-09-08 17:52:20,168 # Version: 1, Seq.: 7
2021-09-08 17:52:20,173 # 00000000  4C  6F  72  65  6D  20  69  70  73  75
2021-09-08 17:52:20,174 # txt: Lorem ipsu
2021-09-08 17:52:20,175 # RSSI: 134, LQI: 164
2021-09-08 17:52:20,176 # 
txtsnd ae8dfee1608937c4 1
2021-09-08 17:52:21,606 # txtsnd ae8dfee1608937c4 1
> 2021-09-08 17:52:21,611 # Tx complete
2021-09-08 17:52:21,789 # txtsnd ae8dfee1608937c4 1
> 2021-09-08 17:52:21,793 # Tx complete
2021-09-08 17:52:21,959 # txtsnd ae8dfee1608937c4 1
> 2021-09-08 17:52:21,962 # Tx complete
2021-09-08 17:52:22,111 # txtsnd ae8dfee1608937c4 1
> 2021-09-08 17:52:22,116 # Tx complete
2021-09-08 17:52:22,261 # txtsnd ae8dfee1608937c4 1
> 2021-09-08 17:52:22,264 # Tx complete
2021-09-08 17:52:22,402 # txtsnd ae8dfee1608937c4 1
> 2021-09-08 17:52:22,405 # Tx complete
txtsnd ae8dfee1608937c4 104
2021-09-08 17:52:24,606 # txtsnd ae8dfee1608937c4 104
> 2021-09-08 17:52:24,614 # Tx complete
txtsnd ae8dfee1608937c4 105
2021-09-08 17:52:25,530 # txtsnd ae8dfee1608937c4 105
> 2021-09-08 17:52:25,570 # No ACK
txtsnd ae8dfee1608937c4 104
2021-09-08 17:52:26,882 # txtsnd ae8dfee1608937c4 104
> 2021-09-08 17:52:26,889 # Tx complete
txtsnd ae8dfee1608937c4 104
2021-09-08 17:52:27,492 # txtsnd ae8dfee1608937c4 104
> 2021-09-08 17:52:27,500 # Tx complete
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
