### PR TITLE
sys/atomic_utils: add atomic_{load,store}_ptr()

### DIFF
--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -236,6 +236,33 @@ static inline uint32_t atomic_load_u32(const volatile uint32_t *var);
  * @return  The value stored in @p var
  */
 static inline uint64_t atomic_load_u64(const volatile uint64_t *var);
+
+/**
+ * @brief   Load an `uintptr_t` atomically
+ *
+ * @param[in]       var     Variable to load atomically
+ * @return  The value stored in @p var
+ */
+static inline uintptr_t atomic_load_uintptr(const volatile uintptr_t *var) {
+    if (sizeof(uintptr_t) == 2) {
+        return atomic_load_u16((const volatile uint16_t *)var);
+    }
+    else if (sizeof(uintptr_t) == 4) {
+        return atomic_load_u32((const volatile uint32_t *)(uintptr_t)var);
+    }
+    else {
+        return atomic_load_u64((const volatile uint64_t *)(uintptr_t)var);
+    }
+}
+/**
+ * @brief   Load an `void *` atomically
+ *
+ * @param[in]       ptr_addr    Address to the pointer to load
+ * @return  Value of the loaded pointer
+ */
+static inline void * atomic_load_ptr(void **ptr_addr) {
+    return (void *)atomic_load_uintptr((const volatile uintptr_t *)ptr_addr);
+}
 /** @} */
 
 /**
@@ -266,6 +293,34 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val);
  * @param[in]       val     Value to write
  */
 static inline void atomic_store_u64(volatile uint64_t *dest, uint64_t val);
+
+/**
+ * @brief   Store an `uintptr_t` atomically
+ *
+ * @param[out]      dest    Location to atomically write the new value to
+ * @param[in]       val     Value to write
+ */
+static inline void atomic_store_uintptr(volatile uintptr_t *dest, uintptr_t val)
+{
+    if (sizeof(uintptr_t) == 2) {
+        atomic_store_u16((volatile uint16_t *)dest, (uint16_t)val);
+    }
+    else if (sizeof(uintptr_t) == 4) {
+        atomic_store_u32((volatile uint32_t *)(uintptr_t)dest, (uint32_t)val);
+    }
+    else {
+        atomic_store_u64((volatile uint64_t *)(uintptr_t)dest, (uint64_t)val);
+    }
+}
+/**
+ * @brief   Store an `void *` atomically
+ *
+ * @param[out]      dest    Location to atomically write the new value to
+ * @param[in]       val     Value to write
+ */
+static inline void atomic_store_ptr(void **dest, const void *val) {
+    atomic_store_uintptr((volatile uintptr_t *)dest, (uintptr_t)val);
+}
 /** @} */
 
 /**

--- a/tests/sys_atomic_utils_unittests/main.c
+++ b/tests/sys_atomic_utils_unittests/main.c
@@ -51,6 +51,10 @@ static void test_load_store(void)
     uint64_t u64 = 42;
     atomic_store_u64(&u64, 0x1337133713371337);
     TEST_ASSERT_EQUAL_INT(atomic_load_u64(&u64), 0x1337133713371337);
+
+    void *ptr = NULL;
+    atomic_store_ptr(&ptr, &u64);
+    TEST_ASSERT(atomic_load_ptr(&ptr) == (void *)&u64);
 }
 
 static void test_fetch_op_u8(fetch_op_u8_t atomic_op, fetch_op_u8_t op)


### PR DESCRIPTION
### Contribution description

As the title says

### Testing procedure

```
$ make -C tests/sys_atomic_utils_unittests flash test
[...]

/home/maribu/Repos/software/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM1" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM1
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2022.01-devel-709-gc360b-sys/atomic_utils)
.......
OK (7 tests)

make: Leaving directory '/home/maribu/Repos/software/RIOT/tests/sys_atomic_utils_unittests'
```

### Issues/PRs references

None