### PR TITLE
boards/adafruit-clue: fix doxygen warnings

### DIFF
--- a/boards/adafruit-clue/include/board.h
+++ b/boards/adafruit-clue/include/board.h
@@ -30,82 +30,84 @@ extern "C" {
  * @name    LEDs pin configuration
  * @{
  */
-#define LED0_PIN                        GPIO_PIN(1, 1)
-#define LED0_MASK                       (1 << 1)
-#define LED0_ON                         (NRF_P1->OUTSET = LED0_MASK)
-#define LED0_OFF                        (NRF_P1->OUTCLR = LED0_MASK)
-#define LED0_TOGGLE                     (NRF_P1->OUT   ^= LED0_MASK)
+#define LED0_PIN               GPIO_PIN(1, 1)                  /**< LED0 pin */
+#define LED0_MASK              (1 << 1)                        /**< LED0 mask */
+#define LED0_ON                (NRF_P1->OUTSET = LED0_MASK)    /**< Turn LED0 on */
+#define LED0_OFF               (NRF_P1->OUTCLR = LED0_MASK)    /**< Turn LED0 off */
+#define LED0_TOGGLE            (NRF_P1->OUT   ^= LED0_MASK)    /**< Toggle LED0 */
 /** @} */
 
 /**
- * @name    Button pin configuration
+ * @name    Buttons pin configuration
  * @{
  */
-#define BTN0_PIN                        GPIO_PIN(1, 2)  /* Button A */
-#define BTN0_MODE                       GPIO_IN_PU
+#define BTN0_PIN               GPIO_PIN(1, 2)  /**< Button A pin */
+#define BTN0_MODE              GPIO_IN_PU      /**< Button A mode */
 
-#define BTN1_PIN                        GPIO_PIN(1, 10) /* Button B */
-#define BTN1_MODE                       GPIO_IN_PU
+#define BTN1_PIN               GPIO_PIN(1, 10) /**< Button B pin */
+#define BTN1_MODE              GPIO_IN_PU      /**< Button B mode */
 /** @} */
 
 /**
  * @name    APDS9960 sensor configuration
  * @{
  */
-#define APDS99XX_PARAM_DEV              I2C_DEV(1)
-#define APDS99XX_PARAM_INT_PIN          GPIO_PIN(0, 9)
+#define APDS99XX_PARAM_DEV     I2C_DEV(1)       /**< I2C device */
+#define APDS99XX_PARAM_INT_PIN GPIO_PIN(0, 9)   /**< Interrupt pin */
 /** @} */
 
 /**
  * @name    BMP280 sensor configuration
  * @{
  */
-#define BMX280_PARAM_I2C_DEV            I2C_DEV(1)
+#define BMX280_PARAM_I2C_DEV   I2C_DEV(1)   /**< I2C device */
 /** @} */
 
 /**
- * @name    LIS3MDL 3-axis magnetometer I2C address
+ * @name    LIS3MDL 3-axis magnetometer
+ * @{
  */
-#define LIS3MDL_PARAM_I2C               I2C_DEV(1)
-#define LIS3MDL_PARAM_ADDR              (0x1C)
+#define LIS3MDL_PARAM_I2C      I2C_DEV(1)   /**< I2C device */
+#define LIS3MDL_PARAM_ADDR     (0x1C)       /**< I2C address */
 /** @} */
 
 /**
- * @name    STH31 temperature and humidity sensor I2C address
+ * @name    STH31 temperature and humidity sensor
+ * @{
  */
-#define SHT3X_PARAM_I2C_DEV             I2C_DEV(1)
-#define SHT3X_PARAM_I2C_ADDR            (SHT3X_I2C_ADDR_1)
+#define SHT3X_PARAM_I2C_DEV    I2C_DEV(1)          /**< I2C device */
+#define SHT3X_PARAM_I2C_ADDR   (SHT3X_I2C_ADDR_1)  /**< I2C address */
 /** @} */
 
 /**
  * @name    Speaker pin
  * @{
  */
-#define SPKR_PIN                        GPIO_PIN(1, 0)
-/** @ */
+#define SPKR_PIN               GPIO_PIN(1, 0)   /**< Speaker pin */
+/** @} */
 
 /**
  * @name    Backlight control defines, default uses LCD_BACKLIGHT_LOW values
  * @{
  */
-#define BACKLIGHT_PIN                   GPIO_PIN(1, 5)
-#define BACKLIGHT_MASK                  (1 << 5)
-#define BACKLIGHT_ON                    (NRF_P1->OUTSET = BACKLIGHT_MASK)
-#define BACKLIGHT_OFF                   (NRF_P1->OUTCLR = BACKLIGHT_MASK)
+#define BACKLIGHT_PIN          GPIO_PIN(1, 5)                       /**< Backlight pin */
+#define BACKLIGHT_MASK         (1 << 5)                             /**< Backlight pin mask */
+#define BACKLIGHT_ON           (NRF_P1->OUTSET = BACKLIGHT_MASK)    /**< Turn backlight on */
+#define BACKLIGHT_OFF          (NRF_P1->OUTCLR = BACKLIGHT_MASK)    /**< Turn backlight off */
 /** @ */
 
 /**
  * @name    Display configuration
  * @{
  */
-#define ILI9341_PARAM_SPI               SPI_DEV(1)
-#define ILI9341_PARAM_CS                GPIO_PIN(0, 12)
-#define ILI9341_PARAM_DCX               GPIO_PIN(0, 13)
-#define ILI9341_PARAM_RST               GPIO_PIN(1, 3)
-#define ILI9341_PARAM_NUM_LINES         (240U)
-#define ILI9341_PARAM_RGB               (1)
-#define ILI9341_PARAM_INVERTED          (1)
-#define ILI9341_PARAM_ROTATION          (ILI9341_ROTATION_HORZ_FLIP)
+#define ILI9341_PARAM_SPI       SPI_DEV(1)                      /**< SPI device */
+#define ILI9341_PARAM_CS        GPIO_PIN(0, 12)                 /**< Chip select pin */
+#define ILI9341_PARAM_DCX       GPIO_PIN(0, 13)                 /**< DCX pin */
+#define ILI9341_PARAM_RST       GPIO_PIN(1, 3)                  /**< Reset pin */
+#define ILI9341_PARAM_NUM_LINES (240U)                          /**< Number of screen lines */
+#define ILI9341_PARAM_RGB       (1)                             /**< RGB configuration */
+#define ILI9341_PARAM_INVERTED  (1)                             /**< Inversion configuration */
+#define ILI9341_PARAM_ROTATION  (ILI9341_ROTATION_HORZ_FLIP)    /**< Rotation mode */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/adafruit-clue/include/periph_conf.h
+++ b/boards/adafruit-clue/include/periph_conf.h
@@ -33,6 +33,9 @@ extern "C" {
  * @name    UART configuration
  * @{
  */
+/**
+ * @brief   UART configuration.
+ */
 static const uart_conf_t uart_config[] = {
     {
         .dev        = NRF_UARTE0,
@@ -46,14 +49,22 @@ static const uart_conf_t uart_config[] = {
     },
 };
 
+/**
+ * @brief   UART 0 Interrupt Service Routine.
+ */
 #define UART_0_ISR          (isr_uart0)
-
+/**
+ * @brief   Number of UART peripherals.
+ */
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
  * @name    I2C configuration
  * @{
+ */
+/**
+ * @brief   I2C configuration.
  */
 static const i2c_conf_t i2c_config[] = {
     {   /* External connectors */
@@ -70,12 +81,18 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 
+/**
+ * @brief   Number of I2C peripherals.
+ */
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**
  * @name    SPI configuration
  * @{
+ */
+/**
+ * @brief   SPI configuration.
  */
 static const spi_conf_t spi_config[] = {
     {   /* External connectors */
@@ -92,6 +109,9 @@ static const spi_conf_t spi_config[] = {
     },
 };
 
+/**
+ * @brief   Number of SPI peripherals.
+ */
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
@@ -100,3 +120,4 @@ static const spi_conf_t spi_config[] = {
 #endif
 
 #endif /* PERIPH_CONF_H */
+/** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -34,45 +34,7 @@ boards/acd52832/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_RX \(mac
 boards/acd52832/include/periph_conf\.h:[0-9]+: warning: Member UART_PIN_TX \(macro definition\) of file periph_conf\.h is not documented\.
 boards/acd52832/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/acd52832/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member APDS99XX_PARAM_DEV \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member APDS99XX_PARAM_INT_PIN \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BACKLIGHT_MASK \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BACKLIGHT_OFF \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BACKLIGHT_ON \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BACKLIGHT_PIN \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BMX280_PARAM_I2C_DEV \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BTN0_MODE \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BTN0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BTN1_MODE \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member BTN1_PIN \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_CS \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_DCX \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_INVERTED \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_NUM_LINES \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_RGB \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_ROTATION \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_RST \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member ILI9341_PARAM_SPI \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LED0_MASK \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LED0_OFF \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LED0_ON \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LED0_TOGGLE \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LIS3MDL_PARAM_ADDR \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member LIS3MDL_PARAM_I2C \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member SHT3X_PARAM_I2C_ADDR \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member SHT3X_PARAM_I2C_DEV \(macro definition\) of file board\.h is not documented\.
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: Member SPKR_PIN \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-clue/include/board\.h:[0-9]+: warning: end of file with unbalanced grouping commands
-boards/adafruit\-clue/include/board\.h:[0-9]+: warning: unbalanced grouping commands
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
-boards/adafruit\-clue/include/periph_conf\.h:[0-9]+: warning: end of file with unbalanced grouping commands
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member APA102_PARAM_CLK_PIN \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member APA102_PARAM_DATA_PIN \(macro definition\) of file board\.h is not documented\.
 boards/adafruit\-itsybitsy\-m4/include/board\.h:[0-9]+: warning: Member APA102_PARAM_LED_NUMOF \(macro definition\) of file board\.h is not documented\.


### PR DESCRIPTION
### Contribution description

Fix warnings of `boards/adafruit-clue`. There is still one warning left that seems to be a false positive:

```
boards/adafruit\-clue/include/board\.h:[0-9]+: warning: end of file with unbalanced grouping commands
```

Because each `@{` is matched with their corresponding `@}`.

### Testing procedure

- `make static-test` on newer Doxygen versions.

### Issues/PRs references
