### PR TITLE
cpu/nrf9160: add Kconfig dependencies

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -26,6 +26,7 @@ mega-xplained
 microbit
 native
 nrf52840dk
+nrf9160dk
 nucleo-f072rb
 nucleo-f103rb
 nucleo-f207zg

--- a/cpu/nrf9160/Kconfig
+++ b/cpu/nrf9160/Kconfig
@@ -37,4 +37,6 @@ config HAS_CPU_NRF9160
     help
         Indicates that the current cpu is 'nrf9160'.
 
-source "$(RIOTCPU)/cortexm_common/Kconfig"
+rsource "vectors/Kconfig"
+
+source "$(RIOTCPU)/nrf5x_common/Kconfig"

--- a/cpu/nrf9160/vectors/Kconfig
+++ b/cpu/nrf9160/vectors/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_NRF9160_VECTORS
+    bool
+    depends on TEST_KCONFIG
+    default y


### PR DESCRIPTION
### Contribution description

These models modules for nrf9160 CPU and the only BOARD using it.

### Testing procedure

- Green CI
- Module list between makefile and Kconfig should match.

### Issues/PRs references

Part of #16875 
