### PR TITLE
pkg/hacl: make compilable with GCC 11 [backport 2021.10]

### DIFF
--- a/pkg/hacl/Makefile
+++ b/pkg/hacl/Makefile
@@ -7,7 +7,7 @@ PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-CFLAGS += -DKRML_NOUINT128 -Wno-unused-parameter
+CFLAGS += -DKRML_NOUINT128 -Wno-unused-parameter -Wno-array-parameter
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
# Backport of #17048

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With GCC 11 [a new warning was introduced](https://www.gnu.org/software/gcc/gcc-11/changes.html): `-Warray-parameter`. When compiling `tests/pkg_hacl` on my system, I get now an error message:

```
build/pkg/hacl/haclnacl.c:243:33: error: argument 1 of type ‘uint8_t[32]’ {aka ‘unsigned char[32]’} with mismatched bound [-Werror=array-parameter=]
  243 | int crypto_sign_keypair(uint8_t pk[32], uint8_t sk[64]){
      |                         ~~~~~~~~^~~~~~
In file included from build/pkg/hacl/haclnacl.c:6:
build/pkg/hacl/haclnacl.h:99:40: note: previously declared as ‘unsigned char *’
   99 | int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
      |                         ~~~~~~~~~~~~~~~^~
build/pkg/hacl/haclnacl.c:243:49: error: argument 2 of type ‘uint8_t[64]’ {aka ‘unsigned char[64]’} with mismatched bound [-Werror=array-parameter=]
  243 | int crypto_sign_keypair(uint8_t pk[32], uint8_t sk[64]){
      |                                         ~~~~~~~~^~~~~~
In file included from build/pkg/hacl/haclnacl.c:6:
build/pkg/hacl/haclnacl.h:99:59: note: previously declared as ‘unsigned char *’
   99 | int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
      |                                            ~~~~~~~~~~~~~~~^~
cc1: all warnings being treated as errors
```

<details><summary>My system:</summary>

```
Operating System Environment
----------------------------
         Operating System: "Arch Linux" 
                   Kernel: Linux 5.14.14-arch1-1 x86_64 unknown
             System shell: GNU bash, version 5.1.8(1)-release (x86_64-pc-linux-gnu)
             make's shell: GNU bash, version 5.1.8(1)-release (x86_64-pc-linux-gnu)

Installed compiler toolchains
-----------------------------
               native gcc: gcc (GCC) 11.1.0
        arm-none-eabi-gcc: arm-none-eabi-gcc (Arch Repository) 11.2.0
                  avr-gcc: avr-gcc (GCC) 11.2.0
         mips-mti-elf-gcc: missing
           msp430-elf-gcc: missing
       riscv-none-elf-gcc: missing
  riscv64-unknown-elf-gcc: missing
     riscv-none-embed-gcc: missing
     xtensa-esp32-elf-gcc: missing
   xtensa-esp8266-elf-gcc: missing
                    clang: clang version 12.0.1

Installed compiler libs
-----------------------
     arm-none-eabi-newlib: "4.1.0"
      mips-mti-elf-newlib: missing
        msp430-elf-newlib: missing
    riscv-none-elf-newlib: missing
riscv64-unknown-elf-newlib: missing
  riscv-none-embed-newlib: missing
  xtensa-esp32-elf-newlib: missing
xtensa-esp8266-elf-newlib: missing
                 avr-libc: "2.0.0" ("20150208")

Installed development tools
---------------------------
                   ccache: ccache version 4.4.2
                    cmake: cmake version 3.21.3
                 cppcheck: Cppcheck 2.6
                  doxygen: 1.9.2
                      git: git version 2.33.1
                     make: GNU Make 4.3
                  openocd: Open On-Chip Debugger 0.10.0+dev-01089-g3bfe49266 (2020-02-26-14:18)
                   python: Python 3.9.7
                  python2: Python 2.7.18
                  python3: Python 3.9.7
                   flake8: 3.9.2 (mccabe: 0.6.1, pycodestyle: 2.7.0, pyflakes: 2.3.1) CPython 3.9.7 on
               coccinelle: spatch version 1.1.1 compiled with OCaml version 4.12.0
```

</details>

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
When compiling with GCC 11, `pkg_hacl` should now compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
