### PR TITLE
nimble/scanner: migrate to errno return values

### DIFF
--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -22,6 +22,7 @@
 #define NIMBLE_SCANNER_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "host/ble_hs.h"
 
@@ -82,10 +83,13 @@ void nimble_scanner_stop(void);
 /**
  * @brief   Get the current scanning status
  *
- * @return  NIMBLE_SCANNER_SCANNING if currently scanning
- * @return  NIMBLE_SCANNER_STOPPED if the scanner is stopped
+ * @return  true if currently scanning
+ * @return  false if the scanner is stopped
  */
-int nimble_scanner_status(void);
+static inline bool nimble_scanner_is_active(void)
+{
+    return ble_gap_disc_active();
+}
 
 /**
  * @brief   Set the duration for the scanning procedure.

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -21,6 +21,7 @@
 #ifndef NIMBLE_SCANNER_H
 #define NIMBLE_SCANNER_H
 
+#include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -29,16 +30,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief   Return values used by this submodule
- */
-enum {
-    NIMBLE_SCANNER_OK       =  0,
-    NIMBLE_SCANNER_SCANNING =  1,
-    NIMBLE_SCANNER_STOPPED  =  2,
-    NIMBLE_SCANNER_ERR      = -1,
-};
 
 /**
  * @brief   Callback signature triggered by this module for each discovered
@@ -61,8 +52,7 @@ typedef void(*nimble_scanner_cb)(uint8_t type,
  *                      default parameters
  * @param[in] disc_cb   callback triggered of each received advertising packet
  *
- * @return  NIMBLE_SCANNER_OK on success
- * @return  NIMBLE_SCANNER_ERR if putting NimBLE into discovery mode failed
+ * @return  0 on success
  */
 int nimble_scanner_init(const struct ble_gap_disc_params *params,
                         nimble_scanner_cb disc_cb);
@@ -72,6 +62,9 @@ int nimble_scanner_init(const struct ble_gap_disc_params *params,
  *
  * @note    Scanning will run for ever unless stopped or unless a different
  *          scan duration is set with @ref nimble_scanner_set_scan_duration
+ *
+ * @return  0 on success
+ * @return  -ECANCELED on error
  */
 int nimble_scanner_start(void);
 

--- a/pkg/nimble/scanner/nimble_scanner.c
+++ b/pkg/nimble/scanner/nimble_scanner.c
@@ -61,11 +61,11 @@ int nimble_scanner_start(void)
                                &_scan_params, _on_scan_evt, NULL);
         if (res != 0) {
             DEBUG("[scanner] err: start failed (%i)\n", res);
-            return NIMBLE_SCANNER_ERR;
+            return -ECANCELED;
         }
     }
 
-    return NIMBLE_SCANNER_OK;
+    return 0;
 }
 
 void nimble_scanner_stop(void)
@@ -76,13 +76,6 @@ void nimble_scanner_stop(void)
         assert(res == 0);
         (void)res;
     }
-}
-
-int nimble_scanner_status(void)
-{
-    return (ble_gap_disc_active())
-        ? NIMBLE_SCANNER_SCANNING
-        : NIMBLE_SCANNER_STOPPED;
 }
 
 void nimble_scanner_set_scan_duration(int32_t duration_ms)
@@ -107,5 +100,5 @@ int nimble_scanner_init(const struct ble_gap_disc_params *params,
     }
     _disc_cb = disc_cb;
 
-    return NIMBLE_SCANNER_OK;
+    return 0;
 }

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -296,7 +296,7 @@ static void _do_scan(nimble_scanner_cb cb, unsigned duration)
         printf("err: duration must be > 0\n");
         return;
     }
-    if (nimble_scanner_status() == NIMBLE_SCANNER_SCANNING) {
+    if (nimble_scanner_is_active()) {
         printf("err: scanner already active\n");
         return;
     }


### PR DESCRIPTION
### Contribution description
Same as #16838: this PR migrates the return values to use `errno` values instead of custom ones.

As further optimization the `nimble_scanner_status()` function was changed to `bool nimble_scanner_is_active()`, as this feels more natural in terms of both wording as well as return value...

### Testing procedure
Build test and code review should do the trick.

### Issues/PRs references
none