### PR TITLE
drivers/periph_i2c: let i2c_acquire return void

### DIFF
--- a/cpu/atmega_common/periph/i2c.c
+++ b/cpu/atmega_common/periph/i2c.c
@@ -22,11 +22,12 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
+
 #include "cpu.h"
 #include "mutex.h"
-#include "assert.h"
 #include "periph/i2c.h"
 #include "periph_conf.h"
 
@@ -219,12 +220,11 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
     return 0;
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -231,14 +231,12 @@ void i2c_init(i2c_t dev)
     DEBUG(" - I2C master status (0x%x).\n", _i2c_master_stat_get());
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
+    (void)dev;
+    assert(dev < I2C_NUMOF);
     DEBUG("%s\n", __FUNCTION__);
-    if (dev < I2C_NUMOF) {
-        mutex_lock(&lock);
-        return 0;
-    }
-    return -1;
+    mutex_lock(&lock);
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/cc26xx_cc13xx/periph/i2c.c
+++ b/cpu/cc26xx_cc13xx/periph/i2c.c
@@ -126,12 +126,11 @@ void i2c_init(i2c_t devnum)
     I2C->MTPR = MTPR_TPR_100KHZ;
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     (void)dev;
     assert(dev < I2C_NUMOF);
     mutex_lock(&_lock);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/efm32/periph/i2c.c
+++ b/cpu/efm32/periph/i2c.c
@@ -142,15 +142,15 @@ void i2c_init(i2c_t dev)
     I2C_Enable(i2c_config[dev].dev, true);
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
+    assert(dev < I2C_NUMOF);
+
     /* acquire lock */
     mutex_lock(&i2c_lock[dev]);
 
     /* power peripheral */
     CMU_ClockEnable(i2c_config[dev].cmu, true);
-
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -145,7 +145,7 @@ static inline void _i2c_delay (uint32_t delay);
 
 void i2c_init(i2c_t dev)
 {
-    CHECK_PARAM (dev < I2C_NUMOF)
+    assert(dev < I2C_NUMOF);
 
     if (i2c_config[dev].speed == I2C_SPEED_FAST_PLUS ||
         i2c_config[dev].speed == I2C_SPEED_HIGH) {
@@ -156,7 +156,7 @@ void i2c_init(i2c_t dev)
 
     mutex_init(&_i2c_bus[dev].lock);
 
-    i2c_acquire (dev);
+    i2c_acquire(dev);
 
     _i2c_bus[dev].cmd = 0;
     _i2c_bus[dev].data = 0;
@@ -262,20 +262,17 @@ void i2c_init(i2c_t dev)
     xt_set_interrupt_handler(CPU_INUM_I2C, _i2c_intr_handler, NULL);
     xt_ints_on(BIT(CPU_INUM_I2C));
 
-    i2c_release (dev);
-
-    return;
+    i2c_release(dev);
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     DEBUG ("%s\n", __func__);
 
-    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
+    assert(dev < I2C_NUMOF);
 
     mutex_lock(&_i2c_bus[dev].lock);
     _i2c_reset_hw(dev);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)
@@ -358,9 +355,9 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t fla
     DEBUG ("%s dev=%u addr=%02x data=%p len=%d flags=%01x\n",
            __func__, dev, addr, data, len, flags);
 
-    CHECK_PARAM_RET (dev < I2C_NUMOF, -EINVAL);
-    CHECK_PARAM_RET (len > 0, -EINVAL);
-    CHECK_PARAM_RET (data != NULL, -EINVAL);
+    assert(dev < I2C_NUMOF);
+    assert(len > 0);
+    assert(data != NULL);
 
     /*  if I2C_NOSTART is not set, START condition and ADDR is used */
     if (!(flags & I2C_NOSTART)) {
@@ -445,9 +442,9 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len, uint
     DEBUG ("%s dev=%u addr=%02x data=%p len=%d flags=%01x\n",
            __func__, dev, addr, data, len, flags);
 
-    CHECK_PARAM_RET (dev < I2C_NUMOF, -EINVAL);
-    CHECK_PARAM_RET (len > 0, -EINVAL);
-    CHECK_PARAM_RET (data != NULL, -EINVAL);
+    assert(dev < I2C_NUMOF);
+    assert(len > 0);
+    assert(data != NULL);
 
     /*  if I2C_NOSTART is not set, START condition and ADDR is used */
     if (!(flags & I2C_NOSTART)) {

--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -246,12 +246,11 @@ void i2c_init(i2c_t dev)
     return;
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     mutex_lock(&_i2c_bus[dev].lock);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/fe310/periph/i2c.c
+++ b/cpu/fe310/periph/i2c.c
@@ -90,11 +90,10 @@ void i2c_init(i2c_t dev)
     DEBUG("[i2c] initialization done\n");
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/kinetis/periph/i2c.c
+++ b/cpu/kinetis/periph/i2c.c
@@ -106,12 +106,11 @@ typedef struct {
 
 static i2c_state_t i2c_state[I2C_NUMOF];
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert((unsigned)dev < I2C_NUMOF);
     mutex_lock(&i2c_state[dev].mtx);
     i2c_state[dev].pid = thread_getpid();
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/lpc23xx/periph/i2c.c
+++ b/cpu/lpc23xx/periph/i2c.c
@@ -103,14 +103,12 @@ static void poweroff(lpc23xx_i2c_t *i2c)
     }
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     mutex_lock(&ctx[dev].lock);
     poweron(i2c_config[dev].dev);
-
-    return 0;
 }
 
 void i2c_release(i2c_t dev)
@@ -332,6 +330,8 @@ static void irq_handler(i2c_t dev)
     }
 
     /* clear interrupt flag */
+    /* cppcheck-suppress redundantAssignment
+     * (reason: writing 1 to volatile register to clear the interrupt) */
     i2c->CONCLR = I2CONCLR_SIC;
 }
 

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -132,12 +132,11 @@ void i2c_init(i2c_t dev)
     i2c(dev)->ENABLE = TWI_ENABLE_ENABLE_Enabled;
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
@@ -154,7 +154,7 @@ void i2c_deinit_pins(i2c_t dev)
 }
 #endif /* MODULE_PERIPH_I2C_RECONFIGURE */
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
@@ -162,7 +162,6 @@ int i2c_acquire(i2c_t dev)
     bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
 
     DEBUG("[i2c] acquired dev %i\n", (int)dev);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/qn908x/periph/i2c.c
+++ b/cpu/qn908x/periph/i2c.c
@@ -153,11 +153,10 @@ void i2c_deinit_pins(i2c_t dev)
 }
 #endif /* MODULE_PERIPH_I2C_RECONFIGURE */
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -194,11 +194,10 @@ void i2c_init(i2c_t dev)
     }
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
     mutex_lock(&locks[dev]);
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -135,7 +135,7 @@ static void _i2c_init(I2C_TypeDef *i2c, uint32_t timing)
     i2c->CR1 |= I2C_CR1_PE;
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
@@ -145,8 +145,6 @@ int i2c_acquire(i2c_t dev)
 
     /* enable device */
     i2c_config[dev].dev->CR1 |= I2C_CR1_PE;
-
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/cpu/stm32/periph/i2c_2.c
+++ b/cpu/stm32/periph/i2c_2.c
@@ -180,7 +180,7 @@ static void _init(i2c_t dev)
     _i2c_init(i2c, i2c_config[dev].clk, ccr);
 }
 
-int i2c_acquire(i2c_t dev)
+void i2c_acquire(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
 
@@ -195,8 +195,6 @@ int i2c_acquire(i2c_t dev)
 
     /* enable device */
     i2c_config[dev].dev->CR1 |= I2C_CR1_PE;
-
-    return 0;
 }
 
 void i2c_release(i2c_t dev)

--- a/drivers/aip31068/aip31068.c
+++ b/drivers/aip31068/aip31068.c
@@ -398,9 +398,7 @@ static int _device_write(aip31068_t* dev, uint8_t *data, uint8_t len)
 {
     i2c_t i2c_dev = dev->params.i2c_dev;
 
-    if (i2c_acquire(i2c_dev) != 0) {
-        return -1;
-    }
+    i2c_acquire(i2c_dev);
 
     int rc = i2c_write_bytes(i2c_dev, dev->params.i2c_addr, data, len, 0);
 

--- a/drivers/apds99xx/apds99xx.c
+++ b/drivers/apds99xx/apds99xx.c
@@ -466,10 +466,7 @@ static int _reg_read(const apds99xx_t *dev, uint8_t reg, uint8_t *data, uint16_t
     assert(data != NULL);
     assert(len != 0);
 
-    if (i2c_acquire(dev->params.dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return -APDS99XX_ERROR_I2C;
-    }
+    i2c_acquire(dev->params.dev);
     int res = i2c_read_regs(dev->params.dev, APDS99XX_I2C_ADDRESS, reg, data, len, 0);
     i2c_release(dev->params.dev);
 
@@ -499,16 +496,15 @@ static int _reg_write(const apds99xx_t *dev, uint8_t reg, uint8_t *data, uint16_
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         printf("[apds99xx] %s i2c dev=%d addr=%02x: write to reg 0x%02x: ",
                __func__, dev->params.dev, APDS99XX_I2C_ADDRESS, reg);
-        for (uint16_t i = 0; i < len; i++) {
-            printf("%02x ", data[i]);
+        if (data && len) {
+            for (uint16_t i = 0; i < len; i++) {
+                printf("%02x ", data[i]);
+            }
         }
         printf("\n");
     }
 
-    if (i2c_acquire(dev->params.dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return -APDS99XX_ERROR_I2C;
-    }
+    i2c_acquire(dev->params.dev);
 
     int res;
 

--- a/drivers/at24cxxx/at24cxxx.c
+++ b/drivers/at24cxxx/at24cxxx.c
@@ -195,9 +195,7 @@ int at24cxxx_init(at24cxxx_t *dev, const at24cxxx_params_t *params)
         at24cxxx_disable_write_protect(dev);
     }
     /* Check I2C bus once */
-    if (i2c_acquire(DEV_I2C_BUS)) {
-        return -AT24CXXX_I2C_ERROR;
-    }
+    i2c_acquire(DEV_I2C_BUS);
     i2c_release(DEV_I2C_BUS);
     return AT24CXXX_OK;
 }

--- a/drivers/at24mac/at24mac.c
+++ b/drivers/at24mac/at24mac.c
@@ -54,10 +54,7 @@ static int _read_reg(at24mac_t dev, uint8_t reg, void *dst, size_t size)
         return -ENOTSUP;
     }
 
-    res = i2c_acquire(params->i2c_dev);
-    if (res) {
-        return res;
-    }
+    i2c_acquire(params->i2c_dev);
 
     res = i2c_read_regs(params->i2c_dev, params->i2c_addr,
                         reg, dst, size, 0);

--- a/drivers/bh1900nux/bh1900nux.c
+++ b/drivers/bh1900nux/bh1900nux.c
@@ -46,15 +46,14 @@ int bh1900nux_read(const bh1900nux_t *dev, int16_t *temp)
 
     /* Read raw sensor value */
     DEBUG("[bh1900nux] read temperature\n");
-    ret = i2c_acquire(dev->i2c);
-    if (ret < 0) {
-        return BH1900NUX_ERR_I2C;
-    }
+
+    i2c_acquire(dev->i2c);
     ret = i2c_read_regs(dev->i2c, dev->addr, BH1900NUX_REG_ADDR, &raw, sizeof(raw), 0);
+    i2c_release(dev->i2c);
+
     if (ret < 0) {
         return ret;
     }
-    i2c_release(dev->i2c);
 
     /* Calculate temperature */
     raw = (int16_t) ntohs(raw) >> 4;

--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -81,9 +81,7 @@ static int _read_burst(const bmx280_t *dev, uint8_t reg, void *buf, size_t len)
 
 static inline int _acquire(const bmx280_t *dev)
 {
-    if (i2c_acquire(BUS) != 0) {
-        return BMX280_ERR_BUS;
-    }
+    i2c_acquire(BUS);
     return BMX280_OK;
 }
 

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -482,12 +482,9 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
     DEBUG_DEV("read %"PRIu32" bytes from sensor registers starting at addr %02x",
               dev, len, reg);
 
-    int res = CCS811_OK;
+    int res;
 
-    if (i2c_acquire(dev->params.i2c_dev) != CCS811_OK) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return -CCS811_ERROR_I2C;
-    }
+    i2c_acquire(dev->params.i2c_dev);
 
 #if MODULE_CCS811_FULL
     if (gpio_is_valid(dev->params.wake_pin)) {
@@ -545,10 +542,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
         printf("\n");
     }
 
-    if (i2c_acquire(dev->params.i2c_dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return -CCS811_ERROR_I2C;
-    }
+    i2c_acquire(dev->params.i2c_dev);
 
 #if MODULE_CCS811_FULL
     if (gpio_is_valid(dev->params.wake_pin)) {

--- a/drivers/ds3231/ds3231.c
+++ b/drivers/ds3231/ds3231.c
@@ -96,8 +96,8 @@ static int _read(const ds3231_t *dev, uint8_t reg, uint8_t *buf, size_t len,
 {
     int res;
 
-    if (acquire && i2c_acquire(dev->bus)) {
-        return -EIO;
+    if (acquire) {
+        i2c_acquire(dev->bus);
     }
     res = i2c_read_regs(dev->bus, DS3231_I2C_ADDR, reg, buf, len, 0);
     if (res < 0) {
@@ -113,8 +113,8 @@ static int _read(const ds3231_t *dev, uint8_t reg, uint8_t *buf, size_t len,
 static int _write(const ds3231_t *dev, uint8_t reg, uint8_t *buf, size_t len,
                   int acquire, int release)
 {
-    if (acquire && i2c_acquire(dev->bus)) {
-        return -EIO;
+    if (acquire) {
+        i2c_acquire(dev->bus);
     }
     if (i2c_write_regs(dev->bus, DS3231_I2C_ADDR, reg, buf, len, 0) < 0) {
         i2c_release(dev->bus);

--- a/drivers/hmc5883l/hmc5883l.c
+++ b/drivers/hmc5883l/hmc5883l.c
@@ -234,11 +234,7 @@ static int _reg_read(const hmc5883l_t *dev, uint8_t reg, uint8_t *data, uint16_t
     DEBUG_DEV("read %d byte from sensor registers starting at addr 0x%02x",
               dev, len, reg);
 
-    if (i2c_acquire(dev->dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return HMC5883L_ERROR_I2C;
-    }
-
+    i2c_acquire(dev->dev);
     int res = i2c_read_regs(dev->dev, HMC5883L_I2C_ADDRESS, reg, data, len, 0);
     i2c_release(dev->dev);
 
@@ -275,11 +271,7 @@ static int _reg_write(const hmc5883l_t *dev, uint8_t reg, uint8_t data)
         printf("\n");
     }
 
-    if (i2c_acquire(dev->dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return HMC5883L_ERROR_I2C;
-    }
-
+    i2c_acquire(dev->dev);
     int res = i2c_write_regs(dev->dev, HMC5883L_I2C_ADDRESS, reg, &data, 1, 0);
     i2c_release(dev->dev);
 

--- a/drivers/hsc/hsc.c
+++ b/drivers/hsc/hsc.c
@@ -46,9 +46,7 @@ int hsc_init(hsc_t *dev, const hsc_params_t *params)
     uint8_t buf[HSC_FULL_DATA_LENGTH];
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -ENODEV;
-    }
+    i2c_acquire(DEV_I2C);
 
     if (i2c_read_bytes(DEV_I2C, DEV_ADDR, buf, sizeof(buf), 0) < 0) {
         i2c_release(DEV_I2C);
@@ -120,9 +118,7 @@ static int _read_ut(const hsc_t *dev, int32_t *output)
     uint8_t buf[HSC_FULL_DATA_LENGTH];
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -ENODEV;
-    }
+    i2c_acquire(DEV_I2C);
 
     if (i2c_read_bytes(DEV_I2C, DEV_ADDR, buf, sizeof(buf), 0) < 0) {
         i2c_release(DEV_I2C);
@@ -144,9 +140,7 @@ static int _read_up(const hsc_t *dev, int32_t *output)
     uint8_t buf[HSC_FULL_DATA_LENGTH];
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -ENODEV;
-    }
+    i2c_acquire(DEV_I2C);
 
     if (i2c_read_bytes(DEV_I2C, DEV_ADDR, buf, sizeof(buf), 0) < 0) {
         i2c_release(DEV_I2C);

--- a/drivers/ina3221/ina3221.c
+++ b/drivers/ina3221/ina3221.c
@@ -58,9 +58,7 @@
  */
 static int _read_reg(const ina3221_t *dev, uint8_t reg, uint16_t *out)
 {
-    if (i2c_acquire(dev->params.i2c)) {
-        return -EIO;
-    }
+    i2c_acquire(dev->params.i2c);
     int status = i2c_read_regs(dev->params.i2c, dev->params.addr, reg, out,
                                INA3221_REG_LEN, 0);
     i2c_release(dev->params.i2c);
@@ -87,9 +85,7 @@ static int _read_reg(const ina3221_t *dev, uint8_t reg, uint16_t *out)
 static int _write_reg(const ina3221_t *dev, uint8_t reg, uint16_t in)
 {
     in = htons(in);
-    if (i2c_acquire(dev->params.i2c)) {
-        return -EIO;
-    }
+    i2c_acquire(dev->params.i2c);
     int status = i2c_write_regs(dev->params.i2c, dev->params.addr, reg, &in,
                                 INA3221_REG_LEN, 0);
     i2c_release(dev->params.i2c);

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -276,11 +276,12 @@ gpio_t i2c_pin_scl(i2c_t dev);
  * In case the I2C device is busy, this function will block until the bus is
  * free again.
  *
- * @param[in] dev           I2C device to access
+ * @pre     Given device is valid, otherwise an assertion blows up
+ *          (if assertions are enabled).
  *
- * @return                  0 on success, -1 on error
+ * @param[in] dev           I2C device to access
  */
-int i2c_acquire(i2c_t dev);
+void i2c_acquire(i2c_t dev);
 
 /**
  * @brief   Release the given I2C device to be used by others

--- a/drivers/itg320x/itg320x.c
+++ b/drivers/itg320x/itg320x.c
@@ -299,11 +299,7 @@ static int _reg_read(const itg320x_t *dev, uint8_t reg, uint8_t *data, uint16_t 
 
     DEBUG_DEV("read %d bytes from reg 0x%02x", dev, len, reg);
 
-    if (i2c_acquire(dev->params.dev) != 0) {
-        DEBUG_DEV("could not acquire the I2C bus", dev);
-        return ITG320X_ERROR_I2C;
-    }
-
+    i2c_acquire(dev->params.dev);
     int res = i2c_read_regs(dev->params.dev, dev->params.addr, reg, data, len, 0);
     i2c_release(dev->params.dev);
 
@@ -332,11 +328,7 @@ static int _reg_write(const itg320x_t *dev, uint8_t reg, uint8_t data)
 
     DEBUG_DEV("write 1 byte to reg 0x%02x: 0x%02x", dev, reg, data);
 
-    if (i2c_acquire(dev->params.dev) != 0) {
-        DEBUG_DEV("could not acquire the I2C bus", dev);
-        return ITG320X_ERROR_I2C;
-    }
-
+    i2c_acquire(dev->params.dev);
     int res = i2c_write_regs(dev->params.dev, dev->params.addr, reg, &data, 1, 0);
     i2c_release(dev->params.dev);
 

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -105,7 +105,8 @@ static int _init_bus(const lis2dh12_t *dev)
 
 static int _acquire(const lis2dh12_t *dev)
 {
-    return i2c_acquire(BUS);
+    i2c_acquire(BUS);
+    return BUS_OK;
 }
 
 static void _release(const lis2dh12_t *dev)

--- a/drivers/lm75/lm75.c
+++ b/drivers/lm75/lm75.c
@@ -66,9 +66,7 @@ int lm75_init(lm75_t *dev, const lm75_params_t *params) {
     uint8_t config = (params->shutdown_mode) | (params->tm_mode << 1) \
                    | (params->polarity << 2) | (params->fault_q << 3);
 
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
 
     /* read the device ID register of the TMP1075 sensor to confirm it is a TMP1075 */
     if (IS_USED(MODULE_TMP1075) && (dev->lm75_params.res == &tmp1075_properties)) {
@@ -112,9 +110,7 @@ int lm75_init(lm75_t *dev, const lm75_params_t *params) {
 int lm75_get_temperature_raw(lm75_t *dev, int *temperature) {
 
     int16_t temp;
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
     /* read the temperature register */
     if (i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_TEMP_REG, &temp, 2, 0) != 0) {
         i2c_release(I2C_BUS);
@@ -184,9 +180,7 @@ int lm75_set_temp_limits(lm75_t *dev, int temp_hyst, int temp_os, gpio_cb_t cb, 
     temp_os_short   = temp_os_short << dev->lm75_params.res->os_shift;
     temp_os_short   = ntohs(temp_os_short);
 
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
 
     if (i2c_write_regs(I2C_BUS, I2C_ADDR, LM75_THYST_REG, &temp_hyst_short, 2, 0) != 0) {
         i2c_release(I2C_BUS);
@@ -207,9 +201,7 @@ int lm75_set_temp_limits(lm75_t *dev, int temp_hyst, int temp_os, gpio_cb_t cb, 
 int lm75_get_os_temp(lm75_t *dev, int *temperature) {
 
     int16_t temp;
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
     /* read the temperature register */
     if (i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_TOS_REG, &temp, 2, 0) != 0) {
         i2c_release(I2C_BUS);
@@ -230,9 +222,7 @@ int lm75_get_os_temp(lm75_t *dev, int *temperature) {
 int lm75_get_hyst_temp(lm75_t *dev, int *temperature) {
 
     int16_t temp;
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
 
     /* read the temperature register */
     if (i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_THYST_REG, &temp, 2, 0) != 0) {
@@ -260,9 +250,7 @@ int lm75_get_os_pin(lm75_t *dev, bool *os_pin_state) {
 
 int lm75_poweroff(lm75_t *dev) {
 
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
 
     uint8_t config;
 
@@ -291,9 +279,7 @@ int lm75_poweroff(lm75_t *dev) {
 
 int lm75_poweron(lm75_t *dev) {
 
-    if (i2c_acquire(I2C_BUS) != 0) {
-        return LM75_ERROR_I2C;
-    }
+    i2c_acquire(I2C_BUS);
 
     uint8_t config;
     if (i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0) != 0) {
@@ -328,9 +314,7 @@ int tmp1075_one_shot(lm75_t *dev) {
     }
 
     else {
-        if (i2c_acquire(I2C_BUS) != 0) {
-            return LM75_ERROR_I2C;
-        }
+       i2c_acquire(I2C_BUS);
 
         uint8_t config;
         if (i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0) != 0) {

--- a/drivers/mpu9x50/mpu9x50.c
+++ b/drivers/mpu9x50/mpu9x50.c
@@ -117,9 +117,7 @@ int mpu9x50_set_accel_power(mpu9x50_t *dev, mpu9x50_pwr_t pwr_conf)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
 
     /* Read current power management 2 configuration */
     i2c_read_reg(DEV_I2C, DEV_ADDR, MPU9X50_PWR_MGMT_2_REG, &pwr_2_setting, 0);
@@ -158,9 +156,7 @@ int mpu9x50_set_gyro_power(mpu9x50_t *dev, mpu9x50_pwr_t pwr_conf)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
 
     /* Read current power management 2 configuration */
     i2c_read_reg(DEV_I2C, DEV_ADDR, MPU9X50_PWR_MGMT_2_REG, &pwr_2_setting, 0);
@@ -206,9 +202,7 @@ int mpu9x50_set_compass_power(mpu9x50_t *dev, mpu9x50_pwr_t pwr_conf)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
 
     /* Read current user control configuration */
     i2c_read_reg(DEV_I2C, DEV_ADDR, MPU9X50_USER_CTRL_REG, &usr_ctrl_setting, 0);
@@ -266,9 +260,7 @@ int mpu9x50_read_gyro(const mpu9x50_t *dev, mpu9x50_results_t *output)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
     /* Read raw data */
     i2c_read_regs(DEV_I2C, DEV_ADDR, MPU9X50_GYRO_START_REG, data, 6, 0);
     /* Release the bus */
@@ -309,9 +301,7 @@ int mpu9x50_read_accel(const mpu9x50_t *dev, mpu9x50_results_t *output)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
     /* Read raw data */
     i2c_read_regs(DEV_I2C, DEV_ADDR, MPU9X50_ACCEL_START_REG, data, 6, 0);
     /* Release the bus */
@@ -333,9 +323,7 @@ int mpu9x50_read_compass(const mpu9x50_t *dev, mpu9x50_results_t *output)
     uint8_t data[6];
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
     /* Read raw data */
     i2c_read_regs(DEV_I2C, DEV_ADDR, MPU9X50_EXT_SENS_DATA_START_REG, data, 6, 0);
     /* Release the bus */
@@ -366,9 +354,7 @@ int mpu9x50_read_temperature(const mpu9x50_t *dev, int32_t *output)
     uint16_t data;
 
     /* Acquire exclusive access */
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
     /* Read raw temperature value */
     i2c_read_regs(DEV_I2C, DEV_ADDR, MPU9X50_TEMP_START_REG, &data, 2, 0);
     /* Release the bus */
@@ -392,9 +378,7 @@ int mpu9x50_set_gyro_fsr(mpu9x50_t *dev, mpu9x50_gyro_ranges_t fsr)
         case MPU9X50_GYRO_FSR_500DPS:
         case MPU9X50_GYRO_FSR_1000DPS:
         case MPU9X50_GYRO_FSR_2000DPS:
-            if (i2c_acquire(DEV_I2C)) {
-                return -1;
-            }
+            i2c_acquire(DEV_I2C);
             i2c_write_reg(DEV_I2C, DEV_ADDR,
                     MPU9X50_GYRO_CFG_REG, (fsr << 3), 0);
             i2c_release(DEV_I2C);
@@ -418,9 +402,7 @@ int mpu9x50_set_accel_fsr(mpu9x50_t *dev, mpu9x50_accel_ranges_t fsr)
         case MPU9X50_ACCEL_FSR_4G:
         case MPU9X50_ACCEL_FSR_8G:
         case MPU9X50_ACCEL_FSR_16G:
-            if (i2c_acquire(DEV_I2C)) {
-                return -1;
-            }
+            i2c_acquire(DEV_I2C);
             i2c_write_reg(DEV_I2C, DEV_ADDR,
                     MPU9X50_ACCEL_CFG_REG, (fsr << 3), 0);
             i2c_release(DEV_I2C);
@@ -447,9 +429,7 @@ int mpu9x50_set_sample_rate(mpu9x50_t *dev, uint16_t rate)
     /* Compute divider to achieve desired sample rate and write to rate div register */
     divider = (1000 / rate - 1);
 
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
     i2c_write_reg(DEV_I2C, DEV_ADDR, MPU9X50_RATE_DIV_REG, divider, 0);
 
     /* Store configured sample rate */
@@ -477,9 +457,7 @@ int mpu9x50_set_compass_sample_rate(mpu9x50_t *dev, uint8_t rate)
     /* Compute divider to achieve desired sample rate and write to slave ctrl register */
     divider = (dev->conf.sample_rate / rate - 1);
 
-    if (i2c_acquire(DEV_I2C)) {
-        return -1;
-    }
+    i2c_acquire(DEV_I2C);
     i2c_write_reg(DEV_I2C, DEV_ADDR, MPU9X50_SLAVE4_CTRL_REG, divider, 0);
     i2c_release(DEV_I2C);
 

--- a/drivers/pca9633/pca9633.c
+++ b/drivers/pca9633/pca9633.c
@@ -259,9 +259,7 @@ int _write_reg(pca9633_t* dev, uint8_t reg, uint8_t data)
 {
     i2c_t i2c_dev = dev->params.i2c_dev;
 
-    if (i2c_acquire(i2c_dev) != 0) {
-        return -PCA9633_ERROR_I2C;
-    }
+    i2c_acquire(i2c_dev);
     int rc = i2c_write_reg(i2c_dev, dev->params.i2c_addr, reg, data, 0);
     i2c_release(i2c_dev);
 
@@ -272,9 +270,7 @@ int _read_reg(pca9633_t* dev, uint8_t reg, uint8_t* data)
 {
     i2c_t i2c_dev = dev->params.i2c_dev;
 
-    if (i2c_acquire(i2c_dev) != 0) {
-        return -PCA9633_ERROR_I2C;
-    }
+    i2c_acquire(i2c_dev);
     int rc = i2c_read_reg(i2c_dev, dev->params.i2c_addr, reg, data, 0);
     i2c_release(i2c_dev);
 

--- a/drivers/pca9685/pca9685.c
+++ b/drivers/pca9685/pca9685.c
@@ -292,10 +292,7 @@ static int _read(const pca9685_t *dev, uint8_t reg, uint8_t *data, uint32_t len)
     DEBUG_DEV("reg=%02x data=%p len=%"PRIu32"", dev, reg, data, len);
 
     /* acquire the I2C device */
-    if (i2c_acquire(dev->params.i2c_dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return -PCA9685_ERROR_I2C;
-    }
+    i2c_acquire(dev->params.i2c_dev);
 
     if (i2c_read_regs(dev->params.i2c_dev,
                       dev->params.i2c_addr, reg, data, len, 0) != 0) {
@@ -313,10 +310,7 @@ static int _write(const pca9685_t *dev, uint8_t reg, const uint8_t *data, uint32
 {
     DEBUG_DEV("reg=%02x data=%p len=%"PRIu32"", dev, reg, data, len);
 
-    if (i2c_acquire(dev->params.i2c_dev)) {
-        DEBUG_DEV("could not acquire I2C bus", dev);
-        return -PCA9685_ERROR_I2C;
-    }
+    i2c_acquire(dev->params.i2c_dev);
 
     if (i2c_write_regs(dev->params.i2c_dev,
                        dev->params.i2c_addr, reg, data, len, 0) != 0) {

--- a/drivers/qmc5883l/qmc5883l.c
+++ b/drivers/qmc5883l/qmc5883l.c
@@ -32,9 +32,7 @@ static int _reg_read(const qmc5883l_t *dev, uint8_t reg,
                      uint8_t *val, int acquire, int release)
 {
     if (acquire) {
-        if (i2c_acquire(dev->i2c) != 0) {
-            return QMC5883L_BUSERR;
-        }
+        i2c_acquire(dev->i2c);
     }
     int res = i2c_read_reg(dev->i2c, ADDR, reg, val, 0);
     if ((release) || (res != 0)) {
@@ -47,9 +45,7 @@ static int _reg_write(const qmc5883l_t *dev, uint8_t reg,
                       uint8_t val, int acquire, int release)
 {
     if (acquire) {
-        if (i2c_acquire(dev->i2c) != 0) {
-            return QMC5883L_BUSERR;
-        }
+        i2c_acquire(dev->i2c);
     }
     int res = i2c_write_reg(dev->i2c, ADDR, reg, val, 0);
     if ((release) || (res != 0)) {

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -97,10 +97,7 @@ static int _rx_tx_data(sgp30_t *dev, uint16_t cmd, uint8_t *data,
 {
     int res = 0;
 
-    if (i2c_acquire(dev->params.i2c_dev) != 0) {
-        DEBUG("[sgp30]: could not acquire I2C bus %d\n", dev->params.i2c_dev);
-        return -1;
-    }
+    i2c_acquire(dev->params.i2c_dev);
 
     uint8_t frame_cmd[sizeof(cmd) + len];
     frame_cmd[0] = cmd >> 8;

--- a/drivers/sht3x/sht3x.c
+++ b/drivers/sht3x/sht3x.c
@@ -283,16 +283,12 @@ static int _send_command(sht3x_dev_t* dev, uint16_t cmd)
 {
     ASSERT_PARAM (dev != NULL);
 
-    int res = SHT3X_OK;
+    int res;
 
     uint8_t data[2] = { cmd >> 8, cmd & 0xff };
     DEBUG_DEV("send command 0x%02x%02x", dev, data[0], data[1]);
 
-    if (i2c_acquire(dev->i2c_dev) != 0) {
-        DEBUG_DEV ("could not acquire I2C bus", dev);
-        return -SHT3X_ERROR_I2C;
-    }
-
+    i2c_acquire(dev->i2c_dev);
     res = i2c_write_bytes(dev->i2c_dev, dev->i2c_addr, (const void*)data, 2, 0);
     i2c_release(dev->i2c_dev);
 
@@ -307,13 +303,9 @@ static int _send_command(sht3x_dev_t* dev, uint16_t cmd)
 
 static int _read_data(sht3x_dev_t* dev, uint8_t *data, uint8_t len)
 {
-    int res = SHT3X_OK;
+    int res;
 
-    if (i2c_acquire(dev->i2c_dev) != 0) {
-        DEBUG_DEV ("could not acquire I2C bus", dev);
-        return -SHT3X_ERROR_I2C;
-    }
-
+    i2c_acquire(dev->i2c_dev);
     res = i2c_read_bytes(dev->i2c_dev, dev->i2c_addr, (void*)data, len, 0);
     i2c_release(dev->i2c_dev);
 

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -147,10 +147,7 @@ static int _rx_tx_data(const sps30_t *dev, uint16_t ptr_addr,
     int res = 0;
     unsigned retr = CONFIG_SPS30_ERROR_RETRY;
 
-    if (i2c_acquire(dev->p.i2c_dev) != 0) {
-        LOG_ERROR("could not acquire I2C bus %d\n", dev->p.i2c_dev);
-        return -SPS30_I2C_ERROR;
-    }
+    i2c_acquire(dev->p.i2c_dev);
 
     do {
         size_t addr_data_crc_len = SPS30_PTR_LEN + len + len / 2;

--- a/drivers/tsl4531x/tsl4531x.c
+++ b/drivers/tsl4531x/tsl4531x.c
@@ -43,11 +43,7 @@ int tsl4531x_init(tsl4531x_t *dev, const tsl4531x_params_t *params)
     uint8_t id;
 
     /* Initialise I2C bus */
-    if ((r = i2c_acquire(params->i2c_dev)) < 0) {
-        DEBUG("I2C_dev is: %d.", params->i2c_dev);
-        DEBUG("[Error] Cannot acquire device. I2C error: %d\n", r);
-        return -ENODEV;
-    }
+    i2c_acquire(params->i2c_dev);
 
     /* Test for connectivity - verify ID and compare against stored value */
     if ((r = i2c_read_reg(params->i2c_dev,
@@ -107,10 +103,7 @@ int tsl4531x_set_low_power_mode(tsl4531x_t *dev, uint8_t low_power_mode)
 
     dev->low_power_mode = low_power_mode;
 
-    if ((r = i2c_acquire(dev->i2c_dev)) < 0) {
-        DEBUG("[Error] Cannot acquire device. I2C error: %d\n", r);
-        return -ENODEV;
-    }
+    i2c_acquire(dev->i2c_dev);
 
     if ((r = i2c_write_reg(dev->i2c_dev,
                            dev->i2c_addr,
@@ -142,10 +135,7 @@ int tsl4531x_start_sample(tsl4531x_t *dev)
 
         int r;
 
-        if ((r = i2c_acquire(dev->i2c_dev)) < 0) {
-            DEBUG("[Error] Cannot acquire device. I2C error: %d\n", r);
-            return -ENODEV;
-        }
+        i2c_acquire(dev->i2c_dev);
 
         if ((r = i2c_write_reg(dev->i2c_dev,
                                dev->i2c_addr,
@@ -195,10 +185,7 @@ int tsl4531x_get_sample(const tsl4531x_t *dev)
     int r;
     uint8_t als_data[2]; /* = {[DATALOW], [DATAHIGH]} */
 
-    if ((r = i2c_acquire(dev->i2c_dev)) < 0) {
-        DEBUG("[Error] Cannot acquire device. I2C error: %d\n", r);
-        return -ENODEV;
-    }
+    i2c_acquire(dev->i2c_dev);
 
     if ((r = i2c_read_regs(dev->i2c_dev,
                            dev->i2c_addr,

--- a/sys/arduino/wireport.cpp
+++ b/sys/arduino/wireport.cpp
@@ -101,13 +101,12 @@ uint8_t TwoWire::requestFrom(uint8_t addr, uint8_t size, uint8_t stop)
 
     uint8_t read = 0;
 
-    if (i2c_acquire(ARDUINO_I2C_DEV) == 0) {
-        if (i2c_read_bytes(ARDUINO_I2C_DEV, addr, rxBuffer, size,
-                           stop ? 0 : I2C_NOSTOP) == 0) {
-            read = size;
-        }
-        i2c_release(ARDUINO_I2C_DEV);
+    i2c_acquire(ARDUINO_I2C_DEV);
+    if (i2c_read_bytes(ARDUINO_I2C_DEV, addr, rxBuffer, size,
+                       stop ? 0 : I2C_NOSTOP) == 0) {
+        read = size;
     }
+    i2c_release(ARDUINO_I2C_DEV);
 
     rxBufferIndex = 0;
     rxBufferLength = read;
@@ -136,9 +135,7 @@ uint8_t TwoWire::endTransmission(uint8_t stop)
         return txError;
     }
 
-    if (i2c_acquire(ARDUINO_I2C_DEV) != 0) {
-        return WIRE_PORT_ERROR_OTHER;
-    }
+    i2c_acquire(ARDUINO_I2C_DEV);
 
     int res = i2c_write_bytes(ARDUINO_I2C_DEV,
                               txAddress, txBuffer, txBufferLength,

--- a/sys/shell/commands/sc_i2c_scan.c
+++ b/sys/shell/commands/sc_i2c_scan.c
@@ -59,10 +59,7 @@ int _i2c_scan(int argc, char **argv)
     }
 
     printf("Scanning I2C device %s...\n", argv[1]);
-    if (i2c_acquire(dev)){
-        puts("Failed to acquire I2C device");
-        return -1;
-    }
+    i2c_acquire(dev);
 
     puts(
         "addr not ack'ed = \"-\", addr ack'ed = \"X\", addr reserved = \"R\", error = \"E\"\n"

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -129,7 +129,6 @@ static int _print_i2c_error(int res)
 
 int cmd_i2c_acquire(int argc, char **argv)
 {
-    int res;
     int dev;
 
     dev = _check_param(argc, argv, 1, 1, "DEV");
@@ -138,12 +137,10 @@ int cmd_i2c_acquire(int argc, char **argv)
     }
 
     printf("Command: i2c_acquire(%i)\n", dev);
-    res = i2c_acquire(dev);
-    if (res == I2C_ACK) {
-        printf("Success: i2c_%i acquired\n", dev);
-        return 0;
-    }
-    return _print_i2c_error(res);
+    i2c_acquire(dev);
+
+    printf("Success: i2c_%i acquired\n", dev);
+    return 0;
 }
 
 int cmd_i2c_release(int argc, char **argv)

--- a/tests/pkg_fff/main.c
+++ b/tests/pkg_fff/main.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 DEFINE_FFF_GLOBALS
 FAKE_VALUE_FUNC(int, i2c_read_bytes, i2c_t, uint16_t, void *, size_t, uint8_t)
-FAKE_VALUE_FUNC(int, i2c_acquire, i2c_t)
+FAKE_VOID_FUNC(i2c_acquire, i2c_t)
 FAKE_VOID_FUNC(i2c_release, i2c_t)
 
 int test_i2c_basic(void *buffer, size_t len);
@@ -35,14 +35,10 @@ const uint8_t flags = 0;
 
 int test_i2c_basic(void *buffer, size_t len)
 {
-    int acquire_return_val;
     int read_return_val;
     int failure = 0;
 
-    acquire_return_val = i2c_acquire(device);
-    if (acquire_return_val != 0) {
-        failure = 1;
-    }
+    i2c_acquire(device);
     read_return_val = i2c_read_bytes(device, address, buffer, len, flags);
     if (read_return_val != 0) {
         failure = 1;
@@ -70,7 +66,6 @@ int main(void)
     puts("Testing fff");
     /* Set fake implementation / return values of the mocks */
     i2c_read_bytes_fake.custom_fake = read_fake_impl;
-    i2c_acquire_fake.return_val = 0;
     /* Run function under test */
     basic_test_return_val = test_i2c_basic(buffer, fake_read_len);
     /* Assert correct interaction of the function under test with the mocked API */


### PR DESCRIPTION
### Contribution description

As follow-up of PR #15902 and based on the discussion in issue #10673 this PR
- changes the signature of `int i2c_acquire(...)` to `void i2c_acquire(...)` because
   - all I2C implementations just return 0 and don't check for any error situation
   - most driver implementations don't check the return value
- adds `assert()` where it is missing to ensure that a correct I2C device identifier is used
- updates all implementations
- updates the few driver implementations that used the return value, but mostly only during `<driver>_init()`.

### Testing procedure

Compilation and tests in Murdock should work.

### Issues/PRs references

Follow-up of #15902
Fixes #10673