### PR TITLE
core/kernel_defines: drop BUILD_BUG_ON()

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -133,18 +133,6 @@ extern "C" {
 #endif
 
 /**
- * @def         BUILD_BUG_ON(condition)
- * @brief       Forces a compilation error if condition is true.
- *              This trick is only needed if the condition can't be evaluated
- *              before compile time (i.e. sizeof(sometype_t) < 42 )
- *              For more details on this see for example:
- *              https://git.kernel.org/pub/scm/linux/kernel/git/stable/
- *              linux-stable.git/tree/include/linux/bug.h
- * @param[in]   condition  A condition that will be evaluated at compile time
- */
-#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
-
-/**
  * @def         IS_ACTIVE(macro)
  * @brief       Allows to verify a macro definition outside the preprocessor.
  *

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -104,7 +104,7 @@ static inline void _cpy_add_crc(uint8_t *data, size_t len, uint8_t *crcd_data)
  * @return       true if all CRCs are valid
  * @return       false if at least one CRC is invalid
  */
-static inline bool _cpy_check_crc(uint8_t *data, size_t len, uint8_t *crcd_data)
+static inline bool _cpy_check_crc(uint8_t *data, size_t len, const uint8_t *crcd_data)
 {
     for (size_t elem = 0; elem < len / 2; elem++) {
         int idx = (elem << 1);

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -223,7 +223,8 @@ int sps30_read_measurement(const sps30_t *dev, sps30_data_t *data)
 {
     /* This compile time check is needed to ensure the below method used for
        endianness conversion will work as expected */
-    BUILD_BUG_ON(sizeof(sps30_data_t) != (sizeof(float) * 10));
+    static_assert(sizeof(sps30_data_t) == (sizeof(float) * 10),
+                  "sps30_data_t must be sized 10 floats");
     assert(dev && data);
 
     /* The target buffer is also used for storing the raw data temporarily */

--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -26,7 +27,6 @@
 
 #include "fs/fatfs.h"
 
-#include "kernel_defines.h" /* needed for BUILD_BUG_ON */
 #include "time.h"
 
 #define ENABLE_DEBUG 0
@@ -50,8 +50,10 @@ static int _mount(vfs_mount_t *mountp)
 {
     /* if one of the lines below fail to compile you probably need to adjust
        vfs buffer sizes ;) */
-    BUILD_BUG_ON(VFS_DIR_BUFFER_SIZE < sizeof(DIR));
-    BUILD_BUG_ON(VFS_FILE_BUFFER_SIZE < sizeof(fatfs_file_desc_t));
+    static_assert(VFS_DIR_BUFFER_SIZE >= sizeof(DIR),
+                  "DIR must fit into VFS_DIR_BUFFER_SIZE");
+    static_assert(VFS_FILE_BUFFER_SIZE >= sizeof(fatfs_file_desc_t),
+                  "fatfs_file_desc_t must fit into VFS_FILE_BUFFER_SIZE");
 
     fatfs_desc_t *fs_desc = (fatfs_desc_t *)mountp->private_data;
 

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -18,14 +18,13 @@
  * @}
  */
 
+#include <assert.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <string.h>
 
 #include "fs/littlefs_fs.h"
-
-#include "kernel_defines.h"
 
 #define ENABLE_DEBUG 0
 #include <debug.h>
@@ -170,8 +169,10 @@ static int _mount(vfs_mount_t *mountp)
 {
     /* if one of the lines below fail to compile you probably need to adjust
        vfs buffer sizes ;) */
-    BUILD_BUG_ON(VFS_DIR_BUFFER_SIZE < sizeof(lfs_dir_t));
-    BUILD_BUG_ON(VFS_FILE_BUFFER_SIZE < sizeof(lfs_file_t));
+    static_assert(VFS_DIR_BUFFER_SIZE >= sizeof(lfs_dir_t),
+                  "lfs_dir_t must fit in VFS_DIR_BUFFER_SIZE");
+    static_assert(VFS_FILE_BUFFER_SIZE >= sizeof(lfs_file_t),
+                  "lfs_file_t must fit in VFS_FILE_BUFFER_SIZE");
 
     littlefs_desc_t *fs = mountp->private_data;
 

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -18,14 +18,13 @@
  * @}
  */
 
+#include <assert.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <string.h>
 
 #include "fs/littlefs2_fs.h"
-
-#include "kernel_defines.h"
 
 #define ENABLE_DEBUG 0
 #include <debug.h>
@@ -176,8 +175,10 @@ static int _mount(vfs_mount_t *mountp)
 {
     /* if one of the lines below fail to compile you probably need to adjust
        vfs buffer sizes ;) */
-    BUILD_BUG_ON(VFS_DIR_BUFFER_SIZE < sizeof(lfs_dir_t));
-    BUILD_BUG_ON(VFS_FILE_BUFFER_SIZE < sizeof(lfs_file_t));
+    static_assert(VFS_DIR_BUFFER_SIZE >= sizeof(lfs_dir_t),
+                  "lfs_dir_t must fit in VFS_DIR_BUFFER_SIZE");
+    static_assert(VFS_FILE_BUFFER_SIZE >= sizeof(lfs_file_t),
+                  "lfs_file_t must fit in VFS_FILE_BUFFER_SIZE");
 
     littlefs2_desc_t *fs = mountp->private_data;
 

--- a/sys/arduino/SPI.cpp
+++ b/sys/arduino/SPI.cpp
@@ -66,8 +66,10 @@ SPISettings::SPISettings(uint32_t clock_hz, uint8_t bitOrder, uint8_t dataMode)
 
 SPIClass::SPIClass(spi_t spi_dev)
 {
-    /* Check if default SPI interface is valid */
-    BUILD_BUG_ON(ARDUINO_SPI_INTERFACE >= SPI_NUMOF);
+    /* Check if default SPI interface is valid. Casting to int to avoid
+     * bogus type-limits warning here. */
+    static_assert((int)ARDUINO_SPI_INTERFACE <= (int)SPI_NUMOF,
+                  "spi_dev out of bounds");
     this->spi_dev = spi_dev;
     this->settings = SPISettings();
     this->is_transaction = false;


### PR DESCRIPTION
### Contribution description

This PR replaces all uses of `BUILD_BUG_ON()` with `static_assert()`. Since C11 `static_assert()` is now a first class feature that provides the exact same functionality. For this reason, this PR also drops `BUILD_BUG_ON()`.

I consider `kernel_defines.h` a RIOT internal, so IMO we can skip the usual deprecation routine. The migration path is relatively easy, just replace `BUG_BUG_ON(<BOOLEAN_EXPRESSION>)` by `static_assert(!<BOOLEAN_EXPRESSION>, "<SOME DEBUG MESSAGE>")`.

### Testing procedure

Since this is a built time feature, Murdock will test that it still works for the case when all requirements are met. Once could test that compilation does fail when requirements are not met e.g. by changing the size of the buffers. But honestly, `static_assert()` is a compiler feature that is well known and well tested - I don't think it is worth to test this.

### Issues/PRs references

None