### PR TITLE
build system: add fallback for RIOT_VERSION_CODE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -58,6 +58,7 @@ PKGDIRBASE                      ?= $(RIOTBASE)/build/pkg
 DLCACHE                         ?= $(RIOTTOOLS)/dlcache/dlcache.sh
 DLCACHE_DIR                     ?= $(RIOTBASE)/.dlcache
 WARNING_EXTERNAL_MODULE_DIRS    ?= 1
+RIOT_VERSION_DUMMY_CODE         ?= RIOT_VERSION_NUM\(2042,5,23,0\)
 
 # include CI info such as BOARD_INSUFFICIENT_MEMORY, if existing
 -include Makefile.ci
@@ -487,7 +488,7 @@ endif
 ifeq ($(RIOT_CI_BUILD),1)
     RIOT_VERSION ?= buildtest
     # set a dummy version number
-    RIOT_VERSION_CODE ?= RIOT_VERSION_NUM\(2042,5,23,0\)
+    RIOT_VERSION_CODE ?= $(RIOT_VERSION_DUMMY_CODE)
     ifneq ($(filter $(BOARD_INSUFFICIENT_MEMORY), $(BOARD)),)
         $(info CI-build: skipping link step)
         RIOTNOLINK:=1
@@ -529,8 +530,9 @@ ifneq (,$(RIOT_VERSION_OVERRIDE))
 endif
 
 # Generate machine readable RIOT VERSION macro
-RIOT_VERSION_CODE ?= $(shell echo ${RIOT_VERSION} | \
-                      sed -E 's/([0-9]+).([0-9]+).?([0-9]+)?.*/RIOT_VERSION_NUM\\\(\1,\2,0\3,${RIOT_EXTRAVERSION}\\\)/')
+RIOT_VERSION_CODE ?= $(shell echo $(RIOT_VERSION) | \
+                      sed -E 's/([0-9]+)\.([0-9]+)\.?([0-9]+)?.*/RIOT_VERSION_NUM\\\(\1,\2,0\3,$(RIOT_EXTRAVERSION)\\\)/' | \
+                      grep RIOT_VERSION_NUM || echo "$(RIOT_VERSION_DUMMY_CODE)")
 
 # Set module by prepending APPLICATION name with 'application_'.
 # It prevents conflict with application and modules with the same name.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If the repository was checked out without tags, parsing `RIOT_VERSION` will fail.

Fall back to creating a fake release version code based on the current year and month.


### Testing procedure

Release tests should be working again. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
