### PR TITLE
.murdock: Add modules/pkgs diff of make/kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -126,6 +126,20 @@ get_supported_kconfig_board_app() {
     return 1
 }
 
+kconfig_module_packages_diff() {
+    local board=$1
+    local appdir=$2
+
+    make clean --no-print-directory -C ${appdir} BOARD=${board}
+    mmp=$(make --no-print-directory info-modules info-packages -C ${appdir} BOARD=${board})
+
+    make clean --no-print-directory -C ${appdir} BOARD=${board}
+    kmp=$(TEST_KCONFIG=1 make --no-print-directory info-modules info-packages -C ${appdir} BOARD=${board})
+
+
+    bash -c "diff <(echo \"${mmp}\") <(echo \"${kmp}\")"
+}
+
 check_label() {
     local label="${1}"
     [ -z "${CI_PULL_LABELS}" ] && return 1
@@ -357,6 +371,7 @@ compile() {
         if [ ${kconfig_test_hash} != ${test_hash} ]; then
             echo "Hashes of binaries with and without Kconfig mismatch for ${appdir}";
             echo "Please check that all used modules are modelled in Kconfig and enabled";
+            kconfig_module_packages_diff ${board} ${appdir}
             RES=1
         fi
     fi

--- a/Makefile.include
+++ b/Makefile.include
@@ -401,7 +401,9 @@ include $(RIOTMAKE)/kconfig.mk
 
 # For testing, use TEST_KCONFIG as a switch between Makefile.dep and Kconfig
 ifeq (1,$(TEST_KCONFIG))
-  $(info === [ATTENTION] Testing Kconfig dependency modelling ===)
+  ifneq ($(RIOT_CI_BUILD),1)
+    $(info === [ATTENTION] Testing Kconfig dependency modelling ===)
+  endif
   KCONFIG_MODULES := $(call lowercase,$(patsubst CONFIG_MODULE_%,%,$(filter CONFIG_MODULE_%,$(.VARIABLES))))
   USEMODULE := $(KCONFIG_MODULES)
   KCONFIG_PACKAGES := $(call lowercase,$(patsubst CONFIG_PACKAGE_%,%,$(filter CONFIG_PACKAGE_%,$(.VARIABLES))))

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -207,7 +207,7 @@ GENERATED_DIR_DEP := $(if $(CLEAN),,|) $(GENERATED_DIR)
 # Generates a .config file by merging multiple sources specified in
 # MERGE_SOURCES. This will also generate KCONFIG_OUT_DEP with the list of used
 # Kconfig files.
-$(KCONFIG_OUT_CONFIG): $(KCONFIG_EXTERNAL_CONFIGS) | pkg-prepare
+$(KCONFIG_OUT_CONFIG): $(KCONFIG_EXTERNAL_CONFIGS)
 $(KCONFIG_OUT_CONFIG): $(GENERATED_DEPENDENCIES_DEP) $(GENCONFIG) $(MERGE_SOURCES) $(GENERATED_DIR_DEP)
 	$(Q) $(GENCONFIG) \
 	  --config-out=$(KCONFIG_OUT_CONFIG) \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When there is a difference between the make dependency resolution and kconfig resolution (ie. `TEST_KCONFIG=1`) this gets murdock to show the diff of the modules and packages.
This gives clearer feedback than the binary mismatch error message.
Note that this comparison only occurs when there is a mismatch and shouldn't affect the a passing PR.

### Testing procedure

I will add a failure commit so it should be viewable from murdock.
One can also check with
```
/bin/bash -c "source .murdock; JOBS=4 compile ${TEST_DIR} ${BOARD}:gnu"
```

or with the `REMOVEME!!!` commit

```
/bin/bash -c "source .murdock; JOBS=4 compile examples/hello-world native:gnu"
```

### Issues/PRs references

