### PR TITLE
cpu/stm32: Add hardening changes to stm32

### DIFF
--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -39,6 +39,26 @@ orsource "kconfigs/*/Kconfig"
 orsource "kconfigs/*/Kconfig.lines"
 orsource "kconfigs/*/Kconfig.models"
 
+choice
+	prompt "ReaDout Protection level"
+	default RDP0
+	help
+	Set minimum running RDP level.
+	RDP0 is full debug permissions, RDP1 disables read from Flash but
+	otherwise leaves debug enabled, RDP2 disables JTAG completely. If
+	there is a mismatch between desired RDP level here and RDP level
+	set on the chip, early cpu init will hang.  This ensures production
+	devices with the wrong RDP level, by fault or malace intent, will
+	not run.  See cpu manual for further details on RDP.
+depends on (CPU_FAM_F1 || CPU_FAM_F2 || CPU_FAM_F3 || CPU_FAM_F4 || CPU_FAM_F5 || CPU_FAM_F6 || CPU_FAM_F7)
+config RDP0
+	bool "RDP0"
+config RDP1
+	bool "RDP1"
+config RDP2
+	bool "RDP2"
+endchoice
+
 if TEST_KCONFIG
 
 rsource "periph/Kconfig"

--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -36,6 +36,16 @@ endif
 include $(RIOTCPU)/stm32/stm32_line.mk
 CPU_LINE ?= $(shell echo $(CPU_MODEL) | cut -c -9 | tr 'a-z-' 'A-Z_')xx
 
+ifeq ($(CONFIG_RDP0),y)
+  CFLAGS += -DCONFIG_STM32_RDP=0
+endif
+ifeq ($(CONFIG_RDP1),y)
+  CFLAGS += -DCONFIG_STM32_RDP=1
+endif
+ifeq ($(CONFIG_RDP2),y)
+  CFLAGS += -DCONFIG_STM32_RDP=2
+endif
+
 # Set CFLAGS
 CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
 CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U

--- a/cpu/stm32/include/periph/f0/periph_cpu.h
+++ b/cpu/stm32/include/periph/f0/periph_cpu.h
@@ -42,6 +42,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES   ((uint32_t*) 0x1FFFF800)
+#define GET_RDP(x) (x & 0xFF)
+
+/**
  * @brief   Override ADC resolution values
  * @{
  */

--- a/cpu/stm32/include/periph/f1/periph_cpu.h
+++ b/cpu/stm32/include/periph/f1/periph_cpu.h
@@ -33,6 +33,12 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFFF000)
 #endif
 
+/**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES   ((uint32_t*) 0x1FFFF800)
+#define GET_RDP(x) (x & 0xFF)
+
 #endif /* ndef DOXYGEN */
 
 /**

--- a/cpu/stm32/include/periph/f2/periph_cpu.h
+++ b/cpu/stm32/include/periph/f2/periph_cpu.h
@@ -39,6 +39,12 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFF0000)
 
 /**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES   ((uint32_t*) 0x1FFFC000)
+#define GET_RDP(x) ((x & 0xFF00) >> 8)
+
+/**
  * @brief   Override the ADC resolution configuration
  * @{
  */

--- a/cpu/stm32/include/periph/f3/periph_cpu.h
+++ b/cpu/stm32/include/periph/f3/periph_cpu.h
@@ -50,6 +50,12 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FFFD800)
 
 /**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES   ((uint32_t*) 0x1FFFF800)
+#define GET_RDP(x) (x & 0xFF)
+
+/**
  * @brief   Override ADC resolution values
  * @{
  */

--- a/cpu/stm32/include/periph/f4/periph_cpu.h
+++ b/cpu/stm32/include/periph/f4/periph_cpu.h
@@ -50,6 +50,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES   ((uint32_t*) 0x1FFFC000)
+#define GET_RDP(x) ((x & 0xFF00) >> 8)
+
+/**
  * @brief   Override the ADC resolution configuration
  * @{
  */

--- a/cpu/stm32/include/periph/f7/periph_cpu.h
+++ b/cpu/stm32/include/periph/f7/periph_cpu.h
@@ -33,6 +33,12 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FF00000)
 
 /**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES    ((uint32_t*) 0x1FFF0000)
+#define GET_RDP(x) ((x & 0xFF00) >> 8)
+
+/**
  * @brief   Override the ADC resolution configuration
  * @{
  */

--- a/cpu/stm32/include/periph/l1/periph_cpu.h
+++ b/cpu/stm32/include/periph/l1/periph_cpu.h
@@ -34,6 +34,12 @@ extern "C" {
 #define STM32_BOOTLOADER_ADDR   (0x1FF00000)
 
 /**
+ * @brief   Readout Protection (RDP) option bytes
+ */
+#define STM32_OPTION_BYTES   ((uint32_t*) 0x1FF80000)
+#define GET_RDP(x) (x & 0xFF)
+
+/**
  * @brief   Override the ADC resolution configuration
  * @{
  */


### PR DESCRIPTION
Initialize STM32 RDP in a glitch-resistant fashion to prevent
debugger use when restrictions are set by the designer.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
