### PR TITLE
boards/samd21-xpro:  Add peripheral usbdev to samd21-xpro

### DIFF
--- a/boards/samd21-xpro/Kconfig
+++ b/boards/samd21-xpro/Kconfig
@@ -20,3 +20,4 @@ config BOARD_SAMD21_XPRO
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -11,3 +11,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -361,6 +361,20 @@ static const adc_conf_chan_t adc_channels[] = {
 #define DAC_VREF            DAC_CTRLB_REFSEL_AVCC
 /** @} */
 
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+/** @} */
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

This changes  adds usbdev support to the SAMD21-XPRO board. 
The GPIO configuration for the usb is exactly the same as in the SAMR21-XPRO.
```txt
USB D-  = GPIO_PIN(PA, 24)
USB D+  = GPIO_PIN(PA, 25)
``` 

### Testing procedure

Go to `examples/usbus_minimal` and type:

```sh
make BOARD=samd21-xpro USB_VID=03eb USB_PID=2169 flash
```

Connect the  port; `USB TARGET` to the computer and type `lsusb`, a device should appear such that::

```sh
Bus 003 Device 037: ID 03eb:2169 Atmel Corp. USB device
```




