### PR TITLE
cpu/stm32: make backup SRAM available

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -137,6 +137,9 @@ void reset_handler_default(void)
     }
 
 #ifdef CPU_HAS_BACKUP_RAM
+#if BACKUP_RAM_HAS_INIT
+    backup_ram_init();
+#endif
     if (!cpu_woke_from_backup() ||
         CPU_BACKUP_RAM_NOT_RETAINED) {
 

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -24,6 +24,16 @@ ifneq (,$(filter $(CPU_FAM),f0 f2 f3 f4 f7 l0 l1 l4 l5 u5 wb wl))
   endif
 endif
 
+STM32_WITH_BKPRAM = stm32f205% stm32f207% stm32f215% stm32f217% \
+                    stm32f405% stm32f407% stm32f415% stm32f417% \
+                    stm32f427% stm32f429% stm32f437% stm32f439% \
+                    stm32f446% stm32f469% stm32f479% \
+                    stm32f7% \
+                    stm32u5%
+ifneq (,$(filter $(STM32_WITH_BKPRAM),$(CPU_MODEL)))
+  FEATURES_PROVIDED += backup_ram
+endif
+
 # The f2, f4 and f7 do not support the pagewise api
 ifneq (,$(filter $(CPU_FAM),f2 f4 f7))
   FEATURES_PROVIDED += periph_flashpage

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -67,7 +67,7 @@
 #elif CPU_FAM_STM32U5
 #include "stm32u5xx.h"
 #include "irqs/u5/irqs.h"
-#define NUM_HEAPS   2
+#define NUM_HEAPS   3
 #elif CPU_FAM_STM32WB
 #include "stm32wbxx.h"
 #include "irqs/wb/irqs.h"

--- a/cpu/stm32/include/periph/cpu_backup_ram.h
+++ b/cpu/stm32/include/periph/cpu_backup_ram.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_stm32
+ * @{
+ *
+ * @file
+ * @brief           Backup SRAM CPU specific definitions for the STM32 family
+ *
+ * @author          Fabian Hüßler <fabian.huessler@ovgu.de>
+ */
+
+#ifndef PERIPH_CPU_BACKUP_RAM_H
+#define PERIPH_CPU_BACKUP_RAM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Backup RAM must be initialized with @ref backup_ram_init on reset
+ */
+#define BACKUP_RAM_HAS_INIT         1
+
+/**
+ * @brief   Enable backup RAM access
+ */
+void backup_ram_init(void);
+
+/**
+ * @brief   Returns true if the CPU woke up from deep sleep (backup/standby)
+ */
+bool cpu_woke_from_backup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CPU_BACKUP_RAM_H */
+/** @} */

--- a/cpu/stm32/include/periph/cpu_pm.h
+++ b/cpu/stm32/include/periph/cpu_pm.h
@@ -50,6 +50,22 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   Check whether the backup domain voltage regulator is on
+ */
+bool pm_backup_regulator_is_on(void);
+
+/**
+ * @brief   Enable the backup domain voltage regulator to retain backup
+ *          register content during standby and VBAT mode
+ */
+void pm_backup_regulator_on(void);
+
+/**
+ * @brief   Disable the backup domain voltage regulator
+ */
+void pm_backup_regulator_off(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -58,6 +58,7 @@
 #include "periph/wl/periph_cpu.h"
 #endif
 
+#include "periph/cpu_backup_ram.h"
 #include "periph/cpu_common.h"
 #include "periph/cpu_dma.h"
 #include "periph/cpu_eth.h"

--- a/cpu/stm32/include/stmclk.h
+++ b/cpu/stm32/include/stmclk.h
@@ -22,6 +22,8 @@
 #ifndef STMCLK_H
 #define STMCLK_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -83,6 +85,14 @@ void stmclk_dbp_unlock(void);
  * @brief   Lock write access to backup control domain
  */
 void stmclk_dbp_lock(void);
+
+/**
+ * @brief   Check whether write access to the backup domain is locked
+ *
+ * @retval  true: locked
+ * @retval  false: unlocked
+ */
+bool stmclk_dbp_is_locked(void);
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32/kconfigs/f2/Kconfig
+++ b/cpu/stm32/kconfigs/f2/Kconfig
@@ -9,6 +9,7 @@ config CPU_FAM_F2
     bool
     select CPU_STM32
     select CPU_CORE_CORTEX_M3
+    select HAS_BACKUP_RAM
     select HAS_CPU_STM32F2
     select HAS_CORTEXM_MPU
     select HAS_PERIPH_FLASHPAGE

--- a/cpu/stm32/kconfigs/f4/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f4/Kconfig.lines
@@ -23,12 +23,14 @@ config CPU_LINE_STM32F401XE
 config CPU_LINE_STM32F405XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F407XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
@@ -83,12 +85,14 @@ config CPU_LINE_STM32F413XX
 config CPU_LINE_STM32F415XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F417XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F423XX
@@ -99,37 +103,44 @@ config CPU_LINE_STM32F423XX
 config CPU_LINE_STM32F427XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F429XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F437XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F439XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F446XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F469XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F479XX
     bool
     select CPU_FAM_F4
+    select HAS_BACKUP_RAM
     select CLOCK_MAX_180MHZ

--- a/cpu/stm32/kconfigs/f7/Kconfig
+++ b/cpu/stm32/kconfigs/f7/Kconfig
@@ -9,6 +9,7 @@ config CPU_FAM_F7
     bool
     select CPU_STM32
     select CPU_CORE_CORTEX_M7
+    select HAS_BACKUP_RAM
     select HAS_CPU_STM32F7
     select HAS_CORTEXM_MPU
     select HAS_PERIPH_FLASHPAGE

--- a/cpu/stm32/kconfigs/u5/Kconfig
+++ b/cpu/stm32/kconfigs/u5/Kconfig
@@ -9,6 +9,7 @@ config CPU_FAM_U5
     bool
     select CPU_STM32
     select CPU_CORE_CORTEX_M33
+    select HAS_BACKUP_RAM
     select HAS_CPU_STM32U5
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_FLASHPAGE_PAGEWISE

--- a/cpu/stm32/ldscripts/stm32.ld
+++ b/cpu/stm32/ldscripts/stm32.ld
@@ -31,8 +31,8 @@ SECTIONS
 {
     .heap2 ALIGN(4) (NOLOAD) :
     {
-        _sheap1 = . ;
-        _eheap1 = ORIGIN(sram4) + LENGTH(sram4);
+        _sheap2 = . ;
+        _eheap2 = ORIGIN(sram4) + LENGTH(sram4);
     } > sram4
 }
 

--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -90,6 +90,10 @@ ifeq ($(STM32_TYPE), F)
     else ifeq ($(STM32_MODEL3), 7)
       RAM_LEN = 128K
     endif
+    ifneq (, $(filter $(STM32_MODEL), 205 207 215 217))
+      BACKUP_RAM_ADDR = 0x40024000
+      BACKUP_RAM_LEN = 0x4K
+    endif
   else ifeq ($(STM32_FAMILY), 3)
     ifeq ($(STM32_MODEL), 301)
       RAM_LEN = 16K
@@ -167,6 +171,10 @@ ifeq ($(STM32_TYPE), F)
     ifneq (, $(filter $(STM32_MODEL3), 5 7 9))
       CCMRAM_LEN = 64K
     endif
+    ifneq (, $(filter $(STM32_MODEL), 405 407 415 417 427 429 437 439 446 469 479))
+      BACKUP_RAM_ADDR = 0x40024000
+      BACKUP_RAM_LEN = 0x4K
+    endif
   else ifeq ($(STM32_FAMILY),7)
     ifneq (, $(filter $(STM32_MODEL2), 2 3))
       RAM_LEN = 256K
@@ -175,6 +183,8 @@ ifeq ($(STM32_TYPE), F)
     else ifneq (, $(filter $(STM32_MODEL2), 6 7))
       RAM_LEN = 512K
     endif
+    BACKUP_RAM_ADDR = 0x40024000
+    BACKUP_RAM_LEN = 0x4K
   endif
 else ifeq ($(STM32_TYPE), G)
   ifeq ($(STM32_FAMILY), 0)
@@ -271,6 +281,8 @@ else ifeq ($(STM32_TYPE), U)
     ifneq (, $(filter $(STM32_MODEL2), 7 8))
       RAM_LEN = 768K
       SRAM4_LEN = 16K
+      BACKUP_RAM_ADDR = 0x40036400
+      BACKUP_RAM_LEN = 0x2K
     endif
   endif
 else ifeq ($(STM32_TYPE), W)

--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -115,5 +115,14 @@ void stmclk_dbp_unlock(void)
 
 void stmclk_dbp_lock(void)
 {
-    PWR->REG_PWR_CR &= ~(BIT_CR_DBP);
+    if (!IS_ACTIVE(CPU_HAS_BACKUP_RAM)) {
+/*  The DBP must be unlocked all the time, if we modify
+    backup RAM content by comfortable BACKUP_RAM variables */
+        PWR->REG_PWR_CR &= ~(BIT_CR_DBP);
+    }
+}
+
+bool stmclk_dbp_is_locked(void)
+{
+    return !(PWR->REG_PWR_CR & BIT_CR_DBP);
 }

--- a/cpu/stm32/stmclk/stmclk_u5.c
+++ b/cpu/stm32/stmclk/stmclk_u5.c
@@ -246,6 +246,11 @@ void stmclk_init_sysclk(void)
     /* Wait Until the Voltage Regulator is ready */
     while (!(PWR->VOSR & PWR_VOSR_VOSRDY)) {}
 
+    /* Backup RAM retention in Standby and VBAT modes:
+       This bit can be written only when the regulator is LDO,
+       which must be configured before switching to SMPS */
+    PWR->BDCR1 |= PWR_BDCR1_BREN;
+
     /* Switch to SMPS regulator instead of LDO */
     PWR->CR3 |= PWR_CR3_REGSEL;
     while (!(PWR->SVMSR & PWR_SVMSR_REGS)) {}

--- a/tests/periph_backup_ram/Kconfig
+++ b/tests/periph_backup_ram/Kconfig
@@ -9,4 +9,5 @@ config APPLICATION
     bool
     default y
     depends on HAS_BACKUP_RAM
+    depends on HAS_PERIPH_RTC
     depends on TEST_KCONFIG

--- a/tests/periph_backup_ram/Makefile
+++ b/tests/periph_backup_ram/Makefile
@@ -1,9 +1,9 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = backup_ram
+FEATURES_REQUIRED += backup_ram
+FEATURES_REQUIRED += periph_rtc
 
 USEMODULE += pm_layered
-USEMODULE += periph_rtc
 USEMODULE += xtimer
 
 DISABLE_MODULE += test_utils_interactive_sync


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR aims to make the backup SRAM available for `stm32` MCUs.
<del>It also includes renaming of `backup_ram` to `periph_backup_ram` to better fit in the line with other peripheral features. I can split out the latter, if you agree to the renaming.</del>

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`tests/periph_backup_ram` with `nucleo-f767zi`
```
2021-09-19 10:35:10,955 # Try to reconnect to /dev/ttyACM0 again...
2021-09-19 10:35:10,957 # Reconnected to serial port /dev/ttyACM0
2021-09-19 10:35:14,657 # counter: 2
2021-09-19 10:35:18,610 # counter: 3
2021-09-19 10:35:22,563 # counter: 4
2021-09-19 10:35:26,517 # counter: 5
2021-09-19 10:35:30,470 # counter: 6
2021-09-19 10:35:34,423 # counter: 7
2021-09-19 10:35:38,375 # counter: 8
2021-09-19 10:35:42,328 # counter: 9
2021-09-19 10:35:46,280 # counter: 10
2021-09-19 10:35:50,232 # counter: 11
2021-09-19 10:35:54,184 # counter: 12
2021-09-19 10:35:58,136 # counter: 13
2021-09-19 10:36:02,086 # counter: 14
2021-09-19 10:36:06,038 # counter: 15
2021-09-19 10:36:09,988 # counter: 16
```
:warning: If I just reflash the board, the following warning occures and the counter is not reset. I am not sure if it should be. Maybe someone has an idea.
```
Welcome to pyterm!
Type '/exit' to exit.
2021-09-19 10:36:51,323 # WARNING: non-backup memory retained - did we really enter deep sleep?
2021-09-19 10:36:51,324 # counter: 27
2021-09-19 10:36:55,279 # WARNING: non-backup memory retained - did we really enter deep sleep?
2021-09-19 10:36:55,281 # counter: 28
2021-09-19 10:36:59,234 # WARNING: non-backup memory retained - did we really enter deep sleep?
2021-09-19 10:36:59,235 # counter: 29
2021-09-19 10:37:03,186 # WARNING: non-backup memory retained - did we really enter deep sleep?
2021-09-19 10:37:03,188 # counter: 30
2021-09-19 10:37:07,142 # WARNING: non-backup memory retained - did we really enter deep sleep?
2021-09-19 10:37:07,142 # counter: 31
2021-09-19 10:37:11,096 # WARNING: non-backup memory retained - did we really enter deep sleep?
2021-09-19 10:37:11,097 # counter: 32
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
