### PR TITLE
boards/stk3200: Fix spi config

### DIFF
--- a/boards/stk3200/include/periph_conf.h
+++ b/boards/stk3200/include/periph_conf.h
@@ -107,6 +107,7 @@ static const i2c_conf_t i2c_config[] = {
 
 /**
  * @name    SPI configuration
+ *
  * @{
  */
 static const spi_dev_t spi_config[] = {
@@ -115,7 +116,8 @@ static const spi_dev_t spi_config[] = {
         .mosi_pin = GPIO_PIN(PD, 7),
         .miso_pin = GPIO_PIN(PD, 6),
         .clk_pin = GPIO_PIN(PC, 15),
-        .loc = USART_ROUTE_LOCATION_LOC1,
+/* page 81 https://www.silabs.com/documents/public/data-sheets/efm32zg-datasheet.pdf */
+        .loc = USART_ROUTE_LOCATION_LOC3,
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     }


### PR DESCRIPTION
### Contribution description

The spi bus for the stk3200 doesn't actually work.
Other efm32 based boards do work.
After some guessing and some checking it turns out that the .loc is wrong.
The original was USART_ROUTE_LOCATION_LOC1, which appears in other periph_conf.
After changing it to USART_ROUTE_LOCATION_LOC2 the spi bus actually outputs data.

### Testing procedure

loopback on the board and run the `tests/periph_spi` with some values or just check the HiL results...


### Issues/PRs references
