### PR TITLE
drivers/ili9341/Kconfig: add feature to indicate hardware

### DIFF
--- a/drivers/ili9341/Kconfig
+++ b/drivers/ili9341/Kconfig
@@ -15,6 +15,12 @@ config MODULE_ILI9341
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
 
+config HAVE_ILI9341
+    bool
+    select MODULE_ILI9341 if MODULE_DISP_DEV
+    help
+      Indicates that an ILI9341 display is present.
+
 menuconfig KCONFIG_USEMODULE_ILI9341
     bool "Configure ILI9341 driver"
     depends on USEMODULE_ILI9341


### PR DESCRIPTION
### Contribution description
This adds a symbol to indicate the presence of an ili9341 display on a board in Kconfig. When present and `MODULE_DISP_DEV` is enabled, it enables the driver.

### Testing procedure
- No board is actually using this so far, but needed for #17232
- Green CI

### Issues/PRs references
#17232
