### PR TITLE
sys/net/dns: mark dns_hdr_t as packed

### DIFF
--- a/sys/include/net/dns/msg.h
+++ b/sys/include/net/dns/msg.h
@@ -45,7 +45,7 @@ extern "C" {
  *
  * @see [RFC 1035, section 4.1.1](https://tools.ietf.org/html/rfc1035#section-4.1.1)
  */
-typedef struct {
+typedef struct __attribute__((packed)) {
     uint16_t id;        /**< identifier */
     /**
      * @brief   flags


### PR DESCRIPTION
### Contribution description

This structure is used to parse data from unaligned buffers, so make sure the compiler issues instructions suitable for unaligned memory access.

### Testing procedure

sock_dns should now work reliably on platforms that do not support unaligned memory access.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14955