### PR TITLE
pkg/lwip: Add netif_t struct, register all netifs

### DIFF
--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -16,12 +16,13 @@
  */
 
 #include "fmt.h"
-#include "lwip/netif.h"
+#include "lwip/netif/compat.h"
 #include "net/netif.h"
 
 int netif_get_name(netif_t *iface, char *name)
 {
-    struct netif *netif = (struct netif *)iface;
+    lwip_netif_t *lwip_netif = (lwip_netif_t*) iface;
+    struct netif *netif = &lwip_netif->lwip_netif;
 
     int res = 2;
     name[0] = netif->name[0];

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -21,6 +21,7 @@
 #include "lwip/ethip6.h"
 #include "lwip/netif.h"
 #include "lwip/netifapi.h"
+#include "lwip/netif/compat.h"
 #include "lwip/netif/netdev.h"
 #include "lwip/opt.h"
 #include "lwip/pbuf.h"
@@ -192,7 +193,6 @@ err_t lwip_netdev_init(struct netif *netif)
     }
     netif->flags |= NETIF_FLAG_IGMP;
     netif->flags |= NETIF_FLAG_MLD6;
-    netdev->context = netif;
 #if LWIP_IPV6_AUTOCONFIG
     netif->ip6_autoconfig_enabled = 1;
 #endif
@@ -279,7 +279,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
         }
     }
     else {
-        struct netif *netif = dev->context;
+        lwip_netif_t *compat_netif = dev->context;
+        struct netif *netif = &compat_netif->lwip_netif;
         switch (event) {
             case NETDEV_EVENT_RX_COMPLETE: {
                 struct pbuf *p = _get_recv_pkt(dev);

--- a/pkg/lwip/include/lwip/netif/compat.h
+++ b/pkg/lwip/include/lwip/netif/compat.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_lwip
+ *
+ * @{
+ *
+ * @file
+ * @brief   lwIP definition based on common netif_t struct for network
+ *          stack-independent API.
+ *
+ * @author  Erik Ekman <eekman@google.com>
+ */
+#ifndef LWIP_NETIF_COMPAT_H
+#define LWIP_NETIF_COMPAT_H
+
+#include "lwip/netif.h"
+#include "net/netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Representation of a network interface
+ */
+typedef struct {
+    netif_t common_netif;                /**< network interface descriptor */
+    struct netif lwip_netif;             /**< lwIP interface data */
+} lwip_netif_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWIP_NETIF_COMPAT_H */
+/** @} */

--- a/pkg/lwip/include/lwip/netif/netdev.h
+++ b/pkg/lwip/include/lwip/netif/netdev.h
@@ -46,6 +46,7 @@ extern "C" {
  * to an existing netdev_t instance
  *
  * @pre netif->state is set to an existing netdev_t instance.
+ *      netif->state->context pointing to the lwip_netif_t containing this netif.
  *
  * @param[in] netif The network interface intended to be initialized.
  *

--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-#include "lwip/netif.h"
+#include "lwip/netif/compat.h"
 #include "net/netdev.h"
 #include "xfa.h"
 
@@ -39,7 +39,7 @@ void lwip_netif_init_devs(void);
  * The netif will be set up using the `lwip_netdev_init` helper.
  * The first netif added will be marked as the default route.
  */
-struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
+struct netif *lwip_add_ethernet(lwip_netif_t *netif, netdev_t *state);
 
 #if IS_USED(MODULE_LWIP_SIXLOWPAN)
 /**
@@ -50,7 +50,7 @@ struct netif *lwip_add_ethernet(struct netif *netif, netdev_t *state);
  *
  * The netif will be set up using the `lwip_netdev_init` helper.
  */
-struct netif *lwip_add_6lowpan(struct netif *netif, netdev_t *state);
+struct netif *lwip_add_6lowpan(lwip_netif_t *netif, netdev_t *state);
 #endif /* MODULE_LWIP_SIXLOWPAN */
 
 typedef void (*lwip_netif_setup_func_t)(void);

--- a/pkg/lwip/init_devs/auto_init_at86rf215.c
+++ b/pkg/lwip/init_devs/auto_init_at86rf215.c
@@ -28,7 +28,7 @@
 #define USED_BANDS (IS_USED(MODULE_AT86RF215_SUBGHZ) + IS_USED(MODULE_AT86RF215_24GHZ))
 #define NETIF_AT86RF215_NUMOF   ARRAY_SIZE(at86rf215_params)
 
-static struct netif netif[NETIF_AT86RF215_NUMOF * USED_BANDS];
+static lwip_netif_t netif[NETIF_AT86RF215_NUMOF * USED_BANDS];
 static at86rf215_t at86rf215_devs[NETIF_AT86RF215_NUMOF * USED_BANDS];
 
 static void auto_init_at86rf215(void)
@@ -38,8 +38,8 @@ static void auto_init_at86rf215(void)
 
         at86rf215_t *dev_09 = NULL;
         at86rf215_t *dev_24 = NULL;
-        struct netif *netif_09 = NULL;
-        struct netif *netif_24 = NULL;
+        lwip_netif_t *netif_09 = NULL;
+        lwip_netif_t *netif_24 = NULL;
 
         if (IS_USED(MODULE_AT86RF215_SUBGHZ)) {
             dev_09   = &at86rf215_devs[i];

--- a/pkg/lwip/init_devs/auto_init_at86rf2xx.c
+++ b/pkg/lwip/init_devs/auto_init_at86rf2xx.c
@@ -27,7 +27,7 @@
 
 #define NETIF_AT86RF2XX_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 
-static struct netif netif[NETIF_AT86RF2XX_NUMOF];
+static lwip_netif_t netif[NETIF_AT86RF2XX_NUMOF];
 static at86rf2xx_t at86rf2xx_devs[NETIF_AT86RF2XX_NUMOF];
 
 static void auto_init_at86rf2xx(void)

--- a/pkg/lwip/init_devs/auto_init_atwinc15x0.c
+++ b/pkg/lwip/init_devs/auto_init_atwinc15x0.c
@@ -27,7 +27,7 @@
 
 #define NETIF_ATWINC_NUMOF ARRAY_SIZE(atwinc15x0_params)
 
-static struct netif netif[NETIF_ATWINC_NUMOF];
+static lwip_netif_t netif[NETIF_ATWINC_NUMOF];
 static atwinc15x0_t atwinc15x0_devs[NETIF_ATWINC_NUMOF];
 
 static void auto_init_atwinc15x0(void)

--- a/pkg/lwip/init_devs/auto_init_cc2538_rf.c
+++ b/pkg/lwip/init_devs/auto_init_cc2538_rf.c
@@ -25,7 +25,7 @@
 #define ENABLE_DEBUG    0
 #include "debug.h"
 
-static struct netif netif;
+static lwip_netif_t netif;
 static netdev_ieee802154_submac_t cc2538_rf_netdev;
 
 static void auto_init_cc2538_rf(void)

--- a/pkg/lwip/init_devs/auto_init_dose.c
+++ b/pkg/lwip/init_devs/auto_init_dose.c
@@ -27,7 +27,7 @@
 
 #define NETIF_DOSE_NUMOF    ARRAY_SIZE(dose_params)
 
-static struct netif netif[NETIF_DOSE_NUMOF];
+static lwip_netif_t netif[NETIF_DOSE_NUMOF];
 static dose_t dose_devs[NETIF_DOSE_NUMOF];
 
 static void auto_init_dose(void)

--- a/pkg/lwip/init_devs/auto_init_enc28j60.c
+++ b/pkg/lwip/init_devs/auto_init_enc28j60.c
@@ -27,7 +27,7 @@
 
 #define NETIF_ENC28J60_NUMOF        ARRAY_SIZE(enc28j60_params)
 
-static struct netif netif[NETIF_ENC28J60_NUMOF];
+static lwip_netif_t netif[NETIF_ENC28J60_NUMOF];
 static enc28j60_t enc28j60_devs[NETIF_ENC28J60_NUMOF];
 
 static void auto_init_enc28j60(void)

--- a/pkg/lwip/init_devs/auto_init_esp_eth.c
+++ b/pkg/lwip/init_devs/auto_init_esp_eth.c
@@ -27,7 +27,7 @@
 extern esp_eth_netdev_t _esp_eth_dev;
 extern void esp_eth_setup(esp_eth_netdev_t* dev);
 
-static struct netif netif;
+static lwip_netif_t netif;
 
 static void auto_init_esp_eth(void)
 {

--- a/pkg/lwip/init_devs/auto_init_esp_wifi.c
+++ b/pkg/lwip/init_devs/auto_init_esp_wifi.c
@@ -27,7 +27,7 @@
 extern esp_wifi_netdev_t _esp_wifi_dev;
 extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
 
-static struct netif netif;
+static lwip_netif_t netif;
 
 static void auto_init_esp_wifi(void)
 {

--- a/pkg/lwip/init_devs/auto_init_ethos.c
+++ b/pkg/lwip/init_devs/auto_init_ethos.c
@@ -27,7 +27,7 @@
 
 #define NETIF_ETHOS_NUMOF        ARRAY_SIZE(ethos_params)
 
-static struct netif netif[NETIF_ETHOS_NUMOF];
+static lwip_netif_t netif[NETIF_ETHOS_NUMOF];
 static ethos_t ethos_devs[NETIF_ETHOS_NUMOF];
 
 static uint8_t _inbuf[NETIF_ETHOS_NUMOF][2048];

--- a/pkg/lwip/init_devs/auto_init_mrf24j40.c
+++ b/pkg/lwip/init_devs/auto_init_mrf24j40.c
@@ -28,7 +28,7 @@
 
 #define NETIF_MRF24J40_NUMOF        ARRAY_SIZE(mrf24j40_params)
 
-static struct netif netif[NETIF_MRF24J40_NUMOF];
+static lwip_netif_t netif[NETIF_MRF24J40_NUMOF];
 static mrf24j40_t mrf24j40_devs[NETIF_MRF24J40_NUMOF];
 
 static void auto_init_mrf24j40(void)

--- a/pkg/lwip/init_devs/auto_init_netdev_tap.c
+++ b/pkg/lwip/init_devs/auto_init_netdev_tap.c
@@ -27,7 +27,7 @@
 
 #define NETIF_TAP_NUMOF        (NETDEV_TAP_MAX)
 
-static struct netif netif[NETIF_TAP_NUMOF];
+static lwip_netif_t netif[NETIF_TAP_NUMOF];
 static netdev_tap_t netdev_taps[NETIF_TAP_NUMOF];
 
 static void auto_init_netdev_tap(void)

--- a/pkg/lwip/init_devs/auto_init_nrf802154.c
+++ b/pkg/lwip/init_devs/auto_init_nrf802154.c
@@ -25,7 +25,7 @@
 #define ENABLE_DEBUG    0
 #include "debug.h"
 
-static struct netif netif;
+static lwip_netif_t netif;
 static netdev_ieee802154_submac_t nrf802154_netdev;
 
 static void auto_init_nrf802154(void)

--- a/pkg/lwip/init_devs/auto_init_sam0_eth.c
+++ b/pkg/lwip/init_devs/auto_init_sam0_eth.c
@@ -27,7 +27,7 @@
 static netdev_t sam0_eth;
 extern void sam0_eth_setup(netdev_t *netdev);
 
-static struct netif netif;
+static lwip_netif_t netif;
 
 static void auto_init_sam0_eth(void)
 {

--- a/pkg/lwip/init_devs/auto_init_socket_zep.c
+++ b/pkg/lwip/init_devs/auto_init_socket_zep.c
@@ -27,7 +27,7 @@
 
 #define NETIF_SOCKET_ZEP_NUMOF        ARRAY_SIZE(socket_zep_params)
 
-static struct netif netif[NETIF_SOCKET_ZEP_NUMOF];
+static lwip_netif_t netif[NETIF_SOCKET_ZEP_NUMOF];
 static socket_zep_t socket_zep_devs[NETIF_SOCKET_ZEP_NUMOF];
 
 static void auto_init_socket_zep(void)

--- a/pkg/lwip/init_devs/auto_init_stm32_eth.c
+++ b/pkg/lwip/init_devs/auto_init_stm32_eth.c
@@ -27,7 +27,7 @@
 static netdev_t stm32_eth;
 extern void stm32_eth_netdev_setup(netdev_t *netdev);
 
-static struct netif netif;
+static lwip_netif_t netif;
 
 static void auto_init_stm32_eth(void)
 {

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -18,8 +18,9 @@
  * @}
  */
 
+#include <kernel_defines.h>
 #include <stdio.h>
-#include "lwip/netif.h"
+#include "lwip/netif/compat.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
 
@@ -43,9 +44,10 @@ static void _netif_list_ipv6(struct netif *netif, int addr_index) {
 
 static void _netif_list(struct netif *netif) {
     int i;
-    char name[8];
+    char name[CONFIG_NETIF_NAMELENMAX];
     struct netdev *dev = netif->state;
-    netif_get_name((netif_t *)netif, name);
+    lwip_netif_t *compat = container_of(netif, lwip_netif_t, lwip_netif);
+    netif_get_name(&compat->common_netif, name);
     printf("Iface %s HWaddr: ", name);
     for (i = 0; i < netif->hwaddr_len; i++) {
         printf("%02x", netif->hwaddr[i]);

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -30,7 +30,7 @@
 #include "lwip/inet_chksum.h"
 #include "lwip/nd6.h"
 #include "lwip/priv/nd6_priv.h"
-#include "lwip/netif.h"
+#include "lwip/netif/compat.h"
 #include "lwip/netif/netdev.h"
 #include "lwip/tcpip.h"
 #include "netif/etharp.h"
@@ -45,7 +45,7 @@
 static msg_t _msg_queue[_MSG_QUEUE_SIZE];
 static uint8_t _netdev_buffer[_NETDEV_BUFFER_SIZE];
 netdev_test_t netdev;
-static struct netif netif;
+static lwip_netif_t lwip_netif;
 static kernel_pid_t _check_pid = KERNEL_PID_UNDEF;
 static mutex_t _netdev_buffer_mutex = MUTEX_INIT;
 static uint8_t _netdev_buffer_size;
@@ -137,6 +137,7 @@ static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 
 void _net_init(void)
 {
+    struct netif *netif = &lwip_netif.lwip_netif;
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
     _check_pid = thread_getpid();
 
@@ -155,14 +156,15 @@ void _net_init(void)
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */
     expect(netdev.netdev.netdev.driver);
+    netdev.netdev.netdev.context = &lwip_netif;
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
     local4.addr = _TEST_ADDR4_LOCAL;
     mask4.addr = _TEST_ADDR4_MASK;
     gw4.addr = _TEST_ADDR4_GW;
-    netif_add(&netif, &local4, &mask4, &gw4, &netdev, lwip_netdev_init, tcpip_input);
+    netif_add(netif, &local4, &mask4, &gw4, &netdev, lwip_netdev_init, tcpip_input);
 #else
-    netif_add(&netif, &netdev, lwip_netdev_init, tcpip_input);
+    netif_add(netif, &netdev, lwip_netdev_init, tcpip_input);
 #endif
 #if LWIP_IPV6
     static const uint8_t local6_a[] = _TEST_ADDR6_LOCAL;
@@ -174,12 +176,12 @@ void _net_init(void)
 
     memcpy(&local6.addr, local6_a, sizeof(local6_a));
     ip6_addr_clear_zone(&local6);
-    netif_add_ip6_address(&netif, &local6, &idx);
+    netif_add_ip6_address(netif, &local6, &idx);
     for (int i = 0; i <= idx; i++) {
-        netif.ip6_addr_state[i] |= IP6_ADDR_VALID;
+        netif->ip6_addr_state[i] |= IP6_ADDR_VALID;
     }
 #endif
-    netif_set_default(&netif);
+    netif_set_default(netif);
     lwip_bootstrap();
     xtimer_sleep(3);    /* Let the auto-configuration run warm */
 }
@@ -209,13 +211,14 @@ void _prepare_send_checks(void)
            LWIP_ND6_NUM_NEIGHBORS * sizeof(struct nd6_neighbor_cache_entry));
     for (int i = 0; i < LWIP_ND6_NUM_NEIGHBORS; i++) {
         struct nd6_neighbor_cache_entry *nc = &neighbor_cache[i];
+        struct netif *netif = &lwip_netif.lwip_netif;
         if (nc->state == ND6_NO_ENTRY) {
             nc->state = ND6_REACHABLE;
             memcpy(&nc->next_hop_address, remote6, sizeof(remote6));
             ip6_addr_assign_zone(&nc->next_hop_address,
-                                 IP6_UNICAST, &netif);
+                                 IP6_UNICAST, netif);
             memcpy(&nc->lladdr, mac, 6);
-            nc->netif = &netif;
+            nc->netif = netif;
             nc->counter.reachable_time = UINT32_MAX;
             break;
         }

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -31,7 +31,7 @@
 #include "lwip/inet_chksum.h"
 #include "lwip/nd6.h"
 #include "lwip/priv/nd6_priv.h"
-#include "lwip/netif.h"
+#include "lwip/netif/compat.h"
 #include "lwip/netif/netdev.h"
 #include "lwip/opt.h"
 #include "lwip/tcpip.h"
@@ -47,7 +47,7 @@
 static msg_t _msg_queue[_MSG_QUEUE_SIZE];
 static uint8_t _netdev_buffer[_NETDEV_BUFFER_SIZE];
 netdev_test_t netdev;
-static struct netif netif;
+static lwip_netif_t lwip_netif;
 static kernel_pid_t _check_pid = KERNEL_PID_UNDEF;
 static mutex_t _netdev_buffer_mutex = MUTEX_INIT;
 static uint8_t _netdev_buffer_size;
@@ -140,6 +140,7 @@ static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 
 void _net_init(void)
 {
+    struct netif *netif = &lwip_netif.lwip_netif;
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
     _check_pid = thread_getpid();
 
@@ -158,14 +159,15 @@ void _net_init(void)
     netdev_test_set_isr_cb(&netdev, _netdev_isr);
     /* netdev needs to be set-up */
     expect(netdev.netdev.netdev.driver);
+    netdev.netdev.netdev.context = &lwip_netif;
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
     local4.addr = _TEST_ADDR4_LOCAL;
     mask4.addr = _TEST_ADDR4_MASK;
     gw4.addr = _TEST_ADDR4_GW;
-    netif_add(&netif, &local4, &mask4, &gw4, &netdev, lwip_netdev_init, tcpip_input);
+    netif_add(netif, &local4, &mask4, &gw4, &netdev, lwip_netdev_init, tcpip_input);
 #else
-    netif_add(&netif, &netdev, lwip_netdev_init, tcpip_input);
+    netif_add(netif, &netdev, lwip_netdev_init, tcpip_input);
 #endif
 #if LWIP_IPV6
     static const uint8_t local6_a[] = _TEST_ADDR6_LOCAL;
@@ -177,12 +179,12 @@ void _net_init(void)
 
     memcpy(&local6.addr, local6_a, sizeof(local6.addr));
     ip6_addr_clear_zone(&local6);
-    netif_add_ip6_address(&netif, &local6, &idx);
+    netif_add_ip6_address(netif, &local6, &idx);
     for (int i = 0; i <= idx; i++) {
-        netif.ip6_addr_state[i] |= IP6_ADDR_VALID;
+        netif->ip6_addr_state[i] |= IP6_ADDR_VALID;
     }
 #endif
-    netif_set_default(&netif);
+    netif_set_default(netif);
     lwip_bootstrap();
     xtimer_sleep(3);    /* Let the auto-configuration run warm */
 }
@@ -212,13 +214,14 @@ void _prepare_send_checks(void)
            LWIP_ND6_NUM_NEIGHBORS * sizeof(struct nd6_neighbor_cache_entry));
     for (int i = 0; i < LWIP_ND6_NUM_NEIGHBORS; i++) {
         struct nd6_neighbor_cache_entry *nc = &neighbor_cache[i];
+        struct netif *netif = &lwip_netif.lwip_netif;
         if (nc->state == ND6_NO_ENTRY) {
             nc->state = ND6_REACHABLE;
             memcpy(&nc->next_hop_address.addr, remote6, sizeof(nc->next_hop_address.addr));
             ip6_addr_assign_zone(&nc->next_hop_address,
-                                 IP6_UNICAST, &netif);
+                                 IP6_UNICAST, netif);
             memcpy(&nc->lladdr, mac, 6);
-            nc->netif = &netif;
+            nc->netif = netif;
             nc->counter.reachable_time = UINT32_MAX;
             break;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

* Add `lwip_netif_t` struct which includes a `netif_t` as well as lwIP's own `struct netif`.
* Register all new netifs (using `netif_register`)
* Update `netif_get_name` implementation to expect the new struct instead of `struct netif`.

Minimizing the change to `sc_lwip_netif.c` for now as it should go away soon.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

* lwIP `ifconfig` shell command still works (for IPv4 and/or IPv6). In `tests/lwip` for example
* lwIP network interfaces still initialize successfully and can send/receive traffic.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Start of fix to part of #9287 

Coming in a later PR: `netif_(get|set)_opt` implementations