### PR TITLE
core/include/kernel_defines.h: add index_of() macro

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -64,6 +64,16 @@ extern "C" {
 #endif
 
 /**
+ * @def         index_of(ARRAY, ELEMENT)
+ * @brief       Returns the index of a pointer to an array element.
+
+ * @param[in]   ARRAY    an array
+ * @param[in]   ELEMENT  pointer to an array element
+ * @return      Index of the element in the array
+ */
+#define index_of(ARRAY, ELEMENT) (((uintptr_t)(ELEMENT) - (uintptr_t)(ARRAY)) / sizeof(*(ELEMENT)))
+
+/**
  * @def NORETURN
  * @brief The *NORETURN* keyword tells the compiler to assume that the function
  *        cannot return.

--- a/tests/unittests/tests-kernel_defines/tests-kernel_defines.c
+++ b/tests/unittests/tests-kernel_defines/tests-kernel_defines.c
@@ -46,10 +46,20 @@ static void test_kernel_version(void)
 #endif
 }
 
+static void test_index_of(void)
+{
+    unsigned foo[8];
+    uint8_t bar[32];
+
+    TEST_ASSERT_EQUAL_INT(5, index_of(foo, &foo[5]));
+    TEST_ASSERT_EQUAL_INT(17, index_of(bar, &bar[17]));
+}
+
 Test *tests_kernel_defines_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_kernel_version),
+        new_TestFixture(test_index_of),
     };
 
     EMB_UNIT_TESTCALLER(kernel_defines_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It can be quite useful to have a macro to get the index of an element in an array.
Instead of open-coding it, add a macro to `kernel_defines.h` so that everyone can use it without code duplication.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
