### PR TITLE
cfg_page: provide/manage of configuration variables in flash

### DIFF
--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -11,3 +11,6 @@ FEATURES_PROVIDED += periph_qdec
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet
 FEATURES_PROVIDED += motor_driver
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -24,7 +24,7 @@
 
 #ifdef MODULE_CFG_PAGE
 #include "cfg_page.h"
-struct cfg_page_desc_t cfgpage;
+cfg_page_desc_t cfgpage;
 #endif
 
 /**

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -22,6 +22,11 @@
 #include "mtd_native.h"
 #endif
 
+#ifdef MODULE_CFG_PAGE
+#include "cfg_page.h"
+struct cfg_page_desc_t cfgpage;
+#endif
+
 /**
  * Nothing to initialize at the moment.
  * Turns the red LED on and the green LED off.
@@ -32,6 +37,9 @@ void board_init(void)
     LED1_ON;
 
     puts("RIOT native board initialized.");
+#ifdef MODULE_CFG_PAGE
+    cfg_page_init(&cfgpage);
+#endif
 }
 
 #ifdef MODULE_MTD
@@ -46,4 +54,21 @@ static mtd_native_dev_t mtd0_dev = {
 };
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd0_dev;
+#endif
+
+#ifdef MODULE_CFG_PAGE
+#ifndef MTD1_SECTOR_NUM
+#define MTD1_SECTOR_NUM 2
+#endif
+static mtd_native_dev_t mtd1_dev = {
+    .dev = {
+        .driver = &native_flash_driver,
+        .sector_count = MTD1_SECTOR_NUM,
+        .pages_per_sector = MTD_SECTOR_SIZE / MTD_PAGE_SIZE,
+        .page_size = MTD_PAGE_SIZE,
+    },
+    .fname = MTD_NATIVE_CFG_FILENAME,
+};
+
+mtd_dev_t *mtd1 = (mtd_dev_t *)&mtd1_dev;
 #endif

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -71,6 +71,9 @@ void _native_LED_RED_TOGGLE(void);
 #ifndef MTD_NATIVE_FILENAME
 #define MTD_NATIVE_FILENAME     "MEMORY.bin"
 #endif
+#ifndef MTD_NATIVE_CFG_FILENAME
+#define MTD_NATIVE_CFG_FILENAME "CONFIG.bin"
+#endif
 /** @} */
 
 /** Default MTD device */
@@ -78,6 +81,12 @@ void _native_LED_RED_TOGGLE(void);
 
 /** mtd flash emulation device */
 extern mtd_dev_t *mtd0;
+
+#ifdef MODULE_CFG_PAGE
+#define MTD_1 mtd1
+extern mtd_dev_t *mtd1;
+#endif
+
 #endif
 
 #if defined(MODULE_SPIFFS) || DOXYGEN

--- a/drivers/cfg_page/Kconfig
+++ b/drivers/cfg_page/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_CFG_PAGE
+    bool "Generic Configuration Data flash interface"
+    depends on TEST_KCONFIG

--- a/drivers/cfg_page/Makefile
+++ b/drivers/cfg_page/Makefile
@@ -1,3 +1,2 @@
 include $(RIOTBASE)/Makefile.base
 
-USEPKG += nanocbor

--- a/drivers/cfg_page/Makefile
+++ b/drivers/cfg_page/Makefile
@@ -1,0 +1,3 @@
+include $(RIOTBASE)/Makefile.base
+
+USEPKG += nanocbor

--- a/drivers/cfg_page/Makefile.dep
+++ b/drivers/cfg_page/Makefile.dep
@@ -1,0 +1,1 @@
+USEPKG += nanocbor

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021  Michael Richardson <mcr@sandelman.ca>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cfg_page
+ * @brief       configuration data flash page
+ * @{
+ *
+ * @file
+ * @brief       configuration page access routines
+ *
+ * @author      Michael Ricahrdson <mcr@sandelman.ca>
+ *
+ * A Configuration Page consists of a fixed 16 byte header, followed by an indefinite map.
+ * The header is a CBOR sequence with 3 elements:
+ *    1) A CBOR-file-magic SEQUENCE with tag "RIOT"
+ *       D9 D9F7         # tag(55799)
+ *          DA 52494F54  # tag(1380536148)
+ *             63        # text(3)
+ *               424F52  # "BOR"
+ *    2) A single byte sequence counter, mod 24 (so 0 > 24)
+ *       01 # unsigned(1)
+ *    3) A 16-bit checksum of the previous 13 bytes.
+ *       19 3345 # unsigned(13125)
+ *    4) An indefinite map containing key/values.
+ * @}
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "cfg_page.h"
+
+#define ENABLE_DEBUG 1
+#include "debug.h"
+
+/* for MTD_1 */
+#include "board.h"
+
+int cfg_page_init(struct cfg_page_desc_t *cpd)
+{
+    DEBUG("cfg_page: init\n");
+#ifdef MTD_1
+    cpd->dev = MTD_1;
+    mtd_init(cpd->dev);
+#endif
+
+    return 0;
+}
+
+#define CBOR_SEQ_TAG      55800             /* per draft-ietf-cbor-file-magic */
+#define CFG_PAGE_RIOT_TAG 1380536148        /* 'RIOT' */
+
+int cfg_page_validate(struct cfg_page_desc_t *cpd)
+{
+  unsigned char header_buffer[CFG_PAGE_HEADER_SIZE];
+  nanocbor_value_t decoder;
+  uint32_t tagval = 0x12345678;
+  int16_t  checksum = 0;
+  int8_t   serialno = 0;
+
+  /* read things in first */
+  if(mtd_read(cpd->dev, header_buffer, 0, sizeof(CFG_PAGE_HEADER_SIZE)) != 0) {
+    return -1;
+  }
+
+  /* validate the checksum */
+  nanocbor_decoder_init(&decoder, header_buffer, CFG_PAGE_HEADER_SIZE);
+
+  /* pull in the tags */
+  if(nanocbor_get_tag(&decoder, &tagval) != NANOCBOR_OK
+     || tagval != CBOR_SEQ_TAG) {
+    return -1;
+  }
+
+  if(nanocbor_get_tag(&decoder, &tagval) != NANOCBOR_OK
+     || tagval != CFG_PAGE_RIOT_TAG) {
+    return -1;
+  }
+
+  if(nanocbor_get_bstr(&val, &bytes, &bytes_len) != NANOCBOR_OK
+     || bytes_len != 3
+     || bytes[0]!= 'B'
+     || bytes[1]!= 'O'
+     || bytes[2]!= 'R') {
+    return -1;
+  }
+
+  if(nanocbor_get_int8(&val, &serialno) != NANOCBOR_OK) {
+    return -1;
+  }
+
+  /* calculate a 16-bit checksum across the bytes so far */
+  int16_t calculated = crc16_ccitt_calc(header_buffer, (val->cur - header_buffer));
+
+  if(nanocbor_get_int16(&val, &checksum) != NANOCBOR_OK) {
+    return -1;
+  }
+
+  if(calculated != checksum) {
+    return -1;
+  }
+
+  /* Good News Everyone! */
+  return 0;
+}

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -303,7 +303,8 @@ int cfg_page_init_writer(cfg_page_desc_t *cpd,
         DEBUG("swap slotno\n");
     }
 
-    size_t writeoffset = (reader.cur-cfg_page_active_buffer);
+    /* -1 to remove 0xff stop code */
+    size_t writeoffset = (reader.cur-cfg_page_active_buffer)-1;
     DEBUG("found end of old values at: %u, amountleft=%u\n",
           writeoffset, amountleft);
 

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -475,7 +475,7 @@ int cfg_page_init_writer(cfg_page_desc_t *cpd,
     size_t amountleft = 0;
 
     while(!foundspace) {
-        DEBUG("finding end of valid values: %d\n", tryswap);
+        //DEBUG("finding end of valid values: %d\n", tryswap);
         /* start by bringin in the content */
         /* XXX could avoid this if we think the content is already loaded */
         if(cfg_page_init_reader(cpd, cfg_page_active_buffer, sizeof(cfg_page_active_buffer), &reader) < 0) {
@@ -519,7 +519,7 @@ int cfg_page_init_writer(cfg_page_desc_t *cpd,
 
     /* -1 to remove 0xff stop code */
     size_t writeoffset = (reader.cur-cfg_page_active_buffer)-1;
-    DEBUG("found end of old values at: %u, amountleft=%u\n",
+    DEBUG("found end of old values at: %04u, amountleft=%04u\n",
           writeoffset, amountleft);
 
     /* initialize the writer at this location, using the writer in cpd->writer */

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -275,12 +275,29 @@ int cfg_page_get_value(cfg_page_desc_t *cpd, uint32_t wantedkey, nanocbor_value_
 
 static void _cfg_page_splat_key(nanocbor_value_t okey1, int keysize)
 {
-  *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT;
+  switch(keysize) {
+  case 1:
+    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT;
+    break;
+
+  case 1+2:
+    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_BYTE;
+    break;
+
+  case 1+4:
+    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_SHORT;
+    break;
+
+  case 1+8:
+    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_WORD;
+    break;
+
+  case 1+16:
+    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_WORD;
+    break;
+  }
   if(keysize > 0) {
-    /*
-     * XXX this is not right.  It needs to make a TYPE_UINT which is
-     * multiple bytes
-     */
+    /* make a zero of a bigger size */
     int i;
     for(i=1; i < keysize; i++) {
       ((uint8_t *)okey1.cur)[i] = 0;

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -499,6 +499,9 @@ int cfg_page_init_writer(cfg_page_desc_t *cpd,
     bool   tryswap    = 0;
     size_t amountleft = 0;
 
+    /* increment valuelen by 5, to account for key */
+    valuelen += 5;
+
     while(!foundspace) {
         //DEBUG("finding end of valid values: %d\n", tryswap);
         /* start by bringin in the content */

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -637,6 +637,14 @@ int cfg_page_init(cfg_page_desc_t *cpd)
     } else if(slot0_serial >= 0  && slot1_serial < 0) {
         cpd->active_page = 0;
         cfgpage.active_serialno = slot0_serial;
+    } else if(slot0_serial == 0 && slot1_serial == 23) {
+        /* wrapped around */
+        cpd->active_page = 0;
+        cfgpage.active_serialno = slot0_serial;
+    } else if(slot0_serial == 23 && slot1_serial == 0) {
+        /* wrapped around */
+        cpd->active_page = 1;
+        cfgpage.active_serialno = slot1_serial;
     } else if(slot0_serial >= slot1_serial) {
         cpd->active_page = 0;
         cfgpage.active_serialno = slot0_serial;

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -261,7 +261,23 @@ int cfg_page_get_value(cfg_page_desc_t *cpd, uint32_t wantedkey, nanocbor_value_
     return ret;
 }
 
-/* this one is a doozy! */
+/*
+ * process through all the attributes in the filled current space,
+ * copying the last value for each key into the new space.
+ *
+ * This is done by going through the old space looking for keys which
+ * have not been copied.
+ * Once a new has been found, it's location is remembered for later.
+ * The old space is processed looking for the last value, and when that is
+ * is found, it is copied to the new space.
+ * While processing the duplicate keys, each one is changed to keyid=0,
+ * which is not allowed.
+ *
+ * After the last value for a given key is found, then the process returns to the
+ * spot in the old space where the first instance of the current key was found.
+ * Processing resumes from there, ingoring keyid=0.
+ *
+ */
 static int cfg_page_swap_slotno(cfg_page_desc_t *cpd, nanocbor_value_t *reader)
 {
     (void)cpd;

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -275,7 +275,7 @@ int cfg_page_get_value(cfg_page_desc_t *cpd, uint32_t wantedkey, nanocbor_value_
 
 static void _cfg_page_splat_key(nanocbor_value_t okey1, int keysize)
 {
-    DEBUG("splat keysize: %d\n", keysize);
+    //DEBUG("splat keysize: %d\n", keysize);
     switch(keysize) {
     case 1:
         *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT;  /* zero */
@@ -375,10 +375,10 @@ static int cfg_page_swap_slotno(cfg_page_desc_t *cpd)
             /* what to do here is unclear */
             DEBUG("failed to get uint32\n");
 
-            printf("old %04x:\n", values.cur - cfg_page_active_buffer);
-            od_hex_dump_ext(cfg_page_active_buffer, MTD_SECTOR_SIZE, 16, 0);
-            printf("new:\n");
-            od_hex_dump_ext(new_page, MTD_SECTOR_SIZE, 16, 0);
+            //printf("old %04x:\n", values.cur - cfg_page_active_buffer);
+            //od_hex_dump_ext(cfg_page_active_buffer, MTD_SECTOR_SIZE, 16, 0);
+            //printf("new:\n");
+            //od_hex_dump_ext(new_page, MTD_SECTOR_SIZE, 16, 0);
             return -1;
         }
         if(key == 0) {
@@ -406,11 +406,15 @@ static int cfg_page_swap_slotno(cfg_page_desc_t *cpd)
             okey2 = nreader2;
             if(nanocbor_get_uint32(&nreader2, &nkey) < 0) {
                 DEBUG("failed to get uint32 nkey\n");
+                //printf("old %04x:\n", values.cur - cfg_page_active_buffer);
+                //od_hex_dump_ext(cfg_page_active_buffer, MTD_SECTOR_SIZE, 16, 0);
+                //printf("new:\n");
+                //od_hex_dump_ext(new_page, MTD_SECTOR_SIZE, 16, 0);
                 /* what to do here is unclear */
                 return -1;
             }
             if(key != nkey) {
-                DEBUG("different key %u=%u\n", nkey, key);
+                //DEBUG("different key %u=%u\n", nkey, key);
                 nanocbor_skip(&nreader2);
                 continue;
             }
@@ -425,7 +429,7 @@ static int cfg_page_swap_slotno(cfg_page_desc_t *cpd)
 
             /* reach back, and obliterate the key we had */
             /* has intimate knowledge of CBOR uint */
-            DEBUG("splatting old key %u %03x\n", key, okey1.cur - cfg_page_active_buffer);
+            //DEBUG("splatting old key %u %03x\n", key, okey1.cur - cfg_page_active_buffer);
             _cfg_page_splat_key(okey1, keysize);
 
             /* skip key forward */
@@ -456,8 +460,8 @@ static int cfg_page_swap_slotno(cfg_page_desc_t *cpd)
      * now, initialize the newpage with serialno+1, and
      * read it back in
      */
-    printf("new:\n");
-    od_hex_dump_ext(new_page, MTD_SECTOR_SIZE, 16, 0);
+    //printf("new:\n");
+    //od_hex_dump_ext(new_page, MTD_SECTOR_SIZE, 16, 0);
 
     /* flip bit on which page is active */
     cpd->active_page = !cpd->active_page;
@@ -532,8 +536,7 @@ int cfg_page_init_writer(cfg_page_desc_t *cpd,
 
     /* -1 to remove 0xff stop code */
     size_t writeoffset = (reader.cur-cfg_page_active_buffer)-1;
-    DEBUG("found end of old values at: %04u, amountleft=%04u\n",
-          writeoffset, amountleft);
+    //DEBUG("found end of old values at: %04u, amountleft=%04u\n",writeoffset, amountleft);
 
     /* initialize the writer at this location, using the writer in cpd->writer */
     if(writer) {

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -134,6 +134,7 @@ int cfg_page_validate(cfg_page_desc_t *cpd, int cfg_slot_no)
     }
 
     if(calculated != checksum) {
+        DEBUG("slot:%d expected %04x got %04x\n", cfg_slot_no, calculated, checksum);
         return -8;
     }
 

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -276,25 +276,29 @@ int cfg_page_get_value(cfg_page_desc_t *cpd, uint32_t wantedkey, nanocbor_value_
 static void _cfg_page_splat_key(nanocbor_value_t okey1, int keysize)
 {
   switch(keysize) {
-  case 1:
+  case 0:
     *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT;
     break;
 
-  case 1+2:
+  case 1:
     *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_BYTE;
     break;
 
-  case 1+4:
+  case 2:
     *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_SHORT;
     break;
 
-  case 1+8:
+  case 4:
     *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_WORD;
     break;
 
-  case 1+16:
-    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_WORD;
+  case 8:
+    *((uint8_t *)okey1.cur) = NANOCBOR_TYPE_UINT+NANOCBOR_SIZE_LONG;
     break;
+
+  default:
+    DEBUG("bad keysize: %d\n", keysize);
+    return;
   }
   if(keysize > 0) {
     /* make a zero of a bigger size */

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -21,7 +21,7 @@
  *    1) A CBOR-file-magic SEQUENCE with tag "RIOT"
  *       D9 D9F7         # tag(55799)
  *          DA 52494F54  # tag(1380536148)
- *             63        # text(3)
+ *             43        # bytes(3)
  *               424F52  # "BOR"
  *    2) A single byte sequence counter, mod 24 (so 0 > 24)
  *       01 # unsigned(1)
@@ -34,7 +34,10 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#include "nanocbor/nanocbor.h"
+#include "checksum/crc16_ccitt.h"
 #include "cfg_page.h"
+#include "od.h"
 
 #define ENABLE_DEBUG 1
 #include "debug.h"
@@ -54,58 +57,74 @@ int cfg_page_init(struct cfg_page_desc_t *cpd)
 }
 
 #define CBOR_SEQ_TAG      55800             /* per draft-ietf-cbor-file-magic */
-#define CFG_PAGE_RIOT_TAG 1380536148        /* 'RIOT' */
+#define CFG_PAGE_RIOT_TAG 1380536148        /* 'RIOT' = 0x52 0x49 0x4f 0x54 */
 
-int cfg_page_validate(struct cfg_page_desc_t *cpd)
+#ifndef CFG_PAGE_HEADER_SIZE
+#define CFG_PAGE_HEADER_SIZE 16
+#endif
+
+
+int cfg_page_validate(struct cfg_page_desc_t *cpd, int cfg_slot_no)
 {
   unsigned char header_buffer[CFG_PAGE_HEADER_SIZE];
   nanocbor_value_t decoder;
   uint32_t tagval = 0x12345678;
-  int16_t  checksum = 0;
+  uint16_t  checksum = 0;
   int8_t   serialno = 0;
+  const uint8_t  *bytes   = NULL;
+  size_t   bytes_len;
 
-  /* read things in first */
-  if(mtd_read(cpd->dev, header_buffer, 0, sizeof(CFG_PAGE_HEADER_SIZE)) != 0) {
+  /* read things in a specific block in first */
+  if(mtd_read(cpd->dev, header_buffer, 0, CFG_PAGE_HEADER_SIZE) != 0) {
+    puts("read failed\n");
     return -1;
   }
+
+  //od_hex_dump_ext(header_buffer, CFG_PAGE_HEADER_SIZE, 16, 0);
 
   /* validate the checksum */
   nanocbor_decoder_init(&decoder, header_buffer, CFG_PAGE_HEADER_SIZE);
 
   /* pull in the tags */
-  if(nanocbor_get_tag(&decoder, &tagval) != NANOCBOR_OK
-     || tagval != CBOR_SEQ_TAG) {
+  if(nanocbor_get_tag(&decoder, &tagval) != NANOCBOR_OK) {
     return -1;
   }
 
-  if(nanocbor_get_tag(&decoder, &tagval) != NANOCBOR_OK
-     || tagval != CFG_PAGE_RIOT_TAG) {
-    return -1;
+  if(tagval != CBOR_SEQ_TAG) {
+    return -2;
   }
 
-  if(nanocbor_get_bstr(&val, &bytes, &bytes_len) != NANOCBOR_OK
+  if(nanocbor_get_tag(&decoder, &tagval) != NANOCBOR_OK) {
+    return -3;
+  }
+
+  if(tagval != CFG_PAGE_RIOT_TAG) {
+    return -4;
+  }
+
+  if(nanocbor_get_bstr(&decoder, &bytes, &bytes_len) != NANOCBOR_OK
      || bytes_len != 3
      || bytes[0]!= 'B'
      || bytes[1]!= 'O'
      || bytes[2]!= 'R') {
-    return -1;
+    return -5;
   }
 
-  if(nanocbor_get_int8(&val, &serialno) != NANOCBOR_OK) {
-    return -1;
+  if(nanocbor_get_int8(&decoder, &serialno) < NANOCBOR_OK) {
+    return -6;
   }
 
   /* calculate a 16-bit checksum across the bytes so far */
-  int16_t calculated = crc16_ccitt_calc(header_buffer, (val->cur - header_buffer));
+  uint16_t calculated = crc16_ccitt_calc(header_buffer, (decoder.cur - header_buffer));
 
-  if(nanocbor_get_int16(&val, &checksum) != NANOCBOR_OK) {
-    return -1;
+  if(nanocbor_get_uint16(&decoder, &checksum) < NANOCBOR_OK) {
+    return -7;
   }
 
   if(calculated != checksum) {
-    return -1;
+    return -8;
   }
 
   /* Good News Everyone! */
-  return 0;
+  return serialno;
 }

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -188,9 +188,14 @@ int cfg_page_format(cfg_page_desc_t *cpd, int cfg_slot_no, int serialno)
     DEBUG("writing %d bytes to slot_no: %d, at offset: %u\n", write_size,
           cfg_slot_no, byte_offset);
 
-    od_hex_dump_ext(header_buffer, write_size, 16, 0);
+    //od_hex_dump_ext(header_buffer, write_size, 16, 0);
 
     int error = 0;
+    /* erase the entire page */
+    if(mtd_erase(cpd->dev, byte_offset, MTD_PAGE_SIZE) != 0) {
+        DEBUG("erase failed\n");
+        return -10;
+    }
     if((error = mtd_write(cpd->dev, header_buffer, byte_offset, write_size)) != NANOCBOR_OK) {
         DEBUG("write failed: %d\n", error);
         return -11;

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -171,13 +171,6 @@ static int _cfg_page_format_stuff(nanocbor_encoder_t *encoder,
         return -7;
     }
 
-    /* now initialize an indefinite map, and stop code */
-    if(nanocbor_fmt_map_indefinite(encoder) < 0) {
-        return -8;
-    }
-    if(nanocbor_fmt_end_indefinite(encoder) < 0) {
-        return -9;
-    }
     return 0;
 }
 
@@ -192,6 +185,13 @@ int cfg_page_format(cfg_page_desc_t *cpd, int cfg_slot_no, int serialno)
 
     if((ret =_cfg_page_format_stuff(&encoder, header_buffer, serialno)) < 0) {
         return ret;
+    }
+    /* now initialize an indefinite map, and stop code */
+    if(nanocbor_fmt_map_indefinite(&encoder) < 0) {
+        return -8;
+    }
+    if(nanocbor_fmt_end_indefinite(&encoder) < 0) {
+        return -9;
     }
 
     unsigned int byte_offset = _calculate_slot_offset(cfg_slot_no);

--- a/drivers/cfg_page/cfg_page.c
+++ b/drivers/cfg_page/cfg_page.c
@@ -40,7 +40,7 @@
 #include "cfg_page.h"
 #include "od.h"
 
-#define ENABLE_DEBUG 1
+#define ENABLE_DEBUG 0
 #include "debug.h"
 
 /* for MTD_1 */

--- a/drivers/cfg_page/cfg_page_print.c
+++ b/drivers/cfg_page/cfg_page_print.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021  Michael Richardson <mcr@sandelman.ca>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cfg_page
+ * @brief       configuration data flash page
+ * @{
+ *
+ * @file
+ * @brief       configuration page debug routines
+ *
+ * @author      Michael Ricahrdson <mcr@sandelman.ca>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "nanocbor/nanocbor.h"
+#include "checksum/crc16_ccitt.h"
+#include "cfg_page.h"
+#include "od.h"
+
+#define ENABLE_DEBUG 1
+#include "debug.h"
+
+/* for MTD_1 */
+#include "board.h"
+
+int cfg_page_print(cfg_page_desc_t *cpd)
+{
+  static unsigned char cfg_page_temp[MTD_PAGE_SIZE];
+  nanocbor_value_t reader;
+  nanocbor_value_t values;
+
+  if(cfg_page_init_reader(cpd, cfg_page_temp, sizeof(cfg_page_temp), &reader) < 0) {
+    return -1;
+  }
+
+  if(nanocbor_get_type(&reader) != NANOCBOR_TYPE_MAP ||
+     nanocbor_enter_map(&reader, &values) != NANOCBOR_OK) {
+    return -2;
+  }
+
+  while(!nanocbor_at_end(&values)) {
+    uint32_t key;
+    unsigned int type;
+    const uint8_t *str = NULL;
+    size_t         len;
+    if(nanocbor_get_uint32(&values, &key) < 0) {
+      DEBUG("non interger key value found: %d", nanocbor_get_type(&values));
+      return -3;
+    }
+
+    type = nanocbor_get_type(&values);
+    printf("key: %u[type=%u]\n", key, type);
+    switch(type) {
+    case NANOCBOR_TYPE_BSTR:
+      if(nanocbor_get_bstr(&values, &str, &len) == NANOCBOR_OK) {
+        od_hex_dump_ext(str, len, 16, 0);
+      }
+      break;
+
+    case NANOCBOR_TYPE_TSTR:
+      if(nanocbor_get_tstr(&values, &str, &len) == NANOCBOR_OK) {
+        /* XXX print as bounded string? */
+        //od_hex_dump_ext(str, len, 16, 0);
+        printf("  value: %.*s\n", len, str);
+      }
+      break;
+
+    default:
+      nanocbor_skip(&values);
+    }
+
+  }
+
+  return 0;
+}
+

--- a/drivers/cfg_page/cfg_page_print.c
+++ b/drivers/cfg_page/cfg_page_print.c
@@ -35,52 +35,52 @@
 
 int cfg_page_print(cfg_page_desc_t *cpd)
 {
-  static unsigned char cfg_page_temp[MTD_PAGE_SIZE];
-  nanocbor_value_t reader;
-  nanocbor_value_t values;
+    static unsigned char cfg_page_temp[MTD_PAGE_SIZE];
+    nanocbor_value_t reader;
+    nanocbor_value_t values;
 
-  if(cfg_page_init_reader(cpd, cfg_page_temp, sizeof(cfg_page_temp), &reader) < 0) {
-    return -1;
-  }
-
-  if(nanocbor_get_type(&reader) != NANOCBOR_TYPE_MAP ||
-     nanocbor_enter_map(&reader, &values) != NANOCBOR_OK) {
-    return -2;
-  }
-
-  while(!nanocbor_at_end(&values)) {
-    uint32_t key;
-    unsigned int type;
-    const uint8_t *str = NULL;
-    size_t         len;
-    if(nanocbor_get_uint32(&values, &key) < 0) {
-      DEBUG("non interger key value found: %d", nanocbor_get_type(&values));
-      return -3;
+    if(cfg_page_init_reader(cpd, cfg_page_temp, sizeof(cfg_page_temp), &reader) < 0) {
+        return -1;
     }
 
-    type = nanocbor_get_type(&values);
-    printf("key: %u[type=%u]\n", key, type);
-    switch(type) {
-    case NANOCBOR_TYPE_BSTR:
-      if(nanocbor_get_bstr(&values, &str, &len) == NANOCBOR_OK) {
-        od_hex_dump_ext(str, len, 16, 0);
-      }
-      break;
-
-    case NANOCBOR_TYPE_TSTR:
-      if(nanocbor_get_tstr(&values, &str, &len) == NANOCBOR_OK) {
-        /* XXX print as bounded string? */
-        //od_hex_dump_ext(str, len, 16, 0);
-        printf("  value: %.*s\n", len, str);
-      }
-      break;
-
-    default:
-      nanocbor_skip(&values);
+    if(nanocbor_get_type(&reader) != NANOCBOR_TYPE_MAP ||
+       nanocbor_enter_map(&reader, &values) != NANOCBOR_OK) {
+        return -2;
     }
 
-  }
+    while(!nanocbor_at_end(&values)) {
+        uint32_t key;
+        unsigned int type;
+        const uint8_t *str = NULL;
+        size_t         len;
+        if(nanocbor_get_uint32(&values, &key) < 0) {
+            DEBUG("non interger key value found: %d", nanocbor_get_type(&values));
+            return -3;
+        }
 
-  return 0;
+        type = nanocbor_get_type(&values);
+        printf("key: %u[type=%u]\n", key, type);
+        switch(type) {
+        case NANOCBOR_TYPE_BSTR:
+            if(nanocbor_get_bstr(&values, &str, &len) == NANOCBOR_OK) {
+                od_hex_dump_ext(str, len, 16, 0);
+            }
+            break;
+
+        case NANOCBOR_TYPE_TSTR:
+            if(nanocbor_get_tstr(&values, &str, &len) == NANOCBOR_OK) {
+                /* XXX print as bounded string? */
+                //od_hex_dump_ext(str, len, 16, 0);
+                printf("  value: %.*s\n", len, str);
+            }
+            break;
+
+        default:
+            nanocbor_skip(&values);
+        }
+
+    }
+
+    return 0;
 }
 

--- a/drivers/cfg_page/cfg_page_print.c
+++ b/drivers/cfg_page/cfg_page_print.c
@@ -35,7 +35,7 @@
 
 int cfg_page_print(cfg_page_desc_t *cpd)
 {
-    static unsigned char cfg_page_temp[MTD_PAGE_SIZE];
+    static unsigned char cfg_page_temp[MTD_SECTOR_SIZE];
     nanocbor_value_t reader;
     nanocbor_value_t values;
 
@@ -48,6 +48,8 @@ int cfg_page_print(cfg_page_desc_t *cpd)
         return -2;
     }
 
+    //printf("buffer is at: %p\n", cfg_page_temp);
+
     while(!nanocbor_at_end(&values)) {
         uint32_t key;
         unsigned int type;
@@ -59,7 +61,8 @@ int cfg_page_print(cfg_page_desc_t *cpd)
         }
 
         type = nanocbor_get_type(&values);
-        printf("key: %u[type=%u]\n", key, type);
+        printf("key: %02u[type=%02u] where=%p:%d ", key, type, values.cur,
+               values.cur-cfg_page_temp);
         switch(type) {
         case NANOCBOR_TYPE_BSTR:
             if(nanocbor_get_bstr(&values, &str, &len) == NANOCBOR_OK) {
@@ -71,12 +74,13 @@ int cfg_page_print(cfg_page_desc_t *cpd)
             if(nanocbor_get_tstr(&values, &str, &len) == NANOCBOR_OK) {
                 /* XXX print as bounded string? */
                 //od_hex_dump_ext(str, len, 16, 0);
-                printf("  value: %.*s\n", len, str);
+                printf("  value[%04u]: %.*s\n", len, len, str);
             }
             break;
 
         default:
             nanocbor_skip(&values);
+            printf("\n");
         }
 
     }

--- a/drivers/cfg_page/cfg_page_print.c
+++ b/drivers/cfg_page/cfg_page_print.c
@@ -61,7 +61,7 @@ int cfg_page_print(cfg_page_desc_t *cpd)
         }
 
         type = nanocbor_get_type(&values);
-        printf("key: %02u[type=%02u] where=%p:%d ", key, type, values.cur,
+        printf("key: %06u[type=%02u] where=%p:%d ", key, type, values.cur,
                values.cur-cfg_page_temp);
         switch(type) {
         case NANOCBOR_TYPE_BSTR:

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -32,16 +32,20 @@ extern "C" {
  * @name    CFG page configuration
  * @{
  */
-struct cfg_page_desc_t {
+typedef struct cfg_page_desc {
   mtd_dev_t *dev;
   nanocbor_encoder_t writer;
   uint8_t            active_page;  /* 0 or 1 */
-};
+} cfg_page_desc_t;
 
-extern int cfg_page_init(struct cfg_page_desc_t *cpd);
-extern int cfg_page_validate(struct cfg_page_desc_t *cpd, int cfg_slot_no);
-extern int cfg_page_format(struct cfg_page_desc_t *cpd, int cfg_slot_no, int slotno);
-extern struct cfg_page_desc_t cfgpage;
+extern int cfg_page_init(cfg_page_desc_t *cpd);
+extern int cfg_page_validate(cfg_page_desc_t *cpd, int cfg_slot_no);
+extern int cfg_page_format(cfg_page_desc_t *cpd, int cfg_slot_no, int slotno);
+extern int cfg_page_print(cfg_page_desc_t *cpd);
+extern int cfg_page_init_reader(cfg_page_desc_t *cpd,
+                                unsigned char *cfg_page_buffer, size_t cfg_page_size,
+                                nanocbor_value_t *cfg_page_reader);
+extern cfg_page_desc_t cfgpage;
 
 #ifdef __cplusplus
 }

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -36,6 +36,7 @@ struct cfg_page_desc_t {
 };
 
 extern int cfg_page_init(struct cfg_page_desc_t *cpd);
+extern int cfg_page_validate(struct cfg_page_desc_t *cpd, int cfg_slot_no);
 extern struct cfg_page_desc_t cfgpage;
 
 #ifdef __cplusplus

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -22,6 +22,7 @@
 #define CFG_PAGE_H
 
 #include "mtd.h"
+#include "nanocbor/nanocbor.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,6 +34,8 @@ extern "C" {
  */
 struct cfg_page_desc_t {
   mtd_dev_t *dev;
+  nanocbor_encoder_t writer;
+  uint8_t            active_page;  /* 0 or 1 */
 };
 
 extern int cfg_page_init(struct cfg_page_desc_t *cpd);

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -29,8 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @name    CFG page configuration
- * @{
+ * @brief    CFG PAGE configuration object
  */
 typedef struct cfg_page_desc {
   mtd_dev_t *dev;
@@ -42,20 +41,118 @@ typedef struct cfg_page_desc {
 
 #define CFG_PAGE_HEADER_SIZE 16
 
+/**
+ * @brief Initialize the configuration page descriptor on @cpd object.
+ *
+ * This will initialize the cfg_page subsystem to start.
+ * Typically, there is a global cfg_page_desc_t called cfgpage.
+ *
+ * The initialization system will validate the CRC of each of the two possible slots
+ * and if both are correct, it will take the slot with the higher serialno.
+ * Serial numbers go from 0 to 23, and then will wrap around to 0 after 23.
+ *
+ * @param[in]   cpd     the global context
+ * @return              negative value for error, 0 on success
+ */
 extern int cfg_page_init(cfg_page_desc_t *cpd);
+
+/**
+ * @brief Validate a page of configuration variables. Normally does not need to be
+ *        called, use cfg_page_init.
+ *
+ * This function will validate the CRC on the initial 16 byte header, and then
+ * validate that all the magic numbers are in place.  It will return the decoded
+ * serial number if successful, negative value if not.
+ *
+ * @param[in]   cpd     the global context
+ * @param[in]   cfg_slot_no   which of two pages to validate
+ * @return              The positive serial number (0->23) if valid. Negative if not.
+ */
 extern int cfg_page_validate(cfg_page_desc_t *cpd, int cfg_slot_no);
-extern int cfg_page_format(cfg_page_desc_t *cpd, int cfg_slot_no, int slotno);
+
+/**
+ * @brief This function will intialize a page number with a header and serial number.
+ *        It inserts a 12 byte header to identify the page as a configuration variable
+ *        page, a one byte serial number and a CRC.  All encoded in CBOR.
+ *        The total is 16 bytes of overhead.
+ *
+ * The page will then have an indefinite map opened, and then immediately ended with a stop
+ * code.  The entire sector (typically 4k) will then be erased and this entire structure
+ * written to flash.
+ *
+ * @param[in]   cpd           the global context
+ * @param[in]   cfg_slot_no   which of two pages to write to.
+ * @param[in]   serialno      the serial number to write to the page
+ * @return                    0 on success, negative on error
+ */
+extern int cfg_page_format(cfg_page_desc_t *cpd, int cfg_slot_no, int serialno);
+
+/**
+ * @brief Dumb the contents of the active page to the console.
+ *        This auxiliary function can be used in debugging.
+ *
+ * @param[in]   cpd           the global context
+ * @return                    0 on success, negative on error
+ */
 extern int cfg_page_print(cfg_page_desc_t *cpd);
+
+/**
+ * @brief This function will intialize a nanocbor reader so that the keys and values
+ *        can be read out.  This is a low-level interface.
+ *
+ * This function figures out which is the correct page to read, and then reads the
+ * entire page in.  The decoder is also initialized.
+ * While an arbirary page can be used, the module includes a static buffer that
+ * is used internally.
+ *
+ * This function is not yet (prematurely) optimized to retain the loaded data across calls.
+ *
+ * @param[in]   cpd           the global context
+ * @param[in]   cfg_page_buffer  some ram to keep the mapping
+ * @param[in]   cfg_page_size    the size of the buffer
+ * @param[out]  cfg_page_reader  a NANOCBOR reader to be initialized
+ * @return                    0 on success, negative on error
+ */
 extern int cfg_page_init_reader(cfg_page_desc_t *cpd,
                                 unsigned char *cfg_page_buffer, size_t cfg_page_size,
                                 nanocbor_value_t *cfg_page_reader);
+
+/**
+ * @brief This function will find the value associated with a given integer key.
+ *
+ * It will intialize the provided NANOCBOR reader to process the value.
+ * It will call cfg_page_init_reader to read all the values in.
+ *
+ * The last/most-recent value of the key will be returned
+ *
+ * @param[in]   cpd           the global context
+ * @param[in]   wantedkey     the unsigned int key to retrieve
+ * @param[out]  valuereader   a NANOCBOR reader to be initialized
+ * @return                    0 on success, negative on error
+ */
 extern int cfg_page_get_value(cfg_page_desc_t *cpd,
                               uint32_t wantedkey,
                               nanocbor_value_t *valuereader);
+
+/**
+ * @brief This function will write a bstr value associated with a given integer key.
+ *
+ * This function will append a new value to the page.
+ *
+ * @param[in]   cpd           the global context
+ * @param[in]   wantedkey     the unsigned int key to retrieve
+ * @param[in]   strvalue      a buffer of bytes to write
+ * @param[in]   valuereader   length of above buffer
+ * @return                    0 on success, negative on error
+ */
 extern int cfg_page_set_str_value(cfg_page_desc_t *cpd,
                                   uint32_t newkey,
                                   const uint8_t *strvalue, size_t strlen);
 
+/**
+ * @brief This global is provided to describe the default set of cfg variables.
+ *
+ */
 extern cfg_page_desc_t cfgpage;
 
 #ifdef __cplusplus

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -49,6 +49,10 @@ extern int cfg_page_init_reader(cfg_page_desc_t *cpd,
 extern int cfg_page_get_value(cfg_page_desc_t *cpd,
                               uint32_t wantedkey,
                               nanocbor_value_t *valuereader);
+extern int cfg_page_set_str_value(cfg_page_desc_t *cpd,
+                                  uint32_t newkey,
+                                  const uint8_t *strvalue, size_t strlen);
+
 extern cfg_page_desc_t cfgpage;
 
 #ifdef __cplusplus

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -37,7 +37,10 @@ typedef struct cfg_page_desc {
   nanocbor_encoder_t writer;
   nanocbor_value_t   reader;
   uint8_t            active_page;  /* 0 or 1 */
+  uint8_t            active_serialno;
 } cfg_page_desc_t;
+
+#define CFG_PAGE_HEADER_SIZE 16
 
 extern int cfg_page_init(cfg_page_desc_t *cpd);
 extern int cfg_page_validate(cfg_page_desc_t *cpd, int cfg_slot_no);

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -37,6 +37,7 @@ struct cfg_page_desc_t {
 
 extern int cfg_page_init(struct cfg_page_desc_t *cpd);
 extern int cfg_page_validate(struct cfg_page_desc_t *cpd, int cfg_slot_no);
+extern int cfg_page_format(struct cfg_page_desc_t *cpd, int cfg_slot_no, int slotno);
 extern struct cfg_page_desc_t cfgpage;
 
 #ifdef __cplusplus

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -35,6 +35,7 @@ extern "C" {
 typedef struct cfg_page_desc {
   mtd_dev_t *dev;
   nanocbor_encoder_t writer;
+  nanocbor_value_t   reader;
   uint8_t            active_page;  /* 0 or 1 */
 } cfg_page_desc_t;
 
@@ -45,6 +46,9 @@ extern int cfg_page_print(cfg_page_desc_t *cpd);
 extern int cfg_page_init_reader(cfg_page_desc_t *cpd,
                                 unsigned char *cfg_page_buffer, size_t cfg_page_size,
                                 nanocbor_value_t *cfg_page_reader);
+extern int cfg_page_get_value(cfg_page_desc_t *cpd,
+                              uint32_t wantedkey,
+                              nanocbor_value_t *valuereader);
 extern cfg_page_desc_t cfgpage;
 
 #ifdef __cplusplus

--- a/drivers/include/cfg_page.h
+++ b/drivers/include/cfg_page.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Michael Richardson <mcr@sandelman.ca>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    cfg_page
+ * @ingroup     notsure
+ * @brief       Driver Configuration Pages
+ *
+ * @{
+ *
+ * @file
+ * @brief       Public interface for CFG Pages driver
+ * @author      Michael Richardson <mcr@sandelman.ca>
+ */
+
+#ifndef CFG_PAGE_H
+#define CFG_PAGE_H
+
+#include "mtd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    CFG page configuration
+ * @{
+ */
+struct cfg_page_desc_t {
+  mtd_dev_t *dev;
+};
+
+extern int cfg_page_init(struct cfg_page_desc_t *cpd);
+extern struct cfg_page_desc_t cfgpage;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_PAGE_H */
+/** @} */

--- a/examples/dtls-sock/cfg-page-shell.c
+++ b/examples/dtls-sock/cfg-page-shell.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Michael Richardson <mcr@sandelman.ca>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+
+#include "mtd.h"
+#include "cfg_page.h"
+#include "od.h"
+#include "board.h"
+
+static char cfg_page_temp[MTD_PAGE_SIZE];
+
+int cfgpage_print_cmd(int argc, char **argv)
+{
+  (void)argc;
+  (void)argv;
+  if(mtd_read(cfgpage.dev, cfg_page_temp, 0, MTD_PAGE_SIZE) != 0) {
+    return -1;
+  }
+
+  od_hex_dump_ext(cfg_page_temp, MTD_PAGE_SIZE, 16, 0);
+
+    return 0;
+}

--- a/tests/driver_cfg_page/Makefile
+++ b/tests/driver_cfg_page/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.tests_common
+
+BOARD?= native
+USEMODULE += mtd
+USEMODULE += mtd_native
+USEMODULE += cfg_page
+USEMODULE += checksum
+USEMODULE += od
+USEPKG += nanocbor
+
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_cfg_page/Makefile.ci
+++ b/tests/driver_cfg_page/Makefile.ci
@@ -1,0 +1,8 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    atmega328p-xplained-mini \
+    #

--- a/tests/driver_cfg_page/README.md
+++ b/tests/driver_cfg_page/README.md
@@ -1,0 +1,7 @@
+# About
+This is a manual test application for the CFG-PAGE driver.
+
+# Usage
+
+This test application will use the native target with a series of input files.
+

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -42,18 +42,19 @@ int main(void)
 
     cfg_page_print(&cfgpage);
 
-    for(i=0; i<127; i++) {
+    for(i=0; i<128; i++) {
+        printf("writing iteration %d\n", i);
         uint8_t buf2[16];
         snprintf((char *)buf2, 16, "bob%04x", i);
         if(cfg_page_set_str_value(&cfgpage, 1, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 1 failed\n");
         }
         snprintf((char *)buf2, 16, "frank%04x", i);
-        if(cfg_page_set_str_value(&cfgpage, 2, buf2, strlen((const char *)buf2)) != 0) {
+        if(cfg_page_set_str_value(&cfgpage, 32, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 2 failed\n");
         }
         snprintf((char *)buf2, 16, "george%04x", i);
-        if(cfg_page_set_str_value(&cfgpage, 3, buf2, strlen((const char *)buf2)) != 0) {
+        if(cfg_page_set_str_value(&cfgpage, 65537, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 3 failed\n");
         }
     }

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -31,20 +31,30 @@ int main(void)
 {
     nanocbor_value_t valuereader;
     const uint8_t *strvalue;
-    size_t strlen;
+    size_t len;
     int i;
     puts("CFG-PAGE test application starting...");
 
     if(cfg_page_get_value(&cfgpage, 1, &valuereader) == 1 &&
-       nanocbor_get_tstr(&valuereader, &strvalue, &strlen) == NANOCBOR_OK) {
-        printf("key: 1 found value: %.*s\n", strlen, strvalue);
+       nanocbor_get_tstr(&valuereader, &strvalue, &len) == NANOCBOR_OK) {
+        printf("key: 1 found value: %.*s\n", len, strvalue);
     }
 
     cfg_page_print(&cfgpage);
 
-    for(i=0; i<2048; i++) {
-        if(cfg_page_set_str_value(&cfgpage, 1, (const uint8_t *)"bob", 3) != 0) {
+    for(i=0; i<127; i++) {
+        uint8_t buf2[16];
+        snprintf((char *)buf2, 16, "bob%04x", i);
+        if(cfg_page_set_str_value(&cfgpage, 1, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 1 failed\n");
+        }
+        snprintf((char *)buf2, 16, "frank%04x", i);
+        if(cfg_page_set_str_value(&cfgpage, 2, buf2, strlen((const char *)buf2)) != 0) {
+            printf("set key 2 failed\n");
+        }
+        snprintf((char *)buf2, 16, "george%04x", i);
+        if(cfg_page_set_str_value(&cfgpage, 3, buf2, strlen((const char *)buf2)) != 0) {
+            printf("set key 3 failed\n");
         }
     }
 

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -42,7 +42,7 @@ int main(void)
 
     cfg_page_print(&cfgpage);
 
-    for(i=0; i<128; i++) {
+    for(i=0; i<256; i++) {
         printf("writing iteration %d\n", i);
         uint8_t buf2[16];
         snprintf((char *)buf2, 16, "bob%04x", i);

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -25,10 +25,13 @@
 #include "board.h"
 #include "cfg_page.h"
 
+#include "native_internal.h"
+
 int main(void)
 {
     puts("CFG-PAGE test application starting...");
 
     cfg_page_print(&cfgpage);
 
+    real_exit(0);
 }

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -48,14 +48,17 @@ int main(void)
         snprintf((char *)buf2, 16, "bob%04x", i);
         if(cfg_page_set_str_value(&cfgpage, 1, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 1 failed\n");
+            break;
         }
         snprintf((char *)buf2, 16, "frank%04x", i);
-        if(cfg_page_set_str_value(&cfgpage, 32, buf2, strlen((const char *)buf2)) != 0) {
+        if(cfg_page_set_str_value(&cfgpage, 21, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 2 failed\n");
+            break;
         }
         snprintf((char *)buf2, 16, "george%04x", i);
-        if(cfg_page_set_str_value(&cfgpage, 65537, buf2, strlen((const char *)buf2)) != 0) {
+        if(cfg_page_set_str_value(&cfgpage, 17, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 3 failed\n");
+            break;
         }
     }
 

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -41,5 +41,11 @@ int main(void)
 
     cfg_page_print(&cfgpage);
 
+    if(cfg_page_set_str_value(&cfgpage, 1, (const uint8_t *)"bob", 3) != 0) {
+        printf("set key 1 failed\n");
+    }
+
+    cfg_page_print(&cfgpage);
+
     real_exit(0);
 }

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -31,11 +31,5 @@ int main(void)
 {
     puts("CFG-PAGE test application starting...");
 
-    cfg_page_init(&cfgpage, 0);
-
-    if(cfg_page_validate(&cfgpage) == 0) {
-      puts("succeed\n");
-    } else {
-      puts("failed\n");
-    }
+    cfg_page_init(&cfgpage);
 }

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Michael Richardson <mcr@sandelman.ca>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the CFG-PAGE driver
+ *
+ * @author      Michael Richardson <mcr@sandelman.ca>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "board.h"
+#include "cfg_page.h"
+
+//static char cfg_page_temp[MTD_PAGE_SIZE];
+
+int main(void)
+{
+    puts("CFG-PAGE test application starting...");
+
+    cfg_page_init(&cfgpage, 0);
+
+    if(cfg_page_validate(&cfgpage) == 0) {
+      puts("succeed\n");
+    } else {
+      puts("failed\n");
+    }
+}

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -29,7 +29,15 @@
 
 int main(void)
 {
+    nanocbor_value_t valuereader;
+    const uint8_t *strvalue;
+    size_t strlen;
     puts("CFG-PAGE test application starting...");
+
+    if(cfg_page_get_value(&cfgpage, 1, &valuereader) == 1 &&
+       nanocbor_get_tstr(&valuereader, &strvalue, &strlen) == NANOCBOR_OK) {
+        printf("key: 1 found value: %.*s\n", strlen, strvalue);
+    }
 
     cfg_page_print(&cfgpage);
 

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -51,12 +51,12 @@ int main(void)
             break;
         }
         snprintf((char *)buf2, 16, "frank%04x", i);
-        if(cfg_page_set_str_value(&cfgpage, 21, buf2, strlen((const char *)buf2)) != 0) {
+        if(cfg_page_set_str_value(&cfgpage, 37, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 2 failed\n");
             break;
         }
         snprintf((char *)buf2, 16, "george%04x", i);
-        if(cfg_page_set_str_value(&cfgpage, 17, buf2, strlen((const char *)buf2)) != 0) {
+        if(cfg_page_set_str_value(&cfgpage, 65537, buf2, strlen((const char *)buf2)) != 0) {
             printf("set key 3 failed\n");
             break;
         }

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -32,6 +32,7 @@ int main(void)
     nanocbor_value_t valuereader;
     const uint8_t *strvalue;
     size_t strlen;
+    int i;
     puts("CFG-PAGE test application starting...");
 
     if(cfg_page_get_value(&cfgpage, 1, &valuereader) == 1 &&
@@ -41,8 +42,10 @@ int main(void)
 
     cfg_page_print(&cfgpage);
 
-    if(cfg_page_set_str_value(&cfgpage, 1, (const uint8_t *)"bob", 3) != 0) {
-        printf("set key 1 failed\n");
+    for(i=0; i<2048; i++) {
+        if(cfg_page_set_str_value(&cfgpage, 1, (const uint8_t *)"bob", 3) != 0) {
+            printf("set key 1 failed\n");
+        }
     }
 
     cfg_page_print(&cfgpage);

--- a/tests/driver_cfg_page/main.c
+++ b/tests/driver_cfg_page/main.c
@@ -25,11 +25,10 @@
 #include "board.h"
 #include "cfg_page.h"
 
-//static char cfg_page_temp[MTD_PAGE_SIZE];
-
 int main(void)
 {
     puts("CFG-PAGE test application starting...");
 
-    cfg_page_init(&cfgpage);
+    cfg_page_print(&cfgpage);
+
 }

--- a/tests/driver_cfg_page/maketest0
+++ b/tests/driver_cfg_page/maketest0
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# this test case is shows how a page is initialized if there is no valid signature
+
+ruby -e 'print "\xff" * 8192;' >CONFIG.bin
+# very empty.
+
+bin/native/tests_driver_cfg_page.elf
+cborseq2diag.rb CONFIG.bin
+

--- a/tests/driver_cfg_page/maketest1
+++ b/tests/driver_cfg_page/maketest1
@@ -20,7 +20,7 @@ ruby -e 'print "\xff" * 8192;' >TEST1.bin
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2diag.rb | diag2cbor.rb
 echo "00 "  | pretty2diag.rb | diag2cbor.rb
 echo "19 c6 3b" | pretty2diag.rb | diag2cbor.rb
-echo "bf 01 65 68656C6C6F ff" | pretty2diag.rb | diag2cbor.rb
+echo "bf 01 65 68656C6C6F ff" | pretty2cbor.rb
 ) | dd of=TEST1.bin bs=1 seek=0 conv=notrunc status=none
 
 cp TEST1.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest1
+++ b/tests/driver_cfg_page/maketest1
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# this test case is the most basic contents of "cfg_page" nvram.
+# it has a single key (1) with value "hello"
+
 # d9 d9f8        # tag(55800)
 #   da 52494f54  # tag(1380536148)
 #      43        # bytes(3)

--- a/tests/driver_cfg_page/maketest1
+++ b/tests/driver_cfg_page/maketest1
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# d9 d9f8        # tag(55800)
+#   da 52494f54  # tag(1380536148)
+#      43        # bytes(3)
+#         424f52 # "BOR"
+# 00 # unsigned(0)
+# 19 c63b # unsigned(50747) - CRC16 of above.
+# bf
+#   01            # unsigned(1)
+#    65            # text(5)
+#      68656C6C6F # "hello"
+
+
+(
+echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2diag.rb | diag2cbor.rb
+echo "00 "  | pretty2diag.rb | diag2cbor.rb
+echo "19 c6 3b" | pretty2diag.rb | diag2cbor.rb
+echo "bf 01 65 68656C6C6F ff" | pretty2diag.rb | diag2cbor.rb
+) >TEST1.bin
+
+cp TEST1.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest1
+++ b/tests/driver_cfg_page/maketest1
@@ -14,12 +14,13 @@
 #    65            # text(5)
 #      68656C6C6F # "hello"
 
+ruby -e 'print "\xff" * 8192;' >TEST1.bin
 
 (
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2diag.rb | diag2cbor.rb
 echo "00 "  | pretty2diag.rb | diag2cbor.rb
 echo "19 c6 3b" | pretty2diag.rb | diag2cbor.rb
 echo "bf 01 65 68656C6C6F ff" | pretty2diag.rb | diag2cbor.rb
-) >TEST1.bin
+) | dd of=TEST1.bin bs=1 seek=0 conv=notrunc status=none
 
 cp TEST1.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest2
+++ b/tests/driver_cfg_page/maketest2
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# this test case has a slightly more complex content, where the first
+# key (2) has a complex (array) value, which must be skipped and then
+# key (1) with value "hello"
+
+# d9 d9f8        # tag(55800)
+#   da 52494f54  # tag(1380536148)
+#      43        # bytes(3)
+#         424f52 # "BOR"
+# 00 # unsigned(0)
+# 19 c63b # unsigned(50747) - CRC16 of above.
+# bf
+#   02
+#     82    # array(2)
+#       01 # unsigned(1)
+#       02 # unsigned(2)
+#   01            # unsigned(1)
+#   65            # text(5)
+#      68656C6C6F # "hello"
+
+
+(
+echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
+echo "00 "  | pretty2cbor.rb
+echo "19 c6 3b" | pretty2cbor.rb
+(echo "bf ";  echo "02 82 01 02 ";  echo "01 65 68656C6C6F";  echo "ff") | pretty2cbor.rb
+) >TEST2.bin
+
+cp TEST2.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest2
+++ b/tests/driver_cfg_page/maketest2
@@ -19,12 +19,13 @@
 #   65            # text(5)
 #      68656C6C6F # "hello"
 
+ruby -e 'print "\xff" * 8192;' >TEST2.bin
 
 (
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
 echo "00 "  | pretty2cbor.rb
 echo "19 c6 3b" | pretty2cbor.rb
 (echo "bf ";  echo "02 82 01 02 ";  echo "01 65 68656C6C6F";  echo "ff") | pretty2cbor.rb
-) >TEST2.bin
+) | dd of=TEST2.bin bs=1 seek=0 conv=notrunc status=none
 
 cp TEST2.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest3
+++ b/tests/driver_cfg_page/maketest3
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# this test has a valid contents at slot 0,
+# but has contents at slot 1 with a higher serial no.
+
+# d9 d9f8        # tag(55800)
+#   da 52494f54  # tag(1380536148)
+#      43        # bytes(3)
+#         424f52 # "BOR"
+# 00 # unsigned(0)
+# 19 c63b # unsigned(50747) - CRC16 of above.
+# bf
+#   02
+#     82    # array(2)
+#       01 # unsigned(1)
+#       02 # unsigned(2)
+#   01            # unsigned(1)
+#   65            # text(5)
+#      68656C6C6F # "hello"
+
+echo -n >TEST3.bin
+
+(
+echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
+echo "00 "  | pretty2cbor.rb
+echo "19 c6 3b" | pretty2cbor.rb
+(echo "bf ";  echo "02 82 01 02 ";  echo "01 65 68656C6C6F";  echo "ff") | pretty2cbor.rb
+) | dd of=TEST3.bin bs=1 seek=0 status=none
+
+(
+echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
+echo "01 "  | pretty2cbor.rb
+echo "19 d6 1a" | pretty2cbor.rb
+(echo "bf ";  echo "02 82 04 05 ";  echo "01 65  63 72 65 61 6d";  echo "ff") | pretty2cbor.rb
+) | dd of=TEST3.bin bs=1 seek=4096 status=none
+
+cp TEST3.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest3
+++ b/tests/driver_cfg_page/maketest3
@@ -18,20 +18,22 @@
 #   65            # text(5)
 #      68656C6C6F # "hello"
 
-echo -n >TEST3.bin
+ruby -e 'print "\xff" * 8192;' >TEST3.bin
 
 (
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
 echo "00 "  | pretty2cbor.rb
+# CRC
 echo "19 c6 3b" | pretty2cbor.rb
 (echo "bf ";  echo "02 82 01 02 ";  echo "01 65 68656C6C6F";  echo "ff") | pretty2cbor.rb
-) | dd of=TEST3.bin bs=1 seek=0 status=none
+) | dd of=TEST3.bin bs=1 seek=0 conv=notrunc status=none
 
 (
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
 echo "01 "  | pretty2cbor.rb
+# CRC
 echo "19 d6 1a" | pretty2cbor.rb
 (echo "bf ";  echo "02 82 04 05 ";  echo "01 65  63 72 65 61 6d";  echo "ff") | pretty2cbor.rb
-) | dd of=TEST3.bin bs=1 seek=4096 status=none
+) | dd of=TEST3.bin bs=1 seek=4096 conv=notrunc status=none
 
 cp TEST3.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest4
+++ b/tests/driver_cfg_page/maketest4
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# this test has a valid contents at slot 0,
+# but has contents at slot 1 with a higher serial no.
+
+# d9 d9f8        # tag(55800)
+#   da 52494f54  # tag(1380536148)
+#      43        # bytes(3)
+#         424f52 # "BOR"
+# 00 # unsigned(0)
+# 19 c63b # unsigned(50747) - CRC16 of above.
+# bf
+#   02
+#     82    # array(2)
+#       01 # unsigned(1)
+#       02 # unsigned(2)
+#   01            # unsigned(1)
+#   65            # text(5)
+#      68656C6C6F # "hello"
+
+ruby -e 'print "\xff" * 8192;' >TEST3.bin
+
+(
+echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
+echo "00 "  | pretty2cbor.rb
+# CRC
+echo "19 c6 3b" | pretty2cbor.rb
+(echo "bf ";  echo "02 82 01 02 ";  echo "01 65 68656C6C6F";  echo "ff") | pretty2cbor.rb
+) | dd of=TEST3.bin bs=1 seek=0 conv=notrunc status=none
+
+(
+echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
+echo "01 "  | pretty2cbor.rb
+# CRC
+echo "19 d6 1a" | pretty2cbor.rb
+(echo "bf "; echo "02 82 04 05 ";
+ echo "01 65  63 72 65 61 6d";
+ echo "01 66  62 75 74 74 65 72";
+ echo "ff") | pretty2cbor.rb
+) | dd of=TEST3.bin bs=1 seek=4096 conv=notrunc status=none
+
+cp TEST3.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf

--- a/tests/driver_cfg_page/maketest4
+++ b/tests/driver_cfg_page/maketest4
@@ -18,7 +18,7 @@
 #   65            # text(5)
 #      68656C6C6F # "hello"
 
-ruby -e 'print "\xff" * 8192;' >TEST3.bin
+ruby -e 'print "\xff" * 8192;' >TEST4.bin
 
 (
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
@@ -26,7 +26,7 @@ echo "00 "  | pretty2cbor.rb
 # CRC
 echo "19 c6 3b" | pretty2cbor.rb
 (echo "bf ";  echo "02 82 01 02 ";  echo "01 65 68656C6C6F";  echo "ff") | pretty2cbor.rb
-) | dd of=TEST3.bin bs=1 seek=0 conv=notrunc status=none
+) | dd of=TEST4.bin bs=1 seek=0 conv=notrunc status=none
 
 (
 echo "d9 d9 f8 da 52 49 4f 54  43 42 4f 52 " | pretty2cbor.rb
@@ -37,6 +37,6 @@ echo "19 d6 1a" | pretty2cbor.rb
  echo "01 65  63 72 65 61 6d";
  echo "01 66  62 75 74 74 65 72";
  echo "ff") | pretty2cbor.rb
-) | dd of=TEST3.bin bs=1 seek=4096 conv=notrunc status=none
+) | dd of=TEST4.bin bs=1 seek=4096 conv=notrunc status=none
 
-cp TEST3.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf
+cp TEST4.bin CONFIG.bin && bin/native/tests_driver_cfg_page.elf


### PR DESCRIPTION

### Contribution description

cfg_page is a driver that provides for an interface to store key/value pairs in flash.
It supports continuous updating of variables (such as is required for RPL lollipop counters).  This is flash write efficient, and it does not overwrite flash, but rather appends to it in a log-like fashion.  The last value is returned.

The keys and values are stored in CBOR format, with a 16-byte header that has a CRC and a revision.
Two "SECTOR"s are needed: when one is full the latest values are copied to the other page and that page is activated.

It is disappointing that the NAND flash interface provided by mtd* means that it is necessary to allocate RAM to read the variables in, and worse, causes the need for a second (4K) page when copying.  
There are many opportunities for optimization: at this point many might be premature.

### Testing procedure

The driver program tests/drivers_cfg_page is provided.
It uses the mtd_native interface to do testing on a host platform.
The testing process is to write three variables 256 times, and then print the results.

### Issues/PRs references

None, but clarifications to mtd interface is desired.