### PR TITLE
pkg/emlearn: bump to 0.12

### DIFF
--- a/pkg/emlearn/Makefile
+++ b/pkg/emlearn/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=emlearn
 PKG_URL=https://github.com/emlearn/emlearn
-PKG_VERSION=e9e9d645fc64b1f764d8a8ece6d6427a5297c098 # 0.11.6
+PKG_VERSION=d8cffb6cdd5619eb26d01287f07a530128958b60 # 0.12
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As the title says, this PR bumps the emlearn package to the latest 0.12 release. There are no fundamental changes in this release and the test application still works as before.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- `tests/pkg_emlearn` works:

<details>

```
BUILD_IN_DOCKER=1 make -C tests/pkg_emlearn/ all test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/pkg_emlearn/' 'riot/riotbuild:latest' make     all
Building application "tests_pkg_emlearn" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/pkg/emlearn
"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
   text	   data	    bss	    dec	    hex	filename
  69151	    628	  47748	 117527	  1cb17	/data/riotbuild/riotbase/tests/pkg_emlearn/bin/native/tests_pkg_emlearn.elf
r
/work/riot/RIOT/tests/pkg_emlearn/bin/native/tests_pkg_emlearn.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.01-devel-20-g17cbab-pr/pkg/emlearn_0.12)
Predicted digit: 6

```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
