### PR TITLE
tools/zep_dispatch: forward based on source addr, not MAC addr

### DIFF
--- a/dist/tools/zep_dispatch/main.c
+++ b/dist/tools/zep_dispatch/main.c
@@ -78,10 +78,10 @@ static void _send_topology(void *ctx, void *buffer, size_t len,
     uint8_t mac_src[8];
     uint8_t mac_src_len;
 
-    if (zep_parse_mac(buffer, len, mac_src, &mac_src_len) &&
-        topology_add(ctx, mac_src, mac_src_len, src_addr)) {
-        topology_send(ctx, sock, mac_src, mac_src_len, buffer, len);
+    if (zep_parse_mac(buffer, len, mac_src, &mac_src_len)) {
+        topology_add(ctx, mac_src, mac_src_len, src_addr);
     }
+    topology_send(ctx, sock, src_addr, buffer, len);
 }
 
 static void dispatch_loop(int sock, dispatch_cb_t dispatch, void *ctx)

--- a/dist/tools/zep_dispatch/topology.c
+++ b/dist/tools/zep_dispatch/topology.c
@@ -198,7 +198,7 @@ int topology_parse(const char *file, topology_t *out)
 }
 
 void topology_send(const topology_t *t, int sock,
-                   const uint8_t *mac_src, size_t mac_src_len,
+                   const struct sockaddr_in6 *src_addr,
                    void *buffer, size_t len)
 {
     for (list_node_t *edge = t->edges.next; edge; edge = edge->next) {
@@ -208,8 +208,7 @@ void topology_send(const topology_t *t, int sock,
             continue;
         }
 
-        if ((mac_src_len == super->a->mac_len) &&
-            (memcmp(super->a->mac, mac_src, mac_src_len) == 0)) {
+        if (memcmp(&super->a->addr, src_addr, sizeof(*src_addr)) == 0) {
             /* packet loss */
             if (random() > super->weight_a_b * RAND_MAX) {
                 return;
@@ -219,8 +218,7 @@ void topology_send(const topology_t *t, int sock,
                    (struct sockaddr *)&super->b->addr,
                    sizeof(super->b->addr));
         }
-        else if ((mac_src_len == super->a->mac_len) &&
-                 (memcmp(super->b->mac, mac_src, mac_src_len) == 0)) {
+        else if (memcmp(&super->b->addr, src_addr, sizeof(*src_addr)) == 0) {
             /* packet loss */
             if (random() > super->weight_b_a * RAND_MAX) {
                 return;

--- a/dist/tools/zep_dispatch/topology.h
+++ b/dist/tools/zep_dispatch/topology.h
@@ -63,13 +63,12 @@ bool topology_add(topology_t *t, const uint8_t *mac, uint8_t mac_len,
  *
  * @param[in] t             topology to use
  * @param[in] sock          socket to use for sending
- * @param[in] mac_src       ZEP source l2 address
- * @param[in] mac_src_len   ZEP source l2 address length
+ * @param[in] src_addr      source node address
  * @param[in] buffer        ZEP frame to send
  * @param[in] len           ZEP frame length
  */
 void topology_send(const topology_t *t, int sock,
-                   const uint8_t *mac_src, size_t mac_src_len,
+                   const struct sockaddr_in6 *src_addr,
                    void *buffer, size_t len);
 
 #ifdef __cplusplus


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Forward data soly based on the real source IPv6 address, not the virtual MAC address.
ACK frames don't have a MAC address and should still be forwarded to all nodes in range.


### Testing procedure

When using advanced topologies (e.g. `-t example.topo`) ACK frames would never be forwarded as they don't contain a MAC addresss.

This PR fixes that. 


### Issues/PRs references

needed for #16932
