### PR TITLE
cpu/native/include: other stacksizes based on default

### DIFF
--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -32,7 +32,7 @@ extern "C" {
 #define THREAD_STACKSIZE_DEFAULT            (163840)
 #endif
 #ifndef THREAD_STACKSIZE_IDLE
-#define THREAD_STACKSIZE_IDLE               (163840)
+#define THREAD_STACKSIZE_IDLE               (THREAD_STACKSIZE_DEFAULT)
 #endif
 #ifndef THREAD_EXTRA_STACKSIZE_PRINTF
 #define THREAD_EXTRA_STACKSIZE_PRINTF       (81920)
@@ -42,10 +42,10 @@ extern "C" {
 #endif
 /* for core/include/thread.h */
 #ifndef THREAD_STACKSIZE_MINIMUM
-#define THREAD_STACKSIZE_MINIMUM            (163840)
+#define THREAD_STACKSIZE_MINIMUM            (THREAD_STACKSIZE_DEFAULT)
 #endif
 #ifndef ISR_STACKSIZE
-#define ISR_STACKSIZE                       (163840)
+#define ISR_STACKSIZE                       (THREAD_STACKSIZE_DEFAULT)
 #endif
 
 #else /* Linux etc. */
@@ -53,7 +53,7 @@ extern "C" {
 #define THREAD_STACKSIZE_DEFAULT            (8192)
 #endif
 #ifndef THREAD_STACKSIZE_IDLE
-#define THREAD_STACKSIZE_IDLE               (8192)
+#define THREAD_STACKSIZE_IDLE               (THREAD_STACKSIZE_DEFAULT)
 #endif
 #ifndef THREAD_EXTRA_STACKSIZE_PRINTF
 #define THREAD_EXTRA_STACKSIZE_PRINTF       (4096)
@@ -63,11 +63,11 @@ extern "C" {
 #endif
 /* for core/include/thread.h */
 #ifndef THREAD_STACKSIZE_MINIMUM
-#define THREAD_STACKSIZE_MINIMUM            (8192)
+#define THREAD_STACKSIZE_MINIMUM            (THREAD_STACKSIZE_DEFAULT)
 #endif
 /* native internal */
 #ifndef ISR_STACKSIZE
-#define ISR_STACKSIZE                       (8192)
+#define ISR_STACKSIZE                       (THREAD_STACKSIZE_DEFAULT)
 #endif
 #endif /* OS */
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR sets native stack values based on `STACKSIZE_DEFAULT`, default values are kept why allowing for easier resizing of all stacks based on the default.

### Testing procedure

- green murdock
- switch the value

```
 CFLAGS=-DTHREAD_STACKSIZE_DEFAULT=4096 make -C examples/saul/ flash term -j
Building application "saul_example" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/drivers/saul
"make" -C /home/francisco/workspace/RIOT/drivers/saul/init_devs
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/phydat
"make" -C /home/francisco/workspace/RIOT/sys/ps
"make" -C /home/francisco/workspace/RIOT/sys/saul_reg
"make" -C /home/francisco/workspace/RIOT/sys/shell
"make" -C /home/francisco/workspace/RIOT/sys/shell/commands
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
   text    data     bss     dec     hex filename
  35315    6812   37560   79687   13747 /home/francisco/workspace/RIOT/examples/saul/bin/native/saul_example.elf
/home/francisco/workspace/RIOT/examples/saul/bin/native/saul_example.elf /dev/ttyACM0
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2022.01-devel-44-g72e052-pr_native_relative_stacksize)
Welcome to RIOT!

Type `help` for help, type `saul` to see all SAUL devices

> ps
ps
        pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current
          - | isr_stack            | -        - |   - |   4096 (   -1) ( 4097) | 0x565d8f20 | 0x565d8f20
          1 | idle                 | pending  Q |  15 |   4096 (  436) ( 3660) | 0x565d4020 | 0x565d4e80
          2 | main                 | running  Q |   7 |   6144 ( 3020) ( 3124) | 0x565d5020 | 0x565d6680
            | SUM                  |            |     |  14336 ( 3456) (10880)
```

