### PR TITLE
sock_dns: include string.h for strlen(3) function prototype

### DIFF
--- a/sys/net/application_layer/sock_dns/dns.c
+++ b/sys/net/application_layer/sock_dns/dns.c
@@ -16,6 +16,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 
 #include "net/dns.h"
 #include "net/dns/msg.h"


### PR DESCRIPTION
Needed by the following code in `dns.c`:

https://github.com/RIOT-OS/RIOT/blob/e8cbc6da85c2f5c39f2f970e058ff7747bcd2ad2/sys/net/application_layer/sock_dns/dns.c#L39-L41

The `string.h` include was present previously and probably wrongfully removed by accident in e8cbc6da85c2f5c39f2f970e058ff7747bcd2ad2 (CC: @miri64).