### PR TITLE
CoAP: add remote and local endpoint data to coap_pkt_t

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -59,8 +59,7 @@ static char proxy_uri[64];
 
 static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context);
-static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
-                          const sock_udp_ep_t *remote);
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
@@ -113,11 +112,8 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
 /*
  * Response callback.
  */
-static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
-                          const sock_udp_ep_t *remote)
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu)
 {
-    (void)remote;       /* not interested in the source currently */
-
     if (memo->state == GCOAP_MEMO_TIMEOUT) {
         printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
         return;
@@ -185,7 +181,7 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
             }
 
             int len = coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
-            gcoap_req_send((uint8_t *)pdu->hdr, len, remote,
+            gcoap_req_send((uint8_t *)pdu->hdr, len, pdu->remote,
                            _resp_handler, memo->context);
         }
         else {

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -27,6 +27,7 @@
 #include "net/utils.h"
 #include "od.h"
 #include "fmt.h"
+#include "net/sock/util.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -114,6 +115,17 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
  */
 static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu)
 {
+    if (IS_ACTIVE(ENABLE_DEBUG)) {
+        char saddr[IPV6_ADDR_MAX_STR_LEN + 6];
+        uint16_t port;
+        sock_udp_ep_fmt(pdu->remote, saddr, &port);
+        printf("remote [%s]:%u\n", saddr, port);
+        if (pdu->local) {
+            sock_udp_ep_fmt(pdu->local, saddr, &port);
+            printf("local [%s]:%u\n", saddr, port);
+        }
+    }
+
     if (memo->state == GCOAP_MEMO_TIMEOUT) {
         printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
         return;
@@ -202,6 +214,17 @@ static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *c
 {
     (void)ctx;
 
+    if (IS_ACTIVE(ENABLE_DEBUG)) {
+        char saddr[IPV6_ADDR_MAX_STR_LEN + 6];
+        uint16_t port;
+        sock_udp_ep_fmt(pdu->remote, saddr, &port);
+        printf("remote [%s]:%u\n", saddr, port);
+        if (pdu->local) {
+            sock_udp_ep_fmt(pdu->local, saddr, &port);
+            printf("local [%s]:%u\n", saddr, port);
+        }
+    }
+
     /* read coap method type in packet */
     unsigned method_flag = coap_method2flag(coap_get_code_detail(pdu));
 
@@ -235,6 +258,18 @@ static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *c
 static ssize_t _riot_board_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
 {
     (void)ctx;
+
+    if (IS_ACTIVE(ENABLE_DEBUG)) {
+        char saddr[IPV6_ADDR_MAX_STR_LEN + 6];
+        uint16_t port;
+        sock_udp_ep_fmt(pdu->remote, saddr, &port);
+        printf("remote [%s]:%u\n", saddr, port);
+        if (pdu->local) {
+            sock_udp_ep_fmt(pdu->local, saddr, &port);
+            printf("local [%s]:%u\n", saddr, port);
+        }
+    }
+
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     coap_opt_add_format(pdu, COAP_FORMAT_TEXT);
     size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -737,8 +737,7 @@ typedef struct gcoap_request_memo gcoap_request_memo_t;
  * If request timed out, the packet header is for the request.
  */
 typedef void (*gcoap_resp_handler_t)(const gcoap_request_memo_t *memo,
-                                     coap_pkt_t* pdu,
-                                     const sock_udp_ep_t *remote);
+                                     coap_pkt_t* pdu);
 
 /**
  * @brief  Extends request memo for resending a confirmable request.

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -180,6 +180,13 @@ typedef struct {
 } coap_optpos_t;
 
 /**
+ * @brief This is a workaround until RIOT
+ *        gets an abstraction of CoAP endpoints
+ *        to support CoAP not only over UDP
+ */
+typedef void coap_ep_t;
+
+/**
  * @brief   CoAP PDU parsing context structure
  */
 typedef struct {
@@ -192,6 +199,8 @@ typedef struct {
 #ifdef MODULE_GCOAP
     uint32_t observe_value;                           /**< observe value           */
 #endif
+    const coap_ep_t *remote;                          /**< remote endpoint */
+    const coap_ep_t *local;                           /**< local endpoint, NULL if unknown */
 } coap_pkt_t;
 
 /**

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -352,6 +352,79 @@ typedef struct {
     sock_aux_flags_t flags; /**< Flags used request information */
 } sock_udp_aux_tx_t;
 
+
+/**
+ * @brief   Access local UDP endpoint information
+ *
+ * @param[in] aux_rx    Received UDP auxiliary data
+ *
+ * @return  Pointer to local UDP endpoint information
+ * @return  NULL if no information is available
+ */
+static inline sock_udp_ep_t *sock_udp_aux_rx_local(sock_udp_aux_rx_t *aux_rx)
+{
+#if defined(MODULE_SOCK_AUX_LOCAL)
+    return &aux_rx->local;
+#else
+    (void)aux_rx;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief   Access auxiliary timestamp of a received datagram
+ *
+ * @param[in] aux_rx    Received UDP auxiliary data
+ *
+ * @return  Pointer to auxiliary timestamp
+ * @return  NULL if no information is available
+ */
+static inline uint64_t *sock_udp_aux_rx_timestamp(sock_udp_aux_rx_t *aux_rx)
+{
+#if defined(MODULE_SOCK_AUX_TIMESTAMP)
+    return &aux_rx->timestamp;
+#else
+    (void)aux_rx;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief   Access auxiliary RSSI of a received datagram
+ *
+ * @param[in] aux_rx    Received UDP auxiliary data
+ *
+ * @return  Pointer to auxiliary RSSI value
+ * @return  NULL if no information is available
+ */
+static inline int16_t *sock_udp_aux_rx_rss(sock_udp_aux_rx_t *aux_rx)
+{
+#if defined(MODULE_SOCK_AUX_RSSI)
+    return &aux_rx->rssi;
+#else
+    (void)aux_rx;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief   Access auxiliary timestamp of a transmitted datagram
+ *
+ * @param[in] aux_tx    Auxiliary data of transmitted UDP datagram
+ *
+ * @return  Pointer to auxiliary timestamp
+ * @return  NULL if no information is available
+ */
+static inline uint64_t *sock_udp_aux_tx_timestamp(sock_udp_aux_tx_t *aux_tx)
+{
+#if defined(MODULE_SOCK_AUX_TIMESTAMP)
+    return &aux_tx->timestamp;
+#else
+    (void)aux_tx;
+    return NULL;
+#endif
+}
+
 /**
  * @brief   Creates a new UDP sock object
  *

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -81,8 +81,7 @@ static int _sync(void)
     }
 }
 
-static void _on_register(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
-                         const sock_udp_ep_t *remote)
+static void _on_register(const gcoap_request_memo_t *memo, coap_pkt_t* pdu)
 {
     thread_flags_t flag = FLAG_ERR;
 
@@ -91,7 +90,7 @@ static void _on_register(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
         /* read the location header and save the RD details on success */
         if (coap_get_location_path(pdu, (uint8_t *)_rd_loc,
                                    sizeof(_rd_loc)) > 0) {
-            memcpy(&_rd_remote, remote, sizeof(_rd_remote));
+            memcpy(&_rd_remote, pdu->remote, sizeof(_rd_remote));
             flag = FLAG_SUCCESS;
         }
         else {
@@ -120,17 +119,13 @@ static void _on_update_remove(unsigned req_state, coap_pkt_t *pdu, uint8_t code)
     thread_flags_set(_waiter, flag);
 }
 
-static void _on_update(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote)
+static void _on_update(const gcoap_request_memo_t *memo, coap_pkt_t *pdu)
 {
-    (void)remote;
     _on_update_remove(memo->state, pdu, COAP_CODE_CHANGED);
 }
 
-static void _on_remove(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
-                       const sock_udp_ep_t *remote)
+static void _on_remove(const gcoap_request_memo_t *memo, coap_pkt_t *pdu)
 {
-    (void)remote;
     _on_update_remove(memo->state, pdu, COAP_CODE_DELETED);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This is an alternative attempt to expose local and remote IP addresses and ports  to the `CoAP` request/response handlers. The `CoAP` PDU now contains pointers to local and remote endpoint data.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`examples/gcoap`:

```
> coap get fe80::4c49:6fff:fe54:5c%6 5683 /.well-known/core
2021-09-09 09:42:24,179 # gcoap_cli: sending msg ID 10865, 23 bytes
2021-09-09 09:42:24,183 # gcoap_remote [fe80::4c49:6fff:fe54:5c%6]:5683
2021-09-09 09:42:24,186 # local [fe80::4c49:6fff:fe54:66]:5683
2021-09-09 09:42:24,190 # gcoap: response Success, code 2.05, 46 bytes
2021-09-09 09:42:24,194 # </cli/stats>;ct=0;rt="count";obs,</riot/board>

> coap get fe80::4c49:6fff:fe54:66%6 5683 /.well-known/core
2021-09-09 09:42:25,593 # gcoap_cli: sending msg ID 35428, 23 bytes
2021-09-09 09:42:25,597 # gcoap_remote [fe80::4c49:6fff:fe54:66%6]:5683
2021-09-09 09:42:25,601 # local [fe80::4c49:6fff:fe54:5c]:5683
2021-09-09 09:42:25,605 # gcoap: response Success, code 2.05, 46 bytes
2021-09-09 09:42:25,609 # </cli/stats>;ct=0;rt="count";obs,</riot/board>

```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Replaces #16429
Trying to solve #15686
