### PR TITLE
pkg/lwip: Don't control IPv6 via IPv4 flag

### DIFF
--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -33,8 +33,9 @@ USEMODULE += ps
 USEMODULE += netdev_default
 USEPKG += paho-mqtt
 
-# paho-mqtt depends on TCP support, choose the stack you want
+# paho-mqtt depends on TCP support, choose which stacks you want
 LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 1
 
 ifneq (0,$(LWIP_IPV4))
   USEMODULE += ipv4_addr
@@ -42,9 +43,6 @@ ifneq (0,$(LWIP_IPV4))
   USEMODULE += lwip_ipv4
   USEMODULE += lwip_dhcp_auto
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
-  LWIP_IPV6 ?= 0
-else
-  LWIP_IPV6 ?= 1
 endif
 
 ifneq (0,$(LWIP_IPV6))

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 1
 
 ifneq (0, $(LWIP_IPV4))
   USEMODULE += ipv4_addr
@@ -8,10 +9,6 @@ ifneq (0, $(LWIP_IPV4))
   USEMODULE += lwip_ipv4
   USEMODULE += lwip_dhcp_auto
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
-  LWIP_IPV6 ?= 0
-else
-  # use IPv6 as default IP protocol when IPv4 is not explicitly selected
-  LWIP_IPV6 ?= 1
 endif
 
 ifneq (0, $(LWIP_IPV6))

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 1
 AUX_LOCAL ?= 1
 
 ifneq (0, $(LWIP_IPV4))
@@ -8,9 +9,6 @@ ifneq (0, $(LWIP_IPV4))
   USEMODULE += lwip_arp
   USEMODULE += lwip_ipv4
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
-  LWIP_IPV6 ?= 0
-else
-  LWIP_IPV6 ?= 1
 endif
 
 ifneq (0, $(LWIP_IPV6))

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -1,15 +1,13 @@
 include ../Makefile.tests_common
 
 LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 1
 
 ifneq (0, $(LWIP_IPV4))
   USEMODULE += ipv4_addr
   USEMODULE += lwip_arp
   USEMODULE += lwip_ipv4
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
-  LWIP_IPV6 ?= 0
-else
-  LWIP_IPV6 ?= 1
 endif
 
 ifneq (0, $(LWIP_IPV6))

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 1
 AUX_LOCAL ?= 1
 
 ifneq (0, $(LWIP_IPV4))
@@ -8,9 +9,6 @@ ifneq (0, $(LWIP_IPV4))
   USEMODULE += lwip_arp
   USEMODULE += lwip_ipv4
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
-  LWIP_IPV6 ?= 0
-else
-  LWIP_IPV6 ?= 1
 endif
 
 ifneq (0, $(LWIP_IPV6))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

lwIP can run in dualstack mode, so there is no reason to disable IPv6 just because IPv4 is enabled.

Enabling `LWIP_IPV4` no longer changes the state of `LWIP_IPV6`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

* `tests/lwip_sock_{ip,tcp,udp}` still pass (in any combination with at least one of IPv4/IPv6 enabled)
* `tests/lwip` still pass with dualstack or IPv6 configured

`paho_mqtt` example needs testing - I don't know how to do it. Try connecting against both IPv4 and IPv6 mqtt via `con` shell command?
It looks like it should work: https://github.com/RIOT-OS/RIOT/blob/master/pkg/paho-mqtt/contrib/riot_iface.c#L128

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Somewhat related to #17162 