### PR TITLE
sys/shell/gnrc_netif: List netifs in registration order

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1791,10 +1791,20 @@ SHELL_COMMAND(txtsnd, "Sends a custom string as is over the link layer", _gnrc_n
 int _gnrc_netif_config(int argc, char **argv)
 {
     if (argc < 2) {
-        netif_t *netif = NULL;
+        netif_t *last = NULL;
 
-        while ((netif = netif_iter(netif))) {
+        /* Get interfaces in reverse order since the list is used like a stack.
+         * Stop when first netif in list already has been listed. */
+        while (last != netif_iter(NULL)) {
+            netif_t *netif = NULL;
+            netif_t *next = netif_iter(netif);
+            /* Step until next is end of list or was previously listed. */
+            do {
+                netif = next;
+                next = netif_iter(netif);
+            } while (next && next != last);
             _netif_list(netif);
+            last = netif;
         }
 
         return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The netif list is used like a stack, so it needs to be iterated in reverse to keep the registration order.

Time complexity in O(n^2), but the the list is normally very short (1-2 items).

Before:
```
> ifconfig
Iface  10  HWaddr: 24:0A:C4:E6:0E:9C  Channel: 0  Link: down
[..]

Iface  7  HWaddr: 24:0A:C4:E6:0E:9F  Link: down
[..]
```

Now they are in the increasing order:
```
> ifconfig
Iface  7  HWaddr: 24:0A:C4:E6:0E:9F  Link: down
[..]

Iface  10  HWaddr: 24:0A:C4:E6:0E:9C  Channel: 0  Link: down
[..]
```

When lwIP is hacked to use the same shell command, it also lists it interfaces in the expected order (was `ET1`,`ET0` before):
```
> ifconfig
Iface  ET0  HWaddr: 24:0A:C4:E6:0E:9F  Link: down
[..]

Iface  ET1  HWaddr: 24:0A:C4:E6:0E:9C  Channel: 0  Link: down
[..]
```




### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `ifconfig` on an app with GNRC (like `examples/gnrc_networking`), preferably while having multiple netifs.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Instead of #16980
