### PR TITLE
doc: Exclude headers that only contain implementations

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -824,6 +824,8 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */board/*/tools/* \
+                         */board/*/periph_conf.h \
+                         */cpu/*/periph_cpu.h \
                          */cpu/atmega_common/include/sys/*.h \
                          */cpu/msp430_common/include/stdatomic.h \
                          */cpu/msp430_common/include/sys/*.h \


### PR DESCRIPTION
### Contribution description

PRs like [this](https://github.com/RIOT-OS/RIOT/pull/17214/files) get caught up in needing to document stuff there is no value in documenting: doxygen checks complain that a board's DAC_NUMOF in periph_config.h is not documented, but there is nothing to say about that, it's just an implementation that happens to live in a header file. Of dac_config next to it there *would* be something to say, but that documentation would need to go into the individual entries (like annotating `{GPIO_PIN(PORT_A, 4), .chan = 0},` with "Labeled DAC1 on the board's silkscreen"), but those aren't visible anyway through doxygen and would need advanced metadata and/or extraction.

This PR excludes header files that follow the pattern "there's a generally defined user, and implementations put in their concrete values" from doxygen in general.

### Testing procedure

* Build before and after
* Apply this normalization:
```
sed -i -e 's/Generated on .*</</' html{,-before}/**/*.html
sed -i -e 's/html#[ag][0-9a-f]\{33,\}"/html"/' html{,-before}/**/*.html
```
* Convince yourself that the documentation was not worsened

Note that the list is still **incomplete** -- I myself don't see yet whether these are equivalent or not. (Doxygen output is a bit messy).

### Open aspects

As some files are now generally excluded, it would be nice to have a check somewhere that verifies that nothing of value is placed there. Not sure this can be done, as the implementers may define own helper macros. (But then again, those would leak to users, so maybe they shouldn't in the first place...).