### PR TITLE
dns_msg: Use correct byteorder for ID

### DIFF
--- a/sys/net/application_layer/dns/msg.c
+++ b/sys/net/application_layer/dns/msg.c
@@ -103,7 +103,7 @@ size_t dns_msg_compose_query(void *dns_buf, const char *domain_name,
 
     dns_hdr_t *hdr = (dns_hdr_t*) buf;
     memset(hdr, 0, sizeof(*hdr));
-    hdr->id = id;
+    hdr->id = htons(id);
     hdr->flags = htons(0x0120);
     hdr->qdcount = htons(1 + (family == AF_UNSPEC));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As the parse function ignores the ID, this was not noticed until now, but the ID was added to the DNS message in the wrong byte order (if you _want_ to check the ID, this becomes a problem) ;-).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gnrc_sock_dns` should still pass:

```sh
./dist/tools/tapsetup/tapsetup
make -C tests/gnrc_sock_dns flash -j test-with-config
```

(reminder that `test-with-config` tests are _not_ run by Murdock ;-)).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
