### PR TITLE
Makefile.include: rename Makefile.ci target to create-Makefile.ci

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -222,7 +222,7 @@ GLOBAL_GOALS += buildtest \
                 info-boards-features-missing \
                 info-boards-supported \
                 info-buildsizes info-buildsizes-diff \
-                Makefile.ci \
+                create-Makefile.ci \
                 #
 
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -143,7 +143,7 @@ info-boards-features-blacklisted:
 info-boards-features-conflicting:
 	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
 
-Makefile.ci:
+create-Makefile.ci:
 	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh --no-docker
 
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -5,7 +5,7 @@
         info-debug-variable-% info-toolchains-supported \
         check-toolchain-supported \
         info-programmers-supported \
-        Makefile.ci \
+        create-Makefile.ci \
         #
 
 info-objsize:


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If we

    -include Makefile.ci

and `Makefile.ci` does not exist, but we provide `make` with a way on how to do so, it will try to create `Makefile.ci`.

This is not what we want, but I don't know how to disable this automagic.
So rename the target to `create-Makefile.ci` to avoid the conflict.


### Testing procedure

    make info-boards-supported

should no longer attempt to create `Makefile.ci`

### Issues/PRs references

alternative to #17204
