### PR TITLE
USB: refactor to xmit-based API

### DIFF
--- a/cpu/nrf52/include/nrfusb.h
+++ b/cpu/nrf52/include/nrfusb.h
@@ -37,11 +37,6 @@ extern "C" {
 #define NRF_USB_NUM_PERIPH 1
 
 /**
- * USB endpoint buffer space
- */
-#define NRF_USB_BUF_SPACE   USBDEV_EP_BUF_SPACE
-
-/**
  * Number of USB IN and OUT endpoints
  */
 #define NRF_USB_NUM_EP      USBDEV_NUM_ENDPOINTS
@@ -65,9 +60,6 @@ typedef struct {
     usbdev_ep_t ep_ins[NRF_USB_NUM_EP];     /**< IN type endpoints              */
     usbdev_ep_t ep_outs[ NRF_USB_NUM_EP];   /**< OUT type endpoints             */
     NRF_USBD_Type *device;                  /**< Ptr to the device registers    */
-    size_t used;                            /**< Number of bytes from the
-                                                 buffer that are used           */
-    uint8_t buffer[NRF_USB_BUF_SPACE];      /**< Buffer space for endpoint data */
     nrfusb_setup_state_t sstate;            /**< Setup request state machine    */
 } nrfusb_t;
 

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -263,6 +263,17 @@ void spi_twi_irq_register_spi(NRF_SPIM_Type *bus,
  */
 void spi_twi_irq_register_i2c(NRF_TWIM_Type *bus,
                               spi_twi_irq_cb_t cb, void *arg);
+
+/**
+ * @brief USBDEV buffers must be word aligned because of DMA restrictions
+ */
+#define USBDEV_CPU_DMA_ALIGNMENT       (4)
+
+/**
+ * @brief USBDEV buffer instantiation requirement
+ */
+#define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -814,6 +814,16 @@ typedef struct {
 #endif
 
 /**
+ * @brief USBDEV buffers must be word aligned because of DMA restrictions
+ */
+#define USBDEV_CPU_DMA_ALIGNMENT       (4)
+
+/**
+ * @brief USBDEV buffer instantiation requirement
+ */
+#define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
+
+/**
  * @brief USB peripheral parameters
  */
 #if defined(USB_INST_NUM) || defined(DOXYGEN)

--- a/cpu/sam0_common/include/sam_usb.h
+++ b/cpu/sam0_common/include/sam_usb.h
@@ -32,11 +32,6 @@ extern "C" {
 #endif
 
 /**
- * USB endpoint buffer space
- */
-#define SAM_USB_BUF_SPACE   USBDEV_EP_BUF_SPACE
-
-/**
  * Number of USB IN and OUT endpoints
  */
 #define SAM_USB_NUM_EP      USBDEV_NUM_ENDPOINTS
@@ -49,11 +44,6 @@ typedef struct {
     const sam0_common_usb_config_t *config;         /**< USB peripheral config   */
     UsbDeviceDescBank banks[2 * SAM_USB_NUM_EP];    /**< Device descriptor banks */
     usbdev_ep_t endpoints[2 * SAM_USB_NUM_EP];      /**< Endpoints               */
-    size_t used;                                    /**< Number of bytes from the
-                                                         buffer that are used    */
-    __attribute__ ((aligned(4)))
-    uint8_t buffer[SAM_USB_BUF_SPACE];              /**< Buffer space, must be
-                                                         32-bit aligned          */
     bool suspended;                                 /**< Suspend active          */
 } sam0_common_usb_t;
 

--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>
+#include "architecture.h"
 #include "cpu.h"
 #include "cpu_conf.h"
 #include "periph/gpio.h"
@@ -46,12 +47,11 @@ static sam0_common_usb_t _usbdevs[USB_INST_NUM];
 const usbdev_driver_t driver;
 
 static void _usbdev_ep_init(usbdev_ep_t *ep);
-static int _usbdev_ep_ready(usbdev_ep_t *ep, size_t len);
+static int _usbdev_ep_xmit(usbdev_ep_t *ep, uint8_t *buf, size_t len);
 static usbdev_ep_t *_usbdev_new_ep(usbdev_t *dev, usb_ep_type_t type,
-                                   usb_ep_dir_t dir, size_t buf_len);
+                                   usb_ep_dir_t dir, size_t len);
 
 static int _bank_set_size(usbdev_ep_t *ep);
-static int _ep_unready(usbdev_ep_t *ep);
 
 static inline unsigned _ep_num(unsigned num, usb_ep_dir_t dir)
 {
@@ -142,13 +142,6 @@ static void _disable_ep_irq_in(UsbDeviceEndpoint *ep_reg)
     DEBUG("Disabling IN irq\n");
     ep_reg->EPINTENCLR.reg = USB_DEVICE_EPINTENCLR_TRCPT1 |
                              USB_DEVICE_EPINTENCLR_STALL1;
-}
-
-static void _bank_set_address(usbdev_ep_t *ep)
-{
-    UsbDeviceDescBank *bank = _bank_from_ep(ep);
-
-    bank->ADDR.reg = (uint32_t)ep->buf;
 }
 
 static int _bank_set_size(usbdev_ep_t *ep)
@@ -255,7 +248,7 @@ static inline void _poweron(sam0_common_usb_t *dev)
 }
 
 static usbdev_ep_t *_usbdev_new_ep(usbdev_t *dev, usb_ep_type_t type,
-                                   usb_ep_dir_t dir, size_t buf_len)
+                                   usb_ep_dir_t dir, size_t size)
 {
     sam0_common_usb_t *usbdev = (sam0_common_usb_t *)dev;
     /* The IP supports all types for all endpoints */
@@ -279,17 +272,9 @@ static usbdev_ep_t *_usbdev_new_ep(usbdev_t *dev, usb_ep_type_t type,
     if (res) {
         res->dev = dev;
         res->dir = dir;
-        if (usbdev->used + buf_len < SAM_USB_BUF_SPACE) {
-            res->buf = usbdev->buffer + usbdev->used;
-            res->len = buf_len;
-            if (_bank_set_size(res) < 0) {
-                return NULL;
-            }
-            usbdev->used += buf_len;
-            _bank_set_address(res);
-            res->type = type;
-            res->dev = dev;
-        }
+        res->type = type;
+        res->len = size;
+        _bank_set_size(res);
     }
     return res;
 }
@@ -334,7 +319,6 @@ static void _usbdev_init(usbdev_t *dev)
     /* Only one usb device on this board */
     sam0_common_usb_t *usbdev = (sam0_common_usb_t *)dev;
 
-    usbdev->used = 0;
     /* Set GPIO */
     gpio_init(usbdev->config->dp, GPIO_IN);
     gpio_init(usbdev->config->dm, GPIO_IN);
@@ -688,16 +672,6 @@ static int _usbdev_ep_set(usbdev_ep_t *ep, usbopt_ep_t opt,
         _ep_set_stall(ep, *(usbopt_enable_t *)value);
         res = sizeof(usbopt_enable_t);
         break;
-    case USBOPT_EP_READY:
-        assert(value_len == sizeof(usbopt_enable_t));
-        if (*((usbopt_enable_t *)value)) {
-            _ep_unready(ep);
-        }
-        else {
-            _usbdev_ep_ready(ep, 0);
-        }
-        res = sizeof(usbopt_enable_t);
-        break;
     default:
         DEBUG("sam_usb: Unhandled set call: 0x%x\n", opt);
         break;
@@ -705,23 +679,13 @@ static int _usbdev_ep_set(usbdev_ep_t *ep, usbopt_ep_t opt,
     return res;
 }
 
-static int _ep_unready(usbdev_ep_t *ep)
+static int _usbdev_ep_xmit(usbdev_ep_t *ep, uint8_t *buf, size_t len)
 {
     UsbDeviceEndpoint *ep_reg = _ep_reg_from_ep(ep);
+    /* Assert the alignment required for the buffers */
+    assert(HAS_ALIGNMENT_OF(buf, USBDEV_CPU_DMA_ALIGNMENT));
 
-    if (ep->dir == USB_EP_DIR_IN) {
-        ep_reg->EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_BK1RDY;
-    }
-    else {
-        ep_reg->EPSTATUSSET.reg = USB_DEVICE_EPSTATUSSET_BK0RDY;
-    }
-    return 0;
-}
-
-static int _usbdev_ep_ready(usbdev_ep_t *ep, size_t len)
-{
-    UsbDeviceEndpoint *ep_reg = _ep_reg_from_ep(ep);
-
+    _bank_from_ep(ep)->ADDR.reg = (uint32_t)(intptr_t)buf;
     if (ep->dir == USB_EP_DIR_IN) {
         _disable_ep_stall_in(ep_reg);
         _bank_from_ep(ep)->PCKSIZE.bit.BYTE_COUNT = len;
@@ -803,5 +767,5 @@ const usbdev_driver_t driver = {
     .ep_get = _usbdev_ep_get,
     .ep_set = _usbdev_ep_set,
     .ep_esr = _usbdev_ep_esr,
-    .ready = _usbdev_ep_ready,
+    .xmit = _usbdev_ep_xmit,
 };

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -783,6 +783,16 @@ typedef struct {
 #endif
 
 /**
+ * @brief USBDEV buffers must be word aligned because of DMA restrictions
+ */
+#define USBDEV_CPU_DMA_ALIGNMENT       (4)
+
+/**
+ * @brief USBDEV buffer instantiation requirement
+ */
+#define USBDEV_CPU_DMA_REQUIREMENTS    __attribute__((aligned(USBDEV_CPU_DMA_ALIGNMENT)))
+
+/**
  * @brief USB OTG peripheral type.
  *
  * High speed peripheral is assumed to have DMA support available.

--- a/cpu/stm32/include/usbdev_stm32.h
+++ b/cpu/stm32/include/usbdev_stm32.h
@@ -57,17 +57,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Buffer space available for endpoint TX/RX data
- */
-#ifndef STM32_USB_OTG_BUF_SPACE
-#define STM32_USB_OTG_BUF_SPACE  USBDEV_EP_BUF_SPACE
-#endif
-
-#if (STM32_USB_OTG_BUF_SPACE % 4) != 0
-#error "STM32_USB_OTG_BUF_SPACE needs to be a multiple of 4"
-#endif
-
-/**
  * @brief Number of endpoints available with the OTG FS peripheral
  *        including the control endpoint
  */
@@ -122,16 +111,22 @@ extern "C" {
 #endif
 
 /**
+ * @brief stm32 USB OTG peripheral device out endpoint struct
+ */
+typedef struct {
+    usbdev_ep_t ep;     /**< Inherited usbdev endpoint struct */
+    uint8_t *out_buf;   /**< Requested data output buffer */
+} stm32_usb_otg_fshs_out_ep_t;
+
+/**
  * @brief stm32 USB OTG peripheral device context
  */
 typedef struct {
     usbdev_t usbdev;                            /**< Inherited usbdev struct */
     const stm32_usb_otg_fshs_config_t *config;  /**< USB peripheral config   */
-    uint8_t buffer[STM32_USB_OTG_BUF_SPACE];    /**< Buffer space for endpoints */
-    size_t occupied;                            /**< Buffer space occupied */
     size_t fifo_pos;                            /**< FIFO space occupied */
     usbdev_ep_t *in;                            /**< In endpoints */
-    usbdev_ep_t *out;                           /**< Out endpoints */
+    stm32_usb_otg_fshs_out_ep_t *out;           /**< Out endpoints */
     bool suspend;                               /**< Suspend status */
 } stm32_usb_otg_fshs_t;
 

--- a/drivers/include/periph/usbdev.h
+++ b/drivers/include/periph/usbdev.h
@@ -119,7 +119,8 @@ typedef struct usbdev_ep usbdev_ep_t;
  * ```
  *
  * @note This is a define and not a typedef so that the above works. With a
- * typedef it would
+ * typedef it would instantiate an array of aligned uint8_t and not an aligned
+ * array of uint8_t (assuming the requirement is alignment).
  */
 #define usbdev_ep_buf_t USBDEV_CPU_DMA_REQUIREMENTS uint8_t
 

--- a/drivers/include/usbdev_mock.h
+++ b/drivers/include/usbdev_mock.h
@@ -40,10 +40,11 @@ typedef enum {
  * @brief usbdev mock device endpoint
  */
 typedef struct {
-    usbdev_ep_t ep;                 /**< Generic endpoint struct        */
-    usbdev_mock_ep_state_t state;   /**< Endpoint state                 */
-    size_t available;               /**< Bytes available in the buffer  */
-    uint8_t *buf_start;             /**< Start location of the buffer   */
+    usbdev_ep_t ep;                 /**< Generic endpoint struct                    */
+    usbdev_mock_ep_state_t state;   /**< Endpoint state                             */
+    size_t available;               /**< Bytes available in the buffer              */
+    uint8_t *target_buf;            /**< Buffer as passed by @ref usbdev_ep_xmit    */
+    uint8_t *buf;                   /**< Internal mock buffer pointer */
 } usbdev_mock_ep_t;
 
 /**

--- a/sys/include/usb/usbopt.h
+++ b/sys/include/usb/usbopt.h
@@ -92,11 +92,6 @@ typedef enum {
     USBOPT_EP_STALL,
 
     /**
-     * @brief   (usbopt_enable_t) Signal data ready or not ready anymore
-     */
-    USBOPT_EP_READY,
-
-    /**
      * @brief   (size_t) Retrieve number of bytes available on endpoint.
      */
     USBOPT_EP_AVAILABLE,

--- a/sys/include/usb/usbus/cdc/acm.h
+++ b/sys/include/usb/usbus/cdc/acm.h
@@ -142,6 +142,16 @@ struct usbus_cdcacm_device {
     usbus_cdcacm_line_state_t state;    /**< Current line state              */
     event_t flush;                      /**< device2host forced flush event  */
     usb_req_cdcacm_coding_t coding;     /**< Current coding configuration    */
+
+    /**
+     * @brief Host to device data buffer
+     */
+    usbdev_ep_buf_t out_buf[CONFIG_USBUS_CDC_ACM_BULK_EP_SIZE];
+
+    /**
+     * @brief Device to host data buffer
+     */
+    usbdev_ep_buf_t in_buf[CONFIG_USBUS_CDC_ACM_STDIO_BUF_SIZE];
 };
 
 /**

--- a/sys/include/usb/usbus/cdc/ecm.h
+++ b/sys/include/usb/usbus/cdc/ecm.h
@@ -106,12 +106,26 @@ typedef struct usbus_cdcecm_device {
     char mac_host[13];                      /**< host side's MAC address as string */
     usbus_string_t mac_str;                 /**< String context for the host side mac address */
     usbus_t *usbus;                         /**< Ptr to the USBUS context */
-    mutex_t out_lock;           /**< mutex used for locking netif/USBUS send */
-    size_t tx_len;              /**< Length of the current tx frame */
-    uint8_t in_buf[ETHERNET_FRAME_LEN]; /**< Buffer for the received frames */
+    mutex_t out_lock;                       /**< mutex used for locking netif/USBUS send */
+    size_t tx_len;                          /**< Length of the current tx frame */
     size_t len;                             /**< Length of the current rx frame */
-    usbus_cdcecm_notif_t notif;    /**< Startup message notification tracker */
-    unsigned active_iface;          /**< Current active data interface */
+    usbus_cdcecm_notif_t notif;             /**< Startup message notification tracker */
+    unsigned active_iface;                  /**< Current active data interface */
+
+    /**
+     * @brief Buffer for received frames
+     */
+    usbdev_ep_buf_t data_out[ETHERNET_FRAME_LEN];
+
+    /**
+     * @brief Host in device out data buffer
+     */
+    usbdev_ep_buf_t data_in[USBUS_CDCECM_EP_DATA_SIZE];
+
+    /**
+     * @brief Host out device in control buffer
+     */
+    usbdev_ep_buf_t control_in[USBUS_CDCECM_EP_CTRL_SIZE];
 } usbus_cdcecm_device_t;
 
 /**

--- a/sys/include/usb/usbus/cdc/ecm.h
+++ b/sys/include/usb/usbus/cdc/ecm.h
@@ -113,7 +113,7 @@ typedef struct usbus_cdcecm_device {
     unsigned active_iface;                  /**< Current active data interface */
 
     /**
-     * @brief Buffer for received frames
+     * @brief Buffer for received frames from the host
      */
     usbdev_ep_buf_t data_out[ETHERNET_FRAME_LEN];
 

--- a/sys/include/usb/usbus/control.h
+++ b/sys/include/usb/usbus/control.h
@@ -69,14 +69,24 @@ typedef struct {
     size_t received_len;
 
     /**
-     * @brief EP0 OUT endpoint
+     * @brief EP0 OUT endpoint reference
      */
     usbdev_ep_t *out;
 
     /**
-     * @brief EP0 IN endpoint
+     * @brief EP0 IN endpoint reference
      */
     usbdev_ep_t *in;
+
+    /**
+     * @brief Host to device control request buffer
+     */
+    usbdev_ep_buf_t out_buf[CONFIG_USBUS_EP0_SIZE];
+
+    /**
+     * @brief Device to host control request buffer
+     */
+    usbdev_ep_buf_t in_buf[CONFIG_USBUS_EP0_SIZE];
 } usbus_control_handler_t;
 
 /**

--- a/sys/include/usb/usbus/hid.h
+++ b/sys/include/usb/usbus/hid.h
@@ -77,6 +77,16 @@ struct usbus_hid_device {
     usbus_hid_cb_t cb;              /**< Callback for data handlers */
     event_t tx_ready;               /**< Transmit ready event */
     mutex_t in_lock;                /**< mutex used for locking hid send */
+
+    /**
+     * @brief Host to device data buffer
+     */
+    usbdev_ep_buf_t out_buf[CONFIG_USBUS_HID_INTERRUPT_EP_SIZE];
+
+    /**
+     * @brief Device to host data buffer
+     */
+    usbdev_ep_buf_t in_buf[CONFIG_USBUS_HID_INTERRUPT_EP_SIZE];
 };
 
 /**

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -115,7 +115,7 @@ static void _notify_link_speed(usbus_cdcecm_device_t *cdcecm)
 {
     DEBUG("CDC ECM: sending link speed indication\n");
     usb_desc_cdcecm_speed_t *notification =
-        (usb_desc_cdcecm_speed_t *)cdcecm->ep_ctrl->ep->buf;
+        (usb_desc_cdcecm_speed_t *)cdcecm->control_in;
     notification->setup.type = USB_SETUP_REQUEST_DEVICE2HOST |
                                USB_SETUP_REQUEST_TYPE_CLASS |
                                USB_SETUP_REQUEST_RECIPIENT_INTERFACE;
@@ -126,7 +126,7 @@ static void _notify_link_speed(usbus_cdcecm_device_t *cdcecm)
 
     notification->down = CONFIG_USBUS_CDC_ECM_CONFIG_SPEED_DOWNSTREAM;
     notification->up = CONFIG_USBUS_CDC_ECM_CONFIG_SPEED_UPSTREAM;
-    usbdev_ep_ready(cdcecm->ep_ctrl->ep,
+    usbdev_ep_xmit(cdcecm->ep_ctrl->ep, cdcecm->control_in,
                     sizeof(usb_desc_cdcecm_speed_t));
     cdcecm->notif = USBUS_CDCECM_NOTIF_SPEED;
 }
@@ -134,7 +134,7 @@ static void _notify_link_speed(usbus_cdcecm_device_t *cdcecm)
 static void _notify_link_up(usbus_cdcecm_device_t *cdcecm)
 {
     DEBUG("CDC ECM: sending link up indication\n");
-    usb_setup_t *notification = (usb_setup_t *)cdcecm->ep_ctrl->ep->buf;
+    usb_setup_t *notification = (usb_setup_t *)cdcecm->control_in;
     notification->type = USB_SETUP_REQUEST_DEVICE2HOST |
                          USB_SETUP_REQUEST_TYPE_CLASS |
                          USB_SETUP_REQUEST_RECIPIENT_INTERFACE;
@@ -142,7 +142,7 @@ static void _notify_link_up(usbus_cdcecm_device_t *cdcecm)
     notification->value = 1;
     notification->index = cdcecm->iface_ctrl.idx;
     notification->length = 0;
-    usbdev_ep_ready(cdcecm->ep_ctrl->ep, sizeof(usb_setup_t));
+    usbdev_ep_xmit(cdcecm->ep_ctrl->ep, cdcecm->control_in, sizeof(usb_setup_t));
     cdcecm->notif = USBUS_CDCECM_NOTIF_LINK_UP;
 }
 
@@ -251,7 +251,8 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
                   setup->value);
             cdcecm->active_iface = (uint8_t)setup->value;
             if (cdcecm->active_iface == 1) {
-                usbdev_ep_ready(cdcecm->ep_out->ep, 0);
+                usbdev_ep_xmit(cdcecm->ep_out->ep, cdcecm->data_out,
+                               USBUS_CDCECM_EP_DATA_SIZE);
                 _notify_link_up(cdcecm);
             }
             break;
@@ -290,36 +291,15 @@ static void _handle_tx_xmit(event_t *ev)
         mutex_unlock(&cdcecm->out_lock);
     }
     /* Data prepared by netdev_send, signal ready to usbus */
-    usbdev_ep_ready(cdcecm->ep_in->ep, cdcecm->tx_len);
-}
-
-static void _handle_rx_flush(usbus_cdcecm_device_t *cdcecm)
-{
-    cdcecm->len = 0;
+    usbdev_ep_xmit(cdcecm->ep_in->ep, cdcecm->data_in, cdcecm->tx_len);
 }
 
 static void _handle_rx_flush_ev(event_t *ev)
 {
     usbus_cdcecm_device_t *cdcecm = container_of(ev, usbus_cdcecm_device_t,
                                                  rx_flush);
-
-    usbdev_ep_ready(cdcecm->ep_out->ep, 0);
-    _handle_rx_flush(cdcecm);
-}
-
-static void _store_frame_chunk(usbus_cdcecm_device_t *cdcecm, size_t len)
-{
-    uint8_t *buf = cdcecm->ep_out->ep->buf;
-
-    /* Truncate if it exceeds the expected MTU size. */
-    /* TODO: Should be converted to an endpoint halt after #17090 is merged */
-    if (cdcecm->len + len < ETHERNET_FRAME_LEN) {
-        memcpy(cdcecm->in_buf + cdcecm->len, buf, len);
-        cdcecm->len += len;
-    }
-    if (len < USBUS_CDCECM_EP_DATA_SIZE) {
-        netdev_trigger_event_isr(&cdcecm->netdev);
-    }
+    cdcecm->len = 0; /* Flush packet */
+    usbdev_ep_xmit(cdcecm->ep_out->ep, cdcecm->data_out, USBUS_CDCECM_EP_DATA_SIZE);
 }
 
 static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
@@ -335,9 +315,14 @@ static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
         }
         size_t len = 0;
         usbdev_ep_get(ep, USBOPT_EP_AVAILABLE, &len, sizeof(size_t));
-        _store_frame_chunk(cdcecm, len);
+        cdcecm->len += len;
         if (len == USBUS_CDCECM_EP_DATA_SIZE) {
-            usbdev_ep_ready(ep, 0);
+            /* ready next chunk */
+            usbdev_ep_xmit(ep, cdcecm->data_out + cdcecm->len,
+                           USBUS_CDCECM_EP_DATA_SIZE);
+        }
+        else {
+            netdev_trigger_event_isr(&cdcecm->netdev);
         }
     }
     else if (ep == cdcecm->ep_in->ep) {
@@ -354,9 +339,9 @@ static void _handle_reset(usbus_t *usbus, usbus_handler_t *handler)
     usbus_cdcecm_device_t *cdcecm = (usbus_cdcecm_device_t *)handler;
 
     DEBUG("CDC ECM: Reset\n");
-    _handle_rx_flush(cdcecm);
     _handle_in_complete(usbus, handler);
     cdcecm->notif = USBUS_CDCECM_NOTIF_NONE;
+    cdcecm->len = 0; /* Flush received data */
     cdcecm->active_iface = 0;
     mutex_unlock(&cdcecm->out_lock);
 }

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -59,7 +59,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     assert(iolist);
     usbus_cdcecm_device_t *cdcecm = _netdev_to_cdcecm(netdev);
-    uint8_t *buf = cdcecm->ep_in->ep->buf;
+    uint8_t *buf = cdcecm->data_in;
     const iolist_t *iolist_start = iolist;
     size_t len = iolist_size(iolist);
     /* interface with alternative function ID 1 is the interface containing the
@@ -142,7 +142,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t max_len, void *info)
         return pktlen;
     }
     if (pktlen <= max_len) {
-        memcpy(buf, cdcecm->in_buf, pktlen);
+        memcpy(buf, cdcecm->data_out, pktlen);
     }
     _signal_rx_flush(cdcecm);
     return (pktlen <= max_len) ? (int)pktlen : -ENOBUFS;

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -142,6 +142,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t max_len, void *info)
         return pktlen;
     }
     if (pktlen <= max_len) {
+        /* Copy the received data from the host to the netif buffer */
         memcpy(buf, cdcecm->data_out, pktlen);
     }
     _signal_rx_flush(cdcecm);

--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -77,7 +77,7 @@ static void _handle_tx_ready(event_t *ev)
 {
     usbus_hid_device_t *hid = container_of(ev, usbus_hid_device_t, tx_ready);
 
-    usbdev_ep_ready(hid->ep_in->ep, hid->occupied);
+    usbdev_ep_xmit(hid->ep_in->ep, hid->in_buf, hid->occupied);
 }
 
 void usbus_hid_init(usbus_t *usbus, usbus_hid_device_t *hid, usbus_hid_cb_t cb,
@@ -138,7 +138,8 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     usbus_enable_endpoint(hid->ep_out);
 
     /* signal that INTERRUPT OUT is ready to receive data */
-    usbdev_ep_ready(hid->ep_out->ep, 0);
+    usbdev_ep_xmit(hid->ep_out->ep, hid->out_buf,
+                    CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
 
     usbus_add_interface(usbus, &hid->iface);
 }
@@ -222,8 +223,8 @@ static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
         size_t len;
         usbdev_ep_get(ep, USBOPT_EP_AVAILABLE, &len, sizeof(size_t));
         if (len > 0) {
-            hid->cb(hid, ep->buf, len);
+            hid->cb(hid, hid->out_buf, len);
         }
-        usbdev_ep_ready(ep, 0);
+        usbdev_ep_xmit(ep, hid->out_buf, CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
     }
 }

--- a/sys/usb/usbus/hid/hid_io.c
+++ b/sys/usb/usbus/hid/hid_io.c
@@ -50,7 +50,7 @@ int usb_hid_io_read_timeout(void *buffer, size_t len, uint32_t timeout)
 void usb_hid_io_write(const void *buffer, size_t len)
 {
     assert(buffer);
-    uint8_t *buffer_ep = hid.ep_in->ep->buf;
+    uint8_t *buffer_ep = hid.in_buf;
     uint16_t max_size = hid.ep_in->maxpacketsize;
     size_t offset = 0;
 

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -166,7 +166,7 @@ usbus_endpoint_t *usbus_add_endpoint(usbus_t *usbus, usbus_interface_t *iface,
     if (usbdev_ep) {
         ep = dir == USB_EP_DIR_IN ? &usbus->ep_in[usbdev_ep->num]
                                   : &usbus->ep_out[usbdev_ep->num];
-        ep->maxpacketsize = usbdev_ep->len;
+        ep->maxpacketsize = len;
         ep->ep = usbdev_ep;
         if (iface) {
             ep->next = iface->ep;
@@ -325,6 +325,7 @@ static void _event_cb(usbdev_t *usbdev, usbdev_event_t event)
                            sizeof(uint8_t));
                 flag = USBUS_HANDLER_FLAG_RESET;
                 msg = USBUS_EVENT_USB_RESET;
+                DEBUG("usbus: USB reset detected\n");
                 break;
             case USBDEV_EVENT_SUSPEND:
                 DEBUG("usbus: USB suspend detected\n");

--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -286,11 +286,11 @@ static void _recv_setup(usbus_t *usbus, usbus_control_handler_t *handler)
             /* Signal ready for new data in case there is more */
             if (handler->received_len < pkt->length) {
                 handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_OUTDATA;
-                usbdev_ep_ready(handler->out, 1);
+                usbdev_ep_xmit(handler->out, handler->out_buf, CONFIG_USBUS_EP0_SIZE);
             }
             else {
                 handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_INACK;
-                usbdev_ep_ready(handler->in, 0);
+                usbdev_ep_xmit(handler->in, handler->in_buf, 0);
             }
         }
 
@@ -307,7 +307,7 @@ static void _usbus_config_ep0(usbus_control_handler_t *ep0_handler)
                   sizeof(usbopt_enable_t));
     usbdev_ep_set(ep0_handler->out, USBOPT_EP_ENABLE, &enable,
                   sizeof(usbopt_enable_t));
-    usbdev_ep_ready(ep0_handler->out, 0);
+    usbdev_ep_xmit(ep0_handler->out, ep0_handler->out_buf, CONFIG_USBUS_EP0_SIZE);
 }
 
 uint8_t *usbus_control_get_out_data(usbus_t *usbus, size_t *len)
@@ -317,10 +317,9 @@ uint8_t *usbus_control_get_out_data(usbus_t *usbus, size_t *len)
     assert(len);
     assert(handler->control_request_state == USBUS_CONTROL_REQUEST_STATE_OUTDATA);
 
-    usbdev_ep_t *ep_out = handler->out;
-    usbdev_ep_get(ep_out, USBOPT_EP_AVAILABLE,
+    usbdev_ep_get(handler->out, USBOPT_EP_AVAILABLE,
                   len, sizeof(size_t));
-    return ep_out->buf;
+    return handler->out_buf;
 }
 
 static void _init(usbus_t *usbus, usbus_handler_t *handler)
@@ -351,14 +350,14 @@ static int _handle_tr_complete(usbus_t *usbus,
                 }
                 ep0_handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_READY;
                 /* Ready for new control request */
-                usbdev_ep_ready(ep0_handler->out, 0);
+                usbdev_ep_xmit(ep0_handler->out, ep0_handler->out_buf, CONFIG_USBUS_EP0_SIZE);
             }
             break;
         case USBUS_CONTROL_REQUEST_STATE_OUTACK:
             if (ep->dir == USB_EP_DIR_OUT) {
                 ep0_handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_READY;
                 /* Ready for new control request */
-                usbdev_ep_ready(ep0_handler->out, 0);
+                usbdev_ep_xmit(ep0_handler->out, ep0_handler->out_buf, CONFIG_USBUS_EP0_SIZE);
             }
             break;
         case USBUS_CONTROL_REQUEST_STATE_INDATA:
@@ -369,7 +368,7 @@ static int _handle_tr_complete(usbus_t *usbus,
                 }
                 else {
                     /* Ready out ZLP */
-                    usbdev_ep_ready(ep0_handler->out, 0);
+                    usbdev_ep_xmit(ep0_handler->out, ep0_handler->out_buf, CONFIG_USBUS_EP0_SIZE);
                     ep0_handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_OUTACK;
                 }
             }
@@ -389,7 +388,7 @@ static int _handle_tr_complete(usbus_t *usbus,
         case USBUS_CONTROL_REQUEST_STATE_READY:
             if (ep->dir == USB_EP_DIR_OUT) {
                 memset(&ep0_handler->slicer, 0, sizeof(usbus_control_slicer_t));
-                memcpy(&ep0_handler->setup, ep0_handler->out->buf,
+                memcpy(&ep0_handler->setup, ep0_handler->out_buf,
                        sizeof(usb_setup_t));
                 ep0_handler->received_len = 0;
                 ep0_handler->slicer.reqlen = ep0_handler->setup.length;

--- a/sys/usb/usbus/usbus_control_slicer.c
+++ b/sys/usb/usbus/usbus_control_slicer.c
@@ -69,7 +69,7 @@ size_t usbus_control_slicer_put_bytes(usbus_t *usbus, const uint8_t *buf,
     size_t start_offset = bldr->cur - bldr->start + byte_offset;
     bldr->cur += len;
     bldr->len += byte_len;
-    memcpy(ep0->in->buf + start_offset, buf + byte_offset, byte_len);
+    memcpy(ep0->in_buf + start_offset, buf + byte_offset, byte_len);
     return byte_len;
 }
 
@@ -81,7 +81,7 @@ size_t usbus_control_slicer_put_char(usbus_t *usbus, char c)
 
     /* Only copy the char if it is within the window */
     if ((bldr->start <=  bldr->cur) && (bldr->cur < end)) {
-        uint8_t *pos = ep0->in->buf + bldr->cur - bldr->start;
+        uint8_t *pos = ep0->in_buf + bldr->cur - bldr->start;
         *pos = c;
         bldr->cur++;
         bldr->len++;
@@ -99,5 +99,5 @@ void usbus_control_slicer_ready(usbus_t *usbus)
 
     len = len < bldr->reqlen - bldr->start ? len : bldr->reqlen - bldr->start;
     bldr->transferred += len;
-    usbdev_ep_ready(ep0->in, len);
+    usbdev_ep_xmit(ep0->in, ep0->in_buf, len);
 }

--- a/tests/usbus/main.c
+++ b/tests/usbus/main.c
@@ -146,7 +146,7 @@ static void _test_sequence(usbdev_mock_t *dev)
         case TESTPHASE_RESET:
             next_phase = TESTPHASE_REQ_DEV_INIT;
             DEBUG("[test]: Requesting device descriptor\n");
-            _build_conf_req(dev->out[0].ep.buf, 8); /* initial config request */
+            _build_conf_req(dev->out[0].buf, 8); /* initial config request */
             dev->req_len = 8;
             dev->out[0].state = EP_STATE_DATA_AVAILABLE;
             dev->out[0].available = 8;
@@ -157,7 +157,7 @@ static void _test_sequence(usbdev_mock_t *dev)
             DEBUG("[test]: validating device descriptor\n");
             TEST_ASSERT_EQUAL_INT(dev->in[0].available, 8);
             _validate_device_desc_init(
-                (usb_descriptor_device_t *)dev->in[0].buf_start);
+                (usb_descriptor_device_t *)dev->in[0].buf);
             /* Reset device */
             DEBUG("[test]: Signalling second USB reset condition\n");
             dev->usbdev.cb(&dev->usbdev, USBDEV_EVENT_RESET);
@@ -166,7 +166,7 @@ static void _test_sequence(usbdev_mock_t *dev)
         case TESTPHASE_RESET2:
             next_phase = TESTPHASE_SET_ADDRESS;
             DEBUG("[test]: Set USB address\n");
-            _build_set_addr(dev->out[0].ep.buf);
+            _build_set_addr(dev->out[0].buf);
             dev->req_len = 0;
             dev->out[0].state = EP_STATE_DATA_AVAILABLE;
             dev->out[0].available = 8;
@@ -175,7 +175,7 @@ static void _test_sequence(usbdev_mock_t *dev)
         case TESTPHASE_SET_ADDRESS:
             next_phase = TESTPHASE_REQ_DEV_FULL;
             DEBUG("[test]: Requesting full device descriptor\n");
-            _build_conf_req(dev->out[0].ep.buf,
+            _build_conf_req(dev->out[0].buf,
                             sizeof(usb_descriptor_device_t));
             dev->req_len = sizeof(usb_descriptor_device_t);
             dev->out[0].state = EP_STATE_DATA_AVAILABLE;
@@ -187,7 +187,7 @@ static void _test_sequence(usbdev_mock_t *dev)
                                   sizeof(usb_descriptor_device_t));
             DEBUG("[test]: Validating full descriptor\n");
             _validate_device_desc_init(
-                (usb_descriptor_device_t *)dev->in[0].buf_start);
+                (usb_descriptor_device_t *)dev->in[0].buf);
 
             next_phase = TESTPHASE_FINAL;
             dev->usbdev.cb(&dev->usbdev, USBDEV_EVENT_ESR);
@@ -261,8 +261,6 @@ static void _handle_data(usbdev_mock_t *dev, usbdev_mock_ep_t *ep, size_t len)
         if (ep->available == dev->req_len) {
             DEBUG("[data]: Full data received from stack\n");
             req_phase = TEST_REQ_PHASE_OUTACK;
-            /* Reset buffer ptr to the start */
-            ep->ep.buf = ep->buf_start;
         }
         else {
             DEBUG("[data]: Expecting more data from stack: %u/%u\n",


### PR DESCRIPTION
### Contribution description

This API change refactors the usbdev API to supply buffers via the
usbdev_ep_xmit function. This changes from the usbdev_ep_ready call to allow
separate buffers per call. 

Main advantage is that the usbdev peripherals no longer have to allocate
oversized buffers for the endpoint data, potentially saving multiple KiB
of unused buffer space. These allocations are now the responsibility of
the individual USB interfaces in the firmware

An usbdev_ep_buf_t pseudotype is available and must
be used when defining buffers used for endpoints to adhere to the DMA alignment
restrictions often required with usb peripherals.

### Testing procedure

usbdev implementations:
 - [x] stm32
 - [x] nrf52
 - [x] sam0_common

Interfaces implemented:
- [x] CDC ECM
- [x] CDC ACM 
- [x] HID

(DFU only uses control requests and didn't need adaptations)

### Issues/PRs references

None