### PR TITLE
pkg/openthread: bump version to 20200818 + adapt to use CMake to configure the build

### DIFF
--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -43,7 +43,7 @@ OPENTHREAD_TYPE ?= ftd
 USEMODULE += openthread-$(OPENTHREAD_TYPE)
 
 # Comment the following line in order to disable the OpenThread CLI
-USEMODULE += openthread-cli
+USEMODULE += openthread-cli-$(OPENTHREAD_TYPE)
 
 USEMODULE += netdev_default
 

--- a/pkg/doc.txt
+++ b/pkg/doc.txt
@@ -37,7 +37,7 @@
  * ~~~~~~~~
  *
  * In this case, the source and the build directory are the same (currently,
- * this applies to the micropython and openthread packages).
+ * this only applies to the micropython package).
  *
  * Porting an external library
  * ===========================

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,70 +1,70 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
-PKG_VERSION=thread-reference-20191113
+PKG_VERSION=54b31928cf65803a9cd83c9f97061b64e465aaf7  # thread-reference-20200818
 PKG_LICENSE=BSD-3-Clause
-
-# OpenThread build system doesn't support (yet) out-of-source builds
-# so clone and build OpenThread within the application build directory
-PKG_BUILD_OUT_OF_SOURCE = 0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
 ifneq (,$(filter openthread-ftd,$(USEMODULE)))
   TD = ftd
+  OT_JOINER := OFF
 else ifneq (,$(filter openthread-mtd,$(USEMODULE)))
   TD = mtd
-  JOINER_ARG = --enable-joiner
+  OT_JOINER := ON
 else
   $(error "Please use either USEMODULE=openthread-ftd or USEMODULE=openthread-mtd")
 endif
 
-ifneq (,$(filter openthread-cli,$(USEMODULE)))
-  CLI_ARG = --enable-cli --enable-$(TD)
+OT_MODULES = mbedcrypto mbedtls openthread-$(TD)
+ifneq (,$(filter openthread-cli-$(TD),$(USEMODULE)))
+  OT_MODULES += openthread-cli-$(TD)
+  OT_APP_CLI ?= ON
 endif
 
-OPENTHREAD_ARGS += $(CLI_ARG) $(JOINER_ARG) --enable-application-coap
-CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"platform_config.h\"'
+# Enable CoAP
+OT_COAP ?= ON
 
-OPENTHREAD_COMMON_FLAGS = -fdata-sections -ffunction-sections -Os
-OPENTHREAD_COMMON_FLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter
-OPENTHREAD_CXXFLAGS += -Wno-class-memaccess
-OPENTHREAD_CXXFLAGS += -DOPENTHREAD_TARGET_RIOT=1
+OT_C_FLAGS = $(CFLAGS_CPU)
+OT_C_FLAGS += -fdata-sections -ffunction-sections -Os
+OT_C_FLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter
+OT_CXXFLAGS += -Wno-class-memaccess -DOPENTHREAD_TARGET_RIOT
 
-OT_LIB_DIR = $(PKG_BUILD_DIR)/output/lib
-MODULE_LIBS = mbedcrypto.a openthread-$(TD).a
-ifneq (,$(filter openthread-cli,$(USEMODULE)))
-  MODULE_LIBS += openthread-cli.a
-endif
+OT_MODULES_ARCHIVES = $(addsuffix .a,$(addprefix $(BINDIR)/,$(OT_MODULES)))
+OT_CORE_LIB_DIR = $(PKG_BUILD_DIR)/src/core
+OT_CLI_LIB_DIR = $(PKG_BUILD_DIR)/src/cli
+OT_MBEDCRYPTO_LIB_DIR = $(PKG_BUILD_DIR)/third_party/mbedtls/repo/library
 
-all: $(addprefix $(BINDIR)/,$(MODULE_LIBS))
-	@true
+all: $(OT_MODULES_ARCHIVES)
+	@:
 
-$(BINDIR)/openthread-$(TD).a: $(OT_LIB_DIR)/libopenthread-$(TD).a
-	@cp $< $@
+$(BINDIR)/mbedtls.a: $(BINDIR)/openthread-$(TD).a
+	@cp $(OT_MBEDCRYPTO_LIB_DIR)/libmbedtls.a $@
 
 $(BINDIR)/mbedcrypto.a: $(BINDIR)/openthread-$(TD).a
-	@cp $(OT_LIB_DIR)/libmbedcrypto.a $@
+	@cp $(OT_MBEDCRYPTO_LIB_DIR)/libmbedcrypto.a $@
 
-$(BINDIR)/openthread-cli.a: $(BINDIR)/openthread-$(TD).a
-	@cp $(OT_LIB_DIR)/libopenthread-cli-$(TD).a $@
+$(BINDIR)/openthread-cli-$(TD).a: $(BINDIR)/openthread-$(TD).a
+	@cp $(OT_CLI_LIB_DIR)/libopenthread-cli-$(TD).a $@
 
-$(OT_LIB_DIR)/libopenthread-$(TD).a: $(PKG_BUILD_DIR)/Makefile
-	$(MAKE) -C $(PKG_BUILD_DIR) --no-print-directory install DESTDIR=$(PKG_BUILD_DIR)/output PREFIX=/
-	$(Q)printf "OpenThread built for %s device\n" $(TD)
+$(BINDIR)/openthread-$(TD).a: $(OT_CORE_LIB_DIR)/libopenthread-$(TD).a
+	@cp $< $@
 
-$(PKG_BUILD_DIR)/Makefile: $(PKG_BUILD_DIR)/configure
-	$(Q)cd $(PKG_BUILD_DIR) && CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)"\
-		OBJC="" OBJCXX="" AR="$(AR)" RANLIB="$(RANLIB)" NM="$(NM)" \
-		STRIP="$(STRIP)" \
-		CPPFLAGS="$(OPENTHREAD_COMMON_FLAGS) $(CFLAGS_CPU) -D$(CONFIG_FILE)" \
-		CFLAGS="$(OPENTHREAD_COMMON_FLAGS) $(CFLAGS_CPU) " \
-		CXXFLAGS="$(OPENTHREAD_COMMON_FLAGS) $(OPENTHREAD_CXXFLAGS) \
-		          $(CFLAGS_CPU) -fno-exceptions -fno-rtti " \
-		LDFLAGS="$(OPENTHREAD_COMMON_FLAGS) $(CFLAGS_CPU) -nostartfiles -specs=nano.specs \
-		-specs=nosys.specs -Wl,--gc-sections -Wl,-Map=map.map " \
-		./configure --disable-docs --host=$(TARGET_ARCH) --target=$(TARGET_ARCH) \
-		--prefix=/ --enable-default-logging $(OPENTHREAD_ARGS)
+$(OT_CORE_LIB_DIR)/libopenthread-$(TD).a: $(PKG_BUILD_DIR)/Makefile
+	$(QQ)"$(MAKE)" -C $(PKG_BUILD_DIR) $(OT_MODULES)
 
-$(PKG_BUILD_DIR)/configure: $(PKG_PREPARED)
-	$(Q)printf "OPENTHREAD_ARGS is [$(OPENTHREAD_ARGS)]\n"
-	$(Q)cd $(PKG_BUILD_DIR) && PREFIX="/" ./bootstrap
+$(PKG_BUILD_DIR)/Makefile:
+	cmake -Wno-dev -B$(PKG_BUILD_DIR) -H$(PKG_SOURCE_DIR) \
+	 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+	 -DCMAKE_C_COMPILER="$(CC)" \
+	 -DCMAKE_C_COMPILER_AR="$(AR)" \
+	 -DCMAKE_C_COMPILER_RANLIB="$(RANLIB)" \
+	 -DCMAKE_C_FLAGS="$(OT_C_FLAGS)" \
+	 -DCMAKE_CXX_COMPILER="$(CXX)" \
+	 -DCMAKE_CXX_FLAGS="$(OT_C_FLAGS) $(OT_CXXFLAGS) -fno-exceptions -fno-rtti" \
+	 -DCMAKE_NM="$(NM)" \
+	 -DCMAKE_STRIP="$(STRIP)" \
+	 -DOT_PLATFORM=NO \
+	 -DOT_CONFIG="$(RIOTBASE)/pkg/openthread/include/platform_config.h" \
+	 -DOT_APP_CLI=$(OT_APP_CLI) \
+	 -DOT_JOINER=$(OT_JOINER) \
+	 -DOT_COAP=$(OT_COAP)

--- a/pkg/openthread/Makefile.include
+++ b/pkg/openthread/Makefile.include
@@ -1,7 +1,7 @@
 OPENTHREAD_DIR = $(RIOTBASE)/pkg/openthread
 
-INCLUDES += -I$(OPENTHREAD_DIR)/include \
-            -I$(BINDIR)/pkg/openthread/include
+INCLUDES += -I$(PKGDIRBASE)/openthread/include
+INCLUDES += -I$(OPENTHREAD_DIR)/include
 
 ifneq (,$(filter openthread_contrib,$(USEMODULE)))
   DIRS += $(OPENTHREAD_DIR)/contrib
@@ -16,3 +16,4 @@ endif
 
 ARCHIVES += $(addprefix $(BINDIR)/,$(addsuffix .a,$(filter openthread-%,$(USEMODULE))))
 ARCHIVES += $(BINDIR)/mbedcrypto.a
+ARCHIVES += $(BINDIR)/mbedtls.a

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -94,10 +94,7 @@ static void *_openthread_event_loop(void *arg)
     /* init OpenThread */
     sInstance = otInstanceInitSingle();
 
-    /* enable OpenThread UART */
-    otPlatUartEnable();
-
-#if defined(MODULE_OPENTHREAD_CLI)
+#if defined(MODULE_OPENTHREAD_CLI_FTD) || defined(MODULE_OPENTHREAD_CLI_MTD)
     otCliUartInit(sInstance);
     /* Init default parameters */
     otPanId panid = OPENTHREAD_PANID;
@@ -108,6 +105,9 @@ static void *_openthread_event_loop(void *arg)
     otIp6SetEnabled(sInstance, true);
     /* Start Thread protocol operation */
     otThreadSetEnabled(sInstance, true);
+#else
+    /* enable OpenThread UART */
+    otPlatUartEnable();
 #endif
 
 #if OPENTHREAD_ENABLE_DIAG

--- a/pkg/openthread/patches/0001-RIOT-use-assert.h.patch
+++ b/pkg/openthread/patches/0001-RIOT-use-assert.h.patch
@@ -1,25 +1,25 @@
-From 51cf02a0ee4d6dd441edbc5e20f58eb1ee4c28f4 Mon Sep 17 00:00:00 2001
-From: Benjamin Valentin <benpicco@googlemail.com>
-Date: Thu, 17 Dec 2020 14:33:22 +0100
-Subject: [PATCH] [RIOT] use <assert.h>
+From 49352494e1e22c9d2d85e13867daee1a0553faa5 Mon Sep 17 00:00:00 2001
+From: Alexandre Abadie <alexandre.abadie@inria.fr>
+Date: Sat, 2 Oct 2021 16:39:28 +0200
+Subject: [PATCH 1/1] RIOT use assert.h
 
 ---
  src/core/common/debug.hpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/core/common/debug.hpp b/src/core/common/debug.hpp
-index 3ab0eb21b..6e48f7d0d 100644
+index 50dd2b2b2..97d44394f 100644
 --- a/src/core/common/debug.hpp
 +++ b/src/core/common/debug.hpp
-@@ -40,7 +40,7 @@
- #include <stdio.h>
- #include "utils/wrap_string.h"
+@@ -41,7 +41,7 @@
  
--#if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX)
-+#if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX) || defined(OPENTHREAD_TARGET_RIOT)
+ #if OPENTHREAD_CONFIG_ASSERT_ENABLE
+ 
+-#if defined(__APPLE__) || defined(__linux__)
++#if defined(__APPLE__) || defined(__linux__) || defined(OPENTHREAD_TARGET_RIOT)
  
  #include <assert.h>
  
 -- 
-2.27.0
+2.30.2
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR bumps the version of openthread to the [latest 20200818 release](https://github.com/openthread/openthread/releases/tag/thread-reference-20200818). Since this release can now be built using CMake, this PR also adapt the package to cmake instead of autotools to build it: this enables out-of-source build like all other packages (except micropython).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green CI
- Follow the readme of `examples/openthread` and ensure that it's still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
