### PR TITLE
boards/nucleo-g431rb: added PWM configuration

### DIFF
--- a/boards/nucleo-g431rb/Kconfig
+++ b/boards/nucleo-g431rb/Kconfig
@@ -17,6 +17,7 @@ config BOARD_NUCLEO_G431RB
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_I2C
     select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/nucleo-g431rb/Makefile.features
+++ b/boards/nucleo-g431rb/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32g431rb
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-g431rb/include/periph_conf.h
+++ b/boards/nucleo-g431rb/include/periph_conf.h
@@ -102,6 +102,26 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR1_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    }
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

Added PWM configuration for nucleo-g431rb board

### Testing procedure

Ran tests/periph_pwm and verified output on PC6



