### PR TITLE
sys/ztimer: remove double ztimer indirection

### DIFF
--- a/bootloaders/riotboot_dfu/Makefile
+++ b/bootloaders/riotboot_dfu/Makefile
@@ -6,7 +6,7 @@ USEMODULE += riotboot_usb_dfu
 
 # Use xtimer for scheduled reboot
 USEMODULE += ztimer
-USEMODULE += ztimer_auto_init
+USEMODULE += ztimer_init
 
 # USB device vendor and product ID
 # pid.codes test VID/PID, not globally unique

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -171,13 +171,10 @@ config MODULE_ZTIMER
 
 if MODULE_ZTIMER
 
-# TODO: only use MODULE_ZTIMER_AUTO_INIT, for now we try to get the same modules
-# as the Makefile dependency resolution. See sys/ztimer/Makefile.dep for more
-# info on why two modules are used.
 config MODULE_AUTO_INIT_ZTIMER
     bool "Auto initialize ztimer"
     depends on MODULE_AUTO_INIT
-    select MODULE_ZTIMER_AUTO_INIT
+    select MODULE_ZTIMER_INIT
     default y
 
 config MODULE_ZTIMER_NOW64
@@ -194,7 +191,7 @@ config MODULE_ZTIMER_MOCK
         manually fired to simulate different scenarios and test the ztimer
         implementation using this as a backing timer.
 
-config MODULE_ZTIMER_AUTO_INIT
+config MODULE_ZTIMER_INIT
     bool
 
 config MODULE_ZTIMER_CORE

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -7,20 +7,11 @@ ifneq (,$(filter ztimer,$(USEMODULE)))
   USEMODULE += ztimer_core
   USEMODULE += ztimer_convert_frac
   USEMODULE += ztimer_convert_shift
-
-  # ztimer's auto_init code resides in it's submodule "ztimer_auto_init",
-  # but RIOT's auto_init scheme expects "auto_init_ztimer" in DEFAULT_MODULES so
-  # it can be disabled (by adding to DISABLE_MODULES).
-  #
-  # "auto_init_%" modules cannot have further dependencies, so we cannot do
-  # "if auto_init_ztimer: use ztimer_auto_init".
-  #
-  # So, if neither "auto_init" nor "auto_init_ztimer" are disabled, pull in
-  # "ztimer_auto_init".
-  DEFAULT_MODULE += auto_init_ztimer
-  ifeq (,$(filter auto_init auto_init_ztimer,$(DISABLE_MODULE)))
-    USEMODULE += ztimer_auto_init
+  ifneq (,$(filter auto_init_ztimer,$(USEMODULE)))
+    USEMODULE += ztimer_init
   endif
+  DEFAULT_MODULE += auto_init_ztimer
+  DEFAULT_MODULE += ztimer_init
 endif
 
 # unless ztimer_xtimer_compat is used, make xtimer use ztimer_usec as backend.

--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -37,7 +37,6 @@
  */
 
 #include "kernel_defines.h"
-#if IS_USED(MODULE_AUTO_INIT_ZTIMER) || RIOTBOOT
 
 #include "board.h"
 #include "ztimer.h"
@@ -302,4 +301,3 @@ void ztimer_init(void)
 #  endif
 #endif
 }
-#endif /* IS_USED(MODULE_AUTO_INIT_ZTIMER) || RIOTBOOT*/


### PR DESCRIPTION
### Contribution description

To avoid confusions between `auto_init_ztimer` and `ztimer_auto_init`
rename `ztimer_auto_init` to `ztimer_init`.

This allows for similar handling as `saul_init_devs` and
`auto_init_devs`. Dependencies are therefore done against the USEMODULE
and not DEFAULT_MODULE or checking DISABLE_MODULE. For this, both
`ztimer_init` and `auto_init_ztimer` are added to DEFAULT_MODULE and
both need disabling if the user does not want that module in.

With this, the comment in Kconfig no longer applies.

### Testing procedure

Murdock should still be green.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
