### PR TITLE
dist/pythonlibs/riotctrl_shell/tests/common: add expect to mock [backport 2021.10]

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/tests/common.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/common.py
@@ -14,6 +14,7 @@ class MockSpawn():
         # set some expected attributes
         self.before = None
         self.echo = False
+        self.expect_res = 0
 
     @property
     def last_command(self):
@@ -41,6 +42,9 @@ class MockSpawn():
     def expect_exact(self, *args, **kwargs):
         # always match on prompt with replwrap
         return 0
+
+    def expect(self, *args, **kwargs):
+        return self.expect_res
 
 
 class MockRIOTCtrl():


### PR DESCRIPTION
# Backport of #17003

### Contribution description

Extends the mock to use in releases tests https://github.com/RIOT-OS/Release-Specs/pull/236 and https://github.com/RIOT-OS/Release-Specs/pull/218.

### Testing procedure

Checkout the https://github.com/RIOT-OS/Release-Specs/pull/218, and set RIOTBASE to use this branch, the self test now passes:

`tox -- --self-test testutils/tests/test_shell.py`
```
testutils/tests/test_shell.py::test_udp_server_start PASSED                                                                                                                                         [  3%]
testutils/tests/test_shell.py::test_udp_server_start_error PASSED                                                                                                                                   [  7%]
testutils/tests/test_shell.py::test_udp_server_stop PASSED                                                                                                                                          [ 11%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence0-5-10-100.0] PASSED                                                                                                     [ 14%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence1-5-10-0.0] PASSED                                                                                                       [ 18%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence2-5-0-20.0] PASSED                                                                                                       [ 22%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence3-10-10-90.0] PASSED                                                                                                     [ 25%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence4-1-10-0.0] PASSED                                                                                                       [ 29%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence5-2-10-50.0] PASSED                                                                                                      [ 33%]
testutils/tests/test_shell.py::test_udp_server_check_output[expect_sequence6-2-10-50.0] PASSED                                                                                                      [ 37%]
testutils/tests/test_shell.py::test_udp_client_send[ff02::1-1337-"Hallo World"-1000-1000-udp send ff02::1 1337 "Hallo World" 1000 1000000] PASSED                                                   [ 40%]
testutils/tests/test_shell.py::test_udp_client_send[affe::1-61616-15-1000-0-udp send affe::1 61616 15 1000 0] PASSED                                                                                [ 44%]
testutils/tests/test_shell.py::test_udp_client_send[fe80::1-52-1000-1000-0.01-udp send fe80::1 52 1000 1000 10] PASSED                                                                              [ 48%]
testutils/tests/test_shell.py::test_udp_client_send_error PASSED                                                                                                                                    [ 51%]
testutils/tests/test_shell.py::test_ping6 PASSED                                                                                                                                                    [ 55%]
testutils/tests/test_shell.py::test_pktbuf_empty PASSED                                                                                                                                             [ 59%]
testutils/tests/test_shell.py::test_pktbuf_not_empty PASSED                                                                                                                                         [ 62%]
testutils/tests/test_shell.py::test_lladdr PASSED                                                                                                                                                   [ 66%]
testutils/tests/test_shell.py::test_lladdr_no_lladdr PASSED                                                                                                                                         [ 70%]
testutils/tests/test_shell.py::test_global_addr PASSED                                                                                                                                              [ 74%]
testutils/tests/test_shell.py::test_global_addr_no_global_addr PASSED                                                                                                                               [ 77%]
testutils/tests/test_shell.py::test_check_pktbuf_empty PASSED                                                                                                                                       [ 81%]
testutils/tests/test_shell.py::test_ifconfig PASSED                                                                                                                                                 [ 85%]
testutils/tests/test_shell.py::test_lorawan_netif_None PASSED                                                                                                                                       [ 88%]
testutils/tests/test_shell.py::test_lorawan_netif_no_lorawan PASSED                                                                                                                                 [ 92%]
testutils/tests/test_shell.py::test_gnrc_lorawan_send_success PASSED                                                                                                                                [ 96%]
testutils/tests/test_shell.py::test_gnrc_lorawan_send_success_downlink PASSED                                                                                                                       [100%
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
