### PR TITLE
pkg/tinydtls: fix detection of Kconfig usage

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -28,7 +28,7 @@ ifeq (,$(filter posix_sockets,$(USEMODULE)))
 endif
 
 # Default cipher suite when not using Kconfig
-ifeq (,$(CONFIG_KCONFIG_PKG_TINYDTLS))
+ifeq (,$(CONFIG_KCONFIG_USEPKG_TINYDTLS))
   # NOTE: PSK should be enabled by default BUT if the user define any other cipher
   #       suite(s) it should not be enabled.
   # TODO: Create the flag DTLS_CIPHERS with keywords PSK, ECC (and future)


### PR DESCRIPTION
### Contribution description
As reported in #16873, the tinyDTLS example fails to build with Kconfig, because the Makefile fails to detect that Kconfig is being used, and injects CFLAGS. This makes PSK and ECC to be built, which is not supported by the example application so far.

### Testing procedure
You can follow the procedure described in #16873.

### Issues/PRs references
Fixes #16873.