### PR TITLE
pkg/jerryscript: bump to 2.4.0

### DIFF
--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -1,10 +1,11 @@
 PKG_NAME=jerryscript
 PKG_URL=https://github.com/jerryscript-project/jerryscript.git
-PKG_VERSION=23bba1c6d9048e9b37cceff05ec6501646e48791  # 2.3.0
+PKG_VERSION=8ba0d1b6ee5a065a42f3b306771ad8e3c0d819bc  # 2.4.0
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+JERRY_PROFILE ?= minimal # Other possible values are es.next, es5.1 and es2015-subset
 JERRY_HEAP ?= 16  # kB
 JERRY_STACK ?= 1  # kB
 JERRY_GC_LIMIT ?= 0  # Use default value, e.g. 1/32 of total heap size
@@ -37,10 +38,10 @@ endif
 all: $(BINDIR)/jerryscript.a
 
 $(BINDIR)/jerryscript.a: $(PKG_BUILD_DIR)/Makefile
-	"$(MAKE)" -C $(PKG_BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
+	"$(MAKE)" -C $(PKG_BUILD_DIR) jerry-core jerry-ext jerry-port-default
 	@cp $(PKG_BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
 	@cp $(PKG_BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
-	@cp $(PKG_BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
+	@cp $(PKG_BUILD_DIR)/lib/libjerry-port-default.a $(BINDIR)/jerryscript-port-default.a
 
 $(PKG_BUILD_DIR)/Makefile:
 	cmake -B$(PKG_BUILD_DIR) -H$(PKG_SOURCE_DIR) \
@@ -49,10 +50,11 @@ $(PKG_BUILD_DIR)/Makefile:
 	 -DCMAKE_C_COMPILER=$(CC) \
 	 -DCMAKE_C_COMPILER_WORKS=TRUE \
 	 -DENABLE_LTO=OFF \
-	 -DENABLE_ALL_IN_ONE=OFF \
+	 -DENABLE_AMALGAM=OFF \
 	 -DHAVE_TIME_H=0 \
 	 -DEXTERNAL_COMPILE_FLAGS="$(INCLUDES) $(EXT_CFLAGS)" \
-	 -DJERRY_LIBM=OFF \
+	 -DJERRY_MATH=OFF \
+	 -DJERRY_PROFILE=$(JERRY_PROFILE) \
 	 -DJERRY_CMDLINE=OFF \
 	 -DJERRY_VALGRIND=OFF \
 	 -DJERRY_GC_LIMIT=$(JERRY_GC_LIMIT) \

--- a/pkg/jerryscript/Makefile.dep
+++ b/pkg/jerryscript/Makefile.dep
@@ -1,4 +1,4 @@
-USEMODULE += jerryport-minimal
+USEMODULE += jerryscript-port-default
 USEMODULE += jerryscript-ext
 
 # Jerryscript is only supported by 32-bit architectures

--- a/pkg/jerryscript/Makefile.include
+++ b/pkg/jerryscript/Makefile.include
@@ -1,8 +1,9 @@
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-core/include
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-ext/include
 
-ARCHIVES += $(BINDIR)/jerryscript.a $(BINDIR)/jerryscript-ext.a
-ARCHIVES += $(BINDIR)/jerryport-minimal.a
+ARCHIVES += $(BINDIR)/jerryscript.a
+ARCHIVES += $(BINDIR)/jerryscript-ext.a
+ARCHIVES += $(BINDIR)/jerryscript-port-default.a
 
 # Ensure MCPU is correctly exported to CMake variables when configuring the
 # Jerrycript build


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR bumps the jerryscript package to [version 2.4](https://github.com/jerryscript-project/jerryscript/releases/tag/v2.4.0).
Some minor things had to be adapted in the build system to fix the build. Then I noticed that by default there was a **100KB increase** on flash. This can be fixed by setting the `JERRY_PROFILE` variable to `minimal` (set as default in RIOT), the default in Jerryscript being set to `es.next` which supports more javascript features but seems to increase significantly flash memory usage. This variable can be configured so users can try other ES profiles.

See below for test outputs. On nrf52840dk compared to master, this PR shaves 63KB (from 154KB to 91KB).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `examples/javascript` works on native:

<details>

```
$ BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 make -C examples/javascript --no-print-directory all term
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/examples/javascript/' 'riot/riotbuild:latest' make     all
Building application "riot_javascript" for "native" with MCU "native".

   text	   data	    bss	    dec	    hex	filename
 202958	   1628	  66296	 270882	  42222	/data/riotbuild/riotbase/examples/javascript/bin/native/riot_javascript.elf
/work/riot/RIOT/examples/javascript/bin/native/riot_javascript.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: buildtest)
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
Executing main.js:
Hello from JerryScript!
^C
native: exiting

```

</details>

- `examples/javascript` works on nrf52840dk:

<details>

```
$ IOTLAB_NODE=auto BUILD_IN_DOCKER=1 RIOT_CI_BUILD=1 BOARD=nrf52840dk make -C examples/javascript flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nrf52840dk' -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/examples/javascript/' 'riot/riotbuild:latest' make     
Building application "riot_javascript" for "nrf52840dk" with MCU "nrf52".

   text	   data	    bss	    dec	    hex	filename
  91240	    108	  28420	 119768	  1d3d8	/data/riotbuild/riotbase/examples/javascript/bin/nrf52840dk/riot_javascript.elf
iotlab-node --jmespath='keys(@)[0]' --format='lambda ret: exit(int(ret))'  --list saclay,nrf52840dk,10 --flash /work/riot/RIOT/examples/javascript/bin/nrf52840dk/riot_javascript.bin
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52840dk-10.saclay.iot-lab.info:20000' 
main(): This is RIOT! (Version: buildtest)
You are running RIOT on a(n) nrf52840dk board.
This board features a(n) nrf52 MCU.
Executing main.js:
Hello from JerryScript!
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
