### PR TITLE
nimble: allow to override host and netif thread priorities

### DIFF
--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -86,12 +86,6 @@ endif
 ifneq (,$(filter nimble_netif,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/netif/include
 
-  # when using IP, the host should have a higher prio than the netif thread, but
-  # MUST always have a lower priority then the controller thread. Setting it to
-  # controller prio plus will guarantee the latter while also matching the first
-  # condition as long as the default netif prio is not changed.
-  CFLAGS += -DNIMBLE_HOST_PRIO="(NIMBLE_CONTROLLER_PRIO + 1)"
-
   # configure NimBLE's internals
   NIMBLE_MAX_CONN ?= 3
   CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=$(NIMBLE_MAX_CONN)

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -23,6 +23,7 @@
 #define NIMBLE_RIOT_H
 
 #include <stdint.h>
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,8 +49,18 @@ extern "C" {
  * @brief   Priority used for NimBLE's host thread
  */
 #ifndef NIMBLE_HOST_PRIO
+#if IS_USED(MODULE_NIMBLE_NETIF)
+/* when using IP, the host should have a higher prio than the netif thread, but
+ * MUST always have a lower priority then the controller thread. Setting it to
+ * controller prio plus will guarantee the latter while also matching the first
+ * condition as long as the default netif prio is not changed. */
+#define NIMBLE_HOST_PRIO            (NIMBLE_CONTROLLER_PRIO + 1)
+#else
 #define NIMBLE_HOST_PRIO            (THREAD_PRIORITY_MAIN - 2)
 #endif
+#endif
+
+
 
 /**
  * @brief   Stacksize used for NimBLE's host thread

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -51,6 +51,10 @@
 #define NETTYPE                 GNRC_NETTYPE_UNDEF
 #endif
 
+#ifndef NIMBLE_NETIF_PRIO
+#define NIMBLE_NETIF_PRIO       GNRC_NETIF_PRIO
+#endif
+
 /* thread flag used for signaling transmit readiness */
 #define FLAG_TX_UNSTALLED       (1u << 13)
 #define FLAG_TX_NOTCONN         (1u << 12)
@@ -556,7 +560,7 @@ void nimble_netif_init(void)
     assert(res == 0);
     (void)res;
 
-    gnrc_netif_create(&_netif, _stack, sizeof(_stack), GNRC_NETIF_PRIO,
+    gnrc_netif_create(&_netif, _stack, sizeof(_stack), NIMBLE_NETIF_PRIO,
                       "nimble_netif", &_nimble_netdev_dummy, &_nimble_netif_ops);
 }
 


### PR DESCRIPTION
### Contribution description
In current master, the thread priority of the nimble host could only be overridden, if `nimble_netif` is not used. This PR allows to override the nimble host thread priority no matter what by moving the priority override from nimbles `Makefile.include` into the `nimble_netif.h`, where the host priority is defined in the first place. This should be much cleaner and easier to comprehend...

Additionally, this PR adds the option to override the thread priority of the `nimble_netif` thread specifically. Before, this was hard coded to always be `GNRC_NETIF_PRIO`. However, when playing with border router configurations, I found that there might be problems when assigning the same thread prio to NimBLE and e.g. usb-cdc-ecm devices. So at least for debugging it is quite useful to have more precise control over the priorities.

### Testing procedure
- build `gnrc_networking` for any supported nRF platform. Run `ps` to see the default thread priorities, they should not have changed.
- build the same with custom priorities, e.g. `CFLAGS="-DNIMBLE_HOST_PRIO=4 -DNIMBLE_NETIF_PRIO=4 make ..`, the according priorities should be displayed when running `ps`


### Issues/PRs references
none