### PR TITLE
cpu/cc2538: don't pollute global namespace with cc2538_rfcore.h

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -25,6 +25,7 @@
 #include <stdbool.h>
 
 #include "board.h"
+#include "cc2538_rfcore.h"
 
 #include "net/ieee802154.h"
 #include "kernel_defines.h"

--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -27,7 +27,6 @@
 #include "cc2538_gptimer.h"
 #include "cc2538_soc_adc.h"
 #include "cc2538_ssi.h"
-#include "cc2538_rfcore.h"
 #include "cc2538_sys_ctrl.h"
 
 #ifdef __cplusplus

--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -25,6 +25,7 @@
 #include "vendor/hw_soc_adc.h"
 
 #include "cpu.h"
+#include "cc2538_rfcore.h"
 #include "periph/hwrng.h"
 
 #define ENABLE_DEBUG 0


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`cc2538_rfcore.h` contains enums with non-prefixed single-word constants.
Those cause ugly naming conflicts down the line.
Only include the file when needed, don't include it in `cpu_conf.h` which gets pulled in everywhere.


### Testing procedure

Everything should still compile.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
