### PR TITLE
sys/shell lwIP: Expand ifconfig command

### DIFF
--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -54,9 +54,10 @@ static void _netif_list(struct netif *netif) {
             printf(":");
         }
     }
-    printf(" Link: %s State: %s\n",
+    printf(" Link: %s State: %s %s\n",
         netif_is_link_up(netif) ? "up" : "down",
-        netif_is_up(netif) ? "up" : "down");
+        netif_is_up(netif) ? "up" : "down",
+        netif == netif_default ? "Default route" : "");
     printf("        Link type: %s\n",
         (dev->driver->get(dev, NETOPT_IS_WIRED, &i, sizeof(i)) > 0) ?
             "wired" : "wireless");
@@ -84,6 +85,8 @@ static void _usage(const char *cmd) {
     puts("      List all or a specific network interface");
     printf("usage: %s <iface> {up|down}\n", cmd);
     puts("      Enable or disable an interface (independent of link)");
+    printf("usage: %s <iface> default\n", cmd);
+    puts("      Set interface as default for routing");
 }
 
 int _lwip_netif_config(int argc, char **argv)
@@ -125,6 +128,9 @@ int _lwip_netif_config(int argc, char **argv)
                 return 0;
             } else if (strcmp(argv[2], "down") == 0) {
                 netifapi_netif_set_down(netif);
+                return 0;
+            } else if (strcmp(argv[2], "default") == 0) {
+                netifapi_netif_set_default(netif);
                 return 0;
             }
         }

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -78,6 +78,11 @@ static void _netif_list(struct netif *netif) {
 #endif
 }
 
+static void _usage(const char *cmd) {
+    printf("usage: %s [iface]\n", cmd);
+    puts("      List all or a specific network interface");
+}
+
 int _lwip_netif_config(int argc, char **argv)
 {
     if (argc < 2) {
@@ -96,7 +101,22 @@ int _lwip_netif_config(int argc, char **argv)
             }
         }
         return 0;
+    } else if (strcmp(argv[1], "help") == 0) {
+        _usage(argv[0]);
+        return 0;
+    } else if (argc == 2) {
+        LOCK_TCPIP_CORE();
+        struct netif *netif = netif_find(argv[1]);
+        UNLOCK_TCPIP_CORE();
+        if (netif) {
+            _netif_list(netif);
+            return 0;
+        } else {
+            printf("Interface '%s' not found.\n", argv[1]);
+            _usage(argv[0]);
+            return 1;
+        }
     }
-    printf("%s takes no arguments.\n", argv[0]);
+    _usage(argv[0]);
     return 1;
 }

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -54,9 +54,9 @@ static void _netif_list(struct netif *netif) {
             printf(":");
         }
     }
-    printf(" Link: %s State: %s %s\n",
-        netif_is_link_up(netif) ? "up" : "down",
-        netif_is_up(netif) ? "up" : "down",
+    printf("  Link: %s  State: %s  %s\n",
+        netif_is_link_up(netif) ? "up  " : "down",
+        netif_is_up(netif) ? "up  " : "down",
         netif == netif_default ? "Default route" : "");
     printf("        Link type: %s\n",
         (dev->driver->get(dev, NETOPT_IS_WIRED, &i, sizeof(i)) > 0) ?

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "lwip/netif.h"
 #include "lwip/netifapi.h"
+#include "lwip/prot/dhcp.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
 
@@ -68,6 +69,19 @@ static void _netif_list(struct netif *netif) {
     ip_addr_debug_print(LWIP_DBG_ON, netif_ip_netmask4(netif));
     printf(" gw: ");
     ip_addr_debug_print(LWIP_DBG_ON, netif_ip_gw4(netif));
+    if (netif_is_flag_set(netif, NETIF_FLAG_ETHERNET)) {
+        printf(" dhcp: ");
+        if (dhcp_supplied_address(netif)) {
+            printf("bound");
+        } else {
+            struct dhcp *dhcp = netif_dhcp_data(netif);
+            if (dhcp && dhcp->state > DHCP_STATE_OFF) {
+                printf("active");
+            } else {
+                printf("off");
+            }
+        }
+    }
     printf("\n");
 #endif
 

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Shell command for printing lwIP network interface status
+ * @brief       Shell command for interacting with lwIP network interfaces
  *
  * @author      Erik Ekman <eekman@google.com>
  *
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "lwip/netif.h"
+#include "lwip/netifapi.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
 
@@ -81,6 +82,8 @@ static void _netif_list(struct netif *netif) {
 static void _usage(const char *cmd) {
     printf("usage: %s [iface]\n", cmd);
     puts("      List all or a specific network interface");
+    printf("usage: %s <iface> {up|down}\n", cmd);
+    puts("      Enable or disable an interface (independent of link)");
 }
 
 int _lwip_netif_config(int argc, char **argv)
@@ -104,17 +107,26 @@ int _lwip_netif_config(int argc, char **argv)
     } else if (strcmp(argv[1], "help") == 0) {
         _usage(argv[0]);
         return 0;
-    } else if (argc == 2) {
+    } else {
         LOCK_TCPIP_CORE();
         struct netif *netif = netif_find(argv[1]);
         UNLOCK_TCPIP_CORE();
-        if (netif) {
-            _netif_list(netif);
-            return 0;
-        } else {
+        if (!netif) {
             printf("Interface '%s' not found.\n", argv[1]);
             _usage(argv[0]);
             return 1;
+        }
+        if (argc == 2) {
+            _netif_list(netif);
+            return 0;
+        } else if (argc == 3) {
+            if (strcmp(argv[2], "up") == 0) {
+                netifapi_netif_set_up(netif);
+                return 0;
+            } else if (strcmp(argv[2], "down") == 0) {
+                netifapi_netif_set_down(netif);
+                return 0;
+            }
         }
     }
     _usage(argv[0]);

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -277,7 +277,7 @@ const shell_command_t _shell_command_list[] = {
     {"openwsn", "OpenWSN commands", _openwsn_handler},
 #endif
 #ifdef MODULE_LWIP_NETIF
-    {"ifconfig", "List network interfaces", _lwip_netif_config},
+    {"ifconfig", "Configure network interfaces", _lwip_netif_config},
 #endif
 #ifdef MODULE_FIB
     {"fibroute", "Manipulate the FIB (info: 'fibroute [add|del]')", _fib_route_handler},


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Add features to lwIP ifconfig:

* Listing a single interface
* Setting interface up or down (interface state, not link state)
* Showing which interface is default route
* Setting interface as default route
* Showing DHCP status
* Starting/stopping DHCP



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Flash an app using lwIP and try out the `ifconfig` command

Example session:
```
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f  Link: up    State: up    Default route
        Link type: wired
        inet addr: 10.4.4.81 mask: 255.255.254.0 gw: 10.4.4.1 dhcp: bound
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9f scope: link
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9f scope: global
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c  Link: up    State: up    
        Link type: wireless
        inet addr: 10.4.4.86 mask: 255.255.254.0 gw: 10.4.4.1 dhcp: bound
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9c scope: link
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9c scope: global
> ifconfig ET0 dhcp stop
Releasing bound address
> ifconfig ET0
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f  Link: up    State: up    Default route
        Link type: wired
        inet addr: 0.0.0.0 mask: 0.0.0.0 gw: 0.0.0.0 dhcp: off
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9f scope: link
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9f scope: global
> ifconfig ET0 down
> ifconfig ET0
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f  Link: up    State: down  Default route
        Link type: wired
        inet addr: 0.0.0.0 mask: 0.0.0.0 gw: 0.0.0.0 dhcp: off
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9f scope: link
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9f scope: global
> ifconfig ET1 default
> ifconfig
Iface ET0 HWaddr: 24:0a:c4:e6:0e:9f  Link: up    State: down
        Link type: wired
        inet addr: 0.0.0.0 mask: 0.0.0.0 gw: 0.0.0.0 dhcp: off
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9f scope: link
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9f scope: global
Iface ET1 HWaddr: 24:0a:c4:e6:0e:9c  Link: up    State: up    Default route
        Link type: wireless
        inet addr: 10.4.4.86 mask: 255.255.254.0 gw: 10.4.4.1 dhcp: bound
        inet6 addr: fe80:0:0:0:260a:c4ff:fee6:e9c scope: link
        inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9c scope: global
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None