### PR TITLE
cpu/atmega_common: make cppcheck happy

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -337,16 +337,17 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     EIMSK |= (1 << int_num);
 
     /* apply flank to interrupt number int_num */
-    if (int_num < 4) {
-        EICRA &= ~(0x3 << (int_num * 2));
-        EICRA |= (flank << (int_num * 2));
-    }
     #if defined(EICRB)
-    else {
+    if (int_num >= 4) {
         EICRB &= ~(0x3 << ((int_num % 4) * 2));
         EICRB |= (flank << ((int_num % 4) * 2));
     }
+    else
     #endif
+    {
+        EICRA &= ~(0x3 << (int_num * 2));
+        EICRA |= (flank << (int_num * 2));
+    }
 
     /* set callback */
     config[int_num].cb = cb;


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

The code should be fully equivalent to what it was before to the point that generated binaries are expected to not differ.

### Issues/PRs references

None