### PR TITLE
cpu/avr8_common: implement printf_float

### DIFF
--- a/cpu/avr8_common/Makefile.include
+++ b/cpu/avr8_common/Makefile.include
@@ -3,4 +3,8 @@ INCLUDES += -I$(RIOTCPU)/avr8_common/include \
             -isystem$(RIOTCPU)/avr8_common/avr_libc_extra/include \
             -isystem$(RIOTCPU)/avr8_common/avr_libc_extra/include/vendor
 
+ifneq (,$(filter printf_float,$(USEMODULE)))
+  LINKFLAGS += -Wl,-u,vfprintf -lprintf_flt -lm
+endif
+
 include $(RIOTMAKE)/arch/avr8.inc.mk


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

tests/thread_float should no report correct output

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/16896