### PR TITLE
sys/{x,z}timer/Kconfig: fix compatibility modules

### DIFF
--- a/sys/xtimer/Kconfig
+++ b/sys/xtimer/Kconfig
@@ -7,13 +7,12 @@
 
 menuconfig MODULE_XTIMER
     bool "xtimer"
-    depends on HAS_PERIPH_TIMER || MODULE_XTIMER_ON_ZTIMER || MODULE_ZTIMER_XTIMER_COMPAT
+    depends on HAS_PERIPH_TIMER
     depends on TEST_KCONFIG
 
     # use timer peripheral unless ztimer compatibility module is used
     select MODULE_PERIPH_TIMER if HAS_PERIPH_TIMER && !MODULE_XTIMER_ON_ZTIMER && !MODULE_ZTIMER_XTIMER_COMPAT
 
-    select MODULE_DIV if !MODULE_ZTIMER_XTIMER_COMPAT
     help
         Include xtimer module. xtimer requires a low-level timer implementation
         that can be provided either by a peripheral timer or the ztimer module

--- a/sys/xtimer/Kconfig
+++ b/sys/xtimer/Kconfig
@@ -13,6 +13,7 @@ menuconfig MODULE_XTIMER
     # use timer peripheral unless ztimer compatibility module is used
     select MODULE_PERIPH_TIMER if HAS_PERIPH_TIMER && !MODULE_XTIMER_ON_ZTIMER && !MODULE_ZTIMER_XTIMER_COMPAT
 
+    select MODULE_DIV if !MODULE_ZTIMER_XTIMER_COMPAT
     help
         Include xtimer module. xtimer requires a low-level timer implementation
         that can be provided either by a peripheral timer or the ztimer module

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -132,15 +132,16 @@ menu "xtimer and evtimer compatibility"
 
 choice
     bool "xtimer compatibility"
-    optional
-    depends on MODULE_ZTIMER_USEC
+    depends on MODULE_XTIMER
 
 config MODULE_XTIMER_ON_ZTIMER
     bool "ztimer_usec as timer backend for xtimer"
+    select MODULE_ZTIMER_USEC
 
 config MODULE_ZTIMER_XTIMER_COMPAT
     bool "map xtimer calls to ztimer"
     select MODULE_DIV
+    select MODULE_ZTIMER_USEC
     help
         This is a wrapper of xtimer API on ztimer_usec and is currently
         incomplete. Unless doing testing, use xtimer on ztimer.


### PR DESCRIPTION
### Contribution description
Currently the xtimer/ztimer compatibility modules choice was optional in Kconfig, but we want one to be enabled when ztimer is selected.

### Testing procedure
- CI should pass

### Issues/PRs references
Pointed out in #17137
