### PR TITLE
tools: bump git cache

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+APPS="examples/hello-world examples/default"
+
 : ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 samr21-xpro"}
 
 # temporarily disabling llvm builds until https://github.com/RIOT-OS/RIOT/pull/15595

--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -34,17 +34,19 @@ startswith() {
 
 add() {
     local repo="$1"
+    local name="$(_remote_name $repo)"
 
-    _locked "$GIT_CACHE_DIR/$name.addlock" _add "$repo"
+    _locked "$GIT_CACHE_DIR/$name.addlock" _add "$repo" "$name"
 }
 
 _add() {
     local repo="$1"
-    local name="$(_remote_name $repo)"
+    local name="$2"
 
     if ! is_cached "$repo"; then
         git_cache remote add "$name" "$repo"
-        git_cache config --add remote.${name}.fetch "+refs/tags/*:refs/tags/${name}/*"
+        git_cache config remote.$name.fetch "refs/heads/*:refs/heads/cache/$name/*"
+        git_cache config --add remote.$name.fetch "refs/tags/*:refs/tags/cache/$name/*"
     else
         echo "git-cache: $url already in cache"
     fi
@@ -85,7 +87,7 @@ update() {
 
     for remote in $REMOTES; do
         echo "git-cache: updating remote $remote"
-        _locked "$GIT_CACHE_DIR/$remote.lock" git_cache --namespace $remote fetch $Q -n $remote
+        _locked "$GIT_CACHE_DIR/$remote.lock" git_cache fetch $Q -n $remote
     done
 }
 
@@ -124,6 +126,15 @@ _check_commit() {
     git_cache cat-file -e ${1}^{commit} 2>/dev/null
 }
 
+_check_ref() {
+    test -n "$(git_cache show-ref ${1})" 2>/dev/null
+}
+
+is_tag() {
+    test -n "$(git -C ${1} tag -l ${2})" 2>/dev/null
+}
+
+
 _remote_name() {
     echo "$*" | git hash-object --stdin
 }
@@ -138,11 +149,9 @@ _check_tag_or_commit() {
     local REMOTE_NAME=$2
 
     if _check_commit $SHA1 ; then
-        local tag=commit$SHA1-$$
-        git_cache tag $tag $SHA1 2> /dev/null || true # ignore possibly already existing tag
-        echo "$tag"
-    elif _tag_to_sha1 ${REMOTE_NAME}/$SHA1 > /dev/null; then
-        echo "${REMOTE_NAME}/$SHA1"
+        echo "$SHA1"
+    elif _check_ref cache/${REMOTE_NAME}/$SHA1 ; then
+        echo "cache/${REMOTE_NAME}/$SHA1"
     fi
 }
 
@@ -153,6 +162,13 @@ clone() {
     local TARGET_PATH="${3}"
 
     [ -z "$TARGET_PATH" ] && TARGET_PATH="$(basename $REMOTE)"
+
+    [ -d "$TARGET_PATH" ] && {
+        [ -n "$(ls -A ${TARGET_PATH})" ] && {
+            echo "git-cache: target folder \"$TARGET_PATH\" exists and is non-empty."
+            exit 1
+        }
+    }
 
     # make sure git won't ask for credentials
     export GIT_TERMINAL_PROMPT=0
@@ -168,49 +184,32 @@ clone() {
             pull=1
         fi
 
-        if [ $pull -eq 0 ]; then
-            local tag="$(_check_tag_or_commit $SHA1 $REMOTE_NAME)"
-            if [ -z "$tag" ]; then
-                # commit / tag not in cache, try updating repo
-                update "$REMOTE"
-                tag="$(_check_tag_or_commit $SHA1 $REMOTE_NAME)"
-            fi
-        else
-            local tag="remotes/$REMOTE_NAME/master"
-            if [ -z "$(_tag_to_sha1 $tag)" ]; then
-                update "$REMOTE"
-            fi
-            tag="$(_check_tag_or_commit $(_tag_to_sha1 $tag) $REMOTE_NAME)"
-            if [ -z "$tag" ]; then
-                echo "git-cache: cannot checkout master branch of $REMOTE"
-                false
-            fi
+        local tag="$(_check_tag_or_commit $SHA1 $REMOTE_NAME)"
+        if [ -z "$tag" ]; then
+            # commit / tag not in cache, try updating repo
+            update "$REMOTE"
+            tag="$(_check_tag_or_commit $SHA1 $REMOTE_NAME)"
         fi
 
         if [ -n "$tag" ]; then
-            echo "git-cache: cloning from cache. tag=$tag"
-            git -c advice.detachedHead=false clone $Q --reference "${GIT_CACHE_DIR}" --shared "${GIT_CACHE_DIR}" "${TARGET_PATH}" --branch $tag
+            echo "git-cache: cloning from cache. branch/tag/commit=$tag"
+            git init $Q "${TARGET_PATH}"
+            echo "${GIT_CACHE_DIR}/objects" > "${TARGET_PATH}/.git/objects/info/alternates"
+            git -C "${TARGET_PATH}" remote add cache "${GIT_CACHE_DIR}"
+            git -C "${TARGET_PATH}" config remote.cache.fetch "refs/heads/cache/$REMOTE_NAME/*:refs/remotes/cache/*"
+            git -C "${TARGET_PATH}" config --add remote.cache.fetch "refs/tags/cache/$REMOTE_NAME/*:refs/tags/*"
+            git -C "${TARGET_PATH}" fetch $Q --no-tags cache
 
-            # rename tags from <remote-hash>/* to *
-            git -C "${TARGET_PATH}" fetch $Q origin "refs/tags/${REMOTE_NAME}/*:refs/tags/*"
-
-            # remove all commit* and <remote-hash>/* tags
-            git -C "${TARGET_PATH}" tag -l \
-                | grep -P '(^[a-f0-9]{40}/|^commit[a-f0-9]{40}(-\d+)?$)' \
-                | xargs git -C "${TARGET_PATH}" tag -d > /dev/null
-
-            # cleanup possibly created helper tag
-            case $tag in
-                commit*)
-                    git_cache tag -d $tag 2>&1 > /dev/null || true
-                    ;;
-            esac
-
-
-            if [ $pull -eq 1 ]; then
-                git -C "${TARGET_PATH}" fetch $Q $REMOTE $SHA1:$SHA1
-                git -C "${TARGET_PATH}" checkout $Q $SHA1
+            if startswith $tag cache/${REMOTE_NAME}/; then
+                if is_tag "${TARGET_PATH}" $SHA1; then
+                    git -C "${TARGET_PATH}" checkout $Q --detach $SHA1
+                else
+                    git -C "${TARGET_PATH}" checkout $Q -b $SHA1 cache/$SHA1
+                fi
+            else
+                    git -C "${TARGET_PATH}" checkout $Q --detach $SHA1
             fi
+
         else
             echo "git-cache: trying checkout from source"
             git clone $Q --reference "${GIT_CACHE_DIR}" --shared "${REMOTE}" "${TARGET_PATH}"

--- a/pkg/cayenne-lpp/Makefile
+++ b/pkg/cayenne-lpp/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=cayenne-lpp
 PKG_URL=https://github.com/aabadie/cayenne-lpp
-PKG_VERSION=0.1.1
+PKG_VERSION=a0f7167d7baf81f9f06cbb58a405bd7f22f9e9b4 # 0.1.1
 PKG_LICENSE=LGPLv2.1
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=cmsis-dsp
 PKG_URL=https://github.com/ARM-software/CMSIS_5
-PKG_VERSION=5.4.0
+PKG_VERSION=0b521765067ac87b142cd96b5f578ffb399090cc # 5.4.0
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cmsis-nn/Makefile
+++ b/pkg/cmsis-nn/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=cmsis-nn
 PKG_URL=https://github.com/ARM-software/CMSIS_5
-PKG_VERSION=5.6.0
+PKG_VERSION=b5f0603d6a584d1724d952fd8b0737458b90d62b # 5.6.0
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/flatbuffers/Makefile
+++ b/pkg/flatbuffers/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=flatbuffers
 PKG_URL=https://github.com/google/flatbuffers
-PKG_VERSION=v1.11.0
+PKG_VERSION=9e7e8cbe9f675123dd41b7c62868acad39188cae #v1.11.0
 PKG_LICENSE=Apache2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanopb
 PKG_URL=https://github.com/nanopb/nanopb
-PKG_VERSION=nanopb-0.4.5
+PKG_VERSION=c9124132a604047d0ef97a09c0e99cd9bed2c818 #nanopb-0.4.5
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR bumps git-cache to the newest version. It has reworked tag handling (remote tags and branches now show up in git-cache-cloned repos), and should be faster. BUT, checking out tags is currently broken.
I'm bumping this anyways as it seems to reduce the current CI slowdown.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
