### PR TITLE
cpu/sam0_common: SPI: don't perform DMA transfer for small buffers

### DIFF
--- a/cpu/sam0_common/periph/Kconfig.spi
+++ b/cpu/sam0_common/periph/Kconfig.spi
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config SPI_DMA_THRESHOLD_BYTES
+    int "SPI DMA threshold (bytes)"
+    depends on MODULE_PERIPH_DMA
+    depends on MODULE_PERIPH_SPI
+    default 16
+    help
+        Threshold in bytes under which no SPI DMA transfer will be performed.
+        Polling will be used instead.

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -37,6 +37,14 @@
 #include "debug.h"
 
 /**
+ * @brief   Threshold under which polling transfers are used instead of DMA
+ *          TODO: determine at run-time based on SPI clock
+ */
+#ifndef CONFIG_SPI_DMA_THRESHOLD_BYTES
+#define CONFIG_SPI_DMA_THRESHOLD_BYTES  16
+#endif
+
+/**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
 static mutex_t locks[SPI_NUMOF];
@@ -508,7 +516,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         gpio_clear((gpio_t)cs);
     }
 
-    if (_use_dma(bus)) {
+    if (_use_dma(bus) && len > CONFIG_SPI_DMA_THRESHOLD_BYTES) {
 #ifdef MODULE_PERIPH_DMA
         /* The DMA promises not to modify the const out data */
         _dma_transfer(bus, out, in, len);

--- a/cpu/samd21/periph/Kconfig.spi
+++ b/cpu/samd21/periph/Kconfig.spi
@@ -1,0 +1,1 @@
+source "$(RIOTCPU)/sam0_common/periph/Kconfig.spi"

--- a/cpu/samd5x/periph/Kconfig.spi
+++ b/cpu/samd5x/periph/Kconfig.spi
@@ -1,0 +1,1 @@
+source "$(RIOTCPU)/sam0_common/periph/Kconfig.spi"

--- a/cpu/saml1x/periph/Kconfig.spi
+++ b/cpu/saml1x/periph/Kconfig.spi
@@ -1,0 +1,1 @@
+source "$(RIOTCPU)/sam0_common/periph/Kconfig.spi"

--- a/cpu/saml21/periph/Kconfig.spi
+++ b/cpu/saml21/periph/Kconfig.spi
@@ -1,0 +1,1 @@
+source "$(RIOTCPU)/sam0_common/periph/Kconfig.spi"

--- a/drivers/periph_common/Kconfig.spi
+++ b/drivers/periph_common/Kconfig.spi
@@ -41,4 +41,7 @@ config MODULE_PERIPH_INIT_SPI_GPIO_MODE
     default y if MODULE_PERIPH_INIT
     depends on MODULE_PERIPH_SPI_GPIO_MODE
 
+# Include CPU specific configurations
+osource "$(RIOTCPU)/$(CPU)/periph/Kconfig.spi"
+
 endif # MODULE_PERIPH_SPI


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Setting up a DMA transfer can take longer than sending out a buffer byte by byte if the buffer is small.

DMA only shows advantages for large buffers, using it for every transfer will cause a net slowdown.

Since we did not come up with a good way to determine the treshold based on the SPI frequency, just use a fixed buffer for now so that DMA can be used without slowing things down overall.


### Testing procedure

The benchmark function of `tests/periph_spi_dma` make the effect apparent:

#### master

```
2021-10-07 13:36:58,396 # init 0 0 3
2021-10-07 13:36:58,406 # Trying to initialize SPI_DEV(0): mode: 0, clk: 3, cs_port: 0, cs_pin: 0
2021-10-07 13:36:58,408 # Note: Failed assertion (crash) means configuration not supported
2021-10-07 13:37:06,204 # bench
2021-10-07 13:37:06,208 # ### Running some benchmarks, all values in [us] ###
2021-10-07 13:37:06,211 # ### Test				Transfer time	user time
2021-10-07 13:37:06,212 # 
2021-10-07 13:37:06,226 #  1 - write 1000 times 1 byte:			11005	6011
2021-10-07 13:37:06,241 #  2 - write 1000 times 2 byte:			10829	5934
2021-10-07 13:37:06,418 #  3 - write 1000 times 100 byte:		173275	5918
2021-10-07 13:37:06,435 #  4 - write 1000 times 1 byte to register:	11713	6800
2021-10-07 13:37:06,452 #  5 - write 1000 times 2 byte to register:	12632	6666
2021-10-07 13:37:06,632 #  6 - write 1000 times 100 byte to register:	175692	6669
2021-10-07 13:37:06,647 #  7 - read 1000 times 2 byte:			10796	5800
2021-10-07 13:37:06,824 #  8 - read 1000 times 100 byte:		173243	5891
2021-10-07 13:37:06,841 #  9 - read 1000 times 2 byte from register:	12607	6632
2021-10-07 13:37:07,022 # 10 - read 1000 times 100 byte from register:	175668	6669
2021-10-07 13:37:07,037 # 11 - transfer 1000 times 2 byte:		11255	6258
2021-10-07 13:37:07,215 # 12 - transfer 1000 times 100 byte:		173258	5872
2021-10-07 13:37:07,232 # 13 - transfer 1000 times 2 byte to register:	12629	6633
2021-10-07 13:37:07,413 # 14 - transfer 1000 times 100 byte to register:175648	6641
2021-10-07 13:37:07,420 # 15 - acquire/release 1000 times:		3437	3442
2021-10-07 13:37:08,423 # -- - SUM:					1143687	91836
2021-10-07 13:37:08,423 # 
2021-10-07 13:37:08,425 # ### All runs complete ###
```

#### this patch

```
2021-10-07 13:38:34,643 # init 0 0 3
2021-10-07 13:38:34,649 # Trying to initialize SPI_DEV(0): mode: 0, clk: 3, cs_port: 0, cs_pin: 0
2021-10-07 13:38:34,655 # Note: Failed assertion (crash) means configuration not supported
2021-10-07 13:38:38,650 # bench
2021-10-07 13:38:38,654 # ### Running some benchmarks, all values in [us] ###
2021-10-07 13:38:38,658 # ### Test				Transfer time	user time
2021-10-07 13:38:38,658 # 
2021-10-07 13:38:38,665 #  1 - write 1000 times 1 byte:			3209	3213
2021-10-07 13:38:38,673 #  2 - write 1000 times 2 byte:			5012	5017
2021-10-07 13:38:38,851 #  3 - write 1000 times 100 byte:		173255	5886
2021-10-07 13:38:38,867 #  4 - write 1000 times 1 byte to register:	11712	6801
2021-10-07 13:38:38,884 #  5 - write 1000 times 2 byte to register:	12633	6675
2021-10-07 13:38:39,065 #  6 - write 1000 times 100 byte to register:	175704	6662
2021-10-07 13:38:39,073 #  7 - read 1000 times 2 byte:			5073	5079
2021-10-07 13:38:39,251 #  8 - read 1000 times 100 byte:		173248	5877
2021-10-07 13:38:39,268 #  9 - read 1000 times 2 byte from register:	12606	6640
2021-10-07 13:38:39,448 # 10 - read 1000 times 100 byte from register:	175625	6635
2021-10-07 13:38:39,457 # 11 - transfer 1000 times 2 byte:		5019	5024
2021-10-07 13:38:39,635 # 12 - transfer 1000 times 100 byte:		173225	5881
2021-10-07 13:38:39,652 # 13 - transfer 1000 times 2 byte to register:	12628	6633
2021-10-07 13:38:39,833 # 14 - transfer 1000 times 100 byte to register:175668	6640
2021-10-07 13:38:39,840 # 15 - acquire/release 1000 times:		3438	3442
2021-10-07 13:38:40,843 # -- - SUM:					1118055	86105
2021-10-07 13:38:40,843 # 
2021-10-07 13:38:40,845 # ### All runs complete ###

```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14261#issuecomment-644314287