### PR TITLE
boards: native: guard motor driver simulation code

### DIFF
--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -127,6 +127,7 @@ extern mtd_dev_t *mtd0;
 /** @} */
 #endif
 
+#if MODULE_PERIPH_QDEC
 /**
  * @brief Simulate QDEC on motor_set() calls
  *
@@ -182,6 +183,7 @@ static const motor_driver_config_t motor_driver_config[] = {
 
 #define MOTOR_DRIVER_NUMOF           ARRAY_SIZE(motor_driver_config)
 /** @} */
+#endif
 
 /**
  * @name    ztimer configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

native has some simulated "motor driver" support, which is *always* compiled in. This PR guards it on ~~`MODULE_MOTOR_DRIVER`~~`MODULE_PERIPH_QDEC`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
