### PR TITLE
tools/zep_dispatch: add support for foren6 sniffer

### DIFF
--- a/dist/tools/zep_dispatch/main.c
+++ b/dist/tools/zep_dispatch/main.c
@@ -79,7 +79,12 @@ static void _send_topology(void *ctx, void *buffer, size_t len,
     uint8_t mac_src_len;
 
     if (zep_parse_mac(buffer, len, mac_src, &mac_src_len)) {
-        topology_add(ctx, mac_src, mac_src_len, src_addr);
+        /* a sniffer node has no MAC address and will receive every packet */
+        if (mac_src_len == 0) {
+            topology_set_sniffer(ctx, src_addr);
+        } else {
+            topology_add(ctx, mac_src, mac_src_len, src_addr);
+        }
     }
     topology_send(ctx, sock, src_addr, buffer, len);
 }

--- a/dist/tools/zep_dispatch/topology.h
+++ b/dist/tools/zep_dispatch/topology.h
@@ -9,6 +9,7 @@
 #define TOPOLOGY_H
 
 #include "list.h"
+#include <netinet/in.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,9 +19,11 @@ extern "C" {
  * @brief   Struct describing a graph of nodes and their connections
  */
 typedef struct {
-    bool flat;          /**< flat topology, all nodes are connected to each other */
     list_node_t nodes;  /**< list of nodes */
     list_node_t edges;  /**< list of connections between nodes. Unused if topology is flat */
+    struct sockaddr_in6 sniffer_addr;   /**< address of sniffer node. Unused if topology is flat */
+    bool has_sniffer;   /**< true if a sniffer node is connected. Unused if topology is flat */
+    bool flat;          /**< flat topology, all nodes are connected to each other */
 } topology_t;
 
 /**
@@ -57,6 +60,16 @@ int topology_print(const char *file_out, const topology_t *t);
  */
 bool topology_add(topology_t *t, const uint8_t *mac, uint8_t mac_len,
                   struct sockaddr_in6 *addr);
+
+/**
+ * @brief   Add a sniffer to the topology
+ *          A sniffer node will receive every packet but won't be able to
+ *          send packets on it's own.
+ *
+ * @param[in, out]  t       topology to configure
+ * @param[in]       addr    real address of the sniffer
+ */
+void topology_set_sniffer(topology_t *t, struct sockaddr_in6 *addr);
 
 /**
  * @brief   Send a buffer to all nodes connected to a source node


### PR DESCRIPTION
### Contribution description

This adds support for a sniffer node to the non-flat topology in ZEP dispatcher

A sniffer is a node (e.g. [foren6](https://cetic.github.io/foren6/)) that should receive every packet sent by any node.
For the flat topology we don't have to do anything as this will by default forward every packet to every node.

In 'advanced' topology mode we have to add a special case: The sniffer should not take up a spot in the topology but instead will just receive a copy of every packet sent by any node.

To identify the sniffer node, the sniffer will not include a (virtual) MAC address in it's HELLO packet.

### Testing procedure

I have a patched version of foren6 that includes support for a ZEP sniffer interface: https://github.com/benpicco/foren6

With this it is possible to analyze a virtual RPL network on `native`:

 - build & start the `gnrc_border_router` example with RPL enabled: 

       USEMODULE=gnrc_rpl BOARD=native make -C examples/gnrc_border_router all term

 - build & start a few instances of the `gnrc_networking` example with ZEP enabled: 

       USE_ZEP=1 CFLAGS=-DCONFIG_GNRC_RPL_DEFAULT_NETIF=7 BOARD=native make -C examples/gnrc_networking all term

 - start `foren6` and in the 'Manage Sources' menu, add a ZEP sniffer
![Screenshot at 2021-09-22 15-39-03](https://user-images.githubusercontent.com/1301112/134354399-7010ad73-044d-4ffa-ad99-61a6838af268.png)

    The 'target' field takes a hostname:port combination, but you can leave it blank. In that case the default `[::1]:17754` will be used

- Start sniffing, you should now see your `native` ZEP nodes appear and form a DODAG with the border router.

![Screenshot at 2021-09-22 15-38-25](https://user-images.githubusercontent.com/1301112/134354251-14abe2f4-9bfe-4f79-b676-9c1de6e17679.png)

### Issues/PRs references

useful for #14623
