### PR TITLE
tests/*: Fix nightly failures due to f-string

### DIFF
--- a/tests/pthread_barrier/tests/01-run.py
+++ b/tests/pthread_barrier/tests/01-run.py
@@ -9,7 +9,7 @@ def testfunc(child):
     children = int(child.match.group(1))
     iterations = int(child.match.group(2))
     for i in range(children):
-        child.expect(f'Start {i + 1}')
+        child.expect('Start {}'.format(i + 1))
     for _ in range(iterations):
         sleeps = []
         for _ in range(children):

--- a/tests/thread_float/tests/01-run.py
+++ b/tests/thread_float/tests/01-run.py
@@ -73,7 +73,7 @@ def testfunc(child):
         if (count_first_thread >= MIN_PRINTS) and (count_second_thread >= MIN_PRINTS):
             break
 
-    msg = f"Either t1 or t3 printed less than {MIN_PRINTS} times within 100 messages"
+    msg = "Either t1 or t3 printed less than {} times within 100 messages".format(MIN_PRINTS)
     assert (count_first_thread >= MIN_PRINTS) and (count_second_thread >= MIN_PRINTS), msg
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A simple PR that replaces the fstring formatting in the tests with a `.format` to support the older version of python use in the pi-fleet for the nightly HiL tests.

### Testing procedure

run murdock with hil tests

### Issues/PRs references

