### PR TITLE
tools/openocd: check OPENOCD_VERIFY after IMAGE_OFFSET is computed

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -330,9 +330,6 @@ do_flash() {
             exit $RETVAL
         fi
     fi
-    if [ -z "${OPENOCD_SKIP_VERIFY}" ]; then
-        OPENOCD_VERIFY="-c 'verify_image \"${IMAGE_FILE}\" ${IMAGE_OFFSET}'"
-    fi
 
     # In case of binary file, IMAGE_OFFSET should include the flash base address
     # This allows flashing normal binary files without env configuration
@@ -342,6 +339,10 @@ do_flash() {
         echo "Binfile detected, adding ROM base address: ${FLASH_ADDR}"
         IMAGE_TYPE=bin
         IMAGE_OFFSET=$(printf "0x%08x\n" "$((${IMAGE_OFFSET} + ${FLASH_ADDR}))")
+    fi
+
+    if [ -z "${OPENOCD_SKIP_VERIFY}" ]; then
+        OPENOCD_VERIFY="-c 'verify_image \"${IMAGE_FILE}\" ${IMAGE_OFFSET}'"
     fi
 
     if [ "${IMAGE_OFFSET}" != "0" ]; then


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes the openocd script as reported [on the forum](https://forum.riot-os.org/t/cant-flash-riotboot-test-on-stm32-nucleo-l552ze-q-wrote-0-bytes-timed-out-while-waiting-for-target-halted/3443).

The problem is that `OPENOCD_VERIFY` is computed before `IMAGE_OFFSET` is updated in the case of binfile and `OPENOCD_VERIFY` might depend on it.

This problems breaks `tests/riotboot` on `nucleo-l552ze-q`.

The bug was introduced by #16911 (found by bisecting).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/riotboot` works as expected:

<details><summary>nucleo-l552ze-q</summary>

```
$ RIOT_CI_BUILD=1 make BOARD=nucleo-l552ze-q -C tests/riotboot flash test --no-print-directory 
Building application "tests_riotboot" for "nucleo-l552ze-q" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/nucleo-l552ze-q
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot0.1637583198.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  14864	    132	   2376	  17372	   43dc	/work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot0-extended.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08000000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J34M25 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.250033
Info : stm32l5x.cpu: hardware has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l5x.cpu on 0
Info : Listening on port 41231 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l5x.cpu       hla_target little stm32l5x.cpu       reset

target halted due to debug-request, current mode: Thread 
xPSR: 0xf9000000 pc: 0x08000440 msp: 0x20000200
Info : device idcode = 0x20006472 (STM32L55/L56xx - Rev: B)
Info : flash size = 512kbytes
Info : flash mode : dual-bank
auto erase enabled
wrote 266240 bytes from file /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot0-extended.bin in 11.719698s (22.185 KiB/s)

verified 266240 bytes in 5.061085s (51.372 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
��
> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b895e

compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot1.1637583199.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot1.1637583199.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08040800
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Warn : Transport "hla_swd" was already selected
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J34M25 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.250033
Info : stm32l5x.cpu: hardware has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l5x.cpu on 0
Info : Listening on port 36865 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l5x.cpu       hla_target little stm32l5x.cpu       reset

target halted due to debug-request, current mode: Thread 
xPSR: 0xf9000000 pc: 0x08000440 msp: 0x20000200
Info : device idcode = 0x20006472 (STM32L55/L56xx - Rev: B)
Info : flash size = 512kbytes
Info : flash mode : dual-bank
Info : Padding image section 0 at 0x08044a94 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08044a98 .. 0x08044fff
auto erase enabled
wrote 17048 bytes from file /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot1.1637583199.riot.bin in 1.031962s (16.133 KiB/s)

verified 17044 bytes in 0.398811s (41.735 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=1
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b895f
Image start address: 0x08041000
Header chksum: 0xcfcea0a0

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x08001800
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001800
slot 1: metadata: 0x8040800 image: 0x08041000
> 
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot0.1637583200.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot0.1637583200.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08001000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Warn : Transport "hla_swd" was already selected
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J34M25 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.250033
Info : stm32l5x.cpu: hardware has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l5x.cpu on 0
Info : Listening on port 41927 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l5x.cpu       hla_target little stm32l5x.cpu       reset

target halted due to debug-request, current mode: Thread 
xPSR: 0xf9000000 pc: 0x08000440 msp: 0x20000200
Info : device idcode = 0x20006472 (STM32L55/L56xx - Rev: B)
Info : flash size = 512kbytes
Info : flash mode : dual-bank
Info : Padding image section 0 at 0x08005294 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08005298 .. 0x080057ff
auto erase enabled
wrote 17048 bytes from file /work/riot/RIOT/tests/riotboot/bin/nucleo-l552ze-q/tests_riotboot-slot0.1637583200.riot.bin in 1.022403s (16.284 KiB/s)

verified 17044 bytes in 0.399939s (41.618 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
t
> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8960
Image start address: 0x08001800
Header chksum: 0xdfcea89d

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x08001800
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001800
slot 1: metadata: 0x8040800 image: 0x08041000
> 
TEST PASSED
```

</details>

<details><summary>nucleo-l073rz</summary>

```
$ RIOT_CI_BUILD=1 make BOARD=nucleo-l073rz -C tests/riotboot flash test --no-print-directory 
Building application "tests_riotboot" for "nucleo-l073rz" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/nucleo-l073rz
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot0.1637583047.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  13768	    132	   2376	  16276	   3f94	/work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot0-extended.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08000000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J24M11 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.224463
Info : stm32l0.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32l0.cpu on 0
Info : Listening on port 34383 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l0.cpu        hla_target little stm32l0.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x08000320 msp: 0x20000200
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (0) size is 96kb, base address is 0x8000000
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (1) size is 96kb, base address is 0x8018000
auto erase enabled
wrote 102400 bytes from file /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot0-extended.bin in 23.338657s (4.285 KiB/s)

verified 100608 bytes in 3.898582s (25.201 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b88c7

compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot1.1637583048.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot1.1637583048.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08018800
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Warn : Transport "hla_swd" was already selected
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J24M11 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.219779
Info : stm32l0.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32l0.cpu on 0
Info : Listening on port 34735 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l0.cpu        hla_target little stm32l0.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x08000320 msp: 0x20000200
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (0) size is 96kb, base address is 0x8000000
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (1) size is 96kb, base address is 0x8018000
Warn : Adding extra erase range, 0x08018000 .. 0x080187ff
auto erase enabled
wrote 14336 bytes from file /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot1.1637583048.riot.bin in 3.443025s (4.066 KiB/s)

verified 14156 bytes in 0.595591s (23.211 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=1
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b88c8
Image start address: 0x08018900
Header chksum: 0xbf701907

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x08001100
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001100
slot 1: metadata: 0x8018800 image: 0x08018900
> 
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot0.1637583049.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot0.1637583049.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08001000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Warn : Transport "hla_swd" was already selected
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J24M11 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.215094
Info : stm32l0.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32l0.cpu on 0
Info : Listening on port 41575 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l0.cpu        hla_target little stm32l0.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x08000320 msp: 0x20000200
Info : Device: STM32L0xx (Cat.5)
Info : STM32L flash has dual banks. Bank (0) size is 96kb, base address is 0x8000000
auto erase enabled
wrote 16384 bytes from file /work/riot/RIOT/tests/riotboot/bin/nucleo-l073rz/tests_riotboot-slot0.1637583049.riot.bin in 3.767596s (4.247 KiB/s)

verified 14156 bytes in 0.595623s (23.210 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b88c9
Image start address: 0x08001100
Header chksum: 0xcf72a106

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x08001100
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001100
slot 1: metadata: 0x8018800 image: 0x08018900
> 
TEST PASSED
```

</details>

<details><summary>samr21-xpro</summary>

```
$ PROGRAMMER=openocd RIOT_CI_BUILD=1 make BOARD=samr21-xpro -C tests/riotboot flash test --no-print-directory 
Building application "tests_riotboot" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/cpu/samd21/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1637583563.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  14084	    132	   2368	  16584	   40c8	/work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0-extended.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00000000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800001644
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 36653 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x00000c84 msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 133376 bytes from file /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0-extended.bin in 14.093499s (9.242 KiB/s)

verified 133376 bytes in 10.784737s (12.077 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8acb

compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot1.1637583564.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot1.1637583564.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00020800
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800001644
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 43359 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x0000032c msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 14592 bytes from file /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot1.1637583564.riot.bin in 1.548771s (9.201 KiB/s)

verified 14472 bytes in 1.212203s (11.659 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=1
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8acc
Image start address: 0x00020900
Header chksum: 0xbf80930b

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x00001100
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x1000 image: 0x00001100
slot 1: metadata: 0x20800 image: 0x00020900
> 
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1637583565.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1637583565.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00001000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800001644
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 34559 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x0000032c msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 14592 bytes from file /work/riot/RIOT/tests/riotboot/bin/samr21-xpro/tests_riotboot-slot0.1637583565.riot.bin in 1.553509s (9.173 KiB/s)

verified 14472 bytes in 1.211689s (11.664 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8acd
Image start address: 0x00001100
Header chksum: 0xcf829b0a

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x00001100
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x1000 image: 0x00001100
slot 1: metadata: 0x20800 image: 0x00020900
> 
TEST PASSED
```

</details>


<details><summary>nrf52832-mdk</summary>

```
$ PROGRAMMER=openocd RIOT_CI_BUILD=1 make BOARD=nrf52832-mdk -C tests/riotboot flash test --no-print-directory 
Building application "tests_riotboot" for "nrf52832-mdk" with MCU "nrf52".

"make" -C /work/riot/RIOT/boards/nrf52832-mdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/vectors
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot0.1637583699.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  12460	    128	   2384	  14972	   3a7c	/work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot0-extended.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00000000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.10
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 45563 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000874 msp: 0x20000200
Info : nRF52832-QFAA(build code: B0) 512kB Flash, 64kB RAM
Warn : Adding extra erase range, 0x00041400 .. 0x00041fff
auto erase enabled
wrote 267264 bytes from file /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot0-extended.bin in 18.325207s (14.243 KiB/s)

verified 267264 bytes in 0.793038s (329.114 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
���c׋�����J�
shell: command not found: ��c׋�����J�> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8b53

compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot1.1637583700.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot1.1637583700.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00041000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.10
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 43725 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000344 msp: 0x20000200
Info : nRF52832-QFAA(build code: B0) 512kB Flash, 64kB RAM
Warn : Adding extra erase range, 0x0004452c .. 0x00044fff
auto erase enabled
wrote 13612 bytes from file /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot1.1637583700.riot.bin in 1.238998s (10.729 KiB/s)

verified 13612 bytes in 0.247021s (53.813 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=1
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8b54
Image start address: 0x00041400
Header chksum: 0xd7a29e95

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x00002400
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x2000 image: 0x00002400
slot 1: metadata: 0x41000 image: 0x00041400
> 
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot0.1637583701.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot0.1637583701.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x00000000
Flashing with IMAGE_OFFSET: 0x00002000
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-10-26-22:35)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Warn : Transport "swd" was already selected
swd
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 1.10
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 41961 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          halted

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000344 msp: 0x20000200
Info : nRF52832-QFAA(build code: B0) 512kB Flash, 64kB RAM
Warn : Adding extra erase range, 0x0000552c .. 0x00005fff
auto erase enabled
wrote 13612 bytes from file /work/riot/RIOT/tests/riotboot/bin/nrf52832-mdk/tests_riotboot-slot0.1637583701.riot.bin in 1.240020s (10.720 KiB/s)

verified 13612 bytes in 0.247992s (53.602 KiB/s)

shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x619b8b55
Image start address: 0x00002400
Header chksum: 0xf7a2ae92

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x00002400
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x2000 image: 0x00002400
slot 1: metadata: 0x41000 image: 0x00041400
> 
TEST PASSED
```

</details>

I don't have ESP32 based board to test that change, since `OPENOCD_VERIFY` was initially introduced for them apparently.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Bug introduced by #16911
https://forum.riot-os.org/t/cant-flash-riotboot-test-on-stm32-nucleo-l552ze-q-wrote-0-bytes-timed-out-while-waiting-for-target-halted/3443

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
