### PR TITLE
cpu/esp: compile optional modules in CI

### DIFF
--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -5,4 +5,34 @@ endif
 # Sets up configuration for openocd
 USEMODULE += esp_jtag
 
+# if compiled in CI, optional modules are selected for compile tests
+ifneq (,$(RIOT_CI_BUILD))
+  USEMODULE += esp_idf_heap
+  USEMODULE += esp_log_startup
+  USEMODULE += esp_log_tagged
+  USEMODULE += esp_qemu
+  USEMODULE += esp_spi_ram
+
+  ifneq (,$(filter periph_i2c,$(USEMODULE)))
+    USEMODULE += esp_i2c_hw
+  endif
+
+  ifneq (,$(filter periph_timer,$(USEMODULE)))
+    USEMODULE += esp_hw_counter
+  endif
+
+  ifneq (,$(filter netdev_default,$(USEMODULE)))
+    # if netdev_default is used, we use gnrc modules that are enabled
+    # in different examples to use different esp_wifi modules
+    ifneq (,$(filter gnrc_netif_single,$(USEMODULE)))
+      # if gnrc_netif_single module is enabled, esp_wifi_enterprise is used
+      USEMODULE += esp_wifi_enterprise
+    else
+      # in all other case esp_wifi_ap is enabled
+      USEMODULE += esp_wifi_ap
+    endif
+  endif
+
+endif
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -125,6 +125,23 @@
 #endif
 /** @} */
 
+#ifndef DOXYGEN
+/**
+ * @name    Default configuration parameters for ESP WiFi Enterprise netdev
+ * @{
+ */
+#ifndef ESP_WIFI_EAP_USER
+/** User name used in phase 2 (inner) EAP authentication. */
+#define ESP_WIFI_EAP_USER   "riot-os@riot-os.org"
+#endif /* ESP_WIFI_EAP_USER */
+
+#ifndef ESP_WIFI_EAP_PASS
+/** Password used in phase 2 (inner) EAP authentication. */
+#define ESP_WIFI_EAP_PASS   "riot-os"
+#endif /* ESP_WIFI_EAP_PASS */
+/** @} */
+#endif /* !DOXYGEN */
+
 /* include common board definitions as last step */
 #include "board_common.h"
 

--- a/boards/esp8266-olimex-mod/Makefile.dep
+++ b/boards/esp8266-olimex-mod/Makefile.dep
@@ -1,1 +1,22 @@
+# if compiled in CI, optional modules are selected for compile tests
+ifneq (,$(RIOT_CI_BUILD))
+  USEMODULE += esp_log_tagged
+  USEMODULE += esp_log_startup
+  USEMODULE += esp_qemu
+
+  ifneq (,$(filter periph_timer,$(USEMODULE)))
+    USEMODULE += esp_sw_timer
+  endif
+
+  ifneq (,$(filter netdev_default,$(USEMODULE)))
+    # if netdev_default is used, we use gnrc modules that are enabled
+    # in different examples to use different esp_wifi modules
+    ifeq (,$(filter gnrc_netif_single,$(USEMODULE)))
+      # if gnrc_netif_single module is not enabled, esp_wifi_ap is used
+      USEMODULE += esp_wifi_ap
+    endif
+  endif
+
+endif
+
 include $(RIOTBOARD)/common/esp8266/Makefile.dep

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -21,11 +21,9 @@ include $(RIOTCPU)/esp_common/Makefile.include
 TARGET_ARCH_ESP32 ?= xtensa-esp32-elf
 TARGET_ARCH ?= $(TARGET_ARCH_ESP32)
 
-PSEUDOMODULES += esp_eth_hw
 PSEUDOMODULES += esp_gdbstub
 PSEUDOMODULES += esp_hw_counter
 PSEUDOMODULES += esp_i2c_hw
-PSEUDOMODULES += esp_idf_newlib
 PSEUDOMODULES += esp_jtag
 PSEUDOMODULES += esp_rtc_timer_32k
 PSEUDOMODULES += esp_spi_ram

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -439,7 +439,7 @@ void IRAM hw_timer_handler(void* arg)
 
 int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    DEBUG("%s dev=%u freq=%lu cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
+    DEBUG("%s dev=%u freq=%u cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  HW_TIMER_NUMOF, -1);
     CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);

--- a/cpu/esp8266/periph/timer.c
+++ b/cpu/esp8266/periph/timer.c
@@ -382,7 +382,7 @@ void IRAM os_timer_handler (void* arg)
 
 int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    DEBUG("%s dev=%u freq=%lu cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
+    DEBUG("%s dev=%u freq=%u cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  OS_TIMER_NUMOF, -1);
     CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);


### PR DESCRIPTION
### Contribution description

A number of optional ESP modules (#12960) can be used by an application to select additional features of the ESP implementation. Since these optional ESP modules are not enabled by default, they are not covered by the compilation test in CI. This led to compilation issues in the past from time to time, for example #17305.

This PR adds some dependencies for two boards (an ESP8266 and an ESP32 board) that enable all these optional ESP modules when compiled in the CI. Some of these optional ESP models are used by these boards by default, others are only used in certain test applications depending on the use of other modules.

This PR is a try to solve the problem without the necessity to create copies of existing test applications for these optional modules like in PR #12971 or to define a new virtual board that uses them.

### Testing procedure

Compilation should succeed in CI.

### Issues/PRs references
