### PR TITLE
core: make SCHED_TEST_STACK boolean and default to 1 with DEVELHELP

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -119,6 +119,15 @@ extern "C" {
  */
 #define PRIkernel_pid PRIi16
 
+#if defined(DEVELHELP) || defined(DOXYGEN)
+/**
+ * Enables detection of stack overflows and measures stack usage when != 0
+ */
+#ifndef SCHED_TEST_STACK
+#define SCHED_TEST_STACK    1
+#endif  /* SCHED_TEST_STACK */
+#endif  /* DEVELHELP */
+
 /**
  * Unique process identifier
  */

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -513,7 +513,7 @@ static inline thread_status_t thread_get_status(const thread_t *thread)
  * @param   thread   thread to work on
  * @returns priority of thread
  */
-static inline  uint8_t thread_get_priority(const thread_t *thread)
+static inline uint8_t thread_get_priority(const thread_t *thread)
 {
     return thread->priority;
 }

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -193,7 +193,7 @@ struct _thread {
     msg_t *msg_array;               /**< memory holding messages sent
                                          to this thread's message queue */
 #endif
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
+#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)
     char *stack_start;              /**< thread's stack start address   */
 #endif
@@ -545,7 +545,7 @@ const char *thread_state_to_string(thread_status_t state);
  */
 static inline void *thread_get_stackstart(const thread_t *thread)
 {
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
+#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD)
     return thread->stack_start;
 #else

--- a/core/sched.c
+++ b/core/sched.c
@@ -119,7 +119,7 @@ static void _unschedule(thread_t *active_thread)
         active_thread->status = STATUS_PENDING;
     }
 
-#ifdef SCHED_TEST_STACK
+#if IS_ACTIVE(SCHED_TEST_STACK)
     if (*((uintptr_t *)active_thread->stack_start) !=
         (uintptr_t)active_thread->stack_start) {
         LOG_WARNING(

--- a/core/thread.c
+++ b/core/thread.c
@@ -233,7 +233,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
     _init_tls(thread->tls);
 #endif
 
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK)
+#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK)
     if (flags & THREAD_CREATE_STACKTEST) {
         /* assign each int of the stack the value of it's address. Alignment
          * has been handled above, so silence -Wcast-align */
@@ -274,7 +274,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
     thread->pid = pid;
     thread->sp = thread_stack_init(function, arg, stack, stacksize);
 
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) || \
+#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) || \
     defined(MODULE_MPU_STACK_GUARD)
     thread->stack_start = stack;
 #endif

--- a/cpu/esp_common/thread_arch.c
+++ b/cpu/esp_common/thread_arch.c
@@ -150,7 +150,7 @@ char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
     sp = (uint8_t*)(((uintptr_t)(top_of_stack + 1) - XT_STK_FRMSZ - XT_CP_SIZE) & ~0xf);
 
     /* Clear whole stack with a known value to assist debugging */
-    #if !defined(DEVELHELP) && !defined(SCHED_TEST_STACK)
+    #if !defined(DEVELHELP) && !IS_ACTIVE(SCHED_TEST_STACK)
         /* Unfortunately, this affects thread_measure_stack_free function */
         memset(stack_start, 0, stack_size);
     #else

--- a/cpu/esp_common/thread_arch.c
+++ b/cpu/esp_common/thread_arch.c
@@ -360,6 +360,8 @@ void thread_isr_stack_init(void)
 
 int thread_isr_stack_usage(void)
 {
+    /* cppcheck-suppress comparePointers
+     * (reason: comes from ESP-SDK, so should be valid) */
     return &port_IntStackTop - &port_IntStack -
            thread_measure_stack_free((char*)&port_IntStack);
 }
@@ -379,6 +381,8 @@ void *thread_isr_stack_start(void)
 void thread_isr_stack_print(void)
 {
     printf("Printing current ISR\n");
+    /* cppcheck-suppress comparePointers
+     * (reason: comes from ESP-SDK, so should be valid) */
     esp_hexdump(&port_IntStack, &port_IntStackTop-&port_IntStack, 'w', 8);
 }
 

--- a/tests/bench_sizeof_coretypes/main.c
+++ b/tests/bench_sizeof_coretypes/main.c
@@ -101,7 +101,7 @@ int main(void)
     P(msg_queue);
     P(msg_array);
 #endif
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) || defined(MODULE_MPU_STACK_GUARD)
+#if defined(DEVELHELP) || IS_ACTIVE(SCHED_TEST_STACK) || defined(MODULE_MPU_STACK_GUARD)
     P(stack_start);
 #endif
 #ifdef DEVELHELP

--- a/tests/driver_dose/Makefile.ci
+++ b/tests/driver_dose/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atxmega-a3bu-xplained \
     atmega328p \
     atmega328p-xplained-mini \
     bluepill-stm32f030c8 \

--- a/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -8,6 +8,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p \
     atmega328p-xplained-mini \
     atxmega-a3bu-xplained \
+    blackpill \
+    bluepill \
     bluepill-stm32f030c8 \
     derfmega128 \
     hifive1 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
I've run into this trap now often enough that I'd like to have a warning about stack overflows, at least with `DEVELHELP`. If *I* still run into this trap, how must newcomers feel.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try causing a stack overflow, the scheduler should warn you about it now when compiled with DEVELHELP (and `SCHED_TEST_STACK` unset).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
