### PR TITLE
pkg/paho-mqtt: migrate to ztimer

### DIFF
--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -60,6 +60,9 @@ USEMODULE += sock_ip
 USEMODULE += sock_udp
 USEMODULE += sock_tcp
 
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+
 ####
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/paho-mqtt/main.c
+++ b/examples/paho-mqtt/main.c
@@ -21,7 +21,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "shell.h"
 #include "thread.h"
 #include "mutex.h"
@@ -294,7 +295,7 @@ int main(void)
 {
 #ifdef MODULE_LWIP
     /* let LWIP initialize */
-    xtimer_sleep(1);
+    ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 #endif
 
     NetworkInit(&network);

--- a/pkg/paho-mqtt/Makefile.dep
+++ b/pkg/paho-mqtt/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 USEMODULE += paho-mqtt-contrib
 USEMODULE += paho-mqtt-packet
 USEMODULE += tsrb

--- a/pkg/paho-mqtt/contrib/riot_iface.c
+++ b/pkg/paho-mqtt/contrib/riot_iface.c
@@ -25,7 +25,8 @@
 #include "net/sock/tcp.h"
 #include "paho_mqtt.h"
 #include "MQTTClient.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "tsrb.h"
 #include "log.h"
 
@@ -71,8 +72,7 @@ static int mqtt_read(struct Network *n, unsigned char *buf, int len,
         _timeout = timeout_ms;
     }
 
-    uint64_t send_tick = xtimer_now64().ticks64 +
-            xtimer_ticks_from_usec64(timeout_ms * US_PER_MS).ticks64;
+    uint32_t send_time = ztimer_now(ZTIMER_MSEC) + timeout_ms;
     do {
         rc = sock_tcp_read(&n->sock, _buf, _len, _timeout);
         if (rc == -EAGAIN) {
@@ -86,7 +86,7 @@ static int mqtt_read(struct Network *n, unsigned char *buf, int len,
 
             rc = tsrb_get(&tsrb_lwip_tcp, buf, len);
         }
-    } while (rc < len && xtimer_now64().ticks64 < send_tick && rc >= 0);
+    } while (rc < len && ztimer_now(ZTIMER_MSEC) < send_time && rc >= 0);
 
     if (IS_ACTIVE(ENABLE_DEBUG) && IS_USED(MODULE_LWIP) && rc > 0) {
         DEBUG("MQTT buf asked for %d, available to read %d\n",
@@ -154,8 +154,8 @@ void NetworkDisconnect(Network *n)
 
 void TimerInit(Timer *timer)
 {
-    timer->set_ticks.ticks64 = 0;
-    timer->ticks_timeout.ticks64 = 0;
+    timer->timeout = 0;
+    timer->time_set = 0;
 }
 
 char TimerIsExpired(Timer *timer)
@@ -165,8 +165,8 @@ char TimerIsExpired(Timer *timer)
 
 void TimerCountdownMS(Timer *timer, unsigned int timeout_ms)
 {
-    timer->set_ticks = xtimer_now64();
-    timer->ticks_timeout = xtimer_ticks_from_usec64(timeout_ms * US_PER_MS);
+    timer->time_set = ztimer_now(ZTIMER_MSEC);
+    timer->timeout = timeout_ms;
 }
 
 void TimerCountdown(Timer *timer, unsigned int timeout_s)
@@ -176,11 +176,10 @@ void TimerCountdown(Timer *timer, unsigned int timeout_s)
 
 int TimerLeftMS(Timer *timer)
 {
-    xtimer_ticks64_t diff_ticks = xtimer_diff64(xtimer_now64(),
-            timer->set_ticks);  /* should be always greater than 0 */
-    if (xtimer_less64(diff_ticks, timer->ticks_timeout)) {
-        diff_ticks = xtimer_diff64(timer->ticks_timeout, diff_ticks);
-        return (xtimer_usec_from_ticks64(diff_ticks) / US_PER_MS);
+    uint32_t left_time = ztimer_now(ZTIMER_MSEC) - timer->time_set; /* should be always greater than 0 */
+    if (left_time < timer->timeout) {
+        left_time = timer->timeout - left_time;
+        return left_time;
     }
     return 0;
 }
@@ -215,7 +214,7 @@ void *mqtt_riot_run(void *arg)
         }
         MutexUnlock(&client->mutex);
         /* let other threads do their work */
-        xtimer_msleep(MQTT_YIELD_POLLING_MS);
+        ztimer_sleep(ZTIMER_MSEC, MQTT_YIELD_POLLING_MS);
     }
     return NULL;
 }

--- a/pkg/paho-mqtt/include/paho_mqtt.h
+++ b/pkg/paho-mqtt/include/paho_mqtt.h
@@ -20,7 +20,6 @@
 #define PAHO_MQTT_H
 
 #include "mutex.h"
-#include "xtimer.h"
 #include "thread.h"
 #include "net/sock/tcp.h"
 
@@ -54,8 +53,8 @@ extern "C" {
  *
  */
 typedef struct {
-    xtimer_ticks64_t set_ticks;             /**< timeout ticks */
-    xtimer_ticks64_t ticks_timeout;         /**< timeout in ticks */
+    uint32_t timeout;                   /**< timeout in ms */
+    uint32_t time_set;                  /**< set time in ms */
 } Timer;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrate the paho-mqtt package to ztimer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `examples/paho-mqtt` is still working: I was able to publish/subscribe on topics between a native instance and a local mosquitto MQTT broker.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Ticks an item in #17111 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
