### PR TITLE
sys/shell: hide random commands behind random_cmd pseudo-module

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -119,6 +119,7 @@ PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng
 PSEUDOMODULES += prng_%
 PSEUDOMODULES += fortuna_reseed
+PSEUDOMODULES += random_cmd
 PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += rtt_cmd
 PSEUDOMODULES += saul_adc

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -29,7 +29,7 @@ endif
 ifneq (,$(filter lpc2387,$(USEMODULE)))
   SRC += sc_heap.c
 endif
-ifneq (,$(filter random,$(USEMODULE)))
+ifneq (,$(filter random_cmd,$(USEMODULE)))
   SRC += sc_random.c
 endif
 ifneq (,$(filter at30tse75x,$(USEMODULE)))

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -86,7 +86,7 @@ extern int _gnrc_icmpv6_ping(int argc, char **argv);
 #endif
 #endif
 
-#ifdef MODULE_RANDOM
+#ifdef MODULE_RANDOM_CMD
 extern int _random_init(int argc, char **argv);
 extern int _random_get(int argc, char **argv);
 #endif
@@ -250,7 +250,7 @@ const shell_command_t _shell_command_list[] = {
     { "ping", "Alias for ping6", _gnrc_icmpv6_ping },
 #endif
 #endif
-#ifdef MODULE_RANDOM
+#ifdef MODULE_RANDOM_CMD
     { "random_init", "initializes the PRNG", _random_init },
     { "random_get", "returns 32 bit of pseudo randomness", _random_get },
 #endif

--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -9,6 +9,7 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN=\($(MAIN_THREAD_SIZE)\)
 
 USEMODULE += fmt
 USEMODULE += random
+USEMODULE += random_cmd
 USEMODULE += shell
 USEMODULE += xtimer
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

These commands cost 248 bytes of memory, we don't want to always include them when the `random` module is selected.



### Testing procedure

Compile `examples/gnrc_networking`

#### master

```
   text	   data	    bss	    dec	    hex	filename
 100384	    188	  18984	 119556	  1d304	/home/benpicco/dev/RIOT-staging/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

#### this PR

```
   text	   data	    bss	    dec	    hex	filename
 100136	    188	  18984	 119308	  1d20c	/home/benpicco/dev/RIOT-staging/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
