### PR TITLE
sys/ztimer: make internal head update static

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -560,15 +560,6 @@ int ztimer_rmutex_lock_timeout(ztimer_clock_t *clock, rmutex_t *rmutex,
                                uint32_t timeout);
 
 /**
- * @brief   Update ztimer clock head list offset
- *
- * @internal
- *
- * @param[in]   clock  ztimer clock to work on
- */
-void ztimer_update_head_offset(ztimer_clock_t *clock);
-
-/**
  * @brief   Initialize the board-specific default ztimer configuration
  */
 void ztimer_init(void);


### PR DESCRIPTION
### Contribution description

this marks `ztimer_update_head_offset` as static to the `ztimer/core` compilation unit since there are no user outside of core
```
$ rg ztimer_update_head_offset\\\(
sys/include/ztimer.h
569:void ztimer_update_head_offset(ztimer_clock_t *clock);

sys/ztimer/core.c
75:        ztimer_update_head_offset(clock);
91:    ztimer_update_head_offset(clock);
189:void ztimer_update_head_offset(ztimer_clock_t *clock)
198:        "clock %p: ztimer_update_head_offset(): diff=%" PRIu32 " old head %p\n",
218:            "ztimer %p: ztimer_update_head_offset(): now=%" PRIu32 " new head %p",
377:            ztimer_update_head_offset(clock);
```
### Testing procedure

compile and run ztimer tests

e.g.:
```
tests/ztimer_overhead$ RIOT_VERSION=test make all test
```
ante patch:  
```
  text    data     bss     dec     hex filename
  28077     636   47824   76537   12af9 tests_ztimer_overhead.elf
```
post patch:
```
  text    data     bss     dec     hex filename
  28045     636   47824   76505   12ad9 tests_ztimer_overhead.elf
```

### Issues/PRs references

