### PR TITLE
sys/posix/socket: fix wrong member access

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -398,7 +398,7 @@ static void _sock_set_cb(socket_t *socket)
     switch (socket->type) {
 #ifdef MODULE_SOCK_IP
         case SOCK_RAW:
-            sock_ip_set_cb(&socket->sock.ip, callback.ip, socket);
+            sock_ip_set_cb(&socket->sock->raw, callback.ip, socket);
             break;
 #endif
 #ifdef MODULE_SOCK_TCP

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -405,11 +405,11 @@ static void _sock_set_cb(socket_t *socket)
         case SOCK_STREAM:
             /* is a TCP client socket */
             if (socket->queue_array == NULL) {
-                sock_tcp_set_cb(&socket->sock.tcp.sock, callback.tcp, socket);
+                sock_tcp_set_cb(&socket->sock->tcp.sock, callback.tcp, socket);
             }
             /* is a TCP listening socket */
             else {
-                sock_tcp_queue_set_cb(&socket->sock.tcp.queue,
+                sock_tcp_queue_set_cb(&socket->sock->tcp.queue,
                                       callback.tcp_queue, socket);
             }
             break;


### PR DESCRIPTION
### Contribution description

Since #12975 was merged the module `posix_sockets` cannot be compiled when `sock_ip` or `sock_tcp` is used.

### Testing procedure

You can test this PR e.g. in conjunction with everything else in #15969.

### Issues/PRs references

This PR is split out from the chunky #15969.