### PR TITLE
Makefile.include: enable verbose asserts with DEVELHELP=2

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -288,8 +288,11 @@ endif
 # which is not needed in a production environment but helps in the
 # development process:
 DEVELHELP ?= 0
-ifeq ($(DEVELHELP),1)
+ifneq (0, $(DEVELHELP))
   CFLAGS += -DDEVELHELP
+endif
+ifeq (2, $(DEVELHELP))
+  CFLAGS += -DDEBUG_ASSERT_VERBOSE
 endif
 
 # Set this to 1 to enable thread names

--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -20,7 +20,7 @@ ifneq (,$(filter cortexm_fpu,$(FEATURES_USED)))
 endif
 
 # Enable the MPU stack guard if develhelp is enabled
-ifeq (1, $(DEVELHELP))
+ifneq (0, $(DEVELHELP))
   FEATURES_OPTIONAL += cortexm_mpu
 endif
 

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -113,7 +113,7 @@ ifeq (1,$(TEST_KCONFIG))
 endif
 
 # Expose DEVELHELP to kconfig
-ifeq (1,$(DEVELHELP))
+ifneq (0, $(DEVELHELP))
   RIOT_CONFIG_DEVELHELP ?= y
 endif
 

--- a/sys/stdio_null/Makefile
+++ b/sys/stdio_null/Makefile
@@ -1,4 +1,4 @@
-ifeq ($(DEVELHELP),1)
+ifneq (0, $(DEVELHELP))
   $(warning STDIO disabled via stdio_null, but DEVELHELP enabled)
 endif
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Verbose asserts can be useful, but I always forget how to enable them.
To ease use, add a second level to the `DEVELHELP` option that can be used to enable more 'expensive' helpers.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
