### PR TITLE
makefiles: RISC-V: prefer target triple from riotdocker

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -10,15 +10,16 @@
 # triple to the least correct triple all that might be able to produce our
 # binaries. Finally, "riscv-none-embed" is also tested for compatibility with
 # an previously popular legacy toolchain.
+# For a CI transition period, it is tested first.
 
 _TRIPLES_TO_TEST := \
+    riscv-none-embed \
     riscv32-none-elf \
     riscv-none-elf \
     riscv32-unknown-elf \
     riscv-unknown-elf \
     riscv64-none-elf \
-    riscv64-unknown-elf \
-    riscv-none-embed
+    riscv64-unknown-elf
 
 TARGET_ARCH_RISCV ?= \
   $(strip \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is an attempt at resolving a catch-22 situation.

Currently riotdocker installs `riscv-none-embed-gcc`. We want to move to `riscv64-unknown-elf` as provided by Debian.
But the Debian toolchain includes no newlib, there is only picolibc.

We can transition to picolibc by default on RISC-V too, but in order to get the riotdocker changes in, it must still build with the old RISC-V toolchain.

Then we can [enable picolibc support](https://github.com/RIOT-OS/RIOT/blob/master/cpu/riscv_common/Makefile.features#L13) in RIOT and switch to the new toolchain.

For this, the old toolchain triple has to take precedence over the new one if both are installed. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
