### PR TITLE
boards/common/arduino due: model kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -8,6 +8,7 @@
 : ${TEST_BOARDS_LLVM_COMPILE:=""}
 
 : ${TEST_KCONFIG_BOARDS_AVAILABLE:="
+arduino-due
 arduino-leonardo
 arduino-mega2560
 arduino-nano

--- a/boards/common/arduino-due/Kconfig
+++ b/boards/common/arduino-due/Kconfig
@@ -17,3 +17,12 @@ config BOARD_COMMON_ARDUINO_DUE
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    select HAVE_SAUL_GPIO
+    select MODULE_BOARDS_COMMON_ARDUINO_DUE if TEST_KCONFIG
+
+config MODULE_BOARDS_COMMON_ARDUINO_DUE
+    bool
+    depends on TEST_KCONFIG
+    help
+      Common code for boards based on arduino-due.


### PR DESCRIPTION
### Contribution description
`sam3` does not seem to need extra modelling, so this just adds does it for the `arduino-due` common group. Build currently limited in 3cade20b79ab5c79c2eb875ed7ada2436f821c2b


### Testing procedure
- Green CI, and consistent module lists between Makefile and Kconfig.


### Issues/PRs references
Part of #16875
