### PR TITLE
netdev: add netdev_register_signal

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -331,6 +331,14 @@ typedef enum {
  */
 #define NETDEV_INDEX_ANY    (0xFF)
 
+#if DOXYGEN
+/**
+ * @brief   Call @ref netdev_register_signal when the netdev device is
+ *          registered.
+ */
+#define CONFIG_NETDEV_REGISTER_SIGNAL 0
+#endif
+
 /**
  * @brief Structure to hold driver state
  *
@@ -357,6 +365,21 @@ struct netdev {
 };
 
 /**
+ * @brief   Signal that the @ref netdev_register function registered the device.
+ *
+ *          This function is called right after @ref netdev_register registered
+ *          the device.
+ *
+ * @note    This function is called only if the CFLAG @ref
+ *          CONFIG_NETDEV_REGISTER_SIGNAL is set.
+ *
+ * @param[in] dev           pointer to the device descriptor
+ * @param[in] type          the driver used for the netdev
+ * @param[in] index         the index in the config struct
+ */
+void netdev_register_signal(struct netdev *dev, netdev_type_t type, uint8_t index);
+
+/**
  * @brief Register a device with netdev.
  *        Must by called by the driver's setup function.
  *
@@ -374,6 +397,10 @@ static inline void netdev_register(struct netdev *dev, netdev_type_t type, uint8
     (void) type;
     (void) index;
 #endif
+
+    if (IS_ACTIVE(CONFIG_NETDEV_REGISTER_SIGNAL)) {
+        netdev_register_signal(dev, type, index);
+    }
 }
 
 /**

--- a/tests/driver_at86rf215/Makefile
+++ b/tests/driver_at86rf215/Makefile
@@ -5,4 +5,6 @@ USEMODULE += at86rf215
 USEMODULE += at86rf215_batmon
 USEMODULE += at86rf215_timestamp
 
+CFLAGS += -DCONFIG_NETDEV_REGISTER_SIGNAL
+
 include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_at86rf215/main.c
+++ b/tests/driver_at86rf215/main.c
@@ -32,6 +32,18 @@
 #include "od.h"
 
 static char batmon_stack[THREAD_STACKSIZE_MAIN];
+static at86rf215_t *dev;
+
+void netdev_register_signal(netdev_t *netdev, netdev_type_t type, uint8_t index)
+{
+   (void) index;
+    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
+                                                          netdev_ieee802154_t,
+                                                          netdev);
+    if (type == NETDEV_AT86RF215 && !dev) {
+        dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
+    }
+}
 
 void *batmon_thread(void *arg)
 {
@@ -91,18 +103,10 @@ static int cmd_set_trim(int argc, char **argv)
         return 1;
     }
 
-    gnrc_netif_t *netif = gnrc_netif_get_by_type(NETDEV_AT86RF215, 0);
-
-    if (netif == NULL) {
+    if (dev == NULL) {
         puts("No at86rf215 radio found");
         return 1;
     }
-
-    netdev_t *netdev = netif->dev;
-    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
-                                                          netdev_ieee802154_t,
-                                                          netdev);
-    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     printf("setting trim to %u fF\n", 300U * trim);
     at86rf215_set_trim(dev, trim);
@@ -147,18 +151,10 @@ static int cmd_set_clock_out(int argc, char **argv)
         freq = tmp;
     }
 
-    gnrc_netif_t *netif = gnrc_netif_get_by_type(NETDEV_AT86RF215, 0);
-
-    if (netif == NULL) {
+    if (dev == NULL) {
         puts("No at86rf215 radio found");
         return 1;
     }
-
-    netdev_t *netdev = netif->dev;
-    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
-                                                          netdev_ieee802154_t,
-                                                          netdev);
-    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     printf("Clock output set to %s %s\n", keys[freq], freq ? "MHz" : "");
     at86rf215_set_clock_output(dev, AT86RF215_CLKO_4mA, freq);
@@ -183,18 +179,10 @@ static int cmd_get_random(int argc, char **argv)
         return 1;
     }
 
-    gnrc_netif_t *netif = gnrc_netif_get_by_type(NETDEV_AT86RF215, 0);
-
-    if (netif == NULL) {
+    if (dev == NULL) {
         puts("No at86rf215 radio found");
         return 1;
     }
-
-    netdev_t *netdev = netif->dev;
-    netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev,
-                                                          netdev_ieee802154_t,
-                                                          netdev);
-    at86rf215_t* dev = container_of(netdev_ieee802154, at86rf215_t, netdev);
 
     at86rf215_get_random(dev, buffer, values);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR is an alternative to #16921 but more generic (as proposed by @benpicco ).

It adds a callback mechanism to indicate the upper layer that a netdev device finished its setup/registration procedure.

This function can be used as a post_setup hook to do clock configuration or trimming, without requiring to get the private descriptor through the network interface (without this PR the device descriptor is retrieved with gnrc_netif_get_by_type).

This PR is required to remove the GNRC<->netdev dependency, because it won't be guaranteed that the device descriptor of GNRC netif points to a netdev device.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile test should be enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to #16921 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
