### PR TITLE
nimble/addr|scanlist: fix nimble_addr_sprint() and use in nimble_scanlist_print()

### DIFF
--- a/pkg/nimble/addr/nimble_addr.c
+++ b/pkg/nimble/addr/nimble_addr.c
@@ -33,7 +33,9 @@ void nimble_addr_print(const ble_addr_t *addr)
 
 void nimble_addr_sprint(char *buf, const ble_addr_t *addr)
 {
-    bluetil_addr_sprint(buf, addr->val);
+    uint8_t addrn[BLE_ADDR_LEN];
+    bluetil_addr_swapped_cp(addr->val, addrn);
+    bluetil_addr_sprint(buf, addrn);
     const char *type;
     switch (addr->type) {
         case BLE_ADDR_PUBLIC:       type = " (public) "; break;
@@ -43,5 +45,5 @@ void nimble_addr_sprint(char *buf, const ble_addr_t *addr)
         default:                    type = " (unknown)"; break;
     }
     memcpy(&buf[BLUETIL_ADDR_STRLEN - 1], type, 10);
-    buf[BLUETIL_ADDR_STRLEN - 1] = '\0';
+    buf[NIMBLE_ADDR_STRLEN - 1] = '\0';
 }

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -23,23 +23,9 @@
 #include <assert.h>
 
 #include "net/bluetil/ad.h"
+#include "nimble_addr.h"
 #include "nimble_scanlist.h"
 #include "nimble/hci_common.h"
-
-static void _print_addr(const ble_addr_t *addr)
-{
-    printf("%02x", (int)addr->val[5]);
-    for (int i = 4; i >= 0; i--) {
-        printf(":%02x", addr->val[i]);
-    }
-    switch (addr->type) {
-        case BLE_ADDR_PUBLIC:       printf(" (PUBLIC)");   break;
-        case BLE_ADDR_RANDOM:       printf(" (RANDOM)");   break;
-        case BLE_ADDR_PUBLIC_ID:    printf(" (PUB_ID)");   break;
-        case BLE_ADDR_RANDOM_ID:    printf(" (RAND_ID)");  break;
-        default:                    printf(" (UNKNOWN)");  break;
-    }
-}
 
 static void _print_type(uint8_t type)
 {
@@ -92,7 +78,7 @@ void nimble_scanlist_print_entry(nimble_scanlist_entry_t *e)
         strncpy(name, "undefined", sizeof(name));
     }
 
-    _print_addr(&e->addr);
+    nimble_addr_print(&e->addr);
     _print_type(e->type);
     unsigned adv_int = ((e->last_update - e->first_update) / e->adv_msg_cnt);
     printf(" \"%s\", adv_msg_cnt: %u, adv_int: %uus, last_rssi: %i\n",


### PR DESCRIPTION
### Contribution description
Seems like `nimble_addr` module hasn't been used too much, as the `nimble_addr_sprint()` function was broken in two cases:
- the byteorder was incorrect: `ble_addr_t` holds the addresses in little endian, however in RIOT (and same for e.g. the Nordic Android app) print the byteorder in big-endian -> so we need to swap it here
- the address type in the output string was cut off: the `\0` termination character needs to be put at he position of `NIMBLE_ADDR_STRLEN` instead of `BLUETIL_ADDR_STRLEN`

Both errors are fixed in this PR.

This PR further cleans up  `nimble_scanlist` by removing the custom print function and instead make use of `nimble_addr_print`. 


### Testing procedure
- Run the NimBLE Scanner `examples/nimble_scanner`
- alternatively run `gnrc_networking` on a IP over BLE capable platform and run the `ble scan` command

in both cases, the scanned device's addresses should show in big-endian byteorder (like e.g. in `ifconfig`) and the address type should be printed.

### Issues/PRs references
none