### PR TITLE
drivers/dose: fix standby mode

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -314,6 +314,7 @@ void uart_poweron(uart_t uart)
 {
     sercom_clk_en(dev(uart));
     dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
+    _syncbusy(dev(uart));
 }
 
 void uart_poweroff(uart_t uart)

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -680,7 +680,10 @@ void dose_setup(dose_t *ctx, const dose_params_t *params, uint8_t index)
     /* The timeout base is the minimal timeout base used for this driver.
      * We have to ensure it is above the XTIMER_BACKOFF. Otherwise state
      * transitions are triggered from another state transition setting up the
-     * timeout. */
+     * timeout.
+     * To calculate how long it takes to transfer one byte we assume
+     * 8 data bits + 1 start bit + 1 stop bit per byte.
+     */
     ctx->timeout_base = CONFIG_DOSE_TIMEOUT_BYTES * 10UL * US_PER_SEC / params->baudrate;
     if (ctx->timeout_base < xtimer_usec_from_ticks(min_timeout)) {
         ctx->timeout_base = xtimer_usec_from_ticks(min_timeout);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Previously we would not disable the sense pin, this meant that a node could still wake up if the standby pin is not connected.
    
Properly disable sensing when in standby and wait for a state transition to IDLE to avoid aborting a reception and messing up the DOSE internal state.



### Testing procedure

Standby / Sleep mode still work

```
2021-11-11 14:30:18,950 #  ping ff02::1
2021-11-11 14:30:18,958 # 12 bytes from fe80::649b:87ff:fe4c:5752%5: icmp_seq=0 ttl=64 time=1.596 ms
2021-11-11 14:30:18,965 # 12 bytes from fe80::ac8d:c2ff:fe75:35de%5: icmp_seq=0 ttl=64 time=8.182 ms (DUP!)
2021-11-11 14:30:19,958 # 12 bytes from fe80::649b:87ff:fe4c:5752%5: icmp_seq=1 ttl=64 time=1.594 ms
2021-11-11 14:30:19,965 # 12 bytes from fe80::ac8d:c2ff:fe75:35de%5: icmp_seq=1 ttl=64 time=8.180 ms (DUP!)
2021-11-11 14:30:20,959 # 12 bytes from fe80::649b:87ff:fe4c:5752%5: icmp_seq=2 ttl=64 time=1.594 ms
2021-11-11 14:30:20,959 # 
2021-11-11 14:30:20,961 # --- ff02::1 PING statistics ---
2021-11-11 14:30:20,967 # 3 packets transmitted, 3 packets received, 2 duplicates, 0% packet loss
2021-11-11 14:30:20,971 # round-trip min/avg/max = 1.594/4.229/8.182 ms

2021-11-11 14:30:23,376 #  ifconfig 5 set state sleep
2021-11-11 14:30:23,381 # success: set state of interface 5 to SLEEP

2021-11-11 14:30:24,573 #  ping ff02::1
2021-11-11 14:30:27,574 # 
2021-11-11 14:30:27,576 # --- ff02::1 PING statistics ---
2021-11-11 14:30:27,582 # 3 packets transmitted, 0 packets received, 100% packet loss

2021-11-11 14:30:30,248 #  ifconfig 5 set state idle
2021-11-11 14:30:30,252 # success: set state of interface 5 to IDLE

2021-11-11 14:30:31,934 #  ping ff02::1
2021-11-11 14:30:32,942 # 12 bytes from fe80::649b:87ff:fe4c:5752%5: icmp_seq=1 ttl=64 time=1.595 ms
2021-11-11 14:30:32,949 # 12 bytes from fe80::ac8d:c2ff:fe75:35de%5: icmp_seq=1 ttl=64 time=8.191 ms (DUP!)
2021-11-11 14:30:33,943 # 12 bytes from fe80::649b:87ff:fe4c:5752%5: icmp_seq=2 ttl=64 time=1.594 ms
2021-11-11 14:30:33,949 # 12 bytes from fe80::ac8d:c2ff:fe75:35de%5: icmp_seq=2 ttl=64 time=8.192 ms (DUP!)
2021-11-11 14:30:34,934 # 
2021-11-11 14:30:34,936 # --- ff02::1 PING statistics ---
2021-11-11 14:30:34,943 # 3 packets transmitted, 2 packets received, 2 duplicates, 33% packet loss
2021-11-11 14:30:34,947 # round-trip min/avg/max = 1.594/4.893/8.192 ms
```

### Issues/PRs references

follow-up on #16752
