### PR TITLE
cpu/cc26x0_cc13x0: fix build

### DIFF
--- a/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_fcfg.h
+++ b/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_fcfg.h
@@ -136,7 +136,7 @@ typedef struct {
 /**
  * @brief FCFG register bank
  */
-#define FCFG    ((fcfg_regs_t *) (FCFG_BASE)
+#define FCFG    ((fcfg_regs_t *) (FCFG_BASE))
 
 #ifdef __cplusplus
 } /* end extern "C" */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

0d9f6ca broke the build for `cpu/cc26xx_cc13xx`


### Testing procedure

CI build should work again. 


### Issues/PRs references

#16813
