### PR TITLE
periph/flashpage.h: add comment about riotboot impact on flashpage la…

### DIFF
--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -213,11 +213,17 @@ void flashpage_erase(unsigned page);
 
 /**
  * @brief Get number of first free flashpage
+ *
+ * If riotboot is used in two slot mode, this number will change across
+ * firmware updates as the firmware slots alternate.
  */
 unsigned flashpage_first_free(void);
 
 /**
  * @brief Get number of last free flashpage
+ *
+ * If riotboot is used in two slot mode, this number will change across
+ * firmware updates as the firmware slots alternate.
  */
 unsigned flashpage_last_free(void);
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Follow up for #16972 adding missing comments about riotboot two slot mode impact on `flashpage_first_free` and `flashpage_last_free` functions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


