### PR TITLE
cpu/stm32: added optional RS485 module to uart periph

### DIFF
--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -67,6 +67,10 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF1,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
+#ifdef MODULE_PERIPH_UART_RS485
+        .de_pin     = GPIO_PIN(PORT_A, 1),
+        .de_af      = GPIO_AF1
+#endif
     },
     {   /* Arduino pinout on D0/D1 */
         .dev        = USART1,

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -15,6 +15,7 @@ config CPU_STM32
     select HAS_PERIPH_RTT_OVERFLOW
     select HAS_PERIPH_UART_MODECFG
     select HAS_PERIPH_UART_NONBLOCKING
+    select HAS_PERIPH_UART_RS485
 
 # Common CPU symbol
 config CPU

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -15,7 +15,6 @@ config CPU_STM32
     select HAS_PERIPH_RTT_OVERFLOW
     select HAS_PERIPH_UART_MODECFG
     select HAS_PERIPH_UART_NONBLOCKING
-    select HAS_PERIPH_UART_RS485
 
 # Common CPU symbol
 config CPU

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -12,6 +12,10 @@ FEATURES_PROVIDED += periph_rtt_overflow
 FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_uart_nonblocking
 
+ifneq (,$(filter $(CPU_FAM),f0 f3 g0 g4 l0 l4 l5 wb))
+  FEATURES_PROVIDED += periph_uart_rs485
+endif
+
 ifneq (,$(filter $(CPU_FAM),f0 f1 f3 g0 g4 l0 l1 l4 l5 wb wl))
   FEATURES_PROVIDED += periph_flashpage
   FEATURES_PROVIDED += periph_flashpage_pagewise

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -678,6 +678,12 @@ typedef struct {
 #endif
     uint8_t bus;            /**< APB bus */
     uint8_t irqn;           /**< IRQ channel */
+#ifdef MODULE_PERIPH_UART_RS485
+    gpio_t de_pin;         /**< DE pin - set to GPIO_UNDEF when not using RS485 */
+#ifndef CPU_FAM_STM32F1
+    gpio_af_t de_af;       /**< alternate function for DE pin */
+#endif
+#endif
 #ifdef MODULE_PERIPH_UART_HW_FC
     gpio_t cts_pin;         /**< CTS pin - set to GPIO_UNDEF when not using HW flow control */
     gpio_t rts_pin;         /**< RTS pin */

--- a/cpu/stm32/kconfigs/f0/Kconfig
+++ b/cpu/stm32/kconfigs/f0/Kconfig
@@ -16,6 +16,7 @@ config CPU_FAM_F0
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/dm00031936-stm32f0x1-stm32f0x2-stm32f0x8-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf section 27.5.16
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/f3/Kconfig
+++ b/cpu/stm32/kconfigs/f3/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_F3
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_FLASHPAGE_RAW
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/dm00043574-stm32f303xb-c-d-e-stm32f303x6-8-stm32f328x8-stm32f358xc-stm32f398xe-advanced-arm-based-mcus-stmicroelectronics.pdf section 29.5.16
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/f7/Kconfig
+++ b/cpu/stm32/kconfigs/f7/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_F7
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_HWRNG
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/dm00124865-stm32f75xxx-and-stm32f74xxx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf section 31.5.16
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/g0/Kconfig
+++ b/cpu/stm32/kconfigs/g0/Kconfig
@@ -13,6 +13,7 @@ config CPU_FAM_G0
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf section 33.5.20
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/g4/Kconfig
+++ b/cpu/stm32/kconfigs/g4/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_G4
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_HWRNG
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/dm00355726-stm32g4-series-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf section 37.5.20
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/l0/Kconfig
+++ b/cpu/stm32/kconfigs/l0/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_L0
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_EEPROM
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/rm0377-ultralowpower-stm32l0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf section 24.5.16
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/l4/Kconfig
+++ b/cpu/stm32/kconfigs/l4/Kconfig
@@ -15,6 +15,7 @@ config CPU_FAM_L4
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_HWRNG
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/rm0351-stm32l47xxx-stm32l48xxx-stm32l49xxx-and-stm32l4axxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf section 40.5.16
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/l5/Kconfig
+++ b/cpu/stm32/kconfigs/l5/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_L5
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_HWRNG
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/dm00346336-stm32l552xx-and-stm32l562xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf section 44.5.20
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/wb/Kconfig
+++ b/cpu/stm32/kconfigs/wb/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_WB
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_HWRNG
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf setion 33.5.20
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/kconfigs/wl/Kconfig
+++ b/cpu/stm32/kconfigs/wl/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_WL
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_RTC_MEM
+    select HAS_PERIPH_UART_RS485 # from https://www.st.com/resource/en/reference_manual/rm0453-stm32wl5x-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf section 35.5.20
     select HAS_PERIPH_WDT
     select HAS_BOOTLOADER_STM32
 

--- a/cpu/stm32/periph/Kconfig
+++ b/cpu/stm32/periph/Kconfig
@@ -17,6 +17,11 @@ config MODULE_PERIPH_UART_NONBLOCKING
     depends on MODULE_PERIPH_UART
     select MODULE_TSRB
 
+
+config MODULE_PERIPH_UART_RS485
+    depends on HAS_PERIPH_UART_RS485
+    depends on MODULE_PERIPH_UART
+
 config MODULE_PERIPH_CAN
     bool
     depends on HAS_PERIPH_CAN

--- a/drivers/periph_common/Kconfig.uart
+++ b/drivers/periph_common/Kconfig.uart
@@ -32,6 +32,10 @@ config MODULE_PERIPH_UART_NONBLOCKING
     bool "Non-blocking support"
     depends on HAS_PERIPH_UART_NONBLOCKING
 
+config MODULE_PERIPH_UART_RS485
+    bool "RS-485 UART support"
+    depends on HAS_PERIPH_UART_RS485
+
 config MODULE_PERIPH_UART_RXSTART_IRQ
     bool "Enable Start Condition Interrupt"
     depends on HAS_PERIPH_UART_RXSTART_IRQ

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -328,6 +328,11 @@ config HAS_PERIPH_UART_HW_FC
     help
         Indicates that the UART peripheral supports hardware flow control.
 
+config HAS_PERIPH_UART_RS485
+    bool
+    help
+        Indicates that the UART peripheral supports RS485 Data Enable control.
+
 config HAS_PERIPH_UART_MODECFG
     bool
     help

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -4,6 +4,7 @@ FEATURES_REQUIRED += periph_uart
 FEATURES_OPTIONAL += periph_lpuart  # STM32 L0 and L4 provides lpuart support
 FEATURES_OPTIONAL += periph_uart_modecfg
 FEATURES_OPTIONAL += periph_uart_rxstart_irq
+FEATURES_OPTIONAL += periph_uart_rs485
 
 USEMODULE += shell
 USEMODULE += xtimer


### PR DESCRIPTION
### Contribution description

added optional RS485 module to uart periph, to leverage DE pin capabilities

### Testing procedure

Updated a board that has a UART with the optional extra data, update the board's makefile to have `FEATURES_REQUIRED += periph_uart_rs485` and verify that the DE pin toggles as expected using a logic analyzer.


### Issues/PRs references


