### PR TITLE
net/uhcp[cd]: use modules to select client/server code

### DIFF
--- a/dist/tools/uhcpd/Makefile
+++ b/dist/tools/uhcpd/Makefile
@@ -1,5 +1,5 @@
 CFLAGS?=-g -O3 -Wall
-CFLAGS_EXTRA=-DUHCP_SERVER
+CFLAGS_EXTRA=-DMODULE_UHCPD
 all: bin bin/uhcpd
 
 bin:

--- a/sys/net/application_layer/uhcp/Makefile
+++ b/sys/net/application_layer/uhcp/Makefile
@@ -1,3 +1,2 @@
 MODULE=uhcpc
-CFLAGS += -DUHCP_CLIENT
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/application_layer/uhcp/uhcp.c
+++ b/sys/net/application_layer/uhcp/uhcp.c
@@ -39,8 +39,8 @@ void uhcp_handle_udp(uint8_t *buf, size_t len, uint8_t *src, uint16_t port, uhcp
         LOG_ERROR("error: wrong protocol version.\n");
     }
 
-    switch (type) {
-#ifdef UHCP_SERVER
+    switch(type) {
+#ifdef MODULE_UHCPD
         case UHCP_REQ:
             if (len < sizeof(uhcp_req_t)) {
                 LOG_ERROR("error: request too small\n");
@@ -50,7 +50,7 @@ void uhcp_handle_udp(uint8_t *buf, size_t len, uint8_t *src, uint16_t port, uhcp
             }
             break;
 #endif
-#ifdef UHCP_CLIENT
+#ifdef MODULE_UHCPC
         case UHCP_PUSH:
             {
                 uhcp_push_t *push = (uhcp_push_t*)hdr;
@@ -70,7 +70,7 @@ void uhcp_handle_udp(uint8_t *buf, size_t len, uint8_t *src, uint16_t port, uhcp
     }
 }
 
-#ifdef UHCP_SERVER
+#ifdef MODULE_UHCPD
 extern char _prefix[16];
 extern unsigned _prefix_len;
 void uhcp_handle_req(uhcp_req_t *req, uint8_t *src, uint16_t port, uhcp_iface_t iface)
@@ -89,9 +89,9 @@ void uhcp_handle_req(uhcp_req_t *req, uint8_t *src, uint16_t port, uhcp_iface_t 
         LOG_ERROR("uhcp_handle_req(): udp_sendto() res=%i\n", res);
     }
 }
-#endif /* UHCP_SERVER */
+#endif /* MODULE_UHCPD */
 
-#ifdef UHCP_CLIENT
+#ifdef MODULE_UHCPC
 void uhcp_handle_push(uhcp_push_t *req, uint8_t *src, uint16_t port, uhcp_iface_t iface)
 {
     char addr_str[INET6_ADDRSTRLEN];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Previously, this used plain defines. This makes it make use of "MODULE_UHCPx" defines.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Confirm `tests/gnrc_border_router` still gets an address, which would show that both host and RIOT side compile in the necessary bits.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
