### PR TITLE
githubworkflow/check-pr: do squash-check on approval

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -19,7 +19,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: [commit-msg, pr_check]
+        check: [commit-msg]
+    steps:
+    - uses: actions/checkout@master
+      with:
+        # Use the SHA of the PR branch as-is, not the PR branch merged
+        # in master (default behavior in GH actions)
+        # See https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Fetch base branch
+      run:
+        git fetch origin '${{ github.base_ref }}:${{ github.base_ref }}'
+    - name: Run checks
+      run: |
+        ./dist/tools/${{ matrix.check }}/check.sh "${{ github.base_ref }}"
+  check-commits-squash:
+    runs-on: ubuntu-latest
+    if: ${{ github.base_ref }} && github.event.review.state == 'approved'
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [pr_check]
     steps:
     - uses: actions/checkout@master
       with:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -13,13 +13,9 @@ jobs:
         access_token: ${{ secrets.GITHUB_TOKEN }}
         unset_labels: 'CI: needs squashing,State: waiting for other PR,Process: blocked by feature freeze'
         cond_labels: '(Process: needs >1 ACK,review.approvals>1),(Area: RDM,review.approvals>2)'
-  check-commits:
+  check-msg:
     runs-on: ubuntu-latest
     if: ${{ github.base_ref }}
-    strategy:
-      fail-fast: false
-      matrix:
-        check: [commit-msg]
     steps:
     - uses: actions/checkout@master
       with:
@@ -29,29 +25,6 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Fetch base branch
-      run:
-        git fetch origin '${{ github.base_ref }}:${{ github.base_ref }}'
+      run: git fetch origin '${{ github.base_ref }}:${{ github.base_ref }}'
     - name: Run checks
-      run: |
-        ./dist/tools/${{ matrix.check }}/check.sh "${{ github.base_ref }}"
-  check-commits-squash:
-    runs-on: ubuntu-latest
-    if: ${{ github.base_ref }} && github.event.review.state == 'approved'
-    strategy:
-      fail-fast: false
-      matrix:
-        check: [pr_check]
-    steps:
-    - uses: actions/checkout@master
-      with:
-        # Use the SHA of the PR branch as-is, not the PR branch merged
-        # in master (default behavior in GH actions)
-        # See https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
-    - name: Fetch base branch
-      run:
-        git fetch origin '${{ github.base_ref }}:${{ github.base_ref }}'
-    - name: Run checks
-      run: |
-        ./dist/tools/${{ matrix.check }}/check.sh "${{ github.base_ref }}"
+      run: ./dist/tools/commit-msg/check.sh "${{ github.base_ref }}"

--- a/.github/workflows/check-squash.yml
+++ b/.github/workflows/check-squash.yml
@@ -1,0 +1,20 @@
+name: check-squash
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  check-squash-commits:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref && github.event.review.state == 'approved'
+    steps:
+    - uses: actions/checkout@master
+      with:
+        # Use the SHA of the PR branch as-is, not the PR branch merged
+        # in master (default behavior in GH actions)
+        # See https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Fetch base branch
+      run:  git fetch origin '${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}'
+    - name: Run checks
+      run: ./dist/tools/pr_check/check.sh "${{ github.event.pull_request.base.ref }}"


### PR DESCRIPTION
### Contribution description

This changes the github workflow that does the check for fixups and squashables until the pr is approved, this is early enough to catch these.
This will lessen the notification noise by a great deal. Using fixup commits is encouraged but prior to this commit they will lead to much noise in the GH notifications.

### Testing procedure

not sure how to test workflows

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
