### PR TITLE
cpu/avr8_common: Clean up cpu_print_last_inscrution()

### DIFF
--- a/cpu/avr8_common/include/cpu.h
+++ b/cpu/avr8_common/include/cpu.h
@@ -180,13 +180,14 @@ static inline void __attribute__((always_inline)) cpu_print_last_instruction(voi
     uint8_t lo;
     uint16_t ptr;
 
-    __asm__ volatile ("in __tmp_reg__, __SP_H__  \n\t"
-                      "mov %0, __tmp_reg__       \n\t"
-                      : "=g" (hi));
-
-    __asm__ volatile ("in __tmp_reg__, __SP_L__  \n\t"
-                      "mov %0, __tmp_reg__       \n\t"
-                      : "=g" (lo));
+    __asm__ volatile (
+        "in %[hi], __SP_H__     \n\t"
+        "in %[lo], __SP_L__     \n\t"
+        : [hi] "=r"(hi),
+          [lo] "=r"(lo)
+        : /* no inputs */
+        : /* no clobbers */
+    );
     ptr = hi << 8 | lo;
     printf("Stack Pointer: 0x%04x\n", ptr);
 }


### PR DESCRIPTION
### Contribution description

Clang doesn't like the inline assembly of `cpu_print_last_instruction()`. The new version should be functionally equivalent, but also safe two instructions.

### Testing procedure

Kernel panics should still print the stack address.

### Issues/PRs references

None