### PR TITLE
sys/auto_init: custom auto-initialization sequence

### DIFF
--- a/sys/auto_init/Kconfig
+++ b/sys/auto_init/Kconfig
@@ -8,13 +8,16 @@
 menuconfig MODULE_AUTO_INIT
     bool "Auto-initialization system"
     default y
-    depends on TEST_KCONFIG
     help
         Auto-initialization module. Can be used to initialize modules (such as
         drivers, or network interfaces) on start-up automatically. Disable if a
         more custom initialization is required. If unsure, say Y.
 
 if MODULE_AUTO_INIT
+
+    config AUTO_INIT_DEBUG
+        bool "print a debug message before a module is initialized"
+        default n
 
 rsource "screen/Kconfig"
 rsource "multimedia/Kconfig"

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -23,305 +23,241 @@
 #include <stdio.h>
 #include "sched.h"
 #include "auto_init.h"
+#include "auto_init_priorities.h"
 #include "kernel_defines.h"
-#include "log.h"
+
+XFA_INIT_CONST(auto_init_fn, auto_init_xfa);
+#if IS_USED(MODULE_AUTO_INIT_ZTIMER)
+extern void ztimer_init(void);
+AUTO_INIT_MODULE(ztimer, AUTO_INIT_PRIO_MOD_ZTIMER, ztimer_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_ZTIMER64)
+extern void ztimer64_init(void);
+AUTO_INIT_MODULE(ztimer64, AUTO_INIT_PRIO_MOD_ZTIMER64, ztimer64_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_XTIMER) && !IS_USED(MODULE_ZTIMER_XTIMER_COMPAT)
+extern void xtimer_init(void);
+AUTO_INIT_MODULE(xtimer, AUTO_INIT_PRIO_MOD_XTIMER, xtimer_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_RANDOM)
+extern void auto_init_random(void);
+AUTO_INIT_MODULE(random, AUTO_INIT_PRIO_MOD_RANDOM, auto_init_random);
+#endif
+#if IS_USED(MODULE_SCHEDSTATISTICS)
+extern void init_schedstatistics(void);
+AUTO_INIT_MODULE(schedstatistics, AUTO_INIT_PRIO_MOD_SCHEDSTATISTICS, init_schedstatistics);
+#endif
+#if IS_USED(MODULE_SCHED_ROUND_ROBIN)
+extern void sched_round_robin_init(void);
+AUTO_INIT_MODULE(sched_round_robin, AUTO_INIT_PRIO_MOD_SCHED_ROUND_ROBIN, sched_round_robin_init);
+#endif
+#if IS_USED(MODULE_DUMMY_THREAD)
+extern void dummy_thread_create(void);
+AUTO_INIT_MODULE(dummy_thread, AUTO_INIT_PRIO_MOD_DUMMY_THREAD, dummy_thread_create);
+#endif
+#if IS_USED(MODULE_EVENT_THREAD)
+extern void auto_init_event_thread(void);
+AUTO_INIT_MODULE(event_thread, AUTO_INIT_PRIO_MOD_EVENT_THREAD, auto_init_event_thread);
+#endif
+#if IS_USED(MODULE_SYS_BUS)
+extern void auto_init_sys_bus(void);
+AUTO_INIT_MODULE(sys_bus, AUTO_INIT_PRIO_MOD_SYS_BUS, auto_init_sys_bus);
+#endif
+#if IS_USED(MODULE_MCI)
+extern void mci_initialize(void);
+AUTO_INIT_MODULE(mci, AUTO_INIT_PRIO_MOD_MCI, mci_initialize);
+#endif
+#if IS_USED(MODULE_PROFILING) /* ? */
+extern void profiling_init(void);
+AUTO_INIT_MODULE(profiling, AUTO_INIT_PRIO_PROFILING, profiling_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_PKTBUF)
+extern void gnrc_pktbuf_init(void);
+AUTO_INIT_MODULE(gnrc_pktbuf, AUTO_INIT_PRIO_MOD_GNRC_PKTBUF, gnrc_pktbuf_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_PKTDUMP)
+extern void gnrc_pktdump_init(void);
+AUTO_INIT_MODULE(gnrc_pktdump, AUTO_INIT_PRIO_MOD_GNRC_PKTDUMP, gnrc_pktdump_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_SIXLOWPAN)
+extern void gnrc_sixlowpan_init(void);
+AUTO_INIT_MODULE(gnrc_sixlowpan, AUTO_INIT_PRIO_MOD_GNRC_SIXLOWPAN, gnrc_sixlowpan_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_IPV6)
+extern kernel_pid_t gnrc_ipv6_init(void);
+AUTO_INIT_MODULE(gnrc_ipv6, AUTO_INIT_PRIO_MOD_GNRC_IPV6, gnrc_ipv6_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_UDP)
+extern void gnrc_udp_init(void);
+AUTO_INIT_MODULE(gnrc_udp, AUTO_INIT_PRIO_MOD_GNRC_UDP, gnrc_udp_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_TCP)
+extern int gnrc_tcp_init(void);
+AUTO_INIT_MODULE(gnrc_tcp, AUTO_INIT_PRIO_MOD_GNRC_TCP, gnrc_tcp_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_LWIP)
+extern void lwip_bootstrap(void);
+AUTO_INIT_MODULE(lwip, AUTO_INIT_PRIO_MOD_LWIP, lwip_bootstrap);
+#endif
+#if IS_USED(MODULE_SOCK_DTLS)
+extern void sock_dtls_init(void);
+AUTO_INIT_MODULE(sock_dtls, AUTO_INIT_PRIO_MOD_SOCK_DTLS, sock_dtls_init);
+#endif
+#if IS_USED(MODULE_OPENTHREAD)
+extern void openthread_bootstrap(void);
+AUTO_INIT_MODULE(openthread, AUTO_INIT_PRIO_MOD_OPENTHREAD, openthread_bootstrap);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_OPENWSN)
+extern void openwsn_bootstrap(void);
+AUTO_INIT_MODULE(openwsn, AUTO_INIT_PRIO_MOD_OPENWSN, openwsn_bootstrap);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_MYNEWT_CORE)
+extern void mynewt_core_init(void);
+AUTO_INIT_MODULE(mynewt_core, AUTO_INIT_PRIO_MOD_MYNEWT, mynewt_core_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_UWB_CORE)
+extern void uwb_core_init(void);
+AUTO_INIT_MODULE(uwb_core, AUTO_INIT_PRIO_MOD_UWB_CORE, uwb_core_init);
+#endif
+#if IS_USED(MODULE_GCOAP) && !IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)
+extern void gcoap_init(void);
+AUTO_INIT_MODULE(gcoap, AUTO_INIT_PRIO_MOD_GCOAP, gcoap_init);
+#endif
+#if IS_USED(MODULE_DEVFS)
+extern void auto_init_devfs(void);
+AUTO_INIT_MODULE(devfs, AUTO_INIT_PRIO_MOD_DEVFS, auto_init_devfs);
+#endif
+#if IS_USED(MODULE_VFS_AUTO_MOUNT)
+extern void auto_init_vfs(void);
+AUTO_INIT_MODULE(vfs, AUTO_INIT_PRIO_MOD_VFS, auto_init_vfs);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_IPV6_NIB)
+extern void gnrc_ipv6_nib_init(void);
+AUTO_INIT_MODULE(gnrc_ipv6_nib, AUTO_INIT_PRIO_MOD_GNRC_IPV6_NIB, gnrc_ipv6_nib_init);
+#endif
+#if IS_USED(MODULE_SKALD)
+extern void skald_init(void);
+AUTO_INIT_MODULE(skald, AUTO_INIT_PRIO_MOD_SKALD, skald_init);
+#endif
+#if IS_USED(MODULE_CORD_COMMON)
+extern void cord_common_init(void);
+AUTO_INIT_MODULE(cord_common, AUTO_INIT_PRIO_MOD_CORD_COMMON, cord_common_init);
+#endif
+#if IS_USED(MODULE_CORD_EP_STANDALONE)
+extern void cord_ep_standalone_run(void);
+AUTO_INIT_MODULE(cord_ep_standalone, AUTO_INIT_PRIO_MOD_CORD_EP_STANDALONE, cord_ep_standalone_run);
+#endif
+#if IS_USED(MODULE_ASYMCUTE)
+extern void asymcute_handler_run(void);
+AUTO_INIT_MODULE(asymcute, AUTO_INIT_PRIO_MOD_ASYMCUTE, asymcute_handler_run);
+#endif
+#if IS_USED(MODULE_NIMBLE)
+extern void nimble_riot_init(void);
+AUTO_INIT_MODULE(nimble, AUTO_INIT_PRIO_NIMBLE, nimble_riot_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_LORAMAC)
+extern void auto_init_loramac(void);
+AUTO_INIT_MODULE(loramac, AUTO_INIT_PRIO_MOD_LORAMAC, auto_init_loramac);
+#endif
+#if IS_USED(MODULE_DSM)
+extern void dsm_init(void);
+AUTO_INIT_MODULE(dsm, AUTO_INIT_PRIO_MOD_DSM, dsm_init);
+#endif
+/* initialize USB devices */
+#if IS_USED(MODULE_AUTO_INIT_USBUS)
+extern void auto_init_usb(void);
+AUTO_INIT_MODULE(usbus, AUTO_INIT_PRIO_MOD_USB, auto_init_usb);
+#endif
+/* initialize network devices */
+#if IS_USED(MODULE_AUTO_INIT_GNRC_NETIF)
+extern void gnrc_netif_init_devs(void);
+AUTO_INIT_MODULE(gnrc_netif, AUTO_INIT_PRIO_MOD_GNRC_NETIF, gnrc_netif_init_devs);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_UHCPC)
+extern void auto_init_gnrc_uhcpc(void);
+AUTO_INIT_MODULE(gnrc_uhcpc, AUTO_INIT_PRIO_GNRC_UHCPC, auto_init_gnrc_uhcpc);
+#endif
+/* initialize NDN module after the network devices are initialized */
+#if IS_USED(MODULE_NDN_RIOT)
+extern void ndn_init(void);
+AUTO_INIT_MODULE(ndn_riot, AUTO_INIT_PRIO_MOD_NDN, ndn_init);
+#endif
+/* initialize sensors and actuators */
+#if IS_USED(MODULE_SHT1X)
+/* The sht1x module needs to be initialized regardless of SAUL being used,
+ * as the shell commands rely on auto-initialization. auto_init_sht1x also
+ * performs SAUL registration, but only if module auto_init_saul is used.
+ */
+extern void auto_init_sht1x(void);
+AUTO_INIT_MODULE(sht1x, AUTO_INIT_PRIO_MOD_SHT1X, auto_init_sht1x);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_SAUL)
+extern void saul_init_devs(void);
+AUTO_INIT_MODULE(saul, AUTO_INIT_PRIO_MOD_SAUL, saul_init_devs);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_GNRC_RPL)
+extern void auto_init_gnrc_rpl(void);
+AUTO_INIT_MODULE(gnrc_rpl, AUTO_INIT_PRIO_MOD_GNRC_RPL, auto_init_gnrc_rpl);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_CAN)
+extern void auto_init_candev(void);
+AUTO_INIT_MODULE(can, AUTO_INIT_PRIO_MOD_CAN, auto_init_candev);
+#endif
+#if IS_USED(MODULE_SUIT)
+extern void suit_init_conditions(void);
+AUTO_INIT_MODULE(suit, AUTO_INIT_PRIO_MOD_SUIT_CONDITIONS, suit_init_conditions);
+#endif
+#if IS_USED(MODULE_MBEDTLS)
+extern void auto_init_mbedtls(void);
+AUTO_INIT_MODULE(mbedtls, AUTO_INIT_PRIO_MOD_MBEDTLS, auto_init_mbedtls);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_SECURITY)
+#if IS_USED(MODULE_CRYPTOAUTHLIB)
+extern void auto_init_atca(void);
+AUTO_INIT_MODULE(cryptoauthlib, AUTO_INIT_PRIO_MOD_CRYPTOAUTHLIB, auto_init_atca);
+#endif
+#endif
+#if IS_USED(MODULE_TEST_UTILS_INTERACTIVE_SYNC) && !IS_USED(MODULE_SHELL)
+extern void test_utils_interactive_sync(void);
+AUTO_INIT_MODULE(test_utils_interactive_sync, AUTO_INIT_PRIO_MOD_TEST_UTILS_INTERACTIVE_SYNC,
+                 test_utils_interactive_sync);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_DHCPV6_CLIENT)
+extern void dhcpv6_client_auto_init(void);
+AUTO_INIT_MODULE(dhcpv6_client, AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT, dhcpv6_client_auto_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_DHCPV6_RELAY)
+extern void dhcpv6_relay_auto_init(void);
+AUTO_INIT_MODULE(dhcpv6_relay, AUTO_INIT_PRIO_MOD_DHCPV6_RELAY, dhcpv6_relay_auto_init);
+#endif
+#if IS_USED(MODULE_GNRC_DHCPV6_CLIENT_SIMPLE_PD)
+extern void gnrc_dhcpv6_client_simple_pd_init(void);
+AUTO_INIT_MODULE(gnrc_dhcpv6_client_simple_pd, AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT_SIMPLE_PD,
+                 gnrc_dhcpv6_client_simple_pd_init);
+#endif
+#if IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_AUTO_INIT)
+extern void gnrc_ipv6_auto_subnets_init(void);
+AUTO_INIT_MODULE(gnrc_ipv6_auto_subnets, AUTO_INIT_PRIO_MOD_GNRC_IPV6_AUTO_SUBNETS,
+                 gnrc_ipv6_auto_subnets_init);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_MULTIMEDIA)
+#if IS_USED(MODULE_DFPLAYER)
+extern void auto_init_dfplayer(void);
+AUTO_INIT_MODULE(multimedia, AUTO_INIT_PRIO_MOD_DFPLAYER, auto_init_dfplayer);
+#endif
+#endif
+#if IS_USED(MODULE_AUTO_INIT_SCREEN)
+extern void auto_init_screen(void);
+AUTO_INIT_MODULE(screen, AUTO_INIT_PRIO_MOD_SCREEN, auto_init_screen);
+#endif
+#if IS_USED(MODULE_AUTO_INIT_BENCHMARK_UDP)
+extern void benchmark_udp_auto_init(void);
+AUTO_INIT_MODULE(benchmark_udp, AUTO_INIT_PRIO_BENCHMARK_UDP, benchmark_udp_auto_init);
+#endif
 
 void auto_init(void)
 {
-    if (IS_USED(MODULE_AUTO_INIT_ZTIMER)) {
-        LOG_DEBUG("Auto init ztimer.\n");
-        void ztimer_init(void);
-        ztimer_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_ZTIMER64)) {
-        LOG_DEBUG("Auto init ztimer64.\n");
-        void ztimer64_init(void);
-        ztimer64_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_XTIMER) &&
-        !IS_USED(MODULE_ZTIMER_XTIMER_COMPAT)) {
-        LOG_DEBUG("Auto init xtimer.\n");
-        extern void xtimer_init(void);
-        xtimer_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_RANDOM)) {
-        LOG_DEBUG("Auto init random.\n");
-        extern void auto_init_random(void);
-        auto_init_random();
-    }
-    if (IS_USED(MODULE_SCHEDSTATISTICS)) {
-        LOG_DEBUG("Auto init schedstatistics.\n");
-        extern void init_schedstatistics(void);
-        init_schedstatistics();
-    }
-    if (IS_USED(MODULE_SCHED_ROUND_ROBIN)) {
-        LOG_DEBUG("Auto init sched_round_robin.\n");
-        extern void sched_round_robin_init(void);
-        sched_round_robin_init();
-    }
-    if (IS_USED(MODULE_DUMMY_THREAD)) {
-        extern void dummy_thread_create(void);
-        dummy_thread_create();
-    }
-    if (IS_USED(MODULE_EVENT_THREAD)) {
-        LOG_DEBUG("Auto init event threads.\n");
-        extern void auto_init_event_thread(void);
-        auto_init_event_thread();
-    }
-    if (IS_USED(MODULE_SYS_BUS)) {
-        LOG_DEBUG("Auto init system buses.\n");
-        extern void auto_init_sys_bus(void);
-        auto_init_sys_bus();
-    }
-    if (IS_USED(MODULE_MCI)) {
-        LOG_DEBUG("Auto init mci.\n");
-        extern void mci_initialize(void);
-        mci_initialize();
-    }
-    if (IS_USED(MODULE_PROFILING)) {
-        LOG_DEBUG("Auto init profiling.\n");
-        extern void profiling_init(void);
-        profiling_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_PKTBUF)) {
-        LOG_DEBUG("Auto init gnrc_pktbuf.\n");
-        extern void gnrc_pktbuf_init(void);
-        gnrc_pktbuf_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_PKTDUMP)) {
-        LOG_DEBUG("Auto init gnrc_pktdump.\n");
-        extern void gnrc_pktdump_init(void);
-        gnrc_pktdump_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_SIXLOWPAN)) {
-        LOG_DEBUG("Auto init gnrc_sixlowpan.\n");
-        extern void gnrc_sixlowpan_init(void);
-        gnrc_sixlowpan_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_IPV6)) {
-        LOG_DEBUG("Auto init gnrc_ipv6.\n");
-        extern kernel_pid_t gnrc_ipv6_init(void);
-        gnrc_ipv6_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_UDP)) {
-        LOG_DEBUG("Auto init gnrc_udp.\n");
-        extern void gnrc_udp_init(void);
-        gnrc_udp_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_TCP)) {
-        LOG_DEBUG("Auto init gnrc_tcp.\n");
-        extern int gnrc_tcp_init(void);
-        gnrc_tcp_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_LWIP)) {
-        LOG_DEBUG("Bootstraping lwIP.\n");
-        extern void lwip_bootstrap(void);
-        lwip_bootstrap();
-    }
-    if (IS_USED(MODULE_SOCK_DTLS)) {
-        LOG_DEBUG("Auto init sock_dtls.\n");
-        extern void sock_dtls_init(void);
-        sock_dtls_init();
-    }
-    if (IS_USED(MODULE_OPENTHREAD)) {
-        LOG_DEBUG("Bootstrapping openthread.\n");
-        extern void openthread_bootstrap(void);
-        openthread_bootstrap();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_OPENWSN)) {
-        LOG_DEBUG("Bootstrapping openwsn.\n");
-        extern void openwsn_bootstrap(void);
-        openwsn_bootstrap();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_MYNEWT_CORE)) {
-        LOG_DEBUG("Bootstrapping mynewt-core.\n");
-        extern void mynewt_core_init(void);
-        mynewt_core_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_UWB_CORE)) {
-        LOG_DEBUG("Bootstrapping uwb core.\n");
-        extern void uwb_core_init(void);
-        uwb_core_init();
-    }
-    if (IS_USED(MODULE_GCOAP) &&
-        !IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
-        LOG_DEBUG("Auto init gcoap.\n");
-        extern void gcoap_init(void);
-        gcoap_init();
-    }
-    if (IS_USED(MODULE_DEVFS)) {
-        LOG_DEBUG("Mounting /dev.\n");
-        extern void auto_init_devfs(void);
-        auto_init_devfs();
-    }
-    if (IS_USED(MODULE_VFS_AUTO_MOUNT)) {
-        LOG_DEBUG("Mounting filesystems.\n");
-        extern void auto_init_vfs(void);
-        auto_init_vfs();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_IPV6_NIB)) {
-        LOG_DEBUG("Auto init gnrc_ipv6_nib.\n");
-        extern void gnrc_ipv6_nib_init(void);
-        gnrc_ipv6_nib_init();
-    }
-    if (IS_USED(MODULE_SKALD)) {
-        LOG_DEBUG("Auto init Skald.\n");
-        extern void skald_init(void);
-        skald_init();
-    }
-    if (IS_USED(MODULE_CORD_COMMON)) {
-        LOG_DEBUG("Auto init cord_common.\n");
-        extern void cord_common_init(void);
-        cord_common_init();
-    }
-    if (IS_USED(MODULE_CORD_EP_STANDALONE)) {
-        LOG_DEBUG("Auto init cord_ep_standalone.\n");
-        extern void cord_ep_standalone_run(void);
-        cord_ep_standalone_run();
-    }
-    if (IS_USED(MODULE_ASYMCUTE)) {
-        LOG_DEBUG("Auto init Asymcute.\n");
-        extern void asymcute_handler_run(void);
-        asymcute_handler_run();
-    }
-    if (IS_USED(MODULE_NIMBLE)) {
-        LOG_DEBUG("Auto init NimBLE.\n");
-        extern void nimble_riot_init(void);
-        nimble_riot_init();
-    }
-    if (IS_USED(MODULE_AUTO_INIT_LORAMAC)) {
-        LOG_DEBUG("Auto init loramac.\n");
-        extern void auto_init_loramac(void);
-        auto_init_loramac();
-    }
-    if (IS_USED(MODULE_DSM)) {
-        LOG_DEBUG("Auto init dsm.\n");
-        extern void dsm_init(void);
-        dsm_init();
-    }
-
-    /* initialize USB devices */
-    if (IS_USED(MODULE_AUTO_INIT_USBUS)) {
-        LOG_DEBUG("Auto init USB.\n");
-        extern void auto_init_usb(void);
-        auto_init_usb();
-    }
-
-    /* initialize network devices */
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_NETIF)) {
-        LOG_DEBUG("Auto init gnrc_netif.\n");
-        extern void gnrc_netif_init_devs(void);
-        gnrc_netif_init_devs();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_UHCPC)) {
-        LOG_DEBUG("Auto init gnrc_uhcpc.\n");
-        extern void auto_init_gnrc_uhcpc(void);
-        auto_init_gnrc_uhcpc();
-    }
-
-    /* initialize NDN module after the network devices are initialized */
-    if (IS_USED(MODULE_NDN_RIOT)) {
-        LOG_DEBUG("Auto init NDN.\n");
-        extern void ndn_init(void);
-        ndn_init();
-    }
-
-    /* initialize sensors and actuators */
-    if (IS_USED(MODULE_SHT1X)) {
-        /* The sht1x module needs to be initialized regardless of SAUL being used,
-         * as the shell commands rely on auto-initialization. auto_init_sht1x also
-         * performs SAUL registration, but only if module auto_init_saul is used.
-         */
-        LOG_DEBUG("Auto init sht1x.\n");
-        extern void auto_init_sht1x(void);
-        auto_init_sht1x();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_SAUL)) {
-        LOG_DEBUG("Auto init SAUL.\n");
-        extern void saul_init_devs(void);
-        saul_init_devs();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_GNRC_RPL)) {
-        LOG_DEBUG("Auto init gnrc_rpl.\n");
-        extern void auto_init_gnrc_rpl(void);
-        auto_init_gnrc_rpl();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_CAN)) {
-        LOG_DEBUG("Auto init CAN.\n");
-
-        extern void auto_init_candev(void);
-        auto_init_candev();
-    }
-
-    if (IS_USED(MODULE_SUIT)) {
-        LOG_DEBUG("Auto init SUIT conditions.\n");
-        extern void suit_init_conditions(void);
-        suit_init_conditions();
-    }
-
-    if (IS_USED(MODULE_MBEDTLS)) {
-        LOG_DEBUG("Auto init mbed TLS.\n");
-        extern void auto_init_mbedtls(void);
-        auto_init_mbedtls();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_SECURITY)) {
-        if (IS_USED(MODULE_CRYPTOAUTHLIB)) {
-            LOG_DEBUG("Auto init cryptoauthlib.\n");
-            extern void auto_init_atca(void);
-            auto_init_atca();
-        }
-    }
-
-    if (IS_USED(MODULE_TEST_UTILS_INTERACTIVE_SYNC) && !IS_USED(MODULE_SHELL)) {
-        extern void test_utils_interactive_sync(void);
-        test_utils_interactive_sync();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_DHCPV6_CLIENT)) {
-        LOG_DEBUG("Auto init DHCPv6 client.\n");
-        extern void dhcpv6_client_auto_init(void);
-        dhcpv6_client_auto_init();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_DHCPV6_RELAY)) {
-        LOG_DEBUG("Auto init DHCPv6 relay agent.\n");
-        extern void dhcpv6_relay_auto_init(void);
-        dhcpv6_relay_auto_init();
-    }
-
-    if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_SIMPLE_PD)) {
-        LOG_DEBUG("Auto init DHCPv6 client for simple prefix delegation\n");
-        extern void gnrc_dhcpv6_client_simple_pd_init(void);
-        gnrc_dhcpv6_client_simple_pd_init();
-    }
-
-    if (IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_AUTO_INIT)) {
-        extern void gnrc_ipv6_auto_subnets_init(void);
-        gnrc_ipv6_auto_subnets_init();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_MULTIMEDIA)) {
-        LOG_DEBUG("auto_init MULTIMEDIA\n");
-        if (IS_USED(MODULE_DFPLAYER)) {
-            extern void auto_init_dfplayer(void);
-            auto_init_dfplayer();
-        }
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_SCREEN)) {
-        LOG_DEBUG("Auto init screen devices\n");
-        extern void auto_init_screen(void);
-        auto_init_screen();
-    }
-
-    if (IS_USED(MODULE_AUTO_INIT_BENCHMARK_UDP)) {
-        LOG_DEBUG("Auto init UDP benchmark\n");
-        extern void benchmark_udp_auto_init(void);
-        benchmark_udp_auto_init();
+    for (unsigned i = 0; i < XFA_LEN(auto_init_fn, auto_init_xfa); i++) {
+        auto_init_xfa[i]();
     }
 }

--- a/sys/include/auto_init_priorities.h
+++ b/sys/include/auto_init_priorities.h
@@ -1,0 +1,416 @@
+/*
+ * Copyright (C) 2021 Otto-von-Guericke Universität Magdebug
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_auto_init_priorities Priority order of modules in the auto-init sequence
+ * @ingroup     sys
+ *
+ * @{
+ * @file
+ * @brief       Auto-initialization priorities
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
+ */
+#ifndef AUTO_INIT_PRIORITIES_H
+#define AUTO_INIT_PRIORITIES_H
+
+#include "debug.h"
+#include "xfa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set to 1 if a debug message should be printed
+ *        before the init function of a module is called
+ */
+#ifndef CONFIG_AUTO_INIT_DEBUG
+#define CONFIG_AUTO_INIT_DEBUG 0
+#endif
+
+#if !defined(CONCAT) || defined(DOXYGEN)
+/**
+ * @brief   @ref CONCAT helper macro
+ * @internal
+ */
+#define CONCAT_HELP(a, b) a ## b
+/**
+ * @brief   Classic concat macro
+ * @internal
+ */
+#define CONCAT(a, b) CONCAT_HELP(a, b)
+#endif
+
+/**
+ * @brief   Auto init function type
+ */
+typedef void (*auto_init_fn)(void);
+
+/**
+ * @brief   Construct the global priority of a subgroup or module of @p group
+ *
+ * @experimental
+ *
+ * @param   group       Supergroup priority of the new group or module
+ *                      priority to be constructed
+ * @param   prio        Priority of the new subgroup or module within
+ *                      the supergroup, one of AUTO_INIT_PRIO_x
+ */
+#define AUTO_INIT_PRIO_ADD(group, prio)                   \
+    CONCAT(group, CONCAT(prio, prio))
+
+/**
+ * @brief   Construct the global priority of a group to be inserted
+ *          after @p group
+ *
+ * @experimental
+ *
+ * @param   group       Group priority before the new group or module priority
+ *                      to be constructed
+ * @param   prio        Priority of the new group or module after @p group
+ *                      , one of AUTO_INIT_PRIO_x
+ */
+#define AUTO_INIT_PRIO_ADD_AFTER_GROUP(group, prio)             \
+    CONCAT(group, CONCAT(AUTO_INIT_PRIO_AFTER, prio))
+
+/**
+ * @brief   Construct the global priority of a group to be inserted
+ *          before @p group
+ *
+ * @experimental
+ *
+ * @param   group       Group priority after the new group or module priority
+ *                      to be constructed
+ * @param   prio        Priority of the new group or module before @p group
+ *                      , one of AUTO_INIT_PRIO_x
+ */
+#define AUTO_INIT_PRIO_ADD_BEFORE_GROUP(group, prio)            \
+    CONCAT(group, CONCAT(AUTO_INIT_PRIO_BEFORE, prio))
+
+/**
+ * @brief   Construct the global priority of a module or a group
+ *          to be inserted after @p module
+ *
+ * @experimental
+ *
+ * @param   group       Priority of the group @p module is in
+ * @param   module      Priority of the module within @p group, before the new group or module
+ * @param   prio        Priority of the new group or module after @p module
+ *                      , one of AUTO_INIT_PRIO_x
+ */
+#define AUTO_INIT_PRIO_ADD_AFTER_MODULE(group, module, prio)    \
+    CONCAT(group, CONCAT(module, CONCAT(AUTO_INIT_PRIO_AFTER, prio)))
+
+/**
+ * @brief   Construct the global priority of a module or group
+ *          to be inserted before @p module
+ *
+ * @experimental
+ *
+ * @param   group       Priority of the group @p module is in
+ * @param   module      Priority of the module within @p group, after the new group or module
+ * @param   prio        Priority of the new group or module before @p module
+ *                      , one of AUTO_INIT_PRIO_x
+ */
+#define AUTO_INIT_PRIO_ADD_BEFORE_MODULE(group, module, prio)    \
+    CONCAT(group, CONCAT(module, CONCAT(AUTO_INIT_PRIO_BEFORE, prio)))
+
+/**
+ * @name Module priority levels from highest to lowest
+ * @experimental
+ * @{
+ */
+#define AUTO_INIT_PRIO_BEFORE                               00  /**< Insert something before */
+#define AUTO_INIT_PRIO_1                                    01  /**< 1 */
+#define AUTO_INIT_PRIO_2                                    02  /**< 2 */
+#define AUTO_INIT_PRIO_3                                    03  /**< 3 */
+#define AUTO_INIT_PRIO_4                                    04  /**< 4 */
+#define AUTO_INIT_PRIO_5                                    05  /**< 5 */
+#define AUTO_INIT_PRIO_6                                    06  /**< 6 */
+#define AUTO_INIT_PRIO_7                                    07  /**< 7 */
+#define AUTO_INIT_PRIO_8                                    08  /**< 8 */
+#define AUTO_INIT_PRIO_9                                    09  /**< 9 */
+#define AUTO_INIT_PRIO_10                                   10  /**< 10 */
+#define AUTO_INIT_PRIO_11                                   11  /**< 11 */
+#define AUTO_INIT_PRIO_12                                   12  /**< 12 */
+#define AUTO_INIT_PRIO_13                                   13  /**< 13 */
+#define AUTO_INIT_PRIO_14                                   14  /**< 14 */
+#define AUTO_INIT_PRIO_15                                   15  /**< 15 */
+#define AUTO_INIT_PRIO_16                                   16  /**< 16 */
+#define AUTO_INIT_PRIO_17                                   17  /**< 17 */
+#define AUTO_INIT_PRIO_18                                   18  /**< 18 */
+#define AUTO_INIT_PRIO_19                                   19  /**< 19 */
+#define AUTO_INIT_PRIO_20                                   20  /**< 20 */
+#define AUTO_INIT_PRIO_21                                   21  /**< 21 */
+#define AUTO_INIT_PRIO_22                                   22  /**< 22 */
+#define AUTO_INIT_PRIO_23                                   23  /**< 23 */
+#define AUTO_INIT_PRIO_24                                   24  /**< 24 */
+#define AUTO_INIT_PRIO_25                                   25  /**< 25 */
+#define AUTO_INIT_PRIO_26                                   26  /**< 26 */
+#define AUTO_INIT_PRIO_27                                   27  /**< 27 */
+#define AUTO_INIT_PRIO_28                                   28  /**< 28 */
+#define AUTO_INIT_PRIO_29                                   29  /**< 29 */
+#define AUTO_INIT_PRIO_30                                   30  /**< 30 */
+#define AUTO_INIT_PRIO_31                                   31  /**< 31 */
+#define AUTO_INIT_PRIO_32                                   32  /**< 32 */
+#define AUTO_INIT_PRIO_33                                   33  /**< 33 */
+#define AUTO_INIT_PRIO_34                                   34  /**< 34 */
+#define AUTO_INIT_PRIO_35                                   35  /**< 35 */
+#define AUTO_INIT_PRIO_36                                   36  /**< 36 */
+#define AUTO_INIT_PRIO_37                                   37  /**< 37 */
+#define AUTO_INIT_PRIO_38                                   38  /**< 38 */
+#define AUTO_INIT_PRIO_39                                   39  /**< 39 */
+#define AUTO_INIT_PRIO_40                                   40  /**< 40 */
+#define AUTO_INIT_PRIO_41                                   41  /**< 41 */
+#define AUTO_INIT_PRIO_42                                   42  /**< 42 */
+#define AUTO_INIT_PRIO_43                                   43  /**< 43 */
+#define AUTO_INIT_PRIO_44                                   44  /**< 44 */
+#define AUTO_INIT_PRIO_45                                   45  /**< 45 */
+#define AUTO_INIT_PRIO_46                                   46  /**< 46 */
+#define AUTO_INIT_PRIO_47                                   47  /**< 47 */
+#define AUTO_INIT_PRIO_48                                   48  /**< 48 */
+#define AUTO_INIT_PRIO_49                                   49  /**< 49 */
+#define AUTO_INIT_PRIO_50                                   50  /**< 50 */
+#define AUTO_INIT_PRIO_51                                   51  /**< 51 */
+#define AUTO_INIT_PRIO_52                                   52  /**< 52 */
+#define AUTO_INIT_PRIO_53                                   53  /**< 53 */
+#define AUTO_INIT_PRIO_54                                   54  /**< 54 */
+#define AUTO_INIT_PRIO_55                                   55  /**< 55 */
+#define AUTO_INIT_PRIO_56                                   56  /**< 56 */
+#define AUTO_INIT_PRIO_57                                   57  /**< 57 */
+#define AUTO_INIT_PRIO_58                                   58  /**< 58 */
+#define AUTO_INIT_PRIO_59                                   59  /**< 59 */
+#define AUTO_INIT_PRIO_60                                   60  /**< 60 */
+#define AUTO_INIT_PRIO_61                                   61  /**< 61 */
+#define AUTO_INIT_PRIO_62                                   62  /**< 62 */
+#define AUTO_INIT_PRIO_63                                   63  /**< 63 */
+#define AUTO_INIT_PRIO_64                                   64  /**< 64 */
+#define AUTO_INIT_PRIO_65                                   65  /**< 65 */
+#define AUTO_INIT_PRIO_66                                   66  /**< 66 */
+#define AUTO_INIT_PRIO_67                                   67  /**< 67 */
+#define AUTO_INIT_PRIO_68                                   68  /**< 68 */
+#define AUTO_INIT_PRIO_69                                   69  /**< 69 */
+#define AUTO_INIT_PRIO_70                                   70  /**< 70 */
+#define AUTO_INIT_PRIO_71                                   71  /**< 71 */
+#define AUTO_INIT_PRIO_72                                   72  /**< 72 */
+#define AUTO_INIT_PRIO_73                                   73  /**< 73 */
+#define AUTO_INIT_PRIO_74                                   74  /**< 74 */
+#define AUTO_INIT_PRIO_75                                   75  /**< 75 */
+#define AUTO_INIT_PRIO_76                                   76  /**< 76 */
+#define AUTO_INIT_PRIO_77                                   77  /**< 77 */
+#define AUTO_INIT_PRIO_78                                   78  /**< 78 */
+#define AUTO_INIT_PRIO_79                                   79  /**< 79 */
+#define AUTO_INIT_PRIO_80                                   80  /**< 80 */
+#define AUTO_INIT_PRIO_81                                   81  /**< 81 */
+#define AUTO_INIT_PRIO_82                                   82  /**< 82 */
+#define AUTO_INIT_PRIO_83                                   83  /**< 83 */
+#define AUTO_INIT_PRIO_84                                   84  /**< 84 */
+#define AUTO_INIT_PRIO_85                                   85  /**< 85 */
+#define AUTO_INIT_PRIO_86                                   86  /**< 86 */
+#define AUTO_INIT_PRIO_87                                   87  /**< 87 */
+#define AUTO_INIT_PRIO_88                                   88  /**< 88 */
+#define AUTO_INIT_PRIO_89                                   89  /**< 89 */
+#define AUTO_INIT_PRIO_90                                   90  /**< 90 */
+#define AUTO_INIT_PRIO_91                                   91  /**< 91 */
+#define AUTO_INIT_PRIO_92                                   92  /**< 92 */
+#define AUTO_INIT_PRIO_93                                   93  /**< 93 */
+#define AUTO_INIT_PRIO_94                                   94  /**< 94 */
+#define AUTO_INIT_PRIO_95                                   95  /**< 95 */
+#define AUTO_INIT_PRIO_96                                   96  /**< 96 */
+#define AUTO_INIT_PRIO_97                                   97  /**< 97 */
+#define AUTO_INIT_PRIO_98                                   98  /**< 98 */
+#define AUTO_INIT_PRIO_AFTER                                99  /**< Insert something after */
+/** @} */
+
+/**
+ * @name Priorities of RIOT auto-init groups
+ * @experimental
+ * @{
+ */
+#define AUTO_INIT_PRIO_GP_CORE                              AUTO_INIT_PRIO_1    /**< Core group priority */
+#define AUTO_INIT_PRIO_GP_TIMERS                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_1)    /**< Timers group priority */
+#define AUTO_INIT_PRIO_GP_RNG                               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_2)    /**< RNG group priority */
+#define AUTO_INIT_PRIO_GP_SCHEDULING                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_3)    /**< Scheduling group priority */
+#define AUTO_INIT_PRIO_GP_EVENTS_AND_MESSAGING              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_4)    /**< Events and messaging group priority */
+#define AUTO_INIT_PRIO_GP_SECURITY                          AUTO_INIT_PRIO_2    /**< Security group priority */
+#define AUTO_INIT_PRIO_GP_BUS                               AUTO_INIT_PRIO_3    /**< Bus group priority */
+#define AUTO_INIT_PRIO_GP_STORAGE                           AUTO_INIT_PRIO_4    /**< Storage group priority */
+#define AUTO_INIT_PRIO_GP_FILESYSTEM                        AUTO_INIT_PRIO_5    /**< Filesystem group priority */
+#define AUTO_INIT_PRIO_GP_INTERFACES                        AUTO_INIT_PRIO_6    /**< Interfaces group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK                           AUTO_INIT_PRIO_7    /**< Network group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_1) /**< GNRC network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_LWIP                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_2) /**< LWIP network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENTHREAD          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_3) /**< Openthread network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENWSN             AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_4) /**< Openwsn network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_APPLICATION               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_5) /**< Network applications group priority */
+#define AUTO_INIT_PRIO_GP_SENSORS_AND_ACTUATORS             AUTO_INIT_PRIO_8    /**< Sensors and Actuators group priority */
+#define AUTO_INIT_PRIO_GP_MULTIMEDIA                        AUTO_INIT_PRIO_9    /**< Multimedia group priority */
+#define AUTO_INIT_PRIO_GP_SCREENS                           AUTO_INIT_PRIO_10   /**< Screens group priority */
+#define AUTO_INIT_PRIO_GP_TEST                              AUTO_INIT_PRIO_98   /**< Test group priority */
+/** @} */
+
+/**
+ * @name Priorities of RIOT auto-init modules
+ * @experimental
+ * @{
+ */
+#define AUTO_INIT_PRIO_ZTIMER                               AUTO_INIT_PRIO_1    /**< Module priority of ztimer within its group */
+#define AUTO_INIT_PRIO_XTIMER                               AUTO_INIT_PRIO_2    /**< Module priority of xtimer within its group */
+#define AUTO_INIT_PRIO_MOD_ZTIMER                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_ZTIMER) /**< Priority of ztimer */
+#define AUTO_INIT_PRIO_MOD_XTIMER                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_XTIMER) /**< Priority of xtimer */
+
+#define AUTO_INIT_PRIO_RANDOM                               AUTO_INIT_PRIO_1    /**< Module priority of random within its group */
+#define AUTO_INIT_PRIO_MOD_RANDOM                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_RNG, AUTO_INIT_PRIO_RANDOM)    /**< Priority of random */
+
+#define AUTO_INIT_PRIO_SCHEDSTATISTICS                      AUTO_INIT_PRIO_1    /**< Module priority of schedstatistics within its group */
+#define AUTO_INIT_PRIO_MOD_SCHEDSTATISTICS                  AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SCHEDULING, AUTO_INIT_PRIO_SCHEDSTATISTICS)    /**< Priority of schedstatistics */
+
+#define AUTO_INIT_PRIO_EVENT_THREAD                         AUTO_INIT_PRIO_1    /**< Module priority of event thread within its group */
+#define AUTO_INIT_PRIO_SYS_BUS                              AUTO_INIT_PRIO_2    /**< Module priority of sys bus within its group */
+#define AUTO_INIT_PRIO_MOD_EVENT_THREAD                     AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_EVENTS_AND_MESSAGING, AUTO_INIT_PRIO_EVENT_THREAD) /**< Priority of event thread */
+#define AUTO_INIT_PRIO_MOD_SYS_BUS                          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_EVENTS_AND_MESSAGING, AUTO_INIT_PRIO_SYS_BUS)      /**< Priority of sys bus */
+
+#define AUTO_INIT_PRIO_MOD_MYNEWT                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_98)   /**< Priority of mynewt */
+
+#define AUTO_INIT_PRIO_SOCK_DTLS                            AUTO_INIT_PRIO_1    /**< Module priority of DTLS sockets within its group */
+#define AUTO_INIT_PRIO_DSM                                  AUTO_INIT_PRIO_2    /**< Module priority of DSM within its group */
+#define AUTO_INIT_PRIO_CRYPTOAUTHLIB                        AUTO_INIT_PRIO_3    /**< Module priority of crypthauthlib within its group */
+#define AUTO_INIT_PRIO_MOD_SOCK_DTLS                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_SOCK_DTLS)        /**< Priority of DTLS sockets */
+#define AUTO_INIT_PRIO_MOD_DSM                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_DSM)              /**< Priority of DSM */
+#define AUTO_INIT_PRIO_MOD_CRYPTOAUTHLIB                    AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_CRYPTOAUTHLIB)    /**< Priority of cryptauthlib */
+
+#define AUTO_INIT_PRIO_USB                                  AUTO_INIT_PRIO_1    /**< Module priority of USB within its group */
+#define AUTO_INIT_PRIO_CAN                                  AUTO_INIT_PRIO_2    /**< Module priority of CAN within its group */
+#define AUTO_INIT_PRIO_MOD_USB                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_BUS, AUTO_INIT_PRIO_USB)   /**< Priority of USB */
+#define AUTO_INIT_PRIO_MOD_CAN                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_BUS, AUTO_INIT_PRIO_CAN)   /**< Priority of CAN */
+
+#define AUTO_INIT_PRIO_MCI                                  AUTO_INIT_PRIO_1    /**< Module priority of MCI within its group */
+#define AUTO_INIT_PRIO_MOD_MCI                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_STORAGE, AUTO_INIT_PRIO_MOD_MCI)   /**< Priority of MSI */
+
+#define AUTO_INIT_PRIO_DEVFS                                AUTO_INIT_PRIO_1    /**< Module priority of DEVFS within its group */
+#define AUTO_INIT_PRIO_MOD_DEVFS                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_FILESYSTEM, AUTO_INIT_PRIO_DEVFS)  /**< Priority of DEVFS */
+
+#define AUTO_INIT_PRIO_GNRC_PKTBUF                          AUTO_INIT_PRIO_1    /**< Module priority of GNRC pktbuf within its group */
+#define AUTO_INIT_PRIO_GNRC_NETIF                           AUTO_INIT_PRIO_2    /**< Module priority of GNRC netif within its group */
+#define AUTO_INIT_PRIO_SKALD                                AUTO_INIT_PRIO_3    /**< Module priority of skald within its group */
+#define AUTO_INIT_PRIO_NIMBLE                               AUTO_INIT_PRIO_4    /**< Module priority of nimble within its group */
+#define AUTO_INIT_PRIO_LORAMAC                              AUTO_INIT_PRIO_5    /**< Module priority of loramac within its group */
+#define AUTO_INIT_PRIO_UWB_CORE                             AUTO_INIT_PRIO_6    /**< Module priority of UWB core within its group */
+#define AUTO_INIT_PRIO_MOD_GNRC_PKTBUF                      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_INTERFACES, AUTO_INIT_PRIO_GNRC_PKTBUF)    /**< Priority of GNRC pktbuf */
+#define AUTO_INIT_PRIO_MOD_GNRC_NETIF                       AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_INTERFACES, AUTO_INIT_PRIO_GNRC_NETIF)     /**< Priority of GNRC netif */
+#define AUTO_INIT_PRIO_MOD_SKALD                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_INTERFACES, AUTO_INIT_PRIO_SKALD)          /**< Priority of skald */
+#define AUTO_INIT_PRIO_MOD_NIMBLE                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_INTERFACES, AUTO_INIT_PRIO_NIMBLE)         /**< Priority of nimble */
+#define AUTO_INIT_PRIO_MOD_LORAMAC                          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_INTERFACES, AUTO_INIT_PRIO_LORAMAC)        /**< Priority of loramac */
+#define AUTO_INIT_PRIO_MOD_UWB_CORE                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_INTERFACES, AUTO_INIT_PRIO_UWB_CORE)       /**< Priority of UWB core */
+
+#define AUTO_INIT_PRIO_GNRC_IPV6                            AUTO_INIT_PRIO_1    /**< Module priority of GNRC IPV6 within its group */
+#define AUTO_INIT_PRIO_GNRC_SIXLOWPAN                       AUTO_INIT_PRIO_2    /**< Module priority of GNRC sixlowpan within its group */
+#define AUTO_INIT_PRIO_GNRC_RPL                             AUTO_INIT_PRIO_3    /**< Module priority of GNRC RPL within its group */
+#define AUTO_INIT_PRIO_GNRC_IPV6_NIB                        AUTO_INIT_PRIO_4    /**< Module priority of GNRC IPV6 NIB within its group */
+#define AUTO_INIT_PRIO_GNRC_UDP                             AUTO_INIT_PRIO_5    /**< Module priority of GNRC UDP within its group */
+#define AUTO_INIT_PRIO_GNRC_TCP                             AUTO_INIT_PRIO_6    /**< Module priority of GNRC TCP within its group */
+#define AUTO_INIT_PRIO_GNRC_UHCPC                           AUTO_INIT_PRIO_7    /**< Module priority of GNRC UHCPC within its group */
+#define AUTO_INIT_PRIO_MOD_GNRC_IPV6                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_IPV6)      /**< Priority of GNRC IPV6 */
+#define AUTO_INIT_PRIO_MOD_GNRC_SIXLOWPAN                   AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_SIXLOWPAN) /**< Priority of GNRC sixlowpan */
+#define AUTO_INIT_PRIO_MOD_GNRC_RPL                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_RPL)       /**< Priority of GNRC RPL */
+#define AUTO_INIT_PRIO_MOD_GNRC_IPV6_NIB                    AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_IPV6_NIB)  /**< Priority of GNRC IPV6 NIB */
+#define AUTO_INIT_PRIO_MOD_GNRC_UDP                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_UDP)       /**< Priority of GNRC UDP */
+#define AUTO_INIT_PRIO_MOD_GNRC_TCP                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_TCP)       /**< Priority of GNRC TCP */
+#define AUTO_INIT_PRIO_MOD_GNRC_UHCPC                       AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC, AUTO_INIT_PRIO_GNRC_UHCPC)     /**< Priority of GNRC UHCPC */
+
+#define AUTO_INIT_PRIO_LWIP                                 AUTO_INIT_PRIO_1    /**< Module priority of LWIP within its group */
+#define AUTO_INIT_PRIO_MOD_LWIP                             AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_LWIP, AUTO_INIT_PRIO_LWIP)   /**< Priority of LWIP */
+
+#define AUTO_INIT_PRIO_OPENTHREAD                           AUTO_INIT_PRIO_1    /**< Module priority of openthread within its group */
+#define AUTO_INIT_PRIO_MOD_OPENTHREAD                       AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENTHREAD, AUTO_INIT_PRIO_OPENTHREAD)   /**< Priority of openthread */
+
+#define AUTO_INIT_PRIO_OPENWSN                              AUTO_INIT_PRIO_1    /**< Module priority of openwsn within its group */
+#define AUTO_INIT_PRIO_MOD_OPENWSN                          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENWSN, AUTO_INIT_PRIO_OPENWSN) /**< Priority of openwsn */
+
+#define AUTO_INIT_PRIO_GCOAP                                AUTO_INIT_PRIO_1    /**< Module priority of gcoap within its group */
+#define AUTO_INIT_PRIO_CORD_COMMON                          AUTO_INIT_PRIO_2    /**< Module priority of CORD within its group */
+#define AUTO_INIT_PRIO_CORD_EP_STANDALONE                   AUTO_INIT_PRIO_3    /**< Module priority of CORD EP within its group */
+#define AUTO_INIT_PRIO_ASYMCUTE                             AUTO_INIT_PRIO_4    /**< Module priority of asymcute within its group */
+#define AUTO_INIT_PRIO_NDN                                  AUTO_INIT_PRIO_5    /**< Module priority of NDN within its group */
+#define AUTO_INIT_PRIO_DHCPV6_CLIENT                        AUTO_INIT_PRIO_6    /**< Module priority of DHCPV6 client within its group */
+#define AUTO_INIT_PRIO_DHCPV6_RELAY                         AUTO_INIT_PRIO_7    /**< Module priority of DHCPV6 relay within its group */
+#define AUTO_INIT_PRIO_DHCPV6_CLIENT_SIMPLE_PD              AUTO_INIT_PRIO_8    /**< Module priority of DHCPV6 client simple PD within its group */
+#define AUTO_INIT_PRIO_GNRC_IPV6_AUTO_SUBNETS               AUTO_INIT_PRIO_9    /**< Module priority of GNRC IPV6 auto-subnets within its group */
+#define AUTO_INIT_PRIO_GNRC_PKTDUMP                         AUTO_INIT_PRIO_10   /**< Module priority of GNRC pktdump within its group */
+#define AUTO_INIT_PRIO_SUIT_CONDITIONS                      AUTO_INIT_PRIO_11   /**< Module priority of SUIT conditions within its group */
+#define AUTO_INIT_PRIO_MOD_GCOAP                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_GCOAP)                     /**< Priority of gcoap */
+#define AUTO_INIT_PRIO_MOD_CORD_COMMON                      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_CORD_COMMON)               /**< Priority of CORD */
+#define AUTO_INIT_PRIO_MOD_CORD_EP_STANDALONE               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_CORD_EP_STANDALONE)        /**< Priority of CORD EP */
+#define AUTO_INIT_PRIO_MOD_ASYMCUTE                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_ASYMCUTE)                  /**< Priority of asymcute */
+#define AUTO_INIT_PRIO_MOD_NDN                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_NDN)                       /**< Priority of NDN */
+#define AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT                    AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_DHCPV6_CLIENT)             /**< Priority of DHCPV6 client */
+#define AUTO_INIT_PRIO_MOD_DHCPV6_RELAY                     AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_DHCPV6_RELAY)              /**< Priority of DHCPV6 relay */
+#define AUTO_INIT_PRIO_MOD_DHCPV6_CLIENT_SIMPLE_PD          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_DHCPV6_CLIENT_SIMPLE_PD)   /**< Priority of DHCPV6 client simple PD */
+#define AUTO_INIT_PRIO_MOD_GNRC_IPV6_AUTO_SUBNETS           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_GNRC_IPV6_AUTO_SUBNETS)    /**< Priority of GNRC IPV6 auto-subnets */
+#define AUTO_INIT_PRIO_MOD_GNRC_PKTDUMP                     AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_GNRC_PKTDUMP)              /**< Priority of GNRC pktdump */
+#define AUTO_INIT_PRIO_MOD_SUIT_CONDITIONS                  AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK_APPLICATION, AUTO_INIT_PRIO_SUIT_CONDITIONS)           /**< Priority of SUIT conditions */
+
+#define AUTO_INIT_PRIO_SHT1X                                AUTO_INIT_PRIO_1    /**< Module priority of SHT1X within its group */
+#define AUTO_INIT_PRIO_SAUL                                 AUTO_INIT_PRIO_2    /**< Module priority of SAUL within its group */
+#define AUTO_INIT_PRIO_MOD_SHT1X                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SENSORS_AND_ACTUATORS, AUTO_INIT_PRIO_SHT1X)   /**< Priority of SHT1X */
+#define AUTO_INIT_PRIO_MOD_SAUL                             AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SENSORS_AND_ACTUATORS, AUTO_INIT_PRIO_SAUL)    /**< Priority of SAUL */
+
+#define AUTO_INIT_PRIO_DFPLAYER                             AUTO_INIT_PRIO_1    /**< Module priority of DFPlayer within its group */
+#define AUTO_INIT_PRIO_MOD_DFPLAYER                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_MULTIMEDIA, AUTO_INIT_PRIO_DFPLAYER)   /**< Priority of DFPlayer */
+
+#define AUTO_INIT_PRIO_SCREENS                              AUTO_INIT_PRIO_1    /**< Module priority of screens within its group */
+#define AUTO_INIT_PRIO_MOD_SCREEN                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SCREENS, AUTO_INIT_PRIO_SCREENS)   /**< Priority of Screens */
+
+#define AUTO_INIT_PRIO_TEST_UTILS_INTERACTIVE_SYNC          AUTO_INIT_PRIO_1    /**< Module priority of test utils interactive sync within its group */
+#define AUTO_INIT_PRIO_BENCHMARK_UDP                        AUTO_INIT_PRIO_2    /**< Module priority of UDP benchmarks */
+#define AUTO_INIT_PRIO_DUMMY_THREAD                         AUTO_INIT_PRIO_3    /**< Module priority of dummy thread within its group */
+#define AUTO_INIT_PRIO_MOD_TEST_UTILS_INTERACTIVE_SYNC      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TEST, AUTO_INIT_PRIO_TEST_UTILS_INTERACTIVE_SYNC)  /**< Priority of test utils interactive sync */
+#define AUTO_INIT_PRIO_MOD_BENCHMARK_UDP                    AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TEST, AUTO_INIT_PRIO_BENCHMARK_UDP)                /**< Priority of UDP benchmarks */
+#define AUTO_INIT_PRIO_MOD_DUMMY_THREAD                     AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TEST, AUTO_INIT_PRIO_DUMMY_THREAD)                 /**< Priority of dummy thread */
+/** @} */
+
+/**
+ * @brief   Add a module to the auto-initialization array
+ *
+ * @param   module      Module name
+ * @param   prio        Priority level
+ * @param   function    Function to be called on initialization
+ *
+ * @experimental
+ */
+#if IS_ACTIVE(CONFIG_AUTO_INIT_DEBUG) || defined(DOXYGEN)
+#define AUTO_INIT_MODULE(module, prio, function)                                        \
+    AUTO_INIT_MODULE_DEBUG(module, prio, function)
+#else
+#define AUTO_INIT_MODULE(module, prio, function)                                        \
+    XFA_CONST(auto_init_xfa, prio)                                                      \
+    auto_init_fn CONCAT(CONCAT(auto_init_xfa, prio), module) = (auto_init_fn)function
+#endif
+
+/**
+ * @brief   Add a module to the auto-initialization array and print a debug
+ *          message when @p function is called
+ *
+ * @internal
+ */
+#define AUTO_INIT_MODULE_DEBUG(module, prio, function)                                  \
+    static inline void CONCAT(CONCAT(_debug_, prio), function)(void) {                  \
+        puts("auto_init: " #module);                                                    \
+        function();                                                                     \
+    }                                                                                   \
+    XFA_CONST(auto_init_xfa, prio)                                                      \
+    auto_init_fn CONCAT(CONCAT(auto_init_xfa, prio), module) =                          \
+        (auto_init_fn)CONCAT(CONCAT(_debug_, prio), function)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AUTO_INIT_PRIORITIES_H */
+/** @} */

--- a/sys/include/auto_init_priorities.h
+++ b/sys/include/auto_init_priorities.h
@@ -273,14 +273,18 @@ typedef void (*auto_init_fn)(void);
  */
 #define AUTO_INIT_PRIO_ZTIMER                               AUTO_INIT_PRIO_1    /**< Module priority of ztimer within its group */
 #define AUTO_INIT_PRIO_XTIMER                               AUTO_INIT_PRIO_2    /**< Module priority of xtimer within its group */
-#define AUTO_INIT_PRIO_MOD_ZTIMER                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_ZTIMER) /**< Priority of ztimer */
-#define AUTO_INIT_PRIO_MOD_XTIMER                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_XTIMER) /**< Priority of xtimer */
+#define AUTO_INIT_PRIO_ZTIMER64                             AUTO_INIT_PRIO_3    /**< Module priority of ztimer64 within its group */
+#define AUTO_INIT_PRIO_MOD_ZTIMER                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_ZTIMER)     /**< Priority of ztimer */
+#define AUTO_INIT_PRIO_MOD_XTIMER                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_XTIMER)     /**< Priority of xtimer */
+#define AUTO_INIT_PRIO_MOD_ZTIMER64                         AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_TIMERS, AUTO_INIT_PRIO_ZTIMER64)   /**< Priority of ztimer64 */
 
 #define AUTO_INIT_PRIO_RANDOM                               AUTO_INIT_PRIO_1    /**< Module priority of random within its group */
 #define AUTO_INIT_PRIO_MOD_RANDOM                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_RNG, AUTO_INIT_PRIO_RANDOM)    /**< Priority of random */
 
 #define AUTO_INIT_PRIO_SCHEDSTATISTICS                      AUTO_INIT_PRIO_1    /**< Module priority of schedstatistics within its group */
+#define AUTO_INIT_PRIO_SCHED_ROUND_ROBIN                    AUTO_INIT_PRIO_2    /**< Module priority of round robin scheduling within its group */
 #define AUTO_INIT_PRIO_MOD_SCHEDSTATISTICS                  AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SCHEDULING, AUTO_INIT_PRIO_SCHEDSTATISTICS)    /**< Priority of schedstatistics */
+#define AUTO_INIT_PRIO_MOD_SCHED_ROUND_ROBIN                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SCHEDULING, AUTO_INIT_PRIO_SCHED_ROUND_ROBIN)  /**< Priority of round robin scheduling */
 
 #define AUTO_INIT_PRIO_EVENT_THREAD                         AUTO_INIT_PRIO_1    /**< Module priority of event thread within its group */
 #define AUTO_INIT_PRIO_SYS_BUS                              AUTO_INIT_PRIO_2    /**< Module priority of sys bus within its group */
@@ -292,9 +296,11 @@ typedef void (*auto_init_fn)(void);
 #define AUTO_INIT_PRIO_SOCK_DTLS                            AUTO_INIT_PRIO_1    /**< Module priority of DTLS sockets within its group */
 #define AUTO_INIT_PRIO_DSM                                  AUTO_INIT_PRIO_2    /**< Module priority of DSM within its group */
 #define AUTO_INIT_PRIO_CRYPTOAUTHLIB                        AUTO_INIT_PRIO_3    /**< Module priority of crypthauthlib within its group */
+#define AUTO_INIT_PRIO_MBEDTLS                              AUTO_INIT_PRIO_4    /**< Module priority of mbed TLS */
 #define AUTO_INIT_PRIO_MOD_SOCK_DTLS                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_SOCK_DTLS)        /**< Priority of DTLS sockets */
 #define AUTO_INIT_PRIO_MOD_DSM                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_DSM)              /**< Priority of DSM */
 #define AUTO_INIT_PRIO_MOD_CRYPTOAUTHLIB                    AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_CRYPTOAUTHLIB)    /**< Priority of cryptauthlib */
+#define AUTO_INIT_PRIO_MOD_MBEDTLS                          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_SECURITY, AUTO_INIT_PRIO_MBEDTLS)          /**< Priority of mbed TLS */
 
 #define AUTO_INIT_PRIO_USB                                  AUTO_INIT_PRIO_1    /**< Module priority of USB within its group */
 #define AUTO_INIT_PRIO_CAN                                  AUTO_INIT_PRIO_2    /**< Module priority of CAN within its group */
@@ -305,7 +311,9 @@ typedef void (*auto_init_fn)(void);
 #define AUTO_INIT_PRIO_MOD_MCI                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_STORAGE, AUTO_INIT_PRIO_MOD_MCI)   /**< Priority of MSI */
 
 #define AUTO_INIT_PRIO_DEVFS                                AUTO_INIT_PRIO_1    /**< Module priority of DEVFS within its group */
+#define AUTO_INIT_PRIO_VFS                                  AUTO_INIT_PRIO_2    /**< Module priority of VFS within its group */
 #define AUTO_INIT_PRIO_MOD_DEVFS                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_FILESYSTEM, AUTO_INIT_PRIO_DEVFS)  /**< Priority of DEVFS */
+#define AUTO_INIT_PRIO_MOD_VFS                              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_FILESYSTEM, AUTO_INIT_PRIO_VFS)    /**< Priority of VFS */
 
 #define AUTO_INIT_PRIO_GNRC_PKTBUF                          AUTO_INIT_PRIO_1    /**< Module priority of GNRC pktbuf within its group */
 #define AUTO_INIT_PRIO_GNRC_NETIF                           AUTO_INIT_PRIO_2    /**< Module priority of GNRC netif within its group */

--- a/sys/include/auto_init_priorities.h
+++ b/sys/include/auto_init_priorities.h
@@ -122,7 +122,22 @@ typedef void (*auto_init_fn)(void);
     CONCAT(group, CONCAT(module, CONCAT(AUTO_INIT_PRIO_BEFORE, prio)))
 
 /**
- * @name Module priority levels from highest to lowest
+ * @name    Numeric group priority prefixes of top level groups
+ * @experimental
+ * @{
+ */
+#define AUTO_INIT_PRIO_GP_CPU                               101     /**< CPU group priority */
+#define AUTO_INIT_PRIO_GP_BOARD                             102     /**< Board group priority */
+#define AUTO_INIT_PRIO_GP_CORE                              103     /**< Core group priority */
+#define AUTO_INIT_PRIO_GP_DRIVERS                           104     /**< Drivers group priority */
+#define AUTO_INIT_PRIO_GP_FILESYSTEM                        105     /**< Filesystem group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK                           106     /**< Network group priority */
+#define AUTO_INIT_PRIO_GP_TEST                              109     /**< Test group priority */
+/** @} */
+
+/**
+ * @name    Priority levels from highest to lowest used for subgrouping
+ *          and enumeration
  * @experimental
  * @{
  */
@@ -229,30 +244,26 @@ typedef void (*auto_init_fn)(void);
 /** @} */
 
 /**
- * @name Priorities of RIOT auto-init groups
+ * @name    Priorities of RIOT auto-init groups, which must be within one top level group
  * @experimental
  * @{
  */
-#define AUTO_INIT_PRIO_GP_CORE                              AUTO_INIT_PRIO_1    /**< Core group priority */
-#define AUTO_INIT_PRIO_GP_TIMERS                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_1)    /**< Timers group priority */
-#define AUTO_INIT_PRIO_GP_RNG                               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_2)    /**< RNG group priority */
-#define AUTO_INIT_PRIO_GP_SCHEDULING                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_3)    /**< Scheduling group priority */
-#define AUTO_INIT_PRIO_GP_EVENTS_AND_MESSAGING              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_4)    /**< Events and messaging group priority */
-#define AUTO_INIT_PRIO_GP_SECURITY                          AUTO_INIT_PRIO_2    /**< Security group priority */
-#define AUTO_INIT_PRIO_GP_BUS                               AUTO_INIT_PRIO_3    /**< Bus group priority */
-#define AUTO_INIT_PRIO_GP_STORAGE                           AUTO_INIT_PRIO_4    /**< Storage group priority */
-#define AUTO_INIT_PRIO_GP_FILESYSTEM                        AUTO_INIT_PRIO_5    /**< Filesystem group priority */
-#define AUTO_INIT_PRIO_GP_INTERFACES                        AUTO_INIT_PRIO_6    /**< Interfaces group priority */
-#define AUTO_INIT_PRIO_GP_NETWORK                           AUTO_INIT_PRIO_7    /**< Network group priority */
-#define AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_1) /**< GNRC network stack group priority */
-#define AUTO_INIT_PRIO_GP_NETWORK_STACK_LWIP                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_2) /**< LWIP network stack group priority */
-#define AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENTHREAD          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_3) /**< Openthread network stack group priority */
-#define AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENWSN             AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_4) /**< Openwsn network stack group priority */
-#define AUTO_INIT_PRIO_GP_NETWORK_APPLICATION               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_5) /**< Network applications group priority */
-#define AUTO_INIT_PRIO_GP_SENSORS_AND_ACTUATORS             AUTO_INIT_PRIO_8    /**< Sensors and Actuators group priority */
-#define AUTO_INIT_PRIO_GP_MULTIMEDIA                        AUTO_INIT_PRIO_9    /**< Multimedia group priority */
-#define AUTO_INIT_PRIO_GP_SCREENS                           AUTO_INIT_PRIO_10   /**< Screens group priority */
-#define AUTO_INIT_PRIO_GP_TEST                              AUTO_INIT_PRIO_98   /**< Test group priority */
+#define AUTO_INIT_PRIO_GP_TIMERS                            AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_1)        /**< Timers group priority */
+#define AUTO_INIT_PRIO_GP_RNG                               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_2)        /**< RNG group priority */
+#define AUTO_INIT_PRIO_GP_SCHEDULING                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_3)        /**< Scheduling group priority */
+#define AUTO_INIT_PRIO_GP_EVENTS_AND_MESSAGING              AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_4)        /**< Events and messaging group priority */
+#define AUTO_INIT_PRIO_GP_SECURITY                          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_5)        /**< Security group priority */
+#define AUTO_INIT_PRIO_GP_BUS                               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_6)        /**< Bus group priority */
+#define AUTO_INIT_PRIO_GP_STORAGE                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_DRIVERS, AUTO_INIT_PRIO_1)     /**< Storage group priority */
+#define AUTO_INIT_PRIO_GP_SCREENS                           AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_DRIVERS, AUTO_INIT_PRIO_2)     /**< Screens group priority */
+#define AUTO_INIT_PRIO_GP_MULTIMEDIA                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_DRIVERS, AUTO_INIT_PRIO_3)     /**< Multimedia group priority */
+#define AUTO_INIT_PRIO_GP_SENSORS_AND_ACTUATORS             AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_DRIVERS, AUTO_INIT_PRIO_4)     /**< Sensors and Actuators group priority */
+#define AUTO_INIT_PRIO_GP_INTERFACES                        AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_DRIVERS, AUTO_INIT_PRIO_5)     /**< Interfaces group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_GNRC                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_1)     /**< GNRC network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_LWIP                AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_2)     /**< LWIP network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENTHREAD          AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_3)     /**< Openthread network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_STACK_OPENWSN             AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_4)     /**< Openwsn network stack group priority */
+#define AUTO_INIT_PRIO_GP_NETWORK_APPLICATION               AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_GP_NETWORK, AUTO_INIT_PRIO_5)     /**< Network applications group priority */
 /** @} */
 
 /**

--- a/tests/auto_init_custom/Makefile
+++ b/tests/auto_init_custom/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+SHOULD_RUN_KCONFIG ?= 1
+
+USEMODULE += ztimer ztimer_msec
+USEMODULE += random
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/auto_init_custom/main.c
+++ b/tests/auto_init_custom/main.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test auto-initialization in custom order
+ *
+ * @author      Fabian Hüßler <fabian@huessler.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "auto_init.h"
+#include "auto_init_priorities.h"
+#include "ztimer.h"
+
+static unsigned _counter;
+static char _init[6];
+
+void my_module_a_init(void)
+{
+    _init[_counter++] = 'a';
+}
+void my_module_b_init(void)
+{
+    _init[_counter++] = 'b';
+}
+void my_module_c_init(void)
+{
+    _init[_counter++] = 'c';
+}
+void my_module_d_init(void)
+{
+    ztimer_sleep(ZTIMER_MSEC, 5);
+    _init[_counter++] = 'd';
+}
+void my_module_e_init(void)
+{
+    ztimer_sleep(ZTIMER_MSEC, 5);
+    _init[_counter++] = 'e';
+}
+void my_module_f_init(void)
+{
+    ztimer_sleep(ZTIMER_MSEC, 5);
+    _init[_counter++] = 'f';
+}
+
+#define AUTO_INIT_PRIO_MY_GROUP_BEFORE  AUTO_INIT_PRIO_ADD_BEFORE_GROUP(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_1)
+#define AUTO_INIT_PRIO_MY_MODULE_A      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_MY_GROUP_BEFORE, AUTO_INIT_PRIO_1)
+#define AUTO_INIT_PRIO_MY_MODULE_B      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_MY_GROUP_BEFORE, AUTO_INIT_PRIO_2)
+AUTO_INIT_MODULE(my_module_a, AUTO_INIT_PRIO_MY_MODULE_A, my_module_a_init);
+AUTO_INIT_MODULE(my_module_b, AUTO_INIT_PRIO_MY_MODULE_B, my_module_b_init);
+
+#define AUTO_INIT_PRIO_MY_MODULE_C  AUTO_INIT_PRIO_ADD_BEFORE_MODULE(AUTO_INIT_PRIO_GP_TIMERS,  \
+                                                                     AUTO_INIT_PRIO_ZTIMER,     \
+                                                                     AUTO_INIT_PRIO_1)
+AUTO_INIT_MODULE(my_module_c, AUTO_INIT_PRIO_MY_MODULE_C, my_module_c_init);
+
+#define AUTO_INIT_PRIO_MY_MODULE_D  AUTO_INIT_PRIO_ADD_AFTER_MODULE(AUTO_INIT_PRIO_GP_TIMERS,   \
+                                                                    AUTO_INIT_PRIO_ZTIMER,      \
+                                                                    AUTO_INIT_PRIO_1)
+AUTO_INIT_MODULE(my_module_d, AUTO_INIT_PRIO_MY_MODULE_D, my_module_d_init);
+
+#define AUTO_INIT_PRIO_MY_GROUP_AFTER   AUTO_INIT_PRIO_ADD_AFTER_GROUP(AUTO_INIT_PRIO_GP_CORE, AUTO_INIT_PRIO_1)
+#define AUTO_INIT_PRIO_MY_MODULE_E      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_MY_GROUP_AFTER, AUTO_INIT_PRIO_1)
+#define AUTO_INIT_PRIO_MY_MODULE_F      AUTO_INIT_PRIO_ADD(AUTO_INIT_PRIO_MY_GROUP_AFTER, AUTO_INIT_PRIO_2)
+AUTO_INIT_MODULE(my_module_e, AUTO_INIT_PRIO_MY_MODULE_E, my_module_e_init);
+AUTO_INIT_MODULE(my_module_f, AUTO_INIT_PRIO_MY_MODULE_F, my_module_f_init);
+
+int main(void)
+{
+    if (_init[0] == 'a' && _init[1] == 'b' &&
+        _init[2] == 'c' && _init[3] == 'd' &&
+        _init[4] == 'e' && _init[5] == 'f') {
+        puts("Success");
+    }
+    else {
+        puts("Failure");
+    }
+}

--- a/tests/auto_init_custom/tests/01-run.py
+++ b/tests/auto_init_custom/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("Success")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/external_module_dirs/external_modules/external_module/external_module.c
+++ b/tests/external_module_dirs/external_modules/external_module/external_module.c
@@ -20,5 +20,19 @@
  */
 
 #include "external_module.h"
+#include "auto_init_priorities.h"
 
+#define AUTO_INIT_PRIO_EXTERNAL_MODULE                          \
+        AUTO_INIT_PRIO_ADD_AFTER_MODULE(AUTO_INIT_PRIO_GP_RNG,  \
+                                        AUTO_INIT_PRIO_RANDOM,  \
+                                        AUTO_INIT_PRIO_1)
+
+AUTO_INIT_MODULE(external_module, AUTO_INIT_PRIO_EXTERNAL_MODULE, auto_init_external_module);
+
+bool external_module_initialized = false;
 char *external_module_message = "Linking worked";
+
+void auto_init_external_module(void)
+{
+    external_module_initialized = true;
+}

--- a/tests/external_module_dirs/external_modules/external_module/include/external_module.h
+++ b/tests/external_module_dirs/external_modules/external_module/include/external_module.h
@@ -20,14 +20,27 @@
 #ifndef EXTERNAL_MODULE_H
 #define EXTERNAL_MODULE_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
+ * @brief   true: this module hase been initialized
+ *          false: this module has not been initialized
+ */
+extern bool external_module_initialized;
+
+/**
  * @brief   A simple string message
  */
 extern char *external_module_message;
+
+/**
+ * @brief   Auto-init function of this module to be called on system start up
+ */
+void auto_init_external_module(void);
 
 #ifdef __cplusplus
 }

--- a/tests/external_module_dirs/main.c
+++ b/tests/external_module_dirs/main.c
@@ -32,7 +32,11 @@
 
 int main(void)
 {
-    puts("If it compiles, it works!");
     printf("Message: %s\n", external_module_message);
+    if (!external_module_initialized) {
+        puts("External module has not been initialized.");
+        return 1;
+    }
+    puts("Initialization worked!");
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR proposes a way to

1. reorder the RIOT auto-init module sequence
2. insert custom auto-init modules

using `Kconfig` and `XFA`.

This could also be useful for some custom boards which must setup some stuff that cannot be done in `board_init()`.
  
### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`tests/auto_init_custom`:
inserts two custom modules A and B that are initialized after `ztimer`.

See also `tests/auto_init_custom/bin/<BOARD>/tests_auto_init_custom.map`
and search for "auto_init_xfa" to look at the auto-init cross file array.

Add `#define ENABLE_DEBUG 1` in `auto_init.c` to print the auto-init sequence of modules.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

See also #16529.