### PR TITLE
cppcheck: output all annotations as error

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -80,7 +80,10 @@ if github_annotate_is_on; then
         DETAILS="${DETAILS}     * (reason: <your reason why you think this is "
         DETAILS="${DETAILS}a false positive>) */\n"
 
-        if echo "${SEVERITY}" | grep -q "\<error\>"; then
+        # contributors get confused if CI errors (i.e. non-zero result), but outputs only warnings
+        # => make all warnings errors on non-zero output. Otherwise, use severity level of output
+        # to determine annotation type.
+        if [ ${RESULT} -ne 0 ] || echo "${SEVERITY}" | grep -q "\<error\>"; then
             github_annotate_error "${FILE}" "${LINENUM}" "${DETAILS}"
         else
             github_annotate_warning "${FILE}" "${LINENUM}" "${DETAILS}"


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
`cppcheck` has a non-zero exit code even on warnings, so to not confuse contributors, align the annotation output with that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I can add a test commit if necessary.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
