### PR TITLE
usbus/hid: fix ep_out readyness

### DIFF
--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -138,6 +138,10 @@ static void _init(usbus_t *usbus, usbus_handler_t *handler)
     usbus_enable_endpoint(hid->ep_out);
 
     usbus_add_interface(usbus, &hid->iface);
+
+    /* Wait for data from HOST */
+    usbdev_ep_xmit(hid->ep_out->ep, hid->out_buf,
+                   CONFIG_USBUS_HID_INTERRUPT_EP_SIZE);
 }
 
 static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR reverts some of the changes introduced by #17230 which broke FIDO2 functionality tested by `tests/sys_fido2_ctap`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
* `tests/usbus_hid`
* `tests/sys_fido2_ctap`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#17230

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
