### PR TITLE
drivers/dose: reduce struct padding

### DIFF
--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -152,17 +152,17 @@ typedef struct {
     uint8_t opts;                           /**< Driver options */
     dose_state_t state;                     /**< Current state of the driver's state machine */
     mutex_t state_mtx;                      /**< Is unlocked every time a state is (re)entered */
-    uint8_t flags;                          /**< Several flags */
     uint8_t recv_buf[DOSE_FRAME_LEN];       /**< Receive buffer for incoming frames */
     size_t recv_buf_ptr;                    /**< Index of the next empty octet of the recveive buffer */
-    uart_t uart;                            /**< UART device to use */
-    uint8_t uart_octet;                     /**< Last received octet */
 #if !defined(MODULE_PERIPH_UART_RXSTART_IRQ) || DOXYGEN
     gpio_t sense_pin;                       /**< GPIO to sense for start bits on the UART's rx line */
 #endif
     gpio_t standby_pin;                     /**< GPIO to put the CAN transceiver in standby mode */
     xtimer_t timeout;                       /**< Timeout timer ensuring always to get back to IDLE state */
     uint32_t timeout_base;                  /**< Base timeout in us */
+    uart_t uart;                            /**< UART device to use */
+    uint8_t uart_octet;                     /**< Last received octet */
+    uint8_t flags;                          /**< Several flags */
 } dose_t;
 
 /**


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

By moving all the single byte struct elements to the end, we can reduce padding inside `dose_t` and ensure that `recv_buf` is always aligned.


### Testing procedure

This saves some RAM:

master
------
       text	   data	    bss	    dec	    hex	filename
      36384	    136	  12944	  49464	   c138 tests/driver_dose/bin/samr21-xpro/tests_driver_dose.e

this patch
----------
       text	   data	    bss	    dec	    hex	filename
      36484	    136	  12936	  49556	   c194	tests/driver_dose/bin/samr21-xpro/tests_driver_dose.elf


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
