### PR TITLE
pkg/openthread: migrate to ztimer

### DIFF
--- a/pkg/openthread/Makefile.dep
+++ b/pkg/openthread/Makefile.dep
@@ -3,7 +3,8 @@ USEMODULE += openthread_contrib
 USEMODULE += netdev
 USEMODULE += openthread_contrib_netdev
 USEMODULE += l2util
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 USEMODULE += event
 
 FEATURES_REQUIRED += cpp

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -21,7 +21,6 @@
 #include "ot.h"
 #include "random.h"
 #include "thread.h"
-#include "xtimer.h"
 
 #ifdef MODULE_AT86RF2XX
 #include "at86rf2xx.h"

--- a/pkg/openthread/contrib/platform_alarm.c
+++ b/pkg/openthread/contrib/platform_alarm.c
@@ -22,8 +22,7 @@
 #include "openthread/platform/alarm-milli.h"
 #include "ot.h"
 #include "thread.h"
-#include "xtimer.h"
-#include "timex.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -44,7 +43,7 @@ void _timeout_cb(void *arg)
     event_post(openthread_get_evq(), &ev_timer);
 }
 
-static xtimer_t ot_timer = {
+static ztimer_t ot_timer = {
     .callback = _timeout_cb,
 };
 
@@ -66,8 +65,7 @@ void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
         event_post(openthread_get_evq(), &ev_timer);
     }
     else {
-        int dt = aDt * US_PER_MS;
-        xtimer_set(&ot_timer, dt);
+        ztimer_set(ZTIMER_MSEC, &ot_timer, aDt);
     }
 }
 
@@ -76,13 +74,13 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
 {
     (void)aInstance;
     DEBUG("openthread: otPlatAlarmStop\n");
-    xtimer_remove(&ot_timer);
+    ztimer_remove(ZTIMER_MSEC, &ot_timer);
 }
 
 /* OpenThread will call this for getting running time in millisecs */
 uint32_t otPlatAlarmMilliGetNow(void)
 {
-    uint32_t now = xtimer_now_usec() / US_PER_MS;
+    uint32_t now = ztimer_now(ZTIMER_MSEC);
     DEBUG("openthread: otPlatAlarmGetNow: %" PRIu32 "\n", now);
     return now;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the openthread package to ztimer (using msec). It's quite straight forward.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `examples/openthread` is still working (untested yet)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
