### PR TITLE
boards/adafruit-clue: use internal RC oscillator

### DIFF
--- a/boards/adafruit-clue/include/periph_conf.h
+++ b/boards/adafruit-clue/include/periph_conf.h
@@ -21,7 +21,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
-#include "cfg_clock_32_1.h"
+#include "cfg_clock_32_0.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Instead of using an external oscillator, since there's none on this board (see @fjmolinas https://github.com/RIOT-OS/RIOT/pull/17031#discussion_r737845745).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- In master `tests/periph_rtt` doesn't work
- With this PR and when increasing the PRECISION value to 0.1, it works:

<details>

```diff
diff --git a/tests/periph_rtt/tests/01-run.py b/tests/periph_rtt/tests/01-run.py
index 2990071a1b..c652bdc3e6 100755
--- a/tests/periph_rtt/tests/01-run.py
+++ b/tests/periph_rtt/tests/01-run.py
@@ -11,7 +11,7 @@ import time
 from testrunner import run
 
 
-PRECISION = 0.05  # 5%
+PRECISION = 0.10  # 10%
 MAX_HELLOS = 5
 
```

```
$ BUILD_IN_DOCKER=1 make BOARD=adafruit-clue -C tests/periph_rtt flash test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=adafruit-clue'  -w '/data/riotbuild/riotbase/tests/periph_rtt/' 'riot/riotbuild:latest' make 'BOARD=adafruit-clue'    
Building application "tests_periph_rtt" for "adafruit-clue" with MCU "nrf52".

"make" -C /data/riotbuild/riotbase/boards/adafruit-clue
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/nrf52
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf52/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf52/vectors
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/auto_init/usb
"make" -C /data/riotbuild/riotbase/sys/event
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/usb/usbus
"make" -C /data/riotbuild/riotbase/sys/usb/usbus/cdc/acm
"make" -C /data/riotbuild/riotbase/sys/usb_board_reset
   text	   data	    bss	    dec	    hex	filename
  18160	    128	   5440	  23728	   5cb0	/data/riotbuild/riotbase/tests/periph_rtt/bin/adafruit-clue/tests_periph_rtt.elf
adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application /work/riot/RIOT/tests/periph_rtt/bin/adafruit-clue/tests_periph_rtt.hex /work/riot/RIOT/tests/periph_rtt/bin/adafruit-clue/tests_periph_rtt.hex.zip
Zip created at /work/riot/RIOT/tests/periph_rtt/bin/adafruit-clue/tests_periph_rtt.hex.zip
adafruit-nrfutil dfu serial --port=/dev/ttyACM0 --baudrate=115200 --touch=1200 --package=/work/riot/RIOT/tests/periph_rtt/bin/adafruit-clue/tests_periph_rtt.hex.zip --singlebank
Upgrading target on /dev/ttyACM0 with DFU package /work/riot/RIOT/tests/periph_rtt/bin/adafruit-clue/tests_periph_rtt.hex.zip. Flow control is disabled, Single bank, Touch 1200
####################################
Activating new firmware
Device programmed.
sleep 2
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.01-devel-279-g45c8e3-pr/boards/adafruit_clue_rtt_conf)

RIOT RTT low-level driver test
RTT configuration:
RTT_MAX_VALUE: 0x00ffffff
RTT_FREQUENCY: 1024

Testing the tick conversion
Trying to convert 1 to seconds and back
Trying to convert 256 to seconds and back
Trying to convert 65536 to seconds and back
Trying to convert 16777216 to seconds and back
Trying to convert 2147483648 to seconds and back
All ok

Initializing the RTT driver
This test will now display 'Hello' every 5 seconds

RTT now: 0
Setting initial alarm to now + 5 s (5120)
rtt_get_alarm() PASSED
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello


```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required for #17031 to work on adafruit-clue

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
