### PR TITLE
cpu/mips: deprecate mips cpu

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -392,6 +392,12 @@ INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBAS
 # process provided features
 include $(RIOTBASE)/Makefile.features
 
+ifneq ($(RIOT_CI_BUILD),1)
+  # Warn about used deprecated boards
+  include $(RIOTMAKE)/deprecated_boards.inc.mk
+  include $(RIOTMAKE)/deprecated_cpus.inc.mk
+endif
+
 # mandatory includes!
 include $(RIOTMAKE)/pseudomodules.inc.mk
 include $(RIOTMAKE)/defaultmodules.inc.mk

--- a/boards/6lowpan-clicker/doc.txt
+++ b/boards/6lowpan-clicker/doc.txt
@@ -2,6 +2,8 @@
 @defgroup    boards_6lowpan-clicker MikroE 6LoWPAN Clicker
 @ingroup     boards
 @brief       Support for the MikroE 6LoWPAN Clicker
+@deprecated  Will not be available after the 2022.07 release. This includes
+             all MIPS based boards and cpus.
 
 ## Overview
 

--- a/boards/pic32-wifire/doc.txt
+++ b/boards/pic32-wifire/doc.txt
@@ -2,6 +2,8 @@
 @defgroup    boards_pic32-wifire Digilent PIC32 WiFire
 @ingroup     boards
 @brief       Support for the Digilent PIC32 WiFire
+@deprecated  Will not be available after the 2022.07 release. This includes
+             all MIPS based boards and cpus.
 
 ## Overview
 

--- a/cpu/mips_pic32_common/doc.txt
+++ b/cpu/mips_pic32_common/doc.txt
@@ -2,6 +2,8 @@
  * @defgroup        cpu_mips_pic32_common Microchip MIPS common
  * @ingroup         cpu
  * @brief           Microchip MIPS common
+ * @deprecated Will not be available after the 2022.07 release. This includes
+               all MIPS based boards and cpus.
  *
  * This module contains all common code and definition to all Microchip MIPS
  * cpu families supported by RIOT: @ref cpu_mips_pic32mx, @ref cpu_mips_pic32mz.

--- a/makefiles/deprecated_boards.inc.mk
+++ b/makefiles/deprecated_boards.inc.mk
@@ -1,0 +1,11 @@
+# Add deprecated modules here
+# Keep this list ALPHABETICALLY SORTED!!!!
+ifeq ($(MAKELEVEL),0)
+  DEPRECATED_BOARDS += 6lowpan-clicker
+  DEPRECATED_BOARDS += pic32-wifire
+
+  ifneq (,$(filter $(DEPRECATED_BOARDS),$(BOARD)))
+    $(shell $(COLOR_ECHO) "$(COLOR_RED)Deprecated board: $(COLOR_RESET)"\
+                          "$(BOARD)" 1>&2)
+  endif
+endif

--- a/makefiles/deprecated_cpus.inc.mk
+++ b/makefiles/deprecated_cpus.inc.mk
@@ -1,0 +1,10 @@
+# Add deprecated modules here
+# Keep this list ALPHABETICALLY SORTED!!!!
+ifeq ($(MAKELEVEL),0)
+  DEPRECATED_CPUS += mips_pic32mx
+  DEPRECATED_CPUS += mips_pic32mz
+  ifneq (,$(filter $(DEPRECATED_CPUS),$(CPU)))
+    $(shell $(COLOR_ECHO) "$(COLOR_RED)Deprecated cpu: $(COLOR_RESET)"\
+                          "$(CPU)" 1>&2)
+  endif
+endif


### PR DESCRIPTION
### Contribution description

Add deprecate note in the mips cpu.
Add warning in make when any mips based board is being used (6lowpan-clicker, pic32-wifire).

After some discussion on the forum and between some maintainers we have decided to drop mips cpu as nobody is willing to continue to maintain it.

### Testing procedure

Read the docs and run:
```
BOARD=6lowpan-clicker make all -C examples/hello-world/ && BOARD=pic32-wifire make all -C examples/hello-world/
```
then check for the error messages.


### Issues/PRs references

Related to #11788
[Forum post discussing dropping mips] (https://forum.riot-os.org/t/dropping-support-of-outdated-poorly-supported-boards-and-modules/3343/19)

