### PR TITLE
sys/ztimer: don't default to rtc for ztimer_sec

### DIFF
--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -74,8 +74,6 @@ config MODULE_ZTIMER_SEC
 choice
     bool "Backend"
     depends on MODULE_ZTIMER_SEC
-    default ZTIMER_SEC_BACKEND_RTC if !BOARD_NATIVE && \
-                                      !HAVE_SHARED_PERIPH_RTT_PERIPH_RTC
     default ZTIMER_SEC_BACKEND_RTT
 
 config ZTIMER_SEC_BACKEND_TIMER

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -111,24 +111,11 @@ endif
 
 ifneq (,$(filter ztimer_sec,$(USEMODULE)))
   USEMODULE += ztimer
-  # try to use RTC unless we are on native, as it is based on xtimer it is
-  # actually buggy
-  ifeq (,$(filter native,$(BOARD)))
-    FEATURES_OPTIONAL += periph_rtc
-  endif
+  FEATURES_OPTIONAL += periph_rtt
   # HACK: see above
-  include $(RIOTMAKE)/features_check.inc.mk
-  ifneq (,$(filter periph_rtc,$(FEATURES_USED)))
-    USEMODULE += ztimer_periph_rtc
+  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
+    USEMODULE += ztimer_periph_rtt
   else
-    # if there is no RTC try to use RTT
-    FEATURES_OPTIONAL += periph_rtt
-    # HACK: see above
-    include $(RIOTMAKE)/features_check.inc.mk
-    ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
-      USEMODULE += ztimer_periph_rtt
-    else
-      USEMODULE += ztimer_periph_timer
-    endif
+    USEMODULE += ztimer_periph_timer
   endif
 endif


### PR DESCRIPTION
### Contribution description

As mentioned in https://github.com/RIOT-OS/RIOT/pull/17099 auto-select rtc for `ztimer_sec` done in https://github.com/RIOT-OS/RIOT/pull/16909 seems to not be a good idea, this reverts that change while still preferring `rtt` over `periph_timer`.

### Testing procedure

- green murdock
