### PR TITLE
stdio_rtt: Convert to ztimer

### DIFF
--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -20,7 +20,7 @@ ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
 endif
 
 ifneq (,$(filter stdio_rtt,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter stdio_ethos,$(USEMODULE)))

--- a/sys/stdio_rtt/README.md
+++ b/sys/stdio_rtt/README.md
@@ -32,7 +32,7 @@ your stdout bandwidth by lowering the poll interval. The default is 50ms.
 A choice of 5ms is good during printf-heavy debugging:
 
 ```
-CFLAGS += -DSTDIO_POLL_INTERVAL=5000U
+CFLAGS += -DSTDIO_POLL_INTERVAL_MS=5U
 ```
 
 SEGGER RTT supports stdin as well, and this is enabled by default. It requires

--- a/sys/stdio_rtt/stdio_rtt.c
+++ b/sys/stdio_rtt/stdio_rtt.c
@@ -87,8 +87,8 @@
 
 /* This parameter affects the bandwidth of both input and output. Decreasing
    it will significantly improve bandwidth at the cost of CPU time. */
-#ifndef STDIO_POLL_INTERVAL
-#define STDIO_POLL_INTERVAL 50U
+#ifndef STDIO_POLL_INTERVAL_MS
+#define STDIO_POLL_INTERVAL_MS 50U
 #endif
 
 #define MIN(a, b)        (((a) < (b)) ? (a) : (b))
@@ -317,7 +317,8 @@ ssize_t stdio_read(void* buffer, size_t count) {
         }
         uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
         while(1) {
-            ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL);
+            ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup,
+                                   STDIO_POLL_INTERVAL_MS);
             res = rtt_read(buffer, count);
             if (res > 0)
                 return res;
@@ -331,7 +332,7 @@ ssize_t stdio_write(const void* in, size_t len) {
     int written = rtt_write(buffer, (unsigned)len);
     uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
     while (blocking_stdout && ((size_t)written < len)) {
-        ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL);
+        ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL_MS);
         written += rtt_write(&buffer[written], len-written);
     }
     return (ssize_t)written;

--- a/sys/stdio_rtt/stdio_rtt.c
+++ b/sys/stdio_rtt/stdio_rtt.c
@@ -79,7 +79,7 @@
 #include "stdio_rtt.h"
 #include "thread.h"
 #include "mutex.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #if MODULE_VFS
 #include "vfs.h"
@@ -88,7 +88,7 @@
 /* This parameter affects the bandwidth of both input and output. Decreasing
    it will significantly improve bandwidth at the cost of CPU time. */
 #ifndef STDIO_POLL_INTERVAL
-#define STDIO_POLL_INTERVAL 50000U
+#define STDIO_POLL_INTERVAL 50U
 #endif
 
 #define MIN(a, b)        (((a) < (b)) ? (a) : (b))
@@ -315,9 +315,9 @@ ssize_t stdio_read(void* buffer, size_t count) {
             /* We only unlock when rtt_stdio_enable_stdin is called
                Note that we assume only one caller invoked this function */
         }
-        xtimer_ticks32_t last_wakeup = xtimer_now();
+        uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
         while(1) {
-            xtimer_periodic_wakeup(&last_wakeup, STDIO_POLL_INTERVAL);
+            ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL);
             res = rtt_read(buffer, count);
             if (res > 0)
                 return res;
@@ -329,9 +329,9 @@ ssize_t stdio_read(void* buffer, size_t count) {
 ssize_t stdio_write(const void* in, size_t len) {
     const char *buffer = (const char *)in;
     int written = rtt_write(buffer, (unsigned)len);
-    xtimer_ticks32_t last_wakeup = xtimer_now();
+    uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
     while (blocking_stdout && ((size_t)written < len)) {
-        xtimer_periodic_wakeup(&last_wakeup, STDIO_POLL_INTERVAL);
+        ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup, STDIO_POLL_INTERVAL);
         written += rtt_write(&buffer[written], len-written);
     }
     return (ssize_t)written;

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -28,7 +28,7 @@
 #include "event.h"
 #include "event/timeout.h"
 #include "event/callback.h"
-#if IS_USED(MODULE_ZTIMER)
+#if IS_USED(MODULE_ZTIMER_USEC)
 #include "ztimer.h"
 #else
 #include "xtimer.h"
@@ -88,7 +88,7 @@ static void timed_callback(void *arg)
     order++;
     expect(order == 6);
     expect(arg == event_callback.arg);
-#if IS_USED(MODULE_ZTIMER)
+#if IS_USED(MODULE_ZTIMER_USEC)
     uint32_t now = ztimer_now(ZTIMER_USEC);
 #else
     uint32_t now = xtimer_now_usec();
@@ -186,7 +186,7 @@ int main(void)
 
     puts("posting timed callback with timeout 1sec");
     event_timeout_init(&event_timeout, &queue, (event_t *)&event_callback);
-#if IS_USED(MODULE_ZTIMER)
+#if IS_USED(MODULE_ZTIMER_USEC)
     before = ztimer_now(ZTIMER_USEC);
 #else
     before = xtimer_now_usec();

--- a/tests/unittests/tests-rtt_rtc/Makefile.include
+++ b/tests/unittests/tests-rtt_rtc/Makefile.include
@@ -1,4 +1,5 @@
 USEMODULE += rtt_rtc
+USEMODULE += ztimer_no_periph_rtt
 
 CFLAGS += -DMOCK_RTT_FREQUENCY=32
 CFLAGS += -DMOCK_RTT_MAX_VALUE=0xFFFF


### PR DESCRIPTION
### Contribution description

Convert `stdio_rtt` to ztimer

### Testing procedure

Tested on the nRF52840dk by adding `USEMODULE += stdio_rtt` to the default example:
```Shellsession
koen@morgen ~/dev/RIOT-review $ make -C examples/default/ BOARD=nrf52840dk RIOT_TERMINAL=jlink term                 
make: Entering directory '/home/koen/dev/RIOT-review/examples/default'                                              
/home/koen/dev/RIOT-review/dist/tools/jlink/jlink.sh term-rtt                                                       
### Starting RTT terminal ###                                                                                       
help                                                                                                                
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-11-03 11:18:26,828 # Host name for TCP connection is missing, defaulting to "localhost"                        
2021-11-03 11:18:26,828 # Connect to localhost:19021                                                                
Welcome to pyterm!                                                                                                  
Type '/exit' to exit.                                                                                               
2021-11-03 11:18:27,831 # SEGGER J-Link V6.80c - Real time terminal output                                          
help                                                                                                                
2021-11-03 11:18:27,832 # J-Link OB-SAM3U128-V2-NordicSemi compiled Mar 17 2020 14:43:00 V1.0, SN=683806234
2021-11-03 11:18:27,832 # Process: JLinkExe                                                                         
2021-11-03 11:18:27,833 # NETOPT_RX_END_IRQ not implemented by driver                                               
2021-11-03 11:18:27,833 # NETOPT_TX_END_IRQ not implemented by driver                                               
2021-11-03 11:18:27,833 # main(): This is RIOT! (Version: 2022.01-devel-324-g1aa18-pr/stdio_rtt/ztimer)             
2021-11-03 11:18:27,833 # Welcome to RIOT!                                                                          
> 2021-11-03 11:18:27,866 # help                                                                                    
2021-11-03 11:18:27,867 # Command              Description                                                          
2021-11-03 11:18:27,867 # ---------------------------------------                                                   
2021-11-03 11:18:27,867 # reboot               Reboot the node                                                      
2021-11-03 11:18:27,867 # version              Prints current RIOT_VERSION                                          
2021-11-03 11:18:27,868 # pm                   interact with layered PM subsystem                                   
2021-11-03 11:18:27,868 # ps                   Prints information about running threads.                            
2021-11-03 11:18:27,868 # random_init          initializes the PRNG                                                 
2021-11-03 11:18:27,869 # random_get           returns 32 bit of pseudo randomness                                  
2021-11-03 11:18:27,869 # ifconfig             Configure network interfaces                                         
2021-11-03 11:18:27,869 # txtsnd               Sends a custom string as is over the link layer                      
```


### Issues/PRs references

Ticks item off #17111