### PR TITLE
core: Add IS_CT_CONSTANT()

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -256,6 +256,27 @@ extern "C" {
 #define DECLARE_CONSTANT(identifier, const_expr) \
     WITHOUT_PEDANTIC(enum { identifier = const_expr };)
 
+#if DOXYGEN
+/**
+ * @brief   Check if given variable / expression is detected as compile time
+ *          constant
+ * @note    This might return 0 on compile time constant expressions if the
+ *          compiler is not able to prove the constness at the given level
+ *          of optimization.
+ * @details This will return 0 if the used compiler does not support this
+ * @warning This is intended for internal use only
+ *
+ * This allows providing two different implementations in C, with one being
+ * more efficient if constant folding is used.
+ */
+#define IS_CT_CONSTANT(expr) <IMPLEMENTATION>
+#elif defined(__GNUC__)
+/* both clang and gcc (which both define __GNUC__) support this */
+#define IS_CT_CONSTANT(expr) __builtin_constant_p(expr)
+#else
+#define IS_CT_CONSTANT(expr) 0
+#endif
+
 /**
  * @cond INTERNAL
  */


### PR DESCRIPTION
### Contribution description

This adds a simple macro to check (at C level) whether a given expression is proven to be compile time constant and suitable for constant folding. This allows writing code like this:

```C
int gpio_read(gpio_t pin) {
    if (IS_CT_CONSTANT(pin)) {
        /* this implementation should even be able to use the port and
         * pin number as immediate in inline assembly */
    }
    else {
        /* less efficient implementation that cannot use port and pin
         * number as immediate in inline assembly */
    }
}
```

### Testing procedure

A unit test was provided that should do the trick.

### Issues/PRs references

None