### PR TITLE
cpu/riscv: model Kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -9,11 +9,13 @@
 
 : ${TEST_KCONFIG_BOARDS_AVAILABLE:="
 dwm1001
+hifive1
 native
 nrf52840dk
 nucleo-f103rb
 remote-revb
 samr21-xpro
+seeedstudio-gd32
 "}
 
 : ${TEST_KCONFIG_ENFORCE_APP_GROUPS:="

--- a/cpu/fe310/Kconfig
+++ b/cpu/fe310/Kconfig
@@ -18,6 +18,10 @@ config CPU_FAM_FE310
     select HAS_PERIPH_RTT_SET_COUNTER
     select HAS_PERIPH_WDT
 
+    select MODULE_PERIPH_PLIC if TEST_KCONFIG
+    select MODULE_PERIPH_CORETIMER if MODULE_PERIPH_TIMER && HAS_PERIPH_CORETIMER
+    select MODULE_PERIPH_RTT if MODULE_PERIPH_RTC && HAS_PERIPH_RTT
+
 config CPU_MODEL_FE310_G000
     bool
     select CPU_FAM_FE310
@@ -46,5 +50,7 @@ config CPU_CORE
     default "rv32imac" if CPU_CORE_RV32IMAC
 
 rsource "Kconfig.clk"
+rsource "periph/Kconfig"
+rsource "vendor/Kconfig"
 
 source "$(RIOTCPU)/riscv_common/Kconfig"

--- a/cpu/fe310/periph/Kconfig
+++ b/cpu/fe310/periph/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_PERIPH
+    bool
+    default y
+    help
+        fe310 common peripheral code.

--- a/cpu/fe310/vendor/Kconfig
+++ b/cpu/fe310/vendor/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_SIFIVE_DRIVERS_FE310
+    bool
+    default y
+    depends on CPU_FAM_FE310
+    help
+        sifive drivers for fe310.

--- a/cpu/gd32v/Kconfig
+++ b/cpu/gd32v/Kconfig
@@ -18,6 +18,9 @@ config CPU_FAM_GD32V
     select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_WDT
 
+    select MODULE_PERIPH_CLIC if TEST_KCONFIG
+    select MODULE_PERIPH_WDT if MODULE_PERIPH_PM && HAS_PERIPH_WDT
+
 config CPU_MODEL_GD32VF103VBT6
     bool
     select CPU_FAM_GD32V
@@ -39,5 +42,7 @@ config CPU
 
 config CPU_CORE
     default "rv32imac" if CPU_CORE_RV32IMAC
+
+rsource "periph/Kconfig"
 
 source "$(RIOTCPU)/riscv_common/Kconfig"

--- a/cpu/gd32v/periph/Kconfig
+++ b/cpu/gd32v/periph/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_PERIPH
+    bool
+    default y

--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -12,8 +12,10 @@ config CPU_ARCH_RISCV
     select HAS_NEWLIB
     select HAS_PERIPH_CORETIMER
     select HAS_PICOLIBC if '$(RIOT_CI_BUILD)' != '1'
-    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
     select HAS_SSP
+
+    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
+    imply MODULE_NEWLIB_NANO
 
 config CPU_CORE_RV32IMAC
     bool
@@ -28,3 +30,17 @@ config HAS_ARCH_RISCV
 
 config CPU_ARCH
     default "rv32" if CPU_CORE_RV32IMAC
+
+config MODULE_RISCV_COMMON
+    bool
+    default y
+    depends on TEST_KCONFIG && CPU_ARCH_RISCV
+    select MODULE_MALLOC_THREAD_SAFE
+    help
+        Common code for RISC-V architecture.
+
+rsource "periph/Kconfig"
+
+choice LIBC_IMPLEMENTATION
+    default MODULE_NEWLIB
+endchoice

--- a/cpu/riscv_common/periph/Kconfig
+++ b/cpu/riscv_common/periph/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_RISCV_COMMON_PERIPH
+    bool
+    default y
+    depends on TEST_KCONFIG && CPU_ARCH_RISCV
+    help
+        Common peripheral code for RISC-V architecture.
+
+if MODULE_RISCV_COMMON_PERIPH
+
+config MODULE_PERIPH_CLIC
+    bool
+    depends on HAS_PERIPH_CLIC
+    help
+        Core-Local interrupt controller driver.
+
+config MODULE_PERIPH_CORETIMER
+    bool
+    depends on HAS_PERIPH_CORETIMER
+    help
+        Low-level timer driver based on the Core-local Interrupt (CLINT)
+
+config MODULE_PERIPH_PLIC
+    bool
+    depends on HAS_PERIPH_PLIC
+    help
+        Platform-Level interrupt controller driver.
+
+endif # MODULE_RISCV_COMMON_PERIPH

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -15,6 +15,9 @@ ifneq (,$(filter periph_init, $(USEMODULE)))
     periph_init% \
     periph_common \
     periph_rtc_rtt \
+    periph_clic \
+    periph_coretimer \
+    periph_plic
     #
   PERIPH_MODULES := $(filter-out $(PERIPH_IGNORE_MODULES),\
                                  $(filter periph_%,$(USEMODULE)))

--- a/sys/Kconfig
+++ b/sys/Kconfig
@@ -30,13 +30,34 @@ rsource "frac/Kconfig"
 rsource "hashes/Kconfig"
 rsource "iolist/Kconfig"
 rsource "isrpipe/Kconfig"
+
+menu "Libc"
+
+choice LIBC_IMPLEMENTATION
+    bool "Libc implementation"
+    depends on TEST_KCONFIG
+
+config MODULE_NEWLIB
+    bool "NewLib"
+    depends on HAS_NEWLIB
+
+config MODULE_PICOLIBC
+    bool "Picolibc"
+    depends on HAS_PICOLIBC
+
+endchoice
+
+rsource "Kconfig.newlib"
+rsource "Kconfig.picolibc"
+
+endmenu # Libc
+
 rsource "luid/Kconfig"
 rsource "malloc_thread_safe/Kconfig"
 rsource "matstat/Kconfig"
 rsource "memarray/Kconfig"
 rsource "mineplex/Kconfig"
 rsource "net/Kconfig"
-rsource "Kconfig.newlib"
 rsource "Kconfig.stdio"
 rsource "od/Kconfig"
 rsource "posix/Kconfig"

--- a/sys/Kconfig.newlib
+++ b/sys/Kconfig.newlib
@@ -5,10 +5,6 @@
 # directory for more details.
 #
 
-menuconfig MODULE_NEWLIB
-    bool "NewLib"
-    depends on TEST_KCONFIG
-
 if MODULE_NEWLIB
 
 config MODULE_NEWLIB_NANO
@@ -18,9 +14,11 @@ config MODULE_NEWLIB_GNU_SOURCE
     bool "NewLib GNU source"
 
 config MODULE_NEWLIB_SYSCALLS_DEFAULT
-    bool "NewLib Syscalls default implementation"
+    bool
     default y
     depends on !HAVE_CUSTOM_NEWLIB_SYSCALLS
+    help
+        Default implementation of newlib system calls.
 
 endif # MODULE_NEWLIB
 

--- a/sys/Kconfig.picolibc
+++ b/sys/Kconfig.picolibc
@@ -1,0 +1,29 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if MODULE_PICOLIBC
+
+config PICOLIBC_STDOUT_BUFFERED
+    bool "Buffered standard output"
+    default USE_STDOUT_BUFFERED
+    help
+        Say y to use buffering in the standard output, usually good for modules that benefit from
+        sending out buffers in larger chunks.
+
+config MODULE_PICOLIBC_SYSCALLS_DEFAULT
+    bool
+    default y
+    depends on !HAVE_CUSTOM_PICOLIBC_SYSCALLS
+    help
+        Default implementation of picolibc system calls.
+
+endif # MODULE_PICOLIBC
+
+config HAVE_CUSTOM_PICOLIB_SYSCALLS
+    bool
+    help
+        Indicates that a custom picolibc syscalls implementation is present.

--- a/sys/Kconfig.stdio
+++ b/sys/Kconfig.stdio
@@ -18,6 +18,7 @@ choice
 config MODULE_SLIPDEV_STDIO
     bool "SLIP network device"
     depends on MODULE_SLIPDEV
+    select USE_STDOUT_BUFFERED
     select MODULE_ISRPIPE
 
 config MODULE_STDIO_NULL
@@ -49,5 +50,10 @@ config MODULE_STDIO_UART_RX
 
 config MODULE_PRINTF_FLOAT
     bool "Float support in printf"
+
+config USE_STDOUT_BUFFERED
+    bool
+    help
+        Select this to prefer buffered standard output if provided by the implementation.
 
 endmenu # Standard Input/Output (STDIO)

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -108,3 +108,27 @@ ifneq (,$(filter ztimer_msec,$(USEMODULE)))
     USEMODULE += ztimer_periph_timer
   endif
 endif
+
+ifneq (,$(filter ztimer_sec,$(USEMODULE)))
+  USEMODULE += ztimer
+  # try to use RTC unless we are on native, as it is based on xtimer it is
+  # actually buggy
+  ifeq (,$(filter native,$(BOARD)))
+    FEATURES_OPTIONAL += periph_rtc
+  endif
+  # HACK: see above
+  include $(RIOTMAKE)/features_check.inc.mk
+  ifneq (,$(filter periph_rtc,$(FEATURES_USED)))
+    USEMODULE += ztimer_periph_rtc
+  else
+    # if there is no RTC try to use RTT
+    FEATURES_OPTIONAL += periph_rtt
+    # HACK: see above
+    include $(RIOTMAKE)/features_check.inc.mk
+    ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
+      USEMODULE += ztimer_periph_rtt
+    else
+      USEMODULE += ztimer_periph_timer
+    endif
+  endif
+endif


### PR DESCRIPTION
### Contribution description
This models the Kconfig modules for risc-v and adds two boards for the CI tests. For this I had to model libc modules, I'd like some feedback on those.

### Testing procedure
- CI should take care of comparing binaries.
- Check list of modules compiled with and without Kconfig

### Issues/PRs references
#16875
