### PR TITLE
drivers/rn2xx3: migrate to ztimer

### DIFF
--- a/drivers/include/rn2xx3.h
+++ b/drivers/include/rn2xx3.h
@@ -23,7 +23,7 @@
 
 #include <stdint.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "periph/uart.h"
 #include "periph/gpio.h"
 #include "net/netdev.h"
@@ -189,7 +189,7 @@ typedef struct {
     uint16_t rx_size;                  /**< counter for received char in RX */
 
     /* timers */
-    xtimer_t sleep_timer;              /**< Timer used to count module sleep time */
+    ztimer_t sleep_timer;              /**< Timer used to count module sleep time */
     uint32_t sleep;                    /**< module sleep duration */
 } rn2xx3_t;
 

--- a/drivers/rn2xx3/Kconfig
+++ b/drivers/rn2xx3/Kconfig
@@ -30,7 +30,8 @@ config MODULE_RN2XX3
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_UART
     select MODULE_FMT
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
 
 endif # TEST_KCONFIG
 

--- a/drivers/rn2xx3/Makefile.dep
+++ b/drivers/rn2xx3/Makefile.dep
@@ -1,4 +1,5 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_uart
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 USEMODULE += fmt

--- a/drivers/rn2xx3/include/rn2xx3_params.h
+++ b/drivers/rn2xx3/include/rn2xx3_params.h
@@ -19,6 +19,7 @@
 #ifndef RN2XX3_PARAMS_H
 #define RN2XX3_PARAMS_H
 
+#include "board.h"
 #include "rn2xx3.h"
 
 #ifdef __cplusplus

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -22,7 +22,7 @@
 #include <errno.h>
 
 #include "assert.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "fmt.h"
 #include "kernel_defines.h"
 
@@ -40,7 +40,7 @@
 /**
  * @brief   Delay when resetting the device, 10ms
  */
-#define RESET_DELAY     (10UL * US_PER_MS)
+#define RESET_DELAY     (10UL)
 
 /*
  * Interrupt callbacks
@@ -166,7 +166,7 @@ int rn2xx3_init(rn2xx3_t *dev)
     /* if reset pin is connected, do a hardware reset */
     if (gpio_is_valid(dev->p.pin_reset)) {
         gpio_clear(dev->p.pin_reset);
-        xtimer_usleep(RESET_DELAY);
+        ztimer_sleep(ZTIMER_MSEC, RESET_DELAY);
         gpio_set(dev->p.pin_reset);
     }
 
@@ -233,7 +233,7 @@ int rn2xx3_sys_sleep(rn2xx3_t *dev)
 
     /* Wait a little to check if the device could go to sleep. No answer means
        it worked. */
-    xtimer_msleep(1);
+    ztimer_sleep(ZTIMER_MSEC, 1);
 
     DEBUG("[rn2xx3] RESP: %s\n", dev->resp_buf);
     if (rn2xx3_process_response(dev) == RN2XX3_ERR_INVALID_PARAM) {
@@ -242,7 +242,7 @@ int rn2xx3_sys_sleep(rn2xx3_t *dev)
     }
 
     rn2xx3_set_internal_state(dev, RN2XX3_INT_STATE_SLEEP);
-    xtimer_set(&dev->sleep_timer, dev->sleep * US_PER_MS);
+    ztimer_set(ZTIMER_MSEC, &dev->sleep_timer, dev->sleep);
 
     return RN2XX3_OK;
 }

--- a/drivers/rn2xx3/rn2xx3_internal.c
+++ b/drivers/rn2xx3/rn2xx3_internal.c
@@ -22,6 +22,9 @@
 #include <string.h>
 
 #include "fmt.h"
+#include "timex.h"
+#include "ztimer.h"
+
 #include "rn2xx3_internal.h"
 
 #define ENABLE_DEBUG 0
@@ -51,22 +54,21 @@ static bool _wait_reply(rn2xx3_t *dev, uint8_t timeout)
     dev->resp_size = 0;
     dev->resp_buf[0] = 0;
 
-    xtimer_ticks64_t sent_time = xtimer_now64();
+    ztimer_now_t sent_time = ztimer_now(ZTIMER_MSEC);
 
-    xtimer_t resp_timer;
+    ztimer_t resp_timer;
     resp_timer.callback = isr_resp_timeout;
     resp_timer.arg = dev;
 
-    xtimer_set(&resp_timer, (uint32_t)timeout * US_PER_SEC);
+    ztimer_set(ZTIMER_MSEC, &resp_timer, (uint32_t)timeout * MS_PER_SEC);
 
     /* wait for results */
     while ((!dev->resp_done) &&
-           xtimer_less(xtimer_diff32_64(xtimer_now64(), sent_time),
-                                        xtimer_ticks_from_usec(timeout * US_PER_SEC))) {
+        ((int32_t)(sent_time + (timeout * MS_PER_SEC) - ztimer_now(ZTIMER_MSEC)) > 0)) {
         mutex_lock(&(dev->resp_lock));
     }
 
-    xtimer_remove(&resp_timer);
+    ztimer_remove(ZTIMER_MSEC, &resp_timer);
 
     if (dev->resp_done == 0) {
         DEBUG("[rn2xx3] response timeout\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the rn2xx3 lora driver to ztimer. Like in #17105 there are use of ticks conversion not directly available in ztimer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- Driver is still functional (I might be able to test this by the end of this week and will report there)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#17111 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
