### PR TITLE
drivers/lis3dh: fix unaligned memory access

### DIFF
--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -746,7 +746,7 @@ typedef struct {
 /**
  * @brief   Result vector for accelerometer measurement
  */
-typedef struct __attribute__((packed))
+typedef struct
 {
     int16_t acc_x;          /**< Acceleration in the X direction in milli-G */
     int16_t acc_y;          /**< Acceleration in the Y direction in milli-G */


### PR DESCRIPTION
### Contribution description

The bogus packed attribute added to lis3dh_data_t resulted in the structure being aligned two 1 byte. It was later casted to an `uint16_t` pointer (which is aligned two 2 bytes). By dropping the packed attribute the alignment mismatch is fixed.

### Testing procedure

Except for potential crashes on architectures that do not support unaligned memory access that this fixes, the driver should work as before.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14955