### PR TITLE
boards: add board support for Alientek Pandora

### DIFF
--- a/boards/alientek-pandora/Kconfig
+++ b/boards/alientek-pandora/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "alientek-pandora" if BOARD_ALIENTEK_PANDORA
+
+config BOARD_ALIENTEK_PANDORA
+    bool
+    default y
+    select CPU_MODEL_STM32L475VE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/alientek-pandora/Makefile
+++ b/boards/alientek-pandora/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/alientek-pandora/Makefile.dep
+++ b/boards/alientek-pandora/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/alientek-pandora/Makefile.features
+++ b/boards/alientek-pandora/Makefile.features
@@ -1,0 +1,11 @@
+CPU = stm32
+CPU_MODEL = stm32l475ve
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot

--- a/boards/alientek-pandora/Makefile.include
+++ b/boards/alientek-pandora/Makefile.include
@@ -1,0 +1,13 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# this board uses openocd with st-link
+PROGRAMMER ?= openocd
+OPENOCD_DEBUG_ADAPTER ?= stlink
+
+# This board can become un-flashable after a hardfault,
+# use connect_assert_srst to always be able to flash or reset the board.
+OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
+
+# openocd programmer is supported
+PROGRAMMERS_SUPPORTED += openocd

--- a/boards/alientek-pandora/board.c
+++ b/boards/alientek-pandora/board.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_alientek-pandora
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Alientek Pandora board
+ *
+ * @author      Luo Jia <luojia@hust.edu.cn>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+}

--- a/boards/alientek-pandora/doc.txt
+++ b/boards/alientek-pandora/doc.txt
@@ -1,0 +1,40 @@
+/**
+@defgroup    boards_alientek-pandora Alientek Pandora
+@ingroup     boards
+@brief       Support for the Alientek Pandora board
+
+## Overview
+
+The Alientek Pandora is a development board manufactured jointly by Alientek and RT-Thread company.
+It is based on STM32L475VET6 and have on-board LCD, SD card and WiFi access.
+Users may connect to its on board ST-Link 2.1 compatible debugger to flash or debug.
+
+Documents of this board are available on its [Alientek official website](http://www.alientek.com/productinfo/716137.html).
+It may require a translation software to read it in English.
+Additional resources may be found on [RT-Thread bsp support page](https://gitee.com/rtthread/rt-thread/tree/master/bsp/stm32/stm32l475-atk-pandora).
+
+### Flashing the board
+
+To flash the board, use the on board ST-Link programmer/debugger.
+Input the following command:
+
+    make BOARD=alientek-pandora -C examples/hello-world flash
+
+The NRST pin is connected to the on board debugger, so users do not need to reset manually
+every time it requires to flash.
+
+If the operating system raised a fault, users may manually reset the chip by pressing the reset button.
+This button has a black color and is located between the four keys and the LED light.
+
+### STDIO
+
+STDIO is connected to pins PA9 (TX) and PA10 (RX).
+Before you begin, check that the both the jumper caps marked as 'USART1' is connected.
+
+Use the `term` target to open a terminal:
+
+    make BOARD=alientek-pandora -C examples/hello-world term
+
+An on-board ST-Link compatible debugger is used to transport serial STDIO message.
+
+ */

--- a/boards/alientek-pandora/include/board.h
+++ b/boards/alientek-pandora/include/board.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_alientek-pandora
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Alientek Pandora board
+ *
+ * @author      Luo Jia <luojia@hust.edu.cn>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_E, 7)  /**< LED0 gpio pin  */
+#define LED0_MASK           (1 << 7)             /**< LED0 gpio mask */
+
+#define LED0_ON             (GPIOB->BSRR = LED0_MASK)  /**< Turn on LED0  */
+#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))  /**< Turn off LED0  */
+#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)  /**< Toggle LED0  */
+
+#define LED1_PIN            GPIO_PIN(PORT_E, 8)  /**< LED1 gpio pin  */
+#define LED1_MASK           (1 << 8)             /**< LED1 gpio mask */
+
+#define LED1_ON             (GPIOE->BSRR = LED1_MASK)  /**< Turn on LED1  */
+#define LED1_OFF            (GPIOE->BSRR = (LED1_MASK << 16))  /**< Turn off LED1  */
+#define LED1_TOGGLE         (GPIOE->ODR  ^= LED1_MASK)  /**< Toggle LED1  */
+
+#define LED2_PIN            GPIO_PIN(PORT_E, 9)  /**< LED2 gpio pin  */
+#define LED2_MASK           (1 << 9)             /**< LED2 gpio mask */
+
+#define LED2_ON             (GPIOE->BSRR = LED2_MASK)  /**< Turn on LED2  */
+#define LED2_OFF            (GPIOE->BSRR = (LED2_MASK << 16))  /**< Turn off LED2  */
+#define LED2_TOGGLE         (GPIOE->ODR  ^= LED2_MASK)  /**< Toggle LED2  */
+
+/** @} */
+
+/**
+ * @name   Wake-up and key buttons
+ * @{
+ */
+#define BTNWK_PIN           GPIO_PIN(PORT_C, 13) /**< Wake button pin  */
+#define BTNWK_MODE          GPIO_IN_PD          /**< Wake button mode */
+
+#define BTN0_PIN            GPIO_PIN(PORT_D, 10) /**< Button 0 pin   */
+#define BTN0_MODE           GPIO_IN_PD          /**< Button 0 mode  */
+
+#define BTN1_PIN            GPIO_PIN(PORT_D, 9) /**< Button 1 pin    */
+#define BTN1_MODE           GPIO_IN_PD          /**< Button 1 mode   */
+
+#define BTN2_PIN            GPIO_PIN(PORT_D, 8) /**< Button 2 pin    */
+#define BTN2_MODE           GPIO_IN_PD          /**< Button 2 mode   */
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/alientek-pandora/include/gpio_params.h
+++ b/boards/alientek-pandora/include/gpio_params.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_alientek-pandora
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Luo Jia <luojia@hust.edu.cn>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+#ifndef MODULE_SAUL_PWM
+    {
+        .name  = "LED Red",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Green",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Blue",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+#endif
+    {
+        .name = "Wakeup Key",
+        .pin = BTNWK_PIN,
+        .mode = BTNWK_MODE
+    },
+    {
+        .name = "Key 0",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Key 1",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "Key 2",
+        .pin = BTN2_PIN,
+        .mode = BTN2_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/alientek-pandora/include/periph_conf.h
+++ b/boards/alientek-pandora/include/periph_conf.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_alientek-pandora
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Alientek Pandora board
+ *
+ * @author      Luo Jia <luojia@hust.edu.cn>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            1   /**< This board provides LSE  */
+#endif
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+#include "cfg_rtt_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+/** All timers on board */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM5,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR1_TIM5EN,
+        .bus      = APB1,
+        .irqn     = TIM5_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim5 /**< Timer 0 ISR number */
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config) /**< Number of timers on this board */
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+/** All UARTs on board */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+#ifdef UART_USE_DMA
+        .dma_stream = 6,
+        .dma_chan   = 4
+#endif
+    }
+};
+
+#define UART_0_ISR          (isr_usart1) /**< Usart1 ISR number */
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config) /**< Number of uarts on this board */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
Alientek Pandora (product info [link](http://www.alientek.com/productinfo/716137.html), board pinout [link](https://blog.csdn.net/weixin_40973138/article/details/89042523)) is a development board with an stm32l475ve. This adds support for serial stdio, RGB-LED and buttons on board for RIOT operating system.