### PR TITLE
pkg/edhoc-c: ignore llvm flagged error

### DIFF
--- a/pkg/edhoc-c/Makefile
+++ b/pkg/edhoc-c/Makefile
@@ -5,6 +5,8 @@ PKG_LICENSE = BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-newline-eof
+
 .PHONY: edhoc-c_%
 
 EDHOC_C_MODULES := $(filter edhoc-c_%,$(USEMODULE))


### PR DESCRIPTION

### Contribution description

Fixed a compilation issue, with llvm.

### Testing procedure

```
TOOLCHAIN=llvm make -C tests/pkg_edhoc_c/ all -j7
Building application "tests_pkg_edhoc_c" for "native" with MCU "native".

make[1]: Nothing to be done for 'prepare'.
[INFO] cloning EDHOC-C
Cloning into '/home/francisco/workspace/RIOT2/build/pkg/EDHOC-C'...
remote: Enumerating objects: 1367, done.
remote: Counting objects: 100% (376/376), done.
remote: Compressing objects: 100% (146/146), done.
remote: Total 1367 (delta 277), reused 265 (delta 225), pack-reused 991
Receiving objects: 100% (1367/1367), 531.33 KiB | 5.21 MiB/s, done.
Resolving deltas: 100% (835/835), done.
HEAD is now at 1366035 src/cbor/nanocbor: bump nanocbor version
[INFO] updating EDHOC-C /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/.pkg-state.git-downloaded
echo 13660352d1c1551b292ba53ece1365f34f60aa2e > /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/.pkg-state.git-downloaded
[INFO] patch EDHOC-C
[INFO] updating nanocbor /home/francisco/workspace/RIOT2/build/pkg/nanocbor/.pkg-state.git-downloaded
echo b2b1d26e4144753c8e91d005c8a4079c0e77439f > /home/francisco/workspace/RIOT2/build/pkg/nanocbor/.pkg-state.git-downloaded
[INFO] patch nanocbor
[INFO] cloning tinycrypt
Cloning into '/home/francisco/workspace/RIOT2/build/pkg/tinycrypt'...
remote: Enumerating objects: 698, done.
remote: Total 698 (delta 0), reused 0 (delta 0), pack-reused 698
Receiving objects: 100% (698/698), 891.88 KiB | 6.46 MiB/s, done.
Resolving deltas: 100% (458/458), done.
HEAD is now at 5969b0e Merge pull request #40 from winnietwo/side_channel_patch
[INFO] updating tinycrypt /home/francisco/workspace/RIOT2/build/pkg/tinycrypt/.pkg-state.git-downloaded
echo 5969b0e0f572a15ed95dc272e57104faeb5eb6b0 > /home/francisco/workspace/RIOT2/build/pkg/tinycrypt/.pkg-state.git-downloaded
[INFO] patch tinycrypt
"make" -C /home/francisco/workspace/RIOT2/pkg/c25519
"make" -C /home/francisco/workspace/RIOT2/pkg/edhoc-c
"make" -C /home/francisco/workspace/RIOT2/pkg/nanocbor
"make" -C /home/francisco/workspace/RIOT2/pkg/tinycrypt
"make" -C /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src/cbor -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=edhoc-c_cbor_nanocbor SRC=nanocbor.c
"make" -C /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src/crypto -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=edhoc-c_crypto_tinycrypt SRC=tinycrypt.c
"make" -C /home/francisco/workspace/RIOT2/build/pkg/c25519/src -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=c25519
"make" -C /home/francisco/workspace/RIOT2/build/pkg/nanocbor/src -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=nanocbor
"make" -C /home/francisco/workspace/RIOT2/build/pkg/tinycrypt/lib/source/ -f /home/francisco/workspace/RIOT2/pkg/tinycrypt/Makefile.tinycrypt -f /home/francisco/workspace/RIOT2/Makefile.base MODULE=tinycrypt
In file included from /home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src/crypto/tinycrypt.c:11:
/home/francisco/workspace/RIOT2/build/pkg/EDHOC-C/src/crypto/tinycrypt/hkdf.h:102:25: error: no newline at end of file [-Werror,-Wnewline-eof]
#endif /*__TC_HKDF_H__*/
                        ^
1 error generated.
make[2]: *** [/home/francisco/workspace/RIOT2/Makefile.base:131: /home/francisco/workspace/RIOT2/tests/pkg_edhoc_c/bin/native/edhoc-c_crypto_tinycrypt/tinycrypt.o] Error 1
make[1]: *** [Makefile:16: edhoc-c_crypto_tinycrypt] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [/home/francisco/workspace/RIOT2/tests/pkg_edhoc_c/../../Makefile.include:741: pkg-build-edhoc-c] Error 2
make: *** Waiting for unfinished jobs....
```

