### PR TITLE
boards/mpfs-icicle-kit: add initial support (RV64IMAC core)

### DIFF
--- a/boards/mpfs-icicle-kit-es/Kconfig
+++ b/boards/mpfs-icicle-kit-es/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 Mesotic SAS
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "mpfs-icicle-kit-es" if BOARD_MPFS_ICICLE_KIT_ES
+
+config BOARD_MPFS_ICICLE_KIT_ES
+    bool
+    default y
+    select CPU_MODEL_MPFS

--- a/boards/mpfs-icicle-kit-es/Makefile
+++ b/boards/mpfs-icicle-kit-es/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/mpfs-icicle-kit-es/Makefile.dep
+++ b/boards/mpfs-icicle-kit-es/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/mpfs-icicle-kit-es/Makefile.features
+++ b/boards/mpfs-icicle-kit-es/Makefile.features
@@ -1,0 +1,4 @@
+CPU = mpfs
+
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_uart

--- a/boards/mpfs-icicle-kit-es/Makefile.include
+++ b/boards/mpfs-icicle-kit-es/Makefile.include
@@ -1,0 +1,8 @@
+PROGRAMMER ?= openocd
+
+FLASHFILE = $(HEXFILE)
+
+# Set debug specific arguments for GDB
+DBG_EXTRA_FLAGS +=  -ex 'set mem inaccessible-by-default off' \
+-ex 'set pagination off' -ex 'set arch riscv:rv64' -ex 'load' -ex 'continue'
+export DBG_EXTRA_FLAGS

--- a/boards/mpfs-icicle-kit-es/board.c
+++ b/boards/mpfs-icicle-kit-es/board.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_mpfs-icicle-kit-es
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for MPFS-Icicle-kit
+ *              (engineering sample)
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/gpio.h"
+
+void led_init(void);
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    led_init();
+    /* initialize the CPU */
+    cpu_init();
+}
+
+/**
+ * @brief Initialize the boards on-board LED
+ */
+void led_init(void)
+{
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_init(LED3_PIN, GPIO_OUT);
+
+    LED0_OFF;
+    LED1_OFF;
+    LED2_OFF;
+    LED3_OFF;
+}

--- a/boards/mpfs-icicle-kit-es/dist/openocd.cfg
+++ b/boards/mpfs-icicle-kit-es/dist/openocd.cfg
@@ -1,0 +1,9 @@
+
+set DEVICE "MPFS"
+source [find board/microsemi-riscv.cfg]
+
+reset_config srst_only
+
+$_TARGETNAME_0 configure -event gdb-attach {
+  halt
+}

--- a/boards/mpfs-icicle-kit-es/doc.txt
+++ b/boards/mpfs-icicle-kit-es/doc.txt
@@ -1,0 +1,36 @@
+/**
+@defgroup    boards_mpfs-icicle-kit-es MPFS Icicle Kit ES
+@ingroup     boards
+@brief       Support for the MPFS Icicle Kit ES
+
+## Overview:
+This board provides support for Microchip PolarFire SoC (Engineering Sample).
+
+## openOCD
+This board needs a special version of openOCD. Upstream support is supposed to be ongoing.
+For now, the only way to get this openOCD version is by installing the Libero tool (available
+on Windows and GNU/Linux).
+If you already have an openOCD installed in your PATH environment, you can still use a
+custom openOCD by calling `OPENOCD=/path/to/openocd/bin/openocd make ..`
+
+## Flash the board
+
+`make flash` is currently unsupported. To test your application, please use
+`make debug` for now. It will load the application to the LIM memory which is
+volatile. You need to Microchip custom openOCD and make sure to have GDB
+in your PATH environment.
+
+TODO: add fpgenprog tool support to RIOT to use it with 'make flash' to
+flash the eNVM memory.
+
+## Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port (J1). On a Linux host, it's
+generally mapped to `/dev/ttyUSB0`.
+MMUART0 is mapped to `/dev/ttyUSB0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=mpfs-icicle-kit-es -C examples/hello-world term
+```
+ */

--- a/boards/mpfs-icicle-kit-es/include/board.h
+++ b/boards/mpfs-icicle-kit-es/include/board.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_mpfs-icicle-kit-es
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for MPFS Icicle Kit.
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(2, 16)
+#define LED1_PIN            GPIO_PIN(2, 17)
+#define LED2_PIN            GPIO_PIN(2, 18)
+#define LED3_PIN            GPIO_PIN(2, 19)
+
+#define LED_PORT            GPIO2_LO
+#define LED0_MASK           (1 << 16)
+#define LED1_MASK           (1 << 17)
+#define LED2_MASK           (1 << 18)
+#define LED3_MASK           (1 << 19)
+
+#define LED0_ON             (LED_PORT->GPIO_SET_BITS = LED0_MASK)
+#define LED0_OFF            (LED_PORT->GPIO_CLR_BITS = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->GPIO_OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->GPIO_SET_BITS = LED1_MASK)
+#define LED1_OFF            (LED_PORT->GPIO_CLR_BITS = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->GPIO_OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED_PORT->GPIO_SET_BITS = LED2_MASK)
+#define LED2_OFF            (LED_PORT->GPIO_CLR_BITS = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT->GPIO_OUT   ^= LED2_MASK)
+
+#define LED3_ON             (LED_PORT->GPIO_SET_BITS = LED3_MASK)
+#define LED3_OFF            (LED_PORT->GPIO_CLR_BITS = LED3_MASK)
+#define LED3_TOGGLE         (LED_PORT->GPIO_OUT   ^= LED3_MASK)
+
+/** @} */
+
+/**
+ * @name SW0 (Button) pin definitions
+ * @{
+ */
+#define BTN0_PORT           2
+#define BTN0_PIN            GPIO_PIN(2, 30)
+#define BTN0_MODE           GPIO_IN
+
+#define BTN1_PORT           2
+#define BTN1_PIN            GPIO_PIN(2, 31)
+#define BTN1_MODE           GPIO_IN
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/mpfs-icicle-kit-es/include/periph_conf.h
+++ b/boards/mpfs-icicle-kit-es/include/periph_conf.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_mpfs-icicle-kit-es
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the MPFS Icicle Kit
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GCLK reference speed
+ */
+#define CLOCK_CORECLOCK     (600000000U)
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TIMER_LO,
+        .num            = 1,
+    },
+    {   /* Timer 0 - System Clock */
+        .dev            = TIMER_LO,
+        .num            = 2,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    1u
+#define TIMER_NUMOF         2u
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define MSS_UART0_LO_BASE           (MSS_UART_TypeDef*)0x20000000UL
+static const uart_conf_t uart_config[] = {
+    {    /* E51 UART */
+        .dev = &g_mss_uart0_lo,
+        .base_addr =  MSS_UART0_LO_BASE,
+        .irqn = MMUART0_PLIC_77,
+        .clk = MSS_PERIPH_MMUART0,
+    },
+};
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/mpfs/Makefile
+++ b/cpu/mpfs/Makefile
@@ -1,0 +1,6 @@
+# define the module that is built
+MODULE = cpu
+
+DIRS += periph $(RIOTCPU)/riscv_common
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mpfs/Makefile.dep
+++ b/cpu/mpfs/Makefile.dep
@@ -1,0 +1,6 @@
+USEMODULE += periph
+
+USEPKG += mpfs_sdk
+FEATURES_REQUIRED += periph_plic
+
+include $(RIOTCPU)/riscv_common/Makefile.dep

--- a/cpu/mpfs/Makefile.features
+++ b/cpu/mpfs/Makefile.features
@@ -1,0 +1,11 @@
+FEATURES_PROVIDED += arch_64bit
+FEATURES_PROVIDED += arch_riscv
+FEATURES_PROVIDED += periph_plic
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio_irq
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_timer_periodic
+FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTCPU)/riscv_common/Makefile.features

--- a/cpu/mpfs/Makefile.include
+++ b/cpu/mpfs/Makefile.include
@@ -1,0 +1,15 @@
+RAM_START_ADDR = 0x800d200
+RAM_LEN = 8K
+
+ROM_START_ADDR = 0x8000000
+ROM_LEN = 32K
+ITIM_START_ADDR = 0x01800000
+ITIM_LEN = 28K
+
+LINKER_SCRIPT ?= riscv.ld
+
+# Force buildsystem to use mpfs sdk csr definitions
+#   instead of the ones provided by riscv_common 
+CFLAGS += -DUSE_OWN_CSR_REG
+
+include $(RIOTCPU)/riscv_common/Makefile.include

--- a/cpu/mpfs/cpu.c
+++ b/cpu/mpfs/cpu.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+/**
+ * @ingroup         cpu_mpfs
+ * @{
+ *
+ * @file
+ * @brief           Polarfire CPU initialization
+ *
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+#include "stdio_uart.h"
+#include "periph/init.h"
+#include "irq_arch.h"
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+extern void __libc_init_array(void);
+
+void cpu_init(void)
+{
+    /* Common RISC-V initialization */
+    riscv_init();
+
+    mss_config_clk_rst(MSS_PERIPH_CFM, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+
+    /* Initialize all GPIOs banks */
+    mss_config_clk_rst(MSS_PERIPH_GPIO0, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+    mss_config_clk_rst(MSS_PERIPH_GPIO1, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+    mss_config_clk_rst(MSS_PERIPH_GPIO2, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+
+    SYSREG->GPIO_INTERRUPT_FAB_CR = 0xFFFFFFFFUL;
+
+    stdio_init();
+    periph_init();
+}

--- a/cpu/mpfs/doc.txt
+++ b/cpu/mpfs/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup        cpu_mpfs   Microchip PolarFire Soc
+ * @ingroup         cpu
+ * @brief           Microchip Polarfire RISC-V Microcontrollers
+ *
+ */

--- a/cpu/mpfs/include/cpu_conf.h
+++ b/cpu/mpfs/include/cpu_conf.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         cpu_mpfs
+ * @{
+ *
+ * @file
+ * @brief           CPU specific configuration options
+ *
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+/* TODO Update vendor CPU core header to Polarfire */
+#include "mpfs_hal/mss_hal.h"
+#include "mpfs_hal/common/mss_peripherals.h"
+#include "mpfs_hal/common/mss_plic.h"
+#include "drivers/mss/mss_gpio/mss_gpio.h"
+#include "drivers/mss/mss_mmuart/mss_uart.h"
+#include "drivers/mss/mss_timer/mss_timer.h"
+
+#include "cpu_conf_common.h"
+
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @brief   Polarfire SoC doesn't use the MIE CSR
+ */
+#define HAVE_CSR_MIE                    (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_CONF_H */
+/** @} */

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_ddr_pll.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_ddr_pll.h
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_clk_ddr_pll.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CLK_DDR_PLL_H_
+#define HW_CLK_DDR_PLL_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_DDR_SOFT_RESET)
+/*This is a compulsory register for all SCB slaves and must be at the same
+offset in all slaves to facilitate global soft reset of all SCB registers with
+a single broadcast write from the SCB master. */
+#define LIBERO_SETTING_DDR_SOFT_RESET    0x00000000UL
+    /* NV_MAP                            [0:1]   RST */
+    /* V_MAP                             [1:1]   RST */
+    /* PERIPH                            [8:1]   RST */
+    /* BLOCKID                           [16:16] ID */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_CTRL)
+/*PLL control register */
+#define LIBERO_SETTING_DDR_PLL_CTRL    0x0100003FUL
+    /* REG_POWERDOWN_B                   [0:1]   RW value= 0x1 */
+    /* REG_RFDIV_EN                      [1:1]   RW value= 0x1 */
+    /* REG_DIVQ0_EN                      [2:1]   RW value= 0x1 */
+    /* REG_DIVQ1_EN                      [3:1]   RW value= 0x1 */
+    /* REG_DIVQ2_EN                      [4:1]   RW value= 0x1 */
+    /* REG_DIVQ3_EN                      [5:1]   RW value= 0x1 */
+    /* REG_RFCLK_SEL                     [6:1]   RW value= 0x0 */
+    /* RESETONLOCK                       [7:1]   RW value= 0x0 */
+    /* BYPCK_SEL                         [8:4]   RW value= 0x0 */
+    /* REG_BYPASS_GO_B                   [12:1]  RW value= 0x0 */
+    /* RESERVE10                         [13:3]  RSVD */
+    /* REG_BYPASSPRE                     [16:4]  RW value= 0x0 */
+    /* REG_BYPASSPOST                    [20:4]  RW value= 0x0 */
+    /* LP_REQUIRES_LOCK                  [24:1]  RW value= 0x1 */
+    /* LOCK                              [25:1]  RO */
+    /* LOCK_INT_EN                       [26:1]  RW value= 0x0 */
+    /* UNLOCK_INT_EN                     [27:1]  RW value= 0x0 */
+    /* LOCK_INT                          [28:1]  SW1C */
+    /* UNLOCK_INT                        [29:1]  SW1C */
+    /* RESERVE11                         [30:1]  RSVD */
+    /* LOCK_B                            [31:1]  RO */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_REF_FB)
+/*PLL reference and feedback registers */
+#define LIBERO_SETTING_DDR_PLL_REF_FB    0x00000500UL
+    /* FSE_B                             [0:1]   RW value= 0x0 */
+    /* FBCK_SEL                          [1:2]   RW value= 0x0 */
+    /* FOUTFB_SELMUX_EN                  [3:1]   RW value= 0x0 */
+    /* RESERVE12                         [4:4]   RSVD */
+    /* RFDIV                             [8:6]   RW value= 0x5 */
+    /* RESERVE13                         [14:2]  RSVD */
+    /* RESERVE14                         [16:12] RSVD */
+    /* RESERVE15                         [28:4]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_FRACN)
+/*PLL fractional register */
+#define LIBERO_SETTING_DDR_PLL_FRACN    0x00000000UL
+    /* FRACN_EN                          [0:1]   RW value= 0x0 */
+    /* FRACN_DAC_EN                      [1:1]   RW value= 0x0 */
+    /* RESERVE16                         [2:6]   RSVD */
+    /* RESERVE17                         [8:24]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_DIV_0_1)
+/*PLL 0/1 division registers */
+#define LIBERO_SETTING_DDR_PLL_DIV_0_1    0x02000100UL
+    /* VCO0PH_SEL                        [0:3]   RO */
+    /* DIV0_START                        [3:3]   RW value= 0x0 */
+    /* RESERVE18                         [6:2]   RSVD */
+    /* POST0DIV                          [8:7]   RW value= 0x1 */
+    /* RESERVE19                         [15:1]  RSVD */
+    /* VCO1PH_SEL                        [16:3]  RO */
+    /* DIV1_START                        [19:3]  RW value= 0x0 */
+    /* RESERVE20                         [22:2]  RSVD */
+    /* POST1DIV                          [24:7]  RW value= 0x2 */
+    /* RESERVE21                         [31:1]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_DIV_2_3)
+/*PLL 2/3 division registers */
+#define LIBERO_SETTING_DDR_PLL_DIV_2_3    0x01000100UL
+    /* VCO2PH_SEL                        [0:3]   RO */
+    /* DIV2_START                        [3:3]   RW value= 0x0 */
+    /* RESERVE22                         [6:2]   RSVD */
+    /* POST2DIV                          [8:7]   RW value= 0x1 */
+    /* RESERVE23                         [15:1]  RSVD */
+    /* VCO3PH_SEL                        [16:3]  RO */
+    /* DIV3_START                        [19:3]  RW value= 0x0 */
+    /* RESERVE24                         [22:2]  RSVD */
+    /* POST3DIV                          [24:7]  RW value= 0x1 */
+    /* CKPOST3_SEL                       [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_CTRL2)
+/*PLL control register */
+#define LIBERO_SETTING_DDR_PLL_CTRL2    0x00001020UL
+    /* BWI                               [0:2]   RW value= 0x0 */
+    /* BWP                               [2:2]   RW value= 0x0 */
+    /* IREF_EN                           [4:1]   RW value= 0x0 */
+    /* IREF_TOGGLE                       [5:1]   RW value= 0x1 */
+    /* RESERVE25                         [6:3]   RSVD */
+    /* LOCKCNT                           [9:4]   RW value= 0x8 */
+    /* RESERVE26                         [13:4]  RSVD */
+    /* ATEST_EN                          [17:1]  RW value= 0x0 */
+    /* ATEST_SEL                         [18:3]  RW value= 0x0 */
+    /* RESERVE27                         [21:11] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_CAL)
+/*PLL calibration register */
+#define LIBERO_SETTING_DDR_PLL_CAL    0x00000D06UL
+    /* DSKEWCALCNT                       [0:3]   RW value= 0x6 */
+    /* DSKEWCAL_EN                       [3:1]   RW value= 0x0 */
+    /* DSKEWCALBYP                       [4:1]   RW value= 0x0 */
+    /* RESERVE28                         [5:3]   RSVD */
+    /* DSKEWCALIN                        [8:7]   RW value= 0xd */
+    /* RESERVE29                         [15:1]  RSVD */
+    /* DSKEWCALOUT                       [16:7]  RO */
+    /* RESERVE30                         [23:9]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_PLL_PHADJ)
+/*PLL phase registers */
+#define LIBERO_SETTING_DDR_PLL_PHADJ    0x00005003UL
+    /* PLL_REG_SYNCREFDIV_EN             [0:1]   RW value= 0x1 */
+    /* PLL_REG_ENABLE_SYNCREFDIV         [1:1]   RW value= 0x1 */
+    /* REG_OUT0_PHSINIT                  [2:3]   RW value= 0x0 */
+    /* REG_OUT1_PHSINIT                  [5:3]   RW value= 0x0 */
+    /* REG_OUT2_PHSINIT                  [8:3]   RW value= 0x0 */
+    /* REG_OUT3_PHSINIT                  [11:3]  RW value= 0x2 */
+    /* REG_LOADPHS_B                     [14:1]  RW value= 0x1 */
+    /* RESERVE31                         [15:17] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_SSCG_REG_0)
+/*SSCG registers 0 */
+#define LIBERO_SETTING_DDR_SSCG_REG_0    0x00000000UL
+    /* DIVVAL                            [0:6]   RW value= 0x0 */
+    /* FRACIN                            [6:24]  RW value= 0x0 */
+    /* RESERVE00                         [30:2]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_SSCG_REG_1)
+/*SSCG registers 1 */
+#define LIBERO_SETTING_DDR_SSCG_REG_1    0x00000000UL
+    /* DOWNSPREAD                        [0:1]   RW value= 0x0 */
+    /* SSMD                              [1:5]   RW value= 0x0 */
+    /* FRACMOD                           [6:24]  RO */
+    /* RESERVE01                         [30:2]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_SSCG_REG_2)
+/*SSCG registers 2 */
+#define LIBERO_SETTING_DDR_SSCG_REG_2    0x00000080UL
+    /* INTIN                             [0:12]  RW value= 0x80 */
+    /* INTMOD                            [12:12] RO */
+    /* RESERVE02                         [24:8]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DDR_SSCG_REG_3)
+/*SSCG registers 3 */
+#define LIBERO_SETTING_DDR_SSCG_REG_3    0x00000001UL
+    /* SSE_B                             [0:1]   RW value= 0x1 */
+    /* SEL_EXTWAVE                       [1:2]   RW value= 0x0 */
+    /* EXT_MAXADDR                       [3:8]   RW value= 0x0 */
+    /* TBLADDR                           [11:8]  RO */
+    /* RANDOM_FILTER                     [19:1]  RW value= 0x0 */
+    /* RANDOM_SEL                        [20:2]  RW value= 0x0 */
+    /* RESERVE03                         [22:1]  RSVD */
+    /* RESERVE04                         [23:9]  RSVD */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CLK_DDR_PLL_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_mss_cfm.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_mss_cfm.h
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_clk_mss_cfm.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CLK_MSS_CFM_H_
+#define HW_CLK_MSS_CFM_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_MSS_BCLKMUX)
+/*Input mux selections */
+#define LIBERO_SETTING_MSS_BCLKMUX    0x00000208UL
+    /* BCLK0_SEL                         [0:5]   RW value= 0x8 */
+    /* BCLK1_SEL                         [5:5]   RW value= 0x10 */
+    /* BCLK2_SEL                         [10:5]  RW value= 0x0 */
+    /* BCLK3_SEL                         [15:5]  RW value= 0x0 */
+    /* BCLK4_SEL                         [20:5]  RW value= 0x0 */
+    /* BCLK5_SEL                         [25:5]  RW value= 0x0 */
+    /* RESERVED                          [30:2]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_CKMUX)
+/*Input mux selections */
+#define LIBERO_SETTING_MSS_PLL_CKMUX    0x00000155UL
+    /* CLK_IN_MAC_TSU_SEL                [0:2]   RW value= 0x1 */
+    /* PLL0_RFCLK0_SEL                   [2:2]   RW value= 0x1 */
+    /* PLL0_RFCLK1_SEL                   [4:2]   RW value= 0x1 */
+    /* PLL1_RFCLK0_SEL                   [6:2]   RW value= 0x1 */
+    /* PLL1_RFCLK1_SEL                   [8:2]   RW value= 0x1 */
+    /* PLL1_FDR_SEL                      [10:5]  RW value= 0x0 */
+    /* RESERVED                          [15:17] RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_MSSCLKMUX)
+/*MSS Clock mux selections */
+#define LIBERO_SETTING_MSS_MSSCLKMUX    0x00000003UL
+    /* MSSCLK_MUX_SEL                    [0:2]   RW value= 0x3 */
+    /* MSSCLK_MUX_MD                     [2:2]   RW value= 0x0 */
+    /* CLK_STANDBY_SEL                   [4:1]   RW value= 0x0 */
+    /* RESERVED                          [5:27]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_SPARE0)
+/*spare logic */
+#define LIBERO_SETTING_MSS_SPARE0    0x00000000UL
+    /* SPARE0                            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_FMETER_ADDR)
+/*Frequency_meter_address_selections */
+#define LIBERO_SETTING_MSS_FMETER_ADDR    0x00000000UL
+    /* ADDR10                            [0:2]   RSVD */
+    /* ADDR                              [2:4]   RW value= 0x0 */
+    /* RESERVE18                         [6:26]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_FMETER_DATAW)
+/*Frequency_meter_data_write */
+#define LIBERO_SETTING_MSS_FMETER_DATAW    0x00000000UL
+    /* DATA                              [0:24]  RW value= 0x0 */
+    /* STROBE                            [24:1]  W1P */
+    /* RESERVE19                         [25:7]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_FMETER_DATAR)
+/*Frequency_meter_data_read */
+#define LIBERO_SETTING_MSS_FMETER_DATAR    0x00000000UL
+    /* DATA                              [0:24]  RO */
+    /* RESERVE20                         [24:8]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_IMIRROR_TRIM)
+/*Imirror TRIM Bits */
+#define LIBERO_SETTING_MSS_IMIRROR_TRIM    0x00000000UL
+    /* BG_CODE                           [0:3]   RW value= 0x0 */
+    /* CC_CODE                           [3:8]   RW value= 0x0 */
+    /* RESERVE21                         [11:21] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_TEST_CTRL)
+/*Test MUX Controls */
+#define LIBERO_SETTING_MSS_TEST_CTRL    0x00000000UL
+    /* OSC_ENABLE                        [0:4]   RW value= 0x0 */
+    /* ATEST_EN                          [4:1]   RW value= 0x0 */
+    /* ATEST_SEL                         [5:5]   RW value= 0x0 */
+    /* DTEST_EN                          [10:1]  RW value= 0x0 */
+    /* DTEST_SEL                         [11:5]  RW value= 0x0 */
+    /* RESERVE22                         [16:16] RSVD */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CLK_MSS_CFM_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_mss_pll.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_mss_pll.h
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_clk_mss_pll.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CLK_MSS_PLL_H_
+#define HW_CLK_MSS_PLL_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_MSS_PLL_CTRL)
+/*PLL control register */
+#define LIBERO_SETTING_MSS_PLL_CTRL    0x01000037UL
+    /* REG_POWERDOWN_B                   [0:1]   RW value= 0x1 */
+    /* REG_RFDIV_EN                      [1:1]   RW value= 0x1 */
+    /* REG_DIVQ0_EN                      [2:1]   RW value= 0x1 */
+    /* REG_DIVQ1_EN                      [3:1]   RW value= 0x0 */
+    /* REG_DIVQ2_EN                      [4:1]   RW value= 0x1 */
+    /* REG_DIVQ3_EN                      [5:1]   RW value= 0x1 */
+    /* REG_RFCLK_SEL                     [6:1]   RW value= 0x0 */
+    /* RESETONLOCK                       [7:1]   RW value= 0x0 */
+    /* BYPCK_SEL                         [8:4]   RW value= 0x0 */
+    /* REG_BYPASS_GO_B                   [12:1]  RW value= 0x0 */
+    /* RESERVE10                         [13:3]  RSVD */
+    /* REG_BYPASSPRE                     [16:4]  RW value= 0x0 */
+    /* REG_BYPASSPOST                    [20:4]  RW value= 0x0 */
+    /* LP_REQUIRES_LOCK                  [24:1]  RW value= 0x1 */
+    /* LOCK                              [25:1]  RO */
+    /* LOCK_INT_EN                       [26:1]  RW value= 0x0 */
+    /* UNLOCK_INT_EN                     [27:1]  RW value= 0x0 */
+    /* LOCK_INT                          [28:1]  SW1C */
+    /* UNLOCK_INT                        [29:1]  SW1C */
+    /* RESERVE11                         [30:1]  RSVD */
+    /* LOCK_B                            [31:1]  RO */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_REF_FB)
+/*PLL reference and feedback registers */
+#define LIBERO_SETTING_MSS_PLL_REF_FB    0x00000500UL
+    /* FSE_B                             [0:1]   RW value= 0x0 */
+    /* FBCK_SEL                          [1:2]   RW value= 0x0 */
+    /* FOUTFB_SELMUX_EN                  [3:1]   RW value= 0x0 */
+    /* RESERVE12                         [4:4]   RSVD */
+    /* RFDIV                             [8:6]   RW value= 0x5 */
+    /* RESERVE13                         [14:2]  RSVD */
+    /* RESERVE14                         [16:12] RSVD */
+    /* RESERVE15                         [28:4]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_FRACN)
+/*PLL fractional register */
+#define LIBERO_SETTING_MSS_PLL_FRACN    0x00000000UL
+    /* FRACN_EN                          [0:1]   RW value= 0x0 */
+    /* FRACN_DAC_EN                      [1:1]   RW value= 0x0 */
+    /* RESERVE16                         [2:6]   RSVD */
+    /* RESERVE17                         [8:24]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_DIV_0_1)
+/*PLL 0/1 division registers */
+#define LIBERO_SETTING_MSS_PLL_DIV_0_1    0x01000200UL
+    /* VCO0PH_SEL                        [0:3]   RO */
+    /* DIV0_START                        [3:3]   RW value= 0x0 */
+    /* RESERVE18                         [6:2]   RSVD */
+    /* POST0DIV                          [8:7]   RW value= 0x2 */
+    /* RESERVE19                         [15:1]  RSVD */
+    /* VCO1PH_SEL                        [16:3]  RO */
+    /* DIV1_START                        [19:3]  RW value= 0x0 */
+    /* RESERVE20                         [22:2]  RSVD */
+    /* POST1DIV                          [24:7]  RW value= 0x1 */
+    /* RESERVE21                         [31:1]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_DIV_2_3)
+/*PLL 2/3 division registers */
+#define LIBERO_SETTING_MSS_PLL_DIV_2_3    0x0F000600UL
+    /* VCO2PH_SEL                        [0:3]   RO */
+    /* DIV2_START                        [3:3]   RW value= 0x0 */
+    /* RESERVE22                         [6:2]   RSVD */
+    /* POST2DIV                          [8:7]   RW value= 0x6 */
+    /* RESERVE23                         [15:1]  RSVD */
+    /* VCO3PH_SEL                        [16:3]  RO */
+    /* DIV3_START                        [19:3]  RW value= 0x0 */
+    /* RESERVE24                         [22:2]  RSVD */
+    /* POST3DIV                          [24:7]  RW value= 0xF */
+    /* CKPOST3_SEL                       [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_CTRL2)
+/*PLL control register */
+#define LIBERO_SETTING_MSS_PLL_CTRL2    0x00001020UL
+    /* BWI                               [0:2]   RW value= 0x0 */
+    /* BWP                               [2:2]   RW value= 0x0 */
+    /* IREF_EN                           [4:1]   RW value= 0x0 */
+    /* IREF_TOGGLE                       [5:1]   RW value= 0x1 */
+    /* RESERVE25                         [6:3]   RSVD */
+    /* LOCKCNT                           [9:4]   RW value= 0x8 */
+    /* RESERVE26                         [13:4]  RSVD */
+    /* ATEST_EN                          [17:1]  RW value= 0x0 */
+    /* ATEST_SEL                         [18:3]  RW value= 0x0 */
+    /* RESERVE27                         [21:11] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_CAL)
+/*PLL calibration register */
+#define LIBERO_SETTING_MSS_PLL_CAL    0x00000D06UL
+    /* DSKEWCALCNT                       [0:3]   RW value= 0x6 */
+    /* DSKEWCAL_EN                       [3:1]   RW value= 0x0 */
+    /* DSKEWCALBYP                       [4:1]   RW value= 0x0 */
+    /* RESERVE28                         [5:3]   RSVD */
+    /* DSKEWCALIN                        [8:7]   RW value= 0xd */
+    /* RESERVE29                         [15:1]  RSVD */
+    /* DSKEWCALOUT                       [16:7]  RO */
+    /* RESERVE30                         [23:9]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_PLL_PHADJ)
+/*PLL phase registers */
+#define LIBERO_SETTING_MSS_PLL_PHADJ    0x00004003UL
+    /* PLL_REG_SYNCREFDIV_EN             [0:1]   RW value= 0x1 */
+    /* PLL_REG_ENABLE_SYNCREFDIV         [1:1]   RW value= 0x1 */
+    /* REG_OUT0_PHSINIT                  [2:3]   RW value= 0x0 */
+    /* REG_OUT1_PHSINIT                  [5:3]   RW value= 0x0 */
+    /* REG_OUT2_PHSINIT                  [8:3]   RW value= 0x0 */
+    /* REG_OUT3_PHSINIT                  [11:3]  RW value= 0x8 */
+    /* REG_LOADPHS_B                     [14:1]  RW value= 0x0 */
+    /* RESERVE31                         [15:17] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_SSCG_REG_0)
+/*SSCG registers 0 */
+#define LIBERO_SETTING_MSS_SSCG_REG_0    0x00000000UL
+    /* DIVVAL                            [0:6]   RW value= 0x0 */
+    /* FRACIN                            [6:24]  RW value= 0x0 */
+    /* RESERVE00                         [30:2]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_SSCG_REG_1)
+/*SSCG registers 1 */
+#define LIBERO_SETTING_MSS_SSCG_REG_1    0x00000000UL
+    /* DOWNSPREAD                        [0:1]   RW value= 0x0 */
+    /* SSMD                              [1:5]   RW value= 0x0 */
+    /* FRACMOD                           [6:24]  RO */
+    /* RESERVE01                         [30:2]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_SSCG_REG_2)
+/*SSCG registers 2 */
+#define LIBERO_SETTING_MSS_SSCG_REG_2    0x000000C0UL
+    /* INTIN                             [0:12]  RW value= 0xC0 */
+    /* INTMOD                            [12:12] RO */
+    /* RESERVE02                         [24:8]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_MSS_SSCG_REG_3)
+/*SSCG registers 3 */
+#define LIBERO_SETTING_MSS_SSCG_REG_3    0x00000001UL
+    /* SSE_B                             [0:1]   RW value= 0x1 */
+    /* SEL_EXTWAVE                       [1:2]   RW value= 0x0 */
+    /* EXT_MAXADDR                       [3:8]   RW value= 0x0 */
+    /* TBLADDR                           [11:8]  RO */
+    /* RANDOM_FILTER                     [19:1]  RW value= 0x0 */
+    /* RANDOM_SEL                        [20:2]  RW value= 0x0 */
+    /* RESERVE03                         [22:1]  RSVD */
+    /* RESERVE04                         [23:9]  RSVD */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CLK_MSS_PLL_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_sgmii_cfm.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_sgmii_cfm.h
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_clk_sgmii_cfm.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CLK_SGMII_CFM_H_
+#define HW_CLK_SGMII_CFM_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_SGMII_REFCLKMUX)
+/*Input mux selections */
+#define LIBERO_SETTING_SGMII_REFCLKMUX    0x00000005UL
+    /* PLL0_RFCLK0_SEL                   [0:2]   RW value= 0x1 */
+    /* PLL0_RFCLK1_SEL                   [2:2]   RW value= 0x1 */
+    /* RESERVED                          [4:28]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_SGMII_CLKMUX)
+/*sgmii clk mux */
+#define LIBERO_SETTING_SGMII_SGMII_CLKMUX    0x00000005UL
+    /* SGMII_CLKMUX                      [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_SPARE0)
+/*spare logic */
+#define LIBERO_SETTING_SGMII_SPARE0    0x00000000UL
+    /* RESERVED                          [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_CLK_XCVR)
+/*Clock_Receiver */
+#define LIBERO_SETTING_SGMII_CLK_XCVR    0x00002C30UL
+    /* EN_UDRIVE_P                       [0:1]   RW value= 0x0 */
+    /* EN_INS_HYST_P                     [1:1]   RW value= 0x0 */
+    /* EN_TERM_P                         [2:2]   RW value= 0x0 */
+    /* EN_RXMODE_P                       [4:2]   RW value= 0x3 */
+    /* EN_UDRIVE_N                       [6:1]   RW value= 0x0 */
+    /* EN_INS_HYST_N                     [7:1]   RW value= 0x0 */
+    /* EN_TERM_N                         [8:2]   RW value= 0x0 */
+    /* EN_RXMODE_N                       [10:2]  RW value= 0x3 */
+    /* CLKBUF_EN_PULLUP                  [12:1]  RW value= 0x0 */
+    /* EN_RDIFF                          [13:1]  RW value= 0x1 */
+    /* RESERVED                          [14:18] RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_TEST_CTRL)
+/*Test MUX Controls */
+#define LIBERO_SETTING_SGMII_TEST_CTRL    0x00000000UL
+    /* OSC_ENABLE                        [0:4]   RW value= 0x0 */
+    /* ATEST_EN                          [4:1]   RW value= 0x0 */
+    /* ATEST_SEL                         [5:5]   RW value= 0x0 */
+    /* DTEST_EN                          [10:1]  RW value= 0x0 */
+    /* DTEST_SEL                         [11:5]  RW value= 0x0 */
+    /* RESERVE22                         [16:16] RSVD */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CLK_SGMII_CFM_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_sgmii_pll.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_sgmii_pll.h
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_clk_sgmii_pll.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CLK_SGMII_PLL_H_
+#define HW_CLK_SGMII_PLL_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_SGMII_SOFT_RESET)
+/*This is a compulsory register for all SCB slaves and must be at the same
+offset in all slaves to facilitate global soft reset of all SCB registers with
+a single broadcast write from the SCB master. */
+#define LIBERO_SETTING_SGMII_SOFT_RESET    0x00000000UL
+    /* NV_MAP                            [0:1]   RST */
+    /* V_MAP                             [1:1]   RST */
+    /* PERIPH                            [8:1]   RST */
+    /* BLOCKID                           [16:16] ID */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_CTRL)
+/*PLL control register */
+#define LIBERO_SETTING_SGMII_PLL_CTRL    0x0100003FUL
+    /* REG_POWERDOWN_B                   [0:1]   RW value= 0x1 */
+    /* REG_RFDIV_EN                      [1:1]   RW value= 0x1 */
+    /* REG_DIVQ0_EN                      [2:1]   RW value= 0x1 */
+    /* REG_DIVQ1_EN                      [3:1]   RW value= 0x1 */
+    /* REG_DIVQ2_EN                      [4:1]   RW value= 0x1 */
+    /* REG_DIVQ3_EN                      [5:1]   RW value= 0x1 */
+    /* REG_RFCLK_SEL                     [6:1]   RW value= 0x0 */
+    /* RESETONLOCK                       [7:1]   RW value= 0x0 */
+    /* BYPCK_SEL                         [8:4]   RW value= 0x0 */
+    /* REG_BYPASS_GO_B                   [12:1]  RW value= 0x0 */
+    /* RESERVE10                         [13:3]  RSVD */
+    /* REG_BYPASSPRE                     [16:4]  RW value= 0x0 */
+    /* REG_BYPASSPOST                    [20:4]  RW value= 0x0 */
+    /* LP_REQUIRES_LOCK                  [24:1]  RW value= 0x1 */
+    /* LOCK                              [25:1]  RO */
+    /* LOCK_INT_EN                       [26:1]  RW value= 0x0 */
+    /* UNLOCK_INT_EN                     [27:1]  RW value= 0x0 */
+    /* LOCK_INT                          [28:1]  SW1C */
+    /* UNLOCK_INT                        [29:1]  SW1C */
+    /* RESERVE11                         [30:1]  RSVD */
+    /* LOCK_B                            [31:1]  RO */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_REF_FB)
+/*PLL reference and feedback registers */
+#define LIBERO_SETTING_SGMII_PLL_REF_FB    0x00000100UL
+    /* FSE_B                             [0:1]   RW value= 0x0 */
+    /* FBCK_SEL                          [1:2]   RW value= 0x0 */
+    /* FOUTFB_SELMUX_EN                  [3:1]   RW value= 0x0 */
+    /* RESERVE12                         [4:4]   RSVD */
+    /* RFDIV                             [8:6]   RW value= 0x1 */
+    /* RESERVE13                         [14:2]  RSVD */
+    /* RESERVE14                         [16:12] RSVD */
+    /* RESERVE15                         [28:4]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_FRACN)
+/*PLL fractional register */
+#define LIBERO_SETTING_SGMII_PLL_FRACN    0x00000000UL
+    /* FRACN_EN                          [0:1]   RW value= 0x0 */
+    /* FRACN_DAC_EN                      [1:1]   RW value= 0x0 */
+    /* RESERVE16                         [2:6]   RSVD */
+    /* RESERVE17                         [8:24]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_DIV_0_1)
+/*PLL 0/1 division registers */
+#define LIBERO_SETTING_SGMII_PLL_DIV_0_1    0x01000100UL
+    /* VCO0PH_SEL                        [0:3]   RO */
+    /* DIV0_START                        [3:3]   RW value= 0x0 */
+    /* RESERVE18                         [6:2]   RSVD */
+    /* POST0DIV                          [8:7]   RW value= 0x1 */
+    /* RESERVE19                         [15:1]  RSVD */
+    /* VCO1PH_SEL                        [16:3]  RO */
+    /* DIV1_START                        [19:3]  RW value= 0x0 */
+    /* RESERVE20                         [22:2]  RSVD */
+    /* POST1DIV                          [24:7]  RW value= 0x1 */
+    /* RESERVE21                         [31:1]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_DIV_2_3)
+/*PLL 2/3 division registers */
+#define LIBERO_SETTING_SGMII_PLL_DIV_2_3    0x01000100UL
+    /* VCO2PH_SEL                        [0:3]   RO */
+    /* DIV2_START                        [3:3]   RW value= 0x0 */
+    /* RESERVE22                         [6:2]   RSVD */
+    /* POST2DIV                          [8:7]   RW value= 0x1 */
+    /* RESERVE23                         [15:1]  RSVD */
+    /* VCO3PH_SEL                        [16:3]  RO */
+    /* DIV3_START                        [19:3]  RW value= 0x0 */
+    /* RESERVE24                         [22:2]  RSVD */
+    /* POST3DIV                          [24:7]  RW value= 0x1 */
+    /* CKPOST3_SEL                       [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_CTRL2)
+/*PLL control register */
+#define LIBERO_SETTING_SGMII_PLL_CTRL2    0x00001020UL
+    /* BWI                               [0:2]   RW value= 0x0 */
+    /* BWP                               [2:2]   RW value= 0x0 */
+    /* IREF_EN                           [4:1]   RW value= 0x0 */
+    /* IREF_TOGGLE                       [5:1]   RW value= 0x1 */
+    /* RESERVE25                         [6:3]   RSVD */
+    /* LOCKCNT                           [9:4]   RW value= 0x8 */
+    /* RESERVE26                         [13:4]  RSVD */
+    /* ATEST_EN                          [17:1]  RW value= 0x0 */
+    /* ATEST_SEL                         [18:3]  RW value= 0x0 */
+    /* RESERVE27                         [21:11] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_CAL)
+/*PLL calibration register */
+#define LIBERO_SETTING_SGMII_PLL_CAL    0x00000D06UL
+    /* DSKEWCALCNT                       [0:3]   RW value= 0x6 */
+    /* DSKEWCAL_EN                       [3:1]   RW value= 0x0 */
+    /* DSKEWCALBYP                       [4:1]   RW value= 0x0 */
+    /* RESERVE28                         [5:3]   RSVD */
+    /* DSKEWCALIN                        [8:7]   RW value= 0xd */
+    /* RESERVE29                         [15:1]  RSVD */
+    /* DSKEWCALOUT                       [16:7]  RO */
+    /* RESERVE30                         [23:9]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_PLL_PHADJ)
+/*PLL phase registers */
+#define LIBERO_SETTING_SGMII_PLL_PHADJ    0x00007443UL
+    /* PLL_REG_SYNCREFDIV_EN             [0:1]   RW value= 0x1 */
+    /* PLL_REG_ENABLE_SYNCREFDIV         [1:1]   RW value= 0x1 */
+    /* REG_OUT0_PHSINIT                  [2:3]   RW value= 0x0 */
+    /* REG_OUT1_PHSINIT                  [5:3]   RW value= 0x2 */
+    /* REG_OUT2_PHSINIT                  [8:3]   RW value= 0x4 */
+    /* REG_OUT3_PHSINIT                  [11:3]  RW value= 0x6 */
+    /* REG_LOADPHS_B                     [14:1]  RW value= 0x1 */
+    /* RESERVE31                         [15:17] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_SSCG_REG_0)
+/*SSCG registers 0 */
+#define LIBERO_SETTING_SGMII_SSCG_REG_0    0x00000000UL
+    /* DIVVAL                            [0:6]   RW value= 0x0 */
+    /* FRACIN                            [6:24]  RW value= 0x0 */
+    /* RESERVE00                         [30:2]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_SSCG_REG_1)
+/*SSCG registers 1 */
+#define LIBERO_SETTING_SGMII_SSCG_REG_1    0x00000000UL
+    /* DOWNSPREAD                        [0:1]   RW value= 0x0 */
+    /* SSMD                              [1:5]   RW value= 0x0 */
+    /* FRACMOD                           [6:24]  RO */
+    /* RESERVE01                         [30:2]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_SSCG_REG_2)
+/*SSCG registers 2 */
+#define LIBERO_SETTING_SGMII_SSCG_REG_2    0x00000014UL
+    /* INTIN                             [0:12]  RW value= 0x14 */
+    /* INTMOD                            [12:12] RO */
+    /* RESERVE02                         [24:8]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_SSCG_REG_3)
+/*SSCG registers 3 */
+#define LIBERO_SETTING_SGMII_SSCG_REG_3    0x00000001UL
+    /* SSE_B                             [0:1]   RW value= 0x1 */
+    /* SEL_EXTWAVE                       [1:2]   RW value= 0x0 */
+    /* EXT_MAXADDR                       [3:8]   RW value= 0x0 */
+    /* TBLADDR                           [11:8]  RO */
+    /* RANDOM_FILTER                     [19:1]  RW value= 0x0 */
+    /* RANDOM_SEL                        [20:2]  RW value= 0x0 */
+    /* RESERVE03                         [22:1]  RSVD */
+    /* RESERVE04                         [23:9]  RSVD */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CLK_SGMII_PLL_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_sysreg.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_clk_sysreg.h
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_clk_sysreg.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CLK_SYSREG_H_
+#define HW_CLK_SYSREG_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_MSS_CLOCK_CONFIG_CR)
+/*Master clock config (00=/1 01=/2 10=/4 11=/8 ) */
+#define LIBERO_SETTING_MSS_CLOCK_CONFIG_CR    0x00000024UL
+    /* DIVIDER_CPU                       [0:2]   RW value= 0x0 */
+    /* DIVIDER_AXI                       [2:2]   RW value= 0x1 */
+    /* DIVIDER_APB_AHB                   [4:2]   RW value= 0x2 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_RTC_CLOCK_CR)
+/*RTC clock divider */
+#define LIBERO_SETTING_MSS_RTC_CLOCK_CR    0x0000007DUL
+    /* PERIOD                            [0:12]  RW value= 0x7D */
+#endif
+#if !defined (LIBERO_SETTING_MSS_ENVM_CR)
+/*ENVM AHB Controller setup - - Clock period = (Value+1) * (1000/AHBFREQMHZ)
+e.g. 7 will generate a 40ns period 25MHz clock if the AHB clock is 200MHz */
+#define LIBERO_SETTING_MSS_ENVM_CR    0x40050006UL
+    /* CLOCK_PERIOD                      [0:6]   RW value= 0x6 */
+    /* CLOCK_CONTINUOUS                  [8:1]   RW value= 0x0 */
+    /* CLOCK_SUPPRESS                    [9:1]   RW value= 0x0 */
+    /* READAHEAD                         [16:1]  RW value= 0x1 */
+    /* SLOWREAD                          [17:1]  RW value= 0x0 */
+    /* INTERRUPT_ENABLE                  [18:1]  RW value= 0x1 */
+    /* TIMER                             [24:8]  RW value= 0x40 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CLK_SYSREG_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/clocks/hw_mss_clks.h
+++ b/cpu/mpfs/include/fpga_design_config/clocks/hw_mss_clks.h
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mss_clks.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MSS_CLKS_H_
+#define HW_MSS_CLKS_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_MSS_EXT_SGMII_REF_CLK)
+/*Ref Clock rate in MHz */
+#define LIBERO_SETTING_MSS_EXT_SGMII_REF_CLK    125000000
+    /* MSS_EXT_SGMII_REF_CLK             [0:32]  RW value= 125000000 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_COREPLEX_CPU_CLK)
+/*CPU Clock rate in MHz */
+#define LIBERO_SETTING_MSS_COREPLEX_CPU_CLK    600000000
+    /* MSS_COREPLEX_CPU_CLK              [0:32]  RW value= 600000000 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_SYSTEM_CLK)
+/*System Clock rate in MHz static power. */
+#define LIBERO_SETTING_MSS_SYSTEM_CLK    600000000
+    /* MSS_SYSTEM_CLK                    [0:32]  RW value= 600000000 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_RTC_TOGGLE_CLK)
+/*RTC toggle Clock rate in MHz static power. */
+#define LIBERO_SETTING_MSS_RTC_TOGGLE_CLK    1000000
+    /* MSS_RTC_TOGGLE_CLK                [0:32]  RW value= 1000000 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_AXI_CLK)
+/*AXI Clock rate in MHz static power. */
+#define LIBERO_SETTING_MSS_AXI_CLK    300000000
+    /* MSS_AXI_CLK                       [0:32]  RW value= 300000000 */
+#endif
+#if !defined (LIBERO_SETTING_MSS_APB_AHB_CLK)
+/*AXI Clock rate in MHz static power. */
+#define LIBERO_SETTING_MSS_APB_AHB_CLK    150000000
+    /* MSS_APB_AHB_CLK                   [0:32]  RW value= 150000000 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MSS_CLKS_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_io_bank.h
+++ b/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_io_bank.h
@@ -1,0 +1,512 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_ddr_io_bank.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_DDR_IO_BANK_H_
+#define HW_DDR_IO_BANK_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_DPC_BITS)
+/*DPC Bits Register */
+#define LIBERO_SETTING_DPC_BITS    0x0004C422UL
+    /* DPC_VS                            [0:4]   RW value= 0x2 */
+    /* DPC_VRGEN_H                       [4:6]   RW value= 0x2 */
+    /* DPC_VRGEN_EN_H                    [10:1]  RW value= 0x1 */
+    /* DPC_MOVE_EN_H                     [11:1]  RW value= 0x0 */
+    /* DPC_VRGEN_V                       [12:6]  RW value= 0xC */
+    /* DPC_VRGEN_EN_V                    [18:1]  RW value= 0x1 */
+    /* DPC_MOVE_EN_V                     [19:1]  RW value= 0x0 */
+    /* RESERVE01                         [20:12] RSVD */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_DQ)
+/*Need to be set by software in all modes but OFF mode. Decoding options should
+follow ODT_STR table, depends on drive STR setting */
+#define LIBERO_SETTING_RPC_ODT_DQ    0x00000006UL
+    /* RPC_ODT_DQ                        [0:32]  RW value= 0x6 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_DQS)
+/*Need to be set by software in all modes but OFF mode. Decoding options should
+follow ODT_STR table, depends on drive STR setting */
+#define LIBERO_SETTING_RPC_ODT_DQS    0x00000006UL
+    /* RPC_ODT_DQS                       [0:32]  RW value= 0x6 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_ADDCMD)
+/*Need to be set by software in all modes but OFF mode. Decoding options should
+follow ODT_STR table, depends on drive STR setting */
+#define LIBERO_SETTING_RPC_ODT_ADDCMD    0x00000002UL
+    /* RPC_ODT_ADDCMD                    [0:32]  RW value= 0x2 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_CLK)
+/*Need to be set by software in all modes but OFF mode. Decoding options should
+follow ODT_STR table, depends on drive STR setting */
+#define LIBERO_SETTING_RPC_ODT_CLK    0x00000002UL
+    /* RPC_ODT_CLK                       [0:32]  RW value= 0x2 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_STATIC_DQ)
+/*0x2000 73A8 (rpc10_ODT) */
+#define LIBERO_SETTING_RPC_ODT_STATIC_DQ    0x00000005UL
+    /* RPC_ODT_STATIC_DQ                 [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_STATIC_DQS)
+/*0x2000 73AC (rpc11_ODT) */
+#define LIBERO_SETTING_RPC_ODT_STATIC_DQS    0x00000005UL
+    /* RPC_ODT_STATIC_DQS                [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_STATIC_ADDCMD)
+/*0x2000 739C (rpc7_ODT) */
+#define LIBERO_SETTING_RPC_ODT_STATIC_ADDCMD    0x00000007UL
+    /* RPC_ODT_STATIC_ADDCMD             [0:32]  RW value= 0x7 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_STATIC_CLKP)
+/*0x2000 73A4 (rpc9_ODT) */
+#define LIBERO_SETTING_RPC_ODT_STATIC_CLKP    0x00000007UL
+    /* RPC_ODT_STATIC_CLKP               [0:32]  RW value= 0x7 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_ODT_STATIC_CLKN)
+/*0x2000 73A0 (rpc8_ODT) */
+#define LIBERO_SETTING_RPC_ODT_STATIC_CLKN    0x00000007UL
+    /* RPC_ODT_STATIC_CLKN               [0:32]  RW value= 0x7 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_IBUFMD_ADDCMD)
+/*0x2000 757C (rpc95) */
+#define LIBERO_SETTING_RPC_IBUFMD_ADDCMD    0x00000003UL
+    /* RPC_IBUFMD_ADDCMD                 [0:32]  RW value= 0x3 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_IBUFMD_CLK)
+/*0x2000 7580 (rpc96) */
+#define LIBERO_SETTING_RPC_IBUFMD_CLK    0x00000004UL
+    /* RPC_IBUFMD_CLK                    [0:32]  RW value= 0x4 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_IBUFMD_DQ)
+/*0x2000 7584 (rpc97) */
+#define LIBERO_SETTING_RPC_IBUFMD_DQ    0x00000003UL
+    /* RPC_IBUFMD_DQ                     [0:32]  RW value= 0x3 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_IBUFMD_DQS)
+/*0x2000 7588 (rpc98) */
+#define LIBERO_SETTING_RPC_IBUFMD_DQS    0x00000004UL
+    /* RPC_IBUFMD_DQS                    [0:32]  RW value= 0x4 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_SPARE0_DQ)
+/*bits 15:14 connect to pc_ibufmx DQ/DQS/DM bits 13:12 connect to pc_ibufmx
+CA/CK Check at ioa pc bit */
+#define LIBERO_SETTING_RPC_SPARE0_DQ    0x00008000UL
+    /* RPC_SPARE0_DQ                     [0:32]  RW value= 0x8000 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_ADDCMD0_OVRT9)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_ADDCMD0_OVRT9    0x00000F00UL
+    /* MSS_DDR_CK0                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_CK_N0                     [1:1]   RW value= 0x0 */
+    /* MSS_DDR_A0                        [2:1]   RW value= 0x0 */
+    /* MSS_DDR_A1                        [3:1]   RW value= 0x0 */
+    /* MSS_DDR_A2                        [4:1]   RW value= 0x0 */
+    /* MSS_DDR_A3                        [5:1]   RW value= 0x0 */
+    /* MSS_DDR_A4                        [6:1]   RW value= 0x0 */
+    /* MSS_DDR_A5                        [7:1]   RW value= 0x0 */
+    /* MSS_DDR_A6                        [8:1]   RW value= 0x1 */
+    /* MSS_DDR_A7                        [9:1]   RW value= 0x1 */
+    /* MSS_DDR_A8                        [10:1]  RW value= 0x1 */
+    /* MSS_DDR_A9                        [11:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_ADDCMD1_OVRT10)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_ADDCMD1_OVRT10    0x00000FFFUL
+    /* MSS_DDR_CK1                       [0:1]   RW value= 0x1 */
+    /* MSS_DDR_CK_N1                     [1:1]   RW value= 0x1 */
+    /* MSS_DDR_A10                       [2:1]   RW value= 0x1 */
+    /* MSS_DDR_A11                       [3:1]   RW value= 0x1 */
+    /* MSS_DDR_A12                       [4:1]   RW value= 0x1 */
+    /* MSS_DDR_A13                       [5:1]   RW value= 0x1 */
+    /* MSS_DDR_A14                       [6:1]   RW value= 0x1 */
+    /* MSS_DDR_A15                       [7:1]   RW value= 0x1 */
+    /* MSS_DDR_A16                       [8:1]   RW value= 0x1 */
+    /* MSS_DDR3_WE_N                     [9:1]   RW value= 0x1 */
+    /* MSS_DDR_BA0                       [10:1]  RW value= 0x1 */
+    /* MSS_DDR_BA1                       [11:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_ADDCMD2_OVRT11)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_ADDCMD2_OVRT11    0x00000FE6UL
+    /* MSS_DDR_RAM_RST_N                 [0:1]   RW value= 0x0 */
+    /* MSS_DDR_BG0                       [1:1]   RW value= 0x1 */
+    /* MSS_DDR_BG1                       [2:1]   RW value= 0x1 */
+    /* MSS_DDR_CS0                       [3:1]   RW value= 0x0 */
+    /* MSS_DDR_CKE0                      [4:1]   RW value= 0x0 */
+    /* MSS_DDR_ODT0                      [5:1]   RW value= 0x1 */
+    /* MSS_DDR_CS1                       [6:1]   RW value= 0x1 */
+    /* MSS_DDR_CKE1                      [7:1]   RW value= 0x1 */
+    /* MSS_DDR_ODT1                      [8:1]   RW value= 0x1 */
+    /* MSS_DDR_ACT_N                     [9:1]   RW value= 0x1 */
+    /* MSS_DDR_PARITY                    [10:1]  RW value= 0x1 */
+    /* MSS_DDR_ALERT_N                   [11:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_DATA0_OVRT12)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_DATA0_OVRT12    0x00000000UL
+    /* MSS_DDR_DQ0                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ1                       [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ2                       [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ3                       [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P0                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N0                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ4                       [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ5                       [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ6                       [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ7                       [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM0                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_DATA1_OVRT13)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_DATA1_OVRT13    0x00000000UL
+    /* MSS_DDR_DQ8                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ9                       [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ10                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ11                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P1                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N1                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ12                      [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ13                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ14                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ15                      [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM1                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_DATA2_OVRT14)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_DATA2_OVRT14    0x00000000UL
+    /* MSS_DDR_DQ16                      [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ17                      [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ18                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ19                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P2                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N2                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ20                      [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ21                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ22                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ23                      [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM2                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_DATA3_OVRT15)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_DATA3_OVRT15    0x00000000UL
+    /* MSS_DDR_DQ24                      [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ25                      [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ26                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ27                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P3                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N3                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ28                      [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ29                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ30                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ31                      [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM3                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC_EN_ECC_OVRT16)
+/*Overrides the I/O, used to disable specific DDR I/0. Each bit corresponding
+to an IO in corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC_EN_ECC_OVRT16    0x0000007FUL
+    /* MSS_DDR_DQ32                      [0:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ33                      [1:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ34                      [2:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ35                      [3:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_P4                    [4:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_N4                    [5:1]   RW value= 0x1 */
+    /* MSS_DDR_DM4                       [6:1]   RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC235_WPD_ADD_CMD0)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC235_WPD_ADD_CMD0    0x00000000UL
+    /* MSS_DDR_CK0                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_CK_N0                     [1:1]   RW value= 0x0 */
+    /* MSS_DDR_A0                        [2:1]   RW value= 0x0 */
+    /* MSS_DDR_A1                        [3:1]   RW value= 0x0 */
+    /* MSS_DDR_A2                        [4:1]   RW value= 0x0 */
+    /* MSS_DDR_A3                        [5:1]   RW value= 0x0 */
+    /* MSS_DDR_A4                        [6:1]   RW value= 0x0 */
+    /* MSS_DDR_A5                        [7:1]   RW value= 0x0 */
+    /* MSS_DDR_A6                        [8:1]   RW value= 0x0 */
+    /* MSS_DDR_A7                        [9:1]   RW value= 0x0 */
+    /* MSS_DDR_A8                        [10:1]  RW value= 0x0 */
+    /* MSS_DDR_A9                        [11:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC236_WPD_ADD_CMD1)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC236_WPD_ADD_CMD1    0x00000000UL
+    /* MSS_DDR_CK1                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_CK_N1                     [1:1]   RW value= 0x0 */
+    /* MSS_DDR_A10                       [2:1]   RW value= 0x0 */
+    /* MSS_DDR_A11                       [3:1]   RW value= 0x0 */
+    /* MSS_DDR_A12                       [4:1]   RW value= 0x0 */
+    /* MSS_DDR_A13                       [5:1]   RW value= 0x0 */
+    /* MSS_DDR_A14                       [6:1]   RW value= 0x0 */
+    /* MSS_DDR_A15                       [7:1]   RW value= 0x0 */
+    /* MSS_DDR_A16                       [8:1]   RW value= 0x0 */
+    /* MSS_DDR3_WE_N                     [9:1]   RW value= 0x0 */
+    /* MSS_DDR_BA0                       [10:1]  RW value= 0x0 */
+    /* MSS_DDR_BA1                       [11:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC237_WPD_ADD_CMD2)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. Note: For LPDDR4 need
+to over-ride MSS_DDR_ODT0 and MSS_DDR_ODT1 and eanble PU i.e. (set OVR_EN ==1 ,
+wpu == 0 , wpd == 1 ) */
+#define LIBERO_SETTING_RPC237_WPD_ADD_CMD2    0x00000120UL
+    /* MSS_DDR_RAM_RST_N                 [0:1]   RW value= 0x0 */
+    /* MSS_DDR_BG0                       [1:1]   RW value= 0x0 */
+    /* MSS_DDR_BG1                       [2:1]   RW value= 0x0 */
+    /* MSS_DDR_CS0                       [3:1]   RW value= 0x0 */
+    /* MSS_DDR_CKE0                      [4:1]   RW value= 0x0 */
+    /* MSS_DDR_ODT0                      [5:1]   RW value= 0x1 */
+    /* MSS_DDR_CS1                       [6:1]   RW value= 0x0 */
+    /* MSS_DDR_CKE1                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_ODT1                      [8:1]   RW value= 0x1 */
+    /* MSS_DDR_ACT_N                     [9:1]   RW value= 0x0 */
+    /* MSS_DDR_PARITY                    [10:1]  RW value= 0x0 */
+    /* MSS_DDR_ALERT_N                   [11:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC238_WPD_DATA0)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC238_WPD_DATA0    0x00000000UL
+    /* MSS_DDR_DQ0                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ1                       [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ2                       [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ3                       [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P0                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N0                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ4                       [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ5                       [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ6                       [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ7                       [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM0                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC239_WPD_DATA1)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC239_WPD_DATA1    0x00000000UL
+    /* MSS_DDR_DQ8                       [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ9                       [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ10                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ11                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P1                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N1                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ12                      [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ13                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ14                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ15                      [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM1                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC240_WPD_DATA2)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC240_WPD_DATA2    0x00000000UL
+    /* MSS_DDR_DQ16                      [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ17                      [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ18                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ19                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P2                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N2                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ20                      [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ21                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ22                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ23                      [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM2                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC241_WPD_DATA3)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC241_WPD_DATA3    0x00000000UL
+    /* MSS_DDR_DQ24                      [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ25                      [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ26                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ27                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P3                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N3                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ28                      [6:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ29                      [7:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ30                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ31                      [9:1]   RW value= 0x0 */
+    /* MSS_DDR_DM3                       [10:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC242_WPD_ECC)
+/*Sets pull-downs when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC242_WPD_ECC    0x00000000UL
+    /* MSS_DDR_DQ32                      [0:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ33                      [1:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ34                      [2:1]   RW value= 0x0 */
+    /* MSS_DDR_DQ35                      [3:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_P4                    [4:1]   RW value= 0x0 */
+    /* MSS_DDR_DQS_N4                    [5:1]   RW value= 0x0 */
+    /* MSS_DDR_DM4                       [6:1]   RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RPC243_WPU_ADD_CMD0)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC243_WPU_ADD_CMD0    0x00000FFFUL
+    /* MSS_DDR_CK0                       [0:1]   RW value= 0x1 */
+    /* MSS_DDR_CK_N0                     [1:1]   RW value= 0x1 */
+    /* MSS_DDR_A0                        [2:1]   RW value= 0x1 */
+    /* MSS_DDR_A1                        [3:1]   RW value= 0x1 */
+    /* MSS_DDR_A2                        [4:1]   RW value= 0x1 */
+    /* MSS_DDR_A3                        [5:1]   RW value= 0x1 */
+    /* MSS_DDR_A4                        [6:1]   RW value= 0x1 */
+    /* MSS_DDR_A5                        [7:1]   RW value= 0x1 */
+    /* MSS_DDR_A6                        [8:1]   RW value= 0x1 */
+    /* MSS_DDR_A7                        [9:1]   RW value= 0x1 */
+    /* MSS_DDR_A8                        [10:1]  RW value= 0x1 */
+    /* MSS_DDR_A9                        [11:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC244_WPU_ADD_CMD1)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC244_WPU_ADD_CMD1    0x00000FFFUL
+    /* MSS_DDR_CK1                       [0:1]   RW value= 0x1 */
+    /* MSS_DDR_CK_N1                     [1:1]   RW value= 0x1 */
+    /* MSS_DDR_A10                       [2:1]   RW value= 0x1 */
+    /* MSS_DDR_A11                       [3:1]   RW value= 0x1 */
+    /* MSS_DDR_A12                       [4:1]   RW value= 0x1 */
+    /* MSS_DDR_A13                       [5:1]   RW value= 0x1 */
+    /* MSS_DDR_A14                       [6:1]   RW value= 0x1 */
+    /* MSS_DDR_A15                       [7:1]   RW value= 0x1 */
+    /* MSS_DDR_A16                       [8:1]   RW value= 0x1 */
+    /* MSS_DDR3_WE_N                     [9:1]   RW value= 0x1 */
+    /* MSS_DDR_BA0                       [10:1]  RW value= 0x1 */
+    /* MSS_DDR_BA1                       [11:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC245_WPU_ADD_CMD2)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC245_WPU_ADD_CMD2    0x00000EDFUL
+    /* MSS_DDR_RAM_RST_N                 [0:1]   RW value= 0x1 */
+    /* MSS_DDR_BG0                       [1:1]   RW value= 0x1 */
+    /* MSS_DDR_BG1                       [2:1]   RW value= 0x1 */
+    /* MSS_DDR_CS0                       [3:1]   RW value= 0x1 */
+    /* MSS_DDR_CKE0                      [4:1]   RW value= 0x1 */
+    /* MSS_DDR_ODT0                      [5:1]   RW value= 0x0 */
+    /* MSS_DDR_CS1                       [6:1]   RW value= 0x1 */
+    /* MSS_DDR_CKE1                      [7:1]   RW value= 0x1 */
+    /* MSS_DDR_ODT1                      [8:1]   RW value= 0x0 */
+    /* MSS_DDR_ACT_N                     [9:1]   RW value= 0x1 */
+    /* MSS_DDR_PARITY                    [10:1]  RW value= 0x1 */
+    /* MSS_DDR_ALERT_N                   [11:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC246_WPU_DATA0)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC246_WPU_DATA0    0x000007FFUL
+    /* MSS_DDR_DQ0                       [0:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ1                       [1:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ2                       [2:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ3                       [3:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_P0                    [4:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_N0                    [5:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ4                       [6:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ5                       [7:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ6                       [8:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ7                       [9:1]   RW value= 0x1 */
+    /* MSS_DDR_DM0                       [10:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC247_WPU_DATA1)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC247_WPU_DATA1    0x000007FFUL
+    /* MSS_DDR_DQ8                       [0:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ9                       [1:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ10                      [2:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ11                      [3:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_P1                    [4:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_N1                    [5:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ12                      [6:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ13                      [7:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ14                      [8:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ15                      [9:1]   RW value= 0x1 */
+    /* MSS_DDR_DM1                       [10:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC248_WPU_DATA2)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC248_WPU_DATA2    0x000007FFUL
+    /* MSS_DDR_DQ16                      [0:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ17                      [1:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ18                      [2:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ19                      [3:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_P2                    [4:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_N2                    [5:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ20                      [6:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ21                      [7:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ22                      [8:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ23                      [9:1]   RW value= 0x1 */
+    /* MSS_DDR_DM2                       [10:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC249_WPU_DATA3)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC249_WPU_DATA3    0x000007FFUL
+    /* MSS_DDR_DQ24                      [0:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ25                      [1:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ26                      [2:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ27                      [3:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_P3                    [4:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_N3                    [5:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ28                      [6:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ29                      [7:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ30                      [8:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ31                      [9:1]   RW value= 0x1 */
+    /* MSS_DDR_DM3                       [10:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_RPC250_WPU_ECC)
+/*Sets pull-ups when override enabled. Each bit corresponding to an IO in
+corresponding IOG lane, starting from p_pair0 to n_pair5. */
+#define LIBERO_SETTING_RPC250_WPU_ECC    0x0000007FUL
+    /* MSS_DDR_DQ32                      [0:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ33                      [1:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ34                      [2:1]   RW value= 0x1 */
+    /* MSS_DDR_DQ35                      [3:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_P4                    [4:1]   RW value= 0x1 */
+    /* MSS_DDR_DQS_N4                    [5:1]   RW value= 0x1 */
+    /* MSS_DDR_DM4                       [6:1]   RW value= 0x1 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_DDR_IO_BANK_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_mode.h
+++ b/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_mode.h
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_ddr_mode.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_DDR_MODE_H_
+#define HW_DDR_MODE_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_DDRPHY_MODE)
+/*DDRPHY MODE (binary)- 000 ddr3, 001 ddr33L, 010 ddr4, 011 LPDDR3, 100 LPDDR4,
+111 OFF_MODE */
+#define LIBERO_SETTING_DDRPHY_MODE    0x00014B24UL
+    /* DDRMODE                           [0:3]   RW value= 0x4 */
+    /* ECC                               [3:1]   RW value= 0x0 */
+    /* CRC                               [4:1]   RW value= 0x0 */
+    /* BUS_WIDTH                         [5:3]   RW value= 0x1 */
+    /* DMI_DBI                           [8:1]   RW value= 0x1 */
+    /* DQ_DRIVE                          [9:2]   RW value= 0x1 */
+    /* DQS_DRIVE                         [11:2]  RW value= 0x1 */
+    /* ADD_CMD_DRIVE                     [13:2]  RW value= 0x2 */
+    /* CLOCK_OUT_DRIVE                   [15:2]  RW value= 0x2 */
+    /* DQ_TERMINATION                    [17:2]  RW value= 0x0 */
+    /* DQS_TERMINATION                   [19:2]  RW value= 0x0 */
+    /* ADD_CMD_INPUT_PIN_TERMINATION     [21:2]  RW value= 0x0 */
+    /* PRESET_ODT_CLK                    [23:2]  RW value= 0x0 */
+    /* POWER_DOWN                        [25:1]  RW value= 0x0 */
+    /* RANK                              [26:1]  RW value= 0x0 */
+    /* RESERVED                          [27:5]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DATA_LANES_USED)
+/*number of lanes used for data- does not include ECC, infer from mode register
+*/
+#define LIBERO_SETTING_DATA_LANES_USED    0x00000004UL
+    /* DATA_LANES                        [0:3]   RW value= 0x4 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_DDR_MODE_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_off_mode.h
+++ b/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_off_mode.h
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_ddr_off_mode.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_DDR_OFF_MODE_H_
+#define HW_DDR_OFF_MODE_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_DDRPHY_MODE_OFF)
+/*DDRPHY MODE Register, ddr off */
+#define LIBERO_SETTING_DDRPHY_MODE_OFF    0x00000000UL
+    /* DDRMODE                           [0:3]   RW value= 0x0 */
+    /* ECC                               [3:1]   RW value= 0x0 */
+    /* CRC                               [4:1]   RW value= 0x0 */
+    /* BUS_WIDTH                         [5:3]   RW value= 0x0 */
+    /* DMI_DBI                           [8:1]   RW value= 0x0 */
+    /* DQ_DRIVE                          [9:2]   RW value= 0x0 */
+    /* DQS_DRIVE                         [11:2]  RW value= 0x0 */
+    /* ADD_CMD_DRIVE                     [13:2]  RW value= 0x0 */
+    /* CLOCK_OUT_DRIVE                   [15:2]  RW value= 0x0 */
+    /* DQ_TERMINATION                    [17:2]  RW value= 0x0 */
+    /* DQS_TERMINATION                   [19:2]  RW value= 0x0 */
+    /* ADD_CMD_INPUT_PIN_TERMINATION     [21:2]  RW value= 0x0 */
+    /* PRESET_ODT_CLK                    [23:2]  RW value= 0x0 */
+    /* POWER_DOWN                        [25:1]  RW value= 0x0 */
+    /* RANK                              [26:1]  RW value= 0x0 */
+    /* RESERVED                          [27:5]  RSVD */
+#endif
+#if !defined (LIBERO_SETTING_DPC_BITS_OFF_MODE)
+/*DPC Bits Register off mode */
+#define LIBERO_SETTING_DPC_BITS_OFF_MODE    0x00000000UL
+    /* DPC_VS                            [0:4]   RW value= 0x0 */
+    /* DPC_VRGEN_H                       [4:6]   RW value= 0x0 */
+    /* DPC_VRGEN_EN_H                    [10:1]  RW value= 0x0 */
+    /* DPC_MOVE_EN_H                     [11:1]  RW value= 0x0 */
+    /* DPC_VRGEN_V                       [12:6]  RW value= 0x0 */
+    /* DPC_VRGEN_EN_V                    [18:1]  RW value= 0x0 */
+    /* DPC_MOVE_EN_V                     [19:1]  RW value= 0x0 */
+    /* RESERVE01                         [20:12] RSVD */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_DDR_OFF_MODE_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_options.h
+++ b/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_options.h
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_ddr_options.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_DDR_OPTIONS_H_
+#define HW_DDR_OPTIONS_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_CA_BUS_RX_OFF_POST_TRAINING)
+/*Tip config: Referenced receivers in the CA bus are turned on for CA training.
+These burn static power.(0x01 => turn off ; 0x00 => no action ) */
+#define LIBERO_SETTING_CA_BUS_RX_OFF_POST_TRAINING    0x00000001UL
+    /* CA_BUS_RX_OFF_POST_TRAINING       [0:1]   RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_USER_INPUT_PHY_RANKS_TO_TRAIN)
+/*Tip config: 1 => 1 rank, 3 => 2 ranks */
+#define LIBERO_SETTING_USER_INPUT_PHY_RANKS_TO_TRAIN    0x00000001UL
+    /* USER_INPUT_PHY_RANKS_TO_TRAIN     [0:2]   RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_TRAINING_SKIP_SETTING)
+/*Tip config: Pick what trainings we want performed by the TIP, default is 0x1F
+*/
+#define LIBERO_SETTING_TRAINING_SKIP_SETTING    0x00000002UL
+    /* SKIP_BCLKSCLK_TIP_TRAINING        [0:1]   RW value= 0x0 */
+    /* SKIP_ADDCMD_TIP_TRAINING          [1:1]   RW value= 0x1 */
+    /* SKIP_WRLVL_TIP_TRAINING           [2:1]   RW value= 0x0 */
+    /* SKIP_RDGATE_TIP_TRAINING          [3:1]   RW value= 0x0 */
+    /* SKIP_DQ_DQS_OPT_TIP_TRAINING      [4:1]   RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_TIP_CFG_PARAMS)
+/*Tip config: default: 0x2,0x4,0x0,0x1F,0x1F */
+#define LIBERO_SETTING_TIP_CFG_PARAMS    0x07CFE02AUL
+    /* ADDCMD_OFFSET                     [0:3]   RW value= 0x2 */
+    /* BCKLSCLK_OFFSET                   [3:3]   RW value= 0x5 */
+    /* WRCALIB_WRITE_COUNT               [6:7]   RW value= 0x0 */
+    /* READ_GATE_MIN_READS               [13:8]  RW value= 0x7F */
+    /* ADDRCMD_WAIT_COUNT                [22:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_TIP_CONFIG_PARAMS_BCLK_VCOPHS_OFFSET)
+/*in simulation we need to set this to 2, for hardware it will be dependent on
+the trace lengths */
+#define LIBERO_SETTING_TIP_CONFIG_PARAMS_BCLK_VCOPHS_OFFSET    0x00000002UL
+    /* TIP_CONFIG_PARAMS_BCLK_VCOPHS     [0:32]  RW value= 0x02 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_DDR_OPTIONS_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_segs.h
+++ b/cpu/mpfs/include/fpga_design_config/ddr/hw_ddr_segs.h
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_ddr_segs.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_DDR_SEGS_H_
+#define HW_DDR_SEGS_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_SEG0_0)
+/*Cached access at 0x00_8000_0000 (-0x80+0x00) */
+#define LIBERO_SETTING_SEG0_0    0x80007F80UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x7F80 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_1)
+/*Cached access at 0x10_0000_000 */
+#define LIBERO_SETTING_SEG0_1    0x80007030UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x7030 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_2)
+/*not used */
+#define LIBERO_SETTING_SEG0_2    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_3)
+/*not used */
+#define LIBERO_SETTING_SEG0_3    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_4)
+/*not used */
+#define LIBERO_SETTING_SEG0_4    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_5)
+/*not used */
+#define LIBERO_SETTING_SEG0_5    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:6]  RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_6)
+/*not used */
+#define LIBERO_SETTING_SEG0_6    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG0_7)
+/*not used */
+#define LIBERO_SETTING_SEG0_7    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_0)
+/*not used */
+#define LIBERO_SETTING_SEG1_0    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_1)
+/*not used */
+#define LIBERO_SETTING_SEG1_1    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_2)
+/*Non-Cached access at 0x00_c000_0000 */
+#define LIBERO_SETTING_SEG1_2    0x80007FB0UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x7FB0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_3)
+/*Non-Cached access at 0x14_0000_0000 */
+#define LIBERO_SETTING_SEG1_3    0x80000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_4)
+/*Non-Cached WCB access at 0x00_d000_0000 */
+#define LIBERO_SETTING_SEG1_4    0x80007FA0UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x7FA0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_5)
+/*Non-Cached WCB 0x18_0000_0000 */
+#define LIBERO_SETTING_SEG1_5    0x80000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:6]  RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_6)
+/*Trace - Trace not in use here so can be left as 0 */
+#define LIBERO_SETTING_SEG1_6    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SEG1_7)
+/*not used */
+#define LIBERO_SETTING_SEG1_7    0x00000000UL
+    /* ADDRESS_OFFSET                    [0:15]  RW value= 0x0 */
+    /* RESERVED                          [15:16] RW value= 0x0 */
+    /* LOCKED                            [31:1]  RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_DDR_SEGS_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/ddr/hw_ddrc.h
+++ b/cpu/mpfs/include/fpga_design_config/ddr/hw_ddrc.h
@@ -1,0 +1,1887 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_ddrc.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_DDRC_H_
+#define HW_DDRC_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_CFG_MANUAL_ADDRESS_MAP)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_MANUAL_ADDRESS_MAP    0x00000000UL
+    /* CFG_MANUAL_ADDRESS_MAP            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CHIPADDR_MAP)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_CHIPADDR_MAP    0x0000001DUL
+    /* CFG_CHIPADDR_MAP                  [0:32]  RW value= 0x00001D */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CIDADDR_MAP)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_CIDADDR_MAP    0x00000000UL
+    /* CFG_CIDADDR_MAP                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MB_AUTOPCH_COL_BIT_POS_LOW)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_MB_AUTOPCH_COL_BIT_POS_LOW    0x00000004UL
+    /* CFG_MB_AUTOPCH_COL_BIT_POS_LOW    [0:32]  RW value= 0x00000004 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MB_AUTOPCH_COL_BIT_POS_HIGH)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_MB_AUTOPCH_COL_BIT_POS_HIGH    0x0000000AUL
+    /* CFG_MB_AUTOPCH_COL_BIT_POS_HIGH        [0:32]  RW value= 0x0000000A */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BANKADDR_MAP_0)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_BANKADDR_MAP_0    0x0000C2CAUL
+    /* CFG_BANKADDR_MAP_0                [0:32]  RW value= 0x00C2CA */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BANKADDR_MAP_1)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_BANKADDR_MAP_1    0x00000000UL
+    /* CFG_BANKADDR_MAP_1                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ROWADDR_MAP_0)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_ROWADDR_MAP_0    0x9140F38DUL
+    /* CFG_ROWADDR_MAP_0                 [0:32]  RW value= 0x9140F38D */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ROWADDR_MAP_1)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_ROWADDR_MAP_1    0x75955134UL
+    /* CFG_ROWADDR_MAP_1                 [0:32]  RW value= 0x75955134 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ROWADDR_MAP_2)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_ROWADDR_MAP_2    0x71B69961UL
+    /* CFG_ROWADDR_MAP_2                 [0:32]  RW value= 0x71B69961 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ROWADDR_MAP_3)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_ROWADDR_MAP_3    0x00000000UL
+    /* CFG_ROWADDR_MAP_3                 [0:32]  RW value= 0x000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_COLADDR_MAP_0)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_COLADDR_MAP_0    0x440C2040UL
+    /* CFG_COLADDR_MAP_0                 [0:32]  RW value= 0x440C2040 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_COLADDR_MAP_1)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_COLADDR_MAP_1    0x02481C61UL
+    /* CFG_COLADDR_MAP_1                 [0:32]  RW value= 0x02481C61 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_COLADDR_MAP_2)
+/*IP Blk = ADDR_MAP Access=RW */
+#define LIBERO_SETTING_CFG_COLADDR_MAP_2    0x00000000UL
+    /* CFG_COLADDR_MAP_2                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_VRCG_ENABLE)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_VRCG_ENABLE    0x00000140UL
+    /* CFG_VRCG_ENABLE                   [0:32]  RW value= 0x00000140 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_VRCG_DISABLE)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_VRCG_DISABLE    0x000000A0UL
+    /* CFG_VRCG_DISABLE                  [0:32]  RW value= 0x000000A0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_LATENCY_SET)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_LATENCY_SET    0x00000000UL
+    /* CFG_WRITE_LATENCY_SET             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_THERMAL_OFFSET)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_THERMAL_OFFSET    0x00000000UL
+    /* CFG_THERMAL_OFFSET                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_SOC_ODT)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_SOC_ODT    0x00000006UL
+    /* CFG_SOC_ODT                       [0:32]  RW value= 0x6 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODTE_CK)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_ODTE_CK    0x00000000UL
+    /* CFG_ODTE_CK                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODTE_CS)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_ODTE_CS    0x00000000UL
+    /* CFG_ODTE_CS                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODTD_CA)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_ODTD_CA    0x00000000UL
+    /* CFG_ODTD_CA                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_LPDDR4_FSP_OP)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_LPDDR4_FSP_OP    0x00000001UL
+    /* CFG_LPDDR4_FSP_OP                 [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_GENERATE_REFRESH_ON_SRX)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_GENERATE_REFRESH_ON_SRX    0x00000001UL
+    /* CFG_GENERATE_REFRESH_ON_SRX       [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DBI_CL)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_DBI_CL    0x00000016UL
+    /* CFG_DBI_CL                        [0:32]  RW value= 0x00000016 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_NON_DBI_CL)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_CFG_NON_DBI_CL    0x00000016UL
+    /* CFG_NON_DBI_CL                    [0:32]  RW value= 0x00000016 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_FORCE_WRITE_DATA_0)
+/*IP Blk = MC_BASE3 Access=RW */
+#define LIBERO_SETTING_INIT_FORCE_WRITE_DATA_0    0x00000000UL
+    /* INIT_FORCE_WRITE_DATA_0           [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_CRC)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_CRC    0x00000000UL
+    /* CFG_WRITE_CRC                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MPR_READ_FORMAT)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_MPR_READ_FORMAT    0x00000000UL
+    /* CFG_MPR_READ_FORMAT               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WR_CMD_LAT_CRC_DM)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WR_CMD_LAT_CRC_DM    0x00000000UL
+    /* CFG_WR_CMD_LAT_CRC_DM             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_FINE_GRAN_REF_MODE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_FINE_GRAN_REF_MODE    0x00000000UL
+    /* CFG_FINE_GRAN_REF_MODE            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TEMP_SENSOR_READOUT)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_TEMP_SENSOR_READOUT    0x00000000UL
+    /* CFG_TEMP_SENSOR_READOUT           [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PER_DRAM_ADDR_EN)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_PER_DRAM_ADDR_EN    0x00000000UL
+    /* CFG_PER_DRAM_ADDR_EN              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_GEARDOWN_MODE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_GEARDOWN_MODE    0x00000000UL
+    /* CFG_GEARDOWN_MODE                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WR_PREAMBLE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WR_PREAMBLE    0x00000001UL
+    /* CFG_WR_PREAMBLE                   [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RD_PREAMBLE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RD_PREAMBLE    0x00000000UL
+    /* CFG_RD_PREAMBLE                   [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RD_PREAMB_TRN_MODE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RD_PREAMB_TRN_MODE    0x00000000UL
+    /* CFG_RD_PREAMB_TRN_MODE            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_SR_ABORT)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_SR_ABORT    0x00000000UL
+    /* CFG_SR_ABORT                      [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CS_TO_CMDADDR_LATENCY)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CS_TO_CMDADDR_LATENCY    0x00000000UL
+    /* CFG_CS_TO_CMDADDR_LATENCY         [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_INT_VREF_MON)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_INT_VREF_MON    0x00000000UL
+    /* CFG_INT_VREF_MON                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TEMP_CTRL_REF_MODE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_TEMP_CTRL_REF_MODE    0x00000000UL
+    /* CFG_TEMP_CTRL_REF_MODE            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TEMP_CTRL_REF_RANGE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_TEMP_CTRL_REF_RANGE    0x00000000UL
+    /* CFG_TEMP_CTRL_REF_RANGE           [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MAX_PWR_DOWN_MODE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_MAX_PWR_DOWN_MODE    0x00000000UL
+    /* CFG_MAX_PWR_DOWN_MODE             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_READ_DBI)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_READ_DBI    0x00000000UL
+    /* CFG_READ_DBI                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_DBI)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_DBI    0x00000000UL
+    /* CFG_WRITE_DBI                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DATA_MASK)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_DATA_MASK    0x00000001UL
+    /* CFG_DATA_MASK                     [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CA_PARITY_PERSIST_ERR)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CA_PARITY_PERSIST_ERR    0x00000000UL
+    /* CFG_CA_PARITY_PERSIST_ERR         [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RTT_PARK)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RTT_PARK    0x00000000UL
+    /* CFG_RTT_PARK                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_INBUF_4_PD)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_INBUF_4_PD    0x00000000UL
+    /* CFG_ODT_INBUF_4_PD                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CA_PARITY_ERR_STATUS)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CA_PARITY_ERR_STATUS    0x00000000UL
+    /* CFG_CA_PARITY_ERR_STATUS          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CRC_ERROR_CLEAR)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CRC_ERROR_CLEAR    0x00000000UL
+    /* CFG_CRC_ERROR_CLEAR               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CA_PARITY_LATENCY)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CA_PARITY_LATENCY    0x00000000UL
+    /* CFG_CA_PARITY_LATENCY             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CCD_S)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CCD_S    0x00000005UL
+    /* CFG_CCD_S                         [0:32]  RW value= 0x00000005 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CCD_L)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_CCD_L    0x00000006UL
+    /* CFG_CCD_L                         [0:32]  RW value= 0x00000006 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_VREFDQ_TRN_ENABLE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_VREFDQ_TRN_ENABLE    0x00000000UL
+    /* CFG_VREFDQ_TRN_ENABLE             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_VREFDQ_TRN_RANGE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_VREFDQ_TRN_RANGE    0x00000000UL
+    /* CFG_VREFDQ_TRN_RANGE              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_VREFDQ_TRN_VALUE)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_VREFDQ_TRN_VALUE    0x00000000UL
+    /* CFG_VREFDQ_TRN_VALUE              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RRD_S)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RRD_S    0x00000004UL
+    /* CFG_RRD_S                         [0:32]  RW value= 0x00000004 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RRD_L)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RRD_L    0x00000003UL
+    /* CFG_RRD_L                         [0:32]  RW value= 0x00000003 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WTR_S)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WTR_S    0x00000003UL
+    /* CFG_WTR_S                         [0:32]  RW value= 0x00000003 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WTR_L)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WTR_L    0x00000003UL
+    /* CFG_WTR_L                         [0:32]  RW value= 0x00000003 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WTR_S_CRC_DM)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WTR_S_CRC_DM    0x00000003UL
+    /* CFG_WTR_S_CRC_DM                  [0:32]  RW value= 0x00000003 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WTR_L_CRC_DM)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WTR_L_CRC_DM    0x00000003UL
+    /* CFG_WTR_L_CRC_DM                  [0:32]  RW value= 0x00000003 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WR_CRC_DM)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_WR_CRC_DM    0x00000006UL
+    /* CFG_WR_CRC_DM                     [0:32]  RW value= 0x00000006 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RFC1    0x00000036UL
+    /* CFG_RFC1                          [0:32]  RW value= 0x00000036 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC2)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RFC2    0x00000036UL
+    /* CFG_RFC2                          [0:32]  RW value= 0x00000036 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC4)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RFC4    0x00000036UL
+    /* CFG_RFC4                          [0:32]  RW value= 0x00000036 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_NIBBLE_DEVICES)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_NIBBLE_DEVICES    0x00000000UL
+    /* CFG_NIBBLE_DEVICES                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS0_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS0_0    0x81881881UL
+    /* CFG_BIT_MAP_INDEX_CS0_0           [0:32]  RW value= 0x81881881 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS0_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS0_1    0x00008818UL
+    /* CFG_BIT_MAP_INDEX_CS0_1           [0:32]  RW value= 0x00008818 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS1_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS1_0    0xA92A92A9UL
+    /* CFG_BIT_MAP_INDEX_CS1_0           [0:32]  RW value= 0xa92a92a9 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS1_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS1_1    0x00002A92UL
+    /* CFG_BIT_MAP_INDEX_CS1_1           [0:32]  RW value= 0x00002a92 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS2_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS2_0    0xC28C28C2UL
+    /* CFG_BIT_MAP_INDEX_CS2_0           [0:32]  RW value= 0xc28c28c2 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS2_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS2_1    0x00008C28UL
+    /* CFG_BIT_MAP_INDEX_CS2_1           [0:32]  RW value= 0x00008c28 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS3_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS3_0    0xEA2EA2EAUL
+    /* CFG_BIT_MAP_INDEX_CS3_0           [0:32]  RW value= 0xea2ea2ea */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS3_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS3_1    0x00002EA2UL
+    /* CFG_BIT_MAP_INDEX_CS3_1           [0:32]  RW value= 0x00002ea2 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS4_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS4_0    0x03903903UL
+    /* CFG_BIT_MAP_INDEX_CS4_0           [0:32]  RW value= 0x03903903 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS4_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS4_1    0x00009039UL
+    /* CFG_BIT_MAP_INDEX_CS4_1           [0:32]  RW value= 0x00009039 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS5_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS5_0    0x2B32B32BUL
+    /* CFG_BIT_MAP_INDEX_CS5_0           [0:32]  RW value= 0x2b32b32b */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS5_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS5_1    0x000032B3UL
+    /* CFG_BIT_MAP_INDEX_CS5_1           [0:32]  RW value= 0x000032b3 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS6_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS6_0    0x44944944UL
+    /* CFG_BIT_MAP_INDEX_CS6_0           [0:32]  RW value= 0x44944944 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS6_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS6_1    0x00009449UL
+    /* CFG_BIT_MAP_INDEX_CS6_1           [0:32]  RW value= 0x00009449 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS7_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS7_0    0x6C36C36CUL
+    /* CFG_BIT_MAP_INDEX_CS7_0           [0:32]  RW value= 0x6c36c36c */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS7_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS7_1    0x000036C3UL
+    /* CFG_BIT_MAP_INDEX_CS7_1           [0:32]  RW value= 0x000036c3 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS8_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS8_0    0x85985985UL
+    /* CFG_BIT_MAP_INDEX_CS8_0           [0:32]  RW value= 0x85985985 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS8_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS8_1    0x00009859UL
+    /* CFG_BIT_MAP_INDEX_CS8_1           [0:32]  RW value= 0x00009859 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS9_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS9_0    0xAD3AD3ADUL
+    /* CFG_BIT_MAP_INDEX_CS9_0           [0:32]  RW value= 0xad3ad3ad */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS9_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS9_1    0x00003AD3UL
+    /* CFG_BIT_MAP_INDEX_CS9_1           [0:32]  RW value= 0x00003ad3 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS10_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS10_0    0xC69C69C6UL
+    /* CFG_BIT_MAP_INDEX_CS10_0          [0:32]  RW value= 0xc69c69c6 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS10_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS10_1    0x00009C69UL
+    /* CFG_BIT_MAP_INDEX_CS10_1          [0:32]  RW value= 0x00009c69 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS11_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS11_0    0xEE3EE3EEUL
+    /* CFG_BIT_MAP_INDEX_CS11_0          [0:32]  RW value= 0xee3ee3ee */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS11_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS11_1    0x00003EE3UL
+    /* CFG_BIT_MAP_INDEX_CS11_1          [0:32]  RW value= 0x00003ee3 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS12_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS12_0    0x07A07A07UL
+    /* CFG_BIT_MAP_INDEX_CS12_0          [0:32]  RW value= 0x07a07a07 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS12_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS12_1    0x0000A07AUL
+    /* CFG_BIT_MAP_INDEX_CS12_1          [0:32]  RW value= 0x0000a07a */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS13_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS13_0    0x2F42F42FUL
+    /* CFG_BIT_MAP_INDEX_CS13_0          [0:32]  RW value= 0x2f42f42f */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS13_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS13_1    0x000042F4UL
+    /* CFG_BIT_MAP_INDEX_CS13_1          [0:32]  RW value= 0x000042f4 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS14_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS14_0    0x48A48A48UL
+    /* CFG_BIT_MAP_INDEX_CS14_0          [0:32]  RW value= 0x48a48a48 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS14_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS14_1    0x0000A48AUL
+    /* CFG_BIT_MAP_INDEX_CS14_1          [0:32]  RW value= 0x0000a48a */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS15_0)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS15_0    0x70470470UL
+    /* CFG_BIT_MAP_INDEX_CS15_0          [0:32]  RW value= 0x70470470 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS15_1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_BIT_MAP_INDEX_CS15_1    0x00004704UL
+    /* CFG_BIT_MAP_INDEX_CS15_1          [0:32]  RW value= 0x00004704 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_NUM_LOGICAL_RANKS_PER_3DS)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_NUM_LOGICAL_RANKS_PER_3DS    0x00000000UL
+    /* CFG_NUM_LOGICAL_RANKS_PER_3DS     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC_DLR1)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RFC_DLR1    0x00000048UL
+    /* CFG_RFC_DLR1                      [0:32]  RW value= 0x00000048 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC_DLR2)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RFC_DLR2    0x0000002CUL
+    /* CFG_RFC_DLR2                      [0:32]  RW value= 0x0000002C */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC_DLR4)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RFC_DLR4    0x00000020UL
+    /* CFG_RFC_DLR4                      [0:32]  RW value= 0x00000020 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RRD_DLR)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_RRD_DLR    0x00000004UL
+    /* CFG_RRD_DLR                       [0:32]  RW value= 0x00000004 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_FAW_DLR)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_FAW_DLR    0x00000010UL
+    /* CFG_FAW_DLR                       [0:32]  RW value= 0x00000010 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ADVANCE_ACTIVATE_READY)
+/*IP Blk = MC_BASE1 Access=RW */
+#define LIBERO_SETTING_CFG_ADVANCE_ACTIVATE_READY    0x00000000UL
+    /* CFG_ADVANCE_ACTIVATE_READY        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CTRLR_SOFT_RESET_N)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CTRLR_SOFT_RESET_N    0x00000001UL
+    /* CTRLR_SOFT_RESET_N                [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_LOOKAHEAD_PCH)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_LOOKAHEAD_PCH    0x00000000UL
+    /* CFG_LOOKAHEAD_PCH                 [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_LOOKAHEAD_ACT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_LOOKAHEAD_ACT    0x00000000UL
+    /* CFG_LOOKAHEAD_ACT                 [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_AUTOINIT_DISABLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_AUTOINIT_DISABLE    0x00000000UL
+    /* INIT_AUTOINIT_DISABLE             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_FORCE_RESET)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_FORCE_RESET    0x00000000UL
+    /* INIT_FORCE_RESET                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_GEARDOWN_EN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_GEARDOWN_EN    0x00000000UL
+    /* INIT_GEARDOWN_EN                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_DISABLE_CKE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_DISABLE_CKE    0x00000000UL
+    /* INIT_DISABLE_CKE                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_CS    0x00000000UL
+    /* INIT_CS                           [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_PRECHARGE_ALL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_PRECHARGE_ALL    0x00000000UL
+    /* INIT_PRECHARGE_ALL                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_REFRESH)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_REFRESH    0x00000000UL
+    /* INIT_REFRESH                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_ZQ_CAL_REQ)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_ZQ_CAL_REQ    0x00000000UL
+    /* INIT_ZQ_CAL_REQ                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_BL    0x00000000UL
+    /* CFG_BL                            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CTRLR_INIT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CTRLR_INIT    0x00000000UL
+    /* CTRLR_INIT                        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AUTO_REF_EN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_AUTO_REF_EN    0x00000001UL
+    /* CFG_AUTO_REF_EN                   [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RAS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RAS    0x00000022UL
+    /* CFG_RAS                           [0:32]  RW value= 0x22 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RCD)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RCD    0x0000000FUL
+    /* CFG_RCD                           [0:32]  RW value= 0xF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RRD)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RRD    0x00000008UL
+    /* CFG_RRD                           [0:32]  RW value= 0x8 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RP)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RP    0x00000011UL
+    /* CFG_RP                            [0:32]  RW value= 0x11 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RC)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RC    0x00000033UL
+    /* CFG_RC                            [0:32]  RW value= 0x33 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_FAW)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_FAW    0x00000020UL
+    /* CFG_FAW                           [0:32]  RW value= 0x20 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RFC)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RFC    0x00000130UL
+    /* CFG_RFC                           [0:32]  RW value= 0x130 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RTP)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RTP    0x00000008UL
+    /* CFG_RTP                           [0:32]  RW value= 0x8 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WR    0x00000010UL
+    /* CFG_WR                            [0:32]  RW value= 0x10 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WTR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WTR    0x00000008UL
+    /* CFG_WTR                           [0:32]  RW value= 0x8 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PASR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_PASR    0x00000000UL
+    /* CFG_PASR                          [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_XP)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_XP    0x00000006UL
+    /* CFG_XP                            [0:32]  RW value= 0x6 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_XSR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_XSR    0x0000001FUL
+    /* CFG_XSR                           [0:32]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CL    0x00000005UL
+    /* CFG_CL                            [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_READ_TO_WRITE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_READ_TO_WRITE    0x0000000FUL
+    /* CFG_READ_TO_WRITE                 [0:32]  RW value= 0xF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_TO_WRITE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_TO_WRITE    0x0000000FUL
+    /* CFG_WRITE_TO_WRITE                [0:32]  RW value= 0xF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_READ_TO_READ)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_READ_TO_READ    0x0000000FUL
+    /* CFG_READ_TO_READ                  [0:32]  RW value= 0xF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_TO_READ)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_TO_READ    0x0000001FUL
+    /* CFG_WRITE_TO_READ                 [0:32]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_CFG_READ_TO_WRITE_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_READ_TO_WRITE_ODT    0x00000001UL
+    /* CFG_READ_TO_WRITE_ODT             [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_TO_WRITE_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_TO_WRITE_ODT    0x00000000UL
+    /* CFG_WRITE_TO_WRITE_ODT            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_READ_TO_READ_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_READ_TO_READ_ODT    0x00000001UL
+    /* CFG_READ_TO_READ_ODT              [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WRITE_TO_READ_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WRITE_TO_READ_ODT    0x00000001UL
+    /* CFG_WRITE_TO_READ_ODT             [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MIN_READ_IDLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MIN_READ_IDLE    0x00000007UL
+    /* CFG_MIN_READ_IDLE                 [0:32]  RW value= 0x7 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MRD)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MRD    0x0000000CUL
+    /* CFG_MRD                           [0:32]  RW value= 0xC */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_BT    0x00000000UL
+    /* CFG_BT                            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DS    0x00000006UL
+    /* CFG_DS                            [0:32]  RW value= 0x6 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_QOFF)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_QOFF    0x00000000UL
+    /* CFG_QOFF                          [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RTT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RTT    0x00000002UL
+    /* CFG_RTT                           [0:32]  RW value= 0x2 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DLL_DISABLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DLL_DISABLE    0x00000000UL
+    /* CFG_DLL_DISABLE                   [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_REF_PER)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_REF_PER    0x00000C34UL
+    /* CFG_REF_PER                       [0:32]  RW value= 0xC34 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARTUP_DELAY)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_STARTUP_DELAY    0x00027100UL
+    /* CFG_STARTUP_DELAY                 [0:32]  RW value= 0x27100 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_COLBITS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MEM_COLBITS    0x0000000AUL
+    /* CFG_MEM_COLBITS                   [0:32]  RW value= 0xA */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_ROWBITS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MEM_ROWBITS    0x00000010UL
+    /* CFG_MEM_ROWBITS                   [0:32]  RW value= 0x10 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_BANKBITS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MEM_BANKBITS    0x00000003UL
+    /* CFG_MEM_BANKBITS                  [0:32]  RW value= 0x3 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS0)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS0    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS0                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS1)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS1    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS1                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS2)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS2    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS2                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS3)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS3    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS3                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS4)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS4    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS4                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS5)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS5    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS5                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS6)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS6    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS6                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_MAP_CS7)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_MAP_CS7    0x00000000UL
+    /* CFG_ODT_RD_MAP_CS7                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS0)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS0    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS0                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS1)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS1    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS1                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS2)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS2    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS2                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS3)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS3    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS3                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS4)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS4    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS4                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS5)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS5    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS5                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS6)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS6    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS6                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_MAP_CS7)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_MAP_CS7    0x00000000UL
+    /* CFG_ODT_WR_MAP_CS7                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_TURN_ON)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_TURN_ON    0x00000000UL
+    /* CFG_ODT_RD_TURN_ON                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_TURN_ON)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_TURN_ON    0x00000000UL
+    /* CFG_ODT_WR_TURN_ON                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_RD_TURN_OFF)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_RD_TURN_OFF    0x00000000UL
+    /* CFG_ODT_RD_TURN_OFF               [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_WR_TURN_OFF)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_WR_TURN_OFF    0x00000000UL
+    /* CFG_ODT_WR_TURN_OFF               [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_EMR3)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_EMR3    0x00000000UL
+    /* CFG_EMR3                          [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TWO_T)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_TWO_T    0x00000000UL
+    /* CFG_TWO_T                         [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TWO_T_SEL_CYCLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_TWO_T_SEL_CYCLE    0x00000001UL
+    /* CFG_TWO_T_SEL_CYCLE               [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_REGDIMM)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_REGDIMM    0x00000000UL
+    /* CFG_REGDIMM                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MOD)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MOD    0x0000000CUL
+    /* CFG_MOD                           [0:32]  RW value= 0xC */
+#endif
+#if !defined (LIBERO_SETTING_CFG_XS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_XS    0x00000005UL
+    /* CFG_XS                            [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_XSDLL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_XSDLL    0x00000200UL
+    /* CFG_XSDLL                         [0:32]  RW value= 0x00000200 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_XPR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_XPR    0x00000005UL
+    /* CFG_XPR                           [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AL_MODE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_AL_MODE    0x00000000UL
+    /* CFG_AL_MODE                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CWL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CWL    0x00000005UL
+    /* CFG_CWL                           [0:32]  RW value= 0x5 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BL_MODE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_BL_MODE    0x00000000UL
+    /* CFG_BL_MODE                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TDQS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_TDQS    0x00000000UL
+    /* CFG_TDQS                          [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RTT_WR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RTT_WR    0x00000000UL
+    /* CFG_RTT_WR                        [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_LP_ASR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_LP_ASR    0x00000000UL
+    /* CFG_LP_ASR                        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AUTO_SR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_AUTO_SR    0x00000000UL
+    /* CFG_AUTO_SR                       [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_SRT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_SRT    0x00000000UL
+    /* CFG_SRT                           [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ADDR_MIRROR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ADDR_MIRROR    0x00000000UL
+    /* CFG_ADDR_MIRROR                   [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQ_CAL_TYPE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQ_CAL_TYPE    0x00000001UL
+    /* CFG_ZQ_CAL_TYPE                   [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQ_CAL_PER)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQ_CAL_PER    0x00027100UL
+    /* CFG_ZQ_CAL_PER                    [0:32]  RW value= 0x27100 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AUTO_ZQ_CAL_EN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_AUTO_ZQ_CAL_EN    0x00000000UL
+    /* CFG_AUTO_ZQ_CAL_EN                [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEMORY_TYPE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MEMORY_TYPE    0x00000400UL
+    /* CFG_MEMORY_TYPE                   [0:32]  RW value= 0x400 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ONLY_SRANK_CMDS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ONLY_SRANK_CMDS    0x00000000UL
+    /* CFG_ONLY_SRANK_CMDS               [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_NUM_RANKS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_NUM_RANKS    0x00000001UL
+    /* CFG_NUM_RANKS                     [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_QUAD_RANK)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_QUAD_RANK    0x00000000UL
+    /* CFG_QUAD_RANK                     [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_EARLY_RANK_TO_WR_START)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_EARLY_RANK_TO_WR_START    0x00000000UL
+    /* CFG_EARLY_RANK_TO_WR_START        [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_EARLY_RANK_TO_RD_START)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_EARLY_RANK_TO_RD_START    0x00000000UL
+    /* CFG_EARLY_RANK_TO_RD_START        [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PASR_BANK)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_PASR_BANK    0x00000000UL
+    /* CFG_PASR_BANK                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PASR_SEG)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_PASR_SEG    0x00000000UL
+    /* CFG_PASR_SEG                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_MRR_MODE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_MRR_MODE    0x00000000UL
+    /* INIT_MRR_MODE                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_MR_W_REQ)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_MR_W_REQ    0x00000000UL
+    /* INIT_MR_W_REQ                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_MR_ADDR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_MR_ADDR    0x00000000UL
+    /* INIT_MR_ADDR                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_MR_WR_DATA)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_MR_WR_DATA    0x00000000UL
+    /* INIT_MR_WR_DATA                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_MR_WR_MASK)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_MR_WR_MASK    0x00000000UL
+    /* INIT_MR_WR_MASK                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_NOP)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_NOP    0x00000000UL
+    /* INIT_NOP                          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_INIT_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_INIT_DURATION    0x00000640UL
+    /* CFG_INIT_DURATION                 [0:32]  RW value= 0x640 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQINIT_CAL_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQINIT_CAL_DURATION    0x00000000UL
+    /* CFG_ZQINIT_CAL_DURATION           [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQ_CAL_L_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQ_CAL_L_DURATION    0x00000000UL
+    /* CFG_ZQ_CAL_L_DURATION             [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQ_CAL_S_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQ_CAL_S_DURATION    0x00000000UL
+    /* CFG_ZQ_CAL_S_DURATION             [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQ_CAL_R_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQ_CAL_R_DURATION    0x00000028UL
+    /* CFG_ZQ_CAL_R_DURATION             [0:32]  RW value= 0x28 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MRR)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MRR    0x00000008UL
+    /* CFG_MRR                           [0:32]  RW value= 0x8 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MRW)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MRW    0x0000000AUL
+    /* CFG_MRW                           [0:32]  RW value= 0xA */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ODT_POWERDOWN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ODT_POWERDOWN    0x00000000UL
+    /* CFG_ODT_POWERDOWN                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WL    0x00000008UL
+    /* CFG_WL                            [0:32]  RW value= 0x8 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RL    0x0000000EUL
+    /* CFG_RL                            [0:32]  RW value= 0xE */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CAL_READ_PERIOD)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CAL_READ_PERIOD    0x00000000UL
+    /* CFG_CAL_READ_PERIOD               [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_NUM_CAL_READS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_NUM_CAL_READS    0x00000001UL
+    /* CFG_NUM_CAL_READS                 [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_SELF_REFRESH)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_SELF_REFRESH    0x00000000UL
+    /* INIT_SELF_REFRESH                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_POWER_DOWN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_POWER_DOWN    0x00000000UL
+    /* INIT_POWER_DOWN                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_FORCE_WRITE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_FORCE_WRITE    0x00000000UL
+    /* INIT_FORCE_WRITE                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_FORCE_WRITE_CS)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_FORCE_WRITE_CS    0x00000000UL
+    /* INIT_FORCE_WRITE_CS               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_INIT_DISABLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_INIT_DISABLE    0x00000000UL
+    /* CFG_CTRLR_INIT_DISABLE            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_RDIMM_COMPLETE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_RDIMM_COMPLETE    0x00000000UL
+    /* INIT_RDIMM_COMPLETE               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RDIMM_LAT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RDIMM_LAT    0x00000000UL
+    /* CFG_RDIMM_LAT                     [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RDIMM_BSIDE_INVERT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RDIMM_BSIDE_INVERT    0x00000001UL
+    /* CFG_RDIMM_BSIDE_INVERT            [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_LRDIMM)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_LRDIMM    0x00000000UL
+    /* CFG_LRDIMM                        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_MEMORY_RESET_MASK)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_MEMORY_RESET_MASK    0x00000000UL
+    /* INIT_MEMORY_RESET_MASK            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RD_PREAMB_TOGGLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RD_PREAMB_TOGGLE    0x00000000UL
+    /* CFG_RD_PREAMB_TOGGLE              [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RD_POSTAMBLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RD_POSTAMBLE    0x00000000UL
+    /* CFG_RD_POSTAMBLE                  [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PU_CAL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_PU_CAL    0x00000001UL
+    /* CFG_PU_CAL                        [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DQ_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DQ_ODT    0x00000002UL
+    /* CFG_DQ_ODT                        [0:32]  RW value= 0x2 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CA_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CA_ODT    0x00000004UL
+    /* CFG_CA_ODT                        [0:32]  RW value= 0x4 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQLATCH_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQLATCH_DURATION    0x00000018UL
+    /* CFG_ZQLATCH_DURATION              [0:32]  RW value= 0x18 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CAL_SELECT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_CAL_SELECT    0x00000000UL
+    /* INIT_CAL_SELECT                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CAL_L_R_REQ)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_CAL_L_R_REQ    0x00000000UL
+    /* INIT_CAL_L_R_REQ                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CAL_L_B_SIZE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_CAL_L_B_SIZE    0x00000000UL
+    /* INIT_CAL_L_B_SIZE                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_RWFIFO)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_RWFIFO    0x00000000UL
+    /* INIT_RWFIFO                       [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_RD_DQCAL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_RD_DQCAL    0x00000000UL
+    /* INIT_RD_DQCAL                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_START_DQSOSC)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_START_DQSOSC    0x00000000UL
+    /* INIT_START_DQSOSC                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_STOP_DQSOSC)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_STOP_DQSOSC    0x00000000UL
+    /* INIT_STOP_DQSOSC                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_ZQ_CAL_START)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_ZQ_CAL_START    0x00000000UL
+    /* INIT_ZQ_CAL_START                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_WR_POSTAMBLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_WR_POSTAMBLE    0x00000000UL
+    /* CFG_WR_POSTAMBLE                  [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CAL_L_ADDR_0)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_CAL_L_ADDR_0    0x00000000UL
+    /* INIT_CAL_L_ADDR_0                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CAL_L_ADDR_1)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_CAL_L_ADDR_1    0x00000000UL
+    /* INIT_CAL_L_ADDR_1                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLUPD_TRIG)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLUPD_TRIG    0x00000000UL
+    /* CFG_CTRLUPD_TRIG                  [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLUPD_START_DELAY)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLUPD_START_DELAY    0x00000000UL
+    /* CFG_CTRLUPD_START_DELAY           [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_T_CTRLUPD_MAX)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DFI_T_CTRLUPD_MAX    0x00000000UL
+    /* CFG_DFI_T_CTRLUPD_MAX             [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_BUSY_SEL)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_BUSY_SEL    0x00000000UL
+    /* CFG_CTRLR_BUSY_SEL                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_BUSY_VALUE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_BUSY_VALUE    0x00000000UL
+    /* CFG_CTRLR_BUSY_VALUE              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_BUSY_TURN_OFF_DELAY)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_BUSY_TURN_OFF_DELAY    0x00000000UL
+    /* CFG_CTRLR_BUSY_TURN_OFF_DELAY     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_BUSY_SLOW_RESTART_WINDOW)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_BUSY_SLOW_RESTART_WINDOW    0x00000000UL
+    /* CFG_CTRLR_BUSY_SLOW_RESTART_WINDOW        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_BUSY_RESTART_HOLDOFF)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_BUSY_RESTART_HOLDOFF    0x00000000UL
+    /* CFG_CTRLR_BUSY_RESTART_HOLDOFF    [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PARITY_RDIMM_DELAY)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_PARITY_RDIMM_DELAY    0x00000000UL
+    /* CFG_PARITY_RDIMM_DELAY            [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CTRLR_BUSY_ENABLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CTRLR_BUSY_ENABLE    0x00000000UL
+    /* CFG_CTRLR_BUSY_ENABLE             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ASYNC_ODT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ASYNC_ODT    0x00000000UL
+    /* CFG_ASYNC_ODT                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ZQ_CAL_DURATION)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_ZQ_CAL_DURATION    0x00000320UL
+    /* CFG_ZQ_CAL_DURATION               [0:32]  RW value= 0x320 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MRRI)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MRRI    0x00000012UL
+    /* CFG_MRRI                          [0:32]  RW value= 0x12 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_ODT_FORCE_EN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_ODT_FORCE_EN    0x00000000UL
+    /* INIT_ODT_FORCE_EN                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_ODT_FORCE_RANK)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_ODT_FORCE_RANK    0x00000000UL
+    /* INIT_ODT_FORCE_RANK               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PHYUPD_ACK_DELAY)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_PHYUPD_ACK_DELAY    0x00000000UL
+    /* CFG_PHYUPD_ACK_DELAY              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MIRROR_X16_BG0_BG1)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_MIRROR_X16_BG0_BG1    0x00000000UL
+    /* CFG_MIRROR_X16_BG0_BG1            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_PDA_MR_W_REQ)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_PDA_MR_W_REQ    0x00000000UL
+    /* INIT_PDA_MR_W_REQ                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_PDA_NIBBLE_SELECT)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_INIT_PDA_NIBBLE_SELECT    0x00000000UL
+    /* INIT_PDA_NIBBLE_SELECT            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DRAM_CLK_DISABLE_IN_SELF_REFRESH)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DRAM_CLK_DISABLE_IN_SELF_REFRESH    0x00000000UL
+    /* CFG_DRAM_CLK_DISABLE_IN_SELF_REFRESH        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CKSRE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CKSRE    0x00000008UL
+    /* CFG_CKSRE                         [0:32]  RW value= 0x00000008 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_CKSRX)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_CKSRX    0x0000000BUL
+    /* CFG_CKSRX                         [0:32]  RW value= 0x0000000b */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RCD_STAB)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_RCD_STAB    0x00000000UL
+    /* CFG_RCD_STAB                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_T_CTRL_DELAY)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DFI_T_CTRL_DELAY    0x00000000UL
+    /* CFG_DFI_T_CTRL_DELAY              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_T_DRAM_CLK_ENABLE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_DFI_T_DRAM_CLK_ENABLE    0x00000000UL
+    /* CFG_DFI_T_DRAM_CLK_ENABLE         [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_IDLE_TIME_TO_SELF_REFRESH)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_IDLE_TIME_TO_SELF_REFRESH    0x00000000UL
+    /* CFG_IDLE_TIME_TO_SELF_REFRESH     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_IDLE_TIME_TO_POWER_DOWN)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_IDLE_TIME_TO_POWER_DOWN    0x00000000UL
+    /* CFG_IDLE_TIME_TO_POWER_DOWN       [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BURST_RW_REFRESH_HOLDOFF)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_BURST_RW_REFRESH_HOLDOFF    0x00000000UL
+    /* CFG_BURST_RW_REFRESH_HOLDOFF      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_BG_INTERLEAVE)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_BG_INTERLEAVE    0x00000001UL
+    /* CFG_BG_INTERLEAVE                 [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_REFRESH_DURING_PHY_TRAINING)
+/*IP Blk = MC_BASE2 Access=RW */
+#define LIBERO_SETTING_CFG_REFRESH_DURING_PHY_TRAINING    0x00000000UL
+    /* CFG_REFRESH_DURING_PHY_TRAINING        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P0)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P0    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P0             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P1)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P1    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P1             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P2)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P2    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P2             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P3)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P3    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P3             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P4)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P4    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P4             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P5)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P5    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P5             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P6)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P6    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P6             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_STARVE_TIMEOUT_P7)
+/*IP Blk = MPFE Access=RW */
+#define LIBERO_SETTING_CFG_STARVE_TIMEOUT_P7    0x00000000UL
+    /* CFG_STARVE_TIMEOUT_P7             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_REORDER_EN)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_REORDER_EN    0x00000001UL
+    /* CFG_REORDER_EN                    [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_REORDER_QUEUE_EN)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_REORDER_QUEUE_EN    0x00000001UL
+    /* CFG_REORDER_QUEUE_EN              [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_INTRAPORT_REORDER_EN)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_INTRAPORT_REORDER_EN    0x00000000UL
+    /* CFG_INTRAPORT_REORDER_EN          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MAINTAIN_COHERENCY)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_MAINTAIN_COHERENCY    0x00000001UL
+    /* CFG_MAINTAIN_COHERENCY            [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_Q_AGE_LIMIT)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_Q_AGE_LIMIT    0x000000FFUL
+    /* CFG_Q_AGE_LIMIT                   [0:32]  RW value= 0x000000FF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RO_CLOSED_PAGE_POLICY)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_RO_CLOSED_PAGE_POLICY    0x00000000UL
+    /* CFG_RO_CLOSED_PAGE_POLICY         [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_REORDER_RW_ONLY)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_REORDER_RW_ONLY    0x00000000UL
+    /* CFG_REORDER_RW_ONLY               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RO_PRIORITY_EN)
+/*IP Blk = REORDER Access=RW */
+#define LIBERO_SETTING_CFG_RO_PRIORITY_EN    0x00000000UL
+    /* CFG_RO_PRIORITY_EN                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DM_EN)
+/*IP Blk = RMW Access=RW */
+#define LIBERO_SETTING_CFG_DM_EN    0x00000001UL
+    /* CFG_DM_EN                         [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_RMW_EN)
+/*IP Blk = RMW Access=RW */
+#define LIBERO_SETTING_CFG_RMW_EN    0x00000000UL
+    /* CFG_RMW_EN                        [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ECC_CORRECTION_EN)
+/*IP Blk = ECC Access=RW */
+#define LIBERO_SETTING_CFG_ECC_CORRECTION_EN    0x00000000UL
+    /* CFG_ECC_CORRECTION_EN             [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ECC_BYPASS)
+/*IP Blk = ECC Access=RW */
+#define LIBERO_SETTING_CFG_ECC_BYPASS    0x00000000UL
+    /* CFG_ECC_BYPASS                    [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_WRITE_DATA_1B_ECC_ERROR_GEN)
+/*IP Blk = ECC Access=RW */
+#define LIBERO_SETTING_INIT_WRITE_DATA_1B_ECC_ERROR_GEN    0x00000000UL
+    /* INIT_WRITE_DATA_1B_ECC_ERROR_GEN        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_WRITE_DATA_2B_ECC_ERROR_GEN)
+/*IP Blk = ECC Access=RW */
+#define LIBERO_SETTING_INIT_WRITE_DATA_2B_ECC_ERROR_GEN    0x00000000UL
+    /* INIT_WRITE_DATA_2B_ECC_ERROR_GEN        [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ECC_1BIT_INT_THRESH)
+/*IP Blk = ECC Access=RW */
+#define LIBERO_SETTING_CFG_ECC_1BIT_INT_THRESH    0x00000000UL
+    /* CFG_ECC_1BIT_INT_THRESH           [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_READ_CAPTURE_ADDR)
+/*IP Blk = READ_CAPT Access=RW */
+#define LIBERO_SETTING_INIT_READ_CAPTURE_ADDR    0x00000000UL
+    /* INIT_READ_CAPTURE_ADDR            [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ERROR_GROUP_SEL)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_ERROR_GROUP_SEL    0x00000000UL
+    /* CFG_ERROR_GROUP_SEL               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DATA_SEL)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_DATA_SEL    0x00000000UL
+    /* CFG_DATA_SEL                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_MODE)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_MODE    0x00000000UL
+    /* CFG_TRIG_MODE                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_POST_TRIG_CYCS)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_POST_TRIG_CYCS    0x00000000UL
+    /* CFG_POST_TRIG_CYCS                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_MASK)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_MASK    0x00000000UL
+    /* CFG_TRIG_MASK                     [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_EN_MASK)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_EN_MASK    0x00000000UL
+    /* CFG_EN_MASK                       [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_MTC_ACQ_ADDR)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_MTC_ACQ_ADDR    0x00000000UL
+    /* MTC_ACQ_ADDR                      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_MT_ADDR_0)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_MT_ADDR_0    0x00000000UL
+    /* CFG_TRIG_MT_ADDR_0                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_MT_ADDR_1)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_MT_ADDR_1    0x00000000UL
+    /* CFG_TRIG_MT_ADDR_1                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_ERR_MASK_0)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_ERR_MASK_0    0x00000000UL
+    /* CFG_TRIG_ERR_MASK_0               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_ERR_MASK_1)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_ERR_MASK_1    0x00000000UL
+    /* CFG_TRIG_ERR_MASK_1               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_ERR_MASK_2)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_ERR_MASK_2    0x00000000UL
+    /* CFG_TRIG_ERR_MASK_2               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_ERR_MASK_3)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_ERR_MASK_3    0x00000000UL
+    /* CFG_TRIG_ERR_MASK_3               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_TRIG_ERR_MASK_4)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_TRIG_ERR_MASK_4    0x00000000UL
+    /* CFG_TRIG_ERR_MASK_4               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_MTC_ACQ_WR_DATA_0)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_MTC_ACQ_WR_DATA_0    0x00000000UL
+    /* MTC_ACQ_WR_DATA_0                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_MTC_ACQ_WR_DATA_1)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_MTC_ACQ_WR_DATA_1    0x00000000UL
+    /* MTC_ACQ_WR_DATA_1                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_MTC_ACQ_WR_DATA_2)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_MTC_ACQ_WR_DATA_2    0x00000000UL
+    /* MTC_ACQ_WR_DATA_2                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_PRE_TRIG_CYCS)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_PRE_TRIG_CYCS    0x00000000UL
+    /* CFG_PRE_TRIG_CYCS                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DATA_SEL_FIRST_ERROR)
+/*IP Blk = MTA Access=RW */
+#define LIBERO_SETTING_CFG_DATA_SEL_FIRST_ERROR    0x00000000UL
+    /* CFG_DATA_SEL_FIRST_ERROR          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DQ_WIDTH)
+/*IP Blk = DYN_WIDTH_ADJ Access=RW */
+#define LIBERO_SETTING_CFG_DQ_WIDTH    0x00000000UL
+    /* CFG_DQ_WIDTH                      [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ACTIVE_DQ_SEL)
+/*IP Blk = DYN_WIDTH_ADJ Access=RW */
+#define LIBERO_SETTING_CFG_ACTIVE_DQ_SEL    0x00000000UL
+    /* CFG_ACTIVE_DQ_SEL                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CA_PARITY_ERROR_GEN_REQ)
+/*IP Blk = CA_PAR_ERR Access=RW */
+#define LIBERO_SETTING_INIT_CA_PARITY_ERROR_GEN_REQ    0x00000000UL
+    /* INIT_CA_PARITY_ERROR_GEN_REQ      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_CA_PARITY_ERROR_GEN_CMD)
+/*IP Blk = CA_PAR_ERR Access=RW */
+#define LIBERO_SETTING_INIT_CA_PARITY_ERROR_GEN_CMD    0x00000000UL
+    /* INIT_CA_PARITY_ERROR_GEN_CMD      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_T_RDDATA_EN)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_T_RDDATA_EN    0x00000015UL
+    /* CFG_DFI_T_RDDATA_EN               [0:32]  RW value= 0x15 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_T_PHY_RDLAT)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_T_PHY_RDLAT    0x00000006UL
+    /* CFG_DFI_T_PHY_RDLAT               [0:32]  RW value= 0x6 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_T_PHY_WRLAT)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_T_PHY_WRLAT    0x00000003UL
+    /* CFG_DFI_T_PHY_WRLAT               [0:32]  RW value= 0x3 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_PHYUPD_EN)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_PHYUPD_EN    0x00000001UL
+    /* CFG_DFI_PHYUPD_EN                 [0:32]  RW value= 0x00000001 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_DFI_LP_DATA_REQ)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_INIT_DFI_LP_DATA_REQ    0x00000000UL
+    /* INIT_DFI_LP_DATA_REQ              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_DFI_LP_CTRL_REQ)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_INIT_DFI_LP_CTRL_REQ    0x00000000UL
+    /* INIT_DFI_LP_CTRL_REQ              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_DFI_LP_WAKEUP)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_INIT_DFI_LP_WAKEUP    0x00000000UL
+    /* INIT_DFI_LP_WAKEUP                [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_INIT_DFI_DRAM_CLK_DISABLE)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_INIT_DFI_DRAM_CLK_DISABLE    0x00000000UL
+    /* INIT_DFI_DRAM_CLK_DISABLE         [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_DATA_BYTE_DISABLE)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_DATA_BYTE_DISABLE    0x00000000UL
+    /* CFG_DFI_DATA_BYTE_DISABLE         [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_LVL_SEL)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_LVL_SEL    0x00000000UL
+    /* CFG_DFI_LVL_SEL                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_LVL_PERIODIC)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_LVL_PERIODIC    0x00000000UL
+    /* CFG_DFI_LVL_PERIODIC              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_DFI_LVL_PATTERN)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_CFG_DFI_LVL_PATTERN    0x00000000UL
+    /* CFG_DFI_LVL_PATTERN               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_DFI_INIT_START)
+/*IP Blk = DFI Access=RW */
+#define LIBERO_SETTING_PHY_DFI_INIT_START    0x00000001UL
+    /* PHY_DFI_INIT_START                [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI1_0)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI1_0    0x00000000UL
+    /* CFG_AXI_START_ADDRESS_AXI1_0      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI1_1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI1_1    0x00000000UL
+    /* CFG_AXI_START_ADDRESS_AXI1_1      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI2_0)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI2_0    0x00000000UL
+    /* CFG_AXI_START_ADDRESS_AXI2_0      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI2_1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_START_ADDRESS_AXI2_1    0x00000000UL
+    /* CFG_AXI_START_ADDRESS_AXI2_1      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI1_0)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI1_0    0x7FFFFFFFUL
+    /* CFG_AXI_END_ADDRESS_AXI1_0        [0:32]  RW value= 0x7FFFFFFF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI1_1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI1_1    0x00000000UL
+    /* CFG_AXI_END_ADDRESS_AXI1_1        [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI2_0)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI2_0    0x7FFFFFFFUL
+    /* CFG_AXI_END_ADDRESS_AXI2_0        [0:32]  RW value= 0x7FFFFFFF */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI2_1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_END_ADDRESS_AXI2_1    0x00000000UL
+    /* CFG_AXI_END_ADDRESS_AXI2_1        [0:32]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI1_0)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI1_0    0x00000000UL
+    /* CFG_MEM_START_ADDRESS_AXI1_0      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI1_1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI1_1    0x00000000UL
+    /* CFG_MEM_START_ADDRESS_AXI1_1      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI2_0)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI2_0    0x00000000UL
+    /* CFG_MEM_START_ADDRESS_AXI2_0      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI2_1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_MEM_START_ADDRESS_AXI2_1    0x00000000UL
+    /* CFG_MEM_START_ADDRESS_AXI2_1      [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ENABLE_BUS_HOLD_AXI1)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_ENABLE_BUS_HOLD_AXI1    0x00000000UL
+    /* CFG_ENABLE_BUS_HOLD_AXI1          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_ENABLE_BUS_HOLD_AXI2)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_ENABLE_BUS_HOLD_AXI2    0x00000000UL
+    /* CFG_ENABLE_BUS_HOLD_AXI2          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_CFG_AXI_AUTO_PCH)
+/*IP Blk = AXI_IF Access=RW */
+#define LIBERO_SETTING_CFG_AXI_AUTO_PCH    0x00000000UL
+    /* CFG_AXI_AUTO_PCH                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_RESET_CONTROL)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_RESET_CONTROL    0x00008001UL
+    /* PHY_RESET_CONTROL                 [0:32]  RW value= 0x8001 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_PC_RANK)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_PC_RANK    0x00000001UL
+    /* PHY_PC_RANK                       [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_RANKS_TO_TRAIN)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_RANKS_TO_TRAIN    0x00000001UL
+    /* PHY_RANKS_TO_TRAIN                [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_WRITE_REQUEST)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_WRITE_REQUEST    0x00000000UL
+    /* PHY_WRITE_REQUEST                 [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_READ_REQUEST)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_READ_REQUEST    0x00000000UL
+    /* PHY_READ_REQUEST                  [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_WRITE_LEVEL_DELAY)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_WRITE_LEVEL_DELAY    0x00000000UL
+    /* PHY_WRITE_LEVEL_DELAY             [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_GATE_TRAIN_DELAY)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_GATE_TRAIN_DELAY    0x0000003FUL
+    /* PHY_GATE_TRAIN_DELAY              [0:32]  RW value= 0x3F */
+#endif
+#if !defined (LIBERO_SETTING_PHY_EYE_TRAIN_DELAY)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_EYE_TRAIN_DELAY    0x0000003FUL
+    /* PHY_EYE_TRAIN_DELAY               [0:32]  RW value= 0x3F */
+#endif
+#if !defined (LIBERO_SETTING_PHY_EYE_PAT)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_EYE_PAT    0x00000000UL
+    /* PHY_EYE_PAT                       [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_START_RECAL)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_START_RECAL    0x00000000UL
+    /* PHY_START_RECAL                   [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_CLR_DFI_LVL_PERIODIC)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_CLR_DFI_LVL_PERIODIC    0x00000000UL
+    /* PHY_CLR_DFI_LVL_PERIODIC          [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_TRAIN_STEP_ENABLE)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_TRAIN_STEP_ENABLE    0x00000018UL
+    /* PHY_TRAIN_STEP_ENABLE             [0:32]  RW value= 0x18 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_LPDDR_DQ_CAL_PAT)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_LPDDR_DQ_CAL_PAT    0x00000000UL
+    /* PHY_LPDDR_DQ_CAL_PAT              [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_INDPNDT_TRAINING)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_INDPNDT_TRAINING    0x00000001UL
+    /* PHY_INDPNDT_TRAINING              [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_ENCODED_QUAD_CS)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_ENCODED_QUAD_CS    0x00000000UL
+    /* PHY_ENCODED_QUAD_CS               [0:32]  RW value= 0x00000000 */
+#endif
+#if !defined (LIBERO_SETTING_PHY_HALF_CLK_DLY_ENABLE)
+/*IP Blk = csr_custom Access=RW */
+#define LIBERO_SETTING_PHY_HALF_CLK_DLY_ENABLE    0x00000000UL
+    /* PHY_HALF_CLK_DLY_ENABLE           [0:32]  RW value= 0x00000000 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_DDRC_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/fpga_design_config.h
+++ b/cpu/mpfs/include/fpga_design_config/fpga_design_config.h
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file fpga_design_config.h
+ * @author Embedded Software
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef FPGA_DESIGN_CONFIG_H_
+#define FPGA_DESIGN_CONFIG_H_
+
+#define  LIBERO_SETTING_MSS_CONFIGURATOR_VERSION                    "2021.1"
+#define  LIBERO_SETTING_DESIGN_NAME                                 "ICICLE_MSS"
+#define  LIBERO_SETTING_MPFS_PART                                   "MPFS250T_ES"
+#define  LIBERO_SETTING_GENERATION_DATE                             "04-11-2021_22:30:25"
+#define  LIBERO_SETTING_XML_VERSION                                 "0.5.3"
+#define  LIBERO_SETTING_XML_VERSION_MAJOR                           0
+#define  LIBERO_SETTING_XML_VERSION_MINOR                           5
+#define  LIBERO_SETTING_XML_VERSION_PATCH                           3
+#define  LIBERO_SETTING_HEADER_GENERATOR_VERSION                    "0.6.3"
+#define  LIBERO_SETTING_HEADER_GENERATOR_VERSION_MAJOR              0
+#define  LIBERO_SETTING_HEADER_GENERATOR_VERSION_MINOR              6
+#define  LIBERO_SETTING_HEADER_GENERATOR_VERSION_PATCH              3
+
+#include "memory_map/hw_memory.h"
+#include "memory_map/hw_apb_split.h"
+#include "memory_map/hw_cache.h"
+#include "memory_map/hw_pmp_hart0.h"
+#include "memory_map/hw_pmp_hart1.h"
+#include "memory_map/hw_pmp_hart2.h"
+#include "memory_map/hw_pmp_hart3.h"
+#include "memory_map/hw_pmp_hart4.h"
+#include "memory_map/hw_mpu_fic0.h"
+#include "memory_map/hw_mpu_fic1.h"
+#include "memory_map/hw_mpu_fic2.h"
+#include "memory_map/hw_mpu_crypto.h"
+#include "memory_map/hw_mpu_gem0.h"
+#include "memory_map/hw_mpu_gem1.h"
+#include "memory_map/hw_mpu_usb.h"
+#include "memory_map/hw_mpu_mmc.h"
+#include "memory_map/hw_mpu_scb.h"
+#include "memory_map/hw_mpu_trace.h"
+#include "io/hw_mssio_mux.h"
+#include "io/hw_hsio_mux.h"
+#include "sgmii/hw_sgmii_tip.h"
+#include "ddr/hw_ddr_options.h"
+#include "ddr/hw_ddr_io_bank.h"
+#include "ddr/hw_ddr_mode.h"
+#include "ddr/hw_ddr_off_mode.h"
+#include "ddr/hw_ddr_segs.h"
+#include "ddr/hw_ddrc.h"
+#include "clocks/hw_mss_clks.h"
+#include "clocks/hw_clk_sysreg.h"
+#include "clocks/hw_clk_mss_pll.h"
+#include "clocks/hw_clk_sgmii_pll.h"
+#include "clocks/hw_clk_ddr_pll.h"
+#include "clocks/hw_clk_mss_cfm.h"
+#include "clocks/hw_clk_sgmii_cfm.h"
+#include "general/hw_gen_peripherals.h"
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+/* No content in this file, used for referencing header */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef FPGA_DESIGN_CONFIG_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/general/hw_gen_peripherals.h
+++ b/cpu/mpfs/include/fpga_design_config/general/hw_gen_peripherals.h
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_gen_peripherals.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_GEN_PERIPHERALS_H_
+#define HW_GEN_PERIPHERALS_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_GPIO_CR)
+/*GPIO Blocks reset control- (soft_reset options chossen in Libero confgurator)
+*/
+#define LIBERO_SETTING_GPIO_CR    0x000F0703UL
+    /* GPIO0_SOFT_RESET_SELECT           [0:2]   RW value= 0x3 */
+    /* GPIO0_DEFAULT                     [4:2]   RW value= 0x0 */
+    /* GPIO1_SOFT_RESET_SELECT           [8:3]   RW value= 0x7 */
+    /* GPIO1_DEFAULT                     [12:3]  RW value= 0x0 */
+    /* GPIO2_SOFT_RESET_SELECT           [16:4]  RW value= 0xF */
+    /* GPIO2_DEFAULT                     [20:4]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CRYPTO_CR_INFO)
+/*Information on how Crypto setup on this MPFS */
+#define LIBERO_SETTING_CRYPTO_CR_INFO    0x00000000UL
+    /* MSS_MODE                          [0:2]   RO */
+    /* RESERVED                          [2:1]   RO */
+    /* STREAM_ENABLE                     [3:1]   RO */
+    /* RESERVED1                         [4:28]  RO */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_GEN_PERIPHERALS_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/io/hw_hsio_mux.h
+++ b/cpu/mpfs/include/fpga_design_config/io/hw_hsio_mux.h
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_hsio_mux.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_HSIO_MUX_H_
+#define HW_HSIO_MUX_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_TRIM_OPTIONS)
+/*User trim options- set option to 1 to use */
+#define LIBERO_SETTING_TRIM_OPTIONS    0x00000000UL
+    /* TRIM_DDR_OPTION                   [0:1]    */
+    /* TRIM_SGMII_OPTION                 [1:1]    */
+#endif
+#if !defined (LIBERO_SETTING_DDR_IOC_REG0)
+/*Manual trim values */
+#define LIBERO_SETTING_DDR_IOC_REG0    0x00000000UL
+    /* BANK_PCODE                        [0:6]   RW value= 0x0 */
+    /* BANK_NCODE                        [6:6]   RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SGMII_IOC_REG0)
+/*Manual trim values */
+#define LIBERO_SETTING_SGMII_IOC_REG0    0x00000000UL
+    /* BANK_PCODE                        [0:6]   RW value= 0x0 */
+    /* BANK_NCODE                        [6:6]   RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_HSIO_MUX_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/io/hw_mssio_mux.h
+++ b/cpu/mpfs/include/fpga_design_config/io/hw_mssio_mux.h
@@ -1,0 +1,340 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mssio_mux.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MSSIO_MUX_H_
+#define HW_MSSIO_MUX_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_IOMUX0_CR)
+/*Selects whether the peripheral is connected to the Fabric or IOMUX structure.
+*/
+#define LIBERO_SETTING_IOMUX0_CR    0x00000F9DUL
+    /* SPI0_FABRIC                       [0:1]   RW value= 0x1 */
+    /* SPI1_FABRIC                       [1:1]   RW value= 0x0 */
+    /* I2C0_FABRIC                       [2:1]   RW value= 0x1 */
+    /* I2C1_FABRIC                       [3:1]   RW value= 0x1 */
+    /* CAN0_FABRIC                       [4:1]   RW value= 0x1 */
+    /* CAN1_FABRIC                       [5:1]   RW value= 0x0 */
+    /* QSPI_FABRIC                       [6:1]   RW value= 0x0 */
+    /* MMUART0_FABRIC                    [7:1]   RW value= 0x1 */
+    /* MMUART1_FABRIC                    [8:1]   RW value= 0x1 */
+    /* MMUART2_FABRIC                    [9:1]   RW value= 0x1 */
+    /* MMUART3_FABRIC                    [10:1]  RW value= 0x1 */
+    /* MMUART4_FABRIC                    [11:1]  RW value= 0x1 */
+    /* MDIO0_FABRIC                      [12:1]  RW value= 0x0 */
+    /* MDIO1_FABRIC                      [13:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_IOMUX1_CR)
+/*Configures the IO Mux structure for each IO pad. 0 implies SD/SDIO, 1 implies
+EMMC, 2 implies QSPI, 3 implies SPI,4 implies USB,5 implies MMUART,6 implies
+I2C,7 implies CAN,8 implies MDIO,9 implies Miscellaneous,0xA implies Reserved
+(Equivalent to Tristate),0xB implies GPIO ,0xC implies Fabric-test,0xD implies
+Logic 0,0xE implies Logic 1, 0xF implies Tristate */
+#define LIBERO_SETTING_IOMUX1_CR    0x11111111UL
+    /* PAD0                              [0:4]   RW value= 0x1 */
+    /* PAD1                              [4:4]   RW value= 0x1 */
+    /* PAD2                              [8:4]   RW value= 0x1 */
+    /* PAD3                              [12:4]  RW value= 0x1 */
+    /* PAD4                              [16:4]  RW value= 0x1 */
+    /* PAD5                              [20:4]  RW value= 0x1 */
+    /* PAD6                              [24:4]  RW value= 0x1 */
+    /* PAD7                              [28:4]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_IOMUX2_CR)
+/*Configures the IO Mux structure for each IO pad. 0 implies SD/SDIO, 1 implies
+EMMC, 2 implies QSPI, 3 implies SPI,4 implies USB,5 implies MMUART,6 implies
+I2C,7 implies CAN,8 implies MDIO,9 implies Miscellaneous,0xA implies Reserved
+(Equivalent to Tristate),0xB implies GPIO ,0xC implies Fabric-test,0xD implies
+Logic 0,0xE implies Logic 1, 0xF implies Tristate */
+#define LIBERO_SETTING_IOMUX2_CR    0x00FF1111UL
+    /* PAD8                              [0:4]   RW value= 0x1 */
+    /* PAD9                              [4:4]   RW value= 0x1 */
+    /* PAD10                             [8:4]   RW value= 0x1 */
+    /* PAD11                             [12:4]  RW value= 0x1 */
+    /* PAD12                             [16:4]  RW value= 0xF */
+    /* PAD13                             [20:4]  RW value= 0xF */
+#endif
+#if !defined (LIBERO_SETTING_IOMUX3_CR)
+/*Configures the IO Mux structure for each IO pad. 0 implies SD/SDIO, 1 implies
+EMMC, 2 implies QSPI, 3 implies SPI,4 implies USB,5 implies MMUART,6 implies
+I2C,7 implies CAN,8 implies MDIO,9 implies Miscellaneous,0xA implies Reserved
+(Equivalent to Tristate),0xB implies GPIO ,0xC implies Fabric-test,0xD implies
+Logic 0,0xE implies Logic 1, 0xF implies Tristate */
+#define LIBERO_SETTING_IOMUX3_CR    0x44444444UL
+    /* PAD14                             [0:4]   RW value= 0x4 */
+    /* PAD15                             [4:4]   RW value= 0x4 */
+    /* PAD16                             [8:4]   RW value= 0x4 */
+    /* PAD17                             [12:4]  RW value= 0x4 */
+    /* PAD18                             [16:4]  RW value= 0x4 */
+    /* PAD19                             [20:4]  RW value= 0x4 */
+    /* PAD20                             [24:4]  RW value= 0x4 */
+    /* PAD21                             [28:4]  RW value= 0x4 */
+#endif
+#if !defined (LIBERO_SETTING_IOMUX4_CR)
+/*Configures the IO Mux structure for each IO pad. 0 implies SD/SDIO, 1 implies
+EMMC, 2 implies QSPI, 3 implies SPI,4 implies USB,5 implies MMUART,6 implies
+I2C,7 implies CAN,8 implies MDIO,9 implies Miscellaneous,0xA implies Reserved
+(Equivalent to Tristate),0xB implies GPIO ,0xC implies Fabric-test,0xD implies
+Logic 0,0xE implies Logic 1, 0xF implies Tristate */
+#define LIBERO_SETTING_IOMUX4_CR    0x88CC4444UL
+    /* PAD22                             [0:4]   RW value= 0x4 */
+    /* PAD23                             [4:4]   RW value= 0x4 */
+    /* PAD24                             [8:4]   RW value= 0x4 */
+    /* PAD25                             [12:4]  RW value= 0x4 */
+    /* PAD26                             [16:4]  RW value= 0xC */
+    /* PAD27                             [20:4]  RW value= 0xC */
+    /* PAD28                             [24:4]  RW value= 0x8 */
+    /* PAD29                             [28:4]  RW value= 0x8 */
+#endif
+#if !defined (LIBERO_SETTING_IOMUX5_CR)
+/*Configures the IO Mux structure for each IO pad. 0 implies SD/SDIO, 1 implies
+EMMC, 2 implies QSPI, 3 implies SPI,4 implies USB,5 implies MMUART,6 implies
+I2C,7 implies CAN,8 implies MDIO,9 implies Miscellaneous,0xA implies Reserved
+(Equivalent to Tristate),0xB implies GPIO ,0xC implies Fabric-test,0xD implies
+Logic 0,0xE implies Logic 1, 0xF implies Tristate */
+#define LIBERO_SETTING_IOMUX5_CR    0xF7772222UL
+    /* PAD30                             [0:4]   RW value= 0x2 */
+    /* PAD31                             [4:4]   RW value= 0x2 */
+    /* PAD32                             [8:4]   RW value= 0x2 */
+    /* PAD33                             [12:4]  RW value= 0x2 */
+    /* PAD34                             [16:4]  RW value= 0x7 */
+    /* PAD35                             [20:4]  RW value= 0x7 */
+    /* PAD36                             [24:4]  RW value= 0x7 */
+    /* PAD37                             [28:4]  RW value= 0xF */
+#endif
+#if !defined (LIBERO_SETTING_IOMUX6_CR)
+/*Sets whether the MMC/SD Voltage select lines are inverted on entry to the
+IOMUX structure */
+#define LIBERO_SETTING_IOMUX6_CR    0x00000000UL
+    /* VLT_SEL                           [0:1]   RW value= 0x0 */
+    /* VLT_EN                            [1:1]   RW value= 0x0 */
+    /* VLT_CMD_DIR                       [2:1]   RW value= 0x0 */
+    /* VLT_DIR_0                         [3:1]   RW value= 0x0 */
+    /* VLT_DIR_1_3                       [4:1]   RW value= 0x0 */
+    /* SD_LED                            [5:1]   RW value= 0x0 */
+    /* SD_VOLT_0                         [6:1]   RW value= 0x0 */
+    /* SD_VOLT_1                         [7:1]   RW value= 0x0 */
+    /* SD_VOLT_2                         [8:1]   RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_CFG_CR)
+/*Configures the MSSIO block using SCB write */
+#define LIBERO_SETTING_MSSIO_BANK4_CFG_CR    0x00040A0DUL
+    /* BANK_PCODE                        [0:6]   RW value= 0xD */
+    /* RESERVED0                         [6:2]   RW value= 0x00 */
+    /* BANK_NCODE                        [8:6]   RW value= 0xA */
+    /* RESERVED1                         [14:2]  RW value= 0x0 */
+    /* VS                                [16:4]  RW value= 0x4 */
+    /* RESERVED2                         [20:12] RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_0_1_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_0_1_CR    0x09280928UL
+    /* IO_CFG_0                          [0:16]  RW value= 0x0928 */
+    /* IO_CFG_1                          [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_2_3_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_2_3_CR    0x09280928UL
+    /* IO_CFG_2                          [0:16]  RW value= 0x0928 */
+    /* IO_CFG_3                          [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_4_5_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_4_5_CR    0x09280928UL
+    /* IO_CFG_4                          [0:16]  RW value= 0x0928 */
+    /* IO_CFG_5                          [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_6_7_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_6_7_CR    0x09280928UL
+    /* IO_CFG_6                          [0:16]  RW value= 0x0928 */
+    /* IO_CFG_7                          [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_8_9_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_8_9_CR    0x09280928UL
+    /* IO_CFG_8                          [0:16]  RW value= 0x0928 */
+    /* IO_CFG_9                          [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_10_11_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_10_11_CR    0x09280928UL
+    /* IO_CFG_10                         [0:16]  RW value= 0x0928 */
+    /* IO_CFG_11                         [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK4_IO_CFG_12_13_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK4_IO_CFG_12_13_CR    0x09280928UL
+    /* IO_CFG_12                         [0:16]  RW value= 0x0928 */
+    /* IO_CFG_13                         [16:16] RW value= 0x0928 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_CFG_CR)
+/*Configures the MSSIO block using SCB write */
+#define LIBERO_SETTING_MSSIO_BANK2_CFG_CR    0x00080907UL
+    /* BANK_PCODE                        [0:6]   RW value= 0x7 */
+    /* RESERVED0                         [6:2]   RW value= 0x00 */
+    /* BANK_NCODE                        [8:6]   RW value= 0x9 */
+    /* RESERVED1                         [14:2]  RW value= 0x0 */
+    /* VS                                [16:4]  RW value= 0x8 */
+    /* RESERVED2                         [20:12] RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_0_1_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_0_1_CR    0x08290829UL
+    /* IO_CFG_0                          [0:16]  RW value= 0x0829 */
+    /* IO_CFG_1                          [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_2_3_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_2_3_CR    0x08290829UL
+    /* IO_CFG_2                          [0:16]  RW value= 0x0829 */
+    /* IO_CFG_3                          [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_4_5_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_4_5_CR    0x08290829UL
+    /* IO_CFG_4                          [0:16]  RW value= 0x0829 */
+    /* IO_CFG_5                          [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_6_7_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_6_7_CR    0x08290829UL
+    /* IO_CFG_6                          [0:16]  RW value= 0x0829 */
+    /* IO_CFG_7                          [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_8_9_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_8_9_CR    0x08290829UL
+    /* IO_CFG_8                          [0:16]  RW value= 0x0829 */
+    /* IO_CFG_9                          [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_10_11_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_10_11_CR    0x08290829UL
+    /* IO_CFG_10                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_11                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_12_13_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_12_13_CR    0x08290829UL
+    /* IO_CFG_12                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_13                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_14_15_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_14_15_CR    0x08290829UL
+    /* IO_CFG_14                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_15                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_16_17_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_16_17_CR    0x08290829UL
+    /* IO_CFG_16                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_17                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_18_19_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_18_19_CR    0x08290829UL
+    /* IO_CFG_18                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_19                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_20_21_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_20_21_CR    0x08290829UL
+    /* IO_CFG_20                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_21                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_BANK2_IO_CFG_22_23_CR)
+/*IO electrical configuration for MSSIO pad */
+#define LIBERO_SETTING_MSSIO_BANK2_IO_CFG_22_23_CR    0x08290829UL
+    /* IO_CFG_22                         [0:16]  RW value= 0x0829 */
+    /* IO_CFG_23                         [16:16] RW value= 0x0829 */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_VB2_CFG)
+/*default dpc values for MSSIO bank 2 */
+#define LIBERO_SETTING_MSSIO_VB2_CFG    0x00000828UL
+    /* DPC_IO_CFG_IBUFMD_0               [0:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_IBUFMD_1               [1:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_IBUFMD_2               [2:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_DRV_0                  [3:1]   RW value= 0x1 */
+    /* DPC_IO_CFG_DRV_1                  [4:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_DRV_2                  [5:1]   RW value= 0x1 */
+    /* DPC_IO_CFG_DRV_3                  [6:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_CLAMP                  [7:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_ENHYST                 [8:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_LOCKDN_EN              [9:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_WPD                    [10:1]  RW value= 0x0 */
+    /* DPC_IO_CFG_WPU                    [11:1]  RW value= 0x1 */
+    /* DPC_IO_CFG_ATP_EN                 [12:1]  RW value= 0x0 */
+    /* DPC_IO_CFG_LP_PERSIST_EN          [13:1]  RW value= 0x0 */
+    /* DPC_IO_CFG_LP_BYPASS_EN           [14:1]  RW value= 0x0 */
+    /* RESERVED                          [15:17] R */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_VB4_CFG)
+/*default dpc values for MSSIO bank 4 */
+#define LIBERO_SETTING_MSSIO_VB4_CFG    0x00000828UL
+    /* DPC_IO_CFG_IBUFMD_0               [0:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_IBUFMD_1               [1:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_IBUFMD_2               [2:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_DRV_0                  [3:1]   RW value= 0x1 */
+    /* DPC_IO_CFG_DRV_1                  [4:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_DRV_2                  [5:1]   RW value= 0x1 */
+    /* DPC_IO_CFG_DRV_3                  [6:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_CLAMP                  [7:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_ENHYST                 [8:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_LOCKDN_EN              [9:1]   RW value= 0x0 */
+    /* DPC_IO_CFG_WPD                    [10:1]  RW value= 0x0 */
+    /* DPC_IO_CFG_WPU                    [11:1]  RW value= 0x1 */
+    /* DPC_IO_CFG_ATP_EN                 [12:1]  RW value= 0x0 */
+    /* DPC_IO_CFG_LP_PERSIST_EN          [13:1]  RW value= 0x0 */
+    /* DPC_IO_CFG_LP_BYPASS_EN           [14:1]  RW value= 0x0 */
+    /* RESERVED                          [15:17] R */
+#endif
+#if !defined (LIBERO_SETTING_MSSIO_CONFIGURATION_OPTIONS)
+/*Indicates if eMMC is configured for use (bit 0 == 1), If SD is configued for
+use (bit 1 == 1). Bit 2 indicates which one should be used by default on MSS
+embedded software startup ( bit2 == 0, implies default is eMMC, bit2 == 1,
+implies default is SD). The eMMC configuration is always defined in xml tag
+(io_mux, the SD configuration is always defined in xml tag (io_mux_alt). All
+other elements in the (o_mux) and (io_mux_alt) not releating to eMMC/SD
+differences should be the same values. */
+#define LIBERO_SETTING_MSSIO_CONFIGURATION_OPTIONS    0x00000000UL
+    /* EMMC_CONFIGURED                   [0:1]   RW value= 0x0 */
+    /* SD_CONFIGURED                     [1:1]   RW value= 0x0 */
+    /* DEFAULT_ON_START                  [2:1]   RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MSSIO_MUX_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_apb_split.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_apb_split.h
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_apb_split.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_APB_SPLIT_H_
+#define HW_APB_SPLIT_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_APB_SPLIT_VERSION)
+/*This version incrments when change to format of this file */
+#define LIBERO_SETTING_APB_SPLIT_VERSION    0x00000001UL
+    /* VERSION                           [0:32]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_MEM_CONFIGS_ENABLED)
+/*Enabled in configurator when bit set to 1 */
+#define LIBERO_SETTING_MEM_CONFIGS_ENABLED    0x00000000UL
+    /* PMP                               [0:0]   RW value= 0x0 */
+    /* MPU                               [1:0]   RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_APBBUS_CR)
+/*AMP Mode peripheral mapping register. When the register bit is '0' the
+peripheral is mapped into the 0x2000000 address range using AXI bus 5 from the
+Coreplex. When the register bit is '1' the peripheral is mapped into the
+0x28000000 address range using AXI bus 6 from the Coreplex. */
+#define LIBERO_SETTING_APBBUS_CR    0x00000000UL
+    /* MMUART0                           [0:1]   RW value= 0x0 */
+    /* MMUART1                           [1:1]   RW value= 0x0 */
+    /* MMUART2                           [2:1]   RW value= 0x0 */
+    /* MMUART3                           [3:1]   RW value= 0x0 */
+    /* MMUART4                           [4:1]   RW value= 0x0 */
+    /* WDOG0                             [5:1]   RW value= 0x0 */
+    /* WDOG1                             [6:1]   RW value= 0x0 */
+    /* WDOG2                             [7:1]   RW value= 0x0 */
+    /* WDOG3                             [8:1]   RW value= 0x0 */
+    /* WDOG4                             [9:1]   RW value= 0x0 */
+    /* SPI0                              [10:1]  RW value= 0x0 */
+    /* SPI1                              [11:1]  RW value= 0x0 */
+    /* I2C0                              [12:1]  RW value= 0x0 */
+    /* I2C1                              [13:1]  RW value= 0x0 */
+    /* CAN0                              [14:1]  RW value= 0x0 */
+    /* CAN1                              [15:1]  RW value= 0x0 */
+    /* GEM0                              [16:1]  RW value= 0x0 */
+    /* GEM1                              [17:1]  RW value= 0x0 */
+    /* TIMER                             [18:1]  RW value= 0x0 */
+    /* GPIO0                             [19:1]  RW value= 0x0 */
+    /* GPIO1                             [20:1]  RW value= 0x0 */
+    /* GPIO2                             [21:1]  RW value= 0x0 */
+    /* RTC                               [22:1]  RW value= 0x0 */
+    /* H2FINT                            [23:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CONTEXT_A_EN)
+/*AMP context A. When the register bit is '0' the peripheral is not allowed
+access from context A. */
+#define LIBERO_SETTING_CONTEXT_A_EN    0x00000000UL
+    /* MMUART0                           [0:1]   RW value= 0x0 */
+    /* MMUART1                           [1:1]   RW value= 0x0 */
+    /* MMUART2                           [2:1]   RW value= 0x0 */
+    /* MMUART3                           [3:1]   RW value= 0x0 */
+    /* MMUART4                           [4:1]   RW value= 0x0 */
+    /* WDOG0                             [5:1]   RW value= 0x0 */
+    /* WDOG1                             [6:1]   RW value= 0x0 */
+    /* WDOG2                             [7:1]   RW value= 0x0 */
+    /* WDOG3                             [8:1]   RW value= 0x0 */
+    /* WDOG4                             [9:1]   RW value= 0x0 */
+    /* SPI0                              [10:1]  RW value= 0x0 */
+    /* SPI1                              [11:1]  RW value= 0x0 */
+    /* I2C0                              [12:1]  RW value= 0x0 */
+    /* I2C1                              [13:1]  RW value= 0x0 */
+    /* CAN0                              [14:1]  RW value= 0x0 */
+    /* CAN1                              [15:1]  RW value= 0x0 */
+    /* GEM0                              [16:1]  RW value= 0x0 */
+    /* GEM1                              [17:1]  RW value= 0x0 */
+    /* TIMER                             [18:1]  RW value= 0x0 */
+    /* GPIO0                             [19:1]  RW value= 0x0 */
+    /* GPIO1                             [20:1]  RW value= 0x0 */
+    /* GPIO2                             [21:1]  RW value= 0x0 */
+    /* RTC                               [22:1]  RW value= 0x0 */
+    /* H2FINT                            [23:1]  RW value= 0x0 */
+    /* CRYPTO                            [24:1]  RW value= 0x0 */
+    /* USB                               [25:1]  RW value= 0x0 */
+    /* QSPIXIP                           [26:1]  RW value= 0x0 */
+    /* ATHENA                            [27:1]  RW value= 0x0 */
+    /* TRACE                             [28:1]  RW value= 0x0 */
+    /* MAILBOX_SC                        [29:1]  RW value= 0x0 */
+    /* EMMC                              [30:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CONTEXT_B_EN)
+/*AMP context B. When the register bit is '0' the peripheral is not allowed
+access from context B. */
+#define LIBERO_SETTING_CONTEXT_B_EN    0x00000000UL
+    /* MMUART0                           [0:1]   RW value= 0x0 */
+    /* MMUART1                           [1:1]   RW value= 0x0 */
+    /* MMUART2                           [2:1]   RW value= 0x0 */
+    /* MMUART3                           [3:1]   RW value= 0x0 */
+    /* MMUART4                           [4:1]   RW value= 0x0 */
+    /* WDOG0                             [5:1]   RW value= 0x0 */
+    /* WDOG1                             [6:1]   RW value= 0x0 */
+    /* WDOG2                             [7:1]   RW value= 0x0 */
+    /* WDOG3                             [8:1]   RW value= 0x0 */
+    /* WDOG4                             [9:1]   RW value= 0x0 */
+    /* SPI0                              [10:1]  RW value= 0x0 */
+    /* SPI1                              [11:1]  RW value= 0x0 */
+    /* I2C0                              [12:1]  RW value= 0x0 */
+    /* I2C1                              [13:1]  RW value= 0x0 */
+    /* CAN0                              [14:1]  RW value= 0x0 */
+    /* CAN1                              [15:1]  RW value= 0x0 */
+    /* GEM0                              [16:1]  RW value= 0x0 */
+    /* GEM1                              [17:1]  RW value= 0x0 */
+    /* TIMER                             [18:1]  RW value= 0x0 */
+    /* GPIO0                             [19:1]  RW value= 0x0 */
+    /* GPIO1                             [20:1]  RW value= 0x0 */
+    /* GPIO2                             [21:1]  RW value= 0x0 */
+    /* RTC                               [22:1]  RW value= 0x0 */
+    /* H2FINT                            [23:1]  RW value= 0x0 */
+    /* CRYPTO                            [24:1]  RW value= 0x0 */
+    /* USB                               [25:1]  RW value= 0x0 */
+    /* QSPIXIP                           [26:1]  RW value= 0x0 */
+    /* ATHENA                            [27:1]  RW value= 0x0 */
+    /* TRACE                             [28:1]  RW value= 0x0 */
+    /* MAILBOX_SC                        [29:1]  RW value= 0x0 */
+    /* EMMC                              [30:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CONTEXT_A_HART_EN)
+/*When the register bit is '0' hart is not associated with context A. */
+#define LIBERO_SETTING_CONTEXT_A_HART_EN    0x00000000UL
+    /* HART0                             [0:1]   RW value= 0x0 */
+    /* HART1                             [1:1]   RW value= 0x0 */
+    /* HART2                             [2:1]   RW value= 0x0 */
+    /* HART3                             [3:1]   RW value= 0x0 */
+    /* HART4                             [4:1]   RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CONTEXT_B_HART_EN)
+/*When the register bit is '0' hart is not associated with context B. */
+#define LIBERO_SETTING_CONTEXT_B_HART_EN    0x00000000UL
+    /* HART0                             [0:1]   RW value= 0x0 */
+    /* HART1                             [1:1]   RW value= 0x0 */
+    /* HART2                             [2:1]   RW value= 0x0 */
+    /* HART3                             [3:1]   RW value= 0x0 */
+    /* HART4                             [4:1]   RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_APB_SPLIT_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_cache.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_cache.h
@@ -1,0 +1,436 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_cache.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_CACHE_H_
+#define HW_CACHE_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_WAY_ENABLE)
+/*Way indexes less than or equal to this register value may be used by the
+cache. E.g. set to 0x7, will allocate 8 cache ways, 0-7 to cache, and leave
+8-15 as LIM. Note 1: Way 0 is always allocated as cache. Note 2: each way is
+128KB. */
+#define LIBERO_SETTING_WAY_ENABLE    0x0000000BUL
+    /* WAY_ENABLE                        [0:8]   RW value= 0xB */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_DMA)
+/*Way mask register master DMA. Set field to zero to disable way from this
+master. The available cache ways are 0 to number set in WAY_ENABLE register. If
+using scratch pad memory, the ways you want reserved for scrathpad are not
+available for selection, you must set to 0. e.g. If three ways reserved for
+scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for all
+masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_DMA    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_AXI4_PORT_0)
+/*Way mask register master DMA. Set field to zero to disable way from this
+master. The available cache ways are 0 to number set in WAY_ENABLE register. If
+using scratch pad memory, the ways you want reserved for scrathpad are not
+available for selection, you must set to 0. e.g. If three ways reserved for
+scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for all
+masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_AXI4_PORT_0    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_AXI4_PORT_1)
+/*Way mask register master DMA. Set field to zero to disable way from this
+master. The available cache ways are 0 to number set in WAY_ENABLE register. If
+using scratch pad memory, the ways you want reserved for scrathpad are not
+available for selection, you must set to 0. e.g. If three ways reserved for
+scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for all
+masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_AXI4_PORT_1    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_AXI4_PORT_2)
+/*Way mask registerAXI slave port 2. Set field to zero to disable way from this
+master. The available cache ways are 0 to number set in WAY_ENABLE register. If
+using scratch pad memory, the ways you want reserved for scrathpad are not
+available for selection, you must set to 0. e.g. If three ways reserved for
+scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for all
+masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_AXI4_PORT_2    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_AXI4_PORT_3)
+/*Way mask register AXI slave port 3. Set field to 1 to disable way from this
+master. Set field to zero to disable way from this master. The available cache
+ways are 0 to number set in WAY_ENABLE register. If using scratch pad memory,
+the ways you want reserved for scrathpad are not available for selection, you
+must set to 0. e.g. If three ways reserved for scratchpad, WAY_MASK_0,
+WAY_MASK_1 and WAY_MASK_2 will be set to zero for all masters, so they can not
+evict the way. */
+#define LIBERO_SETTING_WAY_MASK_AXI4_PORT_3    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_E51_DCACHE)
+/*Way mask register E51 data cache (hart0). Set field to zero to disable way
+from this master. The available cache ways are 0 to number set in WAY_ENABLE
+register. If using scratch pad memory, the ways you want reserved for scrathpad
+are not available for selection, you must set to 0. e.g. If three ways reserved
+for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for
+all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_E51_DCACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_E51_ICACHE)
+/*Way mask registerE52 instruction cache (hart0). Set field to zero to disable
+way from this master. The available cache ways are 0 to number set in
+WAY_ENABLE register. If using scratch pad memory, the ways you want reserved
+for scrathpad are not available for selection, you must set to 0. e.g. If three
+ways reserved for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set
+to zero for all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_E51_ICACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_1_DCACHE)
+/*Way mask register data cache (hart1). Set field to zero to disable way from
+this master. The available cache ways are 0 to number set in WAY_ENABLE
+register. If using scratch pad memory, the ways you want reserved for scrathpad
+are not available for selection, you must set to 0. e.g. If three ways reserved
+for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for
+all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_1_DCACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_1_ICACHE)
+/*Way mask register instruction cache (hart1). Set field to zero to disable way
+from this master. The available cache ways are 0 to number set in WAY_ENABLE
+register. If using scratch pad memory, the ways you want reserved for scrathpad
+are not available for selection, you must set to 0. e.g. If three ways reserved
+for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for
+all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_1_ICACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_2_DCACHE)
+/*Way mask register data cache (hart2). Set field to 1 to disable way from this
+master. Set field to zero to disable way from this master. The available cache
+ways are 0 to number set in WAY_ENABLE register. If using scratch pad memory,
+the ways you want reserved for scrathpad are not available for selection, you
+must set to 0. e.g. If three ways reserved for scratchpad, WAY_MASK_0,
+WAY_MASK_1 and WAY_MASK_2 will be set to zero for all masters, so they can not
+evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_2_DCACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_2_ICACHE)
+/*Way mask register instruction cache (hart2). Set field to zero to disable way
+from this master. The available cache ways are 0 to number set in WAY_ENABLE
+register. If using scratch pad memory, the ways you want reserved for scrathpad
+are not available for selection, you must set to 0. e.g. If three ways reserved
+for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for
+all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_2_ICACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_3_DCACHE)
+/*Way mask register data cache (hart3). Set field to 1 to disable way from this
+master.Set field to zero to disable way from this master. The available cache
+ways are 0 to number set in WAY_ENABLE register. If using scratch pad memory,
+the ways you want reserved for scrathpad are not available for selection, you
+must set to 0. e.g. If three ways reserved for scratchpad, WAY_MASK_0,
+WAY_MASK_1 and WAY_MASK_2 will be set to zero for all masters, so they can not
+evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_3_DCACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_3_ICACHE)
+/*Way mask register instruction cache(hart3). Set field to zero to disable way
+from this master. The available cache ways are 0 to number set in WAY_ENABLE
+register. If using scratch pad memory, the ways you want reserved for scrathpad
+are not available for selection, you must set to 0. e.g. If three ways reserved
+for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for
+all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_3_ICACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_4_DCACHE)
+/*Way mask register data cache (hart4). Set field to 1 to disable way from this
+master. Set field to zero to disable way from this master. The available cache
+ways are 0 to number set in WAY_ENABLE register. If using scratch pad memory,
+the ways you want reserved for scrathpad are not available for selection, you
+must set to 0. e.g. If three ways reserved for scratchpad, WAY_MASK_0,
+WAY_MASK_1 and WAY_MASK_2 will be set to zero for all masters, so they can not
+evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_4_DCACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_WAY_MASK_U54_4_ICACHE)
+/*Way mask register instruction cache (hart4). Set field to zero to disable way
+from this master. The available cache ways are 0 to number set in WAY_ENABLE
+register. If using scratch pad memory, the ways you want reserved for scrathpad
+are not available for selection, you must set to 0. e.g. If three ways reserved
+for scratchpad, WAY_MASK_0, WAY_MASK_1 and WAY_MASK_2 will be set to zero for
+all masters, so they can not evict the way. */
+#define LIBERO_SETTING_WAY_MASK_U54_4_ICACHE    0x0000F0FFUL
+    /* WAY_MASK_0                        [0:1]   RW value= 0x1 */
+    /* WAY_MASK_1                        [1:1]   RW value= 0x1 */
+    /* WAY_MASK_2                        [2:1]   RW value= 0x1 */
+    /* WAY_MASK_3                        [3:1]   RW value= 0x1 */
+    /* WAY_MASK_4                        [4:1]   RW value= 0x1 */
+    /* WAY_MASK_5                        [5:1]   RW value= 0x1 */
+    /* WAY_MASK_6                        [6:1]   RW value= 0x1 */
+    /* WAY_MASK_7                        [7:1]   RW value= 0x1 */
+    /* WAY_MASK_8                        [8:1]   RW value= 0x0 */
+    /* WAY_MASK_9                        [9:1]   RW value= 0x0 */
+    /* WAY_MASK_10                       [10:1]  RW value= 0x0 */
+    /* WAY_MASK_11                       [11:1]  RW value= 0x0 */
+    /* WAY_MASK_12                       [12:1]  RW value= 0x1 */
+    /* WAY_MASK_13                       [13:1]  RW value= 0x1 */
+    /* WAY_MASK_14                       [14:1]  RW value= 0x1 */
+    /* WAY_MASK_15                       [15:1]  RW value= 0x1 */
+#endif
+#if !defined (LIBERO_SETTING_NUM_SCRATCH_PAD_WAYS)
+/*Number of ways reserved for scratchpad. Note 1: This is not a register Note
+2: each way is 128KB. Note 3: Embedded software expects cache ways allocated
+for scratchpad start at way 0, and work up. */
+#define LIBERO_SETTING_NUM_SCRATCH_PAD_WAYS    0x00000004UL
+    /* NUM_OF_WAYS                       [0:8]   RW value= 0x4 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_CACHE_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_memory.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_memory.h
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_memory.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MEMORY_H_
+#define HW_MEMORY_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_RESET_VECTOR_HART0)
+/*Reset vector hart0 */
+#define LIBERO_SETTING_RESET_VECTOR_HART0    0x20220000
+#define LIBERO_SETTING_RESET_VECTOR_HART0_SIZE    0x4    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_RESET_VECTOR_HART1)
+/*Reset vector hart1 */
+#define LIBERO_SETTING_RESET_VECTOR_HART1    0x20220000
+#define LIBERO_SETTING_RESET_VECTOR_HART1_SIZE    0x4    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_RESET_VECTOR_HART2)
+/*Reset vector hart2 */
+#define LIBERO_SETTING_RESET_VECTOR_HART2    0x20220000
+#define LIBERO_SETTING_RESET_VECTOR_HART2_SIZE    0x4    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_RESET_VECTOR_HART3)
+/*Reset vector hart3 */
+#define LIBERO_SETTING_RESET_VECTOR_HART3    0x20220000
+#define LIBERO_SETTING_RESET_VECTOR_HART3_SIZE    0x4    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_RESET_VECTOR_HART4)
+/*Reset vector hart4 */
+#define LIBERO_SETTING_RESET_VECTOR_HART4    0x20220000
+#define LIBERO_SETTING_RESET_VECTOR_HART4_SIZE    0x4    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_DDR_32_CACHE)
+/*example instance of memory */
+#define LIBERO_SETTING_DDR_32_CACHE    0x80000000
+#define LIBERO_SETTING_DDR_32_CACHE_SIZE    0x100000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_DDR_32_NON_CACHE)
+/*example instance */
+#define LIBERO_SETTING_DDR_32_NON_CACHE    0xC0000000
+#define LIBERO_SETTING_DDR_32_NON_CACHE_SIZE    0x100000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_DDR_64_CACHE)
+/*64 bit address  */
+#define LIBERO_SETTING_DDR_64_CACHE    0x1000000000
+#define LIBERO_SETTING_DDR_64_CACHE_SIZE    0x100000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_DDR_64_NON_CACHE)
+/*64 bit address  */
+#define LIBERO_SETTING_DDR_64_NON_CACHE    0x1400000000
+#define LIBERO_SETTING_DDR_64_NON_CACHE_SIZE    0x100000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_DDR_32_WCB)
+/*example instance */
+#define LIBERO_SETTING_DDR_32_WCB    0xD0000000
+#define LIBERO_SETTING_DDR_32_WCB_SIZE    0x100000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_DDR_64_WCB)
+/*64 bit address  */
+#define LIBERO_SETTING_DDR_64_WCB    0x1800000000
+#define LIBERO_SETTING_DDR_64_WCB_SIZE    0x100000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_RESERVED_SNVM)
+/*Offset and size of reserved sNVM. (Not available to MSS) */
+#define LIBERO_SETTING_RESERVED_SNVM    0x00000000
+#define LIBERO_SETTING_RESERVED_SNVM_SIZE    0x00000000    /* Length of memory block*/ 
+#endif
+#if !defined (LIBERO_SETTING_RESERVED_ENVM)
+/*Offset and size of reserved eNVM  (Not available to MSS) */
+#define LIBERO_SETTING_RESERVED_ENVM    0x00000000
+#define LIBERO_SETTING_RESERVED_ENVM_SIZE    0x00000000    /* Length of memory block*/ 
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MEMORY_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_crypto.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_crypto.h
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_crypto.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_CRYPTO_H_
+#define HW_MPU_CRYPTO_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_CRYPTO_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_CRYPTO_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_CRYPTO_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_CRYPTO_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_CRYPTO_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_CRYPTO_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_CRYPTO_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_CRYPTO_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_CRYPTO_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_fic0.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_fic0.h
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_fic0.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_FIC0_H_
+#define HW_MPU_FIC0_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP4)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP4    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP5)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP5    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP6)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP6    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP7)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP7    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP8)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP8    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP9)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP9    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP10)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP10    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP11)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP11    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP12)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP12    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP13)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP13    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP14)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP14    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC0_MPU_CFG_PMP15)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC0_MPU_CFG_PMP15    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_FIC0_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_fic1.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_fic1.h
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_fic1.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_FIC1_H_
+#define HW_MPU_FIC1_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP4)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP4    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP5)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP5    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP6)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP6    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP7)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP7    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP8)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP8    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP9)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP9    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP10)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP10    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP11)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP11    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP12)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP12    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP13)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP13    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP14)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP14    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC1_MPU_CFG_PMP15)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC1_MPU_CFG_PMP15    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_FIC1_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_fic2.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_fic2.h
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_fic2.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_FIC2_H_
+#define HW_MPU_FIC2_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP4)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP4    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP5)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP5    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP6)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP6    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_FIC2_MPU_CFG_PMP7)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_FIC2_MPU_CFG_PMP7    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_FIC2_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_gem0.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_gem0.h
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_gem0.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_GEM0_H_
+#define HW_MPU_GEM0_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP4)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP4    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP5)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP5    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP6)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP6    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM0_MPU_CFG_PMP7)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM0_MPU_CFG_PMP7    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_GEM0_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_gem1.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_gem1.h
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_gem1.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_GEM1_H_
+#define HW_MPU_GEM1_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP4)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP4    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP5)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP5    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP6)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP6    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_GEM1_MPU_CFG_PMP7)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_GEM1_MPU_CFG_PMP7    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_GEM1_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_mmc.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_mmc.h
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_mmc.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_MMC_H_
+#define HW_MPU_MMC_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_MMC_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_MMC_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_MMC_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_MMC_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_MMC_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_MMC_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_MMC_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_MMC_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_MMC_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_scb.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_scb.h
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_scb.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_SCB_H_
+#define HW_MPU_SCB_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP4)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP4    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP5)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP5    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP6)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP6    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_SCB_MPU_CFG_PMP7)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_SCB_MPU_CFG_PMP7    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_SCB_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_trace.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_trace.h
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_trace.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_TRACE_H_
+#define HW_MPU_TRACE_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_TRACE_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_TRACE_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_TRACE_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_TRACE_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_TRACE_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_usb.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_mpu_usb.h
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_mpu_usb.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_MPU_USB_H_
+#define HW_MPU_USB_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_USB_MPU_CFG_PMP0)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_USB_MPU_CFG_PMP0    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_USB_MPU_CFG_PMP1)
+/*mpu setup register, 64 bits */
+#define LIBERO_SETTING_USB_MPU_CFG_PMP1    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_USB_MPU_CFG_PMP2)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_USB_MPU_CFG_PMP2    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+#if !defined (LIBERO_SETTING_USB_MPU_CFG_PMP3)
+/*pmp setup register, 64 bits */
+#define LIBERO_SETTING_USB_MPU_CFG_PMP3    0x1F00000FFFFFFFFFULL
+    /* PMP                               [0:38]  RW value= 0xFFFFFFFFF */
+    /* RESERVED                          [38:18] RW value= 0x0 */
+    /* MODE                              [56:8]  RW value= 0x1F */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_MPU_USB_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart0.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart0.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_pmp_hart0.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_PMP_HART0_H_
+#define HW_PMP_HART0_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPCFG0)
+/*PMP configuration for 8 adress regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART0_CSR_PMPCFG0    0x0000000000000000ULL
+    /* PMP0CFG                           [0:8]   RW value= 0x00 */
+    /* PMP1CFG                           [8:8]   RW value= 0x0 */
+    /* PMP2CFG                           [16:8]  RW value= 0x00 */
+    /* PMP3CFG                           [24:8]  RW value= 0x00 */
+    /* PMP4CFG                           [32:8]  RW value= 0x00 */
+    /* PMP5CFG                           [40:8]  RW value= 0x00 */
+    /* PMP6CFG                           [48:8]  RW value= 0x00 */
+    /* PMP7CFG                           [56:8]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPCFG2)
+/*PMP configuration for 8 address regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART0_CSR_PMPCFG2    0x0000000000000000ULL
+    /* PMP8CFG                           [0:8]   RW value= 0x00 */
+    /* PMP9CFG                           [8:8]   RW value= 0x00 */
+    /* PMP10CFG                          [16:8]  RW value= 0x00 */
+    /* PMP11CFG                          [24:8]  RW value= 0x00 */
+    /* PMP12CFG                          [32:8]  RW value= 0x00 */
+    /* PMP13CFG                          [40:8]  RW value= 0x00 */
+    /* PMP14CFG                          [48:8]  RW value= 0x00 */
+    /* PMP15CFG                          [56:8]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR0)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR0    0x0000000000000000ULL
+    /* CSR_PMPADDR0                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR1)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR1    0x0000000000000000ULL
+    /* CSR_PMPADDR1                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR2)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR2    0x0000000000000000ULL
+    /* CSR_PMPADDR2                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR3)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR3    0x0000000000000000ULL
+    /* CSR_PMPADDR3                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR4)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR4    0x0000000000000000ULL
+    /* CSR_PMPADDR4                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR5)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR5    0x0000000000000000ULL
+    /* CSR_PMPADDR5                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR6)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR6    0x0000000000000000ULL
+    /* CSR_PMPADDR6                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR7)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR7    0x0000000000000000ULL
+    /* CSR_PMPADDR7                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR8)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR8    0x0000000000000000ULL
+    /* CSR_PMPADDR8                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR9)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR9    0x0000000000000000ULL
+    /* CSR_PMPADDR9                      [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR10)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR10    0x0000000000000000ULL
+    /* CSR_PMPADDR10                     [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR11)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR11    0x0000000000000000ULL
+    /* CSR_PMPADDR11                     [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR12)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR12    0x0000000000000000ULL
+    /* CSR_PMPADDR12                     [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR13)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR13    0x0000000000000000ULL
+    /* CSR_PMPADDR13                     [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR14)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR14    0x0000000000000000ULL
+    /* CSR_PMPADDR14                     [0:64]  RW value= 0x00 */
+#endif
+#if !defined (LIBERO_SETTING_HART0_CSR_PMPADDR15)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART0_CSR_PMPADDR15    0x0000000000000000ULL
+    /* CSR_PMPADDR15                     [0:64]  RW value= 0x00 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_PMP_HART0_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart1.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart1.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_pmp_hart1.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_PMP_HART1_H_
+#define HW_PMP_HART1_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPCFG0)
+/*PMP configuration for 8 adress regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART1_CSR_PMPCFG0    0x000000000000009FULL
+    /* PMP0CFG                           [0:8]   RW value= 0x9F */
+    /* PMP1CFG                           [8:8]   RW value= 0x0 */
+    /* PMP2CFG                           [16:8]  RW value= 0x0 */
+    /* PMP3CFG                           [24:8]  RW value= 0x0 */
+    /* PMP4CFG                           [32:8]  RW value= 0x0 */
+    /* PMP5CFG                           [40:8]  RW value= 0x0 */
+    /* PMP6CFG                           [48:8]  RW value= 0x0 */
+    /* PMP7CFG                           [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPCFG2)
+/*PMP configuration for 8 address regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART1_CSR_PMPCFG2    0x0000000000000000ULL
+    /* PMP8CFG                           [0:8]   RW value= 0x0 */
+    /* PMP9CFG                           [8:8]   RW value= 0x0 */
+    /* PMP10CFG                          [16:8]  RW value= 0x0 */
+    /* PMP11CFG                          [24:8]  RW value= 0x0 */
+    /* PMP12CFG                          [32:8]  RW value= 0x0 */
+    /* PMP13CFG                          [40:8]  RW value= 0x0 */
+    /* PMP14CFG                          [48:8]  RW value= 0x0 */
+    /* PMP15CFG                          [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR0)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR0    0xFFFFFFFFFFFFFFFFULL
+    /* CSR_PMPADDR0                      [0:64]  RW value= 0xFFFFFFFFFFFFFFFF */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR1)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR1    0x0000000000000000ULL
+    /* CSR_PMPADDR1                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR2)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR2    0x0000000000000000ULL
+    /* CSR_PMPADDR2                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR3)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR3    0x0000000000000000ULL
+    /* CSR_PMPADDR3                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR4)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR4    0x0000000000000000ULL
+    /* CSR_PMPADDR4                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR5)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR5    0x0000000000000000ULL
+    /* CSR_PMPADDR5                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR6)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR6    0x0000000000000000ULL
+    /* CSR_PMPADDR6                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR7)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR7    0x0000000000000000ULL
+    /* CSR_PMPADDR7                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR8)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR8    0x0000000000000000ULL
+    /* CSR_PMPADDR8                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR9)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR9    0x0000000000000000ULL
+    /* CSR_PMPADDR9                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR10)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR10    0x0000000000000000ULL
+    /* CSR_PMPADDR10                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR11)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR11    0x0000000000000000ULL
+    /* CSR_PMPADDR11                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR12)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR12    0x0000000000000000ULL
+    /* CSR_PMPADDR12                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR13)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR13    0x0000000000000000ULL
+    /* CSR_PMPADDR13                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR14)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR14    0x0000000000000000ULL
+    /* CSR_PMPADDR14                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART1_CSR_PMPADDR15)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART1_CSR_PMPADDR15    0x0000000000000000ULL
+    /* CSR_PMPADDR15                     [0:64]  RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_PMP_HART1_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart2.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart2.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_pmp_hart2.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_PMP_HART2_H_
+#define HW_PMP_HART2_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPCFG0)
+/*PMP configuration for 8 adress regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART2_CSR_PMPCFG0    0x000000000000009FULL
+    /* PMP0CFG                           [0:8]   RW value= 0x9F */
+    /* PMP1CFG                           [8:8]   RW value= 0x0 */
+    /* PMP2CFG                           [16:8]  RW value= 0x0 */
+    /* PMP3CFG                           [24:8]  RW value= 0x0 */
+    /* PMP4CFG                           [32:8]  RW value= 0x0 */
+    /* PMP5CFG                           [40:8]  RW value= 0x0 */
+    /* PMP6CFG                           [48:8]  RW value= 0x0 */
+    /* PMP7CFG                           [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPCFG2)
+/*PMP configuration for 8 address regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART2_CSR_PMPCFG2    0x0000000000000000ULL
+    /* PMP8CFG                           [0:8]   RW value= 0x0 */
+    /* PMP9CFG                           [8:8]   RW value= 0x0 */
+    /* PMP10CFG                          [16:8]  RW value= 0x0 */
+    /* PMP11CFG                          [24:8]  RW value= 0x0 */
+    /* PMP12CFG                          [32:8]  RW value= 0x0 */
+    /* PMP13CFG                          [40:8]  RW value= 0x0 */
+    /* PMP14CFG                          [48:8]  RW value= 0x0 */
+    /* PMP15CFG                          [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR0)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR0    0xFFFFFFFFFFFFFFFFULL
+    /* CSR_PMPADDR0                      [0:64]  RW value= 0xFFFFFFFFFFFFFFFF */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR1)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR1    0x0000000000000000ULL
+    /* CSR_PMPADDR1                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR2)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR2    0x0000000000000000ULL
+    /* CSR_PMPADDR2                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR3)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR3    0x0000000000000000ULL
+    /* CSR_PMPADDR3                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR4)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR4    0x0000000000000000ULL
+    /* CSR_PMPADDR4                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR5)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR5    0x0000000000000000ULL
+    /* CSR_PMPADDR5                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR6)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR6    0x0000000000000000ULL
+    /* CSR_PMPADDR6                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR7)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR7    0x0000000000000000ULL
+    /* CSR_PMPADDR7                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR8)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR8    0x0000000000000000ULL
+    /* CSR_PMPADDR8                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR9)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR9    0x0000000000000000ULL
+    /* CSR_PMPADDR9                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR10)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR10    0x0000000000000000ULL
+    /* CSR_PMPADDR10                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR11)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR11    0x0000000000000000ULL
+    /* CSR_PMPADDR11                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR12)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR12    0x0000000000000000ULL
+    /* CSR_PMPADDR12                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR13)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR13    0x0000000000000000ULL
+    /* CSR_PMPADDR13                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR14)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR14    0x0000000000000000ULL
+    /* CSR_PMPADDR14                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART2_CSR_PMPADDR15)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART2_CSR_PMPADDR15    0x0000000000000000ULL
+    /* CSR_PMPADDR15                     [0:64]  RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_PMP_HART2_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart3.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart3.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_pmp_hart3.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_PMP_HART3_H_
+#define HW_PMP_HART3_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPCFG0)
+/*PMP configuration for 8 adress regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART3_CSR_PMPCFG0    0x000000000000009FULL
+    /* PMP0CFG                           [0:8]   RW value= 0x9F */
+    /* PMP1CFG                           [8:8]   RW value= 0x0 */
+    /* PMP2CFG                           [16:8]  RW value= 0x0 */
+    /* PMP3CFG                           [24:8]  RW value= 0x0 */
+    /* PMP4CFG                           [32:8]  RW value= 0x0 */
+    /* PMP5CFG                           [40:8]  RW value= 0x0 */
+    /* PMP6CFG                           [48:8]  RW value= 0x0 */
+    /* PMP7CFG                           [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPCFG2)
+/*PMP configuration for 8 address regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART3_CSR_PMPCFG2    0x0000000000000000ULL
+    /* PMP8CFG                           [0:8]   RW value= 0x0 */
+    /* PMP9CFG                           [8:8]   RW value= 0x0 */
+    /* PMP10CFG                          [16:8]  RW value= 0x0 */
+    /* PMP11CFG                          [24:8]  RW value= 0x0 */
+    /* PMP12CFG                          [32:8]  RW value= 0x0 */
+    /* PMP13CFG                          [40:8]  RW value= 0x0 */
+    /* PMP14CFG                          [48:8]  RW value= 0x0 */
+    /* PMP15CFG                          [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR0)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR0    0xFFFFFFFFFFFFFFFFULL
+    /* CSR_PMPADDR0                      [0:64]  RW value= 0xFFFFFFFFFFFFFFFF */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR1)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR1    0x0000000000000000ULL
+    /* CSR_PMPADDR1                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR2)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR2    0x0000000000000000ULL
+    /* CSR_PMPADDR2                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR3)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR3    0x0000000000000000ULL
+    /* CSR_PMPADDR3                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR4)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR4    0x0000000000000000ULL
+    /* CSR_PMPADDR4                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR5)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR5    0x0000000000000000ULL
+    /* CSR_PMPADDR5                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR6)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR6    0x0000000000000000ULL
+    /* CSR_PMPADDR6                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR7)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR7    0x0000000000000000ULL
+    /* CSR_PMPADDR7                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR8)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR8    0x0000000000000000ULL
+    /* CSR_PMPADDR8                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR9)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR9    0x0000000000000000ULL
+    /* CSR_PMPADDR9                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR10)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR10    0x0000000000000000ULL
+    /* CSR_PMPADDR10                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR11)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR11    0x0000000000000000ULL
+    /* CSR_PMPADDR11                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR12)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR12    0x0000000000000000ULL
+    /* CSR_PMPADDR12                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR13)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR13    0x0000000000000000ULL
+    /* CSR_PMPADDR13                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR14)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR14    0x0000000000000000ULL
+    /* CSR_PMPADDR14                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART3_CSR_PMPADDR15)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART3_CSR_PMPADDR15    0x0000000000000000ULL
+    /* CSR_PMPADDR15                     [0:64]  RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_PMP_HART3_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart4.h
+++ b/cpu/mpfs/include/fpga_design_config/memory_map/hw_pmp_hart4.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_pmp_hart4.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_PMP_HART4_H_
+#define HW_PMP_HART4_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPCFG0)
+/*PMP configuration for 8 adress regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART4_CSR_PMPCFG0    0x000000000000009FULL
+    /* PMP0CFG                           [0:8]   RW value= 0x9F */
+    /* PMP1CFG                           [8:8]   RW value= 0x0 */
+    /* PMP2CFG                           [16:8]  RW value= 0x0 */
+    /* PMP3CFG                           [24:8]  RW value= 0x0 */
+    /* PMP4CFG                           [32:8]  RW value= 0x0 */
+    /* PMP5CFG                           [40:8]  RW value= 0x0 */
+    /* PMP6CFG                           [48:8]  RW value= 0x0 */
+    /* PMP7CFG                           [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPCFG2)
+/*PMP configuration for 8 address regions, bit 0 read, bit 1 write, bit 2
+execute, bit 7 disable, bits 3,4 address format (0x18 => NAPOT) */
+#define LIBERO_SETTING_HART4_CSR_PMPCFG2    0x0000000000000000ULL
+    /* PMP8CFG                           [0:8]   RW value= 0x0 */
+    /* PMP9CFG                           [8:8]   RW value= 0x0 */
+    /* PMP10CFG                          [16:8]  RW value= 0x0 */
+    /* PMP11CFG                          [24:8]  RW value= 0x0 */
+    /* PMP12CFG                          [32:8]  RW value= 0x0 */
+    /* PMP13CFG                          [40:8]  RW value= 0x0 */
+    /* PMP14CFG                          [48:8]  RW value= 0x0 */
+    /* PMP15CFG                          [56:8]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR0)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR0    0xFFFFFFFFFFFFFFFFULL
+    /* CSR_PMPADDR0                      [0:64]  RW value= 0xFFFFFFFFFFFFFFFF */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR1)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR1    0x0000000000000000ULL
+    /* CSR_PMPADDR1                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR2)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR2    0x0000000000000000ULL
+    /* CSR_PMPADDR2                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR3)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR3    0x0000000000000000ULL
+    /* CSR_PMPADDR3                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR4)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR4    0x0000000000000000ULL
+    /* CSR_PMPADDR4                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR5)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR5    0x0000000000000000ULL
+    /* CSR_PMPADDR5                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR6)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR6    0x0000000000000000ULL
+    /* CSR_PMPADDR6                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR7)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR7    0x0000000000000000ULL
+    /* CSR_PMPADDR7                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR8)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR8    0x0000000000000000ULL
+    /* CSR_PMPADDR8                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR9)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR9    0x0000000000000000ULL
+    /* CSR_PMPADDR9                      [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR10)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR10    0x0000000000000000ULL
+    /* CSR_PMPADDR10                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR11)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR11    0x0000000000000000ULL
+    /* CSR_PMPADDR11                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR12)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR12    0x0000000000000000ULL
+    /* CSR_PMPADDR12                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR13)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR13    0x0000000000000000ULL
+    /* CSR_PMPADDR13                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR14)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR14    0x0000000000000000ULL
+    /* CSR_PMPADDR14                     [0:64]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_HART4_CSR_PMPADDR15)
+/*PMP ADRESS and size, format determined from bit 3 and 4 of configuration byte
+in CSR_PMPCFGx */
+#define LIBERO_SETTING_HART4_CSR_PMPADDR15    0x0000000000000000ULL
+    /* CSR_PMPADDR15                     [0:64]  RW value= 0x0 */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_PMP_HART4_H_ */
+

--- a/cpu/mpfs/include/fpga_design_config/sgmii/hw_sgmii_tip.h
+++ b/cpu/mpfs/include/fpga_design_config/sgmii/hw_sgmii_tip.h
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright 2019-2021 Microchip FPGA Embedded Systems Solutions.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * @file hw_sgmii_tip.h
+ * @author Microchip-FPGA Embedded Systems Solutions
+ *
+ *
+ * Note 1: This file should not be edited. If you need to modify a parameter
+ * without going through regenerating using the MSS Configurator Libero flow 
+ * or editing the associated xml file
+ * the following method is recommended: 
+
+ * 1. edit the following file 
+ * boards/your_board/platform_config/mpfs_hal_config/mss_sw_config.h
+
+ * 2. define the value you want to override there.
+ * (Note: There is a commented example in the platform directory)
+
+ * Note 2: The definition in mss_sw_config.h takes precedence, as
+ * mss_sw_config.h is included prior to the generated header files located in
+ * boards/your_board/fpga_design_config
+ *
+ */
+
+#ifndef HW_SGMII_TIP_H_
+#define HW_SGMII_TIP_H_
+
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+#if !defined (LIBERO_SETTING_SGMII_MODE)
+/*SGMII mode control (SEU) */
+#define LIBERO_SETTING_SGMII_MODE    0x08C0E6FFUL
+    /* REG_PLL_EN                        [0:1]   RW value= 0x1 */
+    /* REG_DLL_EN                        [1:1]   RW value= 0x1 */
+    /* REG_PVT_EN                        [2:1]   RW value= 0x1 */
+    /* REG_BC_VRGEN_EN                   [3:1]   RW value= 0x1 */
+    /* REG_TX0_EN                        [4:1]   RW value= 0x1 */
+    /* REG_RX0_EN                        [5:1]   RW value= 0x1 */
+    /* REG_TX1_EN                        [6:1]   RW value= 0x1 */
+    /* REG_RX1_EN                        [7:1]   RW value= 0x1 */
+    /* REG_DLL_LOCK_FLT                  [8:2]   RW value= 0x2 */
+    /* REG_DLL_ADJ_CODE                  [10:4]  RW value= 0x9 */
+    /* REG_CH0_CDR_RESET_B               [14:1]  RW value= 0x1 */
+    /* REG_CH1_CDR_RESET_B               [15:1]  RW value= 0x1 */
+    /* REG_BC_VRGEN                      [16:6]  RW value= 0x00 */
+    /* REG_CDR_MOVE_STEP                 [22:1]  RW value= 0x1 */
+    /* REG_REFCLK_EN_RDIFF               [23:1]  RW value= 0x1 */
+    /* REG_BC_VS                         [24:4]  RW value= 0x8 */
+    /* REG_REFCLK_EN_UDRIVE_P            [28:1]  RW value= 0x0 */
+    /* REG_REFCLK_EN_INS_HYST_P          [29:1]  RW value= 0x0 */
+    /* REG_REFCLK_EN_UDRIVE_N            [30:1]  RW value= 0x0 */
+    /* REG_REFCLK_EN_INS_HYST_N          [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_PLL_CNTL)
+/*PLL control register (SEU) */
+#define LIBERO_SETTING_PLL_CNTL    0x80140101UL
+    /* REG_PLL_POSTDIV                   [0:7]   RW value= 0x1 */
+    /* ARO_PLL0_LOCK                     [7:1]   RO */
+    /* REG_PLL_RFDIV                     [8:6]   RW value= 0x1 */
+    /* REG_PLL_REG_RFCLK_SEL             [14:1]  RW value= 0x0 */
+    /* REG_PLL_LP_REQUIRES_LOCK          [15:1]  RW value= 0x0 */
+    /* REG_PLL_INTIN                     [16:12] RW value= 0x14 */
+    /* REG_PLL_BWI                       [28:2]  RW value= 0x0 */
+    /* REG_PLL_BWP                       [30:2]  RW value= 0x2 */
+#endif
+#if !defined (LIBERO_SETTING_CH0_CNTL)
+/*Channel0 control register */
+#define LIBERO_SETTING_CH0_CNTL    0x37F07770UL
+    /* REG_TX0_WPU_P                     [0:1]   RW value= 0x0 */
+    /* REG_TX0_WPD_P                     [1:1]   RW value= 0x0 */
+    /* REG_TX0_SLEW_P                    [2:2]   RW value= 0x0 */
+    /* REG_TX0_DRV_P                     [4:4]   RW value= 0x7 */
+    /* REG_TX0_ODT_P                     [8:4]   RW value= 0x7 */
+    /* REG_TX0_ODT_STATIC_P              [12:3]  RW value= 0x7 */
+    /* REG_RX0_TIM_LONG                  [15:1]  RW value= 0x0 */
+    /* REG_RX0_WPU_P                     [16:1]  RW value= 0x0 */
+    /* REG_RX0_WPD_P                     [17:1]  RW value= 0x0 */
+    /* REG_RX0_IBUFMD_P                  [18:3]  RW value= 0x4 */
+    /* REG_RX0_EYEWIDTH_P                [21:3]  RW value= 0x7 */
+    /* REG_RX0_ODT_P                     [24:4]  RW value= 0x7 */
+    /* REG_RX0_ODT_STATIC_P              [28:3]  RW value= 0x3 */
+    /* REG_RX0_EN_FLAG_N                 [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_CH1_CNTL)
+/*Channel1 control register */
+#define LIBERO_SETTING_CH1_CNTL    0x37F07770UL
+    /* REG_TX1_WPU_P                     [0:1]   RW value= 0x0 */
+    /* REG_TX1_WPD_P                     [1:1]   RW value= 0x0 */
+    /* REG_TX1_SLEW_P                    [2:2]   RW value= 0x0 */
+    /* REG_TX1_DRV_P                     [4:4]   RW value= 0x7 */
+    /* REG_TX1_ODT_P                     [8:4]   RW value= 0x7 */
+    /* REG_TX1_ODT_STATIC_P              [12:3]  RW value= 0x7 */
+    /* REG_RX1_TIM_LONG                  [15:1]  RW value= 0x0 */
+    /* REG_RX1_WPU_P                     [16:1]  RW value= 0x0 */
+    /* REG_RX1_WPD_P                     [17:1]  RW value= 0x0 */
+    /* REG_RX1_IBUFMD_P                  [18:3]  RW value= 0x4 */
+    /* REG_RX1_EYEWIDTH_P                [21:3]  RW value= 0x7 */
+    /* REG_RX1_ODT_P                     [24:4]  RW value= 0x7 */
+    /* REG_RX1_ODT_STATIC_P              [28:3]  RW value= 0x3 */
+    /* REG_RX1_EN_FLAG_N                 [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_RECAL_CNTL)
+/*Recalibration control register */
+#define LIBERO_SETTING_RECAL_CNTL    0x000020C8UL
+    /* REG_RECAL_DIFF_RANGE              [0:5]   RW value= 0x8 */
+    /* REG_RECAL_START_EN                [5:1]   RW value= 0x0 */
+    /* REG_PVT_CALIB_START               [6:1]   RW value= 0x1 */
+    /* REG_PVT_CALIB_LOCK                [7:1]   RW value= 0x1 */
+    /* REG_RECAL_UPD                     [8:1]   RW value= 0x0 */
+    /* BC_VRGEN_DIRECTION                [9:1]   RW value= 0x0 */
+    /* BC_VRGEN_LOAD                     [10:1]  RW value= 0x0 */
+    /* BC_VRGEN_MOVE                     [11:1]  RW value= 0x0 */
+    /* REG_PVT_REG_CALIB_CLKDIV          [12:2]  RW value= 0x2 */
+    /* REG_PVT_REG_CALIB_DIFFR_VSEL      [14:2]  RW value= 0x0 */
+    /* SRO_DLL_90_CODE                   [16:7]  RO */
+    /* SRO_DLL_LOCK                      [23:1]  RO */
+    /* SRO_DLL_ST_CODE                   [24:7]  RO */
+    /* SRO_RECAL_START                   [31:1]  RO */
+#endif
+#if !defined (LIBERO_SETTING_CLK_CNTL)
+/*Clock input and routing control registers */
+#define LIBERO_SETTING_CLK_CNTL    0xF00050CCUL
+    /* REG_REFCLK_EN_TERM_P              [0:2]   RW value= 0x0 */
+    /* REG_REFCLK_EN_RXMODE_P            [2:2]   RW value= 0x3 */
+    /* REG_REFCLK_EN_TERM_N              [4:2]   RW value= 0x0 */
+    /* REG_REFCLK_EN_RXMODE_N            [6:2]   RW value= 0x3 */
+    /* REG_REFCLK_CLKBUF_EN_PULLUP       [8:1]   RW value= 0x0 */
+    /* REG_CLKMUX_FCLK_SEL               [9:3]   RW value= 0x0 */
+    /* REG_CLKMUX_PLL0_RFCLK0_SEL        [12:2]  RW value= 0x1 */
+    /* REG_CLKMUX_PLL0_RFCLK1_SEL        [14:2]  RW value= 0x1 */
+    /* REG_CLKMUX_SPARE0                 [16:16] RW value= 0xf000 */
+#endif
+#if !defined (LIBERO_SETTING_DYN_CNTL)
+/*Dynamic control registers */
+#define LIBERO_SETTING_DYN_CNTL    0x00000000UL
+    /* REG_PLL_DYNEN                     [0:1]   RW value= 0x0 */
+    /* REG_DLL_DYNEN                     [1:1]   RW value= 0x0 */
+    /* REG_PVT_DYNEN                     [2:1]   RW value= 0x0 */
+    /* REG_BC_DYNEN                      [3:1]   RW value= 0x0 */
+    /* REG_CLKMUX_DYNEN                  [4:1]   RW value= 0x0 */
+    /* REG_LANE0_DYNEN                   [5:1]   RW value= 0x0 */
+    /* REG_LANE1_DYNEN                   [6:1]   RW value= 0x0 */
+    /* BC_VRGEN_OOR                      [7:1]   RO */
+    /* REG_PLL_SOFT_RESET_PERIPH         [8:1]   RW value= 0x0 */
+    /* REG_DLL_SOFT_RESET_PERIPH         [9:1]   RW value= 0x0 */
+    /* REG_PVT_SOFT_RESET_PERIPH         [10:1]  RW value= 0x0 */
+    /* REG_BC_SOFT_RESET_PERIPH          [11:1]  RW value= 0x0 */
+    /* REG_CLKMUX_SOFT_RESET_PERIPH      [12:1]  RW value= 0x0 */
+    /* REG_LANE0_SOFT_RESET_PERIPH       [13:1]  RW value= 0x0 */
+    /* REG_LANE1_SOFT_RESET_PERIPH       [14:1]  RW value= 0x0 */
+    /* PVT_CALIB_STATUS                  [15:1]  RO */
+    /* ARO_PLL0_VCO0PH_SEL               [16:3]  RO */
+    /* ARO_PLL0_VCO1PH_SEL               [19:3]  RO */
+    /* ARO_PLL0_VCO2PH_SEL               [22:3]  RO */
+    /* ARO_PLL0_VCO3PH_SEL               [25:3]  RO */
+    /* ARO_REF_DIFFR                     [28:4]  RO */
+#endif
+#if !defined (LIBERO_SETTING_PVT_STAT)
+/*PVT calibrator status registers */
+#define LIBERO_SETTING_PVT_STAT    0x00000000UL
+    /* ARO_REF_PCODE                     [0:6]   RO */
+    /* ARO_IOEN_BNK                      [6:1]   RO */
+    /* ARO_IOEN_BNK_B                    [7:1]   RO */
+    /* ARO_REF_NCODE                     [8:6]   RO */
+    /* ARO_CALIB_STATUS                  [14:1]  RO */
+    /* ARO_CALIB_STATUS_B                [15:1]  RO */
+    /* ARO_PCODE                         [16:6]  RO */
+    /* ARO_CALIB_INTRPT                  [22:1]  RO */
+    /* PVT_CALIB_INTRPT                  [23:1]  RO */
+    /* ARO_NCODE                         [24:6]  RO */
+    /* PVT_CALIB_LOCK                    [30:1]  RW value= 0x0 */
+    /* PVT_CALIB_START                   [31:1]  RW value= 0x0 */
+#endif
+#if !defined (LIBERO_SETTING_SPARE_CNTL)
+/*Spare control register */
+#define LIBERO_SETTING_SPARE_CNTL    0xFF000000UL
+    /* REG_SPARE                         [0:32]  RW value= 0xFF000000 */
+#endif
+#if !defined (LIBERO_SETTING_SPARE_STAT)
+/*Spare status register */
+#define LIBERO_SETTING_SPARE_STAT    0x00000000UL
+    /* SRO_SPARE                         [0:32]  RO */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* #ifdef HW_SGMII_TIP_H_ */
+

--- a/cpu/mpfs/include/periph_cpu.h
+++ b/cpu/mpfs/include/periph_cpu.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         cpu_mpfs
+ * @{
+ *
+ * @file
+ * @brief           CPU specific definitions for internal peripheral handling
+ *
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
+
+#include <inttypes.h>
+
+#include "cpu.h"
+#include "clic.h"
+#include "kernel_defines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef DOXYGEN
+/**
+ * @brief   Overwrite the default gpio_t type definition
+ * @{
+ */
+#define HAVE_GPIO_T
+typedef uint32_t gpio_t;
+/** @} */
+
+typedef int GPIO_Type;
+typedef int gpio_af_t;
+/**
+ * @brief   Definition of a fitting UNDEF value
+ */
+#define GPIO_UNDEF          (0xffffffff)
+
+#define GPIO_PIN(x, y) ((gpio_t)(x << 5 | y))
+
+/**
+ * @brief   Generate GPIO mode bitfields
+ *
+ * We use 2 bit to determine the pin functions:
+ * - bit 0: enable output
+ * - bit 1: enable input
+ */
+#define GPIO_MODE(ei, eo)   (eo | (ei << 1))
+
+#ifndef DOXYGEN
+/**
+ * @brief   Override GPIO modes
+ */
+#define HAVE_GPIO_MODE_T
+typedef enum {
+    GPIO_IN    = GPIO_MODE(1, 0),       /**< IN */
+    GPIO_OUT   = GPIO_MODE(0, 1),       /**< OUT (push-pull) */
+    GPIO_IN_PD = 0xfc,                  /**< IN with pull-down */
+    GPIO_IN_PU = 0xfd,                  /**< IN with pull-up */
+    GPIO_OD    = 0xfe,                  /**< not supported by HW */
+    GPIO_OD_PU = 0xff                   /**< not supported by HW */
+} gpio_mode_t;
+#endif
+
+/**
+ * @brief   Override active flank configuration values
+ * @{
+ */
+#define HAVE_GPIO_FLANK_T
+typedef enum {
+    GPIO_FALLING = MSS_GPIO_IRQ_EDGE_NEGATIVE,  /**< emit interrupt on falling flank */
+    GPIO_RISING = MSS_GPIO_IRQ_EDGE_POSITIVE,   /**< emit interrupt on rising flank */
+    GPIO_BOTH = MSS_GPIO_IRQ_EDGE_BOTH          /**< emit interrupt on both flanks */
+} gpio_flank_t;
+/** @} */
+
+#endif /* ndef DOXYGEN */
+
+/** @} */
+
+#define PERIPH_TIMER_PROVIDES_SET
+/**
+ * @brief   Timer device configuration
+ */
+typedef struct {
+    TIMER_TypeDef *dev;           /**< pointer to the used Timer device */
+    unsigned num;
+} timer_conf_t;
+
+typedef struct {
+    mss_uart_instance_t* dev;
+    MSS_UART_TypeDef *base_addr;
+    uint32_t irqn;
+    uint32_t clk;
+} uart_conf_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CPU_H */
+/** @} */

--- a/cpu/mpfs/periph/Makefile
+++ b/cpu/mpfs/periph/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTMAKE)/periph.mk

--- a/cpu/mpfs/periph/gpio.c
+++ b/cpu/mpfs/periph/gpio.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+/**
+ * @ingroup         cpu_mpfs
+ * @{
+ *
+ * @file
+ * @brief           Polarfire GPIO implementation
+ *
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#include <assert.h>
+#include <stdio.h>
+
+#include "cpu.h"
+#include "board.h"
+#include "plic.h"
+#include "periph_cpu.h"
+#include "periph/gpio.h"
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+/* Same as defined in mss_gpio.c */
+#define NB_OF_GPIO_INTR (41u)
+
+static gpio_isr_ctx_t gpio_config[NB_OF_GPIO_INTR];
+#endif /* MODULE_PERIPH_GPIO_IRQ */
+/**
+ * @brief   Extract the port base address from the given pin identifier
+ */
+static  GPIO_TypeDef *_port(gpio_t pin)
+{
+    switch (pin >> 5)
+    {
+        case 0:
+            return GPIO0_LO;
+        case 1:
+            return GPIO1_LO;
+        case 2:
+            return GPIO2_LO;
+        
+        default:
+            assert(0);
+            return 0;
+    }
+}
+
+/**
+ * @brief   Extract the port number form the given identifier
+ *
+ * The port number is extracted by looking at bits 10, 11, 12, 13 of the base
+ * register addresses.
+ */
+static inline unsigned _port_num(gpio_t pin)
+{
+    return (((pin >> 5) & 0xf));
+}
+
+/**
+ * @brief   Extract the pin number from the last 5 bits of the pin identifier
+ */
+static inline int _pin_num(gpio_t pin)
+{
+    return (pin & 0x1f);
+}
+
+int gpio_init(gpio_t pin, gpio_mode_t mode)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+
+    port->GPIO_CFG[pin_num] = mode;
+
+    return 0;
+}
+
+void gpio_init_af(gpio_t pin, gpio_af_t af)
+{
+    (void)pin;
+    (void)af;
+}
+
+int gpio_read(gpio_t pin)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+
+    return  (port->GPIO_IN & (1 << pin_num));
+}
+
+void gpio_set(gpio_t pin)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+
+    port->GPIO_SET_BITS = ( 1 << pin_num);
+}
+
+void gpio_clear(gpio_t pin)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+
+    port->GPIO_CLR_BITS = ( 1 << pin_num);
+}
+
+void gpio_toggle(gpio_t pin)
+{
+    if (gpio_read(pin)) {
+        gpio_clear(pin);
+    }
+    else {
+        gpio_set(pin);
+    }
+}
+
+void gpio_write(gpio_t pin, int value)
+{
+    if (value) {
+        gpio_set(pin);
+    }
+    else {
+        gpio_clear(pin);
+    }
+}
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+
+static uint32_t _get_irq(gpio_t pin)
+{
+    uint32_t port_nb = _port_num(pin);
+    uint32_t irq_line;
+
+    switch (port_nb)
+    {
+        case 0: /* Fall-through */
+        case 2:
+            irq_line = GPIO0_BIT0_or_GPIO2_BIT0_PLIC_0;
+            break;
+        case 1:
+            irq_line = GPIO1_BIT0_or_GPIO2_BIT14_PLIC_14;
+            break;
+        default:
+            assert(0);
+    }
+
+    irq_line += _pin_num(pin);
+
+    return irq_line;
+}
+
+void gpio_isr(int irq)
+{
+    uint32_t ei_line = irq - GPIO0_BIT0_or_GPIO2_BIT0_PLIC_0;
+
+    /* As IRQ is shared between GPIO0/GPIO1 & GPIO2 bank,
+       check which bank was used to clear the IRQ */
+    if ((SYSREG->GPIO_INTERRUPT_FAB_CR & 1 << ei_line) &&
+        (ei_line <= GPIO1_BIT17_or_GPIO2_BIT31_PLIC_31))
+    {
+        /* GPIO IRQ are routed to FPGA Fabric so GPIO bank 2 */
+        MSS_GPIO_clear_irq(GPIO2_LO, ei_line);
+
+    } else {
+        if (ei_line < GPIO1_BIT0_or_GPIO2_BIT14_PLIC_14) {
+            MSS_GPIO_clear_irq(GPIO0_LO, ei_line);
+        } else {
+            MSS_GPIO_clear_irq(GPIO1_LO, ei_line - GPIO1_BIT0_or_GPIO2_BIT14_PLIC_14);
+        }
+    }
+
+    /* callback to user defined function */
+    gpio_config[ei_line].cb(gpio_config[ei_line].arg);
+}
+
+int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                  gpio_cb_t cb, void *arg)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+    /* Get external interrupt line */
+    uint32_t ei_line = _get_irq(pin);
+    /* Store callback and argument */
+    gpio_config[ei_line - GPIO0_BIT0_or_GPIO2_BIT0_PLIC_0].cb = cb;
+    gpio_config[ei_line - GPIO0_BIT0_or_GPIO2_BIT0_PLIC_0].arg = arg;
+    /* Configure GPIO as interrupt */
+    MSS_GPIO_config(port, pin_num, mode | flank);
+
+    plic_set_isr_cb(ei_line, gpio_isr);
+
+    MSS_GPIO_enable_irq(port, pin_num);
+
+    plic_set_priority(ei_line, 2);
+
+    plic_enable_interrupt(ei_line);
+
+    return 0;
+}
+
+void gpio_irq_enable(gpio_t pin)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+
+    MSS_GPIO_enable_irq(port, pin_num);
+}
+void gpio_irq_disable(gpio_t pin)
+{
+    GPIO_TypeDef *port = _port(pin);
+    unsigned pin_num = _pin_num(pin);
+
+    MSS_GPIO_disable_irq(port, pin_num);
+}
+
+#endif /* MODULE_PERIPH_GPIO_IRQ */
+/** @} */

--- a/cpu/mpfs/periph/pm.c
+++ b/cpu/mpfs/periph/pm.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_mpfs
+ * @{
+ *
+ * @brief       Implementation of the CPU power management for Polarfire CPU
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @}
+ */
+
+#include <stdint.h>
+#include "periph/pm.h"
+
+void pm_reboot(void)
+{
+    while (1) {}
+}

--- a/cpu/mpfs/periph/timer.c
+++ b/cpu/mpfs/periph/timer.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_mpfs
+ * @ingroup     drivers_periph_timer
+ * @{
+ *
+ * @file        timer.c
+ * @brief       Low-level timer driver implementation
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "plic.h"
+
+#include "periph/timer.h"
+#include "periph_conf.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static timer_cb_t _callback[2];
+static void* _arg[2];
+void timer_isr(int irq);
+uint16_t prescaler = 1;
+
+static inline TIMER_TypeDef *dev(tim_t tim)
+{
+    return timer_config[tim].dev;
+}
+
+static inline uint32_t _timer_value(uint32_t val)
+{
+    return (val * prescaler);
+}
+
+static bool _is_oneshot(unsigned num)
+{
+    if (num == 1) {
+        return (((TIMER_LO->TIM1_CTRL & TIM1_MODE_MASK) >> TIM1_MODE_SHIFT) == MSS_TIMER_ONE_SHOT_MODE) ?
+                true : false;
+    } else if (num == 2) {
+        return (((TIMER_LO->TIM2_CTRL & TIM2_MODE_MASK) >> TIM2_MODE_SHIFT) == MSS_TIMER_ONE_SHOT_MODE) ?
+                true : false;
+    } else {
+        assert(0);
+    }
+    return false;
+}
+
+int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
+{
+    /* MPFS Timer IP is feed by 600MHz / 4 by default like all others
+       peripherals, and doesn't have a hardware prescaler. Thus we
+       need to emulate it by software to match RIOT timer frequency */
+    prescaler = ((CLOCK_CORECLOCK / 4) / freq);
+    mss_config_clk_rst(MSS_PERIPH_TIMER, (uint8_t) MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+    if (timer_config[tim].num == 1)
+    {
+        _callback[0] = cb;
+        _arg[0] = arg;
+        plic_set_isr_cb(TIMER1_PLIC, timer_isr);
+        plic_set_priority(TIMER1_PLIC, 2);
+        plic_enable_interrupt(TIMER1_PLIC);
+    }
+    else
+    {
+        _callback[1] = cb;
+        _arg[1] = arg;
+        plic_set_isr_cb(TIMER2_PLIC, timer_isr);
+        plic_set_priority(TIMER2_PLIC, 2);
+        plic_enable_interrupt(TIMER2_PLIC);
+    }
+    return 0;
+}
+
+int timer_set(tim_t tim, int channel, unsigned int timeout)
+{
+    if (channel > 0) {
+        return -1;
+    }
+    unsigned int state = irq_disable();
+    unsigned int test = MSS_TIM1_get_current_value(dev(tim)) + timeout;
+    int res = timer_set_absolute(tim, channel, test);
+    irq_restore(state);
+    printf("timer_set %d\n", test);
+    return res;
+}
+
+int timer_set_absolute(tim_t tim, int channel, unsigned int value)
+{
+    if (channel > 0) {
+        return -1;
+    }
+
+    if (timer_config[tim].num == 1)
+    {
+        MSS_TIM1_stop(dev(tim));
+        MSS_TIM1_init(dev(tim), MSS_TIMER_ONE_SHOT_MODE);
+        MSS_TIM1_load_immediate(dev(tim), 150 * value);
+        MSS_TIM1_load_background(dev(tim), UINT32_MAX);
+        MSS_TIM1_enable_irq(dev(tim));
+        MSS_TIM1_start(dev(tim));
+    }
+    else
+    {
+        MSS_TIM2_init(dev(tim), MSS_TIMER_ONE_SHOT_MODE);
+        MSS_TIM2_load_immediate(dev(tim), 150 * value);
+        MSS_TIM2_enable_irq(dev(tim));
+        MSS_TIM2_start(dev(tim));
+    }
+
+    return 0;
+}
+
+int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags)
+{
+    (void)flags;
+    if (channel > 0) {
+        return -1;
+    }
+    unsigned int mask = irq_disable();
+    if (timer_config[tim].num == 1)
+    {
+        MSS_TIM1_stop(dev(tim));
+        MSS_TIM1_init(dev(tim), MSS_TIMER_PERIODIC_MODE);
+        MSS_TIM1_load_background(dev(tim), _timer_value(value));
+        MSS_TIM1_enable_irq(dev(tim));
+        MSS_TIM1_start(dev(tim));
+    }
+    else
+    {
+        MSS_TIM2_init(dev(tim), MSS_TIMER_PERIODIC_MODE);
+        MSS_TIM2_load_background(dev(tim), _timer_value(value));
+        MSS_TIM2_enable_irq(dev(tim));
+        MSS_TIM2_start(dev(tim));
+    }
+    irq_restore(mask);
+    return 0;
+}
+
+int timer_clear(tim_t tim, int channel)
+{ 
+    if (channel > 0) {
+        return -1;
+    }
+    if (timer_config[tim].num == 1)
+    {
+        dev(tim)->TIM1_CTRL &= ~((uint32_t)TIM1_INTEN_MASK);
+    }
+    else
+    {
+        dev(tim)->TIM2_CTRL &= ~((uint32_t)TIM2_INTEN_MASK);
+    }
+    return 0;
+}
+
+unsigned int timer_read(tim_t tim)
+{
+    if (timer_config[tim].num == 1)
+    {
+        return UINT32_MAX - MSS_TIM2_get_current_value(dev(tim)); 
+    }
+    else
+    {
+        return UINT32_MAX - MSS_TIM2_get_current_value(dev(tim));
+    }
+}
+
+void timer_start(tim_t tim)
+{
+    if (timer_config[tim].num == 1)
+    {
+        MSS_TIM1_start(dev(tim));
+    }
+    else
+    {
+        MSS_TIM2_start(dev(tim));
+    }
+}
+
+void timer_stop(tim_t tim)
+{
+    if (timer_config[tim].num == 1)
+    {
+        MSS_TIM1_stop(dev(tim));
+    }
+    else
+    {
+        MSS_TIM2_stop(dev(tim));
+    }
+}
+
+void timer_isr(int irq)
+{
+    /* Compare to n-1 IRQn so index start at 1 */
+    int num = irq - RTC_MATCH_PLIC;
+    if (num == 1) {
+        if (_is_oneshot(num)) {
+            MSS_TIM1_disable_irq(dev(0));
+        }
+        MSS_TIM1_clear_irq(dev(0));
+    } else if (num == 2) {
+        if (_is_oneshot(num)) {
+            MSS_TIM2_disable_irq(dev(0));
+        }
+        MSS_TIM2_clear_irq(dev(0));
+    } else {
+        assert(0);
+    }
+
+    _callback[num-1](_arg[num-1], 0);
+}

--- a/cpu/mpfs/periph/uart.c
+++ b/cpu/mpfs/periph/uart.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2021 Mesotic SAS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_mpfs
+ * @ingroup     drivers_periph_uart
+ * @{
+ *
+ * @file
+ * @brief       Low-level UART driver implementation
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph_cpu.h"
+#include "periph/gpio.h"
+#include "periph/uart.h"
+#include "plic.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   Allocate memory to store the callback functions & buffers
+ */
+static uart_isr_ctx_t uart_ctx[UART_NUMOF];
+
+/**
+ * @brief   Get the pointer to the base register of the given UART device
+ *
+ * @param[in] dev       UART device identifier
+ *
+ * @return              base register address
+ */
+static inline mss_uart_instance_t *dev(uart_t dev)
+{
+    return uart_config[dev].dev;
+}
+
+static inline MSS_UART_TypeDef *base_addr(uart_t dev)
+{
+    return uart_config[dev].base_addr;
+}
+
+static void _uart_isr(mss_uart_instance_t* this_uart, unsigned uartn)
+{
+    uint8_t byte;
+    MSS_UART_get_rx(this_uart, &byte, 1);
+    uart_ctx[uartn].rx_cb(uart_ctx[uartn].arg, byte);
+}
+
+void uart_isr(int num)
+{
+    switch (num) {
+        case MMUART0_PLIC_77:
+            _uart_isr(&g_mss_uart0_lo, 0);
+            break;
+        case MMUART1_PLIC:
+            _uart_isr(&g_mss_uart1_lo, 1);
+            break;
+        case MMUART2_PLIC:
+            _uart_isr(&g_mss_uart2_lo, 2);
+            break;
+        case MMUART3_PLIC:
+            _uart_isr(&g_mss_uart3_lo, 3);
+            break;
+        case MMUART4_PLIC:
+            _uart_isr(&g_mss_uart4_lo, 4);
+            break;
+        default:
+            assert(0);
+            break;
+    }
+}
+
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+    mss_config_clk_rst(uart_config[uart].clk, MPFS_HAL_FIRST_HART, PERIPHERAL_ON);
+
+    MSS_UART_init(dev(uart), baudrate,
+                  MSS_UART_DATA_8_BITS | MSS_UART_NO_PARITY | MSS_UART_ONE_STOP_BIT);
+
+    if (rx_cb) {
+        uart_ctx[uart].rx_cb = rx_cb;
+        uart_ctx[uart].arg = arg;
+        plic_set_isr_cb(uart_config[uart].irqn, uart_isr);
+        plic_set_priority(uart_config[uart].irqn, 2);
+
+        /* Set IRQ trigger level, write directly as register is Write Only */
+        base_addr(uart)->FCR = MSS_UART_FIFO_SINGLE_BYTE;
+        /* Enable Receive data interrupt */
+        base_addr(uart)->IER = MSS_UART_RBF_IRQ;
+        /* Enable PLIC irq */
+        plic_enable_interrupt(uart_config[uart].irqn);
+    }
+    return UART_OK;
+}
+
+void uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+    MSS_UART_polled_tx(dev(uart), data, len);
+}
+
+void uart_poweron(uart_t uart)
+{
+    (void)uart;
+}
+
+void uart_poweroff(uart_t uart)
+{
+    (void)uart;
+}

--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -1,8 +1,14 @@
 ifeq ($(findstring rv32,$(CPU_CORE)),rv32)
   CPU_ARCH := rv32
+  FEATURES_PROVIDED += arch_32bit
 endif
 
-FEATURES_PROVIDED += arch_32bit
+ifeq ($(findstring rv64,$(CPU_CORE)),rv64)
+  CPU_ARCH := rv64
+  FEATURES_PROVIDED += arch_64bit
+endif
+
+
 FEATURES_PROVIDED += arch_riscv
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += libstdcpp

--- a/cpu/riscv_common/include/architecture_arch.h
+++ b/cpu/riscv_common/include/architecture_arch.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_fe310
+ * @ingroup     cpu_riscv_common
  * @{
  *
  * @file
@@ -26,7 +26,11 @@ extern "C" {
 
 /* Doc is provided centrally in architecture.h, hide this from Doxygen */
 #ifndef DOXYGEN
+#ifdef CPU_MPFS
+#define ARCHITECTURE_WORD_BITS      (64U)
+#else
 #define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* CPU_MPFS */
 #endif /* DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/riscv_common/include/vendor/riscv_csr.h
+++ b/cpu/riscv_common/include/vendor/riscv_csr.h
@@ -23,8 +23,15 @@
 #define RISCV_CSR_H
 
 /* Some things missing from the official encoding.h */
+#ifndef USE_OWN_CSR_REG
+#ifndef MCAUSE_INT
 #define MCAUSE_INT         0x80000000
+#endif
+
+#ifndef MCAUSE_CAUSE
 #define MCAUSE_CAUSE       0x7FFFFFFF
+#endif
+#endif
 
 #define MSTATUS_UIE         0x00000001
 #define MSTATUS_SIE         0x00000002
@@ -79,22 +86,59 @@
 #define DCSR_CAUSE_STEP     4
 #define DCSR_CAUSE_HALT     5
 
+#ifndef USE_OWN_CSR_REG
 #define MCONTROL_TYPE(xlen)    (0xfULL<<((xlen)-4))
 #define MCONTROL_DMODE(xlen)   (1ULL<<((xlen)-5))
 #define MCONTROL_MASKMAX(xlen) (0x3fULL<<((xlen)-11))
 
+#ifndef MCONTROL_SELECT
 #define MCONTROL_SELECT     (1<<19)
+#endif
+
+#ifndef MCONTROL_TIMING
 #define MCONTROL_TIMING     (1<<18)
+#endif
+
+#ifndef MCONTROL_ACTION
 #define MCONTROL_ACTION     (0x3f<<12)
+#endif
+
+#ifndef MCONTROL_CHAIN
 #define MCONTROL_CHAIN      (1<<11)
+#endif
+
+#ifndef MCONTROL_MATCH
 #define MCONTROL_MATCH      (0xf<<7)
+#endif
+
+#ifndef MCONTROL_M
 #define MCONTROL_M          (1<<6)
+#endif
+
+#ifndef MCONTROL_H
 #define MCONTROL_H          (1<<5)
+#endif
+
+#ifndef MCONTROL_S
 #define MCONTROL_S          (1<<4)
+#endif
+
+#ifndef MCONTROL_U
 #define MCONTROL_U          (1<<3)
+#endif
+
+#ifndef MCONTROL_EXECUTE
 #define MCONTROL_EXECUTE    (1<<2)
+#endif
+
+#ifndef MCONTROL_STORE
 #define MCONTROL_STORE      (1<<1)
+#endif
+
+#ifndef MCONTROL_LOAD
 #define MCONTROL_LOAD       (1<<0)
+#endif
+#endif
 
 #define MCONTROL_TYPE_NONE      0
 #define MCONTROL_TYPE_MATCH     2
@@ -112,15 +156,43 @@
 #define MCONTROL_MATCH_MASK_LOW  4
 #define MCONTROL_MATCH_MASK_HIGH 5
 
+#ifndef USE_OWN_CSR_REG
+#ifndef MIP_SSIP
 #define MIP_SSIP            (1 << IRQ_S_SOFT)
+#endif
+
+#ifndef MIP_HSIP
 #define MIP_HSIP            (1 << IRQ_H_SOFT)
+#endif
+
+#ifndef MIP_MSIP
 #define MIP_MSIP            (1 << IRQ_M_SOFT)
+#endif
+
+#ifndef MIP_STIP
 #define MIP_STIP            (1 << IRQ_S_TIMER)
+#endif
+
+#ifndef MIP_HTIP
 #define MIP_HTIP            (1 << IRQ_H_TIMER)
+#endif
+
+#ifndef MIP_MTIP
 #define MIP_MTIP            (1 << IRQ_M_TIMER)
+#endif
+
+#ifndef MIP_SEIP
 #define MIP_SEIP            (1 << IRQ_S_EXT)
+#endif
+
+#ifndef MIP_HEIP
 #define MIP_HEIP            (1 << IRQ_H_EXT)
+#endif
+
+#ifndef MIP_MEIP
 #define MIP_MEIP            (1 << IRQ_M_EXT)
+#endif
+#endif
 
 #define SIP_SSIP MIP_SSIP
 #define SIP_STIP MIP_STIP
@@ -173,22 +245,29 @@
 
 #ifdef __riscv
 
+#ifndef USE_OWN_CSR_REG
 #ifdef __riscv64
 # define MSTATUS_SD MSTATUS64_SD
 # define SSTATUS_SD SSTATUS64_SD
 # define RISCV_PGLEVEL_BITS 9
 #else
+#ifndef MSTATUS_SD
 # define MSTATUS_SD MSTATUS32_SD
+#endif
+#ifndef SSTATUS_SD
 # define SSTATUS_SD SSTATUS32_SD
+#endif
+#ifndef RISCV_PGLEVEL_BITS
 # define RISCV_PGLEVEL_BITS 10
+#endif
 #endif
 #define RISCV_PGSHIFT 12
 #define RISCV_PGSIZE (1 << RISCV_PGSHIFT)
-
+#endif
 #ifndef __ASSEMBLER__
 
 #ifdef __GNUC__
-
+#ifndef USE_OWN_CSR_REG
 #define read_csr(reg) ({ unsigned long __tmp; \
   __asm__ volatile ("csrr %0, " #reg : "=r"(__tmp)); \
   __tmp; })
@@ -219,6 +298,7 @@
   else \
     __asm__ volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "r"(bit)); \
   __tmp; })
+#endif /* USE_OWN_CSR_REG */
 
 #define rdtime() read_csr(time)
 #define rdcycle() read_csr(cycle)

--- a/cpu/riscv_common/thread_arch.c
+++ b/cpu/riscv_common/thread_arch.c
@@ -101,11 +101,11 @@ char *thread_stack_init(thread_task_func_t task_func,
     memset(sf, 0, sizeof(*sf));
 
     /* set initial reg values */
-    sf->pc = (uint32_t)task_func;
-    sf->a0 = (uint32_t)arg;
+    sf->pc = (uint64_t)task_func;
+    sf->a0 = (uint64_t)arg;
 
     /* if the thread exits go to sched_task_exit() */
-    sf->ra = (uint32_t)sched_task_exit;
+    sf->ra = (uint64_t)sched_task_exit;
 
     return (char *)stk_top;
 }
@@ -129,15 +129,15 @@ void thread_print_stack(void)
 
 #ifdef DEVELHELP
     printf("thread name: %s\n", active_thread->name);
-    printf("stack start: 0x%08x\n", (unsigned)(active_thread->stack_start));
-    printf("stack end  : 0x%08x\n",
-           (unsigned)(active_thread->stack_start + active_thread->stack_size));
+    printf("stack start: 0x%08lx\n", (unsigned long)(active_thread->stack_start));
+    printf("stack end  : 0x%08lx\n",
+           (unsigned long)(active_thread->stack_start + active_thread->stack_size));
 #endif
 
     printf("  address:      data:\n");
 
     do {
-        printf("  0x%08x:   0x%08x\n", (unsigned)sp, (unsigned)*sp);
+        printf("  0x%08lx:   0x%08lx\n", (unsigned long)sp, (unsigned long)*sp);
         sp++;
         count++;
     } while (*sp != STACK_MARKER);
@@ -188,6 +188,6 @@ void heap_stats(void)
     long int heap_size = &_eheap - &_sheap;
     struct mallinfo minfo = mallinfo();
 
-    printf("heap: %ld (used %u, free %ld) [bytes]\n",
+    printf("heap: %ld (used %lu, free %ld) [bytes]\n",
            heap_size, minfo.uordblks, heap_size - minfo.uordblks);
 }

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -30,7 +30,12 @@ TARGET_ARCH_RISCV ?= \
 TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
 
 # define build specific options
-CFLAGS_CPU   = -march=rv32imac -mabi=ilp32
+ifneq (,$(filter arch_64bit,$(FEATURES_PROVIDED)))
+  CFLAGS_CPU   = -march=rv64imac -mabi=lp64
+else
+  CFLAGS_CPU   = -march=rv32imac -mabi=ilp32
+endif
+
 ifeq ($(TOOLCHAIN),llvm)
   # Always use riscv32-none-elf as target triple for clang, as some
   # autodetected gcc target triples are incompatible with clang

--- a/pkg/mpfs_sdk/Makefile
+++ b/pkg/mpfs_sdk/Makefile
@@ -1,0 +1,28 @@
+PKG_NAME=mpfs_sdk
+PKG_URL=https://github.com/polarfire-soc/platform
+PKG_VERSION=13c8cc74e445008bf8615097d44ea28af4ff8d97
+PKG_LICENSE=MIT
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+ifneq ($(CPU),mpfs)
+  $(error This package can only be used with MPFS CPUs)
+endif
+
+MPFS_MODULES = mpfs_sdk mpfs_hal
+
+
+.PHONY = mpfs_%
+
+all: $(MPFS_MODULES)
+
+# First copy all needed files and gather them in a single place
+mpfs_sdk:
+	@mkdir -p $(PKG_BUILD_DIR)
+	@cp $(PKG_SOURCE_DIR)/drivers/mss/mss_gpio/mss_gpio.c $(PKG_BUILD_DIR)/
+	@cp $(PKG_SOURCE_DIR)/drivers/mss/mss_mmuart/mss_uart.c $(PKG_BUILD_DIR)/
+
+	$(QQ)"$(MAKE)" -C $(PKG_BUILD_DIR)/ -f $(CURDIR)/Makefile.$@
+
+mpfs_hal:
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/mpfs_hal/common -f $(CURDIR)/Makefile.$@

--- a/pkg/mpfs_sdk/Makefile.dep
+++ b/pkg/mpfs_sdk/Makefile.dep
@@ -1,0 +1,3 @@
+
+USEMODULE += mpfs_sdk
+USEMODULE += mpfs_hal

--- a/pkg/mpfs_sdk/Makefile.include
+++ b/pkg/mpfs_sdk/Makefile.include
@@ -1,0 +1,6 @@
+INCLUDES += -I$(PKGDIRBASE)/mpfs_sdk/
+INCLUDES += -I$(PKGDIRBASE)/mpfs_sdk/drivers/mss/mss_mmuart/
+INCLUDES += -I$(PKGDIRBASE)/mpfs_sdk/drivers/mss/mss_gpio/
+INCLUDES += -I$(PKGDIRBASE)/mpfs_sdk/drivers/mss/mss_timer/
+INCLUDES += -I$(PKGDIRBASE)/mpfs_sdk/platform_config_reference/
+INCLUDES += -I$(PKGDIRBASE)/mpfs_sdk/mpfs_hal/common/

--- a/pkg/mpfs_sdk/Makefile.mpfs_hal
+++ b/pkg/mpfs_sdk/Makefile.mpfs_hal
@@ -1,0 +1,6 @@
+MODULE=mpfs_hal
+
+SRC += mss_peripherals.c mss_util.c mss_plic.c mss_mtrap.c mss_irq_handler_stubs.c
+SRC += mss_clint.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/mpfs_sdk/Makefile.mpfs_sdk
+++ b/pkg/mpfs_sdk/Makefile.mpfs_sdk
@@ -1,0 +1,6 @@
+MODULE=mpfs_sdk
+
+SRC += mss_uart.c mss_gpio.c
+
+CFLAGS += -Wno-unused-variable
+include $(RIOTBASE)/Makefile.base

--- a/pkg/mpfs_sdk/doc.txt
+++ b/pkg/mpfs_sdk/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup pkg_gecko_sdk    Vendor library for EFM/EFR/EZR32 MCUs
+ * @ingroup  pkg
+ * @brief    Vendor library for EFM/EFR/EZR32 targets by Silicon Labs
+ * @see      https://siliconlabs.github.io/Gecko_SDK_Doc/
+ */

--- a/pkg/mpfs_sdk/patches/0001-revert-asm-to-__asm__.patch
+++ b/pkg/mpfs_sdk/patches/0001-revert-asm-to-__asm__.patch
@@ -1,0 +1,200 @@
+From 4082db8476103c4e8ae5a6adda9b8f0dbf501383 Mon Sep 17 00:00:00 2001
+From: dylad <dylan.laduranty@mesotic.com>
+Date: Tue, 28 Sep 2021 21:15:45 +0200
+Subject: [PATCH] revert asm to __asm__
+
+---
+ 0001-revert-asm-to-__asm__.patch | 80 ++++++++++++++++++++++++++++++++
+ mpfs_hal/common/atomic.h         |  2 +-
+ mpfs_hal/common/encoding.h       | 16 +++----
+ mpfs_hal/common/mss_util.c       |  6 +--
+ 4 files changed, 92 insertions(+), 12 deletions(-)
+ create mode 100644 0001-revert-asm-to-__asm__.patch
+
+diff --git a/0001-revert-asm-to-__asm__.patch b/0001-revert-asm-to-__asm__.patch
+new file mode 100644
+index 0000000..a5634e6
+--- /dev/null
++++ b/0001-revert-asm-to-__asm__.patch
+@@ -0,0 +1,80 @@
++From 51d7b96446ccbb52975ed62eb303d406a5cf91de Mon Sep 17 00:00:00 2001
++From: dylad <dylan.laduranty@mesotic.com>
++Date: Tue, 28 Sep 2021 21:15:45 +0200
++Subject: [PATCH] revert asm to __asm__
++
++---
++ mpfs_hal/common/atomic.h   |  2 +-
++ mpfs_hal/common/encoding.h | 16 ++++++++--------
++ 2 files changed, 9 insertions(+), 9 deletions(-)
++
++diff --git a/mpfs_hal/common/atomic.h b/mpfs_hal/common/atomic.h
++index 48110f0..9c81adb 100644
++--- a/mpfs_hal/common/atomic.h
+++++ b/mpfs_hal/common/atomic.h
++@@ -36,7 +36,7 @@
++ extern "C" {
++ #endif
++ 
++-#define mb() asm volatile ("fence" ::: "memory")
+++#define mb() __asm__ volatile ("fence" ::: "memory")
++ #define atomic_set(ptr, val) (*(volatile typeof(*(ptr)) *)(ptr) = val)
++ #define atomic_read(ptr) (*(volatile typeof(*(ptr)) *)(ptr))
++ 
++diff --git a/mpfs_hal/common/encoding.h b/mpfs_hal/common/encoding.h
++index c86fb17..ef912ce 100644
++--- a/mpfs_hal/common/encoding.h
+++++ b/mpfs_hal/common/encoding.h
++@@ -228,33 +228,33 @@
++ #ifdef __GNUC__
++ 
++ #define read_reg(reg) ({ unsigned long __tmp; \
++-  asm volatile ("mv %0, " #reg : "=r"(__tmp)); \
+++  __asm__ volatile ("mv %0, " #reg : "=r"(__tmp)); \
++   __tmp; })
++ 
++ #define read_csr(reg) __extension__({ unsigned long __tmp; \
++-  asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
+++  __asm__ volatile ("csrr %0, " #reg : "=r"(__tmp)); \
++   __tmp; })
++ 
++ #define write_csr(reg, val) __extension__({ \
++-  asm volatile ("csrw " #reg ", %0" :: "rK"(val)); })
+++  __asm__ volatile ("csrw " #reg ", %0" :: "rK"(val)); })
++ 
++ #define swap_csr(reg, val) ({ unsigned long __tmp; \
++-  asm volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
+++  __asm__ volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
++   __tmp; })
++ 
++ #define set_csr(reg, bit) __extension__({ unsigned long __tmp; \
++-  asm volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+++  __asm__ volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
++   __tmp; })
++ 
++ #define clear_csr(reg, bit) __extension__({ unsigned long __tmp; \
++-  asm volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+++  __asm__ volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
++   __tmp; })
++ 
++ #if 0
++ #define csr_write(csr, val)                 \
++ ({                              \
++     unsigned long __v = (unsigned long)(val);       \
++-    asm volatile ("csrw " __ASM_STR(csr) ", %0" \
+++    __asm__ volatile ("csrw " ____asm___STR(csr) ", %0" \
++                   : : "rK" (__v)            \
++                   : "memory");          \
++ })
++@@ -262,7 +262,7 @@
++ #define csr_write(csr, val)                 \
++ ({                              \
++     unsigned long __v = (unsigned long)(val);       \
++-    __asm__ __volatile__ ("csrw " __ASM_STR(csr) ", %0" \
+++    ____asm____ __volatile__ ("csrw " ____asm___STR(csr) ", %0" \
++                   : : "rK" (__v)            \
++                   : "memory");          \
++ })
++-- 
++2.17.1
++
+diff --git a/mpfs_hal/common/atomic.h b/mpfs_hal/common/atomic.h
+index 48110f0..9c81adb 100644
+--- a/mpfs_hal/common/atomic.h
++++ b/mpfs_hal/common/atomic.h
+@@ -36,7 +36,7 @@
+ extern "C" {
+ #endif
+ 
+-#define mb() asm volatile ("fence" ::: "memory")
++#define mb() __asm__ volatile ("fence" ::: "memory")
+ #define atomic_set(ptr, val) (*(volatile typeof(*(ptr)) *)(ptr) = val)
+ #define atomic_read(ptr) (*(volatile typeof(*(ptr)) *)(ptr))
+ 
+diff --git a/mpfs_hal/common/encoding.h b/mpfs_hal/common/encoding.h
+index c86fb17..ef912ce 100644
+--- a/mpfs_hal/common/encoding.h
++++ b/mpfs_hal/common/encoding.h
+@@ -228,33 +228,33 @@
+ #ifdef __GNUC__
+ 
+ #define read_reg(reg) ({ unsigned long __tmp; \
+-  asm volatile ("mv %0, " #reg : "=r"(__tmp)); \
++  __asm__ volatile ("mv %0, " #reg : "=r"(__tmp)); \
+   __tmp; })
+ 
+ #define read_csr(reg) __extension__({ unsigned long __tmp; \
+-  asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
++  __asm__ volatile ("csrr %0, " #reg : "=r"(__tmp)); \
+   __tmp; })
+ 
+ #define write_csr(reg, val) __extension__({ \
+-  asm volatile ("csrw " #reg ", %0" :: "rK"(val)); })
++  __asm__ volatile ("csrw " #reg ", %0" :: "rK"(val)); })
+ 
+ #define swap_csr(reg, val) ({ unsigned long __tmp; \
+-  asm volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
++  __asm__ volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
+   __tmp; })
+ 
+ #define set_csr(reg, bit) __extension__({ unsigned long __tmp; \
+-  asm volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
++  __asm__ volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+   __tmp; })
+ 
+ #define clear_csr(reg, bit) __extension__({ unsigned long __tmp; \
+-  asm volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
++  __asm__ volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+   __tmp; })
+ 
+ #if 0
+ #define csr_write(csr, val)                 \
+ ({                              \
+     unsigned long __v = (unsigned long)(val);       \
+-    asm volatile ("csrw " __ASM_STR(csr) ", %0" \
++    __asm__ volatile ("csrw " ____asm___STR(csr) ", %0" \
+                   : : "rK" (__v)            \
+                   : "memory");          \
+ })
+@@ -262,7 +262,7 @@
+ #define csr_write(csr, val)                 \
+ ({                              \
+     unsigned long __v = (unsigned long)(val);       \
+-    __asm__ __volatile__ ("csrw " __ASM_STR(csr) ", %0" \
++    ____asm____ __volatile__ ("csrw " ____asm___STR(csr) ", %0" \
+                   : : "rK" (__v)            \
+                   : "memory");          \
+ })
+diff --git a/mpfs_hal/common/mss_util.c b/mpfs_hal/common/mss_util.c
+index 78ff22b..2102d95 100644
+--- a/mpfs_hal/common/mss_util.c
++++ b/mpfs_hal/common/mss_util.c
+@@ -131,7 +131,7 @@ void sleep_cycles(uint64_t ncycles)
+ __attribute__((aligned(16))) uint64_t get_program_counter(void)
+ {
+     uint64_t prog_counter;
+-    asm volatile ("auipc %0, 0" : "=r"(prog_counter));
++    __asm__ volatile ("auipc %0, 0" : "=r"(prog_counter));
+     return (prog_counter);
+ }
+ 
+@@ -142,7 +142,7 @@ __attribute__((aligned(16))) uint64_t get_program_counter(void)
+ uint64_t get_stack_pointer(void)
+ {
+     uint64_t stack_pointer;
+-    asm volatile ("addi %0, sp, 0" : "=r"(stack_pointer));
++    __asm__ volatile ("addi %0, sp, 0" : "=r"(stack_pointer));
+     return (stack_pointer);
+ }
+ 
+@@ -157,7 +157,7 @@ uint64_t get_stack_pointer(void)
+ uint64_t get_tp_reg(void)
+ {
+     uint64_t tp_reg_val;
+-    asm volatile ("addi %0, tp, 0" : "=r"(tp_reg_val));
++    __asm__ volatile ("addi %0, tp, 0" : "=r"(tp_reg_val));
+     return (tp_reg_val);
+ }
+ 
+-- 
+2.17.1
+

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -75,6 +75,10 @@ typedef int16_t     sword_t;
 #define ARCHITECTURE_WORD_BYTES     (4U)
 typedef uint32_t    uword_t;
 typedef int32_t     sword_t;
+#elif (ARCHITECTURE_WORD_BITS == 64)
+#define ARCHITECTURE_WORD_BYTES     (8U)
+typedef uint64_t    uword_t;
+typedef int64_t     sword_t;
 #else
 #error  "Unsupported word size (check ARCHITECTURE_WORD_BITS in architecture_arch.h)"
 #endif

--- a/tests/buttons/main.c
+++ b/tests/buttons/main.c
@@ -44,37 +44,37 @@
 #if defined (BTN0_PIN) || defined (BTN1_PIN) || defined (BTN2_PIN) || defined (BTN3_PIN)
 static void cb(void *arg)
 {
-    printf("Pressed BTN%d\n", (int)arg);
+    printf("Pressed BTN%" PRIiPTR "\n", (uintptr_t)arg);
 }
 #endif
 
 int main(void)
 {
-    int cnt = 0;
+    unsigned cnt = 0;
     /* get the number of available buttons and init interrupt handler */
 #ifdef BTN0_PIN
-    if (gpio_init_int(BTN0_PIN, BTN0_MODE, BTN0_INT_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN0_PIN, BTN0_MODE, BTN0_INT_FLANK, cb, (void*)(uintptr_t)cnt) < 0) {
         puts("[FAILED] init BTN0!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN1_PIN
-    if (gpio_init_int(BTN1_PIN, BTN1_MODE, BTN1_INT_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN1_PIN, BTN1_MODE, BTN1_INT_FLANK, cb, (void*)(uintptr_t)cnt) < 0) {
         puts("[FAILED] init BTN1!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN2_PIN
-    if (gpio_init_int(BTN2_PIN, BTN2_MODE, BTN2_INT_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN2_PIN, BTN2_MODE, BTN2_INT_FLANK, cb, (void*)(uintptr_t)cnt) < 0) {
         puts("[FAILED] init BTN2!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN3_PIN
-    if (gpio_init_int(BTN3_PIN, BTN3_MODE, BTN3_INT_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(BTN3_PIN, BTN3_MODE, BTN3_INT_FLANK, cb, (void*)(uintptr_t)cnt) < 0) {
         puts("[FAILED] init BTN3!");
         return 1;
     }
@@ -88,7 +88,7 @@ int main(void)
         puts("[FAILED] no buttons available!");
         return 2;
     }
-    printf(" -- Available buttons: %i\n\n", cnt);
+    printf(" -- Available buttons: %d\n\n", cnt);
     puts(" -- Try pressing buttons to test.\n");
     puts("[SUCCESS]");
     return 0;

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -32,7 +32,7 @@
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static void cb(void *arg)
 {
-    printf("INT: external interrupt from pin %i\n", (int)arg);
+    printf("INT: external interrupt from pin %" PRIuMAX "\n", (uintptr_t)arg);
 }
 #endif
 
@@ -89,7 +89,7 @@ static int init_od_pu(int argc, char **argv)
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static int init_int(int argc, char **argv)
 {
-    int po, pi;
+    unsigned po, pi;
     gpio_mode_t mode = GPIO_IN;
     gpio_flank_t flank;
     int fl;
@@ -144,7 +144,7 @@ static int init_int(int argc, char **argv)
         }
     }
 
-    if (gpio_init_int(GPIO_PIN(po, pi), mode, flank, cb, (void *)pi) < 0) {
+    if (gpio_init_int(GPIO_PIN(po, pi), mode, flank, cb, (void *)(uintptr_t)pi) < 0) {
         printf("error: init_int of GPIO_PIN(%i, %i) failed\n", po, pi);
         return 1;
     }

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -43,7 +43,7 @@ static volatile unsigned args[MAX_CHANNELS];
 static void cb(void *arg, int chan)
 {
     timeouts[chan] = sw_count;
-    args[chan] = (unsigned)arg + chan;
+    args[chan] = (uintptr_t)arg + chan;
     fired++;
 }
 
@@ -60,7 +60,7 @@ static int test_timer(unsigned num)
     }
 
     /* initialize and halt timer */
-    if (timer_init(TIMER_DEV(num), TIMER_SPEED, cb, (void *)(COOKIE * num)) < 0) {
+    if (timer_init(TIMER_DEV(num), TIMER_SPEED, cb, (void *)(uintptr_t)(COOKIE * num)) < 0) {
         printf("TIMER_%u: ERROR on initialization - skipping\n\n", num);
         return 0;
     }


### PR DESCRIPTION
### Contribution description

This is a draft PR which adds support for the Microchip PolarFire SoC (MPFS) Icicle kit Engineering Sample board. This board features a quad RV64GC core + one RV64IMAC (and a whole FPGA fabric). Only the single RV64IMAC (Our first 64bits MCU !) support is added by this PR as the idea is to let Linux runs on the quad RV64GC alongside RIOT on the single RV64IMAC.

You can find more informations for the board on [microchip/microsemi website](https://www.microsemi.com/existing-parts/parts/152514) and the SoC documentation is available [here](https://www.microsemi.com/product-directory/soc-fpgas/5498-polarfire-soc-fpga#documentation)

This PR also adds a basic support for 64bits RISC-V architecture and the PLIC controller.
In the current state, only UART, GPIO and timer peripherals (all w/ IRQ support) are implemented. Others peripherals should be added in followup PR.

I used the baremetal SDK as RIOT pkg to include vendor files and lowlevel drivers, except interruptions management which is done by RIOT PLIC driver. ([MPFS SDK link](https://github.com/polarfire-soc/platform))

SoftConsole environment can be downloaded [here](https://www.microsemi.com/product-directory/design-tools/4879-softconsole#downloads) but registration is required.

SoftConsole is not really needed but it provides the custom openOCD needed for the flashing part.
It will not longer be needed if openOCD support is upstreamed.

A lot of documentation is missing, but the board is an "usable shape". I'd like to use this draft PR to discuss some specific points like 64bits architecture for RIOT.

All comments and feedbacks are very welcome.

### Testing procedure

Beware that `make flash` is currently unsupported as the openOCD fork provided by SoftConsole environment (the default Eclipse environment for baremetal development provided by Microchip) currently doesn't implement the flash driver. There is an additionnal tool that can be used for flashing the eNVM but I didn't find time to look at it yet.
For now, RIOT only runs on the onboard LIM memory which is volatile. (One of the many reasons, this PR is a draft). Thus, in order to test any application, please use `make debug` for now. This command uses the combo openOCD/GDB to load the binary to the LIM memory.
It is also needed to use the openOCD provided by SoftConsole for now. (I hope everything will be upstream at some point).
Regarding the toolchain, standard riscv-unknown-elf-gcc can be used in theory but I didn't test it as I am using the riscv-unknown-elf-gcc toolchain provided by the SoftConsole envinronment.

Example make command for flashing `tests/shell` on `mpfs-icicle-kit-es` LIM memory.
`OPENOCD=/path/to/openocd/bin/openocd make BOARD=mpfs-icicle-kit-es -C tests/shell debug`

Please expect (a lot of) compilations errors with `tests/` and `examples/` applications because of "cast from pointer to integer of different size". This is because we heavily use int to cast void argument (like callback argument). I made some fixes for a few tests application but I don't think this subject should be handled by this PR. Thus, it should be fix in another set of PRs.

### Issues/PRs references

None.


Many thanks to @polarfire-soc for providing me this awesome board !
