### PR TITLE
event/timeout: remove forced ZTIMER_USEC dependency

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -516,7 +516,7 @@ ifneq (,$(filter event_periodic_timeout,$(USEMODULE)))
   USEMODULE += ztimer_periodic
 endif
 
-ifneq (,$(filter event_timeout,$(USEMODULE)))
+ifneq (,$(filter event_timeout_legacy,$(USEMODULE)))
   ifneq (,$(filter event_timeout_ztimer,$(USEMODULE)))
     USEMODULE += ztimer_usec
   else

--- a/sys/event/timeout.c
+++ b/sys/event/timeout.c
@@ -9,7 +9,7 @@
  */
 
 #include "kernel_defines.h"
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
 #include "ztimer.h"
 #else
 #include "xtimer.h"
@@ -30,16 +30,18 @@ static void _event_timeout_init(event_timeout_t *event_timeout, event_queue_t *q
     event_timeout->event = event;
 }
 
+#if IS_USED(MODULE_EVENT_TIMEOUT_LEGACY)
 void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, event_t *event)
 {
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
     event_timeout_ztimer_init(event_timeout, ZTIMER_USEC, queue, event);
 #else
     _event_timeout_init(event_timeout, queue, event);
 #endif
 }
+#endif
 
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
 void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t* clock,
                                event_queue_t *queue, event_t *event)
 {
@@ -50,7 +52,7 @@ void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t* c
 
 void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout)
 {
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
     ztimer_set(event_timeout->clock, &event_timeout->timer, timeout);
 #else
     xtimer_set(&event_timeout->timer, timeout);
@@ -59,7 +61,7 @@ void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout)
 
 void event_timeout_clear(event_timeout_t *event_timeout)
 {
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
     if (event_timeout->clock) {
         ztimer_remove(event_timeout->clock, &event_timeout->timer);
     }

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -38,7 +38,7 @@
 #define EVENT_TIMEOUT_H
 
 #include "event.h"
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
 #include "ztimer.h"
 #else
 #include "xtimer.h"
@@ -52,7 +52,7 @@ extern "C" {
  * @brief   Timeout Event structure
  */
 typedef struct {
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER)
+#if IS_USED(MODULE_ZTIMER)
     ztimer_t timer;         /**< ztimer object used for timeout */
     ztimer_clock_t *clock;  /**< ztimer clock to use */
 #else
@@ -62,7 +62,7 @@ typedef struct {
     event_t *event;         /**< event to post after timeout    */
 } event_timeout_t;
 
-#if IS_USED(MODULE_EVENT_TIMEOUT_ZTIMER) || DOXYGEN
+#if IS_USED(MODULE_ZTIMER) || DOXYGEN
 /**
  * @brief   Initialize timeout event object
  *
@@ -75,6 +75,7 @@ void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *c
                                event_queue_t *queue, event_t *event);
 #endif
 
+#if IS_USED(MODULE_EVENT_TIMEOUT_LEGACY) || DOXYGEN
 /**
  * @brief   Initialize timeout event object
  *
@@ -86,6 +87,7 @@ void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *c
  */
 void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
                         event_t *event);
+#endif
 
 /**
  * @brief   Set a timeout

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -214,11 +214,13 @@ static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *
         uint8_t minimum_free = CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS;
         if (dsm_get_num_available_slots() < minimum_free)
         {
-            uint32_t timeout = CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_USEC;
+            uint32_t timeout =
+                CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_USEC / 1000;
             event_callback_init(&_dtls_session_free_up_tmout_cb,
                                 _dtls_free_up_session, NULL);
-            event_timeout_init(&_dtls_session_free_up_tmout, &_queue,
-                               &_dtls_session_free_up_tmout_cb.super);
+            event_timeout_ztimer_init(&_dtls_session_free_up_tmout, ZTIMER_MSEC,
+                                      &_queue,
+                                      &_dtls_session_free_up_tmout_cb.super);
             event_timeout_set(&_dtls_session_free_up_tmout, timeout);
         }
     }
@@ -1147,9 +1149,9 @@ ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
     if (memo != NULL && res == 0) {
         if (timeout > 0) {
             event_callback_init(&memo->resp_tmout_cb, _on_resp_timeout, memo);
-            event_timeout_init(&memo->resp_evt_tmout, &_queue,
-                               &memo->resp_tmout_cb.super);
-            event_timeout_set(&memo->resp_evt_tmout, timeout);
+            event_timeout_ztimer_init(&memo->resp_evt_tmout, ZTIMER_MSEC,
+                                      &_queue, &memo->resp_tmout_cb.super);
+            event_timeout_set(&memo->resp_evt_tmout, timeout / 1000);
         }
         else {
             memset(&memo->resp_evt_tmout, 0, sizeof(event_timeout_t));


### PR DESCRIPTION
### Contribution description
This PR is (for now) simply a rough draft on how #16891 could be addressed. The goal is to remove the forced `ZTIMER_USEC` dependency from `event/timeout`, as this disables low-power modes on many platforms, even if the `USEC` timer is actually never used in the build...

The idea is to change the style of back-end timer selection a little bit for this module:
1. `ztimer` is always preferred -> so if `ztimer` is included in the build, it is automatically selected as backend. In the majority of RIOT builds, this is most likely the case by now...
2. per default, `event_timeout_init()` is not available. If modules (still) use this, it must be actively enabled by declaring a dependency on `event_timeout_legacy`.

TODO: 
- the `event_timeout_ztimer` module can be removed
- existing dependencies to `event_timeout` must be changed to depend on `event_timeout_legacy`
- step-by-step, modules like e.g. `gcoap` or `dhcp_client` shoudl be migrated to use the `event_timeout_ztimer_x()` functions, possibly while migrating the complete modules to `ztimer` :-)

So what do you think?

### Testing procedure
n/a as of now

### Issues/PRs references
fixes #16891 