### PR TITLE
sys/event/thread: add STACKSTEST flag

### DIFF
--- a/sys/event/thread.c
+++ b/sys/event/thread.c
@@ -57,8 +57,8 @@ void event_thread_init_multi(event_queue_t *queues, size_t queues_numof,
 
     void *tagged_ptr = ptrtag(queues, queues_numof - 1);
 
-    thread_create(stack, stack_size, priority, 0, _handler_thread, tagged_ptr,
-                  "event");
+    thread_create(stack, stack_size, priority, THREAD_CREATE_STACKTEST,
+                  _handler_thread, tagged_ptr, "event");
 }
 
 #ifndef EVENT_THREAD_STACKSIZE_DEFAULT


### PR DESCRIPTION
### Contribution description

I've gotten many times scared by having the impression that my event thread is completely collapsed, but it's just because it's the only one not initialized with STACKTEST. This  PR changes the behaviour so its is.

If there is some value in making it configurable I can.

### Testing procedure

Run an application with a shell and `USEMODULE="ps event_thread"`

before:

```
main(): This is RIOT! (Version: 2021.10-devel-492-g719a1-HEAD)
test_shell.
> ps
ps
	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) | 0x5661a720 | 0x5661a720
	  1 | idle                 | pending  Q |  15 |   8192 (  436) ( 7756) | 0x56613020 | 0x56614e7c 
	  2 | main                 | running  Q |   7 |  12288 ( 3020) ( 9268) | 0x56615020 | 0x56617e7c 
	  3 | event                | bl anyfl _ |   6 |   8192 ( 8188) (    4) | 0x5661eac0 | 0x5662091c 
	    | SUM                  |            |     |  36864 (11644) (25220)
```

now
```
main(): This is RIOT! (Version: 2021.10-devel-493-gae5e1-pr_event_thread_stacktest)
test_shell.
> ps
ps
	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) | 0x56588720 | 0x56588720
	  1 | idle                 | pending  Q |  15 |   8192 (  436) ( 7756) | 0x56581020 | 0x56582e7c 
	  2 | main                 | running  Q |   7 |  12288 ( 3020) ( 9268) | 0x56583020 | 0x56585e7c 
	  3 | event                | bl anyfl _ |   6 |   8192 (  960) ( 7232) | 0x5658cac0 | 0x5658e91c 
	    | SUM                  |            |     |  36864 ( 4416) (32448)
```
