### PR TITLE
gnrc_gomach: do not require periph_rtt

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -21,7 +21,6 @@ ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer
   USEMODULE += gnrc_mac
-  FEATURES_REQUIRED += periph_rtt
 endif
 
 ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`gnrc_gomach` has been converted to use xtimer, but the old dependency is still in place.



### Testing procedure

Code should still compile without `periph_rtt` 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
