### PR TITLE
cpu/stm32: added RAM_LEN identifier for stm32g03x

### DIFF
--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -180,6 +180,8 @@ else ifeq ($(STM32_TYPE), G)
   ifeq ($(STM32_FAMILY), 0)
     ifneq (, $(filter $(STM32_MODEL2), 7))
       RAM_LEN = 36K
+    else ifneq (, $(filter $(STM32_MODEL2), 3))
+      RAM_LEN = 8K
     endif
   endif
   ifeq ($(STM32_FAMILY), 4)


### PR DESCRIPTION

### Contribution description

Add definition of RAM_LEN for G03x STM32 MCUs.


### Testing procedure
Without this, compliation failed b/c of undefined RAM_LEN.


### Issues/PRs references
