### PR TITLE
cpu/riscv: add CPU_ARCH information

### DIFF
--- a/cpu/fe310/Kconfig
+++ b/cpu/fe310/Kconfig
@@ -7,7 +7,7 @@
 
 config CPU_FAM_FE310
     bool
-    select CPU_CORE_RV32I
+    select CPU_CORE_RV32IMAC
     select HAS_CPU_FE310
     select HAS_PERIPH_CPUID
     select HAS_PERIPH_GPIO
@@ -41,6 +41,9 @@ config CPU_MODEL
 
 config CPU
     default "fe310" if CPU_FAM_FE310
+
+config CPU_CORE
+    default "rv32imac" if CPU_CORE_RV32IMAC
 
 rsource "Kconfig.clk"
 

--- a/cpu/fe310/Makefile.features
+++ b/cpu/fe310/Makefile.features
@@ -1,3 +1,5 @@
+CPU_CORE := rv32imac
+
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm

--- a/cpu/gd32v/Kconfig
+++ b/cpu/gd32v/Kconfig
@@ -7,7 +7,7 @@
 
 config CPU_FAM_GD32V
     bool
-    select CPU_CORE_RV32I
+    select CPU_CORE_RV32IMAC
     select HAS_CPU_GD32V
     select HAS_PERIPH_CLIC
     select HAS_PERIPH_GPIO
@@ -36,5 +36,8 @@ config CPU_MODEL
 
 config CPU
     default "gd32v" if CPU_FAM_GD32V
+
+config CPU_CORE
+    default "rv32imac" if CPU_CORE_RV32IMAC
 
 source "$(RIOTCPU)/riscv_common/Kconfig"

--- a/cpu/gd32v/Makefile.features
+++ b/cpu/gd32v/Makefile.features
@@ -1,3 +1,5 @@
+CPU_CORE := rv32imac
+
 FEATURES_PROVIDED += periph_clic
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer

--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -15,7 +15,7 @@ config CPU_ARCH_RISCV
     select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
     select HAS_SSP
 
-config CPU_CORE_RV32I
+config CPU_CORE_RV32IMAC
     bool
     select CPU_ARCH_RISCV
     select HAS_ARCH_32BIT
@@ -27,7 +27,4 @@ config HAS_ARCH_RISCV
         Indicates that the current CPU has a RISC-V.
 
 config CPU_ARCH
-    default "risc-v" if CPU_ARCH_RISCV
-
-config CPU_CORE
-    default "rv32i" if CPU_CORE_RV32I
+    default "rv32" if CPU_CORE_RV32IMAC

--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -1,3 +1,7 @@
+ifeq ($(findstring rv32,$(CPU_CORE)),rv32)
+  CPU_ARCH := rv32
+endif
+
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_riscv
 FEATURES_PROVIDED += cpp


### PR DESCRIPTION
### Contribution description

adds CPU_ARCH information to riscv_common similar to arm / mips / xtensa

### Testing procedure

### Issues/PRs references

