### PR TITLE
drivers/xbee: migrate to ztimer_msec

### DIFF
--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -26,7 +26,6 @@
 #include <stdint.h>
 
 #include "mutex.h"
-#include "xtimer.h"
 #include "periph/uart.h"
 #include "periph/gpio.h"
 #include "net/netdev.h"

--- a/drivers/xbee/Makefile.dep
+++ b/drivers/xbee/Makefile.dep
@@ -1,4 +1,5 @@
 FEATURES_REQUIRED += periph_uart
 FEATURES_REQUIRED += periph_gpio
 USEMODULE += ieee802154
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec

--- a/drivers/xbee/include/xbee_params.h
+++ b/drivers/xbee/include/xbee_params.h
@@ -43,8 +43,8 @@ extern "C" {
 #endif
 
 #ifndef XBEE_PARAMS
-#define XBEE_PARAMS             { .uart      = XBEE_PARAM_UART, \
-                                  .br        = XBEE_PARAM_BR, \
+#define XBEE_PARAMS             { .uart = XBEE_PARAM_UART, \
+                                  .br = XBEE_PARAM_BR, \
                                   .pin_sleep = XBEE_PARAM_PIN_SLEEP, \
                                   .pin_reset = XBEE_PARAM_PIN_RESET }
 #endif

--- a/tests/driver_netdev_common/main.c
+++ b/tests/driver_netdev_common/main.c
@@ -29,10 +29,12 @@ int main(void)
     /* enable pktdump output */
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                           gnrc_pktdump_pid);
+
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     /* start the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
+
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -1,6 +1,6 @@
 USEMODULE += xbee
 
 # No need of big buffer for this test
-GNRC_PKTBUF_SIZE=512
+GNRC_PKTBUF_SIZE ?= 512
 
 include ../driver_netdev_common/Makefile.netdev.mk


### PR DESCRIPTION

### Contribution description

This PR makes `xbee` use `ztimer_msec` instead of `xtimer`.

### Testing procedure

I ran the release test spec between `arduino_zero` + `xbee` and `samr21-xpro`

- master

```
2021-11-02 16:59:24,939 # 58 bytes from fe80::213:a200:40c2:d4c4%6: icmp_seq=999 ttl=64 rssi=-52 dBm time=171.931 ms
2021-11-02 16:59:25,759 #
2021-11-02 16:59:25,763 # --- fe80::213:a200:40c2:d4c4 PING statistics ---
2021-11-02 16:59:25,768 # 1000 packets transmitted, 963 packets received, 3% packet loss
2021-11-02 16:59:25,773 # round-trip min/avg/max = 170.971/172.520/213.558 ms
```

- pr

```
2021-11-02 16:56:06,125 #
2021-11-02 16:56:06,129 # --- fe80::213:a200:40c2:d4c4 PING statistics ---
2021-11-02 16:56:06,135 # 1000 packets transmitted, 965 packets received, 3% packet loss
2021-11-02 16:56:06,140 # round-trip min/avg/max = 170.971/172.525/210.119 ms
```

### Issues/PRs references

Ticks items off https://github.com/RIOT-OS/RIOT/issues/17111 and https://github.com/RIOT-OS/RIOT/issues/13667
