### PR TITLE
reference Native CPU from Native Board

### DIFF
--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -33,4 +33,8 @@ On Debian/Ubuntu you can install the required libraries with
 sudo apt install gcc-multilib
 ```
 
+# Native details
+
+Most code about the Native "board" is kept in /cpu/native.
+
  */


### PR DESCRIPTION
### Contribution description

minor update to native "board" documentation to reference Native CPU.
I think that this isn't the right way to do this.

### Testing procedure

none

### Issues/PRs references

I was lost trying to understand the Native Board until I recognized that there was a "native" CPU.

