### PR TITLE
boards/nrf9160dk: add riotboot support

### DIFF
--- a/boards/nrf9160dk/Kconfig
+++ b/boards/nrf9160dk/Kconfig
@@ -15,3 +15,6 @@ config BOARD_NRF9160DK
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/nrf9160dk/Makefile.features
+++ b/boards/nrf9160dk/Makefile.features
@@ -6,3 +6,5 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+FEATURES_PROVIDED += riotboot

--- a/cpu/nrf9160/Makefile.include
+++ b/cpu/nrf9160/Makefile.include
@@ -7,11 +7,10 @@ RAM_START_ADDR ?= 0x20000000
 
 LINKER_SCRIPT ?= cortexm.ld
 
-FLASHFILE = $(BINFILE)
+FLASHFILE ?= $(BINFILE)
 
 PROGRAMMER ?= jlink
 JLINK_DEVICE = NRF9160_XXAA
-
 
 include $(RIOTCPU)/nrf5x_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
### Contribution description

This PR enables riotboot features for nRF9160DK.

### Testing procedure
Play with `tests/riotboot`
or `bootloader/riotboot_serial`

### Issues/PRs references

requires #17225 
