### PR TITLE
core/msg: make msg_avail() return 0 on no queue

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -362,9 +362,9 @@ int msg_reply_int(msg_t *m, msg_t *reply);
  * @brief Check how many messages are available in the message queue
  *
  * @return Number of messages available in our queue on success
- * @return -1, if no caller's message queue is initialized
+ * @return 0, if no caller's message queue is initialized
  */
-int msg_avail(void);
+unsigned msg_avail(void);
 
 /**
  * @brief Initialize the current thread's message queue.

--- a/core/msg.c
+++ b/core/msg.c
@@ -433,20 +433,20 @@ static int _msg_receive(msg_t *m, int block)
     DEBUG("This should have never been reached!\n");
 }
 
-int msg_avail(void)
+unsigned msg_avail(void)
 {
     DEBUG("msg_available: %" PRIkernel_pid ": msg_available.\n",
           thread_getpid());
 
     thread_t *me = thread_get_active();
 
-    int queue_index = -1;
+    unsigned queue_count = 0;
 
     if (thread_has_msg_queue(me)) {
-        queue_index = cib_avail(&(me->msg_queue));
+        queue_count = cib_avail(&(me->msg_queue));
     }
 
-    return queue_index;
+    return queue_count;
 }
 
 void msg_init_queue(msg_t *array, int num)
@@ -462,11 +462,11 @@ void msg_queue_print(void)
     unsigned state = irq_disable();
     thread_t *thread = thread_get_active();
 
-    int msg_counter = msg_avail();
+    unsigned msg_counter = msg_avail();
 
-    if (msg_counter <= -1) {
+    if (msg_counter < 1) {
         /* no msg queue */
-        printf("No message queue\n");
+        printf("No messages or no message queue\n");
         return;
     }
     cib_t *msg_queue = &thread->msg_queue;
@@ -474,9 +474,9 @@ void msg_queue_print(void)
     int first_msg = cib_peek(msg_queue);
 
     printf("Message queue of thread %" PRIkernel_pid "\n", thread->pid);
-    printf("    size: %u (avail: %d)\n", msg_queue->mask + 1, msg_counter);
+    printf("    size: %u (avail: %u)\n", msg_queue->mask + 1, msg_counter);
 
-    for (int i = 0; i < msg_counter; i++) {
+    for (unsigned i = 0; i < msg_counter; i++) {
         msg_t *m = &msg_array[(first_msg + i) & msg_queue->mask];
         printf("    * %u: sender: %" PRIkernel_pid ", type: 0x%04" PRIu16
                ", content: %" PRIu32 " (%p)\n", i, m->sender_pid, m->type,

--- a/tests/msg_avail/main.c
+++ b/tests/msg_avail/main.c
@@ -39,7 +39,7 @@ int main(void)
     puts("[START]");
 
     /* add message to own queue */
-    for (int idx = 0; idx < MSG_QUEUE_LENGTH; ++idx) {
+    for (unsigned idx = 0; idx < MSG_QUEUE_LENGTH; ++idx) {
         msges[idx].type = idx;
         msg_send_to_self(msges + idx);
         LOG_INFO("+ add msg: %d\n", idx);
@@ -49,11 +49,11 @@ int main(void)
         }
     }
     /* receive available messages in queue */
-    for (int idx = msg_avail(); idx > 0; --idx) {
+    for (unsigned idx = msg_avail(); idx > 0; --idx) {
         msg_t msg;
         msg_receive(&msg);
         LOG_INFO("- got msg: %d\n", (MSG_QUEUE_LENGTH - idx));
-        if ((int)msg.type != (MSG_QUEUE_LENGTH - idx)
+        if (msg.type != (MSG_QUEUE_LENGTH - idx)
             || msg_avail() != idx - 1) {
             puts("[FAILED]");
             return 1;

--- a/tests/msg_queue_print/tests/01-run.py
+++ b/tests/msg_queue_print/tests/01-run.py
@@ -14,9 +14,8 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect("No message queue")
-    child.expect(r"Message queue of thread \d+\r\n")
-    child.expect_exact('size: 8 (avail: 0)')
+    child.expect("No messages or no message queue")
+    child.expect("No messages or no message queue")
     child.expect(r"Message queue of thread \d+\r\n")
     child.expect_exact('size: 8 (avail: 8)')
     if os.environ.get('BOARD') == 'native':


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For the caller there should be no difference if there is no message in the queue and if there can't be a message in the queue.

The current API works as one would expect if there is a message queue, but once called from a thread that does not have a message queue configured, code that does

    while (msg_avail())

will end up in an infinite loop.

Remove this foot-gun from the API by making the return value of `msg_avail()` independent of the availability of a message queue.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

prevents issues like  #17261