### PR TITLE
makefiles/suit.base.inc.mk: don't clean existing keys

### DIFF
--- a/makefiles/suit.base.inc.mk
+++ b/makefiles/suit.base.inc.mk
@@ -24,7 +24,7 @@ SUIT_PUB_HDR_DIR = $(dir $(SUIT_PUB_HDR))
 CFLAGS += -I$(SUIT_PUB_HDR_DIR)
 BUILDDEPS += $(SUIT_PUB_HDR)
 
-$(SUIT_SEC): $(CLEAN)
+$(SUIT_SEC):
 	$(Q)echo suit: generating key in $(SUIT_KEY_DIR)
 	$(Q)mkdir -p $(SUIT_KEY_DIR)
 	$(Q)$(RIOTBASE)/dist/tools/suit/gen_key.py $(SUIT_SEC)

--- a/makefiles/suit.base.inc.mk
+++ b/makefiles/suit.base.inc.mk
@@ -24,7 +24,7 @@ SUIT_PUB_HDR_DIR = $(dir $(SUIT_PUB_HDR))
 CFLAGS += -I$(SUIT_PUB_HDR_DIR)
 BUILDDEPS += $(SUIT_PUB_HDR)
 
-$(SUIT_SEC):
+$(SUIT_SEC): $(if $(filter 1,$(RIOT_CI_BUILD)),$(CLEAN),)
 	$(Q)echo suit: generating key in $(SUIT_KEY_DIR)
 	$(Q)mkdir -p $(SUIT_KEY_DIR)
 	$(Q)$(RIOTBASE)/dist/tools/suit/gen_key.py $(SUIT_SEC)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The target for generating SUIT keys (`$(SUIT_SEC)`) had `$(CLEAN)` as prerequisite, causing `make clean all` to essentially overwrite the SUIT key with a new one.

This might be unexpected, e.g., if the CoAP root contaning keys is static, but the application gets re-built with "make clean all", the previous manifests won't work anymore. Worse, if the user stores the key somewhere and sets the key folder (SUIT_KEY_DIR) to that location, the makefile might surprisingly overwrite the user's key.

This PR drops the CLEAN prereq from the keygen target.

(I'm not sure if this only hits when "include $(RIOTMAKE)/suit.base.inc.mk" is included?)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. publish something
2. rebuild app with "make clean"
3. try to SUIT update to the previously published manifest

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
