### PR TITLE
tests/unittests/tests-base64: enlarge test buffer for worst case

### DIFF
--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -414,7 +414,11 @@ static void test_base64_11_urlsafe_encode_int(void)
     unsigned char expected_encoding[] = "-RAAAA";
 
     size_t base64_out_size = 0;
-    char base64_out[sizeof(expected_encoding)];
+
+    /* Up to two = signs are suppressed in urlsafe encoding at the end, but
+     * still written in the implementation. Just allocate 2 bytes more as worst
+     * case */
+    char base64_out[sizeof(expected_encoding) + 2];
 
     /*
     * @Note:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes `base64url_encode()` using some space "behind" the supplied output buffer.

Found with `make -Ctests/unittests all-asan tests-base64`.

<details>

```
❯ /home/kaspar/src/riot/tests/unittests/bin/native/tests_unittests.elf
RIOT native interrupts/signals initialized.                  
LED_RED_OFF                                                              
LED_GREEN_ON                                                             
RIOT native board initialized.                                           
RIOT native hardware initialization complete.                
                                                                         
main(): This is RIOT! (Version: 2022.01-devel-716-g45add4)          
Help: Press s to start test, r to print it is ready
rs                                                                       
READY                        
START                        
............=================================================================
==229897==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x0806a557 at pc 0x08049bc8 bp 0x0806a418 sp 0x0806a408
WRITE of size 1 at 0x0806a557 thread T0
    #0 0x8049bc7 in encode_three_bytes /home/kaspar/src/riot/sys/base64/base64.c:86
    #1 0x8049e5e in base64_encode_base /home/kaspar/src/riot/sys/base64/base64.c:132
    #2 0x804a188 in base64url_encode /home/kaspar/src/riot/sys/base64/base64.c:167
    #3 0x8053867 in test_base64_11_urlsafe_encode_int /home/kaspar/src/riot/tests/unittests/tests-base64/tests-base64.c:430
    #4 0x80506a4 in TestCase_run /home/kaspar/src/riot/sys/embunit/TestCase.c:58
    #5 0x8050315 in TestCaller_run /home/kaspar/src/riot/sys/embunit/TestCaller.c:54
    #6 0x8050e66 in TestRunner_runTest /home/kaspar/src/riot/sys/embunit/TestRunner.c:99
    #7 0x80558e3 in tests_base64 /home/kaspar/src/riot/tests/unittests/tests-base64/tests-base64.c:527
    #8 0x80499e6 in main /home/kaspar/src/riot/tests/unittests/main.c:39
    #9 0x804a739 in main_trampoline /home/kaspar/src/riot/core/init.c:58
    #10 0xf772e498 in makecontext (/usr/lib32/libc.so.6+0x48498)
                                    
0x0806a557 is located 15479 bytes inside of global variable 'main_stack' defined in '/home/kaspar/src/riot/core/init.c:63:13' (0x80668e0) of size 1
6384                             
```

</details>
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
