### PR TITLE
drivers/lpsxxx: add support for lps22hh

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -76,7 +76,7 @@ ifneq (,$(filter tmp1075 lm75%,$(USEMODULE)))
   USEMODULE += lm75
 endif
 
-ifneq (,$(filter lps331ap lps2%hb,$(USEMODULE)))
+ifneq (,$(filter lps331ap lps2%hb lps22hh,$(USEMODULE)))
   USEMODULE += lpsxxx
 endif
 

--- a/drivers/include/lpsxxx.h
+++ b/drivers/include/lpsxxx.h
@@ -81,6 +81,13 @@ typedef enum {
     LPSXXX_RATE_25HZ = 3,       /**< sample with 25Hz, default */
     LPSXXX_RATE_50HZ = 4,       /**< sample with 50Hz */
     LPSXXX_RATE_75HZ = 5        /**< sample with 75Hz */
+#elif MODULE_LPS22HH
+    LPSXXX_RATE_10HZ = 2,       /**< sample with 10Hz */
+    LPSXXX_RATE_25HZ = 3,       /**< sample with 25Hz, default */
+    LPSXXX_RATE_50HZ = 4,       /**< sample with 50Hz */
+    LPSXXX_RATE_75HZ = 5,       /**< sample with 75Hz */
+    LPSXXX_RATE_100HZ = 6,      /**< sample with 100Hz */
+    LPSXXX_RATE_200HZ = 7       /**< sample with 200Hz */
 #endif
 } lpsxxx_rate_t;
 
@@ -89,7 +96,7 @@ typedef enum {
  */
 #if MODULE_LPS331AP || MODULE_LPS25HB
 #define LPSXXX_DEFAULT_RATE     (LPSXXX_RATE_7HZ)
-#else /* MODULE_LPS22HB */
+#else /* MODULE_LPS22HB || MODULE_LPS22HH */
 #define LPSXXX_DEFAULT_RATE     (LPSXXX_RATE_25HZ)
 #endif
 

--- a/drivers/lpsxxx/Kconfig
+++ b/drivers/lpsxxx/Kconfig
@@ -13,7 +13,7 @@ choice
     depends on TEST_KCONFIG
     help
         Device driver for the LPSXXX pressure sensor family
-        (LPS331AP/LPS25HB/LPS22HB). Select a model.
+        (LPS331AP/LPS25HB/LPS22HB/LPS22HH). Select a model.
 
 config MODULE_LPS331AP
     bool "LPS331AP"
@@ -21,6 +21,10 @@ config MODULE_LPS331AP
 
 config MODULE_LPS22HB
     bool "LPS22HB"
+    select MODULE_LPSXXX
+
+config MODULE_LPS22HH
+    bool "LPS22HH"
     select MODULE_LPSXXX
 
 config MODULE_LPS25HB

--- a/drivers/lpsxxx/include/lpsxxx_internal.h
+++ b/drivers/lpsxxx/include/lpsxxx_internal.h
@@ -168,7 +168,57 @@ extern "C" {
  */
 #define LPSXXX_WHO_AM_I                 (0xb1)
 
-#endif /* MODULE_LPS22HB */
+#elif MODULE_LPS22HH
+
+/**
+ * @name    LPS22HH registers
+ * @{
+ */
+#define LPSXXX_REG_INT_CFG              (0x0b)
+#define LPSXXX_REG_THS_P_L              (0x0c)
+#define LPSXXX_REG_THS_P_H              (0x0d)
+#define LPSXXX_REG_IF_CTRL              (0x0e)
+#define LPSXXX_REG_CTRL_REG1            (0x10)
+#define LPSXXX_REG_CTRL_REG2            (0x11)
+#define LPSXXX_REG_CTRL_REG3            (0x12)
+#define LPSXXX_REG_FIFO_CTRL            (0x13)
+#define LPSXXX_REG_FIFO_WTM             (0x14)
+#define LPSXXX_REG_REF_P_L              (0x15)
+#define LPSXXX_REG_REF_P_H              (0x16)
+#define LPSXXX_REG_RPDS_L               (0x18)
+#define LPSXXX_REG_RPDS_H               (0x19)
+#define LPSXXX_REG_INT_SOURCE           (0x24)
+#define LPSXXX_REG_FIFO_STATUS1         (0x25)
+#define LPSXXX_REG_FIFO_STATUS2         (0x26)
+#define LPSXXX_REG_FIFO_OUT_PRESS_XL    (0x78)
+#define LPSXXX_REG_FIFO_OUT_PRESS_L     (0x79)
+#define LPSXXX_REG_FIFO_OUT_PRESS_H     (0x7a)
+#define LPSXXX_REG_FIFO_OUT_TEMP_L      (0x7b)
+#define LPSXXX_REG_FIFO_OUT_TEMP_H      (0x7c)
+/** @} */
+
+/**
+ * @name    LPS22HH CTRL_REG1 bitfields
+ * @{
+ */
+#define LPSXXX_CTRL_REG1_EN_LPFP        (0x08)
+#define LPSXXX_CTRL_REG1_LPFP_CFG       (0x04)
+#define LPSXXX_CTRL_REG1_BDU            (0x02)
+/** @} */
+
+/**
+ * @name    LPS22HH CTRL_REG2 bitfields
+ * @{
+ */
+#define LPSXXX_CTRL_REG2_ID_ADD_INC     (0x10)
+/** @} */
+
+/**
+ * @brief   LPS22HH WHO_AM_I register value
+ */
+#define LPSXXX_WHO_AM_I                 (0xb3)
+
+#endif /* MODULE_LPS22HH */
 
 #ifdef __cplusplus
 }

--- a/drivers/lpsxxx/include/lpsxxx_params.h
+++ b/drivers/lpsxxx/include/lpsxxx_params.h
@@ -55,6 +55,8 @@ extern "C" {
 #define LPSXXX_SAUL_NAME    "lps25hb"
 #elif MODULE_LPS22HB
 #define LPSXXX_SAUL_NAME    "lps22hb"
+#elif MODULE_LPS22HH
+#define LPSXXX_SAUL_NAME    "lps22hh"
 #endif
 #ifndef LPSXXX_SAUL_INFO
 #define LPSXXX_SAUL_INFO                { .name = LPSXXX_SAUL_NAME }

--- a/drivers/lpsxxx/lpsxxx.c
+++ b/drivers/lpsxxx/lpsxxx.c
@@ -106,6 +106,9 @@ int lpsxxx_init(lpsxxx_t *dev, const lpsxxx_params_t * params)
 #elif MODULE_LPS22HB
     tmp = LPSXXX_CTRL_REG1_EN_LPFP | /* Low-pass filter configuration: ODR/9 */
             LPSXXX_CTRL_REG1_BDU | (DEV_RATE << LPSXXX_CTRL_REG1_ODR_POS);
+#elif MODULE_LPS22HH
+    tmp = LPSXXX_CTRL_REG1_EN_LPFP | /* Low-pass filter configuration: ODR/9 */
+            LPSXXX_CTRL_REG1_BDU | (DEV_RATE << LPSXXX_CTRL_REG1_ODR_POS);
 #endif
 
     DEBUG("[lpsxxx] init: update reg1, value: %02X\n", tmp);

--- a/drivers/lpsxxx/lpsxxx_saul.c
+++ b/drivers/lpsxxx/lpsxxx_saul.c
@@ -12,7 +12,8 @@
  * @{
  *
  * @file
- * @brief       LPSXXX (LPS331ap/LPS25HB/LPS22HB) adaption to SAUL interface
+ * @brief       LPSXXX (LPS331ap/LPS25HB/LPS22HB/LPS22HH) adaption to SAUL
+ *              interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -314,6 +314,7 @@ PSEUDOMODULES += ws281x_%
 # include variants of lpsxxx drivers as pseudo modules
 PSEUDOMODULES += lps331ap
 PSEUDOMODULES += lps22hb
+PSEUDOMODULES += lps22hh
 PSEUDOMODULES += lps25hb
 
 # add all pseudo random number generator variants as pseudomodules

--- a/tests/driver_lpsxxx/README.md
+++ b/tests/driver_lpsxxx/README.md
@@ -1,7 +1,7 @@
 # About
 
 This is a manual test application for the LPSXXX family of pressure sensors
-driver. This driver can be used with LPS331AP, LPS25HB and LPS22HB.
+driver. This driver can be used with LPS331AP, LPS25HB, LPS22HB and LPS22HH.
 
 Default driver is `lps331ap`. To use the LPS25HB driver, set the `DRIVER` when
 building the application:
@@ -11,7 +11,7 @@ building the application:
 # Usage
 
 This test application will initialize the pressure sensor with a sampling rate
-of 7Hz (25Hz with lps22hb).
+of 7Hz (25Hz with lps22hb and lps22hh).
 
 After initialization, the sensor reads the pressure and temperature values
 every 250ms and prints them to the STDOUT.

--- a/tests/driver_lpsxxx/main.c
+++ b/tests/driver_lpsxxx/main.c
@@ -12,7 +12,8 @@
  * @{
  *
  * @file
- * @brief       Test application for the LPS331AP/LPS25HB/LPS22HB pressure sensor
+ * @brief       Test application for the LPS331AP/LPS25HB/LPS22HB/LPS22HH
+ *              pressure sensor
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>


### PR DESCRIPTION
### Contribution description

I added support for the [LPS22HH](https://www.st.com/en/mems-and-sensors/lps22hh.html) pressure sensor based on the already supported LPS22HB.
There are a few differences in the register mappings and two new sample rates.

### Testing procedure

I flashed `tests/driver_lpsxxx` on a nrf52840dk with an X-NUCLEO-IKS01A3 (which includes an LPS22HH sensor). It successfully printed sensor readings:

```
2021-09-22 17:34:23,074 # Pressure value: 1021hPa - Temperature: 26.37°C
2021-09-22 17:34:24,009 # Pressure value: 1021hPa - Temperature: 26.37°C
2021-09-22 17:34:25,013 # Pressure value: 1021hPa - Temperature: 26.37°C
2021-09-22 17:34:26,017 # Pressure value: 1021hPa - Temperature: 26.37°C
2021-09-22 17:34:27,020 # Pressure value: 1021hPa - Temperature: 26.36°C
2021-09-22 17:34:28,024 # Pressure value: 1021hPa - Temperature: 26.36°C
2021-09-22 17:34:29,028 # Pressure value: 1021hPa - Temperature: 26.36°C
2021-09-22 17:34:30,032 # Pressure value: 1021hPa - Temperature: 26.36°C
```

### Issues/PRs references

/