### PR TITLE
added APB12 bus multiplier entry for applicable cpus

### DIFF
--- a/cpu/stm32/cpu_common.c
+++ b/cpu/stm32/cpu_common.c
@@ -36,8 +36,18 @@
 static const uint8_t apbmul[] = {
 #if (CLOCK_APB1 < CLOCK_CORECLOCK)
     [APB1] = 2,
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L5) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32G0)
+    [APB12] = 2,
+#endif
 #else
     [APB1] = 1,
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L5) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32G0)
+    [APB12] = 1,
+#endif
 #endif
 #if (CLOCK_APB2 < CLOCK_CORECLOCK)
     [APB2] = 2


### PR DESCRIPTION
### Contribution description

Added `apbmul` array entry for APB12, which is used on several STM32G and L series boards.

### Testing procedure

Loaded to an STM32G030 board and verified that TIM1 (on APB12 bus) was operating at the desired frequency, which was only achievable if the APB12 bus multiplier was set to 2.


### Issues/PRs references


