### PR TITLE
cpu/stm32: added ADC for g0

### DIFF
--- a/boards/nucleo-g070rb/Kconfig
+++ b/boards/nucleo-g070rb/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_G070RB
     select CPU_MODEL_STM32G070RB
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER

--- a/boards/nucleo-g070rb/Makefile.features
+++ b/boards/nucleo-g070rb/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32g070rb
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -87,6 +87,27 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name    ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32G070 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A,  0), .dev = 0, .chan =  0 },
+    { .pin = GPIO_PIN(PORT_A,  1), .dev = 0, .chan =  1 },
+    { .pin = GPIO_PIN(PORT_A,  4), .dev = 0, .chan =  4 },
+    { .pin = GPIO_PIN(PORT_B,  1), .dev = 0, .chan =  9 },
+    { .pin = GPIO_PIN(PORT_B, 11), .dev = 0, .chan = 15 },
+    { .pin = GPIO_PIN(PORT_B, 12), .dev = 0, .chan = 16 },
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+/**
  * @name   SPI configuration
  * @{
  */

--- a/boards/nucleo-g071rb/Kconfig
+++ b/boards/nucleo-g071rb/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_G071RB
     select CPU_MODEL_STM32G071RB
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/nucleo-g071rb/Makefile.features
+++ b/boards/nucleo-g071rb/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32g071rb
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-g071rb/include/periph_conf.h
+++ b/boards/nucleo-g071rb/include/periph_conf.h
@@ -85,6 +85,27 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name    ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32G071 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A,  0), .dev = 0, .chan =  0 },
+    { .pin = GPIO_PIN(PORT_A,  1), .dev = 0, .chan =  1 },
+    { .pin = GPIO_PIN(PORT_A,  4), .dev = 0, .chan =  4 },
+    { .pin = GPIO_PIN(PORT_B,  1), .dev = 0, .chan =  9 },
+    { .pin = GPIO_PIN(PORT_B, 11), .dev = 0, .chan = 15 },
+    { .pin = GPIO_PIN(PORT_B, 12), .dev = 0, .chan = 16 },
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+/**
  * @name   SPI configuration
  * @{
  */

--- a/cpu/stm32/periph/Makefile
+++ b/cpu/stm32/periph/Makefile
@@ -15,6 +15,8 @@ endif
 ifneq (,$(filter periph_adc,$(USEMODULE)))
   ifneq (,$(filter $(CPU_FAM),f4 f7))
     SRC += adc_f4_f7.c
+  else ifneq (,$(filter $(CPU_FAM),f0 g0))
+    SRC += adc_f0_g0.c
   else
     SRC += adc_$(CPU_FAM).c
   endif

--- a/cpu/stm32/periph/adc_f0_g0.c
+++ b/cpu/stm32/periph/adc_f0_g0.c
@@ -24,21 +24,31 @@
 #include "periph/adc.h"
 
 /**
- * @brief   Allocate locks for all three available ADC device
+ * @brief   Allocate lock for the ADC device
  *
- * All STM32F0 CPUs we support so far only come with a single ADC device.
+ * All STM32F0 & STM32G0 CPUs we support so far only come with a single ADC device.
  */
 static mutex_t lock = MUTEX_INIT;
 
 static inline void prep(void)
 {
     mutex_lock(&lock);
+#ifdef RCC_APB2ENR_ADCEN
     periph_clk_en(APB2, RCC_APB2ENR_ADCEN);
+#endif
+#ifdef RCC_APBENR2_ADCEN
+    periph_clk_en(APB12, RCC_APBENR2_ADCEN);
+#endif
 }
 
 static inline void done(void)
 {
+#ifdef RCC_APB2ENR_ADCEN
     periph_clk_dis(APB2, RCC_APB2ENR_ADCEN);
+#endif
+#ifdef RCC_APBENR2_ADCEN
+    periph_clk_dis(APB12, RCC_APBENR2_ADCEN);
+#endif
     mutex_unlock(&lock);
 }
 


### PR DESCRIPTION

### Contribution description

Adding ADC functionality for STM32 G0 series MCUs.


### Testing procedure

Verify calls to `adc_init` and `adc_sample` are compilable and linkable.


### Issues/PRs references

