### PR TITLE
{dev,net}/ieee802154_*: add initial Kconfig modeling

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -101,6 +101,7 @@ tests/xtimer_*
 tests/ztimer_*
 examples/hello-world
 tests/ieee802154_hal
+tests/ieee802154_submac
 "}
 
 # This list prevents boards from being tested by the TEST_KCONFIG_TEST_ALLOWLIST

--- a/cpu/cc2538/radio/Kconfig
+++ b/cpu/cc2538/radio/Kconfig
@@ -9,6 +9,7 @@ menuconfig MODULE_CC2538_RF
     bool "CC2538 IEEE 802.15.4 radio"
     depends on TEST_KCONFIG
     depends on CPU_FAM_CC2538
+    select HAVE_IEEE802154_RADIO_HAL
 
 if MODULE_CC2538_RF
 

--- a/cpu/nrf52/radio/nrf802154/Kconfig
+++ b/cpu/nrf52/radio/nrf802154/Kconfig
@@ -8,5 +8,6 @@
 config HAS_RADIO_NRF802154
     bool
     select HAVE_NRF5X_RADIO
+    select MODULE_NRF802154 if MODULE_NETDEV_DEFAULT
     help
         Indicates that a IEEE 802.15.4 NRF52 radio is present.

--- a/cpu/nrf52/radio/nrf802154/Kconfig
+++ b/cpu/nrf52/radio/nrf802154/Kconfig
@@ -4,23 +4,6 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-menuconfig KCONFIG_USEMODULE_NRF802154
-    bool    "Configure nRF802154"
-    depends on USEMODULE_NRF802154
-    help
-        Configure nRF802154 module using Kconfig.
-
-if KCONFIG_USEMODULE_NRF802154
-
-config NRF802154_CCA_THRESH_DEFAULT
-    hex "Default CCA threshold value"
-    default 0x14
-    range 0x00 0xFF
-    help
-        Default CCA threshold value for the CCACTRL register.
-
-endif # KCONFIG_USEMODULE_NRF802154
-
 ## Related features
 config HAS_RADIO_NRF802154
     bool

--- a/cpu/nrf52/radio/nrf802154/Kconfig
+++ b/cpu/nrf52/radio/nrf802154/Kconfig
@@ -9,6 +9,5 @@ config HAS_RADIO_NRF802154
     bool
     select HAVE_NRF5X_RADIO
     select HAVE_IEEE802154_RADIO
-    select MODULE_NRF802154 if MODULE_NETDEV_DEFAULT
     help
         Indicates that a IEEE 802.15.4 NRF52 radio is present.

--- a/cpu/nrf52/radio/nrf802154/Kconfig
+++ b/cpu/nrf52/radio/nrf802154/Kconfig
@@ -8,6 +8,7 @@
 config HAS_RADIO_NRF802154
     bool
     select HAVE_NRF5X_RADIO
+    select HAVE_IEEE802154_RADIO
     select MODULE_NRF802154 if MODULE_NETDEV_DEFAULT
     help
         Indicates that a IEEE 802.15.4 NRF52 radio is present.

--- a/cpu/nrf5x_common/radio/Kconfig.nrf5x
+++ b/cpu/nrf5x_common/radio/Kconfig.nrf5x
@@ -25,6 +25,7 @@ choice NRF5X_RADIO_BACKEND
 
 config MODULE_NRF802154
     bool "Implementation of the IEEE 802.15.4 for nRF52 radio"
+    depends on TEST_KCONFIG
     depends on HAS_RADIO_NRF802154
     depends on HAS_PERIPH_TIMER
     select MODULE_LUID

--- a/cpu/nrf5x_common/radio/Kconfig.nrf5x
+++ b/cpu/nrf5x_common/radio/Kconfig.nrf5x
@@ -22,6 +22,9 @@ if NRF5X_RADIO
 
 choice NRF5X_RADIO_BACKEND
     bool "nrf5x radio backend"
+    default MODULE_NRF802154 if HAS_RADIO_NRF802154
+    default MODULE_NRFBLE if HAS_RADIO_NRFBLE
+    default MODULE_NRFBLE if HAS_RADIO_NRFMIN
 
 config MODULE_NRF802154
     bool "Implementation of the IEEE 802.15.4 for nRF52 radio"

--- a/cpu/nrf5x_common/radio/Kconfig.nrf5x
+++ b/cpu/nrf5x_common/radio/Kconfig.nrf5x
@@ -31,6 +31,7 @@ config MODULE_NRF802154
     select MODULE_LUID
     select MODULE_PERIPH_TIMER
     select MODULE_IEEE802154
+    select HAVE_IEEE802154_RADIO_HAL
 
 config MODULE_NRFBLE
     bool "Bluetooth low energy radio driver"

--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -22,4 +22,36 @@ rsource "$(RIOTCPU)/native/socket_zep/Kconfig"
 rsource "sx126x/Kconfig"
 rsource "sx127x/Kconfig"
 rsource "tja1042/Kconfig"
+
+config MODULE_NETDEV_IEEE802154
+    bool
+    help
+        Netdev IEEE 802.15.4 module, provides common functionalities for
+        netdev based IEEE 802.15.4 devices.
+
+config MODULE_NETDEV_IEEE802154_SUBMAC
+    bool
+    select MODULE_IEEE802154_SUBMAC
+    help
+        Netdev IEEE 802.15.4 SubMAC, provides a netdev IEEE 802.15.4 device
+        implementation on top of the IEEE 802.15.4 SubMAC.
+
+config HAVE_IEEE802154_RADIO_HAL
+    bool
+    select HAVE_IEEE802154_RADIO
+    help
+        At least one device provides an IEEE 802.15.4 Radio HAL implementation
+
+config HAVE_NETDEV_IEEE802154
+    select HAVE_IEEE802154_RADIO
+    bool
+    help
+        At least one device provides an IEEE 802.15.4 Netdev driver
+        implementation
+
+config HAVE_IEEE802154_RADIO
+    bool
+    help
+        Indicates that a IEEE 802.15.4 radio is present.
+
 endmenu # Network Device Drivers

--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -43,8 +43,8 @@ config HAVE_IEEE802154_RADIO_HAL
         At least one device provides an IEEE 802.15.4 Radio HAL implementation
 
 config HAVE_NETDEV_IEEE802154
-    select HAVE_IEEE802154_RADIO
     bool
+    select HAVE_IEEE802154_RADIO
     help
         At least one device provides an IEEE 802.15.4 Netdev driver
         implementation

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -4,26 +4,38 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-menuconfig MODULE_IEEE802154
-    bool "IEEE 802.15.4 support"
+menuconfig FEATURE_IEEE802154
+    bool "Enable IEEE 802.15.4 support"
     depends on TEST_KCONFIG
+    default y if HAVE_IEEE802154_RADIO && MODULE_NETDEV_DEFAULT
 
-if MODULE_IEEE802154
+if FEATURE_IEEE802154
+
+config MODULE_IEEE802154
+    bool "IEEE 802.15.4 helpers"
+    help
+        Provide IEEE 802.15.4 helpers
 
 config MODULE_IEEE802154_SECURITY
     bool "IEEE 802.15.4 security"
     select MODULE_CRYPTO
     select MODULE_CIPHER_MODES
+    depends on TEST_KCONFIG
+    depends on FEATURE_IEEE802154
     help
         IEEE 802.15.4 security interface
 
 config MODULE_IEEE802154_SUBMAC
-    bool "IEEE 802.15.4 submac"
+    bool "IEEE 802.15.4 SubMAC"
     select MODULE_XTIMER
+    select MODULE_RANDOM
+    depends on FEATURE_IEEE802154
+    depends on TEST_KCONFIG
     help
-        This module defines a common layer for handling the lower part of the IEEE 802.15.4 MAC layer.
+        This module defines a common layer for handling the lower part of the
+        IEEE 802.15.4 MAC layer.
 
-endif # MODULE_IEEE802154
+endif
 
 menuconfig KCONFIG_USEMODULE_IEEE802154
     bool "Configure IEEE802.15.4"

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig IEEE802154
     bool
-    prompt "Enable IEEE 802.15.4 support" !(HAVE_IEEE802154_RADIO && MODULE_NETDEV_DEFAULT)
+    prompt "Enable IEEE 802.15.4 support" if !(HAVE_IEEE802154_RADIO && MODULE_NETDEV_DEFAULT)
     default y if HAVE_IEEE802154_RADIO && MODULE_NETDEV_DEFAULT
     depends on TEST_KCONFIG
 

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -4,12 +4,13 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-menuconfig FEATURE_IEEE802154
-    bool "Enable IEEE 802.15.4 support"
-    depends on TEST_KCONFIG
+menuconfig IEEE802154
+    bool
+    prompt "Enable IEEE 802.15.4 support" !(HAVE_IEEE802154_RADIO && MODULE_NETDEV_DEFAULT)
     default y if HAVE_IEEE802154_RADIO && MODULE_NETDEV_DEFAULT
+    depends on TEST_KCONFIG
 
-if FEATURE_IEEE802154
+if IEEE802154
 
 config MODULE_IEEE802154
     bool "IEEE 802.15.4 helpers"
@@ -20,7 +21,6 @@ config MODULE_IEEE802154_SECURITY
     bool "IEEE 802.15.4 security"
     select MODULE_CRYPTO
     select MODULE_CIPHER_MODES
-    depends on TEST_KCONFIG
     depends on FEATURE_IEEE802154
     help
         IEEE 802.15.4 security interface
@@ -30,7 +30,6 @@ config MODULE_IEEE802154_SUBMAC
     select MODULE_XTIMER
     select MODULE_RANDOM
     depends on FEATURE_IEEE802154
-    depends on TEST_KCONFIG
     help
         This module defines a common layer for handling the lower part of the
         IEEE 802.15.4 MAC layer.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR add the initial Kconfig modeling for the lower layers of IEEE 802.15.4. This includes:
- Adding feature symbols to indicate presence of Radio HAL or Netdev Driver based driver.
- Modeling of SubMAC and `netdev_ieee802154_submac`
- Adding `tests/ieee802154_submac` to the list of Kconfig test executed by Murdock

This PR also refactors the IEEE 802.15.4 menu, because `MODULE_IEEE802154` just provides helper functions for processing IEEE 802.15.4 frames. Last but not least, it removes unused configurations in ` nrf802154`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Murdock should be enough I guess.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #16837
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
