### PR TITLE
murdock: allow specifying redis host

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -65,6 +65,7 @@ export STATIC_TESTS=0
 export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}
+export MURDOCK_REDIS_HOST=${MURDOCK_REDIS_HOST:-127.0.0.1}
 
 # This is a work around for a bug in CCACHE which interacts very badly with
 # some features of RIOT and of murdock. The result is that ccache is
@@ -274,11 +275,11 @@ test_hash_calc() {
 
 test_cache_get() {
     test "${ENABLE_TEST_CACHE}" = "1" || return 1
-    test -n "$(redis-cli get $1)" > /dev/null
+    test -n "$(redis-cli -h ${MURDOCK_REDIS_HOST} get $1)" > /dev/null
 }
 
 test_cache_put() {
-    redis-cli set "$1" ok
+    redis-cli -h ${MURDOCK_REDIS_HOST} set "$1" ok
 }
 
 # compile one app for one board with one toolchain. delete intermediates.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Current .murdock is using `redis-cli` with the default host setting of `127.0.0.1`.
I'm building a docker-compose version of `redis-cli` which runs the ssh tunnel in an extra container. That needs passing to `redis-cli`, which this PR does.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've tested this manually, here's output from `beast` (running the docker-compose worker) with a commit printing the used value when set to "ssh_bridge" as default:
<details>

```
riot on  murdock_redis_host via ⍱ took 54s 
❯ dwqc -q beast -E RUN_TESTS=1 "./.murdock compile tests/fmt_print samr21-xpro:gcc"                                                                
MURDOCK_REDIS_HOST=ssh_bridge                                                                                                                      
-- running on worker beast thread 1, build number 4.                                                                                               
make: Entering directory '/tmp/dwq.0.5923782274112128/ef6e7535825f72d55d391c0a2c6154b2/tests/fmt_print'                                            
Building application "tests_fmt_print" for "samr21-xpro" with MCU "samd21".                                                                        
                                                                         
sha1sum /tmp/dwq.0.5923782274112128/ef6e7535825f72d55d391c0a2c6154b2/tests/fmt_print/tests/01-run.py /tmp/dwq.0.5923782274112128/ef6e7535825f72d55d
391c0a2c6154b2/build/tests_fmt_print.elf > /tmp/dwq.0.5923782274112128/ef6e7535825f72d55d391c0a2c6154b2/build/test-input-hash.sha1
   text    data     bss     dec     hex filename                                                                                                   
  13676     132    2368   16176    3f30 /tmp/dwq.0.5923782274112128/ef6e7535825f72d55d391c0a2c6154b2/build/tests_fmt_print.elf                     
make: Leaving directory '/tmp/dwq.0.5923782274112128/ef6e7535825f72d55d391c0a2c6154b2/tests/fmt_print'
-- test_hash=2e2efc56cabf6a63233e2c45e7248fa52c09c75a
-- skipping test due to positive cache hit
-- build directory size: 1.2M                                            
riot on  murdock_redis_host via ⍱ took 10s                              

```

</details>

Here's `breeze` (one of the production workers) using the default value, but picking up the cache entry:

<details>

```
❯ dwqc -q breeze -E RUN_TESTS=1 "./.murdock compile tests/fmt_print samr21-xpro:gcc"
MURDOCK_REDIS_HOST=127.0.0.1                                             
-- running on worker breeze thread 2, build number 45559.                                                                                          
make: Entering directory '/tmp/dwq.0.8340076810942468/22935ce56c931666e9bb10c09afc06d0/tests/fmt_print'                                            
Building application "tests_fmt_print" for "samr21-xpro" with MCU "samd21".
                                                                         
sha1sum /tmp/dwq.0.8340076810942468/22935ce56c931666e9bb10c09afc06d0/tests/fmt_print/tests/01-run.py /tmp/dwq.0.8340076810942468/22935ce56c931666e9
bb10c09afc06d0/build/tests_fmt_print.elf > /tmp/dwq.0.8340076810942468/22935ce56c931666e9bb10c09afc06d0/build/test-input-hash.sha1                 
   text    data     bss     dec     hex filename                                                                                                   
  13676     132    2368   16176    3f30 /tmp/dwq.0.8340076810942468/22935ce56c931666e9bb10c09afc06d0/build/tests_fmt_print.elf                     
make: Leaving directory '/tmp/dwq.0.8340076810942468/22935ce56c931666e9bb10c09afc06d0/tests/fmt_print'
-- test_hash=2e2efc56cabf6a63233e2c45e7248fa52c09c75a                                                                                              
-- skipping test due to positive cache hit
-- build directory size: 1.2M

```
</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
