### PR TITLE
SECURITY.md: fix broken email reference

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ to the previous release.
 
 If a security issue is discovered, please report it to security@riot-os.org.
 A response will be provided within one week.
-The issue will be tracked in the [security mailing list](security@riot-os.org).
+The issue will be tracked in the [security mailing list](mailto:security@riot-os.org).
 The original reporter will be included in the discussion of the issue.
 
 ## Notification of a Vulnerability


### PR DESCRIPTION
### Contribution description

the `mailto` was missing in the following reference: `The issue will be tracked in the [security mailing list](mailto:security@riot-os.org).`


### Testing procedure

follow the reference in "security mailing list".
