### PR TITLE
dhcpv6_client: keep integers in retransmission calculations signed  [backport 2021.10]

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -473,6 +473,8 @@ static inline uint32_t _irt_ms(uint16_t irt, bool greater_irt)
     if (greater_irt && (factor < 0)) {
         factor = -factor;
     }
+    /* random factor is also in ms, but it is supposed to be without unit,
+     * so we need to divide by ms */
     irt_ms += (factor * irt_ms) / MS_PER_SEC;
     return irt_ms;
 }
@@ -480,12 +482,16 @@ static inline uint32_t _irt_ms(uint16_t irt, bool greater_irt)
 static inline uint32_t _sub_rt_ms(uint32_t rt_prev_ms, uint16_t mrt)
 {
     uint32_t sub_rt_ms = (2 * rt_prev_ms) +
+                         /* random factor is also in ms, but it is supposed to
+                          * be without unit, so we need to divide by ms */
                          ((int32_t)(get_rand_ms_factor() * rt_prev_ms) /
                           (int32_t)MS_PER_SEC);
 
     if (sub_rt_ms > (mrt * MS_PER_SEC)) {
         uint32_t mrt_ms = mrt * MS_PER_SEC;
 
+        /* random factor is also in ms, but it is supposed to be without unit,
+         * so we need to divide by ms */
         sub_rt_ms = mrt_ms + ((int32_t)(get_rand_ms_factor() * mrt_ms) /
                               (int32_t)MS_PER_SEC);
     }


### PR DESCRIPTION
# Backport of #16992

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Otherwise, we get very large numbers here. This causes the retransmissions of SOLICITs to be too far in the future to be of any use, if we did not get and ADVERTISE on first try.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The steps to reproduce in https://github.com/RIOT-OS/RIOT/issues/16971 should yield the expected results.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/16971.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
