### PR TITLE
usbdev: Add dedicated stall functions

### DIFF
--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -277,10 +277,8 @@ static void _recv_setup(usbus_t *usbus, usbus_control_handler_t *handler)
         }
     }
     if (res < 0) {
-        /* Signal stall to indicate unsupported (USB 2.0 spec 9.6.2 */
-        static const usbopt_enable_t enable = USBOPT_ENABLE;
-        usbdev_ep_set(handler->in, USBOPT_EP_STALL, &enable,
-                      sizeof(usbopt_enable_t));
+        /* Signal stall to indicate unsupported (USB 2.0 spec 9.6.2) */
+        usbdev_ep0_stall(usbus->dev);
         handler->control_request_state = USBUS_CONTROL_REQUEST_STATE_READY;
     }
     else if (res) {


### PR DESCRIPTION
### Contribution description

This PR adds dedicated stall functions for usbdev peripherals. Two
functions are added. The first function (usbdev_ep_stall) to enable and
disable the stall condition on generic endpoints. The second function is
a dedicated function to set the stall condition on endpoint zero in both
directions. This status can only be set and should automatically be
cleared by the usbdev implementation (or hardware) after a new setup
request is received from the host.

### Testing procedure

- examples/usbus_minimal should still enumerate correctly on the host side.
- #17085 can be used to demonstrate the ep0_stall function with the `tests/usbus_cdc_acm_stdio/` test

### Issues/PRs references

None