### PR TITLE
native/mtd: fix driver to extend file as needed

### DIFF
--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -94,11 +94,12 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
     if (!f) {
         return -EIO;
     }
-    real_fseek(f, addr, SEEK_SET);
+
     for (size_t i = 0; i < size; i++) {
+        real_fseek(f, addr+i, SEEK_SET);
         uint8_t c = real_fgetc(f);
-        real_fseek(f, -1, SEEK_CUR);
-        real_fputc(c & ((uint8_t*)buff)[i], f);
+        real_fseek(f, addr+i, SEEK_SET);
+        real_fputc(c & ((uint8_t*)buff)[i], f);  /* simulates can only write 1->0 */
     }
     real_fclose(f);
 

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -97,7 +97,8 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
 
     for (size_t i = 0; i < size; i++) {
         real_fseek(f, addr+i, SEEK_SET);
-        uint8_t c = real_fgetc(f);
+        int c = real_fgetc(f);
+        if(c == EOF) { c = 0xff; }
         real_fseek(f, addr+i, SEEK_SET);
         real_fputc(c & ((uint8_t*)buff)[i], f);  /* simulates can only write 1->0 */
     }

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -138,12 +138,7 @@ static int _write_page(mtd_dev_t *dev, const void *buff, uint32_t page, uint32_t
     if (!f) {
         return -EIO;
     }
-    real_fseek(f, addr, SEEK_SET);
-    for (size_t i = 0; i < size; i++) {
-        uint8_t c = real_fgetc(f);
-        real_fseek(f, -1, SEEK_CUR);
-        real_fputc(c & ((uint8_t*)buff)[i], f);
-    }
+    _write_bytes(f, buff, addr, size);
     real_fclose(f);
 
     return size;


### PR DESCRIPTION
### Contribution description

This fixes the mtd_native driver to work correctly when the underlying file is not initialized, or isn't initialized to be big enough for the planned size.

### Testing procedure

pick an example with mtd native and create a zero-length file for the MTD.
The writes to the MTD file will never succeed, because the fgetc() actually returned EOF.
This was tested with an application/library that uses mtd to create cfg_page, which is not yet checked in.


### Issues/PRs references

none.