### PR TITLE
net/gcoap: port to ztimer

### DIFF
--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -26,6 +26,7 @@
 #include "net/cord/common.h"
 #include "net/sock/util.h"
 #include "net/ipv6/addr.h"
+#include "xtimer.h"
 
 #define BUFSIZE             (64U)
 #define STARTUP_DELAY       (3U)    /* wait 3s before sending first request*/

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -543,6 +543,7 @@ ifneq (,$(filter gcoap_dtls,$(USEMODULE)))
   USEMODULE += dsm
   USEMODULE += sock_async_event
   USEMODULE += sock_dtls
+  USEMODULE += ztimer_usec
   USEMODULE += event_thread
   USEMODULE += event_timeout
 endif
@@ -552,6 +553,7 @@ ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += sock_async_event
   USEMODULE += sock_udp
   USEMODULE += sock_util
+  USEMODULE += ztimer_usec
   USEMODULE += event_callback
   USEMODULE += event_timeout
   ifneq (,$(filter openwsn%,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -543,9 +543,10 @@ ifneq (,$(filter gcoap_dtls,$(USEMODULE)))
   USEMODULE += dsm
   USEMODULE += sock_async_event
   USEMODULE += sock_dtls
+  USEMODULE += ztimer_msec
   USEMODULE += ztimer_usec
   USEMODULE += event_thread
-  USEMODULE += event_timeout
+  USEMODULE += event_timeout_ztimer
 endif
 
 ifneq (,$(filter gcoap,$(USEMODULE)))
@@ -553,9 +554,10 @@ ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += sock_async_event
   USEMODULE += sock_udp
   USEMODULE += sock_util
+  USEMODULE += ztimer_msec
   USEMODULE += ztimer_usec
   USEMODULE += event_callback
-  USEMODULE += event_timeout
+  USEMODULE += event_timeout_ztimer
   ifneq (,$(filter openwsn%,$(USEMODULE)))
     USEMODULE += openwsn_sock_udp
   endif

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -433,8 +433,8 @@ extern "C" {
 /**
  * @brief   Timeout for the DTLS handshake process. Set to 0 for infinite time
  */
-#ifndef CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_USEC
-#define CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_USEC    (3 * US_PER_SEC)
+#ifndef CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_MSEC
+#define CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_MSEC    (3 * MS_PER_SEC)
 #endif
 
 /**
@@ -450,8 +450,8 @@ extern "C" {
  * @brief   Timeout for freeing up a session when minimum number of available
  *          sessions is not given.
  */
-#ifndef CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_USEC
-#define CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_USEC  (15 * US_PER_SEC)
+#ifndef CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_MSEC
+#define CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_MSEC  (15 * MS_PER_SEC)
 #endif
 
 /**
@@ -538,12 +538,12 @@ extern "C" {
 
 /**
  * @ingroup net_gcoap_conf
- * @brief   Default time to wait for a non-confirmable response [in usec]
+ * @brief   Default time to wait for a non-confirmable response [in msec]
  *
  * Set to 0 to disable timeout.
  */
-#ifndef CONFIG_GCOAP_NON_TIMEOUT
-#define CONFIG_GCOAP_NON_TIMEOUT       (5000000U)
+#ifndef CONFIG_GCOAP_NON_TIMEOUT_MSEC
+#define CONFIG_GCOAP_NON_TIMEOUT_MSEC       (5000U)
 #endif
 
 /**

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -405,7 +405,7 @@
 #include "net/sock/dtls.h"
 #endif
 #include "net/nanocoap.h"
-#include "xtimer.h"
+#include "timex.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -32,7 +32,7 @@
 #include "mutex.h"
 #include "random.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #if IS_USED(MODULE_GCOAP_DTLS)
 #include "net/sock/dtls.h"
@@ -1010,12 +1010,12 @@ static ssize_t _tl_authenticate(gcoap_socket_t *sock, const sock_udp_ep_t *remot
     msg_t msg;
     bool is_timed_out = false;
     do {
-        uint32_t start = xtimer_now_usec();
-        res = xtimer_msg_receive_timeout(&msg, timeout);
+        uint32_t start = ztimer_now(ZTIMER_USEC);
+        res = ztimer_msg_receive_timeout(ZTIMER_USEC, &msg, timeout);
 
         /* ensure whole timeout time for the case we receive other messages than DTLS_EVENT_CONNECTED */
         if (timeout != SOCK_NO_TIMEOUT) {
-            uint32_t diff = (xtimer_now_usec() - start);
+            uint32_t diff = (ztimer_now(ZTIMER_USEC) - start);
             timeout = (diff > timeout) ? 0: timeout - diff;
             is_timed_out = (res < 0) || (timeout == 0);
         }
@@ -1240,7 +1240,7 @@ int gcoap_resp_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code)
 
     if (coap_get_observe(pdu) == COAP_OBS_REGISTER) {
         /* generate initial notification value */
-        uint32_t now       = xtimer_now_usec();
+        uint32_t now       = ztimer_now(ZTIMER_USEC);
         pdu->observe_value = (now >> GCOAP_OBS_TICK_EXPONENT) & 0xFFFFFF;
         coap_opt_add_uint(pdu, COAP_OPT_OBSERVE, pdu->observe_value);
     }
@@ -1267,7 +1267,7 @@ int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     if (hdrlen > 0) {
         coap_pkt_init(pdu, buf, len, hdrlen);
 
-        uint32_t now       = xtimer_now_usec();
+        uint32_t now       = ztimer_now(ZTIMER_USEC);
         pdu->observe_value = (now >> GCOAP_OBS_TICK_EXPONENT) & 0xFFFFFF;
         coap_opt_add_uint(pdu, COAP_OPT_OBSERVE, pdu->observe_value);
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -32,6 +32,7 @@
 #include "mutex.h"
 #include "random.h"
 #include "thread.h"
+#include "xtimer.h"
 
 #if IS_USED(MODULE_GCOAP_DTLS)
 #include "net/sock/dtls.h"

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -188,7 +188,7 @@ static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *
     if (type & SOCK_ASYNC_CONN_RECV) {
         ssize_t res = sock_dtls_recv(sock, &socket.ctx_dtls_session,
                             _listen_buf, sizeof(_listen_buf),
-                            CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_USEC);
+                            CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_MSEC);
         if (res != -SOCK_DTLS_HANDSHAKE) {
             DEBUG("gcoap: could not establish DTLS session: %zd\n", res);
             sock_dtls_session_destroy(sock, &socket.ctx_dtls_session);
@@ -215,10 +215,10 @@ static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *
         uint8_t minimum_free = CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS;
         if (dsm_get_num_available_slots() < minimum_free)
         {
-            uint32_t timeout = CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_USEC;
+            uint32_t timeout = CONFIG_GCOAP_DTLS_MINIMUM_AVAILABLE_SESSIONS_TIMEOUT_MSEC;
             event_callback_init(&_dtls_session_free_up_tmout_cb,
                                 _dtls_free_up_session, NULL);
-            event_timeout_init(&_dtls_session_free_up_tmout, &_queue,
+            event_timeout_ztimer_init(&_dtls_session_free_up_tmout, ZTIMER_MSEC, &_queue,
                                &_dtls_session_free_up_tmout_cb.super);
             event_timeout_set(&_dtls_session_free_up_tmout, timeout);
         }
@@ -472,9 +472,9 @@ static void _on_resp_timeout(void *arg) {
 #else
         unsigned i        = CONFIG_COAP_MAX_RETRANSMIT - memo->send_limit;
 #endif
-        uint32_t timeout  = ((uint32_t)CONFIG_COAP_ACK_TIMEOUT << i) * US_PER_SEC;
+        uint32_t timeout  = ((uint32_t)CONFIG_COAP_ACK_TIMEOUT << i) * MS_PER_SEC;
 #if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
-        uint32_t end = ((uint32_t)TIMEOUT_RANGE_END << i) * US_PER_SEC;
+        uint32_t end = ((uint32_t)TIMEOUT_RANGE_END << i) * MS_PER_SEC;
         timeout = random_uint32_range(timeout, end);
 #endif
         event_timeout_set(&memo->resp_evt_tmout, timeout);
@@ -1010,12 +1010,12 @@ static ssize_t _tl_authenticate(gcoap_socket_t *sock, const sock_udp_ep_t *remot
     msg_t msg;
     bool is_timed_out = false;
     do {
-        uint32_t start = ztimer_now(ZTIMER_USEC);
-        res = ztimer_msg_receive_timeout(ZTIMER_USEC, &msg, timeout);
+        uint32_t start = ztimer_now(ZTIMER_MSEC);
+        res = ztimer_msg_receive_timeout(ZTIMER_MSEC, &msg, timeout);
 
         /* ensure whole timeout time for the case we receive other messages than DTLS_EVENT_CONNECTED */
         if (timeout != SOCK_NO_TIMEOUT) {
-            uint32_t diff = (ztimer_now(ZTIMER_USEC) - start);
+            uint32_t diff = (ztimer_now(ZTIMER_MSEC) - start);
             timeout = (diff > timeout) ? 0: timeout - diff;
             is_timed_out = (res < 0) || (timeout == 0);
         }
@@ -1158,9 +1158,9 @@ ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
             }
             if (memo->msg.data.pdu_buf) {
                 memo->send_limit  = CONFIG_COAP_MAX_RETRANSMIT;
-                timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
+                timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT * MS_PER_SEC;
 #if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
-                timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END * US_PER_SEC);
+                timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END * MS_PER_SEC);
 #endif
                 memo->state = GCOAP_MEMO_RETRANSMIT;
             }
@@ -1173,7 +1173,7 @@ ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
         case COAP_TYPE_NON:
             memo->send_limit = GCOAP_SEND_LIMIT_NON;
             memcpy(&memo->msg.hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
-            timeout = CONFIG_GCOAP_NON_TIMEOUT;
+            timeout = CONFIG_GCOAP_NON_TIMEOUT_MSEC;
             break;
         default:
             memo->state = GCOAP_MEMO_UNUSED;
@@ -1191,14 +1191,14 @@ ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
 
     _tl_init_coap_socket(&socket);
     if (IS_USED(MODULE_GCOAP_DTLS) && socket.type == GCOAP_SOCKET_TYPE_DTLS) {
-        res = _tl_authenticate(&socket, remote, CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_USEC);
+        res = _tl_authenticate(&socket, remote, CONFIG_GCOAP_DTLS_HANDSHAKE_TIMEOUT_MSEC);
     }
 
     /* set response timeout; may be zero for non-confirmable */
     if (memo != NULL && res == 0) {
         if (timeout > 0) {
             event_callback_init(&memo->resp_tmout_cb, _on_resp_timeout, memo);
-            event_timeout_init(&memo->resp_evt_tmout, &_queue,
+            event_timeout_ztimer_init(&memo->resp_evt_tmout, ZTIMER_MSEC, &_queue,
                                &memo->resp_tmout_cb.super);
             event_timeout_set(&memo->resp_evt_tmout, timeout);
         }

--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -10,6 +10,7 @@
 
 #include "embUnit.h"
 #include "xtimer.h"
+#include "ztimer.h"
 
 #include "test_utils/interactive_sync.h"
 
@@ -24,6 +25,11 @@
 int main(void)
 {
     test_utils_interactive_sync();
+
+#if MODULE_ZTIMER_USEC || MODULE_ZTIMER_MSEC || MODULE_ZTIMER_SEC
+    /* auto_init is disabled, but some modules depends on this module being initialized */
+    ztimer_init();
+#endif
 
 #ifdef MODULE_XTIMER
     /* auto_init is disabled, but some modules depends on this module being initialized */

--- a/tests/unittests/tests-rtt_rtc/Makefile.include
+++ b/tests/unittests/tests-rtt_rtc/Makefile.include
@@ -1,4 +1,5 @@
 USEMODULE += rtt_rtc
+USEMODULE += ztimer_no_periph_rtt
 
 CFLAGS += -DMOCK_RTT_FREQUENCY=32
 CFLAGS += -DMOCK_RTT_MAX_VALUE=0xFFFF

--- a/tests/unittests/tests-ztimer/tests-ztimer-convert-muldiv64.c
+++ b/tests/unittests/tests-ztimer/tests-ztimer-convert-muldiv64.c
@@ -120,7 +120,8 @@ static void test_ztimer_convert_muldiv64_set_speedup(void)
     TEST_ASSERT_EQUAL_INT(4294968LU, ztimer_now(&zmock.super));
 
     /* convert has overflowed ((2000 + 4294966000) % 2**32 = 704U)*/
-    TEST_ASSERT_EQUAL_INT(704LU, ztimer_now(z));
+    /* cast in case ztimer_now_t is uint64_t */
+    TEST_ASSERT_EQUAL_INT(704LU, (uint32_t) ztimer_now(z));
 
     /* assert t hasn't triggered yet */
     TEST_ASSERT_EQUAL_INT(0, val);
@@ -180,21 +181,24 @@ static void test_ztimer_convert_muldiv64_set_slowdown(void)
     ztimer_set(z, &t, 4294968);
 
     ztimer_mock_advance(&zmock, UINT32_MAX);
-    TEST_ASSERT_EQUAL_INT(999, ztimer_now(&zmock.super));
+    /* cast in case ztimer_now_t is uint64_t */
+    TEST_ASSERT_EQUAL_INT(999, (uint32_t) ztimer_now(&zmock.super));
 
     /* ztimer_now(z) is now at (UINT32_MAX + 1000)/1000) == 4294968 */
     TEST_ASSERT_EQUAL_INT(4294968, ztimer_now(z));
     TEST_ASSERT_EQUAL_INT(0, val);
 
     ztimer_mock_advance(&zmock, 704);
-    TEST_ASSERT_EQUAL_INT(1703, ztimer_now(&zmock.super));
+    /* cast in case ztimer_now_t is uint64_t */
+    TEST_ASSERT_EQUAL_INT(1703, (uint32_t) ztimer_now(&zmock.super));
     TEST_ASSERT_EQUAL_INT(4294969, ztimer_now(z));
 
     /* assert that this has not triggered yet. */
     TEST_ASSERT_EQUAL_INT(0, val);
 
     ztimer_mock_advance(&zmock, 1);
-    TEST_ASSERT_EQUAL_INT(1704, ztimer_now(&zmock.super));
+    /* cast in case ztimer_now_t is uint64_t */
+    TEST_ASSERT_EQUAL_INT(1704, (uint32_t) ztimer_now(&zmock.super));
     TEST_ASSERT_EQUAL_INT(4294969, ztimer_now(z));
     TEST_ASSERT_EQUAL_INT(1, val);
     val = 0;


### PR DESCRIPTION
### Contribution description

switches gcoap to use ztimer

### Testing procedure

run and manualy test with examples/gcoap

### Issues/PRs references

~waiting for #16958 which would enable ztimer_msec  use~