### PR TITLE
sys/test_utils/result_output: add sort to multiple output check

### DIFF
--- a/sys/test_utils/result_output/Makefile.dep
+++ b/sys/test_utils/result_output/Makefile.dep
@@ -3,7 +3,7 @@ test_utils_result_output_check \
 test_utils_result_output_json \
 test_utils_result_output_txt
 
-USED_TURO_OUTPUT_FORMAT := $(filter test_utils_result_output_%,$(USEMODULE))
+USED_TURO_OUTPUT_FORMAT := $(sort $(filter test_utils_result_output_%,$(USEMODULE)))
 
 ifeq (0,$(words $(USED_TURO_OUTPUT_FORMAT)))
   USEMODULE += test_utils_result_output_json


### PR DESCRIPTION

### Contribution description

A sort is missing on the filter to no fault on the same module being twice during a dependency resolution loop.

### Testing procedure

In master this patch would make it fail:

```
diff --git a/sys/test_utils/result_output/Makefile.dep b/sys/test_utils/result_output/Makefile.dep
index c02452577c..112a71bdde 100644
--- a/sys/test_utils/result_output/Makefile.dep
+++ b/sys/test_utils/result_output/Makefile.dep
@@ -3,6 +3,9 @@ test_utils_result_output_check \
 test_utils_result_output_json \
 test_utils_result_output_txt
 
+USEMODULE += test_utils_result_output_json
+USEMODULE += test_utils_result_output_json
+
 USED_TURO_OUTPUT_FORMAT := $(filter test_utils_result_output_%,$(USEMODULE))
 
 ifeq (0,$(words $(USED_TURO_OUTPUT_FORMAT)))
```

you get:

```
make -C tests/turo/ 
Only one test_utils_result_output format can be used at a time.
Currently selecting: test_utils_result_output_json test_utils_result_output_json test_utils_result_output_json
/home/francisco/workspace/RIOT2/sys/test_utils/result_output/Makefile.dep:21: *** Please use one of: test_utils_result_output_check test_utils_result_output_json test_utils_result_output_txt.  Stop.
```