### PR TITLE
drivers/periph: use uint_fast8_t as default type

### DIFF
--- a/cpu/esp32/periph/can.c
+++ b/cpu/esp32/periph/can.c
@@ -592,7 +592,7 @@ static int _esp_can_config(can_t *dev)
 
     /* route CAN interrupt source to CPU interrupt and enable it */
     intr_matrix_set(PRO_CPU_NUM, ETS_CAN_INTR_SOURCE, CPU_INUM_CAN);
-    xt_set_interrupt_handler(CPU_INUM_CAN, _esp_can_intr_handler, (void*)dev);
+    xt_set_interrupt_handler(CPU_INUM_CAN, _esp_can_intr_handler, (void*)(uintptr_t)dev);
     xt_ints_on(BIT(CPU_INUM_CAN));
 
     /* set bittiming from parameters as given in device data */
@@ -733,7 +733,7 @@ static int _esp_can_set_mode(can_t *dev, canopt_state_t state)
 
 static void IRAM_ATTR _esp_can_intr_handler(void *arg)
 {
-    can_t* dev = (can_t *)arg;
+    can_t* dev = (can_t *)(uintptr_t)arg;
 
     assert(arg);
 

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -683,7 +683,7 @@ static const uint32_t transfer_int_mask = I2C_TRANS_COMPLETE_INT_ENA
 
 void _i2c_transfer_timeout (void *arg)
 {
-    i2c_t dev = (i2c_t)arg;
+    i2c_t dev = (i2c_t)(uintptr_t)arg;
 
     /* reset the hardware if it I2C got stuck */
     _i2c_reset_hw(dev);
@@ -718,7 +718,7 @@ static void _i2c_transfer (i2c_t dev)
     /* set a timer for the case the I2C hardware gets stuck */
     xtimer_t i2c_timeout = {};
     i2c_timeout.callback = _i2c_transfer_timeout;
-    i2c_timeout.arg = (void*)dev;
+    i2c_timeout.arg = (void*)(uintptr_t)dev;
     xtimer_set(&i2c_timeout, I2C_TRANSFER_TIMEOUT);
 
     /* start execution of commands in command pipeline registers */

--- a/cpu/gd32v/periph/uart.c
+++ b/cpu/gd32v/periph/uart.c
@@ -37,7 +37,7 @@ static struct {
     uint8_t data_mask;      /**< mask applied to the data register */
 } isr_ctx[UART_NUMOF];
 
-static inline void _uart_isr(uart_t uart);
+static inline void _uart_isr(unsigned uart);
 
 static inline USART_Type *dev(uart_t uart)
 {

--- a/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
@@ -125,7 +125,7 @@ void i2c_init(i2c_t dev)
     /* configure dev clock speed */
     bus(dev)->FREQUENCY = i2c_config[dev].speed;
 
-    spi_twi_irq_register_i2c(bus(dev), i2c_isr_handler, (void *)dev);
+    spi_twi_irq_register_i2c(bus(dev), i2c_isr_handler, (void *)(uintptr_t)dev);
 
     /* We expect that the device was being acquired before
      * the i2c_init_master() function is called, so it should be enabled when
@@ -297,7 +297,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
 
 void i2c_isr_handler(void *arg)
 {
-    i2c_t dev = (i2c_t)arg;
+    i2c_t dev = (i2c_t)(uintptr_t)arg;
 
     /* Mask interrupts to ensure that they only trigger once */
     bus(dev)->INTENCLR = TWIM_INTEN_STOPPED_Msk | TWIM_INTEN_ERROR_Msk;

--- a/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
@@ -63,7 +63,7 @@ static inline bool _in_ram(const uint8_t *data)
 #ifdef ERRATA_SPI_SINGLE_BYTE_WORKAROUND
 void spi_gpio_handler(void *arg)
 {
-    spi_t bus = (spi_t)arg;
+    spi_t bus = (spi_t)(uintptr_t)arg;
 
     /**
      * Immediately disable the IRQ, we only care about one PPI event per
@@ -85,7 +85,7 @@ static void _setup_workaround_for_ftpan_58(spi_t bus)
 {
 #ifdef ERRATA_SPI_SINGLE_BYTE_WORKAROUND
     gpio_init_int(spi_config[bus].sclk, GPIO_OUT, GPIO_BOTH,
-                  spi_gpio_handler, (void *)bus);
+                  spi_gpio_handler, (void *)(uintptr_t)bus);
     gpio_irq_disable(spi_config[bus].sclk);
     uint8_t channel = gpio_int_get_exti(spi_config[bus].sclk);
     assert(channel != 0xff);
@@ -145,7 +145,7 @@ void spi_init_pins(spi_t bus)
     SPI_MOSISEL = spi_config[bus].mosi;
     SPI_MISOSEL = spi_config[bus].miso;
     _setup_workaround_for_ftpan_58(bus);
-    spi_twi_irq_register_spi(dev(bus), spi_isr_handler, (void *)bus);
+    spi_twi_irq_register_spi(dev(bus), spi_isr_handler, (void *)(uintptr_t)bus);
 }
 
 void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
@@ -251,7 +251,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
 
 void spi_isr_handler(void *arg)
 {
-    spi_t bus = (spi_t)arg;
+    spi_t bus = (spi_t)(uintptr_t)arg;
 
     mutex_unlock(&busy[bus]);
     dev(bus)->EVENTS_END = 0;

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -69,14 +69,14 @@ extern "C" {
  * @brief   Define default ADC type identifier
  */
 #ifndef HAVE_ADC_T
-typedef unsigned int adc_t;
+typedef uint_fast8_t adc_t;
 #endif
 
 /**
  * @brief   Default ADC undefined value
  */
 #ifndef ADC_UNDEF
-#define ADC_UNDEF           (UINT_MAX)
+#define ADC_UNDEF           (UINT_FAST8_MAX)
 #endif
 
 /**

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -64,7 +64,7 @@ extern "C" {
  * @brief   Define default DAC type identifier
  */
 #ifndef HAVE_DAC_T
-typedef unsigned int dac_t;
+typedef uint_fast8_t dac_t;
 #endif
 
 /**
@@ -79,7 +79,7 @@ enum {
  * @brief   Default DAC undefined value
  */
 #ifndef DAC_UNDEF
-#define DAC_UNDEF           (UINT_MAX)
+#define DAC_UNDEF           (UINT_FAST8_MAX)
 #endif
 
 /**

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -139,7 +139,7 @@ extern "C" {
  * @{
  */
 #ifndef I2C_UNDEF
-#define I2C_UNDEF           (UINT_MAX)
+#define I2C_UNDEF           (UINT_FAST8_MAX)
 #endif
 /** @} */
 
@@ -148,7 +148,7 @@ extern "C" {
  * @{
  */
 #ifndef HAVE_I2C_T
-typedef unsigned int i2c_t;
+typedef uint_fast8_t i2c_t;
 #endif
 /**  @} */
 

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -82,14 +82,14 @@ extern "C" {
  * @brief  Default PWM undefined value
  */
 #ifndef PWM_UNDEF
-#define PWM_UNDEF           (UINT_MAX)
+#define PWM_UNDEF           (UINT_FAST8_MAX)
 #endif
 
 /**
  * @brief   Default PWM type definition
  */
 #ifndef HAVE_PWM_T
-typedef unsigned int pwm_t;
+typedef uint_fast8_t pwm_t;
 #endif
 
 /**

--- a/drivers/include/periph/qdec.h
+++ b/drivers/include/periph/qdec.h
@@ -98,14 +98,14 @@ extern "C" {
  * @brief  Default QDEC undefined value
  */
 #ifndef QDEC_UNDEF
-#define QDEC_UNDEF           (UINT_MAX)
+#define QDEC_UNDEF           (UINT_FAST8_MAX)
 #endif
 
 /**
  * @brief   Default QDEC type definition
  */
 #ifndef HAVE_QDEC_T
-typedef unsigned int qdec_t;
+typedef uint_fast8_t qdec_t;
 #endif
 
 /**

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -91,7 +91,7 @@ extern "C" {
  * @brief   Define global value for undefined SPI device
  */
 #ifndef SPI_UNDEF
-#define SPI_UNDEF       (UINT_MAX)
+#define SPI_UNDEF       (UINT_FAST8_MAX)
 #endif
 
 /**
@@ -116,7 +116,7 @@ extern "C" {
  * @brief   Default type for SPI devices
  */
 #ifndef HAVE_SPI_T
-typedef unsigned int spi_t;
+typedef uint_fast8_t spi_t;
 #endif
 
 /**

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -56,7 +56,7 @@ extern "C" {
  * @brief   Default value for timer not defined
  */
 #ifndef TIMER_UNDEF
-#define TIMER_UNDEF         (UINT_MAX)
+#define TIMER_UNDEF         (UINT_FAST8_MAX)
 #endif
 
 /**
@@ -66,7 +66,7 @@ extern "C" {
  * and vendor device header.
  */
 #ifndef HAVE_TIMER_T
-typedef unsigned int tim_t;
+typedef uint_fast8_t tim_t;
 #endif
 
 /**

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -74,14 +74,14 @@ extern "C" {
  * @brief   Define default UART type identifier
  */
 #ifndef HAVE_UART_T
-typedef unsigned int uart_t;
+typedef uint_fast8_t uart_t;
 #endif
 
 /**
  * @brief   Default UART undefined value
  */
 #ifndef UART_UNDEF
-#define UART_UNDEF          (UINT_MAX)
+#define UART_UNDEF          (UINT_FAST8_MAX)
 #endif
 
 /**

--- a/drivers/soft_uart/soft_uart.c
+++ b/drivers/soft_uart/soft_uart.c
@@ -287,7 +287,7 @@ static void soft_uart_write_byte(soft_uart_t uart, uint8_t data)
     mutex_lock(&ctx->sync);
 }
 
-void soft_uart_write(uart_t uart, const uint8_t *data, size_t len)
+void soft_uart_write(soft_uart_t uart, const uint8_t *data, size_t len)
 {
     const soft_uart_conf_t *cfg = &soft_uart_config[uart];
     struct uart_ctx *ctx = &soft_uart_ctx[uart];

--- a/tests/driver_soft_uart/main.c
+++ b/tests/driver_soft_uart/main.c
@@ -72,7 +72,7 @@ static int parse_dev(char *arg)
 
 static void rx_cb(void *arg, uint8_t data)
 {
-    uart_t dev = (uart_t)arg;
+    uart_t dev = (soft_uart_t)arg;
 
     ringbuffer_add_one(&(ctx[dev].rx_buf), data);
     if (data == '\n' || ringbuffer_full(&(ctx[dev].rx_buf))) {

--- a/tests/periph_qdec/main.c
+++ b/tests/periph_qdec/main.c
@@ -26,17 +26,17 @@
 #include "periph/qdec.h"
 #include "xtimer.h"
 
-void handler(void *arg)
+static void handler(void *arg)
 {
-    qdec_t qdec = (qdec_t)arg;
+    qdec_t qdec = (qdec_t)(uintptr_t)arg;
     printf("QDEC %u counter overflow : reset counter\n", qdec);
     qdec_read_and_reset(QDEC_DEV(qdec));
 }
 
 int main(void)
 {
-    uint32_t i = 0;
-    int32_t value = 0;
+    unsigned i;
+    int32_t value;
     puts("Welcome into Quadrature Decoder (QDEC) test program.");
     puts("This program will count pulses on all available QDEC channels");
     puts("Written for nucleo-f401re, you have to plug signals A and B as follow :");
@@ -45,7 +45,7 @@ int main(void)
     puts("Quadrature decoding mode is set to X4 : counting on all edges on both signals");
 
     for (i = 0; i < QDEC_NUMOF; i++) {
-        int32_t error = qdec_init(QDEC_DEV(i), QDEC_X4, handler, (void *)i);
+        int32_t error = qdec_init(QDEC_DEV(i), QDEC_X4, handler, (void *)(uintptr_t)i);
         if (error) {
             fprintf(stderr,"Not supported mode !\n");
             return error;

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -98,7 +98,7 @@ static void rxs_cb(void *arg)
 
 static void rx_cb(void *arg, uint8_t data)
 {
-    uart_t dev = (uart_t)arg;
+    uart_t dev = (uart_t)(uintptr_t)arg;
 
     ringbuffer_add_one(&ctx[dev].rx_buf, data);
 
@@ -113,7 +113,7 @@ static int _self_test(uart_t dev, unsigned baud)
 {
     const char test_string[] = "Hello UART!";
 
-    if (uart_init(UART_DEV(dev), baud, rx_cb, (void *)dev)) {
+    if (uart_init(UART_DEV(dev), baud, rx_cb, (void *)(uintptr_t)dev)) {
         printf("error configuring %u baud\n", baud);
         return -1;
     }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The default driver type is just an index into a device array defined by the board.

If a platform wants to encode additional information in the device type, it can define a custom type.

This means we can just set the default type to a single byte (similar to enums) and save some memory.

### Testing procedure

Entirely untested. Ideally, nothing should change.
But Murdock will hopefully tell us if anything implicitly relies on those types being a specific size. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
