### PR TITLE
cpu/qn908x: model kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -39,6 +39,7 @@ nucleo-l152re
 nucleo-l433rc
 nucleo-l552ze-q
 p-nucleo-wb55
+qn9080dk
 remote-revb
 samr21-xpro
 seeedstudio-gd32

--- a/boards/common/qn908x/Kconfig
+++ b/boards/common/qn908x/Kconfig
@@ -7,4 +7,11 @@
 config BOARD_COMMON_QN908X
     bool
     depends on CPU_FAM_QN908X
+    select MODULE_BOARD_COMMON_QN908X if TEST_KCONFIG
     # Add common board support here.
+
+config MODULE_BOARDS_COMMON_QN908X
+    bool
+    depends on TEST_KCONFIG
+    help
+      Common code for qn908x boards.

--- a/boards/qn9080dk/Kconfig
+++ b/boards/qn9080dk/Kconfig
@@ -24,4 +24,8 @@ config BOARD_QN9080DK
     select HAS_PERIPH_UART
     select HAS_PERIPH_UART_MODECFG
 
+    select HAVE_SAUL_GPIO
+    select HAVE_MMA8X5X
+    select HAVE_MTD_SPI_NOR
+
 source "$(RIOTBOARD)/common/qn908x/Kconfig"

--- a/cpu/qn908x/Kconfig
+++ b/cpu/qn908x/Kconfig
@@ -19,6 +19,12 @@ config CPU_FAM_QN908X
     select HAS_PERIPH_WDT
     select HAS_PERIPH_WDT_CB
 
+    select MODULE_VENDOR if TEST_KCONFIG
+    # The clock functionality is used by most modules, including cpu.c even when
+    # no peripheral module is being used.
+    select MODULE_VENDOR_FSL_CLOCK if TEST_KCONFIG
+    select MODULE_PERIPH_GPIO_MUX if TEST_KCONFIG
+
 ## CPU Models
 # For cpus QN9080CHN (revision C) and QN9080DHN (revision D)
 config CPU_MODEL_QN9080XHN
@@ -50,5 +56,7 @@ config HAS_CPU_QN908X
 
 # Other cpu configuration
 rsource "Kconfig.clk"
+rsource "periph/Kconfig"
+rsource "vendor/Kconfig"
 
 source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/qn908x/Makefile.dep
+++ b/cpu/qn908x/Makefile.dep
@@ -10,7 +10,7 @@ USEMODULE += vendor_fsl_clock
 # All peripherals use gpio_mux.h
 USEMODULE += periph_gpio_mux
 
-ifneq (,$(filter periph_uart periph_i2c,$(USEMODULE)))
+ifneq (,$(filter periph_uart periph_i2c periph_spi,$(USEMODULE)))
   USEMODULE += periph_flexcomm
 endif
 

--- a/cpu/qn908x/periph/Kconfig
+++ b/cpu/qn908x/periph/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_PERIPH_FLEXCOMM
+    bool
+    depends on TEST_KCONFIG
+    default y if MODULE_PERIPH_UART || MODULE_PERIPH_I2C || MODULE_PERIPH_SPI
+    help
+      Flexcomm interrupt dispatch driver.
+
+config MODULE_PERIPH_GPIO_MUX
+    bool
+    depends on TEST_KCONFIG
+    help
+      Common Pin MUX functions for qn908x CPUs.

--- a/cpu/qn908x/vendor/Kconfig
+++ b/cpu/qn908x/vendor/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_VENDOR
+    bool
+    depends on TEST_KCONFIG
+    help
+      qn908x vendor-specific code.
+
+config MODULE_VENDOR_FSL_CLOCK
+    bool
+    depends on MODULE_VENDOR
+    help
+      qn908x vendor-specific FSL Clock code.

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -14,6 +14,8 @@ ifneq (,$(filter periph_init, $(USEMODULE)))
   PERIPH_IGNORE_MODULES := \
     periph_init% \
     periph_common \
+    periph_flexcomm \
+    periph_gpio_mux \
     periph_rtc_ms \
     periph_rtc_rtt \
     periph_clic \


### PR DESCRIPTION
### Contribution description
This models modules for qn908x CPU and the only board that uses it: qn9080dk

### Testing procedure
- Green CI
- Module list between makefile and Kconfig should match.

### Issues/PRs references
Part of #16875 
