### PR TITLE
shell/gnrc_icmpv6_echo: Fix hang with no msg queue

### DIFF
--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -398,14 +398,12 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6, uint32_t no
         if (rssi != GNRC_NETIF_HDR_NO_RSSI) {
             printf(" rssi=%"PRId16" dBm", rssi);
         }
-        if (data->datalen >= sizeof(uint32_t)) {
-            printf(" time=%lu.%03lu ms", (long unsigned)triptime / 1000,
-                   (long unsigned)triptime % 1000);
-        }
-
         /* we can only calculate RTT (triptime) if payload was large enough for
            a TX timestamp */
         if (data->datalen >= sizeof(uint32_t)) {
+            printf(" time=%lu.%03lu ms", (long unsigned)triptime / 1000,
+                   (long unsigned)triptime % 1000);
+
             data->tsum += triptime;
             if (triptime < data->tmin) {
                 data->tmin = triptime;

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -127,9 +127,7 @@ finish:
     xtimer_remove(&data.sched_timer);
     res = _finish(&data);
     gnrc_netreg_unregister(GNRC_NETTYPE_ICMPV6, &data.netreg);
-    for (unsigned i = 0;
-         i < (unsigned)msg_avail();
-         i++) {
+    while (msg_avail() > 0) {
         msg_t msg;
 
         /* remove all remaining messages (likely caused by duplicates) */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`msg_avail()` will return -1 if the thread has no message queue.
Casting this to unsigned will result in the `ping` command to try receiving 4294967295 messages, which hangs the shell.

Drop the cast to `unsigned` and the loop behaves as intended.
But then it's still wrong: If new messages become available, they would be ignored.

So change the `for` loop to a `while` loop. The index variable is not used at all.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
