### PR TITLE
core/kernel_defines.h: drop ALIGN_OF()

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -133,14 +133,6 @@ extern "C" {
 #endif
 
 /**
- * @def         ALIGN_OF(T)
- * @brief       Calculate the minimal alignment for type T.
- * @param[in]   T   Type to examine
- * @returns     The minimal alignment of T.
- */
-#define ALIGN_OF(T) (offsetof(struct { char c; T t; }, t))
-
-/**
  * @def         BUILD_BUG_ON(condition)
  * @brief       Forces a compilation error if condition is true.
  *              This trick is only needed if the condition can't be evaluated

--- a/core/thread.c
+++ b/core/thread.c
@@ -19,6 +19,7 @@
  */
 
 #include <errno.h>
+#include <stdalign.h>
 #include <stdio.h>
 #ifdef PICOLIBC_TLS
 #include <picotls.h>
@@ -205,9 +206,9 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
 #endif
 
     /* align the stack on a 16/32bit boundary */
-    uintptr_t misalignment = (uintptr_t)stack % ALIGN_OF(void *);
+    uintptr_t misalignment = (uintptr_t)stack % alignof(void *);
     if (misalignment) {
-        misalignment = ALIGN_OF(void *) - misalignment;
+        misalignment = alignof(void *) - misalignment;
         stack += misalignment;
         stacksize -= misalignment;
     }
@@ -216,7 +217,7 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
     stacksize -= sizeof(thread_t);
 
     /* round down the stacksize to a multiple of thread_t alignments (usually 16/32bit) */
-    stacksize -= stacksize % ALIGN_OF(thread_t);
+    stacksize -= stacksize % alignof(thread_t);
 
     if (stacksize < 0) {
         DEBUG("thread_create: stacksize is too small!\n");


### PR DESCRIPTION
### Contribution description

Since we moved to C11 now for all platforms, using `alignof()` provided by `<stdalign.h>` has become the better option.

I personally consider `kernel_defines.h` as a RIOT internal, so that we can drop this without the usual deprecation procedure. Also note that a simple `sed -e 's/ALIGN_OF/alignof/g' -i <FILE_TO_MIGRATE>` would be sufficient to migrate to the C11 macro.

### Testing procedure

The generated binaries must not differ, as `alignof()` and `ALIGN_OF()` must yield the exact same compile time constant number.

### Issues/PRs references

None