### PR TITLE
makefile.dep: require `arch_%` `cpu_core_%` features first

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -93,12 +93,6 @@ ifneq (1, $(RIOTBOOT_BUILD))
   FEATURES_OPTIONAL += periph_pm
 endif
 
-# always select provided architecture features
-FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
-
-# always select CPU core features
-FEATURES_REQUIRED += $(filter cpu_core_%,$(FEATURES_PROVIDED))
-
 # don't use idle thread if architecture has needed support
 FEATURES_OPTIONAL += no_idle_thread
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -406,6 +406,11 @@ ifeq (1,$(TEST_KCONFIG))
   KCONFIG_PACKAGES := $(call lowercase,$(patsubst CONFIG_PACKAGE_%,%,$(filter CONFIG_PACKAGE_%,$(.VARIABLES))))
   USEPKG := $(KCONFIG_PACKAGES)
 else
+  # always select provided architecture features
+  FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
+  # always select CPU core features
+  FEATURES_REQUIRED += $(filter cpu_core_%,$(FEATURES_PROVIDED))
+
   # check if required features are provided and update $(FEATURES_USED)
   include $(RIOTMAKE)/features_check.inc.mk
 

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -47,6 +47,10 @@ define board_unsatisfied_features
   undefine CPU_FAM
 
   include $(RIOTBASE)/Makefile.features
+  # always select provided architecture features
+  FEATURES_REQUIRED += $$(filter arch_%,$$(FEATURES_PROVIDED))
+  # always select CPU core features
+  FEATURES_REQUIRED += $$(filter cpu_core_%,$$(FEATURES_PROVIDED))
   # FEATURES_USED must be populated first in this case so that dependency
   # resolution can take optional features into account during the first pass.
   # Also: This allows us to skip resolution if already a missing feature is

--- a/tests/pkg_arduino_sdi_12/Makefile.ci
+++ b/tests/pkg_arduino_sdi_12/Makefile.ci
@@ -1,3 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
+	arduino-duemilanove \
+	arduino-nano \
+	arduino-uno \
 	nucleo-l011k4 \
 	#


### PR DESCRIPTION
### Contribution description
Currently `arch_%` and `cpu_core_%` features are required after the first iteration of the dependency resolution. This may cause race conditions when checking for them in `FEATURES_USED`. This moves them up, also for the "quick" version used by the CI.

### Testing procedure
- `make info-applications-supported-boards` should stay the same, **BUT** this change caught a race condition in the dependency resolution for the `arduino_sdi_12` package:
https://github.com/RIOT-OS/RIOT/blob/0c9240125e80103bbcb57a7177935be23b854556/pkg/arduino_sdi_12/Makefile.dep#L3-L7

My diff between the results for 5e925e1906a7d10b2ab6f8d9b972755b8d290d19 and after this PR:

```diff
67485a67486,67488
> tests/pkg_arduino_sdi_12 arduino-duemilanove
> tests/pkg_arduino_sdi_12 arduino-leonardo
> tests/pkg_arduino_sdi_12 arduino-mega2560
67489a67493,67494
> tests/pkg_arduino_sdi_12 arduino-nano
> tests/pkg_arduino_sdi_12 arduino-uno
67562a67568
> tests/pkg_arduino_sdi_12 waspmote-pro
```

### Issues/PRs references
#16929 
