### PR TITLE
gnrc_ipv6_nib: queue packets that trigger probing on border router [backport 2021.10]

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -38,6 +38,9 @@ extern "C" {
 #ifndef CONFIG_GNRC_IPV6_NIB_SLAAC
 #define CONFIG_GNRC_IPV6_NIB_SLAAC                    1
 #endif
+#ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT
+#define CONFIG_GNRC_IPV6_NIB_QUEUE_PKT                1
+#endif
 #ifndef CONFIG_GNRC_IPV6_NIB_NUMOF
 #define CONFIG_GNRC_IPV6_NIB_NUMOF                   (16)
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -47,6 +47,7 @@ config GNRC_IPV6_NIB_QUEUE_PKT
 
 config GNRC_IPV6_NIB_ARSM
     bool "Use classic NDP address resolution state-machine"
+    default y if USEMODULE_GNRC_IPV6_NIB_6LBR
     default n if USEMODULE_GNRC_IPV6_NIB_6LN && !GNRC_IPV6_NIB_6LR
     default y
 


### PR DESCRIPTION
# Backport of #16947

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When probing for an unknown neighbor, the NIB on a 6LoWPAN border router currently drops the packet that triggered that probing in accordance with RFC 6775. However, it also does that on the upstream interface, as queuing support is removed at compile-time altogether. This adds an exception to the compile-time config 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try to ping an Internet host via a border router from a 6LoWPAN host (see e.g. [Task 8.5](https://github.com/RIOT-OS/Release-Specs/tree/master/08-interop#task-05---icmpv6-echo-between-iotlab-m3-and-internet-host-through-riot-border-router) of the release specs). The first message should go through with this PR, without it, the message  will get lost.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but the issue in https://github.com/RIOT-OS/RIOT/issues/11988 might be related.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
