### PR TITLE
sys/test_utils/result_output/json: optional space after symbol 

### DIFF
--- a/sys/test_utils/result_output/json/result_output_json.c
+++ b/sys/test_utils/result_output/json/result_output_json.c
@@ -13,10 +13,19 @@
 
 #include "test_utils/result_output.h"
 
+/**
+ * @brief   TURO whitespace symbol macro
+ */
+#if IS_ACTIVE(CONFIG_TURO_JSON_WHITESPACE_AFTER_SYMBOL)
+#define TURO_JSON_POST_SYMBOL_WHITESPACE  " "
+#else
+#define TURO_JSON_POST_SYMBOL_WHITESPACE  ""
+#endif
+
 static void _print_comma(turo_t *ctx, turo_state_t state)
 {
     if (ctx->state == TURO_STATE_NEED_COMMA) {
-        print_str(", ");
+        print_str("," TURO_JSON_POST_SYMBOL_WHITESPACE);
     }
     ctx->state = state;
 }
@@ -92,7 +101,7 @@ void turo_dict_key(turo_t *ctx, const char *key)
     _print_comma(ctx, TURO_STATE_READY);
     print_str("\"");
     print_str(key);
-    print_str("\": ");
+    print_str("\":" TURO_JSON_POST_SYMBOL_WHITESPACE);
 }
 
 void turo_dict_close(turo_t *ctx)

--- a/sys/test_utils/result_output/json/result_output_types.h
+++ b/sys/test_utils/result_output/json/result_output_types.h
@@ -9,8 +9,19 @@
 #ifndef RESULT_OUTPUT_TYPES_H
 #define RESULT_OUTPUT_TYPES_H
 
+#include "kernel_defines.h"
+
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @brief   Enable to add a whitespace after a whitespace after a symbol
+ *
+ * e.g.: {"key1":1,"key2":2}" -> {"key1": 1, "key2: 2}
+ */
+#ifndef CONFIG_TURO_JSON_WHITESPACE_AFTER_SYMBOL
+#define CONFIG_TURO_JSON_WHITESPACE_AFTER_SYMBOL 1
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

This makes the more human-readable spaces optional.

### Testing procedure

Tested on #17029:

- `CONFIG_TURO_WHITESPACE_AFTER_SYMBOL 1`

```
{"nop loop": {"us": 819, "us/call": 0.0008190, "calls/s": 1221001221}

{"mutex_init()": {"us": 808, "us/call": 0.0008079, "calls/s": 1237623762}
{"mutex lock/unlock": {"us": 664589, "us/call": 0.6645889, "calls/s": 1504689}

{"thread_flags_set()": {"us": 318750, "us/call": 0.3187499, "calls/s": 3137254}
{"thread_flags_clear()": {"us": 318774, "us/call": 0.3187740, "calls/s": 3137018}
```

- `CONFIG_TURO_WHITESPACE_AFTER_SYMBOL 0`

```
{"mutex_init()":{"us":890,"us/call":0.0008900,"calls/s":1123595505}
{"mutex lock/unlock":{"us":687004,"us/call":0.6870040,"calls/s":1455595}

{"thread_flags_set()":{"us":317996,"us/call":0.3179959,"calls/s":3144693}
{"thread_flags_clear()":{"us":318639,"us/call":0.3186390,"calls/s":3138347}
{"thread flags set/wait any":{"us":958108,"us/call":0.9581080,"calls/s":1043723}
{"thread flags set/wait all":{"us":955820,"us/call":0.9558200,"calls/s":1046222}
{"thread flags set/wait one":{"us":960349,"us/call":0.9603490,"calls/s":1041288}

{"msg_try_receive()":{"us":324496,"us/call":0.3244960,"calls/s":3081702}
{"msg_avail()":{"us":2932,"us/call":0.0029319,"calls/s":341064120}
```

### Issues/PRs references

Follow up to #17027 as suggested my @miri64 
