### PR TITLE
gha/workflows/release-test: set python version to 3.8

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -97,10 +97,10 @@ jobs:
         path: RIOT
         fetch-depth: 1
         ref: ${{ github.event.inputs.riot_version }}
-    - name: Set up Python
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.8
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION

### Contribution description

Set a value for the python version of the release workflow. Why 3.8? It's the one used in the other workflows.

### Testing procedure

Start a run on this branch workflow.

### Issues/PRs references

See https://github.com/RIOT-OS/RIOT/actions/runs/1363409667/attempts/2