### PR TITLE
boards: add support for stm32f746g-disco

### DIFF
--- a/boards/stm32f746g-disco/Kconfig
+++ b/boards/stm32f746g-disco/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2021 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "stm32f746g-disco" if BOARD_STM32F746G_DISCO
+
+config BOARD_STM32F746G_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32F746NG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32f746g-disco/Makefile
+++ b/boards/stm32f746g-disco/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f746g-disco/Makefile.dep
+++ b/boards/stm32f746g-disco/Makefile.dep
@@ -1,0 +1,7 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += stm32_eth
+endif

--- a/boards/stm32f746g-disco/Makefile.features
+++ b/boards/stm32f746g-disco/Makefile.features
@@ -1,0 +1,15 @@
+CPU = stm32
+CPU_MODEL = stm32f746ng
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_eth
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# stm32f746g-disco provides a custom default Kconfig clock configuration
+KCONFIG_ADD_CONFIG += $(RIOTBOARD)/stm32f746g-disco/clock.config

--- a/boards/stm32f746g-disco/Makefile.include
+++ b/boards/stm32f746g-disco/Makefile.include
@@ -1,0 +1,11 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# this board uses openocd
+PROGRAMMER ?= openocd
+
+# this board has an on-board ST-link adapter
+OPENOCD_DEBUG_ADAPTER ?= stlink
+
+# openocd programmer is supported
+PROGRAMMERS_SUPPORTED += openocd

--- a/boards/stm32f746g-disco/board.c
+++ b/boards/stm32f746g-disco/board.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f746g-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the STM32F746G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+}

--- a/boards/stm32f746g-disco/clock.config
+++ b/boards/stm32f746g-disco/clock.config
@@ -1,0 +1,5 @@
+# stm32f746g-disco provides a 25MHz HSE so they need a custom PLL config
+# to remain in 216MHz max clock.
+CONFIG_CUSTOM_PLL_PARAMS=y
+CONFIG_CLOCK_PLL_M=25
+CONFIG_CLOCK_PLL_N=432

--- a/boards/stm32f746g-disco/doc.txt
+++ b/boards/stm32f746g-disco/doc.txt
@@ -1,0 +1,27 @@
+/**
+ * @defgroup    boards_stm32f746g-disco STM32F746G-DISCO
+ * @ingroup     boards
+ * @brief       Support for the STM32F746G-DISCO board.
+
+## Flashing the device
+
+The STM32F746G-DISCO board includes an on-board ST-LINK programmer and can be
+flashed using OpenOCD.
+The board can be flashed with:
+
+```
+make BOARD=stm32f746g-disco flash
+```
+
+and debug via GDB with
+```
+make BOARD=stm32f746g-disco debug
+```
+
+## Supported Toolchains
+
+For using the STM32F746G-DISCO board we recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
+
+ */

--- a/boards/stm32f746g-disco/include/board.h
+++ b/boards/stm32f746g-disco/include/board.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f746g-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the STM32F746G-DISCO
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name User button
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_I, 11)    /**< BTN0 pin */
+#define BTN0_MODE           GPIO_IN                 /**< BTN0 pin mode */
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/stm32f746g-disco/include/gpio_params.h
+++ b/boards/stm32f746g-disco/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_stm32f746g-disco
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BTN USER",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/stm32f746g-disco/include/periph_conf.h
+++ b/boards/stm32f746g-disco/include/periph_conf.h
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f746g-disco
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for STM32F746G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* This board provides an LSE */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE    1
+#endif
+
+/* This board provides an HSE */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE    1
+#endif
+
+/* The HSE provides a 25MHz clock */
+#define CLOCK_HSE               MHZ(25)
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_tim2.h"
+#include "mii.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    DMA streams configuration
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 15 },   /* DMA2 Stream 7 - USART1_TX */
+    { .stream = 14 },   /* DMA2 Stream 6 - USART6_TX */
+    { .stream = 6 },    /* DMA1 Stream 6 - USART2_TX */
+    { .stream = 3 },    /* DMA1 Stream 3 - SPI2_RX   */
+    { .stream = 4 },    /* DMA1 Stream 4 - SPI2_TX   */
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI4_RX   */
+    { .stream = 12 },   /* DMA2 Stream 4 - SPI4_TX   */
+    { .stream = 8 },    /* DMA2 Stream 0 - ETH_TX    */
+};
+
+#define DMA_0_ISR  isr_dma2_stream7
+#define DMA_1_ISR  isr_dma2_stream6
+#define DMA_2_ISR  isr_dma1_stream6
+
+#define DMA_3_ISR  isr_dma2_stream2
+#define DMA_4_ISR  isr_dma2_stream5
+#define DMA_5_ISR  isr_dma2_stream3
+#define DMA_6_ISR  isr_dma2_stream4
+
+#define DMA_7_ISR  isr_dma2_stream0
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 7),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma = 0,
+        .dma_chan   = 4
+#endif
+    },
+    {  /* Arduino connectors */
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 6),
+        .tx_pin     = GPIO_PIN(PORT_C, 7),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma = 1,
+        .dma_chan   = 5
+#endif
+    },
+};
+
+#define UART_0_ISR          (isr_usart1)
+#define UART_0_DMA_ISR      (isr_dma2_stream7)
+#define UART_6_ISR          (isr_usart6)
+#define UART_6_DMA_ISR      (isr_dma2_stream6)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_I, 1),
+        .cs_pin   = GPIO_UNDEF,
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 4,
+        .tx_dma_chan = 0,
+        .rx_dma   = 3,
+        .rx_dma_chan = 0,
+#endif
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name ETH configuration
+ * @{
+ */
+static const eth_conf_t eth_config = {
+    .mode = RMII,
+    .speed = MII_BMCR_SPEED_100 | MII_BMCR_FULL_DPLX,
+    .dma = 7,
+    .dma_chan = 8,
+    .phy_addr = 0x00,
+    .pins = {
+        GPIO_PIN(PORT_G, 13),   /* TXD0 */
+        GPIO_PIN(PORT_G, 14),   /* TXD1 */
+        GPIO_PIN(PORT_G, 11),   /* TX_EN */
+        GPIO_PIN(PORT_C, 4),    /* RXD0 */
+        GPIO_PIN(PORT_C, 5),    /* RXD1 */
+        GPIO_PIN(PORT_A, 7),    /* CRS_DV */
+        GPIO_PIN(PORT_C, 1),    /* MDC */
+        GPIO_PIN(PORT_A, 2),    /* MDIO */
+        GPIO_PIN(PORT_A, 1),    /* REF_CLK */
+    }
+};
+
+#define ETH_DMA_ISR        isr_dma2_stream0
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14558,6 +14558,29 @@ boards/stm32f469i\-disco/include/periph_conf\.h:[0-9]+: warning: Member PWM_NUMO
 boards/stm32f469i\-disco/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32f469i\-disco/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32f469i\-disco/include/periph_conf\.h:[0-9]+: warning: Member adc_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_HSE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_3_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_4_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_5_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_6_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_7_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member DMA_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member dma_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_0_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_6_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_6_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member ETH_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/stm32f746g\-disco/include/periph_conf\.h:[0-9]+: warning: Member eth_config \(variable\) of file periph_conf\.h is not documented\.
 boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/stm32g0316\-disco/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.

--- a/tests/Makefile.boards.netif
+++ b/tests/Makefile.boards.netif
@@ -45,6 +45,7 @@ BOARD_PROVIDES_NETIF := \
     samr21-xpro \
     samr30-xpro \
     spark-core \
+    stm32f746g-disco \
     telosb \
     thingy52 \
     usb-kw41z \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds support for the [stm32f746g-disco](https://www.st.com/en/evaluation-tools/32f746gdiscovery.html) board.

This board provides USB FS/HS connectors (not configured), an Ethernet interface (configured and tested) and a large screen (272 x 400 with 24bits color depth) with a touch screen. The screen support if not provided by this PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Run `test_and_compile_for_board.py` ~(still running, but DMA is not correctly configured for stdio UART apparently and there's an issue with Kconfig clock configuration)~

<details>

```
$ ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . stm32f746g-disco --jobs=4 --with-test-only
[...]
ERROR:stm32f746g-disco:Tests failed: 9
Failures during compilation:
- [tests/gnrc_sixlowpan_frag_minfwd](tests/gnrc_sixlowpan_frag_minfwd/compilation.failed)
- [tests/gnrc_sixlowpan_frag_sfr](tests/gnrc_sixlowpan_frag_sfr/compilation.failed)
- [tests/kconfig](tests/kconfig/compilation.failed)
- [tests/pkg_libfixmath](tests/pkg_libfixmath/compilation.failed)
- [tests/pkg_libfixmath_unittests](tests/pkg_libfixmath_unittests/compilation.failed)
- [tests/suit_manifest](tests/suit_manifest/compilation.failed)

Failures during test:
- [tests/congure_test](tests/congure_test/test.failed)
- [tests/periph_dma](tests/periph_dma/test.failed)
- [tests/turo](tests/turo/test.failed)

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
