### PR TITLE
sys/include/xtimer.h: deprecate nanosleep

### DIFF
--- a/drivers/include/soft_spi.h
+++ b/drivers/include/soft_spi.h
@@ -14,7 +14,7 @@
  * This module provides a software implemented Serial Peripheral Interface bus.
  * It is intended to be used in situation where hardware spi is not available.
  * The signatures of the functions are similar to the functions declared in spi.h
- * The clock speed is approximated by using xtimer_nanosleep.
+ * The clock speed is approximated by using xtimer_usleep.
  * Currently only the use of MOSI in master mode is implemented. Therefore receiving
  * data from a slave is currently not possible.
  * @{
@@ -116,9 +116,9 @@ typedef enum {
  * delay between two clock edges.
  */
 typedef enum {
-    SOFT_SPI_CLK_100KHZ = 5000,     /**< drive the SPI bus with less than 100kHz */
-    SOFT_SPI_CLK_400KHZ = 1250,     /**< drive the SPI bus with less than 400kHz */
-    SOFT_SPI_CLK_DEFAULT = 0,       /**< drive the SPI bus with maximum speed possible */
+    SOFT_SPI_CLK_100KHZ = 5,     /**< drive the SPI bus with less than 100kHz */
+    SOFT_SPI_CLK_1MHZ   = 1,     /**< drive the SPI bus with less than 1MHz */
+    SOFT_SPI_CLK_DEFAULT = 0,    /**< drive the SPI bus with maximum speed possible */
 } soft_spi_clk_t;
 
 /**

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -154,7 +154,7 @@ static inline uint8_t _transfer_one_byte(soft_spi_t bus, uint8_t out)
         uint8_t bit = out >> 7;
         gpio_write(soft_spi_config[bus].mosi_pin, bit);
 
-        xtimer_nanosleep(soft_spi_config[bus].soft_spi_clk);
+        xtimer_usleep(soft_spi_config[bus].soft_spi_clk);
         gpio_toggle(soft_spi_config[bus].clk_pin);
 
         out <<= 1; /*shift transfer register*/
@@ -162,7 +162,7 @@ static inline uint8_t _transfer_one_byte(soft_spi_t bus, uint8_t out)
         bit = gpio_read(soft_spi_config[bus].miso_pin);
         out = bit ? (out | 0x01) : (out & 0xfe); /*set or delete bit 0*/
 
-        xtimer_nanosleep(soft_spi_config[bus].soft_spi_clk);
+        xtimer_usleep(soft_spi_config[bus].soft_spi_clk);
         --i;
         if (i > 0) {
             gpio_toggle(soft_spi_config[bus].clk_pin);
@@ -172,7 +172,7 @@ static inline uint8_t _transfer_one_byte(soft_spi_t bus, uint8_t out)
     if (SOFT_SPI_MODE_0 == soft_spi_config[bus].soft_spi_mode ||
         SOFT_SPI_MODE_2 == soft_spi_config[bus].soft_spi_mode) {
         /* CPHA = 0 */
-        xtimer_nanosleep(soft_spi_config[bus].soft_spi_clk);
+        xtimer_usleep(soft_spi_config[bus].soft_spi_clk);
         gpio_toggle(soft_spi_config[bus].clk_pin);
     }
 

--- a/pkg/u8g2/contrib/u8x8_riotos.c
+++ b/pkg/u8g2/contrib/u8x8_riotos.c
@@ -103,7 +103,8 @@ uint8_t u8x8_gpio_and_delay_riotos(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, v
             xtimer_usleep(arg_int * 10);
             break;
         case U8X8_MSG_DELAY_100NANO:
-            xtimer_nanosleep(arg_int * 100);
+             /* not used in upstream so approximating to 1us should be fine */
+            xtimer_usleep(1);
             break;
         case U8X8_MSG_GPIO_CS:
             if (u8x8_riot_ptr != NULL && gpio_is_valid(u8x8_riot_ptr->pin_cs)) {

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -176,6 +176,10 @@ static inline void xtimer_usleep64(uint64_t microseconds);
 /**
  * @brief Stop execution of a thread for some time
  *
+ * @deprecated This function is deprecated as no XTIMER backend is currently
+ *             configured to run at more than 1 MHz, making nanoseconds accuracy
+ *             impossible to achieve.
+ *
  * Don't expect nanosecond accuracy. As of now, this function just calls
  * xtimer_usleep(nanoseconds/1000).
  *


### PR DESCRIPTION
### Contribution description

This PR deprecates `nanosleep`, realistically this made no sense since no backend was able at running at this speed.

### Testing procedure

A green ci should be enough...