### PR TITLE
ethos: move bulk of state machine out of ISR context

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -48,6 +48,10 @@ ifneq (,$(filter ccs811_%,$(USEMODULE)))
   USEMODULE += ccs811
 endif
 
+ifneq (,$(filter ethos_%,$(USEMODULE)))
+  USEMODULE += ethos
+endif
+
 ifneq (,$(filter hmc5883l_%,$(USEMODULE)))
   USEMODULE += hmc5883l
 endif

--- a/drivers/ethos/Makefile
+++ b/drivers/ethos/Makefile
@@ -1,1 +1,7 @@
+# exclude submodule sources from *.c wildcard source selection
+SRC := $(filter-out stdio.c,$(wildcard *.c))
+
+# enable submodules
+SUBMODULES := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/drivers/ethos/Makefile.dep
+++ b/drivers/ethos/Makefile.dep
@@ -3,3 +3,7 @@ USEMODULE += iolist
 USEMODULE += netdev_eth
 USEMODULE += random
 USEMODULE += tsrb
+
+ifneq (,$(filter ethos_stdio,$(USEMODULE)))
+  USEMODULE += isrpipe
+endif

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -40,7 +40,7 @@
 #ifdef MODULE_STDIO_ETHOS
 #include "stdio_uart.h"
 #include "isrpipe.h"
-extern isrpipe_t stdio_uart_isrpipe;
+extern isrpipe_t ethos_stdio_isrpipe;
 #endif
 
 #define ENABLE_DEBUG 0
@@ -106,7 +106,7 @@ static void _handle_char(ethos_t *dev, char c)
 #ifdef MODULE_STDIO_ETHOS
         case ETHOS_FRAME_TYPE_TEXT:
             dev->framesize++;
-            isrpipe_write_one(&stdio_uart_isrpipe, c);
+            isrpipe_write_one(&ethos_stdio_isrpipe, c);
 #endif
     }
 }

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -20,6 +20,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "ethos.h"
@@ -37,7 +38,7 @@
 #error USE_ETHOS_FOR_STDIO is deprecated, use USEMODULE+=stdio_ethos instead
 #endif
 
-#ifdef MODULE_STDIO_ETHOS
+#ifdef MODULE_ETHOS_STDIO
 #include "stdio_uart.h"
 #include "isrpipe.h"
 extern isrpipe_t ethos_stdio_isrpipe;
@@ -45,6 +46,8 @@ extern isrpipe_t ethos_stdio_isrpipe;
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+
+#define ETHOS_FRAME_TYPE_ERRORED    (0xff)
 
 static void _get_mac_addr(netdev_t *dev, uint8_t* buf);
 static void ethos_isr(void *arg, uint8_t c);
@@ -59,10 +62,7 @@ void ethos_setup(ethos_t *dev, const ethos_params_t *params, uint8_t idx,
     dev->netdev.driver = &netdev_driver_ethos;
     dev->uart = params->uart;
     dev->state = WAIT_FRAMESTART;
-    dev->framesize = 0;
     dev->frametype = 0;
-    dev->last_framesize = 0;
-    dev->accept_new = true;
 
     tsrb_init(&dev->inbuf, inbuf, inbuf_size);
     mutex_init(&dev->out_mutex);
@@ -81,33 +81,56 @@ static void _reset_state(ethos_t *dev)
 {
     dev->state = WAIT_FRAMESTART;
     dev->frametype = 0;
-    dev->framesize = 0;
-    dev->accept_new = true;
+}
+
+static void _fail_frame(ethos_t *dev)
+{
+    switch (dev->frametype) {
+        case ETHOS_FRAME_TYPE_DATA:
+            tsrb_clear(&dev->inbuf);
+            /* signal to handler thread that frame is at an end (makes handler thread to
+             * truncate frame) */
+            tsrb_add_one(&dev->inbuf, ETHOS_FRAME_DELIMITER);
+            break;
+        case ETHOS_FRAME_TYPE_TEXT:
+            tsrb_clear(&ethos_stdio_isrpipe.tsrb);
+            /* signal to handler thread that frame is at an end (makes handler thread to
+             * truncate frame) */
+            isrpipe_write_one(&ethos_stdio_isrpipe, ETHOS_FRAME_DELIMITER);
+            break;
+        case ETHOS_FRAME_TYPE_ERRORED:
+            return;
+        default:
+            assert(0);
+            break;
+    }
+    dev->frametype = ETHOS_FRAME_TYPE_ERRORED;
 }
 
 static void _handle_char(ethos_t *dev, char c)
 {
     switch (dev->frametype) {
         case ETHOS_FRAME_TYPE_DATA:
-        case ETHOS_FRAME_TYPE_HELLO:
-        case ETHOS_FRAME_TYPE_HELLO_REPLY:
-            if (dev->accept_new) {
-                if (tsrb_add_one(&dev->inbuf, c) == 0) {
-                    dev->framesize++;
-                }
-            }
-            else {
+            if (tsrb_add_one(&dev->inbuf, c) < 0) {
                 //puts("lost frame");
-                dev->inbuf.reads = 0;
-                dev->inbuf.writes = 0;
-                _reset_state(dev);
+                _fail_frame(dev);
             }
             break;
-#ifdef MODULE_STDIO_ETHOS
         case ETHOS_FRAME_TYPE_TEXT:
-            dev->framesize++;
-            isrpipe_write_one(&ethos_stdio_isrpipe, c);
+#ifdef MODULE_ETHOS_STDIO
+            if (isrpipe_write_one(&ethos_stdio_isrpipe, c) < 0) {
+                //puts("lost frame");
+                _fail_frame(dev);
+            }
+            break;
 #endif
+            break;
+        case ETHOS_FRAME_TYPE_ERRORED:
+            break;
+        default:
+            assert(0);
+            break;
+
     }
 }
 
@@ -115,20 +138,15 @@ static void _end_of_frame(ethos_t *dev)
 {
     switch(dev->frametype) {
         case ETHOS_FRAME_TYPE_DATA:
-            if (dev->framesize) {
-                assert(dev->last_framesize == 0);
-                dev->last_framesize = dev->framesize;
-                netdev_trigger_event_isr(&dev->netdev);
-
-            }
+            netdev_trigger_event_isr(&dev->netdev);
             break;
-        case ETHOS_FRAME_TYPE_HELLO:
-            ethos_send_frame(dev, dev->mac_addr, 6, ETHOS_FRAME_TYPE_HELLO_REPLY);
-            /* fall through */
-        case ETHOS_FRAME_TYPE_HELLO_REPLY:
-            if (dev->framesize == 6) {
-                tsrb_get(&dev->inbuf, dev->remote_mac_addr, 6);
-            }
+        case ETHOS_FRAME_TYPE_TEXT:
+            break;
+        case ETHOS_FRAME_TYPE_ERRORED:
+            break;
+        default:
+            /* Unexpected frametype */
+            assert(0);
             break;
     }
 
@@ -142,45 +160,50 @@ static void ethos_isr(void *arg, uint8_t c)
     switch (dev->state) {
         case WAIT_FRAMESTART:
             if (c == ETHOS_FRAME_DELIMITER) {
-                _reset_state(dev);
-                if (dev->last_framesize) {
-                    dev->accept_new = false;
-                }
                 dev->state = IN_FRAME;
+                dev->frametype = ETHOS_FRAME_TYPE_DATA;
             }
             break;
         case IN_FRAME:
+            _handle_char(dev, c);
             if (c == ETHOS_ESC_CHAR) {
                 dev->state = IN_ESCAPE;
             }
             else if (c == ETHOS_FRAME_DELIMITER) {
-                if (dev->framesize) {
-                    _end_of_frame(dev);
-                }
-            }
-            else {
-                _handle_char(dev, c);
+                _end_of_frame(dev);
             }
             break;
         case IN_ESCAPE:
             switch (c) {
                 case (ETHOS_FRAME_DELIMITER ^ 0x20):
-                    _handle_char(dev, ETHOS_FRAME_DELIMITER);
                     break;
                 case (ETHOS_ESC_CHAR ^ 0x20):
-                    _handle_char(dev, ETHOS_ESC_CHAR);
                     break;
                 case (ETHOS_FRAME_TYPE_TEXT ^ 0x20):
                     dev->frametype = ETHOS_FRAME_TYPE_TEXT;
-                    break;
+                    /* reset tsrb (used for networking) */
+                    dev->inbuf.reads = 0;
+                    dev->inbuf.writes = 0;
+                    dev->state = IN_FRAME;
+                    return;
                 case (ETHOS_FRAME_TYPE_HELLO ^ 0x20):
-                    dev->frametype = ETHOS_FRAME_TYPE_HELLO;
-                    break;
                 case (ETHOS_FRAME_TYPE_HELLO_REPLY ^ 0x20):
-                    dev->frametype = ETHOS_FRAME_TYPE_HELLO_REPLY;
+                    dev->frametype = ETHOS_FRAME_TYPE_DATA;
                     break;
+                case ETHOS_FRAME_DELIMITER:
+                    _handle_char(dev, c);
+                    _reset_state(dev);
+                    return;
+                default:
+                    /* unknown escaped character or raw delimiter */
+                    _fail_frame(dev);
+                    return;
             }
             dev->state = IN_FRAME;
+            /* write marker to tsrb for thread layer to handle */
+            _handle_char(dev, c);
+            break;
+        default:
             break;
     }
 }
@@ -231,14 +254,7 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
 {
     uint8_t frame_delim = ETHOS_FRAME_DELIMITER;
 
-    if (!irq_is_in()) {
-        mutex_lock(&dev->out_mutex);
-    }
-    else {
-        /* Send frame delimiter. This cancels the current frame,
-         * but enables in-ISR writes.  */
-        uart_write(dev->uart, &frame_delim, 1);
-    }
+    mutex_lock(&dev->out_mutex);
 
     /* send frame delimiter */
     uart_write(dev->uart, &frame_delim, 1);
@@ -257,9 +273,7 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
     /* end of frame */
     uart_write(dev->uart, &frame_delim, 1);
 
-    if (!irq_is_in()) {
-        mutex_unlock(&dev->out_mutex);
-    }
+    mutex_unlock(&dev->out_mutex);
 }
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
@@ -299,38 +313,110 @@ static void _get_mac_addr(netdev_t *encdev, uint8_t* buf)
     memcpy(buf, dev->mac_addr, 6);
 }
 
+static unsigned _copy_byte(uint8_t *buf, uint8_t byte, bool *escaped)
+{
+    *buf = byte;
+    *escaped = false;
+    return 1U;
+}
+
+unsigned ethos_unstuff_readbyte(uint8_t *buf, uint8_t byte, bool *escaped, uint8_t *frametype)
+{
+    switch (byte) {
+        case ETHOS_ESC_CHAR:
+            *escaped = true;
+            /* Intentionally falls through */
+        case ETHOS_FRAME_DELIMITER:
+            break;
+        case ETHOS_ESC_CHAR ^ 0x20:
+            if (*escaped) {
+                return _copy_byte(buf, ETHOS_ESC_CHAR, escaped);
+            }
+            /* Intentionally falls through */
+            /* to default when !(*escaped) */
+        case ETHOS_FRAME_DELIMITER ^ 0x20:
+            if (*escaped) {
+                return _copy_byte(buf, ETHOS_FRAME_DELIMITER, escaped);
+            }
+            /* Intentionally falls through */
+            /* to default when !(*escaped) */
+        case ETHOS_FRAME_TYPE_TEXT ^ 0x20:
+        case ETHOS_FRAME_TYPE_HELLO ^ 0x20:
+        case ETHOS_FRAME_TYPE_HELLO_REPLY ^ 0x20:
+            if (*escaped) {
+                *frametype = byte ^ 0x20;
+                break;
+            }
+            /* Intentionally falls through */
+        default:
+            return _copy_byte(buf, byte, escaped);
+    }
+    return 0U;
+}
+
 static int _recv(netdev_t *netdev, void *buf, size_t len, void* info)
 {
     (void) info;
     ethos_t * dev = (ethos_t *) netdev;
+    int res = 0;
 
     if (buf) {
-        if (len < dev->last_framesize) {
-            DEBUG("ethos _recv(): receive buffer too small.\n");
-            return -1;
+        int byte;
+        bool escaped = false;
+        uint8_t *ptr = buf;
+        uint8_t frametype = ETHOS_FRAME_TYPE_DATA;
+
+        do {
+            int tmp;
+
+            if ((byte = tsrb_get_one(&dev->inbuf)) < 0) {
+                DEBUG("ethos _recv(): inbuf doesn't contain enough bytes.\n");
+                return -EIO;
+            }
+            tmp = ethos_unstuff_readbyte(ptr, (uint8_t)byte, &escaped, &frametype);
+            ptr += tmp;
+            res += tmp;
+            if ((unsigned)res > len) {
+                while (byte != (int)ETHOS_FRAME_DELIMITER) {
+                    /* clear out unreceived packet */
+                    byte = tsrb_get_one(&dev->inbuf);
+                }
+                return -ENOBUFS;
+            }
+        } while (byte != ETHOS_FRAME_DELIMITER);
+
+        switch (frametype) {
+        case ETHOS_FRAME_TYPE_HELLO:
+            ethos_send_frame(dev, dev->mac_addr, 6, ETHOS_FRAME_TYPE_HELLO_REPLY);
+            /* fall through */
+        case ETHOS_FRAME_TYPE_HELLO_REPLY:
+            if (res == 6) {
+                memcpy(dev->remote_mac_addr, buf, 6);
+            }
+            return 0;
+        default:
+            break;
         }
-
-        len = dev->last_framesize;
-
-        if ((tsrb_get(&dev->inbuf, buf, len) != (int)len)) {
-            DEBUG("ethos _recv(): inbuf doesn't contain enough bytes.\n");
-            dev->last_framesize = 0;
-            return -1;
-        }
-
-        dev->last_framesize = 0;
-        return (int)len;
     }
     else {
         if (len) {
-            int dropsize = dev->last_framesize;
-            dev->last_framesize = 0;
-            return tsrb_drop(&dev->inbuf, dropsize);
+            /* remove data */
+            for (; len > 0; len--) {
+                int byte = tsrb_get_one(&dev->inbuf);
+                if ((byte == (int)ETHOS_FRAME_DELIMITER) || (byte < 0)) {
+                    /* end early if end of packet or ringbuffer is reached;
+                     * len might be larger than the actual packet */
+                    break;
+                }
+            }
         }
         else {
-            return dev->last_framesize;
+            /* set to 2048 in sys/net/gnrc/netif/init_devs/auto_init_ethos.c so safe to cast
+             * unsigned to int */
+            res = (int)tsrb_avail(&dev->inbuf);
         }
     }
+    return res;
 }
 
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)

--- a/drivers/ethos/stdio.c
+++ b/drivers/ethos/stdio.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2013 INRIA
+ *               2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2016 Eistec AB
+ *               2018-21 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Martine S. Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "ethos.h"
+#include "isrpipe.h"
+#include "stdio_uart.h"
+
+extern ethos_t ethos;
+
+static uint8_t _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
+isrpipe_t ethos_stdio_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
+
+static void _isrpipe_write(void *arg, uint8_t data)
+{
+    isrpipe_write_one(arg, (char)data);
+}
+
+void stdio_init(void)
+{
+    uart_init(ETHOS_UART, ETHOS_BAUDRATE, _isrpipe_write, &ethos_stdio_isrpipe);
+
+#if MODULE_VFS
+    vfs_bind_stdio();
+#endif
+}
+
+extern unsigned ethos_unstuff_readbyte(uint8_t *buf, uint8_t byte,
+                                       bool *escaped, uint8_t *frametype);
+
+ssize_t stdio_read(void* buffer, size_t len)
+{
+    return (ssize_t)isrpipe_read(&ethos_stdio_isrpipe, buffer, len);
+}
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    ethos_send_frame(&ethos, (const uint8_t *)buffer, len, ETHOS_FRAME_TYPE_TEXT);
+    return len;
+}
+
+/** @} */

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /* if using ethos + stdio, use STDIO_UART values unless overridden */
-#if IS_USED(MODULE_STDIO_ETHOS) || defined(DOXYGEN)
+#if IS_USED(MODULE_ETHOS_STDIO) || defined(DOXYGEN)
 #include "stdio_uart.h"
 /**
  * @defgroup drivers_ethos_config     Ethernet-over-serial driver driver compile configuration

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -89,11 +89,8 @@ typedef struct {
     uint8_t remote_mac_addr[6]; /**< this device's MAC address */
     tsrb_t inbuf;           /**< ringbuffer for incoming data */
     line_state_t state;     /**< Line status variable */
-    size_t framesize;       /**< size of currently incoming frame */
     unsigned frametype;     /**< type of currently incoming frame */
-    size_t last_framesize;  /**< size of last completed frame */
     mutex_t out_mutex;      /**< mutex used for locking concurrent sends */
-    bool accept_new;        /**< incoming frame can be stored or not */
 } ethos_t;
 
 /**
@@ -127,6 +124,8 @@ void ethos_setup(ethos_t *dev, const ethos_params_t *params, uint8_t index,
  * @brief   Send frame over serial port using ethos' framing
  *
  * This is used by e.g., stdio over ethos to send text frames.
+ *
+ * @note    Uses mutexes to synchronize sending multiple frames so it should not be called from ISR.
  *
  * @param[in]   dev         handle of the device to initialize
  * @param[in]   data        ptr to data to be sent

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -24,6 +24,7 @@ PSEUDOMODULES += dhcpv6_client_mud_url
 PSEUDOMODULES += dhcpv6_relay
 PSEUDOMODULES += dns_msg
 PSEUDOMODULES += ecc_%
+PSEUDOMODULES += ethos_stdio
 PSEUDOMODULES += event_%
 PSEUDOMODULES += event_timeout
 PSEUDOMODULES += event_timeout_ztimer

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -24,9 +24,8 @@ ifneq (,$(filter stdio_rtt,$(USEMODULE)))
 endif
 
 ifneq (,$(filter stdio_ethos,$(USEMODULE)))
-  USEMODULE += ethos
+  USEMODULE += ethos_stdio
   USEMODULE += stdin
-  USEMODULE += stdio_uart
 endif
 
 ifneq (,$(filter stdin,$(USEMODULE)))

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -35,11 +35,6 @@
 #include "periph/uart.h"
 #include "isrpipe.h"
 
-#ifdef MODULE_STDIO_ETHOS
-#include "ethos.h"
-extern ethos_t ethos;
-#endif
-
 #if MODULE_VFS
 #include "vfs.h"
 #endif
@@ -65,11 +60,7 @@ void stdio_init(void)
     arg = NULL;
 #endif
 
-#ifdef MODULE_STDIO_ETHOS
-    uart_init(ETHOS_UART, ETHOS_BAUDRATE, cb, arg);
-#else
     uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, cb, arg);
-#endif
 
 #if MODULE_VFS
     vfs_bind_stdio();
@@ -89,10 +80,6 @@ ssize_t stdio_read(void* buffer, size_t count)
 
 ssize_t stdio_write(const void* buffer, size_t len)
 {
-#ifdef MODULE_STDIO_ETHOS
-    ethos_send_frame(&ethos, (const uint8_t *)buffer, len, ETHOS_FRAME_TYPE_TEXT);
-#else
     uart_write(STDIO_UART_DEV, (const uint8_t *)buffer, len);
-#endif
     return len;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This tries to fix https://github.com/RIOT-OS/RIOT/issues/17254 by eliminating the condition that causes the race altogether. It moves the following parts of ethos' state machine out of ISR context, inspired by the way it is done in `slipdev`:

- Sending and replying to HELLO messages
- Byte-unstuffing

Some escape handling is still needed in the ISR handler, due to ethos' protocol design, to determine if a received byte must go into the netdev queue (tsrb) or the STDIO queue (isrpipe), but the actual unstuffing is now done in the STDIO and netdev handler threads, respectively.

This causes a slight increase of ROM, as byte unstuffing needs to be now handled in both stdio and the netdev context, but we also gain some RAM, as the `ethos_t` members `framesize`, `last_framesize`, and `accept_new` are not needed anymore.

We also have the added benefits, that now multiple frames can be added to the respective pipes, separated by the `FRAME_DELIMITER` byte.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and flash `examples/gnrc_border_router` to a board of your choice. To be closer to the setup in the testbed, I used an `iotlab-m3` and set `ETHOS_BAUDRATE=500000` (but I also tested with `samr21-xpro` with the same `ETHOS_BAUDRATE`):

```sh
BOARD=iotlab-m3 ETHOS_BAUDRATE=500000 make -C examples/gnrc_border_router/ flash -j term
```

get the link-layer address of the `ethos` interface (the one with 6-byte hardware address) using `ifconfig` and pound that address with multiple `ping` instances:

```sh
for _ in $(seq 5); do
    sudo ping -c 1500 -f fe80::a804:28ff:fefa:f3f8%tap0 &
done
```

On `master` I get a significantly worse result, when it comes to packet loss, as with this PR at the cost of slightly higher latency (the cost of cleaner multiplexing, I guess):

#### master
```
[…]
--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 890 received, 40.6667% packet loss, time 24033ms
rtt min/avg/max/mdev = 7.252/17.322/1016.708/33.617 ms, pipe 60, ipg/ewma 16.032/16.285 ms

--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 876 received, 41.6% packet loss, time 24037ms
rtt min/avg/max/mdev = 7.929/18.462/1019.208/47.469 ms, pipe 61, ipg/ewma 16.035/16.224 ms

--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 858 received, 42.8% packet loss, time 24041ms
rtt min/avg/max/mdev = 8.087/19.703/1021.549/58.747 ms, pipe 61, ipg/ewma 16.038/16.559 ms

--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 841 received, 43.9333% packet loss, time 24051ms
rtt min/avg/max/mdev = 7.576/17.265/1016.057/34.544 ms, pipe 60
, ipg/ewma 16.044/15.698 ms
--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 856 received, 42.9333% packet loss, time 24053ms
rtt min/avg/max/mdev = 8.167/17.401/1016.099/34.267 ms, pipe 60, ipg/ewma 16.045/16.766 ms
```

#### This PR
```
--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 1326 received, 11.6% packet loss, time 21439ms
rtt min/avg/max/mdev = 13.336/41.125/55.888/3.944 ms, pipe 4, ipg/ewma 14.301/40.972 ms
...
--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 1315 received, 12.3333% packet loss, time 21521ms
rtt min/avg/max/mdev = 20.581/41.220/55.949/4.130 ms, pipe 5, ipg/ewma 14.356/41.088 ms
   
--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 1297 received, 13.5333% packet loss, time 21639ms
rtt min/avg/max/mdev = 12.583/41.019/56.037/4.523 ms, pipe 4, ipg/ewma 14.435/24.055 ms

--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 1285 received, 14.3333% packet loss, time 21690ms
rtt min/avg/max/mdev = 13.235/41.065/55.867/4.555 ms, pipe 4, ipg/ewma 14.469/23.689 ms

--- fe80::a804:28ff:fefa:f3f8%tap0 ping statistics ---
1500 packets transmitted, 1287 received, 14.2% packet loss, time 21706ms
rtt min/avg/max/mdev = 12.578/41.029/56.543/4.845 ms, pipe 4, ipg/ewma 14.480/21.693 ms
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/17254
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
