### PR TITLE
nrf5x_common: Add qdec peripheral implementation

### DIFF
--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -189,6 +189,17 @@ typedef enum {
 /** @} */
 
 /**
+ * @brief Quadrature decoder configuration struct
+ */
+typedef struct {
+    gpio_t a_pin;          /**< GPIO Pin for phase A */
+    gpio_t b_pin;          /**< GPIO Pin for phase B */
+    gpio_t led_pin;        /**< LED GPIO, GPIO_UNDEF to disable */
+    uint8_t sample_period; /**< Sample period used, e.g. QDEC_SAMPLEPER_SAMPLEPER_128us */
+    bool debounce_filter;  /**< Enable/disable debounce filter */
+} qdec_conf_t;
+
+/**
  * @brief Retrieve the exti(GPIOTE) channel associated with a gpio
  *
  * @param   pin     GPIO pin to retrieve the channel for

--- a/cpu/nrf5x_common/periph/qdec.c
+++ b/cpu/nrf5x_common/periph/qdec.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2021 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_qdec
+ * @{
+ *
+ * @file
+ * @brief       Low-level QDEC driver implementation
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+#include <errno.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph/qdec.h"
+#include "periph/gpio.h"
+
+#ifdef QDEC_NUMOF
+
+
+/**
+ * @brief   Interrupt context for each configured qdec
+ */
+static qdec_isr_ctx_t isr_ctx[QDEC_NUMOF];
+
+static inline NRF_QDEC_Type* dev(qdec_t qdec)
+{
+    (void)qdec;
+    return NRF_QDEC;
+}
+
+static inline const qdec_conf_t* conf(qdec_t qdec)
+{
+    return &qdec_config[qdec];
+}
+
+int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
+{
+    (void)mode;
+    /* Verify parameters */
+    assert((qdec < QDEC_NUMOF));
+
+    /* The nrf5x peripheral counts all edges */
+    if (mode != QDEC_X4) {
+        return -EINVAL;
+    }
+
+    isr_ctx[qdec].cb = cb;
+    isr_ctx[qdec].arg = arg;
+
+    if (cb) {
+        NVIC_EnableIRQ(QDEC_IRQn);
+        dev(qdec)->INTENSET = QDEC_INTENSET_ACCOF_Msk;
+    }
+    else {
+        NVIC_DisableIRQ(QDEC_IRQn);
+        dev(qdec)->INTENCLR = QDEC_INTENCLR_ACCOF_Msk;
+    }
+
+    gpio_init(conf(qdec)->a_pin, GPIO_IN_PU);
+    gpio_init(conf(qdec)->b_pin, GPIO_IN_PU);
+
+    dev(qdec)->PSEL.A = conf(qdec)->a_pin;
+    dev(qdec)->PSEL.B = conf(qdec)->b_pin;
+
+    /** Optionally set or disable the LED */
+    dev(qdec)->PSEL.LED = gpio_is_valid(conf(qdec)->led_pin)
+        ? QDEC_PSEL_LED_CONNECT_Msk
+        : conf(qdec)->led_pin;
+
+    dev(qdec)->DBFEN = conf(qdec)->debounce_filter ? 1 : 0;
+
+    /* Enable the peripheral */
+    dev(qdec)->ENABLE = 1;
+    dev(qdec)->TASKS_START = 1;
+    return 0;
+}
+
+int32_t qdec_read_and_reset(qdec_t qdec)
+{
+    /* Read and clear ACC register */
+    dev(qdec)->TASKS_RDCLRACC = 1;
+    return dev(qdec)->ACCREAD;
+}
+
+int32_t qdec_read(qdec_t qdec)
+{
+    return dev(qdec)->ACC;
+}
+
+void qdec_start(qdec_t qdec)
+{
+    dev(qdec)->TASKS_START = 1;
+}
+
+void qdec_stop(qdec_t qdec)
+{
+    dev(qdec)->TASKS_STOP = 1;
+    while (dev(qdec)->EVENTS_STOPPED == 0) {}
+    dev(qdec)->EVENTS_STOPPED = 0;
+}
+
+void isr_qdec(void)
+{
+    qdec_t qdec = QDEC_DEV(0); /* only one available */
+    dev(qdec)->EVENTS_ACCOF = 0;
+    isr_ctx[qdec].cb(isr_ctx[qdec].arg);
+}
+#endif

--- a/tests/periph_qdec/Makefile
+++ b/tests/periph_qdec/Makefile
@@ -5,4 +5,7 @@ FEATURES_REQUIRED = periph_qdec
 
 USEMODULE += xtimer
 
+# include boards that have are modified to add a qdec peripheral
+EXTERNAL_BOARD_DIRS = $(CURDIR)/boards_modded
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_qdec/boards_modded/nrf52840dk/Kconfig
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840dk" if BOARD_NRF52840DK
+
+config BOARD_NRF52840DK
+    bool
+    default y
+    select BOARDS_COMMON_NRF52XXXDK
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_QDEC
+    select HAS_PERIPH_USBDEV
+    select HAS_VDD_LC_FILTER_REG0
+    select HAVE_MTD_SPI_NOR
+
+source "$(RIOTBOARD)/common/nrf52xxxdk/Kconfig"

--- a/tests/periph_qdec/boards_modded/nrf52840dk/Makefile
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/Makefile
@@ -1,0 +1,6 @@
+# This must be a different name than 'board' as it is implemented by 'native'
+MODULE = board_nrf52840dk_qdec
+
+DIRS += $(RIOTBOARD)/nrf52840dk
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/periph_qdec/boards_modded/nrf52840dk/Makefile.dep
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/Makefile.dep
@@ -1,0 +1,4 @@
+# This must be a different name than 'board' as it is implemented by 'native'
+USEMODULE += board_nrf52840dk_qdec
+
+include $(RIOTBOARD)/nrf52840dk/Makefile.dep

--- a/tests/periph_qdec/boards_modded/nrf52840dk/Makefile.features
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_qdec
+
+include $(RIOTBOARD)/nrf52840dk/Makefile.features

--- a/tests/periph_qdec/boards_modded/nrf52840dk/Makefile.include
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nrf52840dk/Makefile.include

--- a/tests/periph_qdec/boards_modded/nrf52840dk/include/board.h
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/include/board.h
@@ -1,0 +1,1 @@
+../../../../../boards/nrf52840dk/include/board.h

--- a/tests/periph_qdec/boards_modded/nrf52840dk/include/periph_conf.h
+++ b/tests/periph_qdec/boards_modded/nrf52840dk/include/periph_conf.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dk_modded
+ * @{
+ *
+ * @file
+ * @brief       Minimal peripheral set for the nRF52840 DK with quadrature
+ *              decoder enabled
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "kernel_defines.h"
+#include "periph_conf_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name QDEC configuration
+ */
+static const qdec_conf_t qdec_config[] = {
+    {
+        .a_pin  = GPIO_PIN(0, 11),  /* Button 1 */
+        .b_pin  = GPIO_PIN(0, 12),  /* Button 2 */
+        .led_pin = GPIO_PIN(0, 13), /* And the first LED */
+        .sample_period = QDEC_SAMPLEPER_SAMPLEPER_128us,
+        .debounce_filter = true,
+    },
+};
+#define QDEC_NUMOF          ARRAY_SIZE(qdec_config)
+/** @} **/
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    { /* Mapped to USB virtual COM port */
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,8),
+        .tx_pin     = GPIO_PIN(0,6),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR adds a simple implementation of the qdec peripheral for the nrf5x devices.

### Testing procedure

As far as I know there is no board with both an nrf5x chip and a rotary encoder present. 

I have some test output from my own board, but I can imagine that it doesn't look that convincing :)

<details><summary>Output</summary>

```
/home/koen/dev/RIOT-dev/dist/tools/jlink/jlink.sh term-rtt 
### Starting RTT terminal ###
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-11-15 15:15:03,208 # Host name for TCP connection is missing, defaulting to "localhost"
2021-11-15 15:15:03,208 # Connect to localhost:19021
Welcome to pyterm!
Type '/exit' to exit.
2021-11-15 15:15:04,211 # SEGGER J-Link V7.58 - Real time terminal output
2021-11-15 15:15:04,212 # J-Link EDU Mini V1 compiled Nov  2 2021 11:12:01 V1.0, SN=801025014
2021-11-15 15:15:04,212 # Process: JLinkExe
2021-11-15 15:15:04,212 # main(): This is RIOT! (Version: 2022.01-devel-503-g9df79-pr/benchmark/ztimer)
2021-11-15 15:15:04,213 # Welcome into Quadrature Decoder (QDEC) test program.
2021-11-15 15:15:04,213 # This program will count pulses on all available QDEC channels
2021-11-15 15:15:04,213 # Written for nucleo-f401re, you have to plug signals A and B as follow :
2021-11-15 15:15:04,213 #   QDEC0 : signal A on PA6 and signal B on PA7
2021-11-15 15:15:04,213 #   QDEC1 : signal A on PB6 and signal B on PB7
2021-11-15 15:15:04,214 # Quadrature decoding mode is set to X4 : counting on all edges on both signals
2021-11-15 15:15:04,214 # QDEC 0 = 0
2021-11-15 15:15:04,214 # QDEC 0 = 0
2021-11-15 15:15:04,214 # QDEC 0 = 0
2021-11-15 15:15:04,214 # QDEC 0 = 0
2021-11-15 15:15:04,214 # QDEC 0 = 0
2021-11-15 15:15:04,214 # QDEC 0 = 0
2021-11-15 15:15:05,128 # QDEC 0 = 0
2021-11-15 15:15:06,128 # QDEC 0 = -3
2021-11-15 15:15:07,127 # QDEC 0 = 0
2021-11-15 15:15:08,117 # QDEC 0 = -1
2021-11-15 15:15:09,129 # QDEC 0 = -2
2021-11-15 15:15:10,116 # QDEC 0 = -6
2021-11-15 15:15:11,117 # QDEC 0 = -6
2021-11-15 15:15:12,117 # QDEC 0 = -28
2021-11-15 15:15:13,117 # QDEC 0 = 0
2021-11-15 15:15:14,108 # QDEC 0 = 0
2021-11-15 15:15:15,108 # QDEC 0 = 2
2021-11-15 15:15:16,108 # QDEC 0 = 0
2021-11-15 15:15:17,110 # QDEC 0 = 2
2021-11-15 15:15:18,109 # QDEC 0 = 0
2021-11-15 15:15:19,099 # QDEC 0 = 2
2021-11-15 15:15:20,103 # QDEC 0 = 0
2021-11-15 15:15:21,110 # QDEC 0 = 0
2021-11-15 15:15:22,104 # QDEC 0 = 2
2021-11-15 15:15:23,098 # QDEC 0 = 0
2021-11-15 15:15:24,100 # QDEC 0 = 0
2021-11-15 15:15:25,089 # QDEC 0 = 0
2021-11-15 15:15:26,090 # QDEC 0 = 4
2021-11-15 15:15:27,090 # QDEC 0 = 8
2021-11-15 15:15:28,090 # QDEC 0 = 20
2021-11-15 15:15:29,090 # QDEC 0 = 10
2021-11-15 15:15:30,090 # QDEC 0 = 28
2021-11-15 15:15:31,092 # QDEC 0 = 4
2021-11-15 15:15:32,090 # QDEC 0 = 36
2021-11-15 15:15:33,087 # QDEC 0 = 32
2021-11-15 15:15:34,091 # QDEC 0 = 64
2021-11-15 15:15:35,077 # QDEC 0 = 10
2021-11-15 15:15:36,081 # QDEC 0 = 46
2021-11-15 15:15:37,074 # QDEC 0 = 26
2021-11-15 15:15:38,077 # QDEC 0 = 0
2021-11-15 15:15:39,077 # QDEC 0 = 0
2021-11-15 15:15:40,069 # QDEC 0 = 0
2021-11-15 15:15:41,074 # QDEC 0 = 0
2021-11-15 15:15:42,068 # QDEC 0 = 0
2021-11-15 15:15:43,065 # QDEC 0 = 0
2021-11-15 15:15:44,066 # QDEC 0 = 0
2021-11-15 15:15:45,066 # QDEC 0 = 0
2021-11-15 15:15:45,499 # Exiting Pyterm
```

</details>

### Issues/PRs references

None