### PR TITLE
drivers: remove some useless xtimer includes

### DIFF
--- a/drivers/dfplayer/dfplayer.c
+++ b/drivers/dfplayer/dfplayer.c
@@ -29,7 +29,6 @@
 #include "periph/gpio.h"
 #include "periph/uart.h"
 #include "thread.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/drivers/feetech/feetech.c
+++ b/drivers/feetech/feetech.c
@@ -25,7 +25,6 @@
 #include "feetech_writer.h"
 
 #include "periph/uart.h"
-#include "xtimer.h"
 #include "byteorder.h"
 
 #include <string.h>

--- a/drivers/grove_ledbar/grove_ledbar.c
+++ b/drivers/grove_ledbar/grove_ledbar.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #include "log.h"
-#include "xtimer.h"
 
 #include "grove_ledbar.h"
 #include "my9221.h"

--- a/drivers/hmc5883l/hmc5883l.c
+++ b/drivers/hmc5883l/hmc5883l.c
@@ -22,7 +22,6 @@
 #include "hmc5883l.h"
 
 #include "log.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -24,7 +24,6 @@
 
 #include "hts221.h"
 #include "periph/i2c.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG    0
 #include "debug.h"

--- a/drivers/sds011/sds011_saul.c
+++ b/drivers/sds011/sds011_saul.c
@@ -23,7 +23,6 @@
 
 #include "saul.h"
 #include "sds011.h"
-#include "xtimer.h"
 
 static int _read(const void *dev, phydat_t *res)
 {

--- a/drivers/si114x/si114x_saul.c
+++ b/drivers/si114x/si114x_saul.c
@@ -21,7 +21,6 @@
 
 #include "saul.h"
 #include "si114x.h"
-#include "xtimer.h"
 
 static int read_uv(const void *dev, phydat_t *res)
 {

--- a/drivers/tsl2561/tsl2561_saul.c
+++ b/drivers/tsl2561/tsl2561_saul.c
@@ -21,7 +21,6 @@
 
 #include "saul.h"
 #include "tsl2561.h"
-#include "xtimer.h"
 
 static int read_illuminance(const void *dev, phydat_t *res)
 {

--- a/drivers/vcnl40x0/vcnl40x0_saul.c
+++ b/drivers/vcnl40x0/vcnl40x0_saul.c
@@ -24,7 +24,6 @@
 #include "saul.h"
 #include "vcnl40x0.h"
 #include "vcnl40x0_params.h"
-#include "xtimer.h"
 
 static int read_proximity(const void *dev, phydat_t *res)
 {

--- a/drivers/veml6070/veml6070.c
+++ b/drivers/veml6070/veml6070.c
@@ -24,7 +24,6 @@
 #include "veml6070.h"
 #include "veml6070_params.h"
 #include "periph/i2c.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG        0
 #include "debug.h"

--- a/drivers/veml6070/veml6070_saul.c
+++ b/drivers/veml6070/veml6070_saul.c
@@ -22,7 +22,6 @@
 
 #include "saul.h"
 #include "veml6070.h"
-#include "xtimer.h"
 
 static int read_uv(const void *dev, phydat_t *res)
 {

--- a/drivers/ws281x/atmega.c
+++ b/drivers/ws281x/atmega.c
@@ -28,7 +28,7 @@
 #include "ws281x_params.h"
 #include "ws281x_constants.h"
 #include "periph_cpu.h"
-#include "xtimer.h"
+
 /*
  * Data encoding according to the datasheets of the WS2812 and the SK6812:
  * - Encoding of zero bit:

--- a/drivers/ws281x/esp32.c
+++ b/drivers/ws281x/esp32.c
@@ -27,7 +27,6 @@
 #include "ws281x_params.h"
 #include "ws281x_constants.h"
 #include "periph_cpu.h"
-#include "xtimer.h"
 #include "xtensa/core-macros.h"
 #include "soc/rtc.h"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Some old drivers were still including xtimer in their implementation although it's unused.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green CI should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
