### PR TITLE
sys/turo: Add decimal integer printer

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -568,6 +568,16 @@ void print_s64_dec(uint64_t val)
     print(buf, len);
 }
 
+void print_s32_frac_dec(int32_t val, unsigned digit)
+{
+    char buf[12]; /* "-214.7483648" */
+    for (; digit >= TENMAP_SIZE; digit--) {
+        val /= 10;
+    }
+    size_t len = fmt_s32_dfp(buf, val, -(int)digit);
+    print(buf, len);
+}
+
 void print_float(float f, unsigned precision)
 {
     char buf[19];

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -481,6 +481,21 @@ void print_u64_dec(uint64_t val);
 void print_s64_dec(uint64_t val);
 
 /**
+ * @brief Print int32 value with a decimal point
+ *
+ * This avoids floats allowing a decimal point to be inserted in an integer.
+ *
+ * For example: if @p val is -35648 and @p digit is 2, the resulting
+ * string will be "-356.48".
+ *
+ * @note This uses a portion of fmt_s32_dfp()
+ *
+ * @param[in]   val     Value to print
+ * @param[in]   digit   Decimal point place starting from the right
+ */
+void print_s32_frac_dec(int32_t val, unsigned digit);
+
+/**
  * @brief Print float value
  *
  * @note See fmt_float for code size warning!

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -305,11 +305,9 @@ size_t fmt_s16_dfp(char *out, int16_t val, int scale);
  *
  * This multiplies a 32bit signed number by 10^(scale) before formatting.
  *
- * The resulting string will always be padded with zeros after the decimal point.
- *
- * For example: if @p val is -35648 and @p scale is -2, the resulting
- * string will be "-352.48"( -35648*10^-2). The same value for @p val with
- * @p scale of 2 will result in "-3524800" (-35648*10^2).
+ * For example: if @p val is -35648 and @p fp_digits is -2, the resulting
+ * string will be "-356.48". The same value for @p val with @p fp_digits of 2
+ * will result in "-3546800".
  *
  * @param[out] out          Pointer to the output buffer, or NULL
  * @param[in]  val          Fixed point value

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -481,19 +481,20 @@ void print_u64_dec(uint64_t val);
 void print_s64_dec(uint64_t val);
 
 /**
- * @brief Print int32 value with a decimal point
+ * @brief Print int32 value with a scale
  *
- * This avoids floats allowing a decimal point to be inserted in an integer.
+ * This avoids floats allowing scaling of an integer.
  *
- * For example: if @p val is -35648 and @p digit is 2, the resulting
- * string will be "-356.48".
+ * For example: if @p val is -35648 and @p scale is 2, the resulting
+ * string will be "-3564800" or @p scale is -2 then the string will be
+ * "-356.48".
  *
  * @note This uses a portion of fmt_s32_dfp()
  *
  * @param[in]   val     Value to print
- * @param[in]   digit   Decimal point place starting from the right
+ * @param[in]   scale   Scale value
  */
-void print_s32_frac_dec(int32_t val, unsigned digit);
+void print_s32_dfp(int32_t val, int scale);
 
 /**
  * @brief Print float value

--- a/sys/include/test_utils/result_output.h
+++ b/sys/include/test_utils/result_output.h
@@ -130,6 +130,18 @@ void turo_s64(turo_t *ctx, int64_t val);
 void turo_u64(turo_t *ctx, uint64_t val);
 
 /**
+ * @brief  Outputs a formatted signed 32 bit integer with a decimal point.
+ *
+ * @pre `turo_container_open` called
+ * @pre digit < TENMAP_SIZE (== 8)
+ *
+ * @param[in] ctx       The implementation specific turo context.
+ * @param[in] val       The value to output.
+ * @param[in] digit     Decimal point place starting from the right
+ */
+void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit);
+
+/**
  * @brief  Outputs a formatted float result of varied precision.
  *
  * @pre `turo_container_open` called

--- a/sys/include/test_utils/result_output.h
+++ b/sys/include/test_utils/result_output.h
@@ -140,7 +140,7 @@ void turo_u64(turo_t *ctx, uint64_t val);
 void turo_float(turo_t *ctx, float val);
 
 /**
- * @brief  Outputs a formatted string string.
+ * @brief  Outputs a formatted string.
  *
  * @pre `turo_container_open` called
  *

--- a/sys/include/test_utils/result_output.h
+++ b/sys/include/test_utils/result_output.h
@@ -137,9 +137,9 @@ void turo_u64(turo_t *ctx, uint64_t val);
  *
  * @param[in] ctx       The implementation specific turo context.
  * @param[in] val       The value to output.
- * @param[in] digit     Decimal point place starting from the right
+ * @param[in] scale     Scale value
  */
-void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit);
+void turo_s32_dfp(turo_t *ctx, int32_t val, int scale);
 
 /**
  * @brief  Outputs a formatted float result of varied precision.

--- a/sys/test_utils/result_output/check/result_output_check.c
+++ b/sys/test_utils/result_output/check/result_output_check.c
@@ -56,6 +56,13 @@ void turo_u64(turo_t *ctx, uint64_t val)
     _val_check(ctx);
 }
 
+void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit)
+{
+    (void)val;
+    (void)digit;
+    _val_check(ctx);
+}
+
 void turo_float(turo_t *ctx, float val)
 {
     (void)val;

--- a/sys/test_utils/result_output/check/result_output_check.c
+++ b/sys/test_utils/result_output/check/result_output_check.c
@@ -56,10 +56,10 @@ void turo_u64(turo_t *ctx, uint64_t val)
     _val_check(ctx);
 }
 
-void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit)
+void turo_s32_dfp(turo_t *ctx, int32_t val, int scale)
 {
     (void)val;
-    (void)digit;
+    (void)scale;
     _val_check(ctx);
 }
 

--- a/sys/test_utils/result_output/json/result_output_json.c
+++ b/sys/test_utils/result_output/json/result_output_json.c
@@ -65,6 +65,12 @@ void turo_u64(turo_t *ctx, uint64_t val)
     print_u64_dec(val);
 }
 
+void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit)
+{
+    _print_comma(ctx, TURO_STATE_NEED_COMMA);
+    print_s32_frac_dec(val, digit);
+}
+
 void turo_float(turo_t *ctx, float val)
 {
     _print_comma(ctx, TURO_STATE_NEED_COMMA);

--- a/sys/test_utils/result_output/json/result_output_json.c
+++ b/sys/test_utils/result_output/json/result_output_json.c
@@ -65,10 +65,10 @@ void turo_u64(turo_t *ctx, uint64_t val)
     print_u64_dec(val);
 }
 
-void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit)
+void turo_s32_dfp(turo_t *ctx, int32_t val, int scale)
 {
     _print_comma(ctx, TURO_STATE_NEED_COMMA);
-    print_s32_frac_dec(val, digit);
+    print_s32_dfp(val, scale);
 }
 
 void turo_float(turo_t *ctx, float val)

--- a/sys/test_utils/result_output/txt/result_output_txt.c
+++ b/sys/test_utils/result_output/txt/result_output_txt.c
@@ -46,10 +46,10 @@ void turo_u64(turo_t *ctx, uint64_t val)
     print_str(" ");
 }
 
-void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit)
+void turo_s32_dfp(turo_t *ctx, int32_t val, int scale)
 {
     (void)ctx;
-    print_s32_frac_dec(val, digit);
+    print_s32_dfp(val, scale);
     print_str(" ");
 }
 

--- a/sys/test_utils/result_output/txt/result_output_txt.c
+++ b/sys/test_utils/result_output/txt/result_output_txt.c
@@ -46,6 +46,13 @@ void turo_u64(turo_t *ctx, uint64_t val)
     print_str(" ");
 }
 
+void turo_s32_frac(turo_t *ctx, int32_t val, unsigned digit)
+{
+    (void)ctx;
+    print_s32_frac_dec(val, digit);
+    print_str(" ");
+}
+
 void turo_float(turo_t *ctx, float val)
 {
     (void)ctx;

--- a/tests/turo/main.c
+++ b/tests/turo/main.c
@@ -254,10 +254,10 @@ static int cmd_test_multi_element_dict(int argc, char **argv)
     return 0;
 }
 
-static int cmd_test_s32_frac(int argc, char **argv)
+static int cmd_test_s32_dfp(int argc, char **argv)
 {
     int32_t val = 0;
-    int32_t digit = 0;
+    int32_t scale = 0;
 
     if (argc != 3) {
         turo_simple_exit_status(&ctx, -16);
@@ -269,13 +269,13 @@ static int cmd_test_s32_frac(int argc, char **argv)
         return 1;
     }
 
-    if (_sc_arg2s32(argv[2], &digit) != 0) {
+    if (_sc_arg2s32(argv[2], &scale) != 0) {
         turo_simple_exit_status(&ctx, -18);
         return 1;
     }
 
     turo_container_open(&ctx);
-    turo_s32_frac(&ctx, val, digit);
+    turo_s32_dfp(&ctx, val, (int)scale);
     turo_container_close(&ctx, 0);
 
     return 0;
@@ -302,7 +302,7 @@ static const shell_command_t shell_commands[] = {
     { "turo_simple_dict_s32", "", cmd_turo_simple_dict_s32 },
     { "turo_simple_exit_status", "", cmd_turo_simple_exit_status },
     { "test_multi_element_dict", "", cmd_test_multi_element_dict },
-    { "test_s32_frac", "", cmd_test_s32_frac },
+    { "test_s32_dfp", "", cmd_test_s32_dfp},
     { "test_netif", "", cmd_test_netif },
     { NULL, NULL, NULL }
 };

--- a/tests/turo/main.c
+++ b/tests/turo/main.c
@@ -254,6 +254,33 @@ static int cmd_test_multi_element_dict(int argc, char **argv)
     return 0;
 }
 
+static int cmd_test_s32_frac(int argc, char **argv)
+{
+    int32_t val = 0;
+    int32_t digit = 0;
+
+    if (argc != 3) {
+        turo_simple_exit_status(&ctx, -16);
+        return 1;
+    }
+
+    if (_sc_arg2s32(argv[1], &val) != 0) {
+        turo_simple_exit_status(&ctx, -17);
+        return 1;
+    }
+
+    if (_sc_arg2s32(argv[2], &digit) != 0) {
+        turo_simple_exit_status(&ctx, -18);
+        return 1;
+    }
+
+    turo_container_open(&ctx);
+    turo_s32_frac(&ctx, val, digit);
+    turo_container_close(&ctx, 0);
+
+    return 0;
+}
+
 static int cmd_test_netif(int argc, char **argv)
 {
     (void) argc;
@@ -275,6 +302,7 @@ static const shell_command_t shell_commands[] = {
     { "turo_simple_dict_s32", "", cmd_turo_simple_dict_s32 },
     { "turo_simple_exit_status", "", cmd_turo_simple_exit_status },
     { "test_multi_element_dict", "", cmd_test_multi_element_dict },
+    { "test_s32_frac", "", cmd_test_s32_frac },
     { "test_netif", "", cmd_test_netif },
     { NULL, NULL, NULL }
 };

--- a/tests/turo/tests/01-run.py
+++ b/tests/turo/tests/01-run.py
@@ -127,6 +127,27 @@ class TestTuro(TestTuroBase):
         resp = self.exec_turo_cmd(cmd)
         self.assertDictEqual(resp, test_dict)
 
+    def test_test_s32_frac(self):
+        vals = [-0x7FFFFFF, -1, 0, 1, 10, 0x7FFFFFF]
+        decs = [0, 1, 7, 8, 0xFFFF]
+        # Since we are dealing with fixed points comparing to floating
+        # we add a tolerance when comparing.
+        tol = 0.0000001
+        cmd = 'test_s32_frac'
+        for val in vals:
+            for dec in decs:
+                exp = val/(10 ** dec)
+                result = self.exec_turo_cmd(f'{cmd} {val} {dec}')
+                result = float(result)
+                if exp >= 0:
+                    float_tol = exp * tol + tol
+                else:
+                    float_tol = exp * tol - tol
+                if (exp >= 0):
+                    assert (exp - float_tol <= result <= exp + float_tol)
+                else:
+                    assert (exp + float_tol <= result <= exp - float_tol)
+
     def test_test_netif(self):
         resp = self.exec_turo_cmd("test_netif")
 

--- a/tests/turo/tests/01-run.py
+++ b/tests/turo/tests/01-run.py
@@ -127,16 +127,16 @@ class TestTuro(TestTuroBase):
         resp = self.exec_turo_cmd(cmd)
         self.assertDictEqual(resp, test_dict)
 
-    def test_test_s32_frac(self):
-        vals = [-0x7FFFFFF, -1, 0, 1, 10, 0x7FFFFFF]
-        decs = [0, 1, 7, 8, 0xFFFF]
+    def test_test_s32_dfp(self):
+        vals = [-0x7FFFFFF, -1, 9, -9, 0, 1, 20, 10, 0x7FFFFFF]
+        decs = [0, 1, 7, 21, 22, 23, 100, -1, -7, -21, -22, -23]
         # Since we are dealing with fixed points comparing to floating
         # we add a tolerance when comparing.
         tol = 0.0000001
-        cmd = 'test_s32_frac'
+        cmd = 'test_s32_dfp'
         for val in vals:
             for dec in decs:
-                exp = val/(10 ** dec)
+                exp = val * (10 ** dec)
                 result = self.exec_turo_cmd(f'{cmd} {val} {dec}')
                 result = float(result)
                 if exp >= 0:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As a way around using floats and to prevent code bloat a `turo_s32_frac` is added to the turo API.
The functionality is based on the `fmt_s32_dfp` from the `fmt.h` library, however, since a fixed length print buffer is needed we add some constraints to the overall functionality.  This will only be allowed to insert a decimal within an existing int32, not be able to multiply by 10s or be able to divide more that TENMAP (8) 10s.

### Testing procedure
 
Murdock green (unittests and `tests/turo`)

### Issues/PRs references

Can be used by #17029
Depends on #17072