### PR TITLE
gcoap: wrap nanocoap access

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -33,6 +33,7 @@ extern "C" {
 
 /**
  * @name    CoAP option numbers
+ * @anchor  net_coap_opt
  * @{
  */
 #define COAP_OPT_URI_HOST       (3)

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -350,6 +350,22 @@ static inline unsigned coap_get_token_len(const coap_pkt_t *pkt)
 }
 
 /**
+ * @brief   Re-set a message's token length [in byte]
+ *
+ * @param[in] pkt       CoAP packet
+ * @param[in] token_len Desired length of the token
+ *
+ * @warning This should only be used to change the token length before any options are added or for
+ *          an empty CoAP message. The data after the token is not moved by this function.
+ */
+static inline void coap_set_token_len(coap_pkt_t *pkt, uint8_t token_len)
+{
+    assert(!(token_len & 0x0f));    /* token_len <= 0xf */
+
+    pkt->hdr->ver_t_tkl &= (0xf0 | token_len);
+}
+
+/**
  * @brief   Get the total header length (4-byte header + token length)
  *
  * @param[in]   pkt   CoAP packet


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR aims to address the first three tasks in https://github.com/RIOT-OS/RIOT/issues/16855.

This is still WIP, but before I start changing types and documentation, I wanted to have some input.

I followed the following strategies for the wrappers:

- Most of the time the wrapping is straightforward (just call the respective `nanocoap` function in an inline function)
- due to API inconsistencies in `nanocoap` sometimes casting is necessary; I aimed to keep the types consistent in the wrappers
- sometimes there are `\0`-terminated and length variants for adding strings (with the `\0`-terminated variants calling `strlen()` most of the time, so I decided to use the length variants only. 
- some `nanocoap` functions are always used with other functions (e.g. setting the payload always adds the payload marker first) in `gcoap` and its applications), so the wrapper always does this as well.

Future TODOs:
- [ ] introduce `gcoap`-specific type wrappers for `nanocoap` types
- [ ] unify type naming in `gcoap` types to always be prefixed with `gcoap`
- [ ] use the `gcoap`-specific types in newly introduced functions
- [ ] use the newly introduced functions throughout `gcoap` and the applications.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/gcoap` should still compile. Currently, the new wrappers are not used yet, so nothing to test.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresse parts of https://github.com/RIOT-OS/RIOT/issues/16855
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
