### PR TITLE
usbus: check received setup request data amount

### DIFF
--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -264,8 +264,10 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
                 DEBUG("CDCACM: line coding not supported\n");
                 return -1;
             }
-            if ((state == USBUS_CONTROL_REQUEST_STATE_OUTDATA) &&
-                    (setup->length == sizeof(usb_req_cdcacm_coding_t))) {
+            if (setup->length != sizeof(usb_req_cdcacm_coding_t)) {
+                return -1; /* Incorrect amount of data expected */
+            }
+            if (state == USBUS_CONTROL_REQUEST_STATE_OUTDATA) {
                 size_t len = 0;
                 usb_req_cdcacm_coding_t *coding =
                     (usb_req_cdcacm_coding_t*)usbus_control_get_out_data(usbus,


### PR DESCRIPTION
### Contribution description

This PR adds two sanity checks to the usbus stack.
 - A check to verify that the amount of data received with a setup request doesn't exceed the amount indicated within the setup request length field
 - A check to ensure that the length of the line coding setup request in the CDC ACM handler matches the expected length.

### Testing procedure

Testing that the CDC ACM test still works as expected should be sufficient

### Issues/PRs references

None