### PR TITLE
drivers/at86rf215: add function to signal setup finished

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -29,6 +29,12 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+__attribute__((weak)) void at86rf215_signal_setup(at86rf215_t *dev, int index)
+{
+    (void) dev;
+    (void) index;
+}
+
 static void _setup_interface(at86rf215_t *dev, const at86rf215_params_t *params, uint8_t index)
 {
     netdev_t *netdev = &dev->netdev.netdev;
@@ -38,6 +44,7 @@ static void _setup_interface(at86rf215_t *dev, const at86rf215_params_t *params,
     dev->state = AT86RF215_STATE_OFF;
 
     netdev_register(netdev, NETDEV_AT86RF215, index);
+    at86rf215_signal_setup(dev, index);
 }
 
 void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_params_t *params, uint8_t index)
@@ -46,17 +53,18 @@ void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_p
     if (dev_09) {
         dev_09->RF = &RF09_regs;
         dev_09->BBC = &BBC0_regs;
-        _setup_interface(dev_09, params, 2 * index);
         dev_09->sibling = dev_24;
+        _setup_interface(dev_09, params, 2 * index);
     }
 
     /* configure the 2.4 GHz interface */
     if (dev_24) {
         dev_24->RF = &RF24_regs;
         dev_24->BBC = &BBC1_regs;
-        _setup_interface(dev_24, params, 2 * index + 1);
         dev_24->sibling = dev_09;
+        _setup_interface(dev_24, params, 2 * index + 1);
     }
+
 }
 
 void at86rf215_reset_and_cfg(at86rf215_t *dev)

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -677,6 +677,21 @@ int at86rf215_enable_batmon(at86rf215_t *dev, unsigned voltage);
  */
 void at86rf215_disable_batmon(at86rf215_t *dev);
 
+/**
+ * @brief   Signal that the AT86RF215 setup function finished.
+ *
+ *          This function is called right after @ref at86rf215_setup finished
+ *          the initialization of @p dev.
+ *          By default this function is a weak no-op symbol. Override if needed
+ *          (e.g clock configuration and trimming).
+ *
+ * @note    This function is called before @ref netdev_driver_t::init.
+ *
+ * @param[in] dev           pointer to the device descriptor
+ * @param[in] index         index of the device
+ */
+void at86rf215_signal_setup(at86rf215_t *dev, int index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/driver_at86rf215/main.c
+++ b/tests/driver_at86rf215/main.c
@@ -32,6 +32,15 @@
 #include "od.h"
 
 static char batmon_stack[THREAD_STACKSIZE_MAIN];
+static at86rf215_t *dev;
+
+void at86rf215_signal_setup(at86rf215_t *_dev, int index)
+{
+    (void) index;
+    if (!dev) {
+        dev = _dev;
+    }
+}
 
 void *batmon_thread(void *arg)
 {
@@ -91,18 +100,10 @@ static int cmd_set_trim(int argc, char **argv)
         return 1;
     }
 
-    gnrc_netif_t *netif = gnrc_netif_get_by_type(NETDEV_AT86RF215, 0);
-
-    if (netif == NULL) {
+    if (dev == NULL) {
         puts("No at86rf215 radio found");
         return 1;
     }
-
-    netdev_t *netdev = netif->dev;
-    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
-                                                          netdev_ieee802154_t,
-                                                          netdev);
-    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     printf("setting trim to %u fF\n", 300U * trim);
     at86rf215_set_trim(dev, trim);
@@ -147,18 +148,10 @@ static int cmd_set_clock_out(int argc, char **argv)
         freq = tmp;
     }
 
-    gnrc_netif_t *netif = gnrc_netif_get_by_type(NETDEV_AT86RF215, 0);
-
-    if (netif == NULL) {
+    if (dev == NULL) {
         puts("No at86rf215 radio found");
         return 1;
     }
-
-    netdev_t *netdev = netif->dev;
-    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
-                                                          netdev_ieee802154_t,
-                                                          netdev);
-    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     printf("Clock output set to %s %s\n", keys[freq], freq ? "MHz" : "");
     at86rf215_set_clock_output(dev, AT86RF215_CLKO_4mA, freq);
@@ -183,18 +176,10 @@ static int cmd_get_random(int argc, char **argv)
         return 1;
     }
 
-    gnrc_netif_t *netif = gnrc_netif_get_by_type(NETDEV_AT86RF215, 0);
-
-    if (netif == NULL) {
+    if (dev == NULL) {
         puts("No at86rf215 radio found");
         return 1;
     }
-
-    netdev_t *netdev = netif->dev;
-    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
-                                                          netdev_ieee802154_t,
-                                                          netdev);
-    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     at86rf215_get_random(dev, buffer, values);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a callback mechanism to indicate the upper layer that an AT86RF215 device finished its setup procedure.
This function can be used as a post_setup hook to do clock configuration or trimming, without requiring to get the private descriptor through the network interface (without this PR the device descriptor is retrieved with `gnrc_netif_get_by_type`).

This PR is required to remove the GNRC<->netdev dependency, because it won't be guaranteed that the device descriptor of GNRC netif points to a netdev device. Therefore if this gets accepted I propose to deprecate `gnrc_netif_get_by_type` (only used by this test).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Make sure `tests/driver_at86rf215` works as expected.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far, but required for removing the GNRC<->netdev dependency
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
