### PR TITLE
boards/stm32f469i-disco: fix documentation

### DIFF
--- a/boards/stm32f469i-disco/doc.txt
+++ b/boards/stm32f469i-disco/doc.txt
@@ -1,8 +1,7 @@
 /**
- * @defgroup    boards_stm32f469i-disco STM32F469I-DISCO
- * @ingroup     boards
- * @brief       Support for the STM32F469I-DISCO board
- */
+@defgroup    boards_stm32f469i-disco STM32F469I-DISCO
+@ingroup     boards
+@brief       Support for the STM32F469I-DISCO board
 
 ## Table of Contents:
 
@@ -97,3 +96,4 @@ the USB Mini-B connector try to compile and flash some code, type:
 ```
 make flash BOARD=stm32f469i-disco
 ```
+*/


### PR DESCRIPTION
### Contribution description

When the documentation is generated, the current page does not render all the elements for this board, this PR is a tiny fix for the issue.

### Testing procedure

From the RIOT-OS root folder, execute `make doc` before and after this fix:

Before:
![Captura de pantalla de 2021-10-21 21-48-45](https://user-images.githubusercontent.com/10358374/138349463-55ee7fc7-9e67-4d1a-bbef-1e2a0d4c903d.png)

After:
![Captura de pantalla de 2021-10-21 21-54-17](https://user-images.githubusercontent.com/10358374/138349484-6c4db566-3a1f-4793-b8e2-726ccabf2b80.png)

### Issues/PRs references
None
