### PR TITLE
sys/posix/socket: align struct sockaddr{,_storage}

### DIFF
--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -23,13 +23,9 @@ ifeq ($(ROMABLE),1)
   MIPS_HAL_LDFLAGS += -T bootcode.ld
 endif
 
-# define build specific options
-# Remove -std=gnu99 once the MIPS toolchain headers are updated to include upstream
-# newlib commit 81c17949f0419d1c4fee421c60987ea1149522ae
-# https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=commitdiff;h=81c17949f0419d1c4fee421c60987ea1149522ae
 # Otherwise we get an error about a missing declaration of strnlen in some parts.
 ifeq (, $(filter -std=%, $(CFLAGS)))
-  CFLAGS += -std=gnu99
+  CFLAGS += -std=gnu11
 endif
 CFLAGS_CPU   = -EL -mabi=$(ABI)
 CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections

--- a/pkg/ccn-lite/patches/0001-cmake-Use-std-c11-instead-of-std-c99.patch
+++ b/pkg/ccn-lite/patches/0001-cmake-Use-std-c11-instead-of-std-c99.patch
@@ -1,0 +1,28 @@
+From 540627a749f627df4a23fe3fc03757f37616c2eb Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Thu, 11 Nov 2021 09:51:13 +0100
+Subject: [PATCH] cmake: Use -std=c11 instead of -std=c99
+
+---
+ src/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a56946be..a30f77fc 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -89,9 +89,9 @@ if(CCNL_RIOT)
+ endif()
+ 
+ if (NOT CCNL_RIOT)
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -Werror -std=c99 -g -pedantic") #TODO: add -fsanitize=address
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -Werror -std=c11 -g -pedantic") #TODO: add -fsanitize=address
+ else()
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -Werror -std=c99 -g")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -Werror -std=c11 -g")
+ endif()
+ 
+ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -g")
+-- 
+2.33.1
+

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -38,10 +38,12 @@
 #define __SOCKADDR_COMMON_SIZE  (sizeof (unsigned short int))
 #endif
 
+#include <stdalign.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 
+#include "architecture.h"
 #include "net/af.h"
 #include "sys/bytes.h"
 
@@ -120,18 +122,24 @@ typedef unsigned short sa_family_t;   /**< address family type */
 
 /**
  * @brief   Used to define the socket address.
+ *
+ * @details This structure is is forced to be aligned as `uint32_t`, as e.g.
+ *          the IPv4 address is stored as `uint32_t`
  */
 struct sockaddr {
-    sa_family_t sa_family;                  /**< Address family */
+    alignas(uint32_t) sa_family_t sa_family;/**< Address family */
     char sa_data[SOCKADDR_MAX_DATA_LEN];    /**< Socket address (variable length data) */
 };
 
 /**
  * @brief   Implementation based socket address table.
  * @extends struct sockaddr
+ *
+ * @details This structure is is forced to be aligned as `uint32_t`, as e.g.
+ *          the IPv4 address is stored as `uint32_t`
  */
 struct sockaddr_storage {
-    sa_family_t ss_family;                  /**< Address family */
+    alignas(uint32_t) sa_family_t ss_family;/**< Address family */
     uint8_t ss_data[SOCKADDR_MAX_DATA_LEN]; /**< Socket address */
 };
 


### PR DESCRIPTION
### Contribution description

Align the first member of `struct sockaddr` and `struct sockaddr_storage` as `uint32_t` to elevate the alignment of the structure to level of `uint32_t`. This is needed as `struct sockaddr_in` uses an `uint32_t` to store the IPv4 address, previously resulting in `struct sockaddr_in` currently having a greater alignment requirement that `struct sockaddr_storage`.

POSIX sockets should still work, and now do so reliably on platforms that do not support unaligned memory accesses.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14955

This contains the same commit to enable C11 for MIPS as https://github.com/RIOT-OS/RIOT/pull/17195 - so if one of the two gets in first the other should be rebased on `master`.