### PR TITLE
example/gcoap: add LWIP make option

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -12,12 +12,22 @@ RIOTBASE ?= $(CURDIR)/../..
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += netdev_default
-USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules
-USEMODULE += gnrc_ipv6_default
+
+# use GNRC by default
+LWIP ?= 0
+
+ifeq (0,$(LWIP))
+  USEMODULE += auto_init_gnrc_netif
+  # Specify the mandatory networking modules
+  USEMODULE += gnrc_ipv6_default
+  # Additional networking modules that can be dropped if not needed
+  USEMODULE += gnrc_icmpv6_echo
+else
+  USEMODULE += lwip_ipv6
+  USEMODULE += lwip_netdev
+endif
+
 USEMODULE += gcoap
-# Additional networking modules that can be dropped if not needed
-USEMODULE += gnrc_icmpv6_echo
 
 # Required by gcoap example
 USEMODULE += od


### PR DESCRIPTION
### Contribution description

adds the possibility to easily build  the gcoap example with LWIP


### Testing procedure

`LWIP=1 make -C examples/gcoap`

and use  like described in `examples/gcoap/README.md`

### Issues/PRs references

used these lines while testing #16378