### PR TITLE
riscv: Simplify reset trampoline

### DIFF
--- a/cpu/riscv_common/start.S
+++ b/cpu/riscv_common/start.S
@@ -18,11 +18,8 @@ _start:
 .option push
 .option norelax
     csrc CSR_MSTATUS, MSTATUS_MIE
-    la a0, _start
-    li a1, ROM_START_ADDR
-    bleu a1, a0, _start_real
-    la a0, _start_real
-    add a0, a0, a1
+    lui a0, %hi(_start_real)
+    addi a0, a0, %lo(_start_real)
     jr a0
 
 _start_real:


### PR DESCRIPTION
This PR simplifies the code in the reset trampoline that is used to jump to the right flash base address for the real startup code. By loading the absolute address of `_start_real` we can unconditionally jump to it regardless if the PC is somewhere at `0x0` or at `ROM_START_ADDR`.

Background:

The whole logic in this function both before and after this PR is there because on GD32V, the PC jumps to `0x0` on system reset, which is an alias address for the flash, but our code in the ELF file is linked at `0x08000000` which makes GDB not understand any symbol addresses until we jump to the real flash base address. Without jumping to the correct base we also get the wrong address for `__global_pointer$` a few lines below this change.

This change was spawned from a discussion in the Matrix room this morning.