### PR TITLE
cpu/stm32/include/cpu_conf_stm32_common.h: fix typo in macro

### DIFF
--- a/cpu/stm32/include/cpu_conf_stm32_common.h
+++ b/cpu/stm32/include/cpu_conf_stm32_common.h
@@ -43,7 +43,7 @@ static const i2c_timing_param_t timing_params[] = {
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F7) || \
     defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPI_FAM_STM32WL)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32WL)
     [ I2C_SPEED_NORMAL ]    = {
         .presc  = 0xB,
         .scll   = 0x13,     /* t_SCLL   = 5.0us  */


### PR DESCRIPTION
### Contribution description

Not sure what made this not pop up earlier...

### Testing procedure

Look at the code...

