### PR TITLE
cpu/sam0: prevent disabled irq from being called

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -289,8 +289,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* if it's a tamper pin configure wake from Deep Sleep */
     _init_rtc_pin(pin, flank);
 
-    /* make sure EIC channel is valid */
-    if (exti == -1) {
+    /* make sure EIC channel and callback are valid */
+    if (exti == -1 || cb == NULL) {
         return -1;
     }
 
@@ -440,8 +440,8 @@ void isr_eic(void)
 #endif
 {
     /* read & clear interrupt flags */
-    uint32_t state = _EIC->INTFLAG.reg;
-    state &= (1 << NUMOF_IRQS) - 1;
+    uint32_t state = _EIC->INTFLAG.reg & _EIC->INTENSET.reg;
+    state &= EIC_INTFLAG_EXTINT_Msk;
     _EIC->INTFLAG.reg = state;
 
     /* execute interrupt callbacks */


### PR DESCRIPTION
### Contribution description
This PR fixes the issue reported by @biboc with #16978 
With this PR, disabled GPIO IRQs are no longer trigger by another (enabled) GPIO IRQ.
At the same time, ensure callback are defined before calling it and replace some computation with a mask.

I tested the following boards with master and this PR:
- saml10-xpro (Fixed by this PR)
- saml21-xpro (Fixed by this PR)
- same54-xpro (Not affected by #16978 because each GPIO irqs lines have a dedicated IRQ)
- arduino-zero (Fixed by this PR)

### Testing procedure
See #16978 

### Issues/PRs references
Fixes #16978 

Thanks @biboc for spotting this !