### PR TITLE
Makefile.base: add SUBMODULE_NO_SRC to excluded a selected SUBMODULE *.c

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -45,7 +45,11 @@ ifeq (1, $(SUBMODULES))
   BASE_MODULE ?= $(MODULE)
 
   # for each $(BASE_MODULE)_<name> in USEMODULE, add <name>.c to SRC
-  SRC += $(wildcard $(patsubst $(BASE_MODULE)_%,%.c,$(filter $(BASE_MODULE)_%,$(USEMODULE))))
+  # unless in SUBMODULES_NO_SRC
+  SRC += $(wildcard \
+            $(filter-out $(SUBMODULES_NO_SRC),\
+                $(patsubst $(BASE_MODULE)_%,%.c,\
+                    $(filter $(BASE_MODULE)_%,$(USEMODULE)))))
 
   # remove duplicates
   SRC := $(sort $(SRC))

--- a/doc/doxygen/src/creating-modules.md
+++ b/doc/doxygen/src/creating-modules.md
@@ -160,7 +160,8 @@ the only parts of compounded module names and only match against part of that na
 
 See `sys/ztimer/Makefile` for an example in code.
 
-`SUBMODULES` can also be true-pseudomodules.
+`SUBMODULES` can also be true-pseudomodules, or become one by conditionally excluding
+the source files by adding them to `SUBMODULES_NO_SRC`.
 
 # Helper tools
 


### PR DESCRIPTION
### Contribution description

This allows for SUBMODULE PSEUDOMODULES to conditionally not be linked
to an existing *.c file.

### Testing procedure

It can be seen in https://github.com/RIOT-OS/RIOT/pull/16958, where its used to conditionally compile `event/timeout.c`.

### Issues/PRs references

Split out of #16958.
