### PR TITLE
drivers/sx126x/Kconfig: rework model selection

### DIFF
--- a/drivers/sx126x/Kconfig
+++ b/drivers/sx126x/Kconfig
@@ -5,45 +5,80 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-menu "Driver sx126x"
-    depends on TEST_KCONFIG
-
-config MODULE_SX126X
+menuconfig MODULE_SX126X
     bool
+    prompt "SX1261/2/8 and LLCC68 LoRa radio driver" if !(HAVE_SX126X && MODULE_NETDEV_DEFAULT)
+    default y if (HAVE_SX126X && MODULE_NETDEV_DEFAULT)
+    depends on TEST_KCONFIG
+    depends on HAS_PERIPH_SPI
+    depends on HAS_PERIPH_GPIO
+    depends on HAS_PERIPH_GPIO_IRQ
+    select MODULE_PERIPH_GPIO
+    select MODULE_PERIPH_SPI
     select PACKAGE_DRIVER_SX126X
     select MODULE_IOLIST
 
-if HAS_PERIPH_SPI && HAS_PERIPH_GPIO_IRQ
+choice
+    bool "Radio variant"
+    depends on MODULE_SX126X
+    default MODULE_SX1261 if HAVE_SX1261
+    default MODULE_SX1262 if HAVE_SX1262
+    default MODULE_SX1268 if HAVE_SX1268
+    default MODULE_LLCC68 if HAVE_LLCC68
+    default MODULE_SX126X_STM32WL if HAVE_SX126X_STM32WL
 
 config MODULE_SX1261
     bool "SX1261"
-    select MODULE_SX126X
-    select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_SX1262
     bool "SX1262"
-    select MODULE_SX126X
-    select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_SX1268
     bool "SX1268"
-    select MODULE_SX126X
-    select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_LLCC68
     bool "LLCC68"
-    select MODULE_SX126X
-    select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
 
 config MODULE_SX126X_STM32WL
     bool "SX126X-STM32WL"
-    select MODULE_SX126X
-    select MODULE_PERIPH_GPIO
 
-endif
+endchoice
 
-endmenu
+config HAVE_SX1261
+    bool
+    select HAVE_SX126X
+    help
+      Indicates that an sx1261 transceiver is present.
+
+config HAVE_SX1262
+    bool
+    select HAVE_SX126X
+    help
+      Indicates that an sx1262 transceiver is present.
+
+config HAVE_SX1268
+    bool
+    select HAVE_SX126X
+    help
+      Indicates that an sx1268 transceiver is present.
+
+config HAVE_LLCC68
+    bool
+    select HAVE_SX126X
+    help
+      Indicates that an llcc68 transceiver is present.
+
+config HAVE_SX126X_STM32WL
+    bool
+    select HAVE_SX126X
+    help
+      Indicates that an sx126x_stm32wl transceiver is present.
+
+config HAVE_SX126X
+    bool
+    help
+      Indicates that an sx126x transceiver is present.

--- a/tests/driver_sx126x/app.config.test
+++ b/tests/driver_sx126x/app.config.test
@@ -1,5 +1,6 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
+CONFIG_MODULE_SX126X=y
 CONFIG_MODULE_SX1261=y
 
 CONFIG_MODULE_SHELL=y


### PR DESCRIPTION
### Contribution description
Split from #17232. This rework how sx126x driver modules are selected, making the entry-point the driver module and using a choice for model selection, in combination with features to default to the correct option.

### Testing procedure
- Check that the new model makes sense and shows up correctly in menuconfig
- Green CI

### Issues/PRs references
#17232
