### PR TITLE
pkg/nimble: fix scan event type define usage

### DIFF
--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -138,7 +138,7 @@ static void _on_scan_evt(uint8_t type, const ble_addr_t *addr, int8_t rssi,
 
     /* we are only interested in ADV_IND packets, the rest can be dropped right
      * away */
-    if (type != BLE_HCI_ADV_TYPE_ADV_IND) {
+    if (type != BLE_HCI_ADV_RPT_EVTYPE_ADV_IND) {
         return;
     }
 

--- a/pkg/nimble/rpble/nimble_rpble.c
+++ b/pkg/nimble/rpble/nimble_rpble.c
@@ -118,7 +118,7 @@ static void _on_scan_evt(uint8_t type,
     int res;
 
     /* filter out all non-connectible advertisements */
-    if (type != BLE_HCI_ADV_TYPE_ADV_IND) {
+    if (type != BLE_HCI_ADV_RPT_EVTYPE_ADV_IND) {
         return;
     }
 

--- a/pkg/nimble/scanlist/nimble_scanlist_print.c
+++ b/pkg/nimble/scanlist/nimble_scanlist_print.c
@@ -30,20 +30,20 @@
 static void _print_type(uint8_t type)
 {
     switch (type) {
-        case BLE_HCI_ADV_TYPE_ADV_IND:
+        case BLE_HCI_ADV_RPT_EVTYPE_ADV_IND:
             printf(" [IND]");
             break;
-        case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD:
-            printf(" [DIRECT_IND_HD]");
+        case BLE_HCI_ADV_RPT_EVTYPE_DIR_IND:
+            printf(" [DIRECT_IND]");
             break;
-        case BLE_HCI_ADV_TYPE_ADV_SCAN_IND:
+        case BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND:
             printf(" [SCAN_IND]");
             break;
-        case BLE_HCI_ADV_TYPE_ADV_NONCONN_IND:
+        case BLE_HCI_ADV_RPT_EVTYPE_NONCONN_IND:
             printf(" [NONCONN_IND]");
             break;
-        case BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD:
-            printf(" [DIRECT_IND_LD]");
+        case BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP:
+            printf(" [SCAN_RSP]");
             break;
         default:
             printf(" [INVALID]");

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -35,7 +35,8 @@ extern "C" {
  * @brief   Callback signature triggered by this module for each discovered
  *          advertising packet
  *
- * @param[in] type      type of advertising packet, e.g BLE_HCI_ADV_TYPE_ADV_IND
+ * @param[in] type      type of advertising packet, e.g
+ *                      BLE_HCI_ADV_RPT_EVTYPE_ADV_IND
  * @param[in] addr      advertising address of the source node
  * @param[in] rssi      RSSI value for the received packet
  * @param[in] ad        advertising data


### PR DESCRIPTION
### Contribution description
Turns out we have a miss-match of scan type defines used by some RIOT modules and the correct defines as intended by NimBLE in some of the nimble submodules. When scanning (`ble_gap_disc`), the NimBLE GAP APIs callback function returns the scan event type as a list of possible defines, `BLE_HCI_ADV_RPT_EVTYPE_x`. Hoever, in RIOT we are currently using the `BLE_HCI_ADV_TYPE_x` group of defines. Fortunately, this is not a big issue, as those groups are mostly identical:
```c
// from nimble/hci_common.h
#define BLE_HCI_ADV_RPT_EVTYPE_ADV_IND      (0)
#define BLE_HCI_ADV_RPT_EVTYPE_DIR_IND      (1)
#define BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND     (2)
#define BLE_HCI_ADV_RPT_EVTYPE_NONCONN_IND  (3)
#define BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP     (4)

#define BLE_HCI_ADV_TYPE_ADV_IND            (0)
#define BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_HD  (1)
#define BLE_HCI_ADV_TYPE_ADV_SCAN_IND       (2)
#define BLE_HCI_ADV_TYPE_ADV_NONCONN_IND    (3)
#define BLE_HCI_ADV_TYPE_ADV_DIRECT_IND_LD  (4)
#define BLE_HCI_ADV_TYPE_MAX                (4)
```
Only when using the print functions from the `nimble_scanlist` module, the scan responses will not be displayed correclty...

### Testing procedure
lts only a minor fix with mostly cosmetic impact, build test should do the trick...

### Issues/PRs references
This issue was discovered in https://github.com/apache/mynewt-nimble/issues/1049
