### PR TITLE
drivers/encx24j600: fix unaligned memory access

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -149,10 +149,10 @@ static inline void enc_spi_transfer(encx24j600_t *dev, char *out, char *in, int 
 
 static inline uint16_t reg_get(encx24j600_t *dev, uint8_t reg)
 {
-    char cmd[4] = { ENC_RCRU, reg, 0, 0 };
+    char cmd_buf[4] = { ENC_RCRU, reg, 0, 0 };
     char result[4];
 
-    enc_spi_transfer(dev, cmd, result, 4);
+    enc_spi_transfer(dev, cmd_buf, result, 4);
 
     return result[2] | (result[3] << 8);
 }
@@ -173,20 +173,20 @@ static void cmdn(encx24j600_t *dev, uint8_t cmd, char *out, char *in, int len) {
 
 static void reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value)
 {
-    char cmd[4] = { ENC_WCRU, reg, value, value >> 8 };
-    enc_spi_transfer(dev, cmd, NULL, 4);
+    char cmd_buf[4] = { ENC_WCRU, reg, value, value >> 8 };
+    enc_spi_transfer(dev, cmd_buf, NULL, 4);
 }
 
 static void reg_set_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
 {
-    char cmd[4] = { ENC_BFSU, reg, mask, mask >> 8 };
-    enc_spi_transfer(dev, cmd, NULL, 4);
+    char cmd_buf[4] = { ENC_BFSU, reg, mask, mask >> 8 };
+    enc_spi_transfer(dev, cmd_buf, NULL, 4);
 }
 
 static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
 {
-    char cmd[4] = { ENC_BFCU, reg, mask, mask >> 8 };
-    enc_spi_transfer(dev, cmd, NULL, 4);
+    char cmd_buf[4] = { ENC_BFCU, reg, mask, mask >> 8 };
+    enc_spi_transfer(dev, cmd_buf, NULL, 4);
 }
 
 /*

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -326,13 +326,15 @@ static inline int _packets_available(encx24j600_t *dev)
 static void _get_mac_addr(netdev_t *encdev, uint8_t* buf)
 {
     encx24j600_t * dev = (encx24j600_t *) encdev;
-    uint16_t *addr = (uint16_t *) buf;
+    uint16_t addr[3];
 
     lock(dev);
 
     addr[0] = reg_get(dev, ENC_MAADR1);
     addr[1] = reg_get(dev, ENC_MAADR2);
     addr[2] = reg_get(dev, ENC_MAADR3);
+
+    memcpy(buf, addr, sizeof(addr));
 
     unlock(dev);
 }


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

This should prevent crashes on platforms that do not support unaligned memory accesses.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14955