### PR TITLE
cpu/esp32: make CI happy

### DIFF
--- a/cpu/esp32/esp_xtimer.c
+++ b/cpu/esp32/esp_xtimer.c
@@ -21,6 +21,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#include <assert.h>
 #include <string.h>
 
 #include "esp_common.h"
@@ -95,8 +96,8 @@ void IRAM_ATTR _ets_to_xtimer_callback (void *arg)
 {
     struct _ets_to_xtimer* e2xt = (struct _ets_to_xtimer*)arg;
 
-    CHECK_PARAM (e2xt != NULL);
-    CHECK_PARAM (e2xt->ets_timer != NULL);
+    assert(arg != NULL);
+    assert(e2xt->ets_timer != NULL);
 
     irq_isr_enter();
 
@@ -116,7 +117,7 @@ void ets_timer_setfn(ETSTimer *ptimer, ETSTimerFunc *pfunc, void *parg)
 
     struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(ptimer);
 
-    CHECK_PARAM(e2xt != NULL);
+    assert(e2xt != NULL);
 
     e2xt->ets_timer->timer_func = pfunc;
     e2xt->ets_timer->timer_arg  = parg;
@@ -131,7 +132,7 @@ void ets_timer_done(ETSTimer *ptimer)
 
     struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(ptimer);
 
-    CHECK_PARAM(e2xt != NULL);
+    assert(e2xt != NULL);
 
     e2xt->ets_timer->timer_func = NULL;
     e2xt->ets_timer->timer_arg  = NULL;
@@ -143,8 +144,8 @@ void ets_timer_arm_us(ETSTimer *timer, uint32_t tmout, bool repeat)
 
     struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(timer);
 
-    CHECK_PARAM(e2xt != NULL);
-    CHECK_PARAM(e2xt->xtimer.callback != NULL);
+    assert(e2xt != NULL);
+    assert(e2xt->xtimer.callback != NULL);
 
     xtimer_set(&e2xt->xtimer, tmout);
 
@@ -163,7 +164,7 @@ void ets_timer_disarm(ETSTimer *timer)
 
     struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(timer);
 
-    CHECK_PARAM(e2xt != NULL);
+    assert(e2xt != NULL);
 
     xtimer_remove(&e2xt->xtimer);
 }
@@ -182,9 +183,9 @@ void os_timer_setfn(ETSTimer *ptimer, ETSTimerFunc *pfunction, void *parg)
                     __attribute__((alias("ets_timer_setfn")));
 void os_timer_disarm(ETSTimer *ptimer)
                     __attribute__((alias("ets_timer_disarm")));
-void os_timer_arm_us(ETSTimer *ptimer,uint32_t u_seconds,bool repeat_flag)
+void os_timer_arm_us(ETSTimer *ptimer, uint32_t u_seconds, bool repeat_flag)
                     __attribute__((alias("ets_timer_arm_us")));
-void os_timer_arm(ETSTimer *ptimer,uint32_t milliseconds,bool repeat_flag)
+void os_timer_arm(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag)
                   __attribute__((alias("ets_timer_arm")));
 void os_timer_done(ETSTimer *ptimer)
                    __attribute__((alias("ets_timer_done")));

--- a/cpu/esp32/periph/can.c
+++ b/cpu/esp32/periph/can.c
@@ -786,9 +786,9 @@ static void IRAM_ATTR _esp_can_intr_handler(void *arg)
             DEBUG("%s error passive interrupt %d %d\n", __func__,
                   CAN.tx_error_counter_reg.byte,
                   CAN.rx_error_counter_reg.byte);
+            /* save the event */
+            dev->events |= ESP_CAN_EVENT_ERROR_PASSIVE;
         }
-        /* save the event */
-        dev->events |= ESP_CAN_EVENT_ERROR_PASSIVE;
     }
 
     /*

--- a/cpu/esp32/periph/can.c
+++ b/cpu/esp32/periph/can.c
@@ -259,16 +259,27 @@ static int _esp_can_send(candev_t *candev, const struct can_frame *frame)
     esp_frame.rtr = (frame->can_id & CAN_RTR_FLAG);
     esp_frame.eff = (frame->can_id & CAN_EFF_FLAG);
 
+    /* esp_frame is a union that provides two views on the same memory: one
+     * tailored for efficient access and the other for readable code. Likely
+     * due to cppcheck not finding all headers it wrongly assumes that values
+     * are assigned but never read again (unreadVariable). But the union members
+     * are read via the aliases to the same memory. */
     if (esp_frame.eff) {
         uint32_t id = frame->can_id & CAN_EFF_MASK;
+        /* cppcheck-suppress unreadVariable */
         esp_frame.extended.id[0] = (id >> 21) & 0xff;
+        /* cppcheck-suppress unreadVariable */
         esp_frame.extended.id[1] = (id >> 13) & 0xff;
+        /* cppcheck-suppress unreadVariable */
         esp_frame.extended.id[2] = (id >> 5) & 0xff;
+        /* cppcheck-suppress unreadVariable */
         esp_frame.extended.id[3] = (id << 3) & 0xff;
     }
     else {
         uint32_t id = frame->can_id & CAN_SFF_MASK;
+        /* cppcheck-suppress unreadVariable */
         esp_frame.standard.id[0] = (id >> 3) & 0xff;
+        /* cppcheck-suppress unreadVariable */
         esp_frame.standard.id[1] = (id << 5) & 0xff;
     }
 
@@ -769,15 +780,15 @@ static void IRAM_ATTR _esp_can_intr_handler(void *arg)
 
     /* enter to / return from ERROR_PASSIVE state */
     if (int_reg.err_passive) {
-
         /* enter to the ERROR_PASSIVE state when one of the error counters is >= 128 */
         if (CAN.tx_error_counter_reg.byte >= ESP_CAN_ERROR_PASSIVE_LIMIT ||
-            CAN.rx_error_counter_reg.byte >= ESP_CAN_ERROR_PASSIVE_LIMIT)
+            CAN.rx_error_counter_reg.byte >= ESP_CAN_ERROR_PASSIVE_LIMIT) {
             DEBUG("%s error passive interrupt %d %d\n", __func__,
                   CAN.tx_error_counter_reg.byte,
                   CAN.rx_error_counter_reg.byte);
-            /* save the event */
-            dev->events |= ESP_CAN_EVENT_ERROR_PASSIVE;
+        }
+        /* save the event */
+        dev->events |= ESP_CAN_EVENT_ERROR_PASSIVE;
     }
 
     /*
@@ -905,10 +916,17 @@ static void _esp_can_set_bittiming(can_t *dev)
     can_bus_tim_0_reg_t reg_0;
     can_bus_tim_1_reg_t reg_1;
 
+    /* Again cppcheck gets off rails due to missing concept of union (see
+     * explanation above), so we suppress false unreadVariable here */
+    /* cppcheck-suppress unreadVariable */
     reg_0.baud_rate_prescaler = (timing->brp / 2) - 1;
+    /* cppcheck-suppress unreadVariable */
     reg_0.sync_jump_width = timing->sjw - 1;
+    /* cppcheck-suppress unreadVariable */
     reg_1.time_seg_1 = (timing->prop_seg + timing->phase_seg1) - 1;
+    /* cppcheck-suppress unreadVariable */
     reg_1.time_seg_2 = timing->phase_seg2 - 1;
+    /* cppcheck-suppress unreadVariable */
     reg_1.sampling = 0;
 
     _esp_can_set_reset_mode();

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -703,6 +703,10 @@ static void _i2c_transfer (i2c_t dev)
     #if FIFO_USED
     /* reset RX FIFO queue */
     _i2c_hw[dev].regs->fifo_conf.rx_fifo_rst = 1;
+    /* cppcheck-suppress redundantAssignment
+     * Likely due to cppcheck not being able to located all headers, it misses
+     * the volatile qualifier. The assignments are to trigger a reset, but
+     * look like dead writes to tools unaware of volatile */
     _i2c_hw[dev].regs->fifo_conf.rx_fifo_rst = 0;
     #endif
 
@@ -733,6 +737,10 @@ static void _i2c_transfer (i2c_t dev)
     #if FIFO_USED
     /* reset TX FIFO queue */
     _i2c_hw[dev].regs->fifo_conf.tx_fifo_rst = 1;
+    /* cppcheck-suppress redundantAssignment
+     * Likely due to cppcheck not being able to located all headers, it misses
+     * the volatile qualifier. The assignments are to trigger a reset, but
+     * look like dead writes to tools unaware of volatile */
     _i2c_hw[dev].regs->fifo_conf.tx_fifo_rst = 0;
     #endif
 

--- a/cpu/esp32/periph/pm.c
+++ b/cpu/esp32/periph/pm.c
@@ -133,6 +133,7 @@ void pm_set(unsigned mode)
      * slow RTC memory is automatically activated when the .rtc.data section
      * is used to retain initialized data.
      */
+    /* cppcheck-suppress comparePointers */
     if (&_rtc_bss_rtc_end > &_rtc_bss_rtc_start) {
         esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_SLOW_MEM, ESP_PD_OPTION_ON);
     }

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -131,15 +131,18 @@ NORETURN void IRAM call_start_cpu0 (void)
 
     /* Clear BSS. Please do not attempt to do any complex stuff */
     /* (like early logging) before this. */
+    /* cppcheck-suppress comparePointers */
     memset(&_bss_start, 0, (&_bss_end - &_bss_start) * sizeof(_bss_start));
 
     /* if we are not waking up from deep sleep, clear RTC bss */
     if (reset_reason != DEEPSLEEP_RESET) {
+        /* cppcheck-suppress comparePointers */
         memset(&_rtc_bss_start, 0, (&_rtc_bss_end - &_rtc_bss_start));
     }
 
     /* initialize RTC data after power on */
     if (reset_reason == POWERON_RESET || reset_reason == RTCWDT_RTC_RESET) {
+        /* cppcheck-suppress comparePointers */
         memset(&_rtc_bss_rtc_start, 0, (&_rtc_bss_rtc_end - &_rtc_bss_rtc_start));
     }
 
@@ -253,7 +256,7 @@ static void IRAM system_clk_init (void)
                                                set to 2 MHz and handled later */
     }
 
-    uint32_t freq_before = rtc_clk_cpu_freq_value(rtc_clk_cpu_freq_get()) / MHZ ;
+    uint32_t freq_before = rtc_clk_cpu_freq_value(rtc_clk_cpu_freq_get()) / MHZ;
 
     if (freq_before != CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ) {
         /* set configured CPU frequency */


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

- The CI will run the `static-tests`, which should now pass for everything in `cpu/esp32/*`.
- The code changes should *NOT* translate to changed in generated binaries

### Issues/PRs references

None