### PR TITLE
cpu/msp430: add Kconfig

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -49,6 +49,7 @@ slstk3400a
 sltb001a
 slwstk6220a
 waspmote-pro
+z1
 "}
 
 : ${TEST_KCONFIG_ENFORCE_APP_GROUPS:="

--- a/boards/common/msb-430/Kconfig
+++ b/boards/common/msb-430/Kconfig
@@ -9,3 +9,11 @@ config BOARD_COMMON_MSB_430
     bool
     default y
     select CPU_MODEL_MSP430F1612
+
+config MODULE_BOARDS_COMMON_MSB_430
+    bool
+    default y
+    depends on TEST_KCONFIG
+    depends on BOARD_COMMON_MSB_430
+    help
+        Common code for msb-430 boards.

--- a/boards/common/msb-430/Makefile
+++ b/boards/common/msb-430/Makefile
@@ -1,3 +1,3 @@
-MODULE = boards_common_msb-430
+MODULE = boards_common_msb_430
 
 include $(RIOTBASE)/Makefile.base

--- a/boards/msb-430/Kconfig
+++ b/boards/msb-430/Kconfig
@@ -18,4 +18,6 @@ config BOARD_MSB_430
     select HAS_PERIPH_UART
     select BOARD_COMMON_MSB_430
 
+    select HAVE_SHT11
+
 source "$(RIOTBOARD)/common/msb-430/Kconfig"

--- a/boards/msb-430/Makefile.dep
+++ b/boards/msb-430/Makefile.dep
@@ -2,4 +2,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += sht11
 endif
 
-USEMODULE += boards_common_msb-430
+USEMODULE += boards_common_msb_430

--- a/boards/msb-430h/Makefile.dep
+++ b/boards/msb-430h/Makefile.dep
@@ -2,4 +2,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += sht11
 endif
 
-USEMODULE += boards_common_msb-430
+USEMODULE += boards_common_msb_430

--- a/cpu/msp430_common/Kconfig
+++ b/cpu/msp430_common/Kconfig
@@ -6,6 +6,27 @@
 # directory for more details.
 #
 
+config MODULE_MSP430_COMMON
+    bool
+    default y if CPU_CORE_MSP430
+    depends on TEST_KCONFIG
+    imply MODULE_NEWLIB_NANO
+    select MODULE_MALLOC_THREAD_SAFE
+    help
+        Common code for MSP430 cores.
+
+config MODULE_MSP430_COMMON_PERIPH
+    bool
+    default y if CPU_CORE_MSP430
+    depends on TEST_KCONFIG
+    select MODULE_PERIPH
+    help
+        Common peripheral code for MSP430 cores.
+
+choice LIBC_IMPLEMENTATION
+    default MODULE_NEWLIB
+endchoice
+
 config CPU_ARCH_MSP430
     bool
     select HAS_ARCH_16BIT
@@ -15,7 +36,6 @@ config CPU_ARCH_MSP430
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_NEWLIB
     select HAS_PERIPH_PM
-    select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG
 
 config CPU_CORE_MSP430
     bool

--- a/cpu/msp430_common/Makefile.dep
+++ b/cpu/msp430_common/Makefile.dep
@@ -1,4 +1,6 @@
-USEMODULE += msp430_common msp430_common_periph
+USEMODULE += msp430_common
+USEMODULE += msp430_common_periph
+USEMODULE += periph
 
 ifneq (,$(filter newlib,$(USEMODULE)))
   DEFAULT_MODULE += newlib_nano

--- a/cpu/msp430fxyz/Makefile.dep
+++ b/cpu/msp430fxyz/Makefile.dep
@@ -1,2 +1,1 @@
-USEMODULE += periph
 include $(RIOTCPU)/msp430_common/Makefile.dep


### PR DESCRIPTION
### Contribution description

These models modules for msp430 CPU. Only z1 is added to `.murdock` except for the one REMOVE ME commit. 

Netdev is not modeled, since there is also discussion on removing `cc2420`

### Testing procedure

- Green CI
- Module list between makefile and Kconfig should match.

### Issues/PRs references

Part of #16875 
