### PR TITLE
boards/nucleo-l152re: Fix Kconfig board name

### DIFF
--- a/boards/common/nucleo64/Kconfig
+++ b/boards/common/nucleo64/Kconfig
@@ -11,7 +11,7 @@ config BOARD_COMMON_NUCLEO64
 
     # Clock configuration
     select BOARD_HAS_HSE if !CPU_FAM_G0 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4
-    select BOARD_HAS_LSE if !BOARD_NUCLE0_L152RE
+    select BOARD_HAS_LSE if !BOARD_NUCLEO_L152RE
 
 source "$(RIOTBOARD)/common/nucleo/Kconfig"
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/nucleo-l152re/Kconfig
+++ b/boards/nucleo-l152re/Kconfig
@@ -6,9 +6,9 @@
 #
 
 config BOARD
-    default "nucleo-l152re" if BOARD_NUCLE0_L152RE
+    default "nucleo-l152re" if BOARD_NUCLEO_L152RE
 
-config BOARD_NUCLE0_L152RE
+config BOARD_NUCLEO_L152RE
     bool
     default y
     select BOARD_COMMON_NUCLEO64


### PR DESCRIPTION
### Contribution description

Kconfig board name for the nucleo-l152re contained a "0" (zero) instead
of the capital letter "O". All faulty occurrences were replaced.