### PR TITLE
stm32/usbdev: Use ztimer instead of xtimer

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -4,7 +4,8 @@
 USEMODULE += periph stm32_clk stm32_vectors
 
 ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))

--- a/cpu/stm32/periph/Kconfig
+++ b/cpu/stm32/periph/Kconfig
@@ -8,7 +8,8 @@
 config MODULE_PERIPH
     bool
     default y
-    select MODULE_XTIMER if MODULE_PERIPH_USBDEV
+    select MODULE_ZTIMER if MODULE_PERIPH_USBDEV
+    select MODULE_ZTIMER_MSEC if MODULE_PERIPH_USBDEV
     help
         stm32 common peripheral code.
 

--- a/cpu/stm32/periph/usbdev.c
+++ b/cpu/stm32/periph/usbdev.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 
 #include "bitarithm.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "cpu.h"
 #include "cpu_conf.h"
 #include "periph/pm.h"
@@ -606,7 +606,7 @@ static void _set_mode_device(stm32_usb_otg_fshs_t *usbdev)
     _global_regs(conf)->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
     /* Spinlock to prevent a context switch here, needs a delay of 25 ms when
      * force switching mode */
-    xtimer_spin(xtimer_ticks_from_usec(25 * US_PER_MS));
+    ztimer_spin(ZTIMER_MSEC, 25);
 }
 
 static void _usbdev_init(usbdev_t *dev)


### PR DESCRIPTION
### Contribution description

Use ztimer isntead of xtimer for the stm32 usbdev peripheral.

### Testing procedure

- Green murdock,
- Test an stm32f4 with USB port with `examples/usbus_minimal`
- No xtimer in build:

```
make -C examples/usbus_minimal/ info-modules BOARD=nucleo-f446ze | grep xtimer
# empty
```
