### PR TITLE
drivers/bmp180: migrate to ztimer

### DIFF
--- a/drivers/bmp180/Kconfig
+++ b/drivers/bmp180/Kconfig
@@ -10,4 +10,5 @@ config MODULE_BMP180
     depends on HAS_PERIPH_I2C
     depends on TEST_KCONFIG
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC

--- a/drivers/bmp180/Makefile.dep
+++ b/drivers/bmp180/Makefile.dep
@@ -1,2 +1,3 @@
 FEATURES_REQUIRED += periph_i2c
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec

--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -25,7 +25,7 @@
 #include "bmp180_internals.h"
 #include "bmp180_params.h"
 #include "periph/i2c.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -65,7 +65,7 @@ int bmp180_init(bmp180_t *dev, const bmp180_params_t *params)
     }
 
     /* adding delay before reading calibration values to avoid timing issues */
-    xtimer_usleep(BMP180_ULTRALOWPOWER_DELAY);
+    ztimer_sleep(ZTIMER_MSEC, BMP180_ULTRALOWPOWER_DELAY_MS);
 
     uint8_t buffer[22] = {0};
     /* Read calibration values, using contiguous register addresses */
@@ -187,7 +187,7 @@ static int _read_ut(const bmp180_t *dev, int32_t *output)
     uint8_t ut[2] = {0};
     uint8_t control[2] = { BMP180_REGISTER_CONTROL, BMP180_TEMPERATURE_COMMAND };
     i2c_write_bytes(DEV_I2C, DEV_ADDR, control, 2, 0);
-    xtimer_usleep(BMP180_ULTRALOWPOWER_DELAY);
+    ztimer_sleep(ZTIMER_MSEC, BMP180_ULTRALOWPOWER_DELAY_MS);
     if (i2c_read_regs(DEV_I2C, DEV_ADDR, BMP180_REGISTER_DATA, ut, 2, 0) < 0) {
         DEBUG("[Error] Cannot read uncompensated temperature.\n");
         i2c_release(DEV_I2C);
@@ -209,19 +209,19 @@ static int _read_up(const bmp180_t *dev, int32_t *output)
     i2c_write_bytes(DEV_I2C, DEV_ADDR, control, 2, 0);
     switch (OVERSAMPLING) {
     case BMP180_ULTRALOWPOWER:
-        xtimer_usleep(BMP180_ULTRALOWPOWER_DELAY);
+        ztimer_sleep(ZTIMER_MSEC, BMP180_ULTRALOWPOWER_DELAY_MS);
         break;
     case BMP180_STANDARD:
-        xtimer_usleep(BMP180_STANDARD_DELAY);
+        ztimer_sleep(ZTIMER_MSEC, BMP180_STANDARD_DELAY_MS);
         break;
     case BMP180_HIGHRES:
-        xtimer_usleep(BMP180_HIGHRES_DELAY);
+        ztimer_sleep(ZTIMER_MSEC, BMP180_HIGHRES_DELAY_MS);
         break;
     case BMP180_ULTRAHIGHRES:
-        xtimer_usleep(BMP180_ULTRAHIGHRES_DELAY);
+        ztimer_sleep(ZTIMER_MSEC, BMP180_ULTRAHIGHRES_DELAY_MS);
         break;
     default:
-        xtimer_usleep(BMP180_ULTRALOWPOWER_DELAY);
+        ztimer_sleep(ZTIMER_MSEC, BMP180_ULTRALOWPOWER_DELAY_MS);
         break;
     }
     if (i2c_read_regs(DEV_I2C, DEV_ADDR, BMP180_REGISTER_DATA, up, 3, 0) < 0) {

--- a/drivers/bmp180/bmp180_saul.c
+++ b/drivers/bmp180/bmp180_saul.c
@@ -23,7 +23,6 @@
 
 #include "saul.h"
 #include "bmp180.h"
-#include "xtimer.h"
 
 static int read_temperature(const void *dev, phydat_t *res)
 {

--- a/drivers/bmp180/include/bmp180_internals.h
+++ b/drivers/bmp180/include/bmp180_internals.h
@@ -47,10 +47,10 @@ extern "C" {
  * @name    Oversampling modes delays (micros)
  * @{
  */
-#define BMP180_ULTRALOWPOWER_DELAY    (5000UL)
-#define BMP180_STANDARD_DELAY         (8000UL)
-#define BMP180_HIGHRES_DELAY          (14000UL)
-#define BMP180_ULTRAHIGHRES_DELAY     (26000UL)
+#define BMP180_ULTRALOWPOWER_DELAY_MS (5UL)     /**< Ultra low power delay (ms) */
+#define BMP180_STANDARD_DELAY_MS      (8UL)     /**< Standard resolution delay (ms) */
+#define BMP180_HIGHRES_DELAY_MS       (14UL)    /**< High resolution delay (ms) */
+#define BMP180_ULTRAHIGHRES_DELAY_MS  (26UL)    /**< Ultra high resolution delay (ms) */
 /** @} */
 
 #ifdef __cplusplus

--- a/tests/driver_bmp180/Makefile
+++ b/tests/driver_bmp180/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
 USEMODULE += bmp180
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 # set default altitude
 TEST_ALTITUDE ?= 158 # altitude in Polytechnique School campus

--- a/tests/driver_bmp180/app.config.test
+++ b/tests/driver_bmp180/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_BMP180=y
-CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y

--- a/tests/driver_bmp180/main.c
+++ b/tests/driver_bmp180/main.c
@@ -24,7 +24,8 @@
 
 #include "bmp180.h"
 #include "bmp180_params.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "board.h"
 
 int main(void)
@@ -84,7 +85,7 @@ int main(void)
                (unsigned long)pressure_0 / 100, (int)(pressure_0 % 100),
                (int)altitude);
 
-        xtimer_sleep(2);
+        ztimer_sleep(ZTIMER_MSEC, 2 * MS_PER_SEC);
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the bmp180 driver implementation to ztimer. I'm not sure about the Kconfig part.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- Test application is still functional (but I don't have the hardware for testing...)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
