### PR TITLE
pkg/wolfssl: fix minor issues

### DIFF
--- a/pkg/wolfssl/Makefile.dep
+++ b/pkg/wolfssl/Makefile.dep
@@ -8,7 +8,6 @@ ifneq (,$(filter wolfcrypt-benchmark,$(USEMODULE)))
   USEMODULE += wolfcrypt
   USEMODULE += wolfcrypt_coding
   USEMODULE += printf_float
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter wolfcrypt_poly1305,$(USEMODULE)))

--- a/pkg/wolfssl/Makefile.wolfcrypt
+++ b/pkg/wolfssl/Makefile.wolfcrypt
@@ -6,6 +6,10 @@ ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-unused-parameter
 endif
 
+ifeq (native,$(BOARD))
+  CFLAGS += -Wno-array-parameter
+endif
+
 SUBMODULES += 1
 
 NO_AUTO_SRC = 1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes a couple of minor issues with the wolfssl package:
- remove an unnecessary dependency to xtimer with `wolfcrypt-benchmark`. Xtimer is only used by the `tests/pkg_wolfssl` test application which is pulling it itself
- Fix a compilation error with gcc 11 on native

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `tests/pkg_wolfssl` is still working:

<details>

```
$ make -C tests/pkg_wolfssl all test --no-print-directory 
Building application "tests_pkg_wolfssl" for "native" with MCU "native".

"make" -C /work/riot/RIOT/pkg/wolfssl
"make" -C /work/riot/RIOT/build/pkg/wolfssl/wolfcrypt/src -f /work/riot/RIOT/pkg/wolfssl/Makefile.wolfcrypt
"make" -C /work/riot/RIOT/build/pkg/wolfssl/wolfcrypt/benchmark -f /work/riot/RIOT/pkg/wolfssl/Makefile.wolfcrypt-benchmark
"make" -C /work/riot/RIOT/build/pkg/wolfssl/wolfcrypt/test -f /work/riot/RIOT/pkg/wolfssl/Makefile.wolfcrypt-test
"make" -C /work/riot/RIOT/build/pkg/wolfssl/src -f /work/riot/RIOT/pkg/wolfssl/Makefile.wolfssl
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/xtimer
/usr/bin/ld: /work/riot/RIOT/tests/pkg_wolfssl/bin/native/cpu/tramp.o: warning: relocation against `_native_saved_eip' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
   text	   data	    bss	    dec	    hex	filename
 244956	   1328	  70020	 316304	  4d390	/work/riot/RIOT/tests/pkg_wolfssl/bin/native/tests_pkg_wolfssl.elf
r
/work/riot/RIOT/tests/pkg_wolfssl/bin/native/tests_pkg_wolfssl.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.01-devel-343-g425af-pr/pkg/wolfssl_minor_issues)
wolfSSL Crypto Test!
------------------------------------------------------------------------------
 wolfSSL version 4.5.0
------------------------------------------------------------------------------
error    test passed!
MEMORY   test passed!
base64   test passed!
asn      test passed!
RANDOM   test passed!
SHA-256  test passed!
SHA-384  test passed!
SHA-512  test passed!
Hash     test passed!
HC-128   test passed!
Chacha   test passed!
POLY1305 test passed!
ChaCha20-Poly1305 AEAD test passed!
AES      test passed!
AES192   test passed!
AES256   test passed!
ECC      test passed!
ECC buffer test passed!
CURVE25519 test passed!
ED25519  test passed!
logging  test passed!
mutex    test passed!
Test complete
wolfSSL Benchmark!
------------------------------------------------------------------------------
 wolfSSL version 4.5.0
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
RNG                100 MB took 1.039 seconds,   96.281 MB/s
AES-128-CBC-enc    215 MB took 1.017 seconds,  211.328 MB/s
AES-128-CBC-dec    195 MB took 1.005 seconds,  194.013 MB/s
AES-192-CBC-enc    185 MB took 1.005 seconds,  184.126 MB/s
AES-192-CBC-dec    170 MB took 1.022 seconds,  166.408 MB/s
AES-256-CBC-enc    165 MB took 1.001 seconds,  164.906 MB/s
AES-256-CBC-dec    155 MB took 1.027 seconds,  150.865 MB/s
CHACHA             260 MB took 1.016 seconds,  255.938 MB/s
CHA-POLY           180 MB took 1.002 seconds,  179.642 MB/s
POLY1305           605 MB took 1.001 seconds,  604.597 MB/s
SHA-256            230 MB took 1.021 seconds,  225.303 MB/s
SHA-384             90 MB took 1.038 seconds,   86.693 MB/s
SHA-512             90 MB took 1.023 seconds,   87.999 MB/s
ECC      256 key gen       246 ops took 1.003 sec, avg 4.079 ms, 245.185 ops/sec
ECDHE    256 agree         300 ops took 1.245 sec, avg 4.149 ms, 241.043 ops/sec
ECDSA    256 sign          300 ops took 1.307 sec, avg 4.357 ms, 229.527 ops/sec
ECDSA    256 verify        200 ops took 1.560 sec, avg 7.800 ms, 128.202 ops/sec
CURVE  25519 key gen       261 ops took 1.003 sec, avg 3.843 ms, 260.233 ops/sec
CURVE  25519 agree         300 ops took 1.177 sec, avg 3.924 ms, 254.823 ops/sec
ED     25519 key gen       259 ops took 1.002 sec, avg 3.868 ms, 258.506 ops/sec
ED     25519 sign          300 ops took 1.170 sec, avg 3.900 ms, 256.437 ops/sec
ED     25519 verify        200 ops took 1.622 sec, avg 8.109 ms, 123.319 ops/sec
Benchmark complete

```

</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
