### PR TITLE
pkg/wakaama: use ztimer

### DIFF
--- a/pkg/wakaama/Makefile.dep
+++ b/pkg/wakaama/Makefile.dep
@@ -11,7 +11,8 @@ USEMODULE += wakaama_objects
 # include the 'device' object implementation (mandatory)
 USEMODULE += wakaama_objects_device
 
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_sec
 USEPKG += tlsf
 
 # If logs for the package are active, we need fmt

--- a/pkg/wakaama/contrib/lwm2m_platform.c
+++ b/pkg/wakaama/contrib/lwm2m_platform.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "tlsf.h"
 
 #include "lwm2m_platform.h"
@@ -103,7 +103,7 @@ int lwm2m_strncmp(const char *s1, const char *s2, size_t n)
 
 time_t lwm2m_gettime(void)
 {
-    return (time_t)(xtimer_now_usec64() / US_PER_SEC);
+    return (time_t)(ztimer_now(ZTIMER_SEC));
 }
 
 /* For clang we need to specify that the first argument will be a format string


### PR DESCRIPTION
### Contribution description
This changes the platform adaption for Wakaama to use ztimer (`ZTIMER_SEC`) instead of xtimer.

### Testing procedure
- The example application should work as usual. Nodes should update their registration before it expires.

### Issues/PRs references
Ticks an item of #13667
