### PR TITLE
gnrc_netif: move netdev initialization to ops->init

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -79,7 +79,7 @@ static void _notify(int handle, nimble_netif_event_t event, uint8_t *addr)
     }
 }
 
-static void _netif_init(gnrc_netif_t *netif)
+static int _netif_init(gnrc_netif_t *netif)
 {
     (void)netif;
 
@@ -92,6 +92,8 @@ static void _netif_init(gnrc_netif_t *netif)
      * of this */
     _netif.sixlo.max_frag_size = 0;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
+
+    return 0;
 }
 
 static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -83,7 +83,11 @@ static int _netif_init(gnrc_netif_t *netif)
 {
     (void)netif;
 
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
+
     /* save the threads context pointer, so we can set its flags */
     _netif_thread = thread_get_active();
 
@@ -92,8 +96,9 @@ static int _netif_init(gnrc_netif_t *netif)
      * of this */
     _netif.sixlo.max_frag_size = 0;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
+    res = 0;
 
-    return 0;
+    return res;
 }
 
 static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -194,21 +194,26 @@ typedef struct {
  */
 struct gnrc_netif_ops {
     /**
-     * @brief   Initializes network interface beyond the default settings
+     * @brief   Initializes network interface.
      *
      * @pre `netif != NULL`
      *
      * @param[in] netif The network interface.
      *
-     * This is called after the network device's initial configuration, right
-     * before the interface's thread starts receiving messages. It is not
-     * necessary to lock the interface's mutex gnrc_netif_t::mutex, since it is
-     * already locked. Set to @ref gnrc_netif_default_init() if you do not need
-     * any special initialization. If you do need special initialization, it is
-     * recommended to call @ref gnrc_netif_default_init() at the start of the
-     * custom initialization function set here.
+     * This function should init the device driver or MAC underlying MAC layer.
+     * This is called right before the interface's thread starts receiving
+     * messages. It is not necessary to lock the interface's mutex
+     * gnrc_netif_t::mutex, since it is already locked. Set to @ref
+     * gnrc_netif_default_init() if you do not need any special initialization.
+     * If you do need special initialization, it is recommended to call @ref
+     * gnrc_netif_default_init() at the start of the custom initialization
+     * function set here.
+     *
+     * @return 0 if the initialization of the device or MAC layer was
+     * successful
+     * @return negative errno on error.
      */
-    void (*init)(gnrc_netif_t *netif);
+    int (*init)(gnrc_netif_t *netif);
 
     /**
      * @brief   Send a @ref net_gnrc_pkt "packet" over the network interface
@@ -537,7 +542,7 @@ static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
  *
  * @param[in] netif     The network interface.
  */
-void gnrc_netif_default_init(gnrc_netif_t *netif);
+int gnrc_netif_default_init(gnrc_netif_t *netif);
 
 /**
  * @brief   Default operation for gnrc_netif_ops_t::get()

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -194,7 +194,7 @@ typedef struct {
  */
 struct gnrc_netif_ops {
     /**
-     * @brief   Initializes network interface.
+     * @brief   Initializes and registers network interface.
      *
      * @pre `netif != NULL`
      *
@@ -207,7 +207,8 @@ struct gnrc_netif_ops {
      * gnrc_netif_default_init() if you do not need any special initialization.
      * If you do need special initialization, it is recommended to call @ref
      * gnrc_netif_default_init() at the start of the custom initialization
-     * function set here.
+     * function set here. This function MUST call @ref netif_register if the
+     * initialization is successful.
      *
      * @return 0 if the initialization of the device or MAC layer was
      * successful
@@ -538,7 +539,8 @@ static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
 /**
  * @brief   Default operation for gnrc_netif_ops_t::init()
  *
- * @note    Can also be used to be called *before* a custom operation.
+ * @note    Can also be used to be called *before* a custom operation. This
+ *          function calls @ref netif_register internally.
  *
  * @param[in] netif     The network interface.
  */

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -55,7 +55,7 @@
  */
 static kernel_pid_t gomach_pid;
 
-static void _gomach_init(gnrc_netif_t *netif);
+static int _gomach_init(gnrc_netif_t *netif);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static void _gomach_msg_handler(gnrc_netif_t *netif, msg_t *msg);
@@ -2115,7 +2115,7 @@ static void _gomach_event_cb(netdev_t *dev, netdev_event_t event)
     }
 }
 
-static void _gomach_init(gnrc_netif_t *netif)
+static int _gomach_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
@@ -2216,4 +2216,6 @@ static void _gomach_init(gnrc_netif_t *netif)
         gnrc_gomach_set_update(netif, false);
         gomach_update(netif);
     }
+
+    return 0;
 }

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -2119,7 +2119,11 @@ static int _gomach_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+    if (res < 0) {
+        return res;
+    }
+
     dev = netif->dev;
     dev->event_callback = _gomach_event_cb;
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -943,7 +943,12 @@ static int _lwmac_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+
+    if (res < 0) {
+        return res;
+    }
+
     dev = netif->dev;
     dev->event_callback = _lwmac_event_cb;
 
@@ -985,5 +990,5 @@ static int _lwmac_init(gnrc_netif_t *netif)
     netif->mac.prot.lwmac.lwmac_info |= GNRC_LWMAC_RADIO_IS_ON;
 #endif
 
-    return 0;
+    return res;
 }

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -63,7 +63,7 @@ static void rtt_cb(void *arg);
 static void lwmac_set_state(gnrc_netif_t *netif, gnrc_lwmac_state_t newstate);
 static void lwmac_schedule_update(gnrc_netif_t *netif);
 static void rtt_handler(uint32_t event, gnrc_netif_t *netif);
-static void _lwmac_init(gnrc_netif_t *netif);
+static int _lwmac_init(gnrc_netif_t *netif);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg);
@@ -939,7 +939,7 @@ static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg)
     }
 }
 
-static void _lwmac_init(gnrc_netif_t *netif)
+static int _lwmac_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
@@ -984,4 +984,6 @@ static void _lwmac_init(gnrc_netif_t *netif)
     netif->mac.prot.lwmac.awake_duration_sum_ticks = 0;
     netif->mac.prot.lwmac.lwmac_info |= GNRC_LWMAC_RADIO_IS_ON;
 #endif
+
+    return 0;
 }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1577,7 +1577,7 @@ static void _test_options(gnrc_netif_t *netif)
 }
 #endif /* DEVELHELP */
 
-void gnrc_netif_default_init(gnrc_netif_t *netif)
+int gnrc_netif_default_init(gnrc_netif_t *netif)
 {
     _init_from_device(netif);
 #ifdef DEVELHELP
@@ -1590,6 +1590,7 @@ void gnrc_netif_default_init(gnrc_netif_t *netif)
 #ifdef MODULE_GNRC_IPV6_NIB
     gnrc_ipv6_nib_init_iface(netif);
 #endif
+    return 0;
 }
 
 static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back);

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -48,7 +48,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static void _msg_handler(gnrc_netif_t *netif, msg_t *msg);
 static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt);
 static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt);
-static void _init(gnrc_netif_t *netif);
+static int _init(gnrc_netif_t *netif);
 
 static const gnrc_netif_ops_t lorawan_ops = {
     .init = _init,
@@ -252,7 +252,7 @@ netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac)
     return netif->dev;
 }
 
-static void _init(gnrc_netif_t *netif)
+static int _init(gnrc_netif_t *netif)
 {
     gnrc_netif_default_init(netif);
     netif->dev->event_callback = _driver_cb;
@@ -279,6 +279,8 @@ static void _init(gnrc_netif_t *netif)
     ztimer_set_msg(ZTIMER_MSEC, &netif->lorawan.backoff_timer,
                    GNRC_LORAWAN_BACKOFF_WINDOW_TICK / 1000,
                    &backoff_msg, thread_getpid());
+
+    return 0;
 }
 
 int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -254,7 +254,12 @@ netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac)
 
 static int _init(gnrc_netif_t *netif)
 {
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+
+    if (res < 0) {
+        return res;
+    }
+
     netif->dev->event_callback = _driver_cb;
     _reset(netif);
 
@@ -280,7 +285,7 @@ static int _init(gnrc_netif_t *netif)
                    GNRC_LORAWAN_BACKOFF_WINDOW_TICK / 1000,
                    &backoff_msg, thread_getpid());
 
-    return 0;
+    return res;
 }
 
 int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -55,7 +55,7 @@ static bool init_called = false;
 static uint8_t ethernet_groups[ETHERNET_GROUPS_MAX][ETHERNET_ADDR_LEN];
 static BITFIELD(ethernet_groups_set, ETHERNET_GROUPS_MAX);
 
-static inline void _test_init(gnrc_netif_t *netif);
+static inline int _test_init(gnrc_netif_t *netif);
 static inline int _mock_netif_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static inline gnrc_pktsnip_t *_mock_netif_recv(gnrc_netif_t * netif);
 static int _get_netdev_address(netdev_t *dev, void *value, size_t max_len);
@@ -113,11 +113,13 @@ static void _set_up(void)
     while (msg_try_receive(&msg) > 0) {}
 }
 
-static inline void _test_init(gnrc_netif_t *netif)
+static inline int _test_init(gnrc_netif_t *netif)
 {
     (void)netif;
     gnrc_netif_default_init(netif);
     init_called = true;
+
+    return 0;
 }
 
 static void test_creation(void)

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -116,7 +116,12 @@ static void _set_up(void)
 static inline int _test_init(gnrc_netif_t *netif)
 {
     (void)netif;
-    gnrc_netif_default_init(netif);
+    int res = gnrc_netif_default_init(netif);
+
+    if (res < 0) {
+        return res;
+    }
+
     init_called = true;
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR moves the netdev initialization in the gnrc_netif thread to the netif specific `ops`. This is required in order to remove the GNRC<-> netdev dependency and be able to use non netdev layers with GNRC netif (e.g `ieee802154_submac`).
It also has the advantage that the specific interface has control of the netdev callbacks, in cases where the default is replaced ( `gnrc_lorawan`, `gnrc_gomach`, etc).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure that the following modules still work.
- esp_now_gnrc
- nrfmin_gnrc
- gnrc_netif_cc1xxx
- gnrc_netif_nrf24l01p_ng
- gnrc_xbee
- nimble_netif
- gomach
- lwmac
- gnrc_netif_ethernet
- gnrc_netif_raw
- gnrc_netif_ieee802154
- gnrc_netif_lorawan

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Same as https://github.com/RIOT-OS/RIOT/pull/13614/files, but this time going in smaller steps.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
