### PR TITLE
gnrc_netif: add option to always join solicited-node multicast group (for connectivity across border router restart)

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -160,7 +160,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Configure solicited-node multicast address
+ * @brief   Join solicited-node multicast address on interface initialization
  *
  *          Enable this if you want your 6LoWPAN network to recover
  *          from a border router restart.

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -161,6 +161,7 @@ extern "C" {
 
 /**
  * @brief   Join solicited-node multicast address on interface initialization
+ *          This allows to respond to multicast NS from neighbors using ARSM.
  *
  *          Enable this if you want your 6LoWPAN network to recover
  *          from a border router restart.

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -165,11 +165,11 @@ extern "C" {
  *          Enable this if you want your 6LoWPAN network to recover
  *          from a border router restart.
  */
-#ifndef CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST
+#ifndef CONFIG_GNRC_IPV6_NIB_JOIN_SOLICITED_NODES
 #if CONFIG_GNRC_IPV6_NIB_ARSM
-#define CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST     1
+#define CONFIG_GNRC_IPV6_NIB_JOIN_SOLICITED_NODES     1
 #else
-#define CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST     0
+#define CONFIG_GNRC_IPV6_NIB_JOIN_SOLICITED_NODES     0
 #endif
 #endif
 

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -160,6 +160,20 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Configure solicited-node multicast address
+ *
+ *          Enable this if you want your 6LoWPAN network to recover
+ *          from a border router restart.
+ */
+#ifndef CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST
+#if CONFIG_GNRC_IPV6_NIB_ARSM
+#define CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST     1
+#else
+#define CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST     0
+#endif
+#endif
+
+/**
  * @brief    queue packets for address resolution
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_QUEUE_PKT

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -585,24 +585,23 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
         gnrc_netif_release(netif);
         return -ENOMEM;
     }
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ARSM)
-    ipv6_addr_t sol_nodes;
-    int res;
+    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ARSM) || gnrc_netif_is_6ln(netif)) {
+        ipv6_addr_t sol_nodes;
+        int res;
 
-    /* TODO: SHOULD delay join between 0 and MAX_RTR_SOLICITATION_DELAY
-     * for SLAAC */
-    ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
-    res = gnrc_netif_ipv6_group_join_internal(netif, &sol_nodes);
-    if (res < 0) {
-        DEBUG("gnrc_netif: Can't join solicited-nodes of %s on interface %"
-              PRIkernel_pid "\n",
-              ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
-              netif->pid);
-        gnrc_netif_release(netif);
-        return res;
-    }
-#else  /* CONFIG_GNRC_IPV6_NIB_ARSM */
-    if (!gnrc_netif_is_6ln(netif)) {
+        /* TODO: SHOULD delay join between 0 and MAX_RTR_SOLICITATION_DELAY
+         * for SLAAC */
+        ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
+        res = gnrc_netif_ipv6_group_join_internal(netif, &sol_nodes);
+        if (res < 0) {
+            DEBUG("gnrc_netif: Can't join solicited-nodes of %s on interface %"
+                  PRIkernel_pid "\n",
+                  ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
+                  netif->pid);
+            gnrc_netif_release(netif);
+            return res;
+        }
+    } else {
         LOG_WARNING("Address-resolution state-machine not activated. Neighbors "
                     "from interface %u\nwill not be able to resolve address "
                     "%s\n"
@@ -610,7 +609,6 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
                     netif->pid, ipv6_addr_to_str(addr_str, addr,
                                                  sizeof(addr_str)));
     }
-#endif /* CONFIG_GNRC_IPV6_NIB_ARSM */
     netif->ipv6.addrs_flags[idx] = flags;
     memcpy(&netif->ipv6.addrs[idx], addr, sizeof(netif->ipv6.addrs[idx]));
 #ifdef MODULE_GNRC_IPV6_NIB

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -603,10 +603,10 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
         }
     }
     else if (!gnrc_netif_is_6ln(netif)) {
-        LOG_WARNING("Address-resolution state-machine not activated. Neighbors "
+        LOG_WARNING("Not joining solicited-node multicast address. Neighbors "
                     "from interface %u\nwill not be able to resolve address "
                     "%s\n"
-                    "    Use CONFIG_GNRC_IPV6_NIB_ARSM=1 to activate.\n",
+                    "    Use CONFIG_GNRC_IPV6_NIB_JOIN_SOLICITED_NODES=1 to activate.\n",
                     netif->pid, ipv6_addr_to_str(addr_str, addr,
                                                  sizeof(addr_str)));
     }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -585,24 +585,24 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
         gnrc_netif_release(netif);
         return -ENOMEM;
     }
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST)
-    ipv6_addr_t sol_nodes;
-    int res;
+    if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_JOIN_SOLICITED_NODES)) {
+        ipv6_addr_t sol_nodes;
+        int res;
 
-    /* TODO: SHOULD delay join between 0 and MAX_RTR_SOLICITATION_DELAY
-     * for SLAAC */
-    ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
-    res = gnrc_netif_ipv6_group_join_internal(netif, &sol_nodes);
-    if (res < 0) {
-        DEBUG("gnrc_netif: Can't join solicited-nodes of %s on interface %"
-              PRIkernel_pid "\n",
-              ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
-              netif->pid);
-        gnrc_netif_release(netif);
-        return res;
+        /* TODO: SHOULD delay join between 0 and MAX_RTR_SOLICITATION_DELAY
+         * for SLAAC */
+        ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
+        res = gnrc_netif_ipv6_group_join_internal(netif, &sol_nodes);
+        if (res < 0) {
+            DEBUG("gnrc_netif: Can't join solicited-nodes of %s on interface %"
+                  PRIkernel_pid "\n",
+                  ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
+                  netif->pid);
+            gnrc_netif_release(netif);
+            return res;
+        }
     }
-#else  /* CONFIG_GNRC_IPV6_SOLICITED_NODE_MULTICAST */
-    if (!gnrc_netif_is_6ln(netif)) {
+    else if (!gnrc_netif_is_6ln(netif)) {
         LOG_WARNING("Address-resolution state-machine not activated. Neighbors "
                     "from interface %u\nwill not be able to resolve address "
                     "%s\n"
@@ -610,7 +610,6 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
                     netif->pid, ipv6_addr_to_str(addr_str, addr,
                                                  sizeof(addr_str)));
     }
-#endif /* CONFIG_GNRC_IPV6_NIB_ARSM */
     netif->ipv6.addrs_flags[idx] = flags;
     memcpy(&netif->ipv6.addrs[idx], addr, sizeof(netif->ipv6.addrs[idx]));
 #ifdef MODULE_GNRC_IPV6_NIB

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -51,6 +51,12 @@ config GNRC_IPV6_NIB_ARSM
     default n if USEMODULE_GNRC_IPV6_NIB_6LN && !GNRC_IPV6_NIB_6LR
     default y
 
+config GNRC_IPV6_SOLICITED_NODE_MULTICAST
+    bool "Configure solicited-node multicast address"
+    default y if GNRC_IPV6_NIB_ARSM
+    help
+        Enable this if you want your 6LoWPAN network to recover from a border router restart.
+
 config GNRC_IPV6_NIB_DNS
     bool "Support for DNS configuration options"
     default y if USEMODULE_GNRC_IPV6_NIB_DNS

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -55,6 +55,7 @@ config GNRC_IPV6_NIB_JOIN_SOLICITED_NODES
     bool "Join solicited-node multicast address on interface initialization"
     default y if GNRC_IPV6_NIB_ARSM
     help
+        This allows to respond to multicast NS from neighbors using ARSM.
         Enable this if you want your 6LoWPAN network to recover from a border router restart.
 
 config GNRC_IPV6_NIB_DNS

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -51,7 +51,7 @@ config GNRC_IPV6_NIB_ARSM
     default n if USEMODULE_GNRC_IPV6_NIB_6LN && !GNRC_IPV6_NIB_6LR
     default y
 
-config GNRC_IPV6_SOLICITED_NODE_MULTICAST
+config GNRC_IPV6_NIB_JOIN_SOLICITED_NODES
     bool "Join solicited-node multicast address on interface initialization"
     default y if GNRC_IPV6_NIB_ARSM
     help

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -52,7 +52,7 @@ config GNRC_IPV6_NIB_ARSM
     default y
 
 config GNRC_IPV6_SOLICITED_NODE_MULTICAST
-    bool "Configure solicited-node multicast address"
+    bool "Join solicited-node multicast address on interface initialization"
     default y if GNRC_IPV6_NIB_ARSM
     help
         Enable this if you want your 6LoWPAN network to recover from a border router restart.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A border router will send a neighbor solicitation to the solicited-node multicasts if it encounters a packet from a global address that is not registered with the border router.

This happens when the border router is restarted while some nodes were online.

As the nodes were not in the solicited-node multicast group, they would drop the neighbor solicitation which resulted in them not being able to route any packets through the border router until they would reboot themself (or their prefix expired).

To fix this, always join the solicited-node multicast address as a 6LN.
This allows to have a connection across BR restarts.

### Testing procedure

To make sure the border router retains it's address across reboots, we have to provide it with a EUI-64:

```patch
--- a/examples/gnrc_border_router/Makefile.native.conf
+++ b/examples/gnrc_border_router/Makefile.native.conf
@@ -23,3 +23,4 @@ TERMPROG ?= sudo $(RIOTTOOLS)/zep_dispatch/start_network.sh $(TERMPROG_FLAGS)
 
 # -z [::1]:$PORT for each ZEP device
 TERMFLAGS ?= $(patsubst %,-z [::1]:%, $(shell seq $(ZEP_PORT_BASE) $(ZEP_PORT_MAX)))
+TERMFLAGS += -U 7A:37:FC:7D:1A:AF
```

ARSM is enabled for routers, so to reproduce this our node must be a simple 6LN:

```patch
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -14,7 +14,7 @@ USEMODULE += auto_init_gnrc_netif
 # Activate ICMPv6 error messages
 USEMODULE += gnrc_icmpv6_error
 # Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_udp
 # Add a routing protocol
 USEMODULE += gnrc_rpl
```

- start the (`native`) border router:
```
$ make -C examples/gnrc_border_router BOARD=native all term

> ifconfig
Iface  7  HWaddr: 00:00  Channel: 26  NID: 0x23 
          Long HWaddr: 7A:37:FC:7D:1A:AF:00:00 
          L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::7837:fc7d:1aaf:0  scope: link  VAL
          inet6 addr: 2001:db8::7837:fc7d:1aaf:0  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffaf:0
          
Iface  6  HWaddr: 7A:37:FC:7D:1A:AF 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::7837:fcff:fe7d:1aaf  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff7d:1aaf
          inet6 group: ff02::1:ff00:2
```

- start the 6LoWPAN node

```
$ make -C examples/gnrc_networking USE_ZEP=1 all term

> ifconfig
Iface  7  HWaddr: 34:18  Channel: 26  NID: 0x23 
          Long HWaddr: DA:A0:EF:4A:D1:76:34:18 
          L2-PDU:102  MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::d8a0:ef4a:d176:3418  scope: link  VAL
          inet6 addr: 2001:db8::d8a0:ef4a:d176:3418  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff76:3418
          
          Statistics for Layer 2
            RX packets 4  bytes 286
            TX packets 3 (Multicast: 1)  bytes 171
            TX succeeded 6 errors 0
          Statistics for IPv6
            RX packets 3  bytes 304
            TX packets 3 (Multicast: 1)  bytes 224
            TX succeeded 3 errors 0

> ping fdea:dbee:f::1   
12 bytes from fdea:dbee:f::1: icmp_seq=0 ttl=63 rssi=-512 dBm time=0.649 ms
12 bytes from fdea:dbee:f::1: icmp_seq=1 ttl=63 rssi=-512 dBm time=0.600 ms
12 bytes from fdea:dbee:f::1: icmp_seq=2 ttl=63 rssi=-512 dBm time=0.723 ms

--- fdea:dbee:f::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.600/0.657/0.723 ms
```

We can now `reboot` the border router, our node keeps it's packets routed:

```
> ping -c 100 fdea:dbee:f::1
ping -c 100 fdea:dbee:f::1
12 bytes from fdea:dbee:f::1: icmp_seq=0 ttl=63 rssi=-512 dBm time=0.488 ms
12 bytes from fdea:dbee:f::1: icmp_seq=1 ttl=63 rssi=-512 dBm time=0.529 ms
12 bytes from fdea:dbee:f::1: icmp_seq=2 ttl=63 rssi=-512 dBm time=0.539 ms
# border router restart
nib: Creating NCE for (ipv6 = 2001:db8::7837:fc7d:1aaf:0, iface = 7, nud_state = STALE)
nib: Neighbor cache full
12 bytes from fdea:dbee:f::1: icmp_seq=3 ttl=63 rssi=-512 dBm time=1.338 ms
12 bytes from fdea:dbee:f::1: icmp_seq=4 ttl=63 rssi=-512 dBm time=0.528 ms
12 bytes from fdea:dbee:f::1: icmp_seq=5 ttl=63 rssi=-512 dBm time=0.590 ms
12 bytes from fdea:dbee:f::1: icmp_seq=6 ttl=63 rssi=-512 dBm time=0.590 ms
12 bytes from fdea:dbee:f::1: icmp_seq=7 ttl=63 rssi=-512 dBm time=0.592 ms
# border router restart
nib: Creating NCE for (ipv6 = 2001:db8::7837:fc7d:1aaf:0, iface = 7, nud_state = STALE)
nib: Neighbor cache full
12 bytes from fdea:dbee:f::1: icmp_seq=8 ttl=63 rssi=-512 dBm time=1.357 ms
12 bytes from fdea:dbee:f::1: icmp_seq=9 ttl=63 rssi=-512 dBm time=0.602 ms
12 bytes from fdea:dbee:f::1: icmp_seq=10 ttl=63 rssi=-512 dBm time=0.598 ms
```

compared to the situation on `master`:

```
> ifconfig
Iface  7  HWaddr: 08:64  Channel: 26  NID: 0x23 
          Long HWaddr: 7A:30:7B:E2:5D:42:88:64 
          L2-PDU:102  MTU:1280  HL:64  6LO  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::7830:7be2:5d42:8864  scope: link  VAL
          inet6 addr: 2001:db8::7830:7be2:5d42:8864  scope: global  VAL
          inet6 group: ff02::1
          
          Statistics for Layer 2
            RX packets 4  bytes 286
            TX packets 3 (Multicast: 1)  bytes 171
            TX succeeded 6 errors 0
          Statistics for IPv6
            RX packets 3  bytes 304
            TX packets 3 (Multicast: 1)  bytes 224
            TX succeeded 3 errors 0

> ping -c 100 fdea:dbee:f::1
ping -c 100 fdea:dbee:f::1
12 bytes from fdea:dbee:f::1: icmp_seq=0 ttl=63 rssi=3584 dBm time=0.508 ms
12 bytes from fdea:dbee:f::1: icmp_seq=1 ttl=63 rssi=3584 dBm time=0.662 ms
12 bytes from fdea:dbee:f::1: icmp_seq=2 ttl=63 rssi=3584 dBm time=0.330 ms
12 bytes from fdea:dbee:f::1: icmp_seq=3 ttl=63 rssi=3584 dBm time=0.765 ms
12 bytes from fdea:dbee:f::1: icmp_seq=4 ttl=63 rssi=3584 dBm time=0.748 ms
# border router restart - node never recovers
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
