### PR TITLE
tinydtls: sock_dtls: only use ifindex with link-local addresses

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -813,7 +813,13 @@ static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
     session->port = ep->port;
     session->size = sizeof(ipv6_addr_t) +       /* addr */
                     sizeof(unsigned short);     /* port */
-    session->ifindex = ep->netif;
+    if (ipv6_addr_is_link_local((ipv6_addr_t *)ep->addr.ipv6)) {
+        /* set ifindex for link-local addresses */
+        session->ifindex = ep->netif;
+    }
+    else {
+        session->ifindex = SOCK_ADDR_ANY_NETIF;
+    }
     memcpy(&session->addr, &ep->addr.ipv6, sizeof(ipv6_addr_t));
 }
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
For global addresses, the out-going interface is typically decided by the forwarding information base, so _requiring_ the user to set it with `sock_dtls` is undesirable. This has the caveat, that now on `sock_udp_send()` in the `_write()` method, the sock does not know via which network interface to send a packet with a global address, but again: this is really more a task for the underlying network stack, not the sock layer.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I used `tests/pkg_tinydtls_sock_async` to test this. I needed to restart both applications between sending to global and link-local, as the server otherwise runs into an assert. But that is the case on master as well (but you have to use `2001:db8::2%7` as the address there).

###### Terminal 1 (`tap1`)

```console
> dtlss start 
dtlss start 
> ifconfig 7 add 2001:db8::2/64
ifconfig 7 add 2001:db8::2/64
success: added 2001:db8::2/64 to interface 7
> nib route add 7 default fe80::e0bc:7dff:fecb:f550
nib route add 7 default fe80::e0bc:7dff:fecb:f550
> ifconfig
ifconfig
Iface  7  HWaddr: DA:27:1D:A8:64:24 
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::d827:1dff:fea8:6424  scope: link  VAL
          inet6 addr: 2001:db8::2  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffa8:6424
          inet6 group: ff02::1:ff00:2
> Session handshake received
New client connected
Session became ready: [fe80::e0bc:7dff:fecb:f550%7]:12345
Received 4 bytes -- (echo)
Session was destroyed by peer: [fe80::e0bc:7dff:fecb:f550%7]:12345
> Session handshake received
New client connected
Session became ready: [2001:db8::1%7]:12345
Received 4 bytes -- (echo)
Session was destroyed by peer: [2001:db8::1%7]:12345
```

###### Terminal 2 (`tap0`)

```console
ifconfig 7 add 2001:db8::1/64
ifconfig 7 add 2001:db8::1/64
success: added 2001:db8::1/64 to interface 7
> nib route add 7 default fe80::d827:1dff:fea8:6424
nib route add 7 default fe80::d827:1dff:fea8:6424
> ifconfig
ifconfig
Iface  7  HWaddr: E2:BC:7D:CB:F5:50 
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::e0bc:7dff:fecb:f550  scope: link  VAL
          inet6 addr: 2001:db8::1  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffcb:f550
          inet6 group: ff02::1:ff00:1
> dtlsc 2001:db8::2 test
dtlsc 2001:db8::2 test
> Session handshake received
Connection to server successful
Sending data "test"
Sent DTLS message
Session became ready: [2001:db8::2%7]:20220
DTLS message was sent
Received 4 bytes: "test"
Terminating session
> dtlsc fe80::d827:1dff:fea8:6424%7 test
dtlsc fe80::d827:1dff:fea8:6424%7 test
> Session handshake received
Connection to server successful
Sending data "test"
Sent DTLS message
Session became ready: [fe80::d827:1dff:fea8:6424%7]:20220
DTLS message was sent
Received 4 bytes: "test"
Terminating session
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
