### PR TITLE
boards/dwm1001: fix SPI0 miso/mosi pins

### DIFF
--- a/boards/dwm1001/include/periph_conf.h
+++ b/boards/dwm1001/include/periph_conf.h
@@ -46,8 +46,8 @@ static const spi_conf_t spi_config[] = {
     {
         .dev  = NRF_SPIM0,
         .sclk = GPIO_PIN(0, 4),
-        .mosi = GPIO_PIN(0, 5),
-        .miso = GPIO_PIN(0, 6),
+        .mosi = GPIO_PIN(0, 6),
+        .miso = GPIO_PIN(0, 7),
         .ppi = 0,
     },
     {   /* Connected to the DWM1001 UWB transceiver */


### PR DESCRIPTION
### Contribution description

Trying to connect an spi device to the dwm1001 I realized the pin assignment was wrong:

![image](https://user-images.githubusercontent.com/23060007/141762761-ff6dc610-8e12-4a8b-89ca-5992d818426d.png)

### Testing procedure

Test with any SPI device, I used an sd card, without this change the init would fail:

```
2021-11-15 10:54:29,872 # WARNING: using 'write' or 'copy' commands WILL overwrite data on your sd-card and
2021-11-15 10:54:29,872 # init
2021-11-15 10:54:29,884 # Initializing SD-card at SPI_0...[OK]
> 2021-11-15 10:54:34,232 # Exiting Pyterm
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14314, was not tested at the time.
