### PR TITLE
sys/suit: adjust dependencies for CoAP transport

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -39,7 +39,6 @@ QUIET ?= 1
 # SUIT update specific stuff
 #
 
-USEMODULE += nanocoap_sock sock_util
 USEMODULE += suit suit_transport_coap
 
 # Display a progress bar during firmware download

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -723,7 +723,8 @@ ifneq (,$(filter suit_transport_%, $(USEMODULE)))
 endif
 
 ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
-  USEMODULE += nanocoap
+  USEMODULE += nanocoap_sock
+  USEMODULE += sock_util
 endif
 
 ifneq (,$(filter suit_storage_%, $(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the `sock_util` module dependency to the SUIT CoAP transport module and automatically loads the `nanocoap_sock` module instead of the `nanocoap` module. Without these changes, choosing CoAP transport and a UDP socket implementation, e.g. `USEMODULE += gnrc_sock_udp`, will leave undefined references at link time. The missing functions are from the `sock_util` and `nanocoap_sock` modules. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Compiling examples/suit as modified in the second commit of this PR without the changes of the first commit will result in undefined references at link time.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
