### PR TITLE
turo: some json fixes

### DIFF
--- a/sys/test_utils/result_output/json/result_output_json.c
+++ b/sys/test_utils/result_output/json/result_output_json.c
@@ -59,7 +59,7 @@ void turo_u64(turo_t *ctx, uint64_t val)
 void turo_float(turo_t *ctx, float val)
 {
     _print_comma(ctx, TURO_STATE_NEED_COMMA);
-    print_float(val, 8);
+    print_float(val, 7);
 }
 
 void turo_string(turo_t *ctx, const char *str)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes some turo json output issues:

1. missing comma after "," for dicts, e.g., `{"key": 1,"other key":2}"` -> `{"key": 1, "other key: 2}`
    (this might be a style issue, but there is a space after ":", so IMO as is, more consistent
2. fix `turo_float()` hitting an assert for nonexistent precision. It used to use 8, which is used as an index for an array with 8 values...

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
