### PR TITLE
pkg: migrate some packages to ztimer

### DIFF
--- a/drivers/bme680/Kconfig
+++ b/drivers/bme680/Kconfig
@@ -9,7 +9,8 @@ menuconfig MODULE_BME680
     bool "BME680 Temperature/Humidity/Pressure/Gas sensor"
     depends on TEST_KCONFIG
     select PACKAGE_DRIVER_BME680
-    select MODULE_XTIMER if MODULE_SAUL
+    select MODULE_ZTIMER if MODULE_SAUL
+    select MODULE_ZTIMER_MSEC if MODULE_SAUL
 
 if MODULE_BME680
 

--- a/drivers/bme680/Makefile.dep
+++ b/drivers/bme680/Makefile.dep
@@ -1,7 +1,8 @@
 USEPKG += driver_bme680
 
 ifneq (,$(filter saul%,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter bme680_i2c,$(USEMODULE)))

--- a/drivers/bme680/bme680_saul.c
+++ b/drivers/bme680/bme680_saul.c
@@ -21,7 +21,7 @@
 #include "saul.h"
 #include "bme680.h"
 #include "bme680_params.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 extern bme680_t bme680_devs_saul[BME680_NUMOF];
 
@@ -65,7 +65,7 @@ static int _read(int dev)
     if ((drt = bme680_get_duration(&bme680_devs_saul[dev])) < 0) {
         return BME680_INVALID;
     }
-    xtimer_msleep(drt);
+    ztimer_sleep(ZTIMER_MSEC, drt);
 
     bme680_field_data_t data;
     if ((res = bme680_get_data(&bme680_devs_saul[dev], &data)) != BME680_OK) {

--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 FEATURES_REQUIRED += periph_i2c
 FEATURES_OPTIONAL += periph_i2c_reconfigure
 DEFAULT_MODULE += auto_init_security

--- a/pkg/cryptoauthlib/contrib/atca.c
+++ b/pkg/cryptoauthlib/contrib/atca.c
@@ -19,7 +19,8 @@
  */
 #include <stdio.h>
 #include <stdint.h>
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "periph/i2c.h"
 #include "periph/gpio.h"
 
@@ -29,17 +30,17 @@
 /* Timer functions */
 void atca_delay_us(uint32_t delay)
 {
-    xtimer_usleep(delay);
+    ztimer_sleep(ZTIMER_USEC, delay);
 }
 
 void atca_delay_10us(uint32_t delay)
 {
-    xtimer_usleep(delay * 10);
+    ztimer_sleep(ZTIMER_USEC, delay * 10);
 }
 
 void atca_delay_ms(uint32_t delay)
 {
-    xtimer_usleep(delay * 1000);
+    ztimer_sleep(ZTIMER_USEC, delay * US_PER_MS);
 }
 
 /* Hal I2C implementation */

--- a/pkg/driver_bme680/Kconfig
+++ b/pkg/driver_bme680/Kconfig
@@ -9,6 +9,8 @@ config PACKAGE_DRIVER_BME680
     bool "BME680 sensor driver package"
     depends on TEST_KCONFIG
     select MODULE_DRIVER_BME680_CONTRIB
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
 
 config MODULE_DRIVER_BME680_CONTRIB
     bool

--- a/pkg/driver_bme680/Makefile.dep
+++ b/pkg/driver_bme680/Makefile.dep
@@ -1,1 +1,3 @@
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 USEMODULE += driver_bme680_contrib

--- a/pkg/driver_bme680/contrib/bme680_hal.c
+++ b/pkg/driver_bme680/contrib/bme680_hal.c
@@ -33,7 +33,7 @@
 #include "periph/spi.h"
 #endif
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifndef BME680_SPI_SPEED
 #define BME680_SPI_SPEED    (SPI_CLK_1MHZ)
@@ -45,7 +45,7 @@
 
 void bme680_ms_sleep(uint32_t msleep)
 {
-    xtimer_msleep(msleep);
+    ztimer_sleep(ZTIMER_MSEC, msleep);
 }
 
 #ifdef MODULE_PERIPH_I2C

--- a/pkg/u8g2/Kconfig
+++ b/pkg/u8g2/Kconfig
@@ -10,7 +10,8 @@ config PACKAGE_U8G2
     depends on TEST_KCONFIG
     depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_GPIO
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_USEC
     select MODULE_U8G2_RIOT
     select MODULE_U8G2_CSRC
 

--- a/pkg/u8g2/Makefile.dep
+++ b/pkg/u8g2/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 
 FEATURES_REQUIRED += periph_gpio
 

--- a/pkg/u8g2/contrib/u8x8_riotos.c
+++ b/pkg/u8g2/contrib/u8x8_riotos.c
@@ -24,7 +24,7 @@
 
 #include "u8x8_riotos.h"
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_PERIPH_SPI
 #include "periph/spi.h"
@@ -97,14 +97,14 @@ uint8_t u8x8_gpio_and_delay_riotos(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, v
             _enable_pins(u8x8_riot_ptr);
             break;
         case U8X8_MSG_DELAY_MILLI:
-            xtimer_usleep(arg_int * 1000);
+            ztimer_sleep(ZTIMER_USEC, arg_int * 1000);
             break;
         case U8X8_MSG_DELAY_10MICRO:
-            xtimer_usleep(arg_int * 10);
+            ztimer_sleep(ZTIMER_USEC, arg_int * 10);
             break;
         case U8X8_MSG_DELAY_100NANO:
              /* not used in upstream so approximating to 1us should be fine */
-            xtimer_usleep(1);
+            ztimer_sleep(ZTIMER_USEC, 1);
             break;
         case U8X8_MSG_GPIO_CS:
             if (u8x8_riot_ptr != NULL && gpio_is_valid(u8x8_riot_ptr->pin_cs)) {

--- a/pkg/ucglib/Kconfig
+++ b/pkg/ucglib/Kconfig
@@ -10,7 +10,8 @@ config PACKAGE_UCGLIB
     depends on TEST_KCONFIG
     depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_GPIO
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_USEC
     select MODULE_UCGLIB_RIOT
     select MODULE_UCGLIB_CSRC
 

--- a/pkg/ucglib/Makefile.dep
+++ b/pkg/ucglib/Makefile.dep
@@ -1,4 +1,5 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 
 FEATURES_REQUIRED += periph_gpio
 

--- a/pkg/ucglib/contrib/ucg_riotos.c
+++ b/pkg/ucglib/contrib/ucg_riotos.c
@@ -23,7 +23,7 @@
 
 #include "ucg_riotos.h"
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_PERIPH_SPI
 #include "periph/spi.h"
@@ -98,7 +98,7 @@ int16_t ucg_com_hw_spi_riotos(ucg_t *ucg, int16_t msg, uint16_t arg, uint8_t *da
             spi_release(dev);
             break;
         case UCG_COM_MSG_DELAY:
-            xtimer_usleep(arg);
+            ztimer_sleep(ZTIMER_USEC, arg);
             break;
         case UCG_COM_MSG_CHANGE_RESET_LINE:
             if (ucg_riot_ptr != NULL && gpio_is_valid(ucg_riot_ptr->pin_reset)) {

--- a/tests/driver_bme680/Makefile
+++ b/tests/driver_bme680/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 DRIVER ?= bme680_i2c
 
 USEMODULE += $(DRIVER)
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 ifeq ($(ENABLE_FP),1)
   USEMODULE += bme680_fp

--- a/tests/driver_bme680/app.config.test
+++ b/tests/driver_bme680/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_BME680=y
-CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y

--- a/tests/driver_bme680/main.c
+++ b/tests/driver_bme680/main.c
@@ -25,15 +25,16 @@
 #include "bme680.h"
 #include "bme680_params.h"
 #include "mutex.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 
-#define BME680_TEST_PERIOD_US   (5 * US_PER_SEC)
+#define BME680_TEST_PERIOD_MS   (5 * MS_PER_SEC)    /* 5s */
 
-xtimer_t timer;
+ztimer_t timer;
 
 static void _timer_cb(void *arg)
 {
-    xtimer_set(&timer, BME680_TEST_PERIOD_US);
+    ztimer_set(ZTIMER_MSEC, &timer, BME680_TEST_PERIOD_MS);
     mutex_unlock(arg);
 }
 
@@ -64,7 +65,7 @@ int main(void)
 
     timer.callback = _timer_cb;
     timer.arg = &timer_mtx;
-    xtimer_set(&timer, BME680_TEST_PERIOD_US);
+    ztimer_set(ZTIMER_MSEC, &timer, BME680_TEST_PERIOD_MS);
 
     while (1)
     {
@@ -76,7 +77,7 @@ int main(void)
             /* get the duration for the measurement */
             int duration = bme680_get_duration(&dev[i]);
             /* wait for the duration */
-            xtimer_msleep(duration);
+            ztimer_sleep(ZTIMER_MSEC, duration);
             /* read the data */
             int res = bme680_get_data(&dev[i], &data);
 

--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 
 USEPKG += u8g2
 

--- a/tests/pkg_u8g2/main.c
+++ b/tests/pkg_u8g2/main.c
@@ -70,7 +70,8 @@
 #include "periph/i2c.h"
 #endif
 
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 
 #include "u8g2.h"
 #include "u8x8_riotos.h"
@@ -200,7 +201,7 @@ int main(void)
         screen = (screen + 1) % 3;
 
         /* sleep a little */
-        xtimer_sleep(1);
+        ztimer_sleep(ZTIMER_USEC, US_PER_SEC);
     }
 
     return 0;

--- a/tests/pkg_ucglib/main.c
+++ b/tests/pkg_ucglib/main.c
@@ -54,7 +54,8 @@
 #include "periph/spi.h"
 #endif
 
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 
 #include "ucg.h"
 #include "ucg_riotos.h"
@@ -139,7 +140,7 @@ int main(void)
         screen = (screen + 1) % 3;
 
         /* sleep a little */
-        xtimer_sleep(1);
+        ztimer_sleep(ZTIMER_USEC, US_PER_SEC);
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates a few packages to ztimer:
- cryptoauthlib
- driver_bme680
- u8g2
- ucglib

The changes are quite straight forward but needs careful review because of conversions used.

After that PR only lwip and tinydtls will be missing. lwip is addressed by #17115. For tinydtls, we will have to check its dependencies since some are still using xtimer and evtimer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- The affected applications are still working but unfortunately I don't have the hardware (maybe I have a bme680 somewhere but need to find it)

**test output:**

<details><summary>bme680:</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=b-l475e-iot01a -C tests/driver_bme680 flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=b-l475e-iot01a'  -w '/data/riotbuild/riotbase/tests/driver_bme680/' 'riot/riotbuild:latest' make 'BOARD=b-l475e-iot01a'    
Building application "tests_driver_bme680" for "b-l475e-iot01a" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/driver_bme680
"make" -C /data/riotbuild/riotbase/build/pkg/driver_bme680 -f /data/riotbuild/riotbase/Makefile.base
"make" -C /data/riotbuild/riotbase/boards/b-l475e-iot01a
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/bme680
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/pkg/driver_bme680/contrib
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  18444	    132	   2528	  21104	   5270	/data/riotbuild/riotbase/tests/driver_bme680/bin/b-l475e-iot01a/tests_driver_bme680.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/driver_bme680/bin/b-l475e-iot01a/tests_driver_bme680.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0 (2021-11-22-14:28)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.247989
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 33321 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080008b8 msp: 0x20000200
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev 4 : 0x1007)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Warn : Adding extra erase range, 0x08004890 .. 0x08004fff
auto erase enabled
wrote 18576 bytes from file /work/riot/RIOT/tests/driver_bme680/bin/b-l475e-iot01a/tests_driver_bme680.elf in 1.037011s (17.493 KiB/s)

verified 18576 bytes in 0.656049s (27.651 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-12-02 10:07:04,747 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2021-12-02 10:07:06,252 # START
2021-12-02 10:07:06,257 # main(): This is RIOT! (Version: 2022.01-devel-851-g24ff8f-pr/pkg/ztimer)
2021-12-02 10:07:06,293 # Initialize BME680 sensor 0 ... OK
2021-12-02 10:07:06,659 # [bme680]: dev=0, T = 23.00 degC, P = 100599 Pa, H = 55.397 %, G = 44831 ohms
2021-12-02 10:07:06,662 # +-----------------------------------------+
2021-12-02 10:07:11,658 # [bme680]: dev=0, T = 22.98 degC, P = 100597 Pa, H = 55.402 %, G = 42383 ohms
2021-12-02 10:07:11,662 # +-----------------------------------------+
2021-12-02 10:07:16,658 # [bme680]: dev=0, T = 22.96 degC, P = 100599 Pa, H = 55.404 %, G = 40736 ohms
2021-12-02 10:07:16,662 # +-----------------------------------------+
2021-12-02 10:07:21,657 # [bme680]: dev=0, T = 22.93 degC, P = 100595 Pa, H = 55.437 %, G = 39507 ohms
2021-12-02 10:07:21,661 # +-----------------------------------------+
2021-12-02 10:07:26,657 # [bme680]: dev=0, T = 22.89 degC, P = 100595 Pa, H = 55.487 %, G = 38210 ohms
2021-12-02 10:07:26,661 # +-----------------------------------------+
2021-12-02 10:07:29,663 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
