### PR TITLE
build system: add convenience PICOLIBC variable

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -93,6 +93,11 @@ ifneq (1, $(RIOTBOOT_BUILD))
   FEATURES_OPTIONAL += periph_pm
 endif
 
+# convenience variable to select picolibc from command line
+ifeq (1, $(PICOLIBC))
+  FEATURES_REQUIRED += picolibc
+endif
+
 # always select provided architecture features
 FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
 

--- a/tests/malloc_thread_safety/Makefile
+++ b/tests/malloc_thread_safety/Makefile
@@ -1,9 +1,5 @@
 include ../Makefile.tests_common
 
-PICOLIBC ?= 0
-ifneq (0,$(PICOLIBC))
-  FEATURES_REQUIRED += picolibc
-endif
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Before picolibc was a feature, it could be selected by adding

    PICOLIBC=1

to the build command line (similar to `LTO=1`).

Bring this feature back since it's easier to type than adding

    FEATURES_REQUIRED += picolibc

to the application Makefile



### Testing procedure

Build any application with `PICOLIBC=1` (and observe the size decrease of the binary) 


### Issues/PRs references

brings back feature dropped in #15011
