### PR TITLE
sys/test_utils/result_output: fix turo_float() precision value

### DIFF
--- a/sys/test_utils/result_output/txt/result_output_txt.c
+++ b/sys/test_utils/result_output/txt/result_output_txt.c
@@ -49,7 +49,7 @@ void turo_u64(turo_t *ctx, uint64_t val)
 void turo_float(turo_t *ctx, float val)
 {
     (void)ctx;
-    print_float(val, 8);
+    print_float(val, 7);
     print_str(" ");
 }
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`print_float()` only allows values from 0-7.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixed for json here: #17029

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
