### PR TITLE
pkg/semtech-loramac: fix get/set dr command

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -155,7 +155,7 @@ void semtech_loramac_set_dr(semtech_loramac_t *mac, uint8_t dr)
     mutex_lock(&mac->lock);
     DEBUG("[semtech-loramac] set dr %d\n", dr);
     MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_CHANNELS_DEFAULT_DATARATE;
+    mibReq.Type = MIB_CHANNELS_DATARATE;
     mibReq.Param.ChannelsDatarate = dr;
     LoRaMacMibSetRequestConfirm(&mibReq);
     mutex_unlock(&mac->lock);
@@ -167,7 +167,7 @@ uint8_t semtech_loramac_get_dr(semtech_loramac_t *mac)
     DEBUG("[semtech-loramac] get dr\n");
     uint8_t datarate;
     MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_CHANNELS_DEFAULT_DATARATE;
+    mibReq.Type = MIB_CHANNELS_DATARATE;
     LoRaMacMibGetRequestConfirm(&mibReq);
     datarate = (uint8_t)mibReq.Param.ChannelsDatarate;
     mutex_unlock(&mac->lock);

--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -334,7 +334,6 @@ void semtech_loramac_set_rx2_freq(semtech_loramac_t *mac, uint32_t freq)
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_RX2_DEFAULT_CHANNEL;
     LoRaMacMibGetRequestConfirm(&mibReq);
-    p.Frequency = freq;
     p.Datarate = mibReq.Param.Rx2DefaultChannel.Datarate;
     semtech_loramac_channel_params_t params;
     params.frequency = freq;
@@ -364,7 +363,6 @@ void semtech_loramac_set_rx2_dr(semtech_loramac_t *mac, uint8_t dr)
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_RX2_DEFAULT_CHANNEL;
     LoRaMacMibGetRequestConfirm(&mibReq);
-    p.Datarate = dr;
     p.Frequency = mibReq.Param.Rx2DefaultChannel.Frequency;
     semtech_loramac_channel_params_t params;
     params.datarate = dr;


### PR DESCRIPTION

### Contribution description

This PR fixes the issue reported in #17056. For the get/set the default values where being fetched.

### Testing procedure

See testing procedure in #17056:

```
2021-11-02 21:56:44,254 # main(): This is RIOT! (Version: 2022.01-devel-322-g49cec-HEAD)
2021-11-02 21:56:44,256 # All up, running the shell now
> loramac join otaa
2021-11-02 21:56:47,804 # loramac join otaa
2021-11-02 21:56:56,172 # Join procedure succeeded!
loramac link_check
2021-11-02 21:57:02,469 # loramac link_check
2021-11-02 21:57:02,471 # Link check request scheduled
loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:57:04,975 # loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:57:13,000 # Link check information:
2021-11-02 21:57:13,002 #   - Demodulation margin: 27
2021-11-02 21:57:13,005 #   - Number of gateways: 2
2021-11-02 21:57:13,007 # Received ACK from network
2021-11-02 21:57:13,009 # Message sent with success
> loramac get dr
2021-11-02 21:57:23,789 # loramac get dr
2021-11-02 21:57:23,790 # DATARATE: 0
> loramac set adr on
2021-11-02 21:57:27,309 # loramac set adr on
loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:57:37,999 # loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:57:38,003 # Cannot send: dutycycle restriction
> loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:58:11,430 # loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:58:11,434 # Cannot send: dutycycle restriction
> loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:58:42,111 # loramac tx This\ is\ RIOT! cnf 2
2021-11-02 21:58:42,115 # Cannot send: dutycycle restriction
> loramac tx This\ is\ RIOT! cnf 2
2021-11-02 22:01:00,662 # loramac tx This\ is\ RIOT! cnf 2
2021-11-02 22:01:08,690 # Received ACK from network
2021-11-02 22:01:08,692 # Message sent with success
> loramac get dr
2021-11-02 22:01:19,404 # loramac get dr
2021-11-02 22:01:19,406 # DATARATE: 4
> loramac ger adr
2021-11-02 22:01:23,524 # loramac ger adr
```

### Issues/PRs references

Fixes #17056 