### PR TITLE
Fido2 follow up

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -892,6 +892,7 @@ endif
 
 ifneq (,$(filter fido2_ctap,$(USEMODULE)))
   FEATURES_REQUIRED += periph_flashpage
+  FEATURES_REQUIRED += periph_flashpage_in_address_space
   FEATURES_REQUIRED += periph_gpio_irq
 
   USEPKG += tiny-asn1

--- a/sys/fido2/ctap/Kconfig
+++ b/sys/fido2/ctap/Kconfig
@@ -7,6 +7,7 @@
 menuconfig MODULE_FIDO2_CTAP
     bool "FIDO2 CTAP"
     depends on HAS_PERIPH_FLASHPAGE
+    depends on HAS_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
     depends on MODULE_FIDO2
@@ -27,6 +28,7 @@ menuconfig MODULE_FIDO2_CTAP
     select MODULE_CRYPTO_AES_256
     select MODULE_CIPHER_MODES
     select MODULE_HASHES
+    select MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
     help
         Y to enable CTAP protocol support. The Client-to-Authenticator
         Protocol (CTAP) is an application layer protocol for the communication
@@ -108,12 +110,19 @@ config FIDO2_CTAP_UP_BUTTON_FLANK_RISING
 
 endchoice
 
-config FIDO2_CTAP_FLASH_START_PAGE
-    int "First flash page to store data in"
-    default -1
+config FIDO2_CTAP_NUM_FLASHPAGES
+    int "Amount of flashpages to use"
+    range 2 256
+    default 4
     help
-        Configuring this incorrectly can lead to firmware corruption so make sure
-        the flash page is located after the firmware.
+        Configure how many flashpages are used to store FIDO2 CTAP data.
+
+        To save a credential (rk) in flash memory, roughly 156 bytes are needed. This
+        number might change slightly depending on the flash block size.
+        Therefore, if one wants to e.g. save 40 credentials and the flashpage
+        size is 4096 bytes roughly 156 * 40 / 4096 (2) flashpages are needed.
+        To save authenticator state data one additional flashpage is needed.
+        So in total one has to configure 3 to save 40 credentials.
 
 rsource "transport/Kconfig"
 

--- a/sys/fido2/ctap/ctap_cbor.c
+++ b/sys/fido2/ctap/ctap_cbor.c
@@ -1574,6 +1574,7 @@ static int _parse_allow_list(CborValue *it, ctap_cred_desc_alt_t *allow_list,
 {
     size_t len2 = *allow_list_len;
     int retval = _parse_exclude_list(it, allow_list, &len2);
+
     *allow_list_len = (uint8_t)len2;
     return retval;
 }
@@ -1729,6 +1730,7 @@ static int _parse_byte_array_u8len(CborValue *it, uint8_t *dst, uint8_t *len)
 {
     size_t len2 = *len;
     int retval = _parse_byte_array(it, dst, &len2);
+
     *len = (uint8_t)len2;
     return retval;
 }
@@ -1757,6 +1759,7 @@ static int _parse_text_string_u8len(CborValue *it, char *dst, uint8_t *len)
 {
     size_t len2 = *len;
     int retval = _parse_text_string(it, dst, &len2);
+
     *len = (uint8_t)len2;
     return retval;
 }

--- a/sys/fido2/ctap/ctap_mem.c
+++ b/sys/fido2/ctap/ctap_mem.c
@@ -26,15 +26,15 @@
 #include "debug.h"
 
 /**
+ * @brief Reserve flash memory to store CTAP data
+ */
+FLASH_WRITABLE_INIT(_backing_memory, CONFIG_FIDO2_CTAP_NUM_FLASHPAGES);
+
+/**
  * @brief   MTD device descriptor initialized with flash-page driver
  */
 static mtd_flashpage_t _mtd_flash_dev = MTD_FLASHPAGE_INIT_VAL(CTAP_FLASH_PAGES_PER_SECTOR);
 static mtd_dev_t *_mtd_dev = &_mtd_flash_dev.base;
-
-/**
- * @brief   Max amount of resident keys that can be stored
- */
-static uint16_t _max_rk_amnt;
 
 /**
  * @brief   Check if flash region is erased
@@ -42,28 +42,22 @@ static uint16_t _max_rk_amnt;
 static bool _flash_is_erased(int page, int offset, size_t len);
 
 /**
- * @brief   Get amount of flashpages
+ * @brief   Get available amount of flashpages to store resident keys
  */
-static unsigned _amount_of_flashpages(void);
+static unsigned _amount_flashpages_rk(void);
 
 int fido2_ctap_mem_init(void)
 {
-    int ret;
-
-    ret = mtd_init(_mtd_dev);
+    int ret = mtd_init(_mtd_dev);
 
     if (ret < 0) {
         return ret;
     }
 
-    for (unsigned i = CTAP_FLASH_RK_START_PAGE; i < _amount_of_flashpages(); i++) {
-        _max_rk_amnt += flashpage_size(i) / CTAP_FLASH_RK_SZ;
-    }
-
     return CTAP2_OK;
 }
 
-static unsigned _amount_of_flashpages(void)
+static unsigned _amount_flashpages_rk(void)
 {
     return _mtd_dev->sector_count * _mtd_dev->pages_per_sector;
 }
@@ -120,16 +114,13 @@ static bool _flash_is_erased(int page, int offset, size_t len)
     return true;
 }
 
-uint16_t fido2_ctap_mem_get_max_rk_amount(void)
-{
-    return _max_rk_amnt;
-}
-
 int fido2_ctap_mem_get_flashpage_number_of_rk(uint16_t rk_idx)
 {
     uint16_t idx = 0;
+    unsigned start = fido2_ctap_mem_flash_page() + CTAP_FLASH_RK_OFF;
+    unsigned amount = _amount_flashpages_rk();
 
-    for (unsigned i = CTAP_FLASH_RK_START_PAGE; i < _amount_of_flashpages(); i++) {
+    for (unsigned i = start; i < start + amount; i++) {
         idx += flashpage_size(i) / CTAP_FLASH_RK_SZ;
 
         if (idx >= rk_idx) {
@@ -143,8 +134,10 @@ int fido2_ctap_mem_get_flashpage_number_of_rk(uint16_t rk_idx)
 int fido2_ctap_mem_get_offset_of_rk_into_flashpage(uint16_t rk_idx)
 {
     uint16_t idx = 0;
+    unsigned start = fido2_ctap_mem_flash_page() + CTAP_FLASH_RK_OFF;
+    unsigned amount = _amount_flashpages_rk();
 
-    for (unsigned i = CTAP_FLASH_RK_START_PAGE; i < _amount_of_flashpages(); i++) {
+    for (unsigned i = start; i < start + amount; i++) {
         uint16_t old_idx = idx;
         idx += flashpage_size(i) / CTAP_FLASH_RK_SZ;
 
@@ -154,4 +147,21 @@ int fido2_ctap_mem_get_offset_of_rk_into_flashpage(uint16_t rk_idx)
     }
 
     return -1;
+}
+
+unsigned fido2_ctap_mem_flash_page(void)
+{
+    return flashpage_page((void *)_backing_memory);
+}
+
+int fido2_ctap_mem_erase_flash(void)
+{
+    unsigned start = fido2_ctap_mem_flash_page();
+    unsigned end = start + CONFIG_FIDO2_CTAP_NUM_FLASHPAGES;
+
+    for (unsigned page = start; page < end; page++) {
+        flashpage_erase(page);
+    }
+
+    return CTAP2_OK;
 }

--- a/sys/fido2/ctap/ctap_utils.c
+++ b/sys/fido2/ctap/ctap_utils.c
@@ -29,8 +29,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#if !IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_UP)
-
 /**
  * @brief Flag holding information if user is present or not
  */
@@ -63,9 +61,9 @@ int fido2_ctap_utils_user_presence_test(void)
 
     gpio_irq_enable(_pin);
 
-#if !IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)
-    fido2_ctap_utils_led_animation();
-#endif
+    if (!IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)) {
+        fido2_ctap_utils_led_animation();
+    }
 
     ret = _user_present ? CTAP2_OK : CTAP2_ERR_ACTION_TIMEOUT;
 
@@ -81,7 +79,6 @@ static void _gpio_cb(void *arg)
     _user_present = true;
 }
 
-#if !IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED)
 void fido2_ctap_utils_led_animation(void)
 {
     uint32_t start = ztimer_now(ZTIMER_MSEC);
@@ -118,5 +115,3 @@ void fido2_ctap_utils_led_animation(void)
     LED2_OFF;
 #endif
 }
-#endif  /* !IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_LED) */
-#endif  /* CONFIG_FIDO2_CTAP_DISABLE_UP */

--- a/sys/fido2/doc.txt
+++ b/sys/fido2/doc.txt
@@ -17,6 +17,10 @@
  *
  * @warning The FIDO2 implementation currently stores private keys in plain text inside flash memory.
  *
+ * @warning This implementation persists FIDO CTAP data across reboots and when unpowered;
+ *          any firmware update loses the data because it will be overwritten. This applies both to firmware updates through
+ *          bootloaders and to firmware updates through external programmers.
+ *
  * FIDO2 is an authentication standard that seeks to solve the password problem
  * by enabling passwordless authentication. Instead of using passwords to
  * authenticate to web services, FIDO2 enables users to use common devices
@@ -102,6 +106,8 @@
  *
  * Abstraction for flash operations. Uses the RIOT [Flashpage MTD driver](http://api.riot-os.org/group__drivers__mtd__flashpage.html).
  *
+ * Flash memory is reserved at build time using the `FLASH_WRITABLE_INIT` macro. The amount of flashpages reserved can be configured as `FIDO2_CTAP_NUM_FLASHPAGES` in KConfig. The implementation needs at least 1 flashpage to store state information and 1 flashpage to store credentials also called resident keys (rks). Therefore, the minimum amount of flashpages needed is 2. State information is stored on the first flashpage, credentials (rks) on the following flashpages.
+ *
  * Adds additional functionality to speedup flash accesses (e.g. by checking if a flash page is erased to avoid unnecessary erasures of flash pages).
  *
  * **ctap_utils**
@@ -134,6 +140,8 @@
  *
  *  * Resident Credentials
  *      * Resident credentials are credentials stored on the authenticator.
+ *      * They are also called resident key (rk) credentials due to the key material
+ *        being stored on the device.
  *      * This implementation stores resident keys in flash memory.
  *      @warning As of now the credentials (containing a private key) are stored
  *       in plain text inside flash memory

--- a/sys/include/fido2/ctap/ctap.h
+++ b/sys/include/fido2/ctap/ctap.h
@@ -131,7 +131,6 @@ extern "C" {
 #define CTAP_STACKSIZE 15000
 #endif
 
-#if !IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_UP)
 /**
  * @brief CTAP user presence button
  */
@@ -142,10 +141,13 @@ extern "C" {
 /* set default button if no button is configured */
 #ifdef BTN0_PIN
 #define CTAP_UP_BUTTON BTN0_PIN
-/* if no button available disable UP test */
 #else
+#define CTAP_UP_BUTTON 0
+/**
+ * @brief Disable user presence test configuration
+ */
 #define CONFIG_FIDO2_CTAP_DISABLE_UP 1
-#endif
+#endif /* BTN0_PIN */
 #endif
 
 /**
@@ -174,7 +176,19 @@ extern "C" {
 #define CTAP_UP_BUTTON_FLANK GPIO_FALLING
 #endif
 
-#endif /* !IS_ACTIVE(CONFIG_FIDO2_CTAP_DISABLE_UP) */
+/**
+ * @brief Disable user presence test configuration
+ */
+#ifndef CONFIG_FIDO2_CTAP_DISABLE_UP
+#define CONFIG_FIDO2_CTAP_DISABLE_UP 0
+#endif
+
+/**
+ * @brief Disable user LED animation configuration
+ */
+#ifndef CONFIG_FIDO2_CTAP_DISABLE_LED
+#define CONFIG_FIDO2_CTAP_DISABLE_LED 0
+#endif
 
 /**
  * @brief Max size of relying party name

--- a/sys/include/fido2/ctap/ctap_crypto.h
+++ b/sys/include/fido2/ctap/ctap_crypto.h
@@ -227,7 +227,7 @@ int fido2_ctap_crypto_get_sig(uint8_t *hash, size_t hash_len, uint8_t *sig,
  *
  * @return @ref ctap_status_codes_t
  */
-int fido2_ctap_crypto_aes_enc(uint8_t *out, size_t *out_len, uint8_t * in,
+int fido2_ctap_crypto_aes_enc(uint8_t * out, size_t *out_len, uint8_t * in,
                               size_t in_len, const uint8_t * key, size_t key_len);
 
 /**
@@ -242,7 +242,7 @@ int fido2_ctap_crypto_aes_enc(uint8_t *out, size_t *out_len, uint8_t * in,
  *
  * @return @ref ctap_status_codes_t
  */
-int fido2_ctap_crypto_aes_dec(uint8_t *out, size_t *out_len, uint8_t * in,
+int fido2_ctap_crypto_aes_dec(uint8_t * out, size_t *out_len, uint8_t * in,
                               size_t in_len, const uint8_t * key, size_t key_len);
 
 /**

--- a/tests/sys_fido2_ctap/README.md
+++ b/tests/sys_fido2_ctap/README.md
@@ -25,6 +25,12 @@ Note:
 * When registering and authenticating on [Webauthn.io](https://webauthn.io/) you
 will need to push button 1 on your device in order to show user presence.
 
+**Resetting the authenticator**
+* To reset the authenticator, meaning that all credentials and state information
+will be deleted, execute the `reset.py` file located in this directory.
+  * This requires you to install the python fido2 package. To install run:
+    `pip install fido2==0.8.1`.
+
 ### Unit testing
 Unit testing is based on the `fido2_tests` package.
 

--- a/tests/sys_fido2_ctap/reset.py
+++ b/tests/sys_fido2_ctap/reset.py
@@ -1,0 +1,23 @@
+from fido2.hid import CtapHidDevice
+from fido2.ctap2 import CTAP2
+
+
+def get_device():
+    devs = list(CtapHidDevice.list_devices())
+    assert len(devs) == 1
+    return devs[0]
+
+
+if __name__ == '__main__':
+    try:
+        dev = get_device()
+    except Exception:
+        print("Unable to find authenticator")
+        exit(-1)
+
+    ctap = CTAP2(dev)
+    try:
+        ctap.reset()
+        print("Device successfully reset")
+    except Exception as e:
+        print(e)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adjusts the FIDO2 CTAP flash handling to reserve flash memory at compile time using a `static const` buffer. This ensures that the FIDO2 CTAP implementation does not interfere with other modules wanting to use flash memory and doesn't corrupt firmware or e.g. bootloaders at the end of flash. Furthermore configuring `CONFIG_FIDO2_CTAP_NUM_FLASHPAGES` such that more flash than available is required will fail at build time rather than runtime.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
*  `tests/sys_fido2_ctap`

I successfully ran the tests on the `nrf52840dongle` and `nrf52840dk`.