### PR TITLE
sys/fmt: clamp fmt_s32_dfp() fp_digits parameter

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -315,8 +315,6 @@ size_t fmt_s16_dfp(char *out, int16_t val, int fp_digits)
 
 size_t fmt_s32_dfp(char *out, int32_t val, int fp_digits)
 {
-    assert(fp_digits > -(int)TENMAP_SIZE);
-
     unsigned  pos = 0;
 
     if (fp_digits == 0) {
@@ -331,6 +329,13 @@ size_t fmt_s32_dfp(char *out, int32_t val, int fp_digits)
     }
     else {
         fp_digits *= -1;
+
+        /* ensure we're not using a higher precision than we can handle */
+        while ((unsigned)fp_digits >= TENMAP_SIZE) {
+            val /= 10;
+            fp_digits -= 1;
+        }
+
         uint32_t e = _tenmap[fp_digits];
         int32_t abs = (val / (int32_t)e);
         int32_t div = val - (abs * e);

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -287,8 +287,7 @@ size_t fmt_s16_dec(char *out, int16_t val);
  *
  * @param[out] out          Pointer to the output buffer, or NULL
  * @param[in]  val          Fixed point value
- * @param[in]  fp_digits    Number of digits after the decimal point, MUST be
- *                          >= -7
+ * @param[in]  fp_digits    Number of digits after the decimal point
  *
  * @return      Length of the resulting string
  */
@@ -310,12 +309,12 @@ size_t fmt_s16_dfp(char *out, int16_t val, int fp_digits);
  * will be "-35.48". The same value for @p val with @p fp_digits of 2 will
  * result in "-354800".
  *
- * @pre fp_digits > -8 (TENMAP_SIZE)
+ * If fp_digits is negative, it will only print up to (TENMAP_SIZE-1) digits
+ * after the decimal point.
  *
  * @param[out] out          Pointer to the output buffer, or NULL
  * @param[in]  val          Fixed point value
- * @param[in]  fp_digits    Number of digits after the decimal point, MUST be
- *                          >= -7
+ * @param[in]  fp_digits    Number of digits after the decimal point
  *
  * @return      Length of the resulting string
  */

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -738,6 +738,15 @@ static void test_fmt_s32_dfp(void)
     out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-0.0000001", (char *)out);
 
+    val = -1234567890;
+    fpp = -10;     /* exceeding TENMAP_SIZE */
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-0.1234567", (char *)out);
+
     /* check that the buffer was not overflowed */
     TEST_ASSERT_EQUAL_STRING("z", &out[28]);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR makes `fmt_s32_dfp()` accept smaller fp_digits values than `-(TENMAP_SIZE-1)` (which would be -7).
Previously, this would lead to an assert. Now, this will divide `value` and increment fp_digits` until the value fits.

This *does* enlarge the function (+28b on Cortex-M4, +44b on Cortex-M0), but makes it IMO much friendlier to use, as `-7` is a limit that's not very intuitive.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A unit test for the new functionality was added, and all previous unit tests still pass, so CI should be sufficient.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
