### PR TITLE
boards/stm32f469i-disco: Add DAC

### DIFF
--- a/boards/stm32f469i-disco/Kconfig
+++ b/boards/stm32f469i-disco/Kconfig
@@ -8,6 +8,7 @@ config BOARD_STM32F469I_DISCO
 
     # MCU peripherals (in alphabetical order)
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM

--- a/boards/stm32f469i-disco/Makefile.features
+++ b/boards/stm32f469i-disco/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f469ni
 
 # MCU peripherals (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc

--- a/boards/stm32f469i-disco/include/periph_conf.h
+++ b/boards/stm32f469i-disco/include/periph_conf.h
@@ -241,6 +241,23 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF   ARRAY_SIZE(adc_config)
 /** @} */
 
+/**
+ * @brief DAC configuration
+ * @{
+ */
+static const dac_conf_t dac_config[] = {
+    {GPIO_PIN(PORT_A, 4), .chan = 0},
+    {GPIO_PIN(PORT_A, 5), .chan = 1},
+};
+/** @}*/
+
+/**
+ * @brief Number of DACs
+ * @{
+ */
+#define DAC_NUMOF   ARRAY_SIZE(dac_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

Adds DAC support for the stm32f469i-disco board

### Testing procedure

Tested with `tests/periph_dac/` the output on the terminal is:

```sh
2021-11-16 12:38:02,701 # main(): This is RIOT! (Version: 2022.01-devel-498-g39b9c-stm32f469i-disco)
2021-11-16 12:38:02,701 # 
2021-11-16 12:38:02,704 # RIOT DAC peripheral driver test
2021-11-16 12:38:02,704 # 
2021-11-16 12:38:02,709 # This test application produces a saw tooth signal on each available
2021-11-16 12:38:02,715 # DAC line. The period of the signal should be around 100ms
2021-11-16 12:38:02,716 # 
2021-11-16 12:38:02,718 # Successfully initialized DAC_LINE(0)
2021-11-16 12:38:02,721 # Successfully initialized DAC_LINE(1)
2021-11-16 12:38:02,721 #
```
We have `PORT_A, 5`  available on the  connector CN12, pin 7. The oscilloscope shows us the following image

![20211116_123007](https://user-images.githubusercontent.com/10358374/141979943-16a32829-9d21-4078-9343-6e62aa3031bc.jpg)


### Issues/PRs references

None