### PR TITLE
cpu/nrf9160: add periph_flashpage support

### DIFF
--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -1,12 +1,12 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_pagewise
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer_periodic
 FEATURES_PROVIDED += periph_uart_modecfg
 
 ifneq (nrf9160,$(CPU_MODEL))
-  FEATURES_PROVIDED += periph_flashpage
-  FEATURES_PROVIDED += periph_flashpage_pagewise
   FEATURES_PROVIDED += periph_hwrng
   FEATURES_PROVIDED += periph_rtt_overflow
   FEATURES_PROVIDED += periph_temperature

--- a/cpu/nrf5x_common/periph/flashpage.c
+++ b/cpu/nrf5x_common/periph/flashpage.c
@@ -23,6 +23,10 @@
 #include "assert.h"
 #include "periph/flashpage.h"
 
+#ifndef NRF_NVMC
+#define NRF_NVMC NRF_NVMC_S
+#endif
+
 void flashpage_erase(unsigned page)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
@@ -31,7 +35,14 @@ void flashpage_erase(unsigned page)
 
     /* erase given page */
     NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
+#ifndef NRF_NVMC_S
     NRF_NVMC->ERASEPAGE = (uint32_t)page_addr;
+#else
+    /* NRF_NVMC->ERASEPAGE doesn't exist on nRF9160 family, the proper
+       way to erase a page is to write 0xFFFFFFFF in the first 32-bit
+       word of the page to erase it (see Chap 4.4.2 from nRF9160 datasheet ) */
+    *page_addr = UINT32_MAX;
+#endif
     while (NRF_NVMC->READY == 0) {}
 }
 

--- a/cpu/nrf9160/Kconfig
+++ b/cpu/nrf9160/Kconfig
@@ -8,6 +8,8 @@ config CPU_FAM_NRF9160
     bool
     select HAS_CPU_NRF9160
     select HAS_PERIPH_CPUID
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_GPIO
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER_PERIODIC

--- a/cpu/nrf9160/include/cpu_conf.h
+++ b/cpu/nrf9160/include/cpu_conf.h
@@ -42,6 +42,21 @@ extern "C" {
 #define CPU_IRQ_NUMOF                   (65U)   /**< nRF9160 specific IRQ count */
 /** @} */
 
+/**
+ * @name   Flash page configuration
+ * @{
+ */
+#define FLASHPAGE_SIZE              (4096U) /**< Size of a page in bytes */
+#define FLASHPAGE_NUMOF             (256U)  /**< Total number of flash pages */
+
+/* The minimum block size which can be written is 4B. However, the erase
+ * block is always FLASHPAGE_SIZE.
+ */
+#define FLASHPAGE_WRITE_BLOCK_SIZE      (4U) /**< Minimum block size */
+/* Writing should be always 4 bytes aligned */
+#define FLASHPAGE_WRITE_BLOCK_ALIGNMENT (4U) /**< Mandatory alignment */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

This PR adds periph_flashpage support for nRF9160 family. Changes in nrf5x_common driver is minimal (only the erase page is different from nRF51/nRF52).

### Testing procedure

Flash tests/periph_flashpage on `nrf9160dk` board and play with the test app.

I provide the following [gist](https://gist.github.com/dylad/8285886a66a393773f803a497c4bbcbe) for some test output.
I also tried riotboot_serial on my custom nrf9160 board and it works like a charm.


### Issues/PRs references
None.
