### PR TITLE
drivers/ads101x: migrate to ztimer

### DIFF
--- a/drivers/ads101x/Kconfig
+++ b/drivers/ads101x/Kconfig
@@ -14,7 +14,8 @@ config MODULE_ADS101X
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
     help
         This driver works with the ads1013, ads1014, ads1015, ads1113, ads1114
         and ads1115 models.

--- a/drivers/ads101x/Makefile.dep
+++ b/drivers/ads101x/Makefile.dep
@@ -1,3 +1,4 @@
 FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_i2c
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec

--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -22,7 +22,7 @@
 #include "assert.h"
 #include "periph/i2c.h"
 #include "periph/gpio.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "ads101x.h"
 #include "ads101x_params.h"
@@ -31,8 +31,8 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifndef ADS101X_READ_DELAY
-#define ADS101X_READ_DELAY (8 * US_PER_MS)    /* Compatible with 128SPS */
+#ifndef ADS101X_READ_DELAY_MS
+#define ADS101X_READ_DELAY_MS           8   /* ompatible with 128SPS */
 #endif
 
 #define DEV (dev->params.i2c)
@@ -138,7 +138,7 @@ int ads101x_read_raw(const ads101x_t *dev, int16_t *raw)
     i2c_write_regs(DEV, ADDR, ADS101X_CONF_ADDR, &regs, 2, 0x0);
 
     /* Wait for the sample to be acquired */
-    xtimer_usleep(ADS101X_READ_DELAY);
+    ztimer_sleep(ZTIMER_MSEC, ADS101X_READ_DELAY_MS);
 
     /* Read the sample */
     if (i2c_read_regs(DEV, ADDR, ADS101X_CONV_RES_ADDR, &regs, 2, 0x0) < 0) {

--- a/tests/driver_ads101x/Makefile
+++ b/tests/driver_ads101x/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += ads101x
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ads101x/Makefile.ci
+++ b/tests/driver_ads101x/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_ads101x/app.config.test
+++ b/tests/driver_ads101x/app.config.test
@@ -1,3 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_ADS101X=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y

--- a/tests/driver_ads101x/main.c
+++ b/tests/driver_ads101x/main.c
@@ -21,13 +21,12 @@
 
 #include <stdio.h>
 
-#include "xtimer.h"
-#include "timex.h"
+#include "ztimer.h"
 #include "ads101x.h"
 #include "ads101x_params.h"
 #include "ads101x_regs.h"
 
-#define SLEEP_USEC  (100 * US_PER_MS)
+#define SLEEP_MSEC      100
 
 static ads101x_t dev;
 static ads101x_alert_t alert_dev;
@@ -117,7 +116,7 @@ int main(void)
 
         puts("");
 
-        xtimer_usleep(SLEEP_USEC);
+        ztimer_sleep(ZTIMER_MSEC, SLEEP_MSEC);
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the ads101x driver to ztimer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- Test application still works (cannot test because of missing hardware)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
