### PR TITLE
boards/common/silabs: fix dependencies

### DIFF
--- a/boards/common/silabs/Makefile.dep
+++ b/boards/common/silabs/Makefile.dep
@@ -1,3 +1,3 @@
 ifneq (,$(filter silabs_pic,$(USEMODULE)))
-  USEMODULE += periph_i2c
+  FEATURES_REQUIRED += periph_i2c
 endif


### PR DESCRIPTION
### Contribution description

The module silabs_pic depends on the feature periph_i2c. However, the
dependency resolution just selected the module implementing that
feature which bypasses feature checks.

### Testing procedure

E.g. add `FEATURES_BLACKLIST += periph_i2c` to the `Makefile` of `examples/default` and check if it now fails to build, which is not the case in `master`.

### Issues/PRs references

Bug detected in https://github.com/RIOT-OS/RIOT/pull/17076