### PR TITLE
murdock: add some doc on how to efficiently limit builds

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# uncomment and change this to limit builds, e.g.,
+#export BOARDS="samr21-xpro native"
+# and / or
+#export APPS="examples/hello-world tests/unittests"
+
 : ${TEST_BOARDS_AVAILABLE:="esp32-wroom-32 samr21-xpro"}
 
 # temporarily disabling llvm builds until https://github.com/RIOT-OS/RIOT/pull/15595


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When limiting builds by just adding `BOARDS` or `APPS`, murdock calls "make info-boards-supported", then filters by BOARDS. This is slower than just exporting BOARDS, which is honoured by "make info-boards-supported".

This PR adds some (uncommented) examples on how to limit builds, with "export" in place. Hopefully users will use those in the future.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
