### PR TITLE
usbus_hid: Fix possible null pointer dereference

### DIFF
--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -174,7 +174,7 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
                                            hid->report_desc_size);
         }
         else if (desc_type == USB_HID_DESCR_HID) {
-            _gen_hid_descriptor(usbus, NULL);
+            _gen_hid_descriptor(usbus, hid);
         }
         break;
     }


### PR DESCRIPTION
### Contribution description

This fixes a possible null pointer dereference in the USBUS HID code by always supplying an argument to the `_gen_hid_descriptor` function
 
### Testing procedure

Not sure what the best way is to trigger the issue though.

### Issues/PRs references

Pointed out by cppcheck