### PR TITLE
pkg/lwip: use ztimer_msec instead of xtimer

### DIFF
--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -87,7 +87,7 @@ endif
 
 ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   USEMODULE += sema
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter lwip_netif,$(USEMODULE)))

--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -28,7 +28,7 @@
 #include "msg.h"
 #include "sema.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define _MSG_SUCCESS    (0x5cac)
 #define _MSG_TIMEOUT    (0x5cad)
@@ -40,7 +40,7 @@ void sys_init(void)
 
 u32_t sys_now(void)
 {
-    return (uint32_t)(xtimer_now_usec64() / US_PER_MS);
+    return ztimer_now(ZTIMER_MSEC);
 }
 
 err_t sys_mutex_new(sys_mutex_t *mutex)
@@ -85,14 +85,14 @@ u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t count)
 {
     LWIP_ASSERT("invalid semaphore", sys_sem_valid(sem));
     if (count != 0) {
-        uint64_t stop, start;
-        start = xtimer_now_usec64();
-        int res = sema_wait_timed((sema_t *)sem, count * US_PER_MS);
-        stop = xtimer_now_usec64() - start;
+        uint32_t stop, start;
+        start = ztimer_now(ZTIMER_MSEC);
+        int res = sema_wait_timed_ztimer((sema_t *)sem, ZTIMER_MSEC, count);
+        stop = ztimer_now(ZTIMER_MSEC);
         if (res == -ETIMEDOUT) {
             return SYS_ARCH_TIMEOUT;
         }
-        return (u32_t)(stop / US_PER_MS);
+        return stop - start;
     }
     else {
         sema_wait((sema_t *)sem);
@@ -142,21 +142,20 @@ static void _mbox_timeout(void *arg)
 u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout)
 {
     msg_t m;
-    xtimer_t timer = { .callback = _mbox_timeout, .arg = &mbox->mbox };
-    uint64_t start, stop;
+    ztimer_t timer = { .callback = _mbox_timeout, .arg = &mbox->mbox };
+    uint32_t start, stop;
 
-    start = xtimer_now_usec64();
+    start = ztimer_now(ZTIMER_MSEC);
     if (timeout > 0) {
-        uint64_t u_timeout = (timeout * US_PER_MS);
-        xtimer_set64(&timer, u_timeout);
+        ztimer_set(ZTIMER_MSEC, &timer, timeout);
     }
     mbox_get(&mbox->mbox, &m);
-    stop = xtimer_now_usec64();
-    xtimer_remove(&timer);  /* in case timer did not time out */
+    stop = ztimer_now(ZTIMER_MSEC);
+    ztimer_remove(ZTIMER_MSEC, &timer);  /* in case timer did not time out */
     switch (m.type) {
         case _MSG_SUCCESS:
             *msg = m.content.ptr;
-            return (u32_t)((stop - start) / US_PER_MS);
+            return stop - start;
         case _MSG_TIMEOUT:
             break;
         default:    /* should not happen */

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -31,6 +31,7 @@ USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += od
 USEMODULE += netdev_default
+USEMODULE += ztimer_usec
 
 ifeq ($(BOARD),native)
   USEMODULE += lwip_ethernet

--- a/tests/lwip/ip.c
+++ b/tests/lwip/ip.c
@@ -29,7 +29,7 @@
 #include "shell.h"
 #include "thread.h"
 #include "test_utils/expect.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_SOCK_IP
 static char sock_inbuf[SOCK_INBUF_SIZE];
@@ -57,20 +57,26 @@ static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 
             printf("Received IP data from ");
             switch (src.family) {
-#if IS_USED(MODULE_LWIP_IPV4)
                 case AF_INET:
+#if IS_USED(MODULE_LWIP_IPV4)
                     printf("[%s]:\n",
                            ipv4_addr_to_str(addrstr,
                                             (ipv4_addr_t *)&src.addr.ipv4,
                                             sizeof(addrstr)));
                     break;
+#else
+                    printf("unsupported protocol IPV4\n");
+                    break;
 #endif
-#if IS_USED(MODULE_LWIP_IPV6)
                 case AF_INET6:
+#if IS_USED(MODULE_LWIP_IPV6)
                     printf("[%s]:\n",
                            ipv6_addr_to_str(addrstr,
                                             (ipv6_addr_t *)&src.addr.ipv6,
                                             sizeof(addrstr)));
+                    break;
+#else
+                    printf("unsupported protocol IPV6\n");
                     break;
 #endif
                 default:
@@ -154,7 +160,7 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
                    (dst.family == AF_INET6) ? "IPv6" : "IPv4",
                    addr_str, protocol);
         }
-        xtimer_usleep(delay);
+        ztimer_sleep(ZTIMER_USEC, delay);
     }
     return 0;
 }

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -29,7 +29,7 @@
 #include "shell.h"
 #include "test_utils/expect.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_SOCK_TCP
 static char sock_inbuf[SOCK_INBUF_SIZE];
@@ -174,7 +174,7 @@ static int tcp_send(char *data, unsigned int num, unsigned int delay)
         else {
             printf("Success: send %u byte over TCP to server\n", (unsigned)data_len);
         }
-        xtimer_usleep(delay);
+        ztimer_sleep(ZTIMER_USEC, delay);
     }
     return 0;
 }

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -29,7 +29,7 @@
 #include "shell.h"
 #include "test_utils/expect.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_SOCK_UDP
 static char sock_inbuf[SOCK_INBUF_SIZE];
@@ -121,7 +121,7 @@ static int udp_send(char *addr_str, char *data, unsigned int num,
             printf("Success: send %u byte over UDP to %s\n",
                    (unsigned)data_len, addr_str);
         }
-        xtimer_usleep(delay);
+        ztimer_sleep(ZTIMER_USEC, delay);
     }
     return 0;
 }

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -25,7 +25,7 @@
 
 #include "net/sock/ip.h"
 #include "test_utils/expect.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "constants.h"
 #include "stack.h"
@@ -421,7 +421,7 @@ static void test_sock_ip_send4__socketed_no_local_no_netif(void)
                                           _TEST_PROTO, NULL));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -438,7 +438,7 @@ static void test_sock_ip_send4__socketed_no_netif(void)
                                           _TEST_PROTO, NULL));
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -454,7 +454,7 @@ static void test_sock_ip_send4__socketed_no_local(void)
                                           _TEST_PROTO, NULL));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -472,7 +472,7 @@ static void test_sock_ip_send4__socketed(void)
                                           _TEST_PROTO, NULL));
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -492,7 +492,7 @@ static void test_sock_ip_send4__socketed_other_remote(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -507,7 +507,7 @@ static void test_sock_ip_send4__unsocketed_no_local_no_netif(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -524,7 +524,7 @@ static void test_sock_ip_send4__unsocketed_no_netif(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -540,7 +540,7 @@ static void test_sock_ip_send4__unsocketed_no_local(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -558,7 +558,7 @@ static void test_sock_ip_send4__unsocketed(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -571,7 +571,7 @@ static void test_sock_ip_send4__no_sock_no_netif(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -585,7 +585,7 @@ static void test_sock_ip_send4__no_sock(void)
                                           _TEST_PROTO, &remote));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 #endif  /* MODULE_LWIP_IPV4 */
@@ -993,7 +993,7 @@ static void test_sock_ip_send6__socketed_no_local_no_netif(void)
                                           _TEST_PROTO, NULL));
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1012,7 +1012,7 @@ static void test_sock_ip_send6__socketed_no_netif(void)
                                           _TEST_PROTO, NULL));
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1029,7 +1029,7 @@ static void test_sock_ip_send6__socketed_no_local(void)
                                           _TEST_PROTO, NULL));
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1049,7 +1049,7 @@ static void test_sock_ip_send6__socketed(void)
                                           _TEST_PROTO, NULL));
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1071,7 +1071,7 @@ static void test_sock_ip_send6__socketed_other_remote(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1087,7 +1087,7 @@ static void test_sock_ip_send6__unsocketed_no_local_no_netif(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1106,7 +1106,7 @@ static void test_sock_ip_send6__unsocketed_no_netif(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1123,7 +1123,7 @@ static void test_sock_ip_send6__unsocketed_no_local(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1143,7 +1143,7 @@ static void test_sock_ip_send6__unsocketed(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1157,7 +1157,7 @@ static void test_sock_ip_send6__no_sock_no_netif(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), SOCK_ADDR_ANY_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1172,7 +1172,7 @@ static void test_sock_ip_send6__no_sock(void)
                                           _TEST_PROTO, &remote));
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 #endif  /* MODULE_LWIP_IPV6 */

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -23,7 +23,8 @@
 #include "net/sock.h"
 #include "sched.h"
 #include "test_utils/expect.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 
 #include "lwip.h"
 #include "lwip/ip4.h"
@@ -181,7 +182,7 @@ void _net_init(void)
 #endif
     netif_set_default(&netif);
     lwip_bootstrap();
-    xtimer_sleep(3);    /* Let the auto-configuration run warm */
+    ztimer_sleep(ZTIMER_MSEC, 3 * MS_PER_SEC);    /* Let the auto-configuration run warm */
 }
 
 void _prepare_send_checks(void)

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -28,7 +28,8 @@
 #include "sched.h"
 #include "test_utils/expect.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 
 #include "constants.h"
 #include "stack.h"
@@ -515,7 +516,7 @@ static void test_tcp_write4__success(void)
     expect(((ssize_t)exp_data.iov_len) == sock_tcp_write(&_sock, "Hello!",
                                                         sizeof("Hello!")));
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
-    xtimer_usleep(5000);            /* wait for server */
+    ztimer_sleep(ZTIMER_MSEC, 5);            /* wait for server */
 }
 #endif /* MODULE_LWIP_IPV4 */
 
@@ -947,7 +948,7 @@ static void test_tcp_write6__success(void)
     expect(((ssize_t)exp_data.iov_len) == sock_tcp_write(&_sock, "Hello!",
                                                         sizeof("Hello!")));
     expect(memcmp(exp_data.iov_base, _test_buffer, exp_data.iov_len) == 0);
-    xtimer_usleep(5000);            /* wait for server */
+    ztimer_sleep(ZTIMER_MSEC, 5);            /* wait for server */
 }
 #endif /* MODULE_LWIP_IPV6 */
 

--- a/tests/lwip_sock_tcp/stack.c
+++ b/tests/lwip_sock_tcp/stack.c
@@ -13,9 +13,6 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @}
  */
-
-#include "xtimer.h"
-
 #include "lwip.h"
 #include "lwip/netif.h"
 

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -25,7 +25,7 @@
 
 #include "net/sock/udp.h"
 #include "test_utils/expect.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "constants.h"
 #include "stack.h"
@@ -525,7 +525,7 @@ static void test_sock_udp_send4__socketed_no_local_no_netif(void)
                                            NULL));
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0, _TEST_PORT_REMOTE,
                           "ABCD", sizeof("ABCD"), SOCK_ADDR_ANY_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -544,7 +544,7 @@ static void test_sock_udp_send4__socketed_no_netif(void)
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -561,7 +561,7 @@ static void test_sock_udp_send4__socketed_no_local(void)
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -581,7 +581,7 @@ static void test_sock_udp_send4__socketed(void)
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -604,7 +604,7 @@ static void test_sock_udp_send4__socketed_other_remote(void)
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -620,7 +620,7 @@ static void test_sock_udp_send4__unsocketed_no_local_no_netif(void)
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -639,7 +639,7 @@ static void test_sock_udp_send4__unsocketed_no_netif(void)
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -656,7 +656,7 @@ static void test_sock_udp_send4__unsocketed_no_local(void)
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -676,7 +676,7 @@ static void test_sock_udp_send4__unsocketed(void)
     expect(_check_4packet(_TEST_ADDR4_LOCAL, _TEST_ADDR4_REMOTE, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -691,7 +691,7 @@ static void test_sock_udp_send4__no_sock_no_netif(void)
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -707,7 +707,7 @@ static void test_sock_udp_send4__no_sock(void)
     expect(_check_4packet(0, _TEST_ADDR4_REMOTE, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 #endif /* MODULE_LWIP_IPV4 */
@@ -1223,7 +1223,7 @@ static void test_sock_udp_send6__socketed_no_local_no_netif(void)
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1244,7 +1244,7 @@ static void test_sock_udp_send6__socketed_no_netif(void)
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1262,7 +1262,7 @@ static void test_sock_udp_send6__socketed_no_local(void)
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1284,7 +1284,7 @@ static void test_sock_udp_send6__socketed(void)
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1316,7 +1316,7 @@ static void test_sock_udp_sendv6__socketed(void)
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                          _TEST_PORT_REMOTE, "ABCDEFGH", sizeof("ABCDEFGH"),
                          _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let GNRC stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let GNRC stack finish */
     expect(_check_net());
 }
 
@@ -1341,7 +1341,7 @@ static void test_sock_udp_send6__socketed_other_remote(void)
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1358,7 +1358,7 @@ static void test_sock_udp_send6__unsocketed_no_local_no_netif(void)
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1379,7 +1379,7 @@ static void test_sock_udp_send6__unsocketed_no_netif(void)
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1397,7 +1397,7 @@ static void test_sock_udp_send6__unsocketed_no_local(void)
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"), _TEST_NETIF,
                           true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1419,7 +1419,7 @@ static void test_sock_udp_send6__unsocketed(void)
     expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, false));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1435,7 +1435,7 @@ static void test_sock_udp_send6__no_sock_no_netif(void)
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           SOCK_ADDR_ANY_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 
@@ -1452,7 +1452,7 @@ static void test_sock_udp_send6__no_sock(void)
     expect(_check_6packet(&ipv6_addr_unspecified, &dst_addr, 0,
                           _TEST_PORT_REMOTE, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF, true));
-    xtimer_usleep(1000);    /* let lwIP stack finish */
+    ztimer_sleep(ZTIMER_MSEC, 1);    /* let lwIP stack finish */
     expect(_check_net());
 }
 #endif /* MODULE_LWIP_IPV6 */

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -24,7 +24,8 @@
 #include "net/udp.h"
 #include "sched.h"
 #include "test_utils/expect.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 
 #include "lwip.h"
 #include "lwip/ip4.h"
@@ -184,7 +185,7 @@ void _net_init(void)
 #endif
     netif_set_default(&netif);
     lwip_bootstrap();
-    xtimer_sleep(3);    /* Let the auto-configuration run warm */
+    ztimer_sleep(ZTIMER_MSEC, 3 * MS_PER_SEC);    /* Let the auto-configuration run warm */
 }
 
 void _prepare_send_checks(void)


### PR DESCRIPTION
### Contribution description

This package changes `lwip` to use `ztimer_msec` instead of `xtimer`.

### Testing procedure

Run all `tests/lwip*` tests


- `test/lwip_sock_ip`

```
main(): This is RIOT! (Version: 2022.01-devel-323-g3f03ac-pr_lwip_use_ztimer)
code 0x41
Calling test_sock_ip_create6__EAFNOSUPPORT()
Calling test_sock_ip_create6__EINVAL_addr()
Calling test_sock_ip_create6__EINVAL_netif()
Calling test_sock_ip_create6__no_endpoints()
Calling test_sock_ip_create6__only_local()
Calling test_sock_ip_create6__only_local_reuse_ep()
Calling test_sock_ip_create6__only_remote()
Calling test_sock_ip_create6__full()
Calling test_sock_ip_recv6__EADDRNOTAVAIL()
Calling test_sock_ip_recv6__EAGAIN()
Calling test_sock_ip_recv6__ENOBUFS()
Calling test_sock_ip_recv6__ETIMEDOUT()
 * Calling sock_ip_recv()
 * (timed out with timeout 1000000)
Calling test_sock_ip_recv6__socketed()
Calling test_sock_ip_recv6__socketed_with_remote()
Calling test_sock_ip_recv6__unsocketed()
Calling test_sock_ip_recv6__unsocketed_with_remote()
Calling test_sock_ip_recv6__with_timeout()
Calling test_sock_ip_recv6__non_blocking()
Calling test_sock_ip_recv6__aux()
Calling test_sock_ip_recv_buf6__success()
Calling test_sock_ip_send6__EAFNOSUPPORT()
Calling test_sock_ip_send6__EINVAL_addr()
Calling test_sock_ip_send6__EINVAL_netif()
Calling test_sock_ip_send6__EHOSTUNREACH()
Calling test_sock_ip_send6__ENOTCONN()
Calling test_sock_ip_send6__socketed_no_local_no_netif()
Calling test_sock_ip_send6__socketed_no_netif()
Calling test_sock_ip_send6__socketed_no_local()
Calling test_sock_ip_send6__socketed()
Calling test_sock_ip_send6__socketed_other_remote()
Calling test_sock_ip_send6__unsocketed_no_local_no_netif()
Calling test_sock_ip_send6__unsocketed_no_netif()
Calling test_sock_ip_send6__unsocketed_no_local()
Calling test_sock_ip_send6__unsocketed()
Calling test_sock_ip_send6__no_sock_no_netif()
Calling test_sock_ip_send6__no_sock()
ALL TESTS SUCCESSFUL

```

- `test/lwip_sock_udp`

```
main(): This is RIOT! (Version: 2022.01-devel-323-g3f03ac-pr_lwip_use_ztimer)
code 0x41
Calling test_sock_udp_create6__EADDRINUSE()
Calling test_sock_udp_create6__EAFNOSUPPORT()
Calling test_sock_udp_create6__EINVAL_addr()
Calling test_sock_udp_create6__EINVAL_netif()
Calling test_sock_udp_create6__no_endpoints()
Calling test_sock_udp_create6__only_local()
Calling test_sock_udp_create6__only_local_port0()
Calling test_sock_udp_create6__only_local_reuse_ep()
Calling test_sock_udp_create6__only_remote()
Calling test_sock_udp_create6__full()
Calling test_sock_udp_recv6__EADDRNOTAVAIL()
Calling test_sock_udp_recv6__EAGAIN()
Calling test_sock_udp_recv6__ENOBUFS()
Calling test_sock_udp_recv6__ETIMEDOUT()
 * Calling sock_udp_recv()
 * (timed out with timeout 1000000)
Calling test_sock_udp_recv6__socketed()
Calling test_sock_udp_recv6__socketed_with_remote()
Calling test_sock_udp_recv6__socketed_with_port0()
Calling test_sock_udp_recv6__unsocketed()
Calling test_sock_udp_recv6__unsocketed_with_remote()
Calling test_sock_udp_recv6__with_timeout()
Calling test_sock_udp_recv6__non_blocking()
Calling test_sock_udp_recv6__aux()
Calling test_sock_udp_recv_buf6__success()
Calling test_sock_udp_send6__EAFNOSUPPORT()
Calling test_sock_udp_send6__EINVAL_addr()
Calling test_sock_udp_send6__EINVAL_netif()
Calling test_sock_udp_send6__EINVAL_port()
Calling test_sock_udp_send6__EHOSTUNREACH()
Calling test_sock_udp_send6__ENOTCONN()
Calling test_sock_udp_send6__socketed_no_local_no_netif()
Calling test_sock_udp_send6__socketed_no_netif()
Calling test_sock_udp_send6__socketed_no_local()
Calling test_sock_udp_send6__socketed()
Calling test_sock_udp_send6__socketed_other_remote()
Calling test_sock_udp_send6__unsocketed_no_local_no_netif()
Calling test_sock_udp_send6__unsocketed_no_netif()
Calling test_sock_udp_send6__unsocketed_no_local()
Calling test_sock_udp_send6__unsocketed()
Calling test_sock_udp_send6__no_sock_no_netif()
Calling test_sock_udp_send6__no_sock()
ALL TESTS SUCCESSFUL

```

- `test/lwip_sock_tcp`
```
main(): This is RIOT! (Version: 2022.01-devel-323-g0a10d-pr_lwip_use_ztimer)
code 0x41
Calling test_tcp_connect6__EADDRINUSE()
Calling test_tcp_connect6__EAFNOSUPPORT()
Calling test_tcp_connect6__EINVAL_addr()
Calling test_tcp_connect6__EINVAL_netif()
Calling test_tcp_connect6__success_without_port()
Calling test_tcp_connect6__success_local_port()
Calling test_tcp_listen6__EADDRINUSE()
Calling test_tcp_listen6__EAFNOSUPPORT()
Calling test_tcp_listen6__EINVAL()
Calling test_tcp_listen6__success_any_netif()
Calling test_tcp_listen6__success_spec_netif()
Calling test_tcp_accept6__EAGAIN()
Calling test_tcp_accept6__EINVAL()
Calling test_tcp_accept6__ETIMEDOUT()
 * Calling sock_tcp_accept()
 * (timed out with timeout 1000000)
Calling test_tcp_accept6__success()
Calling test_tcp_read6__EAGAIN()
Calling test_tcp_read6__ECONNRESET()
Calling test_tcp_read6__ENOTCONN()
Calling test_tcp_read6__ETIMEDOUT()
 * Calling sock_tcp_read()
 * (timed out with timeout 1000000)
Calling test_tcp_read6__success()
Calling test_tcp_read6__success_with_timeout()
Calling test_tcp_read6__success_non_blocking()
Calling test_tcp_write6__ENOTCONN()
Calling test_tcp_write6__success()
ALL TESTS SUCCESSFUL
```

### Related Issues

Ticks item off https://github.com/RIOT-OS/RIOT/issues/13667