### PR TITLE
usbus/hid: fix ep_out readyness

### DIFF
--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -137,10 +137,6 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
 
     usbus_enable_endpoint(hid->ep_out);
 
-    /* signal that INTERRUPT OUT is ready to receive data */
-    usbdev_ep_xmit(hid->ep_out->ep, hid->out_buf,
-                    CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
-
     usbus_add_interface(usbus, &hid->iface);
 }
 
@@ -195,6 +191,9 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
         }
         break;
     case USB_HID_REQUEST_SET_IDLE:
+        /* Wait for data from HOST */
+        usbdev_ep_xmit(hid->ep_out->ep, hid->out_buf,
+                       CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
         break;
     case USB_HID_REQUEST_SET_PROTOCOL:
         break;


### PR DESCRIPTION
### Contribution description

This PR corrects the readyness of the OUT endpoint for HID.
Before that, EP was configured as waiting for OUT data during the initialization phase.
Unfortunately, during the enumeration phase, the USB endpoint is reset and thus, the endpoint configuration is lost.
Somehow, nRF52 and SAM0 usbdev implementation are able to workaround this issue but this should be fixed on HID side.

### Testing procedure

Flash `tests/usbus_hid` and follow the test procedure.

### Issues/PRs references
None.
