### PR TITLE
CODEOWNERS: remove Robert Hartung

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,8 +40,8 @@
 /core/                                      @kaspar030
 
 /cpu/arm7_common/                           @kaspar030 @maribu
-/cpu/avr8_common/                           @kYc0o @roberthartung @maribu @nandojve
-/cpu/atmega*/                               @kYc0o @roberthartung @maribu
+/cpu/avr8_common/                           @kYc0o @maribu @nandojve
+/cpu/atmega*/                               @kYc0o @maribu
 /cpu/atxmega/                               @nandojve
 /cpu/cc2538/                                @hexluthor @smlng @fjmolinas
 /cpu/cc26x0/                                @hexluthor @smlng
@@ -126,7 +126,7 @@
 /sys/net/gnrc/netif/                        @miri64 @jia200x
 /sys/net/gnrc/routing/rpl/                  @cgundogan @emmanuelsearch
 /sys/net/                                   @miri64 @haukepetersen @PeterKietzmann @cgundogan
-/sys/pm_layered/                            @roberthartung @kaspar030
+/sys/pm_layered/                            @kaspar030
 /sys/random/fortuna/                        @basilfx
 /sys/riotboot/                              @kaspar030 @fjmolinas
 /sys/suit                                   @kaspar030 @fjmolinas @bergzand
@@ -150,4 +150,4 @@
 
 # KConfig maintainers will be notified about all KConfig changes
 Kconfig                                     @leandrolanzieri @jia200x @cgundogan
-pm.c                                        @roberthartung @kaspar030
+pm.c                                        @kaspar030


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Following the maintainer ping, Robert Hartung answered that he has no longer time for maintaining RIOT and requested to be taken off the CODEOWNERS list.

This PR implements this request. 

> I was quite busy with my PhD thesis (and still am), therefore, feel free
> to take me off the active maintainers list.
> Note: I am still listed as a code owner at some places, can you remove
> @roberthartung from there for now as well?


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
