### PR TITLE
cpu/{cc26xx, cc13xx}: model kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -8,6 +8,8 @@
 : ${TEST_BOARDS_LLVM_COMPILE:=""}
 
 : ${TEST_KCONFIG_BOARDS_AVAILABLE:="
+cc1352-launchpad
+cc2650-launchpad
 dwm1001
 hifive1
 native

--- a/boards/cc1312-launchpad/Kconfig
+++ b/boards/cc1312-launchpad/Kconfig
@@ -17,3 +17,5 @@ config BOARD_CC1312_LAUNCHPAD
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/boards/cc1350-launchpad/Kconfig
+++ b/boards/cc1350-launchpad/Kconfig
@@ -17,3 +17,5 @@ config BOARD_CC1350_LAUNCHPAD
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/boards/cc1352-launchpad/Kconfig
+++ b/boards/cc1352-launchpad/Kconfig
@@ -17,3 +17,5 @@ config BOARD_CC1352_LAUNCHPAD
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/boards/cc1352p-launchpad/Kconfig
+++ b/boards/cc1352p-launchpad/Kconfig
@@ -17,3 +17,5 @@ config BOARD_CC1352P_LAUNCHPAD
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/boards/cc2650-launchpad/Kconfig
+++ b/boards/cc2650-launchpad/Kconfig
@@ -17,3 +17,5 @@ config BOARD_CC2650_LAUNCHPAD
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO

--- a/cpu/cc26x0_cc13x0/Kconfig
+++ b/cpu/cc26x0_cc13x0/Kconfig
@@ -12,12 +12,17 @@ config CPU_FAM_CC26X0
     select HAS_CPU_CC26X0_CC13X0
     select HAS_CORTEXM_MPU
 
+    select MODULE_CC26XX_CC13XX if TEST_KCONFIG
+    select MODULE_CC26X0_DRIVERLIB if TEST_KCONFIG
+
 config CPU_FAM_CC13X0
     bool
     select CPU_CORE_CORTEX_M3
     select CPU_COMMON_CC26XX_CC13XX
     select HAS_CPU_CC26X0_CC13X0
     select HAS_CORTEXM_MPU
+
+    select MODULE_CC26XX_CC13XX if TEST_KCONFIG
 
 ## CPU Models
 config CPU_MODEL_CC26X0F128
@@ -47,3 +52,4 @@ config CPU
     default "cc26x0_cc13x0"
 
 source "$(RIOTCPU)/cc26xx_cc13xx/Kconfig"
+rsource "vendor/driverlib/Kconfig"

--- a/cpu/cc26x0_cc13x0/vendor/driverlib/Kconfig
+++ b/cpu/cc26x0_cc13x0/vendor/driverlib/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_CC26X0_DRIVERLIB
+    bool
+    depends on TEST_KCONFIG
+    depends on CPU_FAM_CC26X0
+    help
+      Functions for SetupTrimDevice.

--- a/cpu/cc26x2_cc13x2/Kconfig
+++ b/cpu/cc26x2_cc13x2/Kconfig
@@ -13,6 +13,8 @@ config CPU_FAM_CC13X2
     select HAS_CPU_CC26X2_CC13X2
     select HAS_CORTEXM_MPU
 
+    select MODULE_CC26XX_CC13XX if TEST_KCONFIG
+
 ## CPU Models
 config CPU_MODEL_CC1312R1F3
     bool

--- a/cpu/cc26xx_cc13xx/Kconfig
+++ b/cpu/cc26xx_cc13xx/Kconfig
@@ -84,3 +84,15 @@ endif # CC26XX_CC13XX_ROM_BOOTLOADER
 endif # CC26XX_CC13XX_UPDATE_CCFG
 
 source "$(RIOTCPU)/cortexm_common/Kconfig"
+
+config MODULE_CC26XX_CC13XX
+    bool
+    depends on TEST_KCONFIG
+    depends on CPU_COMMON_CC26XX_CC13XX
+    select MODULE_PERIPH_COMMON
+    select MODULE_CC26XX_CC13XX_PERIPH
+    default y
+    help
+      Common code for TI cc26xx/cc13xx family.
+
+rsource "periph/Kconfig"

--- a/cpu/cc26xx_cc13xx/periph/Kconfig
+++ b/cpu/cc26xx_cc13xx/periph/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_CC26XX_CC13XX_PERIPH
+    bool
+    depends on TEST_KCONFIG
+    depends on CPU_COMMON_CC26XX_CC13XX
+    help
+      Common peripheral drivers for TI cc26xx/cc13xx family.


### PR DESCRIPTION
### Contribution description
This models the Kconfig modules for all boards based on cc26xx and cc13xx CPUs. The list of boards is:

- cc1312-launchpad
- cc1352-launchpad
- cc1352p-launchpad
- cc2650-launchpad
- cc2650stk
- cc1350-launchpad

### Testing procedure
- Green CI
- Check the modelling and compare `make info-modules` list with and without `TEST_KCONFIG=1`, they should match.

### Issues/PRs references
Part of #16875