### PR TITLE
sys/picolibc_syscalls_default: make stdin and stderr strong refs

### DIFF
--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -236,9 +236,18 @@ FILE picolibc_stdio =
     FDEV_SETUP_STREAM(picolibc_put, picolibc_get, picolibc_flush, _FDEV_SETUP_RW);
 
 #ifdef PICOLIBC_STDIO_GLOBALS
-FILE *const stdout = &picolibc_stdio;
+#ifdef __strong_reference
+/* This saves two const pointers.
+ * See https://github.com/RIOT-OS/RIOT/pull/17001#issuecomment-945936918
+ */
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__picolibc_stdio;
+#endif
+
 FILE *const stdin = &picolibc_stdio;
-FILE *const stderr = &picolibc_stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);
 #else
 FILE *const __iob[] = {
     &picolibc_stdio,        /* stdin  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This PR changes our picolibc stdin and stderr to be string references to stdout, allowing to share flash space for them, if used.

Result:

PR:
```
riot/examples/default on  picolibc_stdio_strong_reference 
❯ FEATURES_REQUIRED=picolibc USEMODULE=picolibc RIOT_CI_BUILD=1 BOARD=nrf52840dk make clean all -j8 
Building application "default" for "nrf52840dk" with MCU "nrf52".
                                    
   text    data     bss     dec     hex filename
  34936     416    6348   41700    a2e4 /home/kaspar/src/riot/examples/default/bin/nrf52840dk/default.elf
```

master:
```
❯ FEATURES_REQUIRED=picolibc USEMODULE=picolibc RIOT_CI_BUILD=1 BOARD=nrf52840dk make clean all -j8                                      [35/34163]
Building application "default" for "nrf52840dk" with MCU "nrf52".
                                    
   text    data     bss     dec     hex filename
  34940     416    6348   41704    a2e8 /home/kaspar/src/riot/examples/default/bin/nrf52840dk/default.elf
```

Note that master uses 4 bytes more in .text. Probably no stderr is used in examples/default.
Applications not using stdin won't show a difference, e.g., examples/hello-world.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

See #17001.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
