### PR TITLE
sys/net/uhcp: use LOG_DEBUG instead of LOG_INFO

### DIFF
--- a/sys/net/application_layer/uhcp/uhcp.c
+++ b/sys/net/application_layer/uhcp/uhcp.c
@@ -39,7 +39,7 @@ void uhcp_handle_udp(uint8_t *buf, size_t len, uint8_t *src, uint16_t port, uhcp
         LOG_ERROR("error: wrong protocol version.\n");
     }
 
-    switch(type) {
+    switch (type) {
 #ifdef UHCP_SERVER
         case UHCP_REQ:
             if (len < sizeof(uhcp_req_t)) {

--- a/sys/net/application_layer/uhcp/uhcp.c
+++ b/sys/net/application_layer/uhcp/uhcp.c
@@ -17,7 +17,7 @@ void uhcp_handle_udp(uint8_t *buf, size_t len, uint8_t *src, uint16_t port, uhcp
 {
     char addr_str[INET6_ADDRSTRLEN];
     inet_ntop(AF_INET6, src, addr_str, INET6_ADDRSTRLEN);
-    LOG_INFO("got packet from %s port %u\n", addr_str, (unsigned)port);
+    LOG_DEBUG("got packet from %s port %u\n", addr_str, (unsigned)port);
 
     if (len < sizeof(uhcp_req_t)) {
         LOG_ERROR("error: packet too small.\n");
@@ -108,7 +108,7 @@ void uhcp_handle_push(uhcp_push_t *req, uint8_t *src, uint16_t port, uhcp_iface_
 
     inet_ntop(AF_INET6, prefix, prefix_str, INET6_ADDRSTRLEN);
 
-    LOG_INFO("uhcp: push from %s:%u prefix=%s/%u\n", addr_str, (unsigned)port,
+    LOG_DEBUG("uhcp: push from %s:%u prefix=%s/%u\n", addr_str, (unsigned)port,
              prefix_str, req->prefix_len);
     uhcp_handle_prefix(prefix, req->prefix_len, 0xFFFF, src, iface);
 }

--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -45,7 +45,7 @@ void uhcp_client(uhcp_iface_t iface)
 
     uint8_t buf[sizeof(uhcp_push_t) + 16];
 
-    while(1) {
+    while (1) {
         LOG_DEBUG("uhcp_client(): sending REQ...\n");
         sock_udp_send(&sock, &req, sizeof(uhcp_req_t), &req_target);
         res = sock_udp_recv(&sock, buf, sizeof(buf), 10U*US_PER_SEC, &remote);

--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -46,7 +46,7 @@ void uhcp_client(uhcp_iface_t iface)
     uint8_t buf[sizeof(uhcp_push_t) + 16];
 
     while(1) {
-        LOG_INFO("uhcp_client(): sending REQ...\n");
+        LOG_DEBUG("uhcp_client(): sending REQ...\n");
         sock_udp_send(&sock, &req, sizeof(uhcp_req_t), &req_target);
         res = sock_udp_recv(&sock, buf, sizeof(buf), 10U*US_PER_SEC, &remote);
         if (res > 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

uhcp is pretty noisy compared to DHCPv6 as INFO log level is enabled by default.

Tone it down to LOG_DEBUG to keep the output clean.


### Testing procedure

Run `examples/gnrc_border_router`.
The console should no longer be spammed with output from uhcp. 


### Issues/PRs references


