### PR TITLE
pkg/nimble: version bump to fix broken scanning

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = cddb7c4ccee72e718c8b1a57166e702917e02c13
+PKG_VERSION = 6c9f70972e8c68efe1fd38d413778c9487c5d997
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description
With #16539 we accidentally pulled in a NimBLE Upstream bug (https://github.com/apache/mynewt-nimble/issues/1049) that breaks the GAP discovery procedure (BLE scanning). We just fixed this bug in NimBLE upstream (https://github.com/apache/mynewt-nimble/pull/1051), so all thats left is to pull these fixes into RIOT :-)


### Testing procedure
Run the `examples/nimble_scanner` application on master and on this PR, scanning with the old NimBLE version is broken and only SCAN response messages are reported, scanning with the upstream bugfix included in NimBLE works as expected again.

With this PR, scanning looks something like this:
```
2021-10-07 09:07:44,915 # scan 3000
2021-10-07 09:07:47,918 # Scanning for 3000 ms now ... done
2021-10-07 09:07:47,919 # 
2021-10-07 09:07:47,920 # Results:
2021-10-07 09:07:47,928 # [ 0] 7F:05:DF:2F:22:8F (random)  [IND] "undefined", adv_msg_cnt: 1, adv_int: 0us, last_rssi: -82
2021-10-07 09:07:47,937 # [ 1] F0:E5:70:D0:A4:4C (random)  [IND] "undefined", adv_msg_cnt: 46, adv_int: 54825us, last_rssi: -65
2021-10-07 09:07:47,946 # [ 2] DB:E4:F4:C2:21:DA (random)  [IND] "undefined", adv_msg_cnt: 29, adv_int: 101232us, last_rssi: -74
2021-10-07 09:07:47,956 # [ 3] D0:D0:03:70:8A:A9 (public)  [NONCONN_IND] "undefined", adv_msg_cnt: 12, adv_int: 232388us, last_rssi: -75
2021-10-07 09:07:47,966 # [ 4] 06:CA:A0:30:FE:36 (random)  [NONCONN_IND] "undefined", adv_msg_cnt: 25, adv_int: 109647us, last_rssi: -46
2021-10-07 09:07:47,975 # [ 5] 28:39:5E:32:5A:30 (public)  [NONCONN_IND] "undefined", adv_msg_cnt: 5, adv_int: 371000us, last_rssi: -78
2021-10-07 09:07:47,985 # [ 6] CC:AC:6B:4A:AE:DF (random)  [NONCONN_IND] "undefined", adv_msg_cnt: 2, adv_int: 997517us, last_rssi: -48
2021-10-07 09:07:47,995 # [ 7] A5:C9:39:E0:3B:B6 (random)  [NONCONN_IND] "undefined", adv_msg_cnt: 3, adv_int: 669666us, last_rssi: -60
2021-10-07 09:07:48,004 # [ 8] 35:A5:BF:DE:D5:EE (random)  [NONCONN_IND] "undefined", adv_msg_cnt: 3, adv_int: 269993us, last_rssi: -82
2021-10-07 09:07:48,014 # [ 9] 46:8B:FE:58:3A:2E (random)  [NONCONN_IND] "undefined", adv_msg_cnt: 4, adv_int: 503447us, last_rssi: -65
2021-10-07 09:07:48,024 # [10] FC:76:A8:C4:1D:CF (random)  [NONCONN_IND] "undefined", adv_msg_cnt: 2, adv_int: 501883us, last_rssi: -81
```

On master it looks like this (same radio environment, so similar number of detected nodes is expected):
```
2021-10-07 09:12:27,954 # scan 3000
2021-10-07 09:12:30,958 # Scanning for 3000 ms now ... done
2021-10-07 09:12:30,958 # 
2021-10-07 09:12:30,972 # Results:
2021-10-07 09:12:30,973 # [ 0] DB:E4:F4:C2:21:DA (random)  [DIRECT_IND_LD] "undefined", adv_msg_cnt: 11, adv_int: 239370us, last_rssi: -77
2021-10-07 09:12:30,978 # [ 1] F0:E5:70:D0:A4:4C (random)  [DIRECT_IND_LD] "undefined", adv_msg_cnt: 18, adv_int: 155672us, last_rssi: -60
```

### Issues/PRs references
Upstream NimBLE bugfix: https://github.com/apache/mynewt-nimble/pull/1051

