### PR TITLE
gnrc_pktbuf_cmd: add od dependency with gnrc_pktbuf_static 

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -444,6 +444,12 @@ ifneq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
   USEMODULE += gnrc_pktbuf # make MODULE_GNRC_PKTBUF macro available for all implementations
 endif
 
+ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
+  ifneq (,$(filter gnrc_pktbuf_static,$(USEMODULE)))
+    USEMODULE += od
+  endif
+endif
+
 ifneq (,$(filter gnrc_netif_%,$(USEMODULE)))
   USEMODULE += gnrc_netif
 endif

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -8,7 +8,6 @@ USEMODULE += gnrc_pktbuf_cmd
 USEMODULE += gnrc_udp
 USEMODULE += gnrc_rpl
 USEMODULE += auto_init_gnrc_rpl
-USEMODULE += od
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += shell
 USEMODULE += shell_commands


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The `pktbuf` shell command only prints something with `gnrc_pktbuf_static`, when the `od` module is also compiled in. Currently, it is up to the user to include that module, however, I don't think there is much sense behind that. This PR pulls in `od` when `gnrc_pktbuf_cmd` and `gnrc_pktbuf_static` are compiled in.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Revert the commit that adds the new dependency (d4f7f9182b172cdbbd48218997e2e0f5a22bb4ac when this PR was opened). Flash `tests/gnrc_udp` to a board of your choice, run `make term` and type `pktbuf`. No output will be shown. If you then reintroduce the addition of the dependency and repeat the flashing, `pktbuf` will show a similar output (if not the same) as in master.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
