### PR TITLE
stdio_semihosting: Convert to ztimer

### DIFF
--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -45,7 +45,7 @@ ifneq (,$(filter stdio_uart,$(USEMODULE)))
 endif
 
 ifneq (,$(filter stdio_semihosting,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
   FEATURES_REQUIRED_ANY += cpu_core_cortexm|arch_riscv
 endif
 

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -25,7 +25,7 @@
 #include <string.h>
 
 #include "stdio_semihosting.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #if MODULE_VFS
 #include "vfs.h"
@@ -35,7 +35,7 @@
  * @brief Rate at which the stdin read polls (breaks) the debugger for input
  * data
  */
-#define STDIO_SEMIHOSTING_POLL_RATE     (10 * US_PER_MS)
+#define STDIO_SEMIHOSTING_POLL_RATE     (10)
 
 /**
  * @brief ARM Semihosting STDIN file descriptor. Also used with RISC-V
@@ -157,10 +157,11 @@ void stdio_init(void)
 ssize_t stdio_read(void* buffer, size_t count)
 {
     if (STDIO_SEMIHOSTING_RX) {
-        xtimer_ticks32_t last_wakeup = xtimer_now();
+        uint32_t last_wakeup = ztimer_now(ZTIMER_MSEC);
         ssize_t bytes_read = _semihosting_read(buffer, count);
         while (bytes_read == 0) {
-            xtimer_periodic_wakeup(&last_wakeup, STDIO_SEMIHOSTING_POLL_RATE);
+            ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup,
+                                   STDIO_SEMIHOSTING_POLL_RATE);
             bytes_read = _semihosting_read(buffer, count);
         }
         return bytes_read;

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -33,9 +33,9 @@
 
 /**
  * @brief Rate at which the stdin read polls (breaks) the debugger for input
- * data
+ * data in milliseconds
  */
-#define STDIO_SEMIHOSTING_POLL_RATE     (10)
+#define STDIO_SEMIHOSTING_POLL_RATE_MS     (10)
 
 /**
  * @brief ARM Semihosting STDIN file descriptor. Also used with RISC-V
@@ -161,7 +161,7 @@ ssize_t stdio_read(void* buffer, size_t count)
         ssize_t bytes_read = _semihosting_read(buffer, count);
         while (bytes_read == 0) {
             ztimer_periodic_wakeup(ZTIMER_MSEC, &last_wakeup,
-                                   STDIO_SEMIHOSTING_POLL_RATE);
+                                   STDIO_SEMIHOSTING_POLL_RATE_MS);
             bytes_read = _semihosting_read(buffer, count);
         }
         return bytes_read;


### PR DESCRIPTION
### Contribution description

Convert stdio_semihosting to ztimer

### Testing procedure

Tested on the samr21-xpro by adding `USEMODULE += stdio_semihosting` to the default example:

```Shellsession
koen@morgen ~/dev/RIOT-review $ make -C examples/default/ BOARD=samr21-xpro term RIOT_TERMINAL=semihosting
make: Entering directory '/home/koen/dev/RIOT-review/examples/default'
/home/koen/dev/RIOT-review/dist/tools/openocd/openocd.sh debug /home/koen/dev/RIOT-review/examples/default/bin/samr21-xpro/default.elf 
### Starting Debugging ###
Reading symbols from /home/koen/dev/RIOT-review/examples/default/bin/samr21-xpro/default.elf...
Open On-Chip Debugger 0.11.0+dev-gd2928fa86 (2021-10-26-12:15)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Remote debugging using :3333
0xfffffffe in ?? ()
(gdb) run
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Starting program: /home/koen/dev/RIOT-review/examples/default/bin/samr21-xpro/default.elf 
main(): This is RIOT! (Version: 2022.01-devel-324-g8911ff-pr/stdio_semihosting/ztimer)
Welcome to RIOT!
> ps
keep_alive() was not invoked in the 1000 ms timelimit. GDB alive packet not sent! (2474 ms). Workaround: increase "set remotetimeout" in GDB
ps
        pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
          - | isr_stack            | -        - |   - |    512 (  312) (  200) | 0x20000000 | 0x200001c0
          1 | main                 | running  Q |   7 |   1536 (  704) (  832) | 0x200002b8 | 0x200007b4 
          2 | pktdump              | bl rx    _ |   6 |   1536 (  244) ( 1292) | 0x20001018 | 0x20001524 
          3 | at86rf2xx            | bl rx    _ |   2 |   1024 (  452) (  572) | 0x20000998 | 0x20000c5c 
            | SUM                  |            |     |   4608 ( 1712) ( 2896)
> 
```


### Issues/PRs references

Ticks item off #17111
