### PR TITLE
core: add WITHOUT_PEDANTIC() and DECLARE_CONSTANT()

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -225,6 +225,37 @@ extern "C" {
 #define RIOT_VERSION_NUM(major, minor, patch, extra)   \
     (((0ULL + major) << 48) + ((0ULL + minor) << 32) + \
      ((0ULL + patch) << 16) + (extra))
+
+/**
+ * @brief   Disable -Wpedantic for the argument, but restore diagnostic
+ *          settings afterwards
+ * @param   ...     The expression that -Wpendantic should not apply to
+ *
+ * @warning This is intended for internal use only
+ *
+ * This is particularly useful when declaring non-strictly conforming
+ * preprocessor macros, as the diagnostics need to be disabled where the
+ * macro is evaluated, not where the macro is declared.
+ */
+#define WITHOUT_PEDANTIC(...) \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
+    __VA_ARGS__ \
+    _Pragma("GCC diagnostic pop")
+
+/**
+ * @brief   Declare a constant named @p identifier as anonymous `enum` that has
+ *          the value @p const_expr
+ *
+ * @warning This is intended for internal use only
+ *
+ * This turns any expression that is constant and known at compile time into
+ * a formal compile time constant. This allows e.g. using non-formally but
+ * still constant expressions in `static_assert()`.
+ */
+#define DECLARE_CONSTANT(identifier, const_expr) \
+    WITHOUT_PEDANTIC(enum { identifier = const_expr };)
+
 /**
  * @cond INTERNAL
  */


### PR DESCRIPTION
### Contribution description

`WITHOUT_PEDANTIC(expr)` disables `-Wpedantic` for `expr`, but switches back to the previous diagnostic settings afterwards. This helps defining macros that are not strictly ISO compliant without having to drop the `-Wpedantic` flag entirely.

`DECLARE_CONSTANT(identifier, const_expr)` declares an anonymous `enum` constant named `identifier` and assigns it the value `const_expr`. Here, `const_expr` has to be a compile time constant, but is not needed to be an integer constant expression. It basically is a tool to magically convert a non-integer constant expression into a integer constant
expression.

### Testing procedure

A unit test was added to check if it works as intended. As this uses `static_assert()`, there is no need to actually run the test.

### Issues/PRs references

Needed by https://github.com/RIOT-OS/RIOT/pull/17177.