### PR TITLE
pkg/lwip: Fix dualstack build when only using 6lowpan

### DIFF
--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -161,7 +161,7 @@ err_t lwip_netdev_init(struct netif *netif)
             }
             /* netif_create_ip6_linklocal_address() does weird byte-swapping
              * with full IIDs, so let's do it ourselves */
-            addr = &(netif->ip6_addr[0]);
+            addr = ip_2_ip6(&(netif->ip6_addr[0]));
             /* addr->addr is a uint32_t array */
             if (l2util_ipv6_iid_from_addr(dev_type,
                                           netif->hwaddr, netif->hwaddr_len,

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -32,7 +32,7 @@ extern "C" {
  * @see     lwIP documentation
  * @{
  */
-#ifdef MODULE_LWIP_ARP
+#if defined(MODULE_LWIP_ARP) && defined(MODULE_LWIP_ETHERNET)
 #define LWIP_ARP                1
 #else  /* MODULE_LWIP_ARP */
 #define LWIP_ARP                0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

* Disable ARP if Ethernet is not used
* Use macro converting netif v6 address to `ip6_addr_t` (which is noop in v6-only setup)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=iotlab-m3 LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/lwip  -j` now works

`BOARD=iotlab-m3 LWIP_IPV4=1 make -C tests/lwip  -j` is still broken (since it disables IPv6): linking fails with `undefined reference to 'ipv6_addr_link_local_prefix'`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Part of #17162 
