### PR TITLE
drivers/dsp0401: migrate to ztimer

### DIFF
--- a/drivers/dsp0401/Kconfig
+++ b/drivers/dsp0401/Kconfig
@@ -12,4 +12,5 @@ config MODULE_DSP0401
     depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_PWM
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_USEC

--- a/drivers/dsp0401/Makefile.dep
+++ b/drivers/dsp0401/Makefile.dep
@@ -1,3 +1,4 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_pwm

--- a/drivers/dsp0401/dsp0401.c
+++ b/drivers/dsp0401/dsp0401.c
@@ -22,7 +22,8 @@
 #include <string.h>
 
 #include "dsp0401.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "periph/gpio.h"
 #include "periph/pwm.h"
 
@@ -164,11 +165,11 @@ static void _shift_char(const dsp0401_t *dev, uint8_t c)
 
 static void _latch(const dsp0401_t *dev)
 {
-    xtimer_usleep(LATCH_DELAY);
+    ztimer_sleep(ZTIMER_USEC, LATCH_DELAY);
     gpio_set(LAT);
-    xtimer_usleep(LATCH_DELAY);
+    ztimer_sleep(ZTIMER_USEC, LATCH_DELAY);
     gpio_clear(LAT);
-    xtimer_usleep(LATCH_DELAY);
+    ztimer_sleep(ZTIMER_USEC, LATCH_DELAY);
 }
 
 int dsp0401_init(dsp0401_t *dev, const dsp0401_params_t *params)
@@ -238,12 +239,12 @@ void dsp0401_scroll_text(const dsp0401_t *dev, char *text, uint16_t delay)
     for (unsigned i = 0; i < strlen(text); ++i) {
         _shift_char(dev, text[i]);
         _latch(dev);
-        xtimer_msleep(delay);
+        ztimer_sleep(ZTIMER_USEC, delay * US_PER_MS);
     }
 
     for (unsigned i = 0; i < MOD_COUNT * 4; ++i) {
         _shift_char(dev, ' ');
         _latch(dev);
-        xtimer_msleep(delay);
+        ztimer_sleep(ZTIMER_USEC, delay * US_PER_MS);
     }
 }

--- a/tests/driver_dsp0401/Makefile
+++ b/tests/driver_dsp0401/Makefile
@@ -1,6 +1,8 @@
 include ../Makefile.tests_common
 
 USEMODULE += dsp0401
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 
 LOOPS ?= 3
 CFLAGS += -DLOOPS=$(LOOPS)

--- a/tests/driver_dsp0401/app.config.test
+++ b/tests/driver_dsp0401/app.config.test
@@ -1,3 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_DSP0401=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_USEC=y

--- a/tests/driver_dsp0401/main.c
+++ b/tests/driver_dsp0401/main.c
@@ -23,11 +23,12 @@
 
 #include "dsp0401_params.h"
 #include "dsp0401.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 
-#define TEST_DELAY      (2U)               /* 2 seconds delay between each test */
-#define WORD_DELAY      (750U)             /* 750 milliseconds delay between each word */
-#define SCROLL_DELAY    (200U)             /* 200 milliseconds delay between character shift */
+#define TEST_DELAY_US   (2U * US_PER_SEC)  /* 2 seconds delay between each test */
+#define WORD_DELAY_US   (750U * US_PER_MS) /* 750 milliseconds delay between each word */
+#define SCROLL_DELAY_MS (200U)             /* 200 milliseconds delay between character shift */
 #ifndef LOOPS
 #define LOOPS           (3U)               /* Number of display loops before exit */
 #endif
@@ -49,19 +50,19 @@ int main(void)
     while (loop < LOOPS) {
         puts("[INFO] Displaying 'THIS IS RIOT'");
         dsp0401_display_text(&dev, (char*)"THIS");
-        xtimer_msleep(WORD_DELAY);
+        ztimer_sleep(ZTIMER_USEC, WORD_DELAY_US);
         dsp0401_display_text(&dev, (char*)" IS ");
-        xtimer_msleep(WORD_DELAY);
+        ztimer_sleep(ZTIMER_USEC, WORD_DELAY_US);
         dsp0401_display_text(&dev, (char*)"RIOT");
-        xtimer_sleep(TEST_DELAY);
+        ztimer_sleep(ZTIMER_USEC, TEST_DELAY_US);
 
         puts("[INFO] Clearing text!");
         dsp0401_clear_text(&dev);
-        xtimer_sleep(TEST_DELAY);
+        ztimer_sleep(ZTIMER_USEC, TEST_DELAY_US);
 
         puts("[INFO] Scrolling 'THIS IS RIOT'");
-        dsp0401_scroll_text(&dev, (char*)("THIS IS RIOT"), SCROLL_DELAY);
-        xtimer_sleep(TEST_DELAY);
+        dsp0401_scroll_text(&dev, (char*)("THIS IS RIOT"), SCROLL_DELAY_MS);
+        ztimer_sleep(ZTIMER_USEC, TEST_DELAY_US);
         puts("[INFO] Done\n");
         ++loop;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the dsp0401 (16 segment alphanumeric LED display) driver to ztimer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Test application should still work (let's see if I can wire-up my module and try by the end of the week)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
