### PR TITLE
drivers/periph/gpio: state that interrupt callback must not be NULL

### DIFF
--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -182,6 +182,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode);
  * @note    You have to add the module `periph_gpio_irq` to your project to
  *          enable this function
  *
+ * @pre     @p cb must not be NULL
+ *
  * @param[in] pin       pin to initialize
  * @param[in] mode      mode of the pin, see @c gpio_mode_t
  * @param[in] flank     define the active flank(s)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This allows us to use `assert(cb != NULL)` inside `gpio_init_int()` and save a few cycles of interrupt latency.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17007#discussion_r731257586
