### PR TITLE
usbus/cdc_acm: Return stall on line coding not supported

### DIFF
--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -259,6 +259,11 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
     usbus_cdcacm_device_t *cdcacm = (usbus_cdcacm_device_t*)handler;
     switch(setup->request) {
         case USB_CDC_MGNT_REQUEST_SET_LINE_CODING:
+            if (!(cdcacm->coding_cb)) {
+                /* Line coding not supported, return STALL */
+                DEBUG("CDCACM: line coding not supported\n");
+                return -1;
+            }
             if ((state == USBUS_CONTROL_REQUEST_STATE_OUTDATA) &&
                     (setup->length == sizeof(usb_req_cdcacm_coding_t))) {
                 size_t len = 0;


### PR DESCRIPTION
### Contribution description

The SetLineCoding request is optional to support (CDC PSTN subclass). No
need to claim to support it to the host and actually discard the data if
it is not supported by the implementation.

### Testing procedure

Running the `tests/usbus_cdc_acm_stdio/` case, use a serial console to change the baud rate. This should still work. Bonus points for sniffing the USB traffic with wireshark, that should look like this:

![usb_wireshark](https://user-images.githubusercontent.com/5160052/139528495-b1241fe8-27b3-48f9-815d-fe615c64ea93.png)

Main thing is the "Broken pipe" in the reply packet which indicates a stall from the device side.

### Issues/PRs references

None