### PR TITLE
periph/flashpage: fix wrong doxygen group

### DIFF
--- a/cpu/cortexm_common/periph/flashpage.c
+++ b/cpu/cortexm_common/periph/flashpage.c
@@ -8,7 +8,7 @@
 
 /**
  * @ingroup     cpu_cortexm_common
- * @ingroup     drivers_periph_pm
+ * @ingroup     drivers_periph_flashpage
  * @{
  * @file
  * @brief       common periph/flashpage functions

--- a/cpu/riscv_common/periph/flashpage.c
+++ b/cpu/riscv_common/periph/flashpage.c
@@ -8,7 +8,7 @@
 
 /**
  * @ingroup     cpu_riscv_common
- * @ingroup     drivers_periph_pm
+ * @ingroup     drivers_periph_flashpage
  * @{
  * @file
  * @brief       common periph/flashpage functions


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Fix incorrect doxygen group in some flashpage files based on the [comment](https://github.com/RIOT-OS/RIOT/pull/16972#issuecomment-966298211) from @PeterKietzmann .

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
