### PR TITLE
cpu/{atxmega,atmega_common}: fix invalid use of PSTR() [backport 2021.10]

### DIFF
--- a/cpu/atmega_common/atmega_cpu.c
+++ b/cpu/atmega_common/atmega_cpu.c
@@ -26,8 +26,6 @@
  * @}
  */
 
-#include <avr/pgmspace.h>
-
 #include "board.h"
 #include "cpu.h"
 #include "panic.h"
@@ -100,8 +98,7 @@ ISR(BADISR_vect)
     LED_PANIC;
 #endif
 
-    core_panic(PANIC_GENERAL_ERROR, PSTR("FATAL ERROR: BADISR_vect called, unprocessed Interrupt.\n"
-                  "STOP Execution.\n"));
+    core_panic(PANIC_GENERAL_ERROR, "BADISR");
 }
 
 #if defined(CPU_ATMEGA128RFA1) || defined (CPU_ATMEGA256RFR2)

--- a/cpu/atxmega/atxmega_cpu.c
+++ b/cpu/atxmega/atxmega_cpu.c
@@ -18,8 +18,6 @@
  * @}
  */
 
-#include <avr/pgmspace.h>
-
 #include "cpu.h"
 #include "cpu_clock.h"
 #include "cpu_pm.h"
@@ -121,7 +119,5 @@ ISR(BADISR_vect)
     LED_PANIC;
 #endif
 
-    core_panic(PANIC_GENERAL_ERROR,
-               PSTR("FATAL ERROR: BADISR_vect called, unprocessed Interrupt.\n"
-                    "STOP Execution.\n"));
+    core_panic(PANIC_GENERAL_ERROR, "BADISR");
 }


### PR DESCRIPTION
# Backport of #16920

### Contribution description

core_panic() doesn't expect the message to be in program memory, but
in data memory. Bad things will happen on AVR when the address is
interpreted as being in data address space, but the allocation is
done in program address space.

### Testing procedure

The corresponding panics (and IRQ without provided ISR) should print something sensible again.

### Issues/PRs references

None