### PR TITLE
static-tests: disable cppcheck

### DIFF
--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -116,7 +116,9 @@ DIFFFILTER="MR" ERROR_EXIT_CODE=0 run ./dist/tools/licenses/check.sh
 DIFFFILTER="AC" run ./dist/tools/licenses/check.sh
 run ./dist/tools/doccheck/check.sh
 run ./dist/tools/externc/check.sh
-run ./dist/tools/cppcheck/check.sh
+# broken configuration produces many false positives
+# TODO: fix config and re-enable
+# run ./dist/tools/cppcheck/check.sh
 run ./dist/tools/vera++/check.sh
 run ./dist/tools/coccinelle/check.sh
 run ./dist/tools/flake8/check.sh


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

cppcheck produces too many false positives to be useful.
This is likely due to a configuration error (not all header files are included?) but until this is sorted out, disable the tool as it currently does more harm than good.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
