### PR TITLE
CODING_CONVENTIONS.md: Update line length limit

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -19,8 +19,8 @@
 * Please obey the Linux coding style as described in
   https://www.kernel.org/doc/Documentation/process/coding-style.rst with the
   following modifications and additions:
-    * Line length: aim for no more than 80 characters per line, the absolute
-      maximum should be 100 characters per line.
+    * Line length: aim for no more than 100 characters per line, the absolute
+      maximum should be 120 characters per line.
     * All line endings shall be set to LF (`\n`). (How to handle line endings in
       Git: https://help.github.com/articles/dealing-with-line-endings)
     * There must be no trailing whitespace in any line.


### PR DESCRIPTION
### Contribution description

In https://github.com/RIOT-OS/RIOT/pull/15793 the line limit was increased to 100 chars (with 120 chars the absolute maximum) - but the coding convention document was not updated. This fixes the issue.

### Testing procedure

Proof read the change.

### Issues/PRs references

Follow-up of https://github.com/RIOT-OS/RIOT/pull/15793