### PR TITLE
drivers/ata8520e: migrate to ztimer

### DIFF
--- a/drivers/ata8520e/Kconfig
+++ b/drivers/ata8520e/Kconfig
@@ -15,4 +15,5 @@ config MODULE_ATA8520E
     select MODULE_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_SPI
     select MODULE_FMT
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC

--- a/drivers/ata8520e/Makefile.dep
+++ b/drivers/ata8520e/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 USEMODULE += fmt
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/include/ata8520e.h
+++ b/drivers/include/ata8520e.h
@@ -27,7 +27,7 @@
 
 #include <stdint.h>
 #include <inttypes.h>
-#include "xtimer.h"
+#include "mutex.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the ata8520e driver (for SigFox) to ztimer. It's still untested, and I don't know how to test it TBH since my SigFox test account has expired  for quite some time now.

The migration is not straight forward since there's some timer based logic to wait for an event from the driver. I tried to adapt it but it seems to me that there are no ztimer equivalent to all xtimer functions used there.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- The driver is still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#17111 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
