### PR TITLE
Makefile.include: remove warning about EXTERNAL_MODULE_DIRS API change

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -57,7 +57,6 @@ BINDIR                          ?= $(BINDIRBASE)/$(BOARD)
 PKGDIRBASE                      ?= $(RIOTBASE)/build/pkg
 DLCACHE                         ?= $(RIOTTOOLS)/dlcache/dlcache.sh
 DLCACHE_DIR                     ?= $(RIOTBASE)/.dlcache
-WARNING_EXTERNAL_MODULE_DIRS    ?= 1
 RIOT_VERSION_DUMMY_CODE         ?= RIOT_VERSION_NUM\(2042,5,23,0\)
 
 # include CI info such as BOARD_INSUFFICIENT_MEMORY, if existing
@@ -114,14 +113,6 @@ ifneq ($(RIOT_CI_BUILD),1)
     ifneq (,$(BOARDSDIR))
       $(warning Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead)
       $(info EXTERNAL_BOARD_DIRS can contain multiple folders separated by space)
-    endif
-
-    # API change warning for EXTERNAL_MODULE_DIRS, remove by 2021.10
-    ifneq (,$(EXTERNAL_MODULE_DIRS))
-      ifeq (1,$(WARNING_EXTERNAL_MODULE_DIRS))
-        $(info Warning! EXTERNAL_MODULE_DIRS is a search folder since 2021.07-branch, see \
-               https://doc.riot-os.org/creating-modules.html#modules-outside-of-riotbase)
-      endif
     endif
   endif
 endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The warning about the API change is scheduled to be removed by 2020.10. 
Since the release has been branched off, we can now drop the warning going forward.


### Testing procedure

Using external modules should no longer produce a warning. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
