### PR TITLE
nimble/netif_conn: fix _conn_get_itvl_ms()

### DIFF
--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -224,7 +224,7 @@ unsigned nimble_netif_conn_count(uint16_t filter)
 
 uint16_t nimble_netif_conn_get_itvl_ms(int handle)
 {
-    if ((handle == 0) || (handle >= CONN_CNT)) {
+    if ((handle < 0) || (handle >= CONN_CNT)) {
         return 0;
     }
 


### PR DESCRIPTION
### Contribution description
Straight forward bug fix: the validity check for `nimble_netif_conn_get_itvl_ms()` should test for a handle value < 0, as `0` is actually a valid input value...

### Testing procedure
Compile test and code review should do the trick here, as this line is (not yet) used anywhere in RIOT... 

### Issues/PRs references
none