### PR TITLE
cpu/esp32: place freertos and periph in IRAM

### DIFF
--- a/cpu/esp32/ld/esp32.common.ld
+++ b/cpu/esp32/ld/esp32.common.ld
@@ -133,7 +133,9 @@ SECTIONS
     /* part of the RIOT port that should run in IRAM */
     *cpu/*(.literal .text .literal.* .text.*)
     *esp_common/*(.literal .text .literal.* .text.*)
+    *esp_freertos_common/*(.literal .text .literal.* .text.*)
     *periph/*(.literal .text .literal.* .text.*)
+    *esp_periph_common/*(.literal .text .literal.* .text.*)
     *mtd/**(.literal .text .literal.* .text.*)
 
     INCLUDE esp32.spiram.rom-functions-iram.ld


### PR DESCRIPTION
### Contribution description

This PR moves the code from `cpu/esp_common/periph` and `cpu/esp_common/freertos` from IROM to IRAM.

The IRAM is much faster than the IROM. Furthermore, IROM can only be accessed via a cache which is sometimes disabled, e.g. by the WiFi module or when writing to the flash. Therefore, time-critical code as well as code that has to work even when the IROM cache is disabled must be placed in the IRAM.

The PR should increase stability.

### Testing procedure

Tests in Murdock should still success.

Additionally, a networking application should be tested.
```
USEMODULE='esp_wifi' CFLAGS='-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\"' make -C examples/gnrc_networking BOARD=esp32-wroom-32 flash term
```

### Issues/PRs references

Found when fixing #16281.