### PR TITLE
sys/include/event/periodic: add count

### DIFF
--- a/sys/event/periodic.c
+++ b/sys/event/periodic.c
@@ -28,7 +28,11 @@ static int _event_periodic_callback(void *arg)
 
     event_post(event_periodic->queue, event_periodic->event);
 
-    return 0;
+    if (event_periodic->count && --event_periodic->count == 0) {
+        return !ZTIMER_PERIODIC_KEEP_GOING;
+    }
+
+    return ZTIMER_PERIODIC_KEEP_GOING;
 }
 
 void event_periodic_init(event_periodic_t *event_periodic,
@@ -37,6 +41,7 @@ void event_periodic_init(event_periodic_t *event_periodic,
 {
     ztimer_periodic_init(clock, &event_periodic->timer, _event_periodic_callback,
                          event_periodic, 0);
+    event_periodic->count = EVENT_PERIODIC_FOREVER;
     event_periodic->queue = queue;
     event_periodic->event = event;
 }

--- a/sys/include/event/periodic.h
+++ b/sys/include/event/periodic.h
@@ -44,16 +44,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief Run the periodic event forever
+ */
+#define EVENT_PERIODIC_FOREVER      0
+
+/**
  * @brief   Timeout Event structure
  */
 typedef struct {
     ztimer_periodic_t timer;    /**< ztimer object used for timeout */
     event_queue_t *queue;       /**< event queue to post event to */
     event_t *event;             /**< event to post after timeout */
+    uint32_t count;             /**< times the event should repeat itself */
 } event_periodic_t;
 
 /**
- * @brief    Initialize a periodic event timeout
+ * @brief   Initialize a periodic event timeout
+ *
+ * @note: On init the periodic event is to to run forever.
  *
  * @param[in]       event_periodic  event_periodic object to initialize
  * @param[in]       clock           the clock to configure this timer on
@@ -73,14 +81,30 @@ void event_periodic_init(event_periodic_t *event_periodic, ztimer_clock_t *clock
  * @note: the used event_periodic struct must stay valid until after the timeout
  *        event has been processed!
  *
+ * @note: this function does not touch the current count value.
+ *
  * @param[in]   event_periodic   event_timout context object to use
  * @param[in]   interval         period length for the event
  */
-static inline void event_periodic_start(event_periodic_t *event_periodic,
-                                        uint32_t interval)
+static inline void event_periodic_start(event_periodic_t *event_periodic, uint32_t interval)
 {
     event_periodic->timer.interval = interval;
     ztimer_periodic_start(&event_periodic->timer);
+}
+
+/**
+ * @brief   Set the amount of times the periodic event should repeat itself.
+ *
+ * @param[in]   event_periodic   event_timout context object to use
+ * @param[in]   count            times the event should repeat itself,
+ *                               EVENT_PERIODIC_FOREVER to run for ever.
+ */
+static inline void event_periodic_set_count(event_periodic_t *event_periodic, uint32_t count)
+{
+    unsigned state = irq_disable();
+
+    event_periodic->count = count;
+    irq_restore(state);
 }
 
 /**
@@ -90,6 +114,10 @@ static inline void event_periodic_start(event_periodic_t *event_periodic,
  * timer. If the timer has already fired before calling this function, the
  * connected event will be put already into the given event queue and this
  * function does not have any effect.
+ *
+ * @note Calling this function does not touch event_periodic->count, if the
+ * periodic event was not set to run for ever and did run until expiration,
+ * then count will be != 0 after this function is called.
  *
  * @param[in]   event_periodic  event_periodic_timeout context object to use
  */

--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -43,10 +43,13 @@ static void _ztimer_periodic_reset(ztimer_periodic_t *timer, ztimer_now_t now)
 static void _ztimer_periodic_callback(void *arg)
 {
     ztimer_periodic_t *timer = arg;
-    ztimer_now_t now = ztimer_now(timer->clock);
 
     if (timer->callback(timer->arg) == ZTIMER_PERIODIC_KEEP_GOING) {
+        ztimer_now_t now = ztimer_now(timer->clock);
         _ztimer_periodic_reset(timer, now);
+    }
+    else {
+        timer->last = timer->last + timer->interval;
     }
 }
 

--- a/tests/event_ztimer/main.c
+++ b/tests/event_ztimer/main.c
@@ -72,8 +72,14 @@ static void callback_4times(void *arg)
         printf("trigger %d of periodic timeout, elapsed time: %" PRIu32 " us\n",
                *count, elapsed);
     }
-    if (*count == 4) {
+    if (*count == 2) {
+        puts("stop periodic event");
         event_periodic_stop(&event_periodic);
+        puts("resume periodic event, 2 triggers remaining");
+        event_periodic_start(&event_periodic, EVENT_TIMEOUT_TIME);
+        before = event_periodic.timer.last;
+    }
+    if (*count == 4) {
         mutex_unlock(&lock);
     }
     else if (*count > 4) {
@@ -103,6 +109,7 @@ int main(void)
     puts("posting periodic timed callback with timeout 1sec");
     event_periodic_init(&event_periodic, ZTIMER_USEC, EVENT_PRIO_MEDIUM,
                         &event_4times.super);
+    event_periodic_set_count(&event_periodic, 4);
     event_periodic_start(&event_periodic, EVENT_TIMEOUT_TIME);
     before = event_periodic.timer.last;
     puts("waiting for periodic callback to be triggered 4 times");


### PR DESCRIPTION
### Contribution description

This PR adds a count parameter to the `event_periodic` api, this allows setting a periodic event for x iterations.

Not sure if this should be optional to keep api compatibility, the api is quite new. I could also add a new `event_periodic_start_n()` for `n` times, and leave the old function as is, or another name.

### Testing procedure

```
make -C tests/event_ztimer/ flash test -j
Building application "tests_event_ztimer" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/event
"make" -C /home/francisco/workspace/RIOT/sys/frac
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/ztimer
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
   text	   data	    bss	    dec	    hex	filename
  38941	    672	  56168	  95781	  17625	/home/francisco/workspace/RIOT/tests/event_ztimer/bin/native/tests_event_ztimer.elf
r
/home/francisco/workspace/RIOT/tests/event_ztimer/bin/native/tests_event_ztimer.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.01-devel-708-g58c80e-HEAD)
posting periodic timed callback with timeout 1sec
waiting for periodic callback to be triggered 4 times
trigger 1 of periodic timeout, elapsed time: 1000000 us
trigger 2 of periodic timeout, elapsed time: 1000000 us
trigger 3 of periodic timeout, elapsed time: 1000000 us
trigger 4 of periodic timeout, elapsed time: 1000000 us
posting timed callback with timeout 0.5sec, clear right after
posting timed callback with timeout 1sec
waiting for timed callback to trigger
triggered timed callback after 1000075us
[SUCCESS]
```