### PR TITLE
drivers/lm75: minor cleanup

### DIFF
--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -31,8 +31,8 @@
 extern "C" {
 #endif
 
-#ifndef LM75_PARAMS_I2C
-#define LM75_PARAMS_I2C    I2C_DEV(0) /**< I2C BUS used */
+#ifndef LM75_PARAM_I2C
+#define LM75_PARAM_I2C               I2C_DEV(0) /**< I2C BUS used */
 #endif
 
 /** 7-bit I2C slave address: 1-0-0-1-A2-A1-A0, where
@@ -145,7 +145,7 @@ extern "C" {
 #define LM75_PARAMS        {     .res             = &lm75a_properties, \
                                  .gpio_alarm      = LM75_PARAM_INT, \
                                  .conv_rate       = LM75A_CONV_RATE, \
-                                 .i2c_bus         = LM75_PARAMS_I2C, \
+                                 .i2c_bus         = LM75_PARAM_I2C, \
                                  .i2c_addr        = CONFIG_LM75_I2C_ADDR, \
                                  .shutdown_mode   = CONFIG_OPERATION_MODE, \
                                  .tm_mode         = CONFIG_THERMOSTAT_MODE, \
@@ -158,7 +158,7 @@ extern "C" {
 #define LM75_PARAMS        {    .res                 = &tmp1075_properties, \
                                 .gpio_alarm          = LM75_PARAM_INT, \
                                 .conv_rate           = TMP1075_CONV_RATE, \
-                                .i2c_bus             = LM75_PARAMS_I2C, \
+                                .i2c_bus             = LM75_PARAM_I2C, \
                                 .i2c_addr            = CONFIG_LM75_I2C_ADDR, \
                                 .shutdown_mode       = CONFIG_OPERATION_MODE, \
                                 .tm_mode             = CONFIG_THERMOSTAT_MODE, \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR just makes a minor rename cleanup change in the LM75 driver.
The I2C definition was named as `PARAMS`, changed that to `PARAM`. Aligned the definition to the other i2c definition as well. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
