### PR TITLE
hacl: Switch git address to RIOT-OS-pkgmirror

### DIFF
--- a/pkg/hacl/Makefile
+++ b/pkg/hacl/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=hacl
 # TODO: switch to https://github.com/project-everest/hacl-star
-# backup of last state before upstream was deleted
-PKG_URL=https://github.com/benpicco/hacl-c_archived
+# The mirror was promoted from backup to main URL because upstream was deleted
+PKG_URL=https://github.com/RIOT-OS-pkgmirror/hacl-c_archived
 PKG_VERSION=aac05f5094fc92569169d5a2af54c12387160634
 PKG_LICENSE=MIT
 


### PR DESCRIPTION
### Contribution description

hacl is a pkg we already use in mirrored mode since the upstream went away. So far, @benpicco has persisted a copy of that repository, and there is no indication it'd go away -- this is primarily to set a precedent for the next repo where there is not already a good upstream.

This commit itself keeps Ben's repository as the main pkg_url, and sets https://github.com/RIOT-OS-pkgmirror/hacl-c_archived as the mirror URL using the mechanism introduced in #16927.

Had we used the pkgmirror concept already, it'd have been a great fit -- but what'd we do when upstream goes away for good? Right now, if the upstream goes away the PR builds keep working, but the nightlies start failing because there the original URLs are used.

So in a situation like this (assuming that the upstream mirror would be gone), …
* would the fast fix (like #15452 did) just have promoted the previous backup URL to the primary one? (If so, I should change this commit to just use the repo in RIOT-OS-pkgmirror).
* Or would we leave out the main URL? (If so, I should alter the mechanism of #16927 to use the mirror even for nightlies if there is no main).
* If we don't want to make a decision yet, that's also fine (in which case we can reject this PR or accept in in the current form that for the time being depends on both Ben's fork and the RIOT-OS-pkgmirror one until a decision is made).

### Testing procedure

* Look at code change (and trout me if this does not come out as green from everywhere)

### Issues/PRs references

#16927 established the mirror mechanism. The hacl pkg was switched to its current ("external") mirror in #15452.

[OT: this github autoformatting is getting unpredictably fancier all the time ... i *guess* that the reason why some of the PR references have the name is that they decide based on it being in a list that it's probably good to have the full text, without making an effort to see whether someone is using flowed text in an item list.]