### PR TITLE
sys/benchmark: use turo

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -571,7 +571,6 @@ endif
 
 ifneq (,$(filter benchmark,$(USEMODULE)))
   USEMODULE += xtimer
-  USEMODULE += fmt
   # default to json output. override by including a different output module
   ifeq (,$(filter test_utils_result_output_%, $(USEMODULE)))
     USEMODULE += test_utils_result_output_json

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -571,6 +571,11 @@ endif
 
 ifneq (,$(filter benchmark,$(USEMODULE)))
   USEMODULE += xtimer
+  USEMODULE += fmt
+  # default to json output. override by including a different output module
+  ifeq (,$(filter test_utils_result_output_%, $(USEMODULE)))
+    USEMODULE += test_utils_result_output_json
+  endif
 endif
 
 ifneq (,$(filter skald_%,$(USEMODULE)))

--- a/sys/benchmark/Kconfig
+++ b/sys/benchmark/Kconfig
@@ -8,4 +8,5 @@
 config MODULE_BENCHMARK
     bool "Simple benchmarks support"
     depends on MODULE_XTIMER
+    depends on MODULE_FMT
     depends on TEST_KCONFIG

--- a/sys/benchmark/Kconfig
+++ b/sys/benchmark/Kconfig
@@ -8,5 +8,4 @@
 config MODULE_BENCHMARK
     bool "Simple benchmarks support"
     depends on MODULE_XTIMER
-    depends on MODULE_FMT
     depends on TEST_KCONFIG

--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -20,17 +20,31 @@
 
 #include <stdio.h>
 
+#include "fmt.h"
 #include "benchmark.h"
+#include "test_utils/result_output.h"
 
 void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
 {
-    uint32_t full = (time / runs);
-    uint32_t div  = (time - (full * runs)) / (runs / 1000);
+    uint64_t per_sec = (uint64_t)(((uint64_t)1000000UL * runs) / time);
 
-    uint32_t per_sec = (uint32_t)(((uint64_t)1000000UL * runs) / time);
+    turo_t ctx;
+    turo_init(&ctx);
+    turo_dict_open(&ctx);
 
-    printf("%25s: %9" PRIu32 "us"
-           "  ---  %2" PRIu32 ".%03" PRIu32 "us per call"
-           "  ---  %9" PRIu32 " calls per sec\n",
-           name, time, full, div, per_sec);
+    turo_dict_key(&ctx, name);
+    turo_dict_open(&ctx);
+
+    turo_dict_key(&ctx, "us");
+    turo_u32(&ctx, time);
+
+    turo_dict_key(&ctx, "us/call");
+    turo_float(&ctx, (float)time/(float)runs);
+
+    turo_dict_key(&ctx, "calls/s");
+    turo_u64(&ctx, per_sec);
+
+    turo_dict_close(&ctx);
+
+    print("", 1);
 }

--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -46,5 +46,5 @@ void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
 
     turo_dict_close(&ctx);
 
-    print("", 1);
+    print("\n", 1);
 }

--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -20,16 +20,16 @@
 
 #include <stdio.h>
 
-#include "fmt.h"
 #include "benchmark.h"
 #include "test_utils/result_output.h"
 
 void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
 {
-    uint64_t per_sec = (uint64_t)(((uint64_t)1000000UL * runs) / time);
+    uint64_t per_sec = ((uint64_t)1000000UL * runs) / time;
 
     turo_t ctx;
     turo_init(&ctx);
+    turo_container_open(&ctx);
     turo_dict_open(&ctx);
 
     turo_dict_key(&ctx, name);
@@ -45,6 +45,5 @@ void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
     turo_u64(&ctx, per_sec);
 
     turo_dict_close(&ctx);
-
-    print("\n", 1);
+    turo_container_close(&ctx, 0);
 }

--- a/tests/bench_runtime_coreapis/Makefile
+++ b/tests/bench_runtime_coreapis/Makefile
@@ -4,4 +4,8 @@ include ../Makefile.tests_common
 USEMODULE += core_thread_flags
 USEMODULE += benchmark
 
+# select output format
+OUTPUT_FORMAT ?= json
+USEMODULE += test_utils_result_output_${OUTPUT_FORMAT}
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_runtime_coreapis/tests/01-run.py
+++ b/tests/bench_runtime_coreapis/tests/01-run.py
@@ -12,8 +12,11 @@ from testrunner import run
 
 # The default timeout is not enough for this test on some of the slower boards
 TIMEOUT = 30
-BENCHMARK_REGEXP = r"\s+{func}:\s+\d+us\s+---\s+\d*\.*\d+us per call\s+---\s+\d+ calls per sec"
 
+# expecting turo output like this:
+# {"nop loop": {"us": 616, "us/call": 0.0006159, "calls/s": 1623376623}
+# not checking the whole json object here, just ensure that everything is there.
+BENCHMARK_REGEXP = r"{{\"{func}\":"
 
 def testfunc(child):
     child.expect_exact('Runtime of Selected Core API functions')
@@ -27,6 +30,7 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
+
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -9,6 +9,10 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += benchmark
 
+# select benchmark output format
+OUTPUT_FORMAT ?= json
+USEMODULE += test_utils_result_output_${OUTPUT_FORMAT}
+
 # disable native GPIOs for automatic test
 ifeq (native,$(BOARD))
   USEMODULE += periph_gpio_mock

--- a/tests/periph_gpio/tests/02-bench.py
+++ b/tests/periph_gpio/tests/02-bench.py
@@ -18,18 +18,19 @@ PORT_UNDER_TEST = int(os.environ.get('PORT_UNDER_TEST') or 0)
 def testfunc(child):
     for pin in range(0, 8):
         child.sendline("bench {} {}".format(PORT_UNDER_TEST, pin))
-        child.expect(r" *nop loop: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
-        child.expect(r" *gpio_set: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
-        child.expect(r" *gpio_clear: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
-        child.expect(r" *gpio_toggle: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
-        child.expect(r" *gpio_read: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
-        child.expect(r" *gpio_write: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+
+        functions = ["nop loop", "gpio_set", "gpio_clear", "gpio_toggle",
+                    "gpio_read", "gpio_write"]
+
+        for f in functions:
+            child.expect(
+            r'{"%s": {"us": \d+, "us/call": \d+\.\d+, "calls/s": \d+}' % f)
+
         child.expect_exact(" --- DONE ---")
         child.expect_exact(">")
 
     # TODO do some automated verification here? E.g. all pins should have the
     #      same timing?
-    # TODO parse output data and put in some unified format?
 
     print("Benchmark was successful")
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This changes sys/benchmark to use turo.

This enables the results to be collected by CI along with the other metrics.

For seamless use, sys/benchmark depends on the json output *if no other turo output is selected*.

The only users (tests/bench_runtime_coreapis and tests/periph_gpio) have their makefiles adopted to allow choosing the output format.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Currently depends on https://github.com/RIOT-OS/RIOT/pull/17027.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
