### PR TITLE
boards/common/saml1x: model kconfig

### DIFF
--- a/boards/common/saml1x/Kconfig
+++ b/boards/common/saml1x/Kconfig
@@ -16,3 +16,14 @@ config BOARD_COMMON_SAML1X
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_RIOTBOOT
+
+    select HAVE_SAUL_GPIO
+
+config MODULE_BOARDS_COMMON_SAML1X
+    bool
+    depends on TEST_KCONFIG
+    depends on BOARD_COMMON_SAML1X
+    default y
+    help
+        Board specific code for the Microchip SAML10 and SAML11 Xplained Pro
+        boards.


### PR DESCRIPTION
### Contribution description
SAML1X CPU requires no special handling for Kconfig, this just adds the missing boards common module. The boards using this CPU are:
- saml10-xpro
- saml11-xpro

4afc1e986b3cc9d7833ce40c2d73a0d0da073200 limits the CI to test only these boards.


### Testing procedure
- Green CI

### Issues/PRs references
Part of #16875