### PR TITLE
cpu/esp8266: place freertos functions in IRAM

### DIFF
--- a/cpu/esp8266/ld/esp8266.riot-os.ld
+++ b/cpu/esp8266/ld/esp8266.riot-os.ld
@@ -240,6 +240,7 @@ SECTIONS
     *core/sched.o(.literal .text .literal.* .text.*)
     *esp_wifi/*(.literal .text .literal.* .text.*)
     *freertos/*(.literal .text .literal.* .text.*)
+    *freertos_common/*(.literal .text .literal.* .text.*)
     *periph/*(.literal .text .literal.* .text.*)
     *xtimer/*(.literal .text .literal.* .text.*)
 


### PR DESCRIPTION
### Contribution description

This PR places also functions implemented in `cpu/esp_common/freetos/*.c` in IRAM.

The functions of the `esp*/freetos` libraries must be placed in IRAM because they can be called even when the IROM cache is disabled. While the functions implemented in `cpu/esp8266/freetos/*.c` are already placed in IRAM, the functions implemented in `cpu/esp_common/freetos/*.c` are not placed in IRAM. The reason for this is that the object files of these files are created in the `esp_freertos_common` directory, which is not included in the `esp.riot-os.ld` file because the library is named `esp_freertos_common`.

### Testing procedure

Compile and flash `examples/filesystem` with enabled `esp_wifi` module
```
USEMODULE="esp_spiffs esp_wifi lwip_netdev lwip_arp" make BOARD=esp8266-esp-12x -C examples/filesystem flash
```
and execute command `format` multiple times. A WiFi connection isn't neccessary.

Without this PR the formatting command hangs at the second time at the latest. With this PR the formatting command works several times.

### Issues/PRs references

Fixes #16281 