### PR TITLE
cpu/native: fix build with gcc 11

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -150,8 +150,8 @@ extern volatile int _native_sigpend;
 extern volatile int _native_in_isr;
 extern volatile int _native_in_syscall;
 
-extern char __isr_stack[SIGSTKSZ];
-extern char __end_stack[SIGSTKSZ];
+extern char __isr_stack[];
+extern char __end_stack[];
 extern ucontext_t native_isr_context;
 extern ucontext_t end_context;
 extern ucontext_t *_native_cur_ctx, *_native_isr_ctx;

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -170,7 +170,7 @@ void cpu_switch_context_exit(void)
         irq_disable();
         _native_in_isr = 1;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
-        native_isr_context.uc_stack.ss_size = sizeof(__isr_stack);
+        native_isr_context.uc_stack.ss_size = SIGSTKSZ;
         native_isr_context.uc_stack.ss_flags = 0;
         makecontext(&native_isr_context, isr_cpu_switch_context_exit, 0);
         if (setcontext(&native_isr_context) == -1) {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This fixes the following warning with GCC 11.2:

    cpu/native/include/native_internal.h:153:13: error: variably modified ‘__isr_stack’ at file scope
      153 | extern char __isr_stack[SIGSTKSZ];
          |             ^~~~~~~~~~~
    cpu/native/include/native_internal.h:154:13: error: variably modified ‘__end_stack’ at file scope
      154 | extern char __end_stack[SIGSTKSZ];


### Testing procedure

Build e.g `examples/gnrc_networking` on native with GCC 11 (ships with Ubuntu 21.10)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
