### PR TITLE
drivers/cc110x: use pseudo-modules for band selection

### DIFF
--- a/boards/avsextrem/Makefile.dep
+++ b/boards/avsextrem/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc1100
+  USEMODULE += cc110x_868mhz
 endif

--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc1100
+  USEMODULE += cc110x_868mhz
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))

--- a/boards/msbiot/Makefile.dep
+++ b/boards/msbiot/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc1101
+  USEMODULE += cc110x_868mhz
 endif
 
 # add support for LEDs and buttons as default saul devices

--- a/drivers/cc110x/Makefile.dep
+++ b/drivers/cc110x/Makefile.dep
@@ -8,3 +8,8 @@ FEATURES_REQUIRED += periph_spi
 ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan
 endif
+
+# default to 433 MHz operation
+ifeq (,$(filter cc110x_%mhz,$(USEMODULE)))
+  USEMODULE += cc110x_433mhz
+endif

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -59,7 +59,13 @@ extern "C" {
  * Choose the one matching the base frequency your transceiver uses, otherwise
  * the TX power setting will be incorrect.
  */
+#if IS_USED(MODULE_CC110X_433MHZ)
+#define CC110X_PARAM_PATABLE        (&cc110x_patable_433mhz)
+#elif IS_USED(MODULE_CC110X_868MHZ)
 #define CC110X_PARAM_PATABLE        (&cc110x_patable_868mhz)
+#elif IS_USED(MODULE_CC110X_915MHZ)
+#define CC110X_PARAM_PATABLE        (&cc110x_patable_915mhz)
+#endif
 #endif
 
 #ifndef CC110X_PARAM_CONFIG
@@ -68,7 +74,11 @@ extern "C" {
  *
  * If 868 MHz is used as base frequency, you can set this to `NULL`
  */
+#if IS_USED(MODULE_CC110X_433MHZ)
+#define CC110X_PARAM_CONFIG         (&cc110x_config_433mhz_250kbps_300khz)
+#else
 #define CC110X_PARAM_CONFIG         NULL
+#endif
 #endif
 
 #ifndef CC110X_PARAM_CHANNELS
@@ -77,7 +87,11 @@ extern "C" {
  *
  * This must match to configuration you have chosen
  */
+#if IS_USED(MODULE_CC110X_433MHZ)
+#define CC110X_PARAM_CHANNELS       (&cc110x_chanmap_433mhz_300khz)
+#else
 #define CC110X_PARAM_CHANNELS       (&cc110x_chanmap_868mhz_lora)
+#endif
 #endif
 
 #ifndef CC110X_PARAMS

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -219,6 +219,11 @@ PSEUDOMODULES += cc1100
 PSEUDOMODULES += cc1100e
 PSEUDOMODULES += cc1101
 
+# use pseudo-module for band selection
+PSEUDOMODULES += cc110x_433mhz
+PSEUDOMODULES += cc110x_868mhz
+PSEUDOMODULES += cc110x_915mhz
+
 # include variants of ds3231 drivers as pseudo modules
 PSEUDOMODULES += ds3231_int
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

CC110x modules on ebay are commonly using the 433 MHz band.
Add a pseudo-module for band selection and default to that band, manually select band for 868 MHz boards.


### Testing procedure

The code should not change compared to `master`.
Boards from this branch (e.g `msba2`) should still be able to communicate with boards on the master branch.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16232#issuecomment-861267025
