### PR TITLE
Remove merge chance shield (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![License][license-badge]][license-link]
 [![API docs][api-badge]][api-link]
 [![Wiki][wiki-badge]][wiki-link]
-[![Merge chance][merge-chance-badge]][merge-chance-link]
 [![Stack Overflow questions][stackoverflow-badge]][stackoverflow-link]
 [![Twitter][twitter-badge]][twitter-link]
 [![Matrix][matrix-badge]][matrix-link]
@@ -150,7 +149,6 @@ https://www.riot-os.org
 [master-ci-link]: https://ci.riot-os.org/nightlies.html#master
 [matrix-badge]: https://img.shields.io/badge/chat-Matrix-brightgreen.svg
 [matrix-link]: https://matrix.to/#/#riot-os:matrix.org
-[merge-chance-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fmerge-chance.info%2Fbadge%3Frepo%3DRIOT-OS/RIOT&color=informational
 [merge-chance-link]: https://merge-chance.info/target?repo=RIOT-OS/RIOT
 [release-badge]: https://img.shields.io/github/release/RIOT-OS/RIOT.svg
 [release-link]: https://github.com/RIOT-OS/RIOT/releases/latest


### PR DESCRIPTION
### Contribution description


Merge chance is going to be deprecated soon. This PR removes its shield from your README to avoid displaying a broken element.

### Testing procedure

readme only change


### Issues/PRs references

none
