### PR TITLE
drivers/sx126x: fix sync word and TX PA configuration

### DIFF
--- a/boards/lora-e5-dev/board.c
+++ b/boards/lora-e5-dev/board.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include "kernel_defines.h"
 #include "cpu.h"
 #include "board.h"
@@ -72,6 +73,8 @@ void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mode)
         gpio_set(FE_CTRL2);
         break;
     default:
+        /* SX126X_RF_MODE_TX_LPA is not supported */
+        assert(0);
         break;
     }
 }

--- a/boards/lora-e5-dev/include/board.h
+++ b/boards/lora-e5-dev/include/board.h
@@ -34,6 +34,7 @@ extern "C" {
  * @{
  */
 #define SX126X_PARAM_SPI                    (SPI_DEV(0))
+#define SX126X_PARAM_TX_PA_MODE             SX126X_RF_MODE_TX_HPA
 #if IS_USED(MODULE_SX126X_STM32WL)
 extern void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mode);
 #define SX126X_PARAM_SET_RF_MODE_CB         lora_e5_dev_sx126x_set_rf_mode

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14564,3 +14564,6 @@ boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member timer_co
 boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/lora\-e5\-dev/include/board\.h:[0-9]+: warning: Member SX126X_PARAM_TX_PA_MODE \(macro definition\) of file board\.h is not documented\.
+drivers/sx126x/include/sx126x_params\.h:[0-9]+: warning: Member SX126X_PARAM_TX_PA_MODE \(macro definition\) of file sx126x_params\.h is not documented\.
+drivers/sx126x/include/sx126x_params\.h:[0-9]+: warning: Member SX126X_TX_PA_MODE \(macro definition\) of file sx126x_params\.h is not documented\.

--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -95,6 +95,7 @@ typedef struct {
      * @ brief  Interface to set RF switch parameters
      */
     void(*set_rf_mode)(sx126x_t *dev, sx126x_rf_mode_t rf_mode);
+    sx126x_rf_mode_t tx_pa_mode;        /**< Power amplifier TX operating mode*/
 #endif
 } sx126x_params_t;
 

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -61,6 +61,10 @@ extern "C" {
 #define SX126X_PARAM_SET_RF_MODE_CB         NULL
 #endif
 
+#ifndef SX126X_PARAM_TX_PA_MODE
+#define SX126X_PARAM_TX_PA_MODE             SX126X_RF_MODE_TX_LPA
+#endif
+
 #ifndef SX126X_PARAM_TYPE
 #    if IS_USED(MODULE_SX1261)
 #        define SX126X_PARAM_TYPE SX126X_TYPE_SX1261
@@ -78,9 +82,11 @@ extern "C" {
 #endif
 
 #if IS_USED(MODULE_SX126X_RF_SWITCH)
-#define SX126X_SET_RF_MODE  .set_rf_mode = SX126X_PARAM_SET_RF_MODE_CB
+#define SX126X_SET_RF_MODE  .set_rf_mode = SX126X_PARAM_SET_RF_MODE_CB,
+#define SX126X_TX_PA_MODE   .tx_pa_mode = SX126X_PARAM_TX_PA_MODE
 #else
 #define SX126X_SET_RF_MODE
+#define SX126X_TX_PA_MODE
 #endif
 
 #define SX126X_PARAMS             { .spi = SX126X_PARAM_SPI,            \
@@ -90,7 +96,8 @@ extern "C" {
                                     .dio1_pin = SX126X_PARAM_DIO1,      \
                                     .type     = SX126X_PARAM_TYPE,      \
                                     .regulator = SX126X_PARAM_REGULATOR, \
-                                    SX126X_SET_RF_MODE }
+                                    SX126X_SET_RF_MODE \
+                                    SX126X_TX_PA_MODE}
 
 /**@}*/
 

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -49,13 +49,6 @@
 #define CONFIG_SX126X_RAMP_TIME_DEFAULT         (SX126X_RAMP_10_US)
 #endif
 
-const sx126x_pa_cfg_params_t sx1262_pa_cfg = {
-    .pa_duty_cycle = 0x02,
-    .hp_max = 0x02,
-    .device_sel = 0x00,
-    .pa_lut = 0x01
-};
-
 const sx126x_pa_cfg_params_t sx1268_pa_cfg = {
     .pa_duty_cycle = 0x04,
     .hp_max = 0x06,
@@ -63,10 +56,17 @@ const sx126x_pa_cfg_params_t sx1268_pa_cfg = {
     .pa_lut = 0x01
 };
 
-const sx126x_pa_cfg_params_t sx1261_pa_cfg = {
+const sx126x_pa_cfg_params_t lpa_cfg = {
     .pa_duty_cycle = 0x04,
     .hp_max = 0x00,
     .device_sel = 0x01,
+    .pa_lut = 0x01
+};
+
+const sx126x_pa_cfg_params_t hpa_cfg = {
+    .pa_duty_cycle = 0x02,
+    .hp_max = 0x02,
+    .device_sel = 0x00,
     .pa_lut = 0x01
 };
 
@@ -108,14 +108,21 @@ static void sx126x_init_default_config(sx126x_t *dev)
      * and are optimal for a TX output power of 14dBm.
      */
     if (sx126x_is_llcc68(dev) || sx126x_is_sx1262(dev)) {
-        sx126x_set_pa_cfg(dev, &sx1262_pa_cfg);
+        sx126x_set_pa_cfg(dev, &hpa_cfg);
     }
     else if (sx126x_is_sx1268(dev)) {
         sx126x_set_pa_cfg(dev, &sx1268_pa_cfg);
     }
-    else { /* sx126x_is_sx1261(dev) or sx126x_is_stm32wl(dev)  */
-        sx126x_set_pa_cfg(dev, &sx1261_pa_cfg);
+    else if (sx126x_is_sx1261(dev)) {
+        sx126x_set_pa_cfg(dev, &lpa_cfg);
     }
+#if IS_USED(MODULE_SX126X_RF_SWITCH)
+    if (dev->params->tx_pa_mode == SX126X_RF_MODE_TX_LPA){
+        sx126x_set_pa_cfg(dev, &lpa_cfg);
+    } else {
+        sx126x_set_pa_cfg(dev, &hpa_cfg);
+    }
+#endif
     sx126x_set_tx_params(dev, CONFIG_SX126X_TX_POWER_DEFAULT, CONFIG_SX126X_RAMP_TIME_DEFAULT);
 
     dev->mod_params.bw = (sx126x_lora_bw_t)(CONFIG_LORA_BW_DEFAULT + SX126X_LORA_BW_125);

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -333,7 +333,7 @@ static int _set_state(sx126x_t *dev, netopt_state_t state)
         DEBUG("[sx126x] netdev: set NETOPT_STATE_TX state\n");
 #if IS_USED(MODULE_SX126X_RF_SWITCH)
         if (dev->params->set_rf_mode) {
-            dev->params->set_rf_mode(dev, SX126X_RF_MODE_TX_LPA);
+            dev->params->set_rf_mode(dev, dev->params->tx_pa_mode);
         }
 #endif
         sx126x_set_tx(dev, 0);


### PR DESCRIPTION
### Contribution description

I was testing OTAA and LoRaWAN altogether on sx126x devices and realized that it was actually not working on `lora-e5-dev` (not sure how I was able to get it to work on the original PR).

One of the reasons is incorrect sync-word selections, for these devices, it's actually 16bit and has different values than the other sx12xxx devices. This might need fixing for `gnrc_lorawan` as well @jia200x.

The second is that this BOARD  only supports HPA, and the driver was hardcoded to use LPA.

### Testing procedure

- `lora-e5-dev`

```
2021-11-04 21:56:42,700 # loramac              Control Semtech loramac stack
: loramac set deveui 70B3D57ED0045DBC
2021-11-04 21:56:44,600 # loramac set deveui 70B3D57ED0045DBC
loramac set appeui 0000000000000000C
2021-11-04 21:56:45,848 # loramac set appeui 0000000000000000
: loramac set appkey 11DD98C96E8F2AB983AFB16B00AC5DA9
2021-11-04 21:56:48,264 # loramac set appkey 11DD98C96E8F2AB983AFB16B00AC5DA9
: loramac join otaa
2021-11-04 21:56:50,014 # loramac join otaa
2021-11-04 21:56:58,340 # Join procedure succeeded!
```

- `nucleo-wl55jc`

```
loramac set deveui 70B3D57ED0045DBC
2021-11-04 21:58:55,856 # loramac set deveui 70B3D57ED0045DBC
loramac set appkey 11DD98C96E8F2AB983AFB16B00AC5DA9
2021-11-04 21:58:57,104 # loramac set appkey 11DD98C96E8F2AB983AFB16B00AC5DA9
loramac set appeui 0000000000000000A9
2021-11-04 21:58:58,661 # loramac set appeui 0000000000000000
: loramac join otaa
2021-11-04 21:59:00,370 # loramac join otaa
2021-11-04 21:59:08,699 # Join procedure succeeded!
```