### PR TITLE
Makefile.base: do not clean objects of bindist modules

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -114,7 +114,11 @@ $(BINDIR)/$(MODULE)/:
 	$(Q)mkdir -p $@
 
 OLD_OBJECTS = $(wildcard $(BINDIR)/$(MODULE)/*.o)
-OBJECTS_TO_REMOVE = $(filter-out $(OBJ),$(OLD_OBJECTS))
+
+# do not clean objects from bindist modules
+ifeq (,$(filter $(MODULE),$(BIN_USEMODULE)))
+  OBJECTS_TO_REMOVE = $(filter-out $(OBJ),$(OLD_OBJECTS))
+endif
 
 $(MODULE).module compile-commands $(OBJ): | $(BINDIR)/$(MODULE)/
 

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -21,6 +21,7 @@ export CXXINCLUDES           # The extra include paths for c++, set by the vario
 export NATIVEINCLUDES        # The native include paths, set by the various native Makefile.include files.
 
 export USEMODULE             # Sys Module dependencies of the application. Set in the application's Makefile.
+export BIN_USEMODULE         # Modules specific to bindist (see bindist.ink.mk). Set in the application's Makefile.
 export USEPKG                # Pkg dependencies (third party modules) of the application. Set in the application's Makefile.
 export DISABLE_MODULE        # Used in the application's Makefile to suppress DEFAULT_MODULEs.
 # APPDEPS                    # Files / Makefile targets that need to be created before the application can be build. Set in the application's Makefile.


### PR DESCRIPTION
### Contribution description
Since #16945 we cleanup unneeded object files. The list of "needed object files" is defined based on present source files, but bindist is a special case, as bindist objects should always be preserved. As described in #16977, the bindist example fails to link due to the cleanup. This PR avoids cleaning bindist modules object files when building.

### Testing procedure
- `examples/bindist` should work (note that the binary check does not pass for `native` at least since the linking was fixed in #14754)
- The testing procedure from #16945 should pass

### Issues/PRs references
Fixes #16977
Issue introduced in #16945
