### PR TITLE
boards/nucleo-g07xrb: fix or exclude some doxygen warnings [backport 2021.10]

### DIFF
--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -106,6 +106,7 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
 
 /**
  * @name   SPI configuration

--- a/boards/nucleo-g071rb/include/periph_conf.h
+++ b/boards/nucleo-g071rb/include/periph_conf.h
@@ -104,6 +104,7 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
 
 /**
  * @name   SPI configuration

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14535,3 +14535,7 @@ sys/posix/pthread/include/pthread_cancellation\.h:[0-9]+: warning: Member PTHREA
 sys/posix/pthread/include/pthread_cancellation\.h:[0-9]+: warning: Member PTHREAD_CANCEL_ENABLE \(macro definition\) of file pthread_cancellation\.h is not documented\.
 sys/posix/pthread/include/pthread_mutex_attr\.h:[0-9]+: warning: Member pthread_mutexattr_getprioceiling\(const pthread_mutexattr_t \*attr, int \*prioceiling\) \(function\) of file pthread_mutex_attr\.h is not documented\.
 sys/posix/pthread/include/pthread_mutex_attr\.h:[0-9]+: warning: Member pthread_mutexattr_setprioceiling\(pthread_mutexattr_t \*attr, int prioceiling\) \(function\) of file pthread_mutex_attr\.h is not documented\.
+boards/nucleo\-g071rb/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-g071rb/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-g070rb/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-g070rb/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.


### PR DESCRIPTION
# Backport of #17079

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes some doxygen warnings, and adds the remaining patterns that focal's doxygen still complains.
~~For future use, a commit also adds a script to create the patterns from doxygen warnings, with the logic taken from https://github.com/RIOT-OS/RIOT/pull/16779#issue-980190050.~~ (split out into #17082)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should be fine.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/riotdocker/pull/104
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
