### PR TITLE
make: support package mirrors

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -72,7 +72,11 @@ NIGHTLY=${NIGHTLY:-0}
 RUN_TESTS=${RUN_TESTS:-${NIGHTLY}}
 
 DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE
-         -E TEST_HASH -E CI_PULL_LABELS"
+         -E TEST_HASH -E CI_PULL_LABELS -EPKG_USE_MIRROR"
+
+if [ ${NIGHTLY} -eq 1 ]; then
+    export PKG_USE_MIRROR=0
+fi
 
 get_supported_kconfig_board_app() {
     local board=$1

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -24,6 +24,12 @@ ifeq (,$(PKG_LICENSE))
   $(error PKG_LICENSE not defined)
 endif
 
+ifneq (, $(PKG_MIRROR_URL))
+  ifneq (0, $(PKG_USE_MIRROR))
+    PKG_URL = $(PKG_MIRROR_URL)
+  endif
+endif
+
 PKG_DIR ?= $(CURDIR)
 PKG_PATCH_DIR ?= $(PKG_DIR)/patches
 

--- a/pkg/yxml/Makefile
+++ b/pkg/yxml/Makefile
@@ -1,5 +1,6 @@
 PKG_NAME=yxml
 PKG_URL=https://g.blicky.net/yxml.git
+PKG_MIRROR_URL=https://github.com/RIOT-OS-pkgmirror/yxml.git
 PKG_VERSION=f9438757fc49b9f86961ddb55ae430e36bb88ebb
 PKG_LICENSE=MIT
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As discussed on today's weekly, this PR:

1. adds support for specifying a package mirror URL, sets that as default
2. makes murdock not use mirrors for nightlies
3. adds a mirror for yxml

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
