### PR TITLE
boards/ek-lm4f120xl: model kconfig

### DIFF
--- a/boards/ek-lm4f120xl/Kconfig
+++ b/boards/ek-lm4f120xl/Kconfig
@@ -17,3 +17,5 @@ config BOARD_EK_LM4F120XL
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO


### PR DESCRIPTION
### Contribution description
Turns out that `lm4f120` does not require extra modelling, so just adding the single board that uses it: `ek-lm4f120xl`. I don't think it is really worth it add it to the CI list to test every single time, so I added a temporary commit for that.

### Testing procedure
- Green CI
- Module lists should match between makefile and kconfig

### Issues/PRs references
Part of #16875