### PR TITLE
tests/lwip_sock: Take lock before calling etharp

### DIFF
--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -198,7 +198,9 @@ void _prepare_send_checks(void)
     netdev_test_set_send_cb(&netdev, _netdev_send);
 #if LWIP_ARP
     const ip4_addr_t remote4 = { .addr = _TEST_ADDR4_REMOTE };
+    LOCK_TCPIP_CORE();
     expect(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
+    UNLOCK_TCPIP_CORE();
 #endif
 #if LWIP_IPV6
     memset(destination_cache, 0,

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -201,7 +201,9 @@ void _prepare_send_checks(void)
     netdev_test_set_send_cb(&netdev, _netdev_send);
 #if LWIP_ARP
     const ip4_addr_t remote4 = { .addr = _TEST_ADDR4_REMOTE };
+    LOCK_TCPIP_CORE();
     expect(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
+    UNLOCK_TCPIP_CORE();
 #endif
 #if LWIP_IPV6
     memset(destination_cache, 0,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Lock lwIP before adding static entry to etharp (fixing assert)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=native LWIP_IPV6=0 LWIP_IPV4=1 make -C tests/lwip_sock_ip/ clean flash test -j`

`BOARD=native LWIP_IPV6=0 LWIP_IPV4=1 make -C tests/lwip_sock_udp/ clean flash test -j`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #17144
