### PR TITLE
examples/lorawan: use ztimer_msec if not rtc

### DIFF
--- a/examples/lorawan/Makefile
+++ b/examples/lorawan/Makefile
@@ -27,7 +27,7 @@ USEPKG += semtech-loramac
 
 USEMODULE += $(DRIVER)
 USEMODULE += fmt
-FEATURES_REQUIRED += periph_rtc
+FEATURES_OPTIONAL += periph_rtc
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/lorawan/Makefile.ci
+++ b/examples/lorawan/Makefile.ci
@@ -1,4 +1,10 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p-xplained-mini \
+    atmega328p \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \


### PR DESCRIPTION

### Contribution description

`examples/lorawan` currently forces the use of `periph_rtc`. This makes sense when wanting to achieve the deepest sleeps, but instead of blacklisting all `BOARD`s that do not have this feature make it optional and allow `ztimer_msec` (and therefore potentially rtt) to be used.

### Testing procedure

Test the example on any BOARD with no rtt, eg. `lora-e5-dev`

```
2021-11-11 10:33:53,817 # LoRaWAN Class A low-power application
2021-11-11 10:33:53,820 # =====================================
2021-11-11 10:33:53,835 # Starting join procedure
2021-11-11 10:33:58,974 # Join procedure succeeded
2021-11-11 10:33:58,975 # Sending: This is RIOT!
2021-11-11 10:34:24,081 # Sending: This is RIOT!
2021-11-11 10:34:49,188 # Sending: This is RIOT!
2021-11-11 10:35:14,290 # Sending: This is RIOT!
2021-11-11 10:35:39,391 # Sending: This is RIOT!
2021-11-11 10:36:04,494 # Sending: This is RIOT!
2021-11-11 10:36:29,596 # Sending: This is RIOT!
2021-11-11 10:36:54,697 # Sending: This is RIOT!
2021-11-11 10:37:19,800 # Sending: This is RIOT!
2021-11-11 10:37:44,902 # Sending: This is RIOT!
2021-11-11 10:38:10,004 # Sending: This is RIOT!
2021-11-11 10:38:35,106 # Sending: This is RIOT!
```
![image](https://user-images.githubusercontent.com/23060007/141275085-1403b4f5-8557-482b-b8ac-ec74b4b00b3d.png)

