### PR TITLE
pkg/uwb-core: multiple cleanups

### DIFF
--- a/examples/twr_aloha/control.c
+++ b/examples/twr_aloha/control.c
@@ -227,19 +227,10 @@ void init_ranging(void)
               (uint16_t)ceilf(uwb_dwt_usecs_to_usecs(rng->config.
                                                      tx_holdoff_delay)));
 
-    if (IS_USED(MODULE_UWB_CORE_TWR_SS_ACK)) {
-        uwb_set_autoack(udev, true);
-        uwb_set_autoack_delay(udev, 12);
-    }
-
     dpl_callout_init(&_rng_req_callout, dpl_eventq_dflt_get(),
                      uwb_ev_cb, rng);
     dpl_callout_reset(&_rng_req_callout, RANGE_REQUEST_T_MS);
     dpl_event_init(&_slot_event, _slot_complete_cb, rng);
-
-    /* Apply config */
-    uwb_mac_config(udev, NULL);
-    uwb_txrf_config(udev, &udev->config.txrf);
 
     if ((udev->role & UWB_ROLE_ANCHOR)) {
         printf("Node role: ANCHOR \n");

--- a/pkg/uwb-core/Kconfig
+++ b/pkg/uwb-core/Kconfig
@@ -74,6 +74,10 @@ config MODULE_UWB-CORE_UWBCFG
     bool "uwb-core configuration module"
     select MODULE_UWB-CORE_CONFIG
 
+config MODULE_UWB-CORE_EVENT_THREAD
+    bool "Use event-thread loop as uwb-core's event loop"
+    select MODULE_UWB-CORE_CONFIG
+
 config MODULE_UWB-CORE_CONFIG
     bool
 

--- a/pkg/uwb-core/Makefile.dep
+++ b/pkg/uwb-core/Makefile.dep
@@ -30,6 +30,10 @@ ifneq (,$(filter uwb-core_dpl,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter uwb-core_event_thread,$(USEMODULE)))
+  USEMODULE += event_thread
+endif
+
 # Some stdlib functions used by the pkg are not in avr-gcc
 FEATURES_BLACKLIST += arch_avr8
 # uwb-core has specific compilation sources when compiling kernel

--- a/pkg/uwb-core/contrib/uwb_core.c
+++ b/pkg/uwb-core/contrib/uwb_core.c
@@ -19,43 +19,37 @@
 
 #include "thread.h"
 #include "event.h"
-#include "event/callback.h"
 #include "uwb_core.h"
 
-#include "os/os_cputime.h"
-#include "hal/hal_timer.h"
-
-#ifndef UWB_CORE_STACKSIZE
-#define UWB_CORE_STACKSIZE  (THREAD_STACKSIZE_LARGE)
-#endif
-#ifndef UWB_CORE_PRIO
-#define UWB_CORE_PRIO       (THREAD_PRIORITY_MAIN - 5)
-#endif
-
-static char _stack_uwb_core[UWB_CORE_STACKSIZE];
-
+#if !IS_USED(MODULE_UWB_CORE_EVENT_THREAD)
 static event_queue_t _queue;
-
+static char _stack_uwb_core[UWB_CORE_STACKSIZE];
 static void *_uwb_core_thread(void *arg)
 {
     (void)arg;
-
     event_queue_init(&_queue);
     event_loop(&_queue);
     /* never reached */
     return NULL;
 }
+#endif
 
 event_queue_t *uwb_core_get_eventq(void)
 {
+#if !IS_USED(MODULE_UWB_CORE_EVENT_THREAD)
     return &_queue;
+#else
+    return UWB_CORE_EVENT_THREAD_QUEUE;
+#endif
 }
 
 void uwb_core_riot_init(void)
 {
+#if !IS_USED(MODULE_UWB_CORE_EVENT_THREAD)
     thread_create(_stack_uwb_core, sizeof(_stack_uwb_core),
                   UWB_CORE_PRIO,
                   THREAD_CREATE_STACKTEST,
                   _uwb_core_thread, NULL,
-                  "uwb_core");
+                  "uwb_core_event");
+#endif
 }

--- a/pkg/uwb-core/contrib/uwb_core_init.c
+++ b/pkg/uwb-core/contrib/uwb_core_init.c
@@ -53,13 +53,11 @@ void uwb_core_init(void)
     extern void uwb_rng_pkg_init(void);
     uwb_rng_pkg_init();
 #endif
-
     /* uwb configuration module */
 #if IS_USED(MODULE_UWB_CORE_UWBCFG)
     extern int uwbcfg_pkg_init(void);
     uwbcfg_pkg_init();
 #endif
-
     /* ranging algorithms */
 #if IS_USED(MODULE_UWB_CORE_TWR_SS)
     twr_ss_pkg_init();

--- a/pkg/uwb-core/contrib/uwb_core_init.c
+++ b/pkg/uwb-core/contrib/uwb_core_init.c
@@ -47,6 +47,9 @@ void uwb_core_init(void)
     uwb_dw1000_setup(&dev, (void *) &dw1000_params[0]);
     /* this will start a thread handling dw1000 device */
     uwb_dw1000_config_and_start(&dev);
+    /* apply default configuration */
+    uwb_mac_config(&dev.uwb_dev, NULL);
+    uwb_txrf_config(&dev.uwb_dev, &dev.uwb_dev.config.txrf);
 
     /* init uwb pkg's */
 #if IS_USED(MODULE_UWB_CORE_RNG)
@@ -64,6 +67,8 @@ void uwb_core_init(void)
 #endif
 #if IS_USED(MODULE_UWB_CORE_TWR_SS_ACK)
     twr_ss_ack_pkg_init();
+    uwb_set_autoack(&dev.uwb_dev, true);
+    uwb_set_autoack_delay(&dev.uwb_dev, 12);
 #endif
 #if IS_USED(MODULE_UWB_CORE_TWR_SS_EXT)
     twr_ss_ext_pkg_init();

--- a/pkg/uwb-core/include/uwb_core.h
+++ b/pkg/uwb-core/include/uwb_core.h
@@ -21,23 +21,33 @@
 
 #include <stdint.h>
 #include "event.h"
+#if IS_USED(MODULE_UWB_CORE_EVENT_THREAD)
+#include "event/thread"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief   Priority used for
+ * @brief   The event queue if uwb_core_event_thread is used
  */
-#ifndef UWB_CORE__PRIO
-#define UWB_CORE__PRIO            (THREAD_PRIORITY_MAIN - 2)
+#ifndef UWB_CORE_EVENT_THREAD_QUEUE
+#define UWB_CORE_EVENT_THREAD_QUEUE     EVENT_PRIO_MEDIUM
 #endif
 
 /**
- * @brief   Stacksize used for
+ * @brief   Priority used for uwb-core event queue
  */
-#ifndef UWB_CORE__STACKSIZE
-#define UWB_CORE__STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
+#ifndef UWB_CORE_PRIO
+#define UWB_CORE_PRIO                   (THREAD_PRIORITY_MAIN - 2)
+#endif
+
+/**
+ * @brief   Stacksize used for uwb-core event queue
+ */
+#ifndef UWB_CORE_STACKSIZE
+#define UWB_CORE_STACKSIZE              (THREAD_STACKSIZE_LARGE)
 #endif
 
 /**
@@ -48,8 +58,8 @@ void uwb_core_riot_init(void);
 /**
  * @brief   Retrieves the default event queue.
  *
- * As there is no default event queue in RIOT, uwb-core will start and
- * handle a default event queue.
+ * if uwb_core_event_thread is used then the event_thread module queue will be
+ * used. Otherwise uwb-core will start and handle its own event queue.
  *
  * @return  the default event queue.
  */

--- a/pkg/uwb-dw1000/include/uwb_dw1000_config.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000_config.h
@@ -199,10 +199,11 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default MAC FrameFilter (0x0000 = no filter)
+ * @brief   Default MAC FrameFilter (0x00ff = frame filtering enabled, all frames
+ *          matching PANID and destination address accepted)
  */
 #ifndef DW1000_FRAME_FILTER_DEFAULT
-#define DW1000_FRAME_FILTER_DEFAULT     0x0000
+#define DW1000_FRAME_FILTER_DEFAULT     0x00ff
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

Some cleanups to the port:
- allow for using a common event thread instead of a custom one, this can save some RAM
- It enables frame filtering but accepting all type of frames with matching PANID, destination address.
- moves common configuration to the init function

### Testing procedure

`examples/twr_aloha` still works:

```
2021-11-24 17:04:28,351 # main(): This is RIOT! (Version: 2022.01-devel-719-gc860f-pr_pkg_uwb_core_fixes)
2021-11-24 17:04:28,352 # pkg uwb-dw1000 + uwb-core test application
2021-11-24 17:04:28,353 # {"utime": 24578,"exec": "/home/francisco/workspace/RIOT2/examples/twr_aloha/control.c"}
2021-11-24 17:04:28,355 # {"device_id"="deca0130","panid="DECA","addr"="C329","part_id"="cc95c329","lot_id"="82b3107"}
2021-11-24 17:04:28,355 # {"utime": 24578,"msg": "frame_duration = 201 usec"}
2021-11-24 17:04:28,356 # {"utime": 24578,"msg": "SHR_duration = 139 usec"}
2021-11-24 17:04:28,357 # {"utime": 24578,"msg": "holdoff = 821 usec"}
2021-11-24 17:04:28,357 # Node role: TAG
help
2021-11-24 17:04:32,325 # help
2021-11-24 17:04:32,328 # Command              Description
2021-11-24 17:04:32,332 # ---------------------------------------
2021-11-24 17:04:32,335 # range                Control command
2021-11-24 17:04:32,338 # reboot               Reboot the node
2021-11-24 17:04:32,343 # version              Prints current RIOT_VERSION
2021-11-24 17:04:32,348 # pm                   interact with layered PM subsystem
2021-11-24 17:04:32,353 # ps                   Prints information about running threads.
> range
2021-11-24 17:04:34,101 # range
2021-11-24 17:04:34,102 # Usage:
2021-11-24 17:04:34,105 #       range start: to start ranging
2021-11-24 17:04:34,107 #       range stop:  to stop  ranging
> range start
2021-11-24 17:04:36,982 # range start
2021-11-24 17:04:36,983 # Start ranging
> 2021-11-24 17:04:37,037 # {"utime": 9503112,"c": 278,"uid": 49961,"ouid": 4660,"raz": [0.129899],"rssi": [-83.226806],"los": [1.000000]}
2021-11-24 17:04:37,167 # {"utime": 9633270,"c": 274,"uid": 49961,"ouid": 4660,"raz": [0.128972],"rssi": [-83.430267],"los": [1.000000]}
2021-11-24 17:04:37,210 # {"utime": 9676513,"c": 282,"uid": 49961,"ouid": 4660,"raz": [0.131678],"rssi": [-84.083312],"los": [1.000000]}
2021-11-24 17:04:37,253 # {"utime": 9719848,"c": 278,"uid": 49961,"ouid": 4660,"raz": [0.138098],"rssi": [-83.290252],"los": [1.000000]}
2021-11-24 17:04:37,341 # {"utime": 9807617,"c": 296,"uid": 4660,"ouid": 49961,"raz": [0.128764],"rssi": [-84.385604],"los": [1.000000]}
2021-11-24 17:04:37,384 # {"utime": 9850219,"c": 274,"uid": 49961,"ouid": 4660,"raz": [0.133866],"rssi": [-83.674804],"los": [1.000000]}
2021-11-24 17:04:37,427 # {"utime": 9893463,"c": 282,"uid": 49961,"ouid": 4660,"raz": [0.141513],"rssi": [-83.599517],"los": [1.000000]}
2021-11-24 17:04:37,470 # {"utime": 9936798,"c": 278,"uid": 49961,"ouid": 4660,"raz": [0.100131],"rssi": [-84.083312],"los": [1.000000]}
```
