### PR TITLE
boards/lora-e5-dev: enable 3.3V and 5V output by default

### DIFF
--- a/boards/lora-e5-dev/Kconfig
+++ b/boards/lora-e5-dev/Kconfig
@@ -23,3 +23,11 @@ config BOARD_LORA_E5_DEV
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
+
+config LORA_E5_DEV_ENABLE_3P3V
+    bool "LoRa-E5 Development Kit - Enable 3.3V output"
+    default y
+
+config LORA_E5_DEV_ENABLE_5V
+    bool "LoRa-E5 Development Kit - Enable 5V output"
+    default y

--- a/boards/lora-e5-dev/Makefile.dep
+++ b/boards/lora-e5-dev/Makefile.dep
@@ -6,4 +6,5 @@ ifneq (,$(filter sx126x_stm32wl,$(USEMODULE)))
 endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += lm75a
 endif

--- a/boards/lora-e5-dev/board.c
+++ b/boards/lora-e5-dev/board.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include "kernel_defines.h"
 #include "cpu.h"
 #include "board.h"
 #include "periph/gpio.h"
@@ -33,6 +34,16 @@ void board_init(void)
     gpio_init(LED0_PIN, GPIO_OUT);
     LED0_OFF;
 #endif
+
+    if(IS_ACTIVE(CONFIG_LORA_E5_DEV_ENABLE_3P3V)) {
+        gpio_init(LORA_E5_DEV_3P3V_ENABLE_PIN, GPIO_OUT);
+        gpio_set(LORA_E5_DEV_3P3V_ENABLE_PIN);
+    }
+
+    if(IS_ACTIVE(CONFIG_LORA_E5_DEV_ENABLE_5V)) {
+        gpio_init(LORA_E5_DEV_5V_ENABLE_PIN, GPIO_OUT);
+        gpio_set(LORA_E5_DEV_5V_ENABLE_PIN);
+    }
 
     if (IS_USED(MODULE_SX126X_STM32WL)) {
         /* Initialize the GPIO control for RF 3-port switch (SP3T) */

--- a/boards/lora-e5-dev/include/board.h
+++ b/boards/lora-e5-dev/include/board.h
@@ -83,6 +83,27 @@ extern void lora_e5_dev_sx126x_set_rf_mode(sx126x_t *dev, sx126x_rf_mode_t rf_mo
 /** @} */
 
 /**
+ * @brief    Enable 3.3V output
+ */
+#ifndef CONFIG_LORA_E5_DEV_ENABLE_3P3V
+#define CONFIG_LORA_E5_DEV_ENABLE_3P3V      1
+#endif
+/**
+ * @brief    Enable 5V output
+ */
+#ifndef CONFIG_LORA_E5_DEV_ENABLE_5V
+#define CONFIG_LORA_E5_DEV_ENABLE_5V        1
+#endif
+/**
+ * @brief    lora-e5-dev 3.3V gpio enable pin
+ */
+#define LORA_E5_DEV_3P3V_ENABLE_PIN         GPIO_PIN(PORT_A, 9)
+/**
+ * @brief    lora-e5-dev 5V gpio enable pin
+ */
+#define LORA_E5_DEV_5V_ENABLE_PIN           GPIO_PIN(PORT_B, 10)
+
+/**
  * @brief   Board level initialization
  */
 void board_init(void);


### PR DESCRIPTION
### Contribution description

While trying to fix #17052, I realized that when connecting  groove sensor the power led did not turn on, when checking the [schematic](https://files.seeedstudio.com/products/113990934/LoRa-E5%20Dev%20Board%20v1.0.pdf) I realized two GPIO's enable/disable 3.3V and 5V output. This being disabled was the only reason why i2c was not working and therefore the lm75 sensor.

![image](https://user-images.githubusercontent.com/23060007/140656200-e0723037-1b22-4d9e-b109-bd831df27ca8.png)

![image](https://user-images.githubusercontent.com/23060007/140656208-fc04f188-d2b1-4c04-8313-f7b90b09441a.png)

### Testing procedure

`BOARD=lora-e5-dev make -C tests/saul/ clean flash term -j`
```
2021-11-07 18:52:39,010 # ##########################
2021-11-07 18:52:39,991 # 
2021-11-07 18:52:39,992 # Dev: LED(red)	Type: ACT_SWITCH
2021-11-07 18:52:39,992 # Data:	              1 
2021-11-07 18:52:39,992 # 
2021-11-07 18:52:39,997 # Dev: Button(B1 Boot)	Type: SENSE_BTN
2021-11-07 18:52:39,998 # Data:	              0 
2021-11-07 18:52:39,998 # 
2021-11-07 18:52:40,003 # Dev: Button(B2 D0)	Type: SENSE_BTN
2021-11-07 18:52:40,003 # Data:	              0 
2021-11-07 18:52:40,003 # 
2021-11-07 18:52:40,008 # Dev: lm75	Type: SENSE_TEMP
2021-11-07 18:52:40,009 # Data:	          20.87 °C
2021-11-07 18:52:40,009 # 
2021-11-07 18:52:40,010 # ##########################
2021-11-07 18:52:40,991 # 
2021-11-07 18:52:40,992 # Dev: LED(red)	Type: ACT_SWITCH
2021-11-07 18:52:40,992 # Data:	              1 
2021-11-07 18:52:40,992 # 
2021-11-07 18:52:40,997 # Dev: Button(B1 Boot)	Type: SENSE_BTN
2021-11-07 18:52:40,998 # Data:	              0 
2021-11-07 18:52:40,998 # 
2021-11-07 18:52:41,003 # Dev: Button(B2 D0)	Type: SENSE_BTN
2021-11-07 18:52:41,004 # Data:	              0 
2021-11-07 18:52:41,004 # 
2021-11-07 18:52:41,008 # Dev: lm75	Type: SENSE_TEMP
2021-11-07 18:52:41,009 # Data:	          24.87 °C
2021-11-07 18:52:41,009 # 
2021-11-07 18:52:41,010 # ##########################
2021-11-07 18:52:41,991 # 
2021-11-07 18:52:41,992 # Dev: LED(red)	Type: ACT_SWITCH
2021-11-07 18:52:41,992 # Data:	              1 
2021-11-07 18:52:41,992 # 
2021-11-07 18:52:41,997 # Dev: Button(B1 Boot)	Type: SENSE_BTN
2021-11-07 18:52:41,998 # Data:	              0 
2021-11-07 18:52:41,998 # 
2021-11-07 18:52:42,003 # Dev: Button(B2 D0)	Type: SENSE_BTN
2021-11-07 18:52:42,003 # Data:	              0 
2021-11-07 18:52:42,003 # 
2021-11-07 18:52:42,008 # Dev: lm75	Type: SENSE_TEMP
2021-11-07 18:52:42,009 # Data:	          25.87 °C
2021-11-07 18:52:42,009 # 
2021-11-07 18:52:42,010 # ##########################
```

### Issues/PRs references

Fixes #17052