### PR TITLE
boards/stm32f746g-disco: add usbdev feature

### DIFF
--- a/boards/stm32f746g-disco/Kconfig
+++ b/boards/stm32f746g-disco/Kconfig
@@ -21,6 +21,7 @@ config BOARD_STM32F746G_DISCO
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/boards/stm32f746g-disco/Makefile.features
+++ b/boards/stm32f746g-disco/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
 
 # stm32f746g-disco provides a custom default Kconfig clock configuration
 KCONFIG_ADD_CONFIG += $(RIOTBOARD)/stm32f746g-disco/clock.config

--- a/boards/stm32f746g-disco/include/periph_conf.h
+++ b/boards/stm32f746g-disco/include/periph_conf.h
@@ -39,6 +39,7 @@
 #include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
+#include "cfg_usb_otg_fs.h"
 #include "mii.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR provides and configure usbdev feature to the stm32f746g-disco board. The change is straight forward.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- USB is working:

<details><summary>Using `examples/usbus-minimal`</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=stm32f746g-disco -C examples/usbus_minimal flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stm32f746g-disco'  -w '/data/riotbuild/riotbase/examples/usbus_minimal/' 'riot/riotbuild:latest' make 'BOARD=stm32f746g-disco'    
Building application "usbus_minimal" for "stm32f746g-disco" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/stm32f746g-disco
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/auto_init/usb
"make" -C /data/riotbuild/riotbase/sys/event
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/usb/usbus
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  17052	    112	   4036	  21200	   52d0	/data/riotbuild/riotbase/examples/usbus_minimal/bin/stm32f746g-disco/usbus_minimal.elf
Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!
MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!
Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!
MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/usbus_minimal/bin/stm32f746g-disco/usbus_minimal.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0 (2021-11-22-14:28)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.229921
Warn : Silicon bug: single stepping may enter pending exception handler!
Info : stm32f7x.cpu: hardware has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f7x.cpu on 0
Info : Listening on port 37959 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f7x.cpu       hla_target little stm32f7x.cpu       running

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000870 msp: 0x20000200
Info : device id = 0x10016449
Info : flash size = 1024 kbytes
auto erase enabled
wrote 32768 bytes from file /work/riot/RIOT/examples/usbus_minimal/bin/stm32f746g-disco/usbus_minimal.elf in 0.813131s (39.354 KiB/s)

verified 17164 bytes in 0.110807s (151.269 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-11-29 09:34:30,398 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2021-11-29 09:34:36,464 # main(): This is RIOT! (Version: 2022.01-devel-728-g1b914)
2021-11-29 09:34:36,470 # RIOT USB stack example application
2021-11-29 09:34:36,471 # Started USB stack!
2021-11-29 09:34:39,595 # Exiting Pyterm
```

On the host in `/var/log/syslog`:

```
Nov 29 09:34:36 trek kernel: [326736.434075] usb 1-1.5.6: USB disconnect, device number 20
Nov 29 09:34:36 trek kernel: [326736.684789] usb 1-1.5.6: new full-speed USB device number 21 using xhci_hcd
Nov 29 09:34:36 trek kernel: [326736.809724] usb 1-1.5.6: config 1 has no interfaces?
Nov 29 09:34:36 trek kernel: [326736.810473] usb 1-1.5.6: New USB device found, idVendor=1209, idProduct=7d01, bcdDevice= 0.00
Nov 29 09:34:36 trek kernel: [326736.810486] usb 1-1.5.6: New USB device strings: Mfr=3, Product=2, SerialNumber=4
Nov 29 09:34:36 trek kernel: [326736.810492] usb 1-1.5.6: Product: USB device
Nov 29 09:34:36 trek kernel: [326736.810496] usb 1-1.5.6: Manufacturer: RIOT-os.org
Nov 29 09:34:36 trek kernel: [326736.810500] usb 1-1.5.6: SerialNumber: 5B00DF1A134A1282
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
