### PR TITLE
drivers/mhz19: migrate to ztimer

### DIFF
--- a/drivers/mhz19/Kconfig
+++ b/drivers/mhz19/Kconfig
@@ -15,14 +15,16 @@ config MODULE_MHZ19_UART
     depends on HAS_PERIPH_UART
     select MODULE_PERIPH_UART
     select MODULE_MHZ19
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
 
 config MODULE_MHZ19_PWM
     bool "MH-Z19 over PWM"
     depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_GPIO
     select MODULE_MHZ19
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
 
 config MODULE_MHZ19
     bool

--- a/drivers/mhz19/Makefile.dep
+++ b/drivers/mhz19/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 ifneq (,$(filter mhz19_pwm,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/mhz19/mhz19_pwm.c
+++ b/drivers/mhz19/mhz19_pwm.c
@@ -22,7 +22,7 @@
 
 #include "mhz19.h"
 #include "mhz19_params.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "mutex.h"
 
 #define ENABLE_DEBUG 0
@@ -61,26 +61,26 @@ int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm)
     DEBUG("%s: Waiting for high level to end\n", __func__);
     while (gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_msleep(1);
+        ztimer_sleep(ZTIMER_MSEC, 1);
     }
 
     DEBUG("%s: Waiting for initial rising edge\n", __func__);
     while (!gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_msleep(1);
+        ztimer_sleep(ZTIMER_MSEC, 1);
     }
 
-    start = xtimer_now_usec() / US_PER_MS;
+    start = ztimer_now(ZTIMER_MSEC);
     DEBUG("%s: Waiting for falling edge\n", __func__);
     while (gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_msleep(1);
+        ztimer_sleep(ZTIMER_MSEC, 1);
     }
-    middle = xtimer_now_usec() / US_PER_MS;
+    middle = ztimer_now(ZTIMER_MSEC);
     DEBUG("%s: Waiting for rising edge\n", __func__);
     while (!gpio_read(dev->pin) && timeout) {
         timeout--;
-        xtimer_msleep(1);
+        ztimer_sleep(ZTIMER_MSEC, 1);
     }
 
     /* If we waited too long for flanks, something went wrong */
@@ -88,7 +88,7 @@ int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm)
         DEBUG("%s: Measurement timed out\n", __func__);
         return MHZ19_ERR_TIMEOUT;
     }
-    end = xtimer_now_usec() / US_PER_MS;
+    end = ztimer_now(ZTIMER_MSEC);
 
     th = (middle - start);
     tl = (end - middle);

--- a/drivers/mhz19/mhz19_uart.c
+++ b/drivers/mhz19/mhz19_uart.c
@@ -24,7 +24,7 @@
 
 #include "mhz19.h"
 #include "mhz19_params.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "mutex.h"
 
 #define ENABLE_DEBUG 0
@@ -137,7 +137,7 @@ static void mhz19_cmd(mhz19_t *dev, const uint8_t *in)
     uart_write(dev->params->uart, in, MHZ19_BUF_SIZE + 1);
 
     /* Add some delay after executing command */
-    xtimer_msleep(MHZ19_TIMEOUT_CMD);
+    ztimer_sleep(ZTIMER_MSEC, MHZ19_TIMEOUT_CMD);
 
     /* Unlock concurrency guard mutex */
     mutex_unlock(&dev->mutex);
@@ -165,10 +165,10 @@ static void mhz19_xmit(mhz19_t *dev, const uint8_t *in)
 
     /* By locking the same mutex another time, this thread blocks until
      * the UART ISR received all bytes and unlocks the mutex. If that does not
-     * happen, then xtimer_mutex_lock_timeout unlocks the mutex after as well
+     * happen, then ztimer_mutex_lock_timeout unlocks the mutex after as well
      * after the timeout expired.
      */
-    xtimer_mutex_lock_timeout(&dev->sync, MHZ19_TIMEOUT_CMD * US_PER_MS);
+    ztimer_mutex_lock_timeout(ZTIMER_MSEC, &dev->sync, MHZ19_TIMEOUT_CMD);
 
     /* Unlock synchronization for next transmission */
     mutex_unlock(&dev->sync);

--- a/tests/driver_mhz19/Makefile
+++ b/tests/driver_mhz19/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 # set default device parameters in case they are undefined
 TEST_MODE ?= 1

--- a/tests/driver_mhz19/app.config.test
+++ b/tests/driver_mhz19/app.config.test
@@ -1,6 +1,7 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
-CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y
 
 # Use UART mode by default
 CONFIG_MODULE_MHZ19_UART=y

--- a/tests/driver_mhz19/main.c
+++ b/tests/driver_mhz19/main.c
@@ -30,7 +30,7 @@
 #endif
 
 #include <stdio.h>
-#include "xtimer.h"
+#include "ztimer.h"
 #include "mhz19.h"
 #include "mhz19_params.h"
 
@@ -79,7 +79,7 @@ int main(void)
         printf("CO2: %d ppm\n", ppm);
 
         /* sleep between measurements */
-        xtimer_sleep(1);
+        ztimer_sleep(ZTIMER_MSEC, 1000);
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Changes should be straight forward but care should be taken with the ppm computation which depends on ztimer_now results (expressed in ticks).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `tests/driver_mhz19` is still working (but I don't have the hardware to test)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
