### PR TITLE
sys/picolibc_syscalls_default: support new picolibc stdio globals [backport 2021.10]

### DIFF
--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -235,11 +235,17 @@ static int picolibc_get(FILE *file)
 FILE picolibc_stdio =
     FDEV_SETUP_STREAM(picolibc_put, picolibc_get, picolibc_flush, _FDEV_SETUP_RW);
 
+#ifdef PICOLIBC_STDIO_GLOBALS
+FILE *const stdout = &picolibc_stdio;
+FILE *const stdin = &picolibc_stdio;
+FILE *const stderr = &picolibc_stdio;
+#else
 FILE *const __iob[] = {
-    &picolibc_stdio,    /* stdin  */
-    &picolibc_stdio,    /* stdout */
-    &picolibc_stdio,    /* stderr */
+    &picolibc_stdio,        /* stdin  */
+    &picolibc_stdio,        /* stdout */
+    &picolibc_stdio,        /* stderr */
 };
+#endif
 
 #include <thread.h>
 /**


### PR DESCRIPTION
# Backport of #17001

This is needed to fix the build with recent versions of picolibc (e.g. shipped with Ubuntu 21.10).

### Contribution description

Since https://github.com/picolibc/picolibc/pull/159, picolibc uses simple globals for stdout, stdin and stderr, by default.
This PR fixes compilation for those newer picolibc versions. It *should* fall back to the old behaviour.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Does CI test any picolibc? if not, try building, at least with the current riotbuild version.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
