### PR TITLE
tests/pthread_barrier: fix test script

### DIFF
--- a/tests/pthread_barrier/tests/01-run.py
+++ b/tests/pthread_barrier/tests/01-run.py
@@ -9,13 +9,17 @@ def testfunc(child):
     children = int(child.match.group(1))
     iterations = int(child.match.group(2))
     for i in range(children):
-        child.expect('Start {}'.format(i + 1))
-    for _ in range(children * iterations):
-        child.expect(r'Child \d sleeps for [" "\d]+ us.')
-    child.expect('Done 2')
-    child.expect('Done 1')
-    child.expect('Done 3')
-    child.expect('Done 4')
+        child.expect(f'Start {i + 1}')
+    for _ in range(iterations):
+        sleeps = []
+        for _ in range(children):
+            child.expect(r'Child (\d+) sleeps for \s* (\d+) us.\r\n')
+            child_num = int(child.match.group(1))
+            sleep = int(child.match.group(2))
+            sleeps.append([sleep, child_num])
+    for _, child_num in sorted(sleeps):
+        child.expect(r'Done (\d+)\r\n')
+        assert(child_num == int(child.match.group(1)))
     child.expect('SUCCESS')
 
 


### PR DESCRIPTION
### Contribution description

Previously the test script relied on the exact sequence of numbers
returned by the used PRNG. This resulting e.g. in

```
$ USEMODULE=prng_musl_lcg make -C tests/pthread_barrier flash test
```

to fail, only because the order in which the children completed is
slightly different due to different sleep durations. This fixes the
issue.

### Testing procedure

The command above should succeed, no with and without `USEMODULE=prng_musl_lcg` before the invocation of `make`.

### Issues/PRs references

Useful for https://github.com/RIOT-OS/RIOT/pull/17188