### PR TITLE
sys/ztimer: add 'ztimer_no_periph_rtt

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -22,6 +22,11 @@
  * On many CPUs, certain power states might need to be blocked in rtt_init(), so
  * that it is ensured that the RTT will function properly while it is enabled.
  *
+ * @warning     This module will be automatically be used as a backend for
+ *              ztimer_msec and ztimer_sec. If direct access to RTT is needed
+ *              then disable `ztimer_periph_rtt_auto_select` to avoid auto-selection,
+ *              i.e.: `DISABLE_MODULE += ztimer_periph_rtt_auto_select`.
+ *
  * @{
  * @file
  * @brief       Low-level RTT (Real Time Timer) peripheral driver interface

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -5,6 +5,10 @@ DEFAULT_MODULE += auto_init
 # Initialize all used peripherals by default
 DEFAULT_MODULE += periph_init
 
+# If ztimer is used enable rtt autoselection for ztimer_msec, and ztimer_sec.
+# This will enable inclusion of `ztimer_periph_rtt` if `periph_rtt` is supported.
+DEFAULT_MODULE += ztimer_periph_rtt_auto_select
+
 # Include potentially added default modules by the board
 -include $(BOARDDIR)/Makefile.default
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -745,7 +745,7 @@ ifneq (,$(filter suit_%,$(USEMODULE)))
 endif
 
 # include ztimer dependencies
-ifneq (,$(filter ztimer% %ztimer,$(USEMODULE)))
+ifneq (,$(filter-out ztimer_periph_rtt_auto_select,$(filter ztimer% %ztimer,$(USEMODULE))))
   include $(RIOTBASE)/sys/ztimer/Makefile.dep
 endif
 

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -197,6 +197,11 @@
  *              if if these are missing it will use same basic timer
  *              as ZTIMER_USEC does.
  *
+ * If `periph_rtt` is required with direct access by another MODULE or
+ * application, `ztimer_periph_rtt_auto_select` can be disabled to avoid automatic
+ * selection of `ztimer_periph_rtt` as a backend for ZTIMER_SEC and ZTIMER_MSEC.
+ * i.e.: `DISABLE_MODULE += ztimer_periph_rtt_auto_select`.
+ *
  * These pointers are defined in `ztimer.h` and can be used like this:
  *
  *     ztimer_now(ZTIMER_USEC);

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -7,6 +7,15 @@
 
 menu "ztimer - High level timer abstraction layer"
 
+config MODULE_ZTIMER_PERIPH_RTT_AUTO_SELECT
+    default y
+    depends on TEST_KCONFIG
+    bool "ztimer_periph_rtt auto inclusion"
+    help
+        This module enables the auto-inclusion of ztimer_periph_rtt as a backend
+        for ztimer_msec and ztimer_sec if those are selected and periph_rtt is
+        available
+
 config ZTIMER_CUSTOM_BACKEND_CONFIGURATION
     bool "Override default backend selection"
 
@@ -56,7 +65,7 @@ config MODULE_ZTIMER_MSEC
 choice
     bool "Backend"
     depends on MODULE_ZTIMER_MSEC
-    default ZTIMER_MSEC_BACKEND_RTT
+    default ZTIMER_MSEC_BACKEND_RTT if MODULE_ZTIMER_PERIPH_RTT_AUTO_SELECT
 
 config ZTIMER_MSEC_BACKEND_TIMER
     bool "Timer"
@@ -85,7 +94,7 @@ config ZTIMER_SEC_BACKEND_TIMER
 config ZTIMER_SEC_BACKEND_RTT
     bool "RTT"
     depends on HAS_PERIPH_RTT
-    select MODULE_ZTIMER_PERIPH_RTT
+    select MODULE_ZTIMER_PERIPH_RTT if MODULE_ZTIMER_PERIPH_RTT_AUTO_SELECT
 
 config ZTIMER_SEC_BACKEND_RTC
     bool "RTC"

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -87,35 +87,26 @@ ifneq (,$(filter ztimer_usec,$(USEMODULE)))
   USEMODULE += ztimer_periph_timer
 endif
 
-ifneq (,$(filter ztimer_msec,$(USEMODULE)))
+ifneq (,$(filter ztimer_msec ztimer_sec,$(USEMODULE)))
   USEMODULE += ztimer
-  FEATURES_OPTIONAL += periph_rtt
-  # HACK: periph_rtt will get used only in the next iteration but an updated
-  # state for FEATURES_USED is needed here so include `features_check.inc.mk`
-  # here instead.
-  # An other option would be to check FEATURES_PROVIDED this would avoid the
-  # order of inclusion problem but it would no take into account possible conflicts
-  # and is also currently not allowed in the build system.
-  # An other alternative would be to delay to the next loop, but this produce a
-  # case where another loop is not executed and the conditional not evaluated
-  # If these kind of usecases pop up before Kconfig migration is completed
-  # then another alternative would be introduce a variable to require an extra
-  # loop independent of USEMODULE, FEATURES_REQUIRED and USEPKG
-  include $(RIOTMAKE)/features_check.inc.mk
-  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-    USEMODULE += ztimer_periph_rtt
-  else
-    USEMODULE += ztimer_periph_timer
-  endif
-endif
-
-ifneq (,$(filter ztimer_sec,$(USEMODULE)))
-  USEMODULE += ztimer
-  FEATURES_OPTIONAL += periph_rtt
-  # HACK: see above
-  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-    USEMODULE += ztimer_periph_rtt
-  else
-    USEMODULE += ztimer_periph_timer
+  ifneq (,$(filter ztimer_periph_rtt_auto_select,$(USEMODULE)))
+    FEATURES_OPTIONAL += periph_rtt
+    # HACK: periph_rtt will get used only in the next iteration but an updated
+    # state for FEATURES_USED is needed here so include `features_check.inc.mk`
+    # here instead.
+    # An other option would be to check FEATURES_PROVIDED this would avoid the
+    # order of inclusion problem but it would no take into account possible conflicts
+    # and is also currently not allowed in the build system.
+    # An other alternative would be to delay to the next loop, but this produce a
+    # case where another loop is not executed and the conditional not evaluated
+    # If these kind of usecases pop up before Kconfig migration is completed
+    # then another alternative would be introduce a variable to require an extra
+    # loop independent of USEMODULE, FEATURES_REQUIRED and USEPKG
+    include $(RIOTMAKE)/features_check.inc.mk
+    ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
+      USEMODULE += ztimer_periph_rtt
+    else
+      USEMODULE += ztimer_periph_timer
+    endif
   endif
 endif

--- a/sys/ztimer/Makefile.include
+++ b/sys/ztimer/Makefile.include
@@ -4,6 +4,8 @@ ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
   PSEUDOMODULES += xtimer
 endif
 
+MODULES_ZTIMER_ON_RTT_CONFLICT = rtt_rtc gnrc_lwmac gnrc_gomach
+
 # By defaul use highest possible RTT_FREQUENCY for platforms that allow it. This
 # might not be the most optimized for conversion guarantees that ztimer_periph_rtt
 # will have a capable backend.
@@ -11,5 +13,11 @@ ifneq (,$(filter ztimer_periph_rtt,$(USEMODULE)))
   ifneq (,$(filter stm32 nrf5% sam% kinetis efm32 fe310,$(CPU)))
     RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
     CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+  endif
+
+  MODULES_ZTIMER_ON_RTT_CONFLICTING = $(filter $(MODULES_ZTIMER_ON_RTT_CONFLICT),$(USEMODULE))
+  ifneq (0,$(words $(MODULES_ZTIMER_ON_RTT_CONFLICTING)))
+    $(info $(COLOR_YELLOW)WARNING! The following modules conflict with 'ztimer_periph_rtt': '$(MODULES_ZTIMER_ON_RTT_CONFLICTING)'')
+    $(info To disable ztimer periph_rtt auto-inclusion add 'ztimer_periph_rtt_auto_select' to 'DISABLE_MODULE'$(COLOR_RESET))
   endif
 endif

--- a/tests/ztimer_msg/Makefile
+++ b/tests/ztimer_msg/Makefile
@@ -2,10 +2,10 @@ include ../Makefile.tests_common
 
 USEMODULE += ztimer_usec
 
-# uncomment this to test using ztimer msec on rtt
-#USEMODULE += ztimer_msec ztimer_periph_rtt
+# uncomment this to test using ztimer msec
+#USEMODULE += ztimer_msec
 
-# uncomment this to test using ztimer sec on rtc
-#USEMODULE += ztimer_sec ztimer_periph_rtc
+# uncomment this to test using ztimer sec
+#USEMODULE += ztimer_sec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_underflow/Makefile
+++ b/tests/ztimer_underflow/Makefile
@@ -6,7 +6,6 @@ USEMODULE += ztimer
 USEMODULE += ztimer_usec
 ifeq ($(TEST_ZTIMER_CLOCK), ZTIMER_MSEC)
   USEMODULE += ztimer_msec
-  USEMODULE += ztimer_periph_rtt
 	# the same for Kconfig
   ifeq (1,$(TEST_KCONFIG))
     KCONFIG_ADD_CONFIG += $(APPDIR)/app.config.msec.test
@@ -14,7 +13,6 @@ ifeq ($(TEST_ZTIMER_CLOCK), ZTIMER_MSEC)
 endif
 ifeq ($(TEST_ZTIMER_CLOCK), ZTIMER_SEC)
   USEMODULE += ztimer_sec
-  USEMODULE += ztimer_periph_rtc
 endif
 
 CFLAGS += -DTEST_ZTIMER_CLOCK=$(TEST_ZTIMER_CLOCK)


### PR DESCRIPTION
### Contribution description

This is a temporary fix for Issue #17060. It allows disabling
auto inclusion of `ztimer_periph_rt*` in cases where another
module or application requires direct access.

Limitations:
- as ifeq are involved order of inclusion matters, therefore
  these modules should be included early in the build at the application
  level and not in modules `Makefile.dep`
- this does not disallow direct inclusions of `ztimer_periph_rt*`,
  since this only disables auto inclusion of these modules

This is a temporary solution since this is already possible with
Kconfig, but not in make.

This implements the easiest fix proposed in #17060 to be able to move forward with the migration.

### Testing procedure

```
USEMODULE="ztimer_msec ztimer_no_periph_rtt" BOARD=samr21-xpro make -C tests/ztimer_msg/ info-modules  | grep periph_rtt
ztimer_no_periph_rtt
```
```
DISABLE_MODULES=ztimer_periph_rtt_auto_select BOARD=samr21-xpro make -C tests/ztimer_msg/ info-modules  | grep periph_rtt
```

### Issues/PRs references

#17060 
