### PR TITLE
core/msg: yield after thread_flags_wake() in queue_msg()

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -119,7 +119,10 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
                   " has a msg_queue. Queueing message.\n", RIOT_FILE_RELATIVE,
                   __LINE__, target_pid);
             irq_restore(state);
-            if (me->status == STATUS_REPLY_BLOCKED) {
+            if (me->status == STATUS_REPLY_BLOCKED
+                || (IS_USED(MODULE_CORE_THREAD_FLAGS) &&
+                    sched_context_switch_request)
+                ) {
                 thread_yield_higher();
             }
             return 1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Alternative version of #16751, doesn't require changing `thread_yield_higher()` semantics.

Without this fix, it is possible that a thread got set to "PENDING"
after being woken up by a message flag, but no scheduling gets
triggered. `thread_flag_wake()` (called by `queue_msg()`) does set `sched_context_switch_request=1`, which in all other cases
in msg.c will be used to conditionally call `thread_yield_higher()`.
This PR adds the missing case in `_msg_send()`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/16751

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
