### PR TITLE
sys/net/gnrc: fix compilation with -Wcast-align

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -22,7 +22,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdalign.h>
 
+#include "architecture.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/pkt.h"
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_SFR
@@ -99,13 +101,14 @@ typedef struct {
      * @brief   The reassembled packet in the packet buffer
      */
     gnrc_pktsnip_t *pkt;
-#if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR)
+#if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR) || defined(DOXYGEN)
     /**
      * @brief   Bitmap for received fragments
      *
      * @note    Only available with module `gnrc_sixlowpan_frag_sfr` compiled
      *          in.
      */
+    alignas(gnrc_sixlowpan_frag_sfr_bitmap_t)
     BITFIELD(received, SIXLOWPAN_SFR_ACK_BITMAP_SIZE);
     int8_t offset_diff;                         /**< offset change due to
                                                  *   recompression */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
@@ -1401,7 +1401,7 @@ static int _resend_frag(clist_node_t *node, void *fbuf_ptr)
     cur_frag_size = _find_offset_and_copy_rest(data, &pkt, frag_size,
                                                frag_desc->offset);
     /* copy remaining packet snips */
-    cur_frag_size = _copy_pkt_to_frag(data, pkt, frag_size, cur_frag_size);
+    _copy_pkt_to_frag(data, pkt, frag_size, cur_frag_size);
     DEBUG("6lo sfr: resending fragment (retry: %u, tag: %u, X: %i, seq: %u, "
           "frag_size: %u, %s: %u)\n", frag_desc->retries,
           hdr->base.tag, sixlowpan_sfr_rfrag_ack_req(hdr),


### PR DESCRIPTION
### Contribution description

This PR fixes compilation with `-Wcast-align`. It also adds a `static_assert()` to check that the alignment is indeed word size (why word size: Because the alignment of `uint32_t` is word sized for all architectures).

### Testing procedure

1. No change in generated binaries
2. Compilation should fail if the following patch is applied

```diff
diff --git a/sys/include/net/gnrc/sixlowpan/frag/rb.h b/sys/include/net/gnrc/sixlowpan/frag/rb.h
index 2cf6110b38..b6395a6938 100644
--- a/sys/include/net/gnrc/sixlowpan/frag/rb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/rb.h
@@ -101,13 +101,14 @@ typedef struct {
      */
     gnrc_pktsnip_t *pkt;
 #if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR) || defined(DOXYGEN)
+    uint8_t padding;
     /**
      * @brief   Bitmap for received fragments
      *
      * @note    Only available with module `gnrc_sixlowpan_frag_sfr` compiled
      *          in.
      */
-    WORD_ALIGNED BITFIELD(received, SIXLOWPAN_SFR_ACK_BITMAP_SIZE);
+    BITFIELD(received, SIXLOWPAN_SFR_ACK_BITMAP_SIZE);
     int8_t offset_diff;                         /**< offset change due to
                                                  *   recompression */
 #endif /* IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR) */
```

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14955 ~~and depends on https://github.com/RIOT-OS/RIOT/pull/17177~~