### PR TITLE
pkg/nimble/netif: migrate to use errno return values

### DIFF
--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -78,7 +78,7 @@ static void _on_state_change(struct ble_npl_event *ev)
         nimble_scanner_stop();
         /* start advertising/accepting */
         int res = nimble_netif_accept(_ad.buf, _ad.pos, &_adv_params);
-        assert((res == NIMBLE_NETIF_OK) || (res == NIMBLE_NETIF_NOMEM));
+        assert((res == 0) || (res == -ENOMEM));
         (void)res;
 
         /* schedule next state change */

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -67,6 +67,7 @@
 #define NIMBLE_NETIF_H
 
 #include <stdint.h>
+#include <errno.h>
 
 #include "net/ble.h"
 
@@ -132,19 +133,6 @@ extern "C" {
  * @brief   Minimum spacing of connection interval when using randomized
  *          intervals, in multiples of 1.25ms
  */
-
-/**
- * @brief   Return codes used by the NimBLE netif module
- */
-enum {
-    NIMBLE_NETIF_OK         =  0,   /**< everything went fine */
-    NIMBLE_NETIF_NOTCONN    = -1,   /**< not connected */
-    NIMBLE_NETIF_DEVERR     = -2,   /**< internal BLE stack error */
-    NIMBLE_NETIF_BUSY       = -3,   /**< network device is busy */
-    NIMBLE_NETIF_NOMEM      = -4,   /**< insufficient memory */
-    NIMBLE_NETIF_NOTADV     = -5,   /**< not advertising */
-    NIMBLE_NETIF_NOTFOUND   = -6,   /**< no fitting entry found */
-};
 
 /**
  * @brief   Event types triggered by the NimBLE netif module
@@ -219,10 +207,10 @@ void nimble_netif_eventcb(nimble_netif_eventcb_t cb);
  * @param[in] timeout       connect timeout [in ms]
  *
  * @return  the used connection handle on success
- * @return  NIMBLE_NETIF_BUSY if already connected to the given address or if
+ * @return  -EBUSY if already connected to the given address or if
  *          a connection setup procedure is in progress
- * @return  NIMBLE_NETIF_NOMEM if no connection context memory is available
- * @return  NIMBLE_NETIF_NOTFOUND if unable to find valid connection interval
+ * @return  -ENOMEM if no connection context memory is available
+ * @return  -ECANCELED if unable to find valid connection interval
  */
 int nimble_netif_connect(const ble_addr_t *addr,
                          struct ble_gap_conn_params *conn_params,
@@ -233,9 +221,9 @@ int nimble_netif_connect(const ble_addr_t *addr,
  *
  * @param[in] handle        handle for the connection to be closed
  *
- * @return  NIMBLE_NETIF_OK on success
- * @return  NIMBLE_NETIF_NOTFOUND if the handle is invalid
- * @return  NIMBLE_NETIF_NOTCONN if context for given handle is not connected
+ * @return  0 on success
+ * @return  -EINVAL if the handle is invalid
+ * @return  -ENOTCONN if context for given handle is not connected
  */
 int nimble_netif_close(int handle);
 
@@ -246,9 +234,9 @@ int nimble_netif_close(int handle);
  * @param[in] ad_len        length of @p ad in bytes
  * @param[in] adv_params    advertising (timing) parameters to use
  *
- * @return  NIMBLE_NETIF_OK on success
- * @return  NIMBLE_NETIF_BUSY if already advertising
- * @return  NIMBLE_NETIF_NOMEM on insufficient connection memory
+ * @return  0 on success
+ * @return  -EALREADY if already advertising
+ * @return  -ENOMEM on insufficient connection memory
  */
 int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
                         const struct ble_gap_adv_params *adv_params);
@@ -262,9 +250,9 @@ int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
  *                          BLE_HS_FOREVER to disable timeout
  * @param[in] adv_params    advertising (timing) parameters to use
  *
- * @return  NIMBLE_NETIF_OK on success
- * @return  NIMBLE_NETIF_BUSY if already advertising
- * @return  NIMBLE_NETIF_NOMEM on insufficient connection memory
+ * @return  0 on success
+ * @return  -EALREADY if already advertising
+ * @return  -ENOMEM on insufficient connection memory
  */
 int nimble_netif_accept_direct(const ble_addr_t *addr, uint32_t timeout_ms,
                                const struct ble_gap_adv_params *adv_params);
@@ -272,8 +260,8 @@ int nimble_netif_accept_direct(const ble_addr_t *addr, uint32_t timeout_ms,
 /**
  * @brief   Stop accepting incoming connections (stop advertising)
  * *
- * @return  NIMBLE_NETIF_OK on success
- * @return  NIMBLE_NETIF_NOTADV if not currently advertising
+ * @return  0 on success
+ * @return  -EALREADY if not currently advertising
  */
 int nimble_netif_accept_stop(void);
 
@@ -283,9 +271,9 @@ int nimble_netif_accept_stop(void);
  * @param[in] handle        connection handle
  * @param[in] conn_params   new connection parameters to apply
  *
- * @return  NIMBLE_NETIF_OK on success
- * @return  NIMBLE_NETIF_NOTCONN if handle does not point to a connection
- * @return  NIMBLE_NETIF_DEVERR if applying the given parameters failed
+ * @return  0 on success
+ * @return  -ENOTCONN if handle does not point to a connection
+ * @return  -ECANCELED if applying the given parameters failed
  */
 int nimble_netif_update(int handle,
                         const struct ble_gap_upd_params *conn_params);
@@ -299,9 +287,9 @@ int nimble_netif_update(int handle,
  *                          map[1] chan 8-15, ..., map[5] channels 33 to 36.
  *                          **must** be able to hold 5 bytes.
  *
- * @return  NIMBLE_NETIF_OK on success
- * @return  NIMBLE_NETIF_NOTCONN if handle dos not point to a connection
- * @return  NIMBLE_NETIF_DEVERR if reading the channel map failed otherwise
+ * @return  0 on success
+ * @return  -ENOTCONN if handle dos not point to a connection
+ * @return  -ECANCELED if reading the channel map failed otherwise
  */
 int nimble_netif_used_chanmap(int handle, uint8_t map[5]);
 

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -130,11 +130,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Minimum spacing of connection interval when using randomized
- *          intervals, in multiples of 1.25ms
- */
-
-/**
  * @brief   Event types triggered by the NimBLE netif module
  */
 typedef enum {

--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -167,7 +167,8 @@ int nimble_netif_conn_start_connection(const uint8_t *addr);
  *          connection
  *
  * @return  handle of the reserved context
- * @return  NIMBLE_NETIF_CONN_INVALID if no unused context was available
+ * @return  -EALREADY if already advertising
+ * @return  -ENOMEM if no memory slot is available
  */
 int nimble_netif_conn_start_adv(void);
 

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -582,13 +582,13 @@ int nimble_netif_connect(const ble_addr_t *addr,
     /* check that there is no open connection with the given address */
     if (nimble_netif_conn_connected(addrn) ||
         nimble_netif_conn_connecting()) {
-        return NIMBLE_NETIF_BUSY;
+        return -EBUSY;
     }
 
     /* get empty connection context */
     int handle = nimble_netif_conn_start_connection(addrn);
     if (handle == NIMBLE_NETIF_CONN_INVALID) {
-        return NIMBLE_NETIF_NOMEM;
+        return -ENOMEM;
     }
 
     if ((conn_params != NULL)
@@ -600,7 +600,7 @@ int nimble_netif_connect(const ble_addr_t *addr,
 
         uint16_t itvl = nimble_netif_conn_gen_itvl(itvl_min, itvl_max);
         if (itvl == 0) {
-            return NIMBLE_NETIF_NOTFOUND;
+            return -ECANCELED;
         }
         conn_params->itvl_min = itvl;
         conn_params->itvl_max = itvl;
@@ -625,10 +625,10 @@ int nimble_netif_close(int handle)
 {
     nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
     if (conn == NULL) {
-        return NIMBLE_NETIF_NOTFOUND;
+        return -EINVAL;
     }
     else if (!(conn->state & NIMBLE_NETIF_L2CAP_CONNECTED)) {
-        return NIMBLE_NETIF_NOTCONN;
+        return -ENOTCONN;
     }
 
     int res = ble_gap_terminate(ble_l2cap_get_conn_handle(conn->coc),
@@ -636,7 +636,7 @@ int nimble_netif_close(int handle)
     assert(res == 0);
     (void)res;
 
-    return NIMBLE_NETIF_OK;
+    return 0;
 }
 
 static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
@@ -673,7 +673,7 @@ static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
 
     _notify(handle, NIMBLE_NETIF_ACCEPTING, _netif.l2addr);
 
-    return NIMBLE_NETIF_OK;
+    return 0;
 }
 
 int nimble_netif_accept(const uint8_t *ad, size_t ad_len,
@@ -694,7 +694,7 @@ int nimble_netif_accept_stop(void)
 {
     int handle = nimble_netif_conn_get_adv();
     if (handle == NIMBLE_NETIF_CONN_INVALID) {
-        return NIMBLE_NETIF_NOTADV;
+        return -EALREADY;
     }
 
     int res = ble_gap_adv_stop();
@@ -703,7 +703,7 @@ int nimble_netif_accept_stop(void)
     nimble_netif_conn_free(handle, NULL);
     _notify(handle, NIMBLE_NETIF_ACCEPT_STOP, _netif.l2addr);
 
-    return NIMBLE_NETIF_OK;
+    return 0;
 }
 
 int nimble_netif_update(int handle,
@@ -711,28 +711,28 @@ int nimble_netif_update(int handle,
 {
     nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
     if (conn == NULL) {
-        return NIMBLE_NETIF_NOTCONN;
+        return -ENOTCONN;
     }
 
     int res = ble_gap_update_params(conn->gaphandle, conn_params);
     if (res != 0) {
-        return NIMBLE_NETIF_DEVERR;
+        return -ECANCELED;
     }
 
-    return NIMBLE_NETIF_OK;
+    return 0;
 }
 
 int nimble_netif_used_chanmap(int handle, uint8_t map[5])
 {
     nimble_netif_conn_t *conn = nimble_netif_conn_get(handle);
     if (conn == NULL) {
-        return NIMBLE_NETIF_NOTCONN;
+        return -ENOTCONN;
     }
 
     int res = ble_hs_hci_read_chan_map(conn->gaphandle, map);
     if (res != 0) {
-        return NIMBLE_NETIF_DEVERR;
+        return -ECANCELED;
     }
 
-    return NIMBLE_NETIF_OK;
+    return 0;
 }

--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -142,7 +142,7 @@ int nimble_netif_conn_start_adv(void)
     mutex_lock(&_lock);
     handle = _find_by_state(NIMBLE_NETIF_ADV);
     if (handle != NIMBLE_NETIF_CONN_INVALID) {
-        handle = NIMBLE_NETIF_BUSY;
+        handle = -EALREADY;
     }
     else {
         handle = _find_by_state(NIMBLE_NETIF_UNUSED);
@@ -150,7 +150,7 @@ int nimble_netif_conn_start_adv(void)
             _conn[handle].state = NIMBLE_NETIF_ADV;
         }
         else {
-            handle = NIMBLE_NETIF_NOMEM;
+            handle = -ENOMEM;
         }
 
     }

--- a/pkg/nimble/rpble/nimble_rpble.c
+++ b/pkg/nimble/rpble/nimble_rpble.c
@@ -108,7 +108,7 @@ static void _children_accept(void)
 
     /* start advertising this node */
     res = nimble_netif_accept(ad.buf, ad.pos, &_adv_params);
-    assert(res == NIMBLE_NETIF_OK);
+    assert(res == 0);
 }
 
 static void _on_scan_evt(uint8_t type,

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -233,7 +233,7 @@ static void _cmd_adv(const char *name)
 
     /* start listening for incoming connections */
     res = nimble_netif_accept(ad.buf, ad.pos, &_adv_params);
-    if (res != NIMBLE_NETIF_OK) {
+    if (res != 0) {
         printf("err: unable to start advertising (%i)\n", res);
     }
     else {
@@ -271,7 +271,7 @@ static void _cmd_adv_direct(const char *addr_str)
 
     /* start advertising directed advertising with the given BLE address */
     res = nimble_netif_accept_direct(&addr, BLE_HS_FOREVER, &_adv_params);
-    if (res != NIMBLE_NETIF_OK) {
+    if (res != 0) {
         printf("err: unable to start directed advertising (%i)\n", res);
     }
     else {
@@ -282,10 +282,10 @@ static void _cmd_adv_direct(const char *addr_str)
 static void _cmd_adv_stop(void)
 {
     int res = nimble_netif_accept_stop();
-    if (res == NIMBLE_NETIF_OK) {
+    if (res == 0) {
         puts("canceled advertising");
     }
-    else if (res == NIMBLE_NETIF_NOTADV) {
+    else {
         puts("no advertising in progress");
     }
 }
@@ -371,7 +371,7 @@ static void _cmd_connect_scanlist(unsigned pos)
 static void _cmd_close(int handle)
 {
     int res = nimble_netif_close(handle);
-    if (res != NIMBLE_NETIF_OK) {
+    if (res != 0) {
         puts("err: unable to close connection with given handle");
     }
     else {
@@ -390,7 +390,7 @@ static void _cmd_update(int handle, int itvl, int timeout)
     params.max_ce_len = BLE_GAP_INITIAL_CONN_MAX_CE_LEN;
 
     int res = nimble_netif_update(handle, &params);
-    if (res != NIMBLE_NETIF_OK) {
+    if (res != 0) {
         puts("err: unable to update connection parameters for given handle");
     }
     else {


### PR DESCRIPTION
### Contribution description
Took me some time but at some point even I started to understand the value of using `errno` values for functions :-)

This PR adapts `nimble_netif` to do just so, its pretty much a plain replacement of custom values with fitting `errno` values, so this change should be straight forward.

### Testing procedure
Build test and a manual code review should be sufficient in this case

### Issues/PRs references
none