### PR TITLE
sys/shell/gnrc_netif: Allow 'ifconfig help'

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1432,6 +1432,7 @@ static void _l2filter_usage(const char *cmd)
 static void _usage(char *cmd)
 {
     printf("usage: %s\n", cmd);
+    printf("usage: %s help\n", cmd);
     _link_usage(cmd);
     _set_usage(cmd);
     _flag_usage(cmd);
@@ -1797,8 +1798,14 @@ int _gnrc_netif_config(int argc, char **argv)
     else {
         netif_t *iface = netif_get_by_name(argv[1]);
         if (!iface) {
-            puts("error: invalid interface given");
-            return 1;
+            if ((strcmp(argv[1], "help") == 0) ||
+                (strcmp(argv[1], "--help") == 0)) {
+                _usage(argv[0]);
+                return 0;
+            } else {
+                puts("error: invalid interface given");
+                return 1;
+            }
         }
 
         if (argc < 3) {


### PR DESCRIPTION
### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


Currently a valid netif name must be passed to show the usage
instructions:

```
> ifconfig help
error: invalid interface given
> ifconfig 6 help
usage: ifconfig
usage: ifconfig <if_id> [up|down]
[...]
```

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Flash an app using GNRC and shell (like `examples/gnrc_networking`), and run `ifconfig help`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
