### PR TITLE
net/ieee802154_security doc: Shape security expectations

### DIFF
--- a/sys/include/net/ieee802154_security.h
+++ b/sys/include/net/ieee802154_security.h
@@ -10,6 +10,12 @@
  * @defgroup    net_ieee802154_security  IEEE 802.15.4 security
  * @ingroup     net
  * @brief       IEEE 802.15.4 security header
+ *
+ * @warning
+ * This module is exposing raw 802.15.4 encryption without an underlying key
+ * management framework. This is intended for experimentation with the security
+ * modes of 802.15.4, and not for use cases where its security is depended on.
+ *
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

The security module introduced in #15150 was, in my understanding, not intended for security critical use ("waives to use a proper key store to mitigate complexity"), but that didn't come across clearly in the documentation, and might thus give wrong impressions.

### Testing procedure

* Doc only change: Look at the new infobox in ~~ieee802154__security_8h.html~~ group__net__ieee802154__security.html of the built documentation.

### Issues/PRs references

#15150 was where the module was introduced

[edit: Hotfixed after I found that the box wound up in the header file and not the module description]