### PR TITLE
sys/posix/socket: use explicit bind

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -1037,8 +1037,7 @@ static ssize_t socket_sendto(socket_t *s, const void *buffer, size_t length,
             return -1;
         }
 #endif
-        /* bind implicitly */
-        if ((res = _bind_connect(s, NULL, 0)) < 0) {
+        if ((res = _bind_connect(s, address, address_len)) < 0) {
             return res;
         }
     }


### PR DESCRIPTION
### Contribution description

Implicit bind leads to StoreProhibitedCause on esp32 and an implicit bind at this point does not really makes sense to me either. Can someone explain why it was an implicit bind?

### Testing procedure

You can test this PR e.g. in conjunction with everything else in #15969.

### Issues/PRs references

This PR is split out from the chunky #15969.