### PR TITLE
[WIP] gnrc_border_router usability improvements

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -4,6 +4,28 @@ APPLICATION = gnrc_border_router
 # If no BOARD is found in the environment, use this default:
 BOARD ?= samr21-xpro
 
+# Things that'll stay on the build command line for sure
+BOARD = nrf52840dongle
+# Same, but I'd eventually like to change the defaults (but getting the info here in the build system is tricky)
+UPLINK=cdc-ecm
+# Don't know any more why I needed them increased, possibly ULA related; also possibly we don't need that many leases if ULA filtering is in there (but see questions there)
+CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=6 -DCONFIG_DHCPV6_CLIENT_PFX_LEASE_MAX=4
+# Things that really should just work out of the box (maybe they do by now)
+# the "nrf802154" thread, which is the radio ifconfig thread
+CFLAGS += -DCONFIG_GNRC_RPL_DEFAULT_NETIF=7
+
+# Better debugging, and also helpful for reviewing https://github.com/RIOT-OS/RIOT/pull/14623
+USEMODULE += netstats_l2
+USEMODULE += netstats_ipv6
+USEMODULE += netstats_rpl
+
+USEMODULE += netstats_neighbor_etx
+USEMODULE += netstats_neighbor_count
+USEMODULE += netstats_neighbor_rssi
+USEMODULE += netstats_neighbor_lqi
+USEMODULE += netstats_neighbor_tx_time
+
+
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -27,6 +49,7 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_sixlowpan_border_router_default
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
+USEMODULE += gnrc_icmpv6_error # as tracrouting is a common debugging operation too
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands
@@ -34,7 +57,7 @@ USEMODULE += ps
 
 # Optionally include RPL as a routing protocol. When includede gnrc_uhcpc will
 # configure the node as a RPL DODAG root when receiving a prefix.
-#USEMODULE += gnrc_rpl
+USEMODULE += gnrc_rpl
 
 # Optionally include DNS support. This includes resolution of names at an
 # upstream DNS server and the handling of RDNSS options in Router Advertisements

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -833,6 +833,13 @@ static bool _parse_ia_pd_option(dhcpv6_opt_ia_pd_t *ia_pd)
         if (lease->parent.ia_id.id != ia_id) {
             continue;
         }
+        // Is taking the routable one(s) really *better* than taking the ULA?
+        // The ULA might be what is more stable, or what persists through
+        // renumberings ... but probably picking routable *is* best, and when
+        // that prefix becomes unavailable we'll just wait for a network
+        // reconfiguration to bring everyone up on ULAs instead. (If of course
+        // we had the capacity for multiple prefixes on all devices...).
+        bool take_only_routable = true;
         /* check for status */
         for (dhcpv6_opt_t *ia_pd_opt = (dhcpv6_opt_t *)(ia_pd + 1);
              ia_pd_len > 0;
@@ -852,6 +859,10 @@ static bool _parse_ia_pd_option(dhcpv6_opt_ia_pd_t *ia_pd)
                 }
                 case DHCPV6_OPT_IAPFX: {
                     dhcpv6_opt_iapfx_t *this_iapfx = (dhcpv6_opt_iapfx_t *)ia_pd_opt;
+                    if (take_only_routable && (this_iapfx->pfx.u8[0] & 0xfe) == 0xfc) {
+                        // It's a ULA, look for something better to come
+                        continue;
+                    }
                     if ((!lease->leased) ||
                         (iapfx == NULL) ||
                         ((this_iapfx->pfx_len == lease->pfx_len) &&


### PR DESCRIPTION
### Contribution description

This draft PR describes the changes necessary to get the gnrc_border_router easy to use without configuration. It roughly contains the changes I had to make to the 6LBR running at my home system, and I expect that what's in here explicitly right now to evolve into more and more of a tracking issue of non-draft PRs.

### Testing procedure

* Take a board with 6lowpan and USB Ethernet; I'm using nrf52840dongle.
  * Most of this should equally apply to boards with actual Ethernet instead of USB Ethernet -- but do we have them? (The custom mikrobusboard I'm often using RIOT with has ENC28J60 Ethernet, but I don't have a radio there; finding for a board that has both would be *really* great because these you could just plug into your switch and off you go).
* On an OpenWRT router of your choosing, install the kmod-usb-net-cdc-ether package, and plug in the board.
  * In its network config GUI you'll find a USB device; add it to the LAN group.
  * kmod-usb-cdc-acm and socat are great for debugging while CoAP based remote configuration is not yet the default ;-)
  * Note that OpenWRT devices by default pick a ULA and announce that for stable operation when upstream goes away.
* As an alternative to the OpenWRT router, plug it into your PC and tell your NetworkManager to make this interface "shared to other computers". (Works just as well, but as it involves two legs of prefix delegation, there's more that can go wrong with it).
* Any other 6LoWPAN device should see a network come up that hands out routable addresses and actually routes them.

### Issues/PRs references (including TBD)

* Changes like setting the BOARD and UPLINK to cdc-ecm are really more of placeholders for documentation that'll tell users who want to set up something like this to put those on the command line.
  * CDC-ECM would be a good default for the boards, but with the current Makefile based setup it's hard to know that the board can do it, and we'll have to know a few lines down already which upstream is used
* This enables RPL by default.
* This enables ICMPv6 errors by default, which IIRC allow traceroutes to be used. Will become a teeny tiny pull request, or lumped together with other better defaults.
* ULAs are rejected for delegatable prefixes. This is a rough version, a better one would take as many prefixes as are usable but take the global addresses first. The bad thing is that upstream doesn't give priorities, so we have to priorize, and worse we have to pick as many as the downstream devices can use. Might need more discussion too.
* Some defaults are tuned (eg. netif choice), which might be an artifact of how long this has been sitting on my git stash; others are possibly obsoleted by the ULA change if that sticks.

This would also benefit greatly from:

* https://github.com/RIOT-OS/RIOT/pull/14623 (MRHOF)
* A bit more on the security side

because then I think it's something each and every one of us should just have running 24/7 in their homes just to see the practical operation when we're not using the `[affe:affe::]` network.

CC'ing @haukepetersen on following up on exchanged mails.