### PR TITLE
drivers: migrate some drivers to ztimer

### DIFF
--- a/drivers/ccs811/Kconfig
+++ b/drivers/ccs811/Kconfig
@@ -12,7 +12,9 @@ menuconfig MODULE_CCS811
     depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_USEC
+    select MODULE_ZTIMER_PERIPH_TIMER
 
 config MODULE_CCS811_FULL
     bool "Full functionalities"

--- a/drivers/ccs811/Makefile.dep
+++ b/drivers/ccs811/Makefile.dep
@@ -1,6 +1,7 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_i2c
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
 
 ifneq (,$(filter ccs811_full,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 
 #include "log.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "ccs811_regs.h"
 #include "ccs811.h"
@@ -82,11 +82,11 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
         /* enable low active reset signal */
         gpio_clear(dev->params.reset_pin);
         /* t_RESET (reset impuls) has to be at least 20 us, we wait 1 ms */
-        xtimer_usleep(1000);
+        ztimer_sleep(ZTIMER_USEC, 1000);
         /* disable low active reset signal */
         gpio_set(dev->params.reset_pin);
         /* t_START after reset is 1 ms, we wait 1 further ms */
-        xtimer_usleep(1000);
+        ztimer_sleep(ZTIMER_USEC, 1000);
     }
 
     if (gpio_is_valid(dev->params.wake_pin) &&
@@ -112,7 +112,7 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
     uint8_t status;
 
     /* wait 100 ms after the reset */
-    xtimer_usleep(100000);
+    ztimer_sleep(ZTIMER_USEC, 100000);
 
     /* get the status to check whether sensor is in bootloader mode */
     if (_reg_read(dev, CCS811_REG_STATUS, &status, 1) != CCS811_OK) {
@@ -139,7 +139,7 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
         }
 
         /* wait 100 ms after starting the app */
-        xtimer_usleep(100000);
+        ztimer_sleep(ZTIMER_USEC, 100000);
 
         /* get the status to check whether sensor switched to application mode */
         if (_reg_read(dev, CCS811_REG_STATUS, &status, 1) != CCS811_OK) {
@@ -482,7 +482,7 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
         /* wake the sensor with low active WAKE signal */
         gpio_clear(dev->params.wake_pin);
         /* t_WAKE is 50 us */
-        xtimer_usleep(50);
+        ztimer_sleep(ZTIMER_USEC, 50);
     }
 #endif
 
@@ -494,7 +494,7 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
         /* let the sensor enter to sleep mode */
         gpio_set(dev->params.wake_pin);
         /* minimum t_DWAKE is 20 us */
-        xtimer_usleep(20);
+        ztimer_sleep(ZTIMER_USEC, 20);
     }
 #endif
 
@@ -540,7 +540,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
         /* wake the sensor with low active WAKE signal */
         gpio_clear(dev->params.wake_pin);
         /* t_WAKE is 50 us */
-        xtimer_usleep(50);
+        ztimer_sleep(ZTIMER_USEC, 50);
     }
 #endif
 
@@ -557,7 +557,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
         /* let the sensor enter to sleep mode */
         gpio_set(dev->params.wake_pin);
         /* minimum t_DWAKE is 20 us */
-        xtimer_usleep(20);
+        ztimer_sleep(ZTIMER_USEC, 20);
     }
 #endif
 

--- a/drivers/lsm6dsl/Kconfig
+++ b/drivers/lsm6dsl/Kconfig
@@ -10,4 +10,5 @@ config MODULE_LSM6DSL
     depends on HAS_PERIPH_I2C
     depends on TEST_KCONFIG
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC

--- a/drivers/lsm6dsl/Makefile.dep
+++ b/drivers/lsm6dsl/Makefile.dep
@@ -1,2 +1,3 @@
 FEATURES_REQUIRED += periph_i2c
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec

--- a/drivers/lsm6dsl/include/lsm6dsl_internal.h
+++ b/drivers/lsm6dsl/include/lsm6dsl_internal.h
@@ -22,8 +22,6 @@
 #ifndef LSM6DSL_INTERNAL_H
 #define LSM6DSL_INTERNAL_H
 
-#include "xtimer.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -159,9 +157,9 @@ extern "C" {
 #define LSM6DSL_TEMP_OFFSET                 (0x1900)
 
 /**
- * @brief 	Reboot wait interval in us (15ms)
+ * @brief 	Reboot wait interval in ms (15ms)
  */
-#define LSM6DSL_BOOT_WAIT                   (15 * US_PER_MS)
+#define LSM6DSL_BOOT_WAIT_MS                (15)
 
 #ifdef __cplusplus
 }

--- a/drivers/lsm6dsl/lsm6dsl.c
+++ b/drivers/lsm6dsl/lsm6dsl.c
@@ -22,7 +22,7 @@
 
 #include <assert.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "lsm6dsl.h"
 #include "lsm6dsl_internal.h"
@@ -62,7 +62,7 @@ int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params)
     /* Reboot */
     i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL3_C, LSM6DSL_CTRL3_C_BOOT, 0);
 
-    xtimer_usleep(LSM6DSL_BOOT_WAIT);
+    ztimer_sleep(ZTIMER_MSEC, LSM6DSL_BOOT_WAIT_MS);
 
     if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_WHO_AM_I, &tmp, 0) < 0) {
         i2c_release(BUS);

--- a/drivers/si114x/Kconfig
+++ b/drivers/si114x/Kconfig
@@ -31,6 +31,7 @@ config MODULE_SI114X
     bool
     depends on HAS_PERIPH_I2C
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
 
 endif # TEST_KCONFIG

--- a/drivers/si114x/Makefile.dep
+++ b/drivers/si114x/Makefile.dep
@@ -1,2 +1,3 @@
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 FEATURES_REQUIRED += periph_i2c

--- a/drivers/si114x/include/si114x_internals.h
+++ b/drivers/si114x/include/si114x_internals.h
@@ -161,8 +161,8 @@ extern "C" {
 #define SI1145_ID                              (0x45)
 #define SI1146_ID                              (0x46)
 #define SI1147_ID                              (0x47)
-#define SI114X_STARTUP_TIME                    (25000UL) /* 25ms */
-#define SI114X_WAIT_10MS                       (10000UL) /* 10ms */
+#define SI114X_STARTUP_TIME_MS                 (25UL)   /**< startup time (25ms) */
+#define SI114X_WAIT_10MS                       (10UL)   /* 10ms */
 #define SI114X_INIT_VALUE                      (0x17)
 #define SI114X_UCOEF0_DEFAULT                  (0x29)
 #define SI114X_UCOEF1_DEFAULT                  (0x89)

--- a/drivers/si114x/si114x.c
+++ b/drivers/si114x/si114x.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "periph/i2c.h"
 
@@ -50,7 +50,7 @@ int8_t si114x_init(si114x_t *dev, const si114x_params_t *params)
     dev->params = *params;
 
     /* wait before sensor is ready */
-    xtimer_usleep(SI114X_STARTUP_TIME);
+    ztimer_sleep(ZTIMER_MSEC, SI114X_STARTUP_TIME_MS);
 
     /* acquire exclusive access */
     i2c_acquire(DEV_I2C);
@@ -178,12 +178,12 @@ void _reset(si114x_t *dev)
     /* perform RESET command */
     i2c_write_reg(DEV_I2C, SI114X_ADDR,
                   SI114X_REG_COMMAND, SI114X_RESET, 0);
-    xtimer_usleep(SI114X_WAIT_10MS);
+    ztimer_sleep(ZTIMER_MSEC, SI114X_WAIT_10MS);
 
     /* write HW_KEY for proper operation */
     i2c_write_reg(DEV_I2C, SI114X_ADDR,
                   SI114X_REG_HW_KEY, SI114X_INIT_VALUE, 0);
-    xtimer_usleep(SI114X_WAIT_10MS);
+    ztimer_sleep(ZTIMER_MSEC, SI114X_WAIT_10MS);
 }
 
 void _initialize(si114x_t *dev)

--- a/drivers/stmpe811/Kconfig
+++ b/drivers/stmpe811/Kconfig
@@ -9,9 +9,12 @@ config MODULE_STMPE811
     bool
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
+    depends on HAS_PERIPH_I2C
+    depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
     depends on TEST_KCONFIG
 
 choice

--- a/drivers/stmpe811/Makefile.dep
+++ b/drivers/stmpe811/Makefile.dep
@@ -8,4 +8,5 @@ ifneq (,$(filter stmpe811_i2c,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec

--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -20,7 +20,7 @@
 
 #include <inttypes.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #if IS_USED(MODULE_STMPE811_SPI)
 #include "periph/spi.h"
 #else
@@ -135,13 +135,13 @@ static int _soft_reset(const stmpe811_t *dev)
         DEBUG("[stmpe811] soft reset: cannot write soft reset bit to SYS_CTRL1 register\n");
         return -EPROTO;
     }
-    xtimer_msleep(10);
+    ztimer_sleep(ZTIMER_MSEC, 10);
 
     if (_write_reg(dev, STMPE811_SYS_CTRL1, 0) < 0) {
         DEBUG("[stmpe811] soft reset: cannot clear SYS_CTRL1 register\n");
         return -EPROTO;
     }
-    xtimer_msleep(2);
+    ztimer_sleep(ZTIMER_MSEC, 2);
 
     return 0;
 }

--- a/drivers/tsl2561/Kconfig
+++ b/drivers/tsl2561/Kconfig
@@ -10,4 +10,5 @@ config MODULE_TSL2561
     depends on HAS_PERIPH_I2C
     depends on TEST_KCONFIG
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC

--- a/drivers/tsl2561/Makefile.dep
+++ b/drivers/tsl2561/Makefile.dep
@@ -1,2 +1,3 @@
 FEATURES_REQUIRED += periph_i2c
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec

--- a/drivers/tsl2561/tsl2561.c
+++ b/drivers/tsl2561/tsl2561.c
@@ -25,7 +25,7 @@
 #include "tsl2561.h"
 #include "tsl2561_internals.h"
 #include "periph/i2c.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG        0
 #include "debug.h"
@@ -220,16 +220,16 @@ static void _read_data(const tsl2561_t *dev, uint16_t *full, uint16_t *ir)
 
     /* Wait integration time in ms for ADC to complete */
     switch (DEV_INTEGRATION) {
-        case TSL2561_INTEGRATIONTIME_13MS:
-            xtimer_usleep(13700);
+        case TSL2561_INTEGRATIONTIME_13MS: /* 13700us */
+            ztimer_sleep(ZTIMER_MSEC, 14);
             break;
 
         case TSL2561_INTEGRATIONTIME_101MS:
-            xtimer_usleep(101000);
+            ztimer_sleep(ZTIMER_MSEC, 101);
             break;
 
         default: /* TSL2561_INTEGRATIONTIME_402MS */
-            xtimer_usleep(402000);
+            ztimer_sleep(ZTIMER_MSEC, 402);
             break;
     }
 

--- a/tests/driver_ccs811/Makefile
+++ b/tests/driver_ccs811/Makefile
@@ -2,4 +2,7 @@ include ../Makefile.tests_common
 
 USEMODULE += ccs811
 
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ccs811/app.config.test
+++ b/tests/driver_ccs811/app.config.test
@@ -1,3 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_CCS811=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_USEC=y

--- a/tests/driver_ccs811/main.c
+++ b/tests/driver_ccs811/main.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "ccs811.h"
 #include "ccs811_params.h"
@@ -54,7 +54,7 @@ int main(void)
 
         /* wait and check for for new data every 10 ms */
         while (ccs811_data_ready (&sensor) != CCS811_OK) {
-            xtimer_usleep(10000);
+            ztimer_sleep(ZTIMER_USEC, 10000);
         }
 
         /* read the data and print them on success */

--- a/tests/driver_ccs811_full/main.c
+++ b/tests/driver_ccs811_full/main.c
@@ -35,7 +35,6 @@
 #include <string.h>
 
 #include "thread.h"
-#include "xtimer.h"
 
 #include "ccs811.h"
 #include "ccs811_params.h"

--- a/tests/driver_lsm6dsl/Makefile
+++ b/tests/driver_lsm6dsl/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += lsm6dsl
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lsm6dsl/app.config.test
+++ b/tests/driver_lsm6dsl/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_LSM6DSL=y
-CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y

--- a/tests/driver_lsm6dsl/main.c
+++ b/tests/driver_lsm6dsl/main.c
@@ -22,11 +22,11 @@
 
 #include <stdio.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "lsm6dsl.h"
 #include "lsm6dsl_params.h"
 
-#define SLEEP_USEC  (500UL * US_PER_MS)
+#define SLEEP_MSEC  (500UL)
 
 int main(void)
 {
@@ -55,7 +55,7 @@ int main(void)
     }
     puts("[SUCCESS]\n");
 
-    xtimer_sleep(1);
+    ztimer_sleep(ZTIMER_MSEC, 1 * 1000);
 
     puts("Powering up LSM6DSL sensor...");
     if (lsm6dsl_acc_power_up(&dev) != LSM6DSL_OK) {
@@ -95,7 +95,7 @@ int main(void)
         }
 
         puts("");
-        xtimer_usleep(SLEEP_USEC);
+        ztimer_sleep(ZTIMER_MSEC, SLEEP_MSEC);
     }
 
     return 0;

--- a/tests/driver_si114x/Makefile
+++ b/tests/driver_si114x/Makefile
@@ -1,5 +1,8 @@
 include ../Makefile.tests_common
 
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+
 # This test should also work with Si1146 and Si1147 variants.
 USEMODULE += si1145
 

--- a/tests/driver_si114x/app.config.test
+++ b/tests/driver_si114x/app.config.test
@@ -1,5 +1,8 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y
+
 # This test should also work with Si1146 and Si1147 variants.
 CONFIG_MODULE_SI1145=y

--- a/tests/driver_si114x/main.c
+++ b/tests/driver_si114x/main.c
@@ -25,7 +25,8 @@
 
 #include "si114x.h"
 #include "si114x_params.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "board.h"
 
 static si114x_t dev;
@@ -63,7 +64,7 @@ int main(void)
                si114x_read_response(&dev));
 
         /* 2 seconds delay between measures */
-        xtimer_sleep(2);
+        ztimer_sleep(ZTIMER_MSEC, 2 * MS_PER_SEC);
     }
 
     return 0;

--- a/tests/driver_stmpe811/Makefile.ci
+++ b/tests/driver_stmpe811/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/driver_tsl2561/Makefile
+++ b/tests/driver_tsl2561/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += tsl2561
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tsl2561/app.config.test
+++ b/tests/driver_tsl2561/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_TSL2561=y
-CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y

--- a/tests/driver_tsl2561/main.c
+++ b/tests/driver_tsl2561/main.c
@@ -21,13 +21,12 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "board.h"
 
 #include "tsl2561.h"
 #include "tsl2561_params.h"
-
-#define SLEEP_1S   (1 * 1000 * 1000u) /* 1 second delay between printf */
 
 int main(void)
 {
@@ -58,7 +57,7 @@ int main(void)
                "\n+-------------------------------------+\n",
                (int)tsl2561_read_illuminance(&dev));
 
-        xtimer_usleep(SLEEP_1S);
+        ztimer_sleep(ZTIMER_MSEC, MS_PER_SEC); /* 1s delay */
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates a few drivers to ztimer: ccs811, lsm6dsl, si114x, tsl2561 and stmpe811. Some changes were applied blindly using the coccinelle script, but build system dependencies needs to be adapted by hand anyway and sometimes the code needs manual adjustments.
Where possible, the code is adapted to use `ztimer_msec`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Corresponding test applications are still working. The drivers migrated by this PR were selected because I have this hardware so I can provide test output when I'm back at the office.

**test output:**

<details><summary>stmpe811</summary>

```
$ BUILD_IN_DOCKER=1 make -C tests/driver_stmpe811/ flash term --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/driver_stmpe811/' 'riot/riotbuild:latest' make     
Building application "tests_driver_stmpe811" for "stm32f429i-disc1" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/stm32f429i-disc1
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/stmpe811
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  14012	    156	   2508	  16676	   4124	/data/riotbuild/riotbase/tests/driver_stmpe811/bin/stm32f429i-disc1/tests_driver_stmpe811.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/driver_stmpe811/bin/stm32f429i-disc1/tests_driver_stmpe811.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0 (2021-11-22-14:28)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 2.850698
Warn : target stm32f4x.cpu examination failed
Error: jtag status contains invalid mode value - communication failure
Polling target stm32f4x.cpu failed, trying to reexamine
Examination failed, GDB will be halted. Polling again in 100ms
Info : Previous state query failed, trying to reconnect
Error: jtag status contains invalid mode value - communication failure
Polling target stm32f4x.cpu failed, trying to reexamine
Examination failed, GDB will be halted. Polling again in 300ms
Info : starting gdb server for stm32f4x.cpu on 0
Info : Listening on port 39973 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f4x.cpu       hla_target little stm32f4x.cpu       unknown

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Error: mem2array: Read @ 0xe0042004, w=4, cnt=1, failed
Error executing event examine-end on target stm32f4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:6: Error: 
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32f4x.cfg", line 85
in procedure 'mrw' called at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 36
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 6
Info : Previous state query failed, trying to reconnect
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000a44 msp: 0x20000200
Polling target stm32f4x.cpu failed, trying to reexamine
Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : device id = 0x20016419
Info : flash size = 2048 kbytes
Info : Dual Bank 2048 kiB STM32F42x/43x/469/479 found
auto erase enabled
wrote 16384 bytes from file /work/riot/RIOT/tests/driver_stmpe811/bin/stm32f429i-disc1/tests_driver_stmpe811.elf in 0.673389s (23.760 KiB/s)

verified 14168 bytes in 0.144796s (95.555 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-12-03 10:17:33,516 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2021-12-03 10:17:39,344 # main(): This is RIOT! (Version: 2022.01-devel-879-gf2eca2-pr/drivers/ztimer)
2021-12-03 10:17:39,350 # STMPE811 test application
2021-12-03 10:17:39,350 # 
2021-12-03 10:17:39,352 # +------------Initializing------------+
2021-12-03 10:17:39,372 # Initialization successful
2021-12-03 10:17:40,950 # Pressed!
2021-12-03 10:17:40,956 # X: 92, Y:199
2021-12-03 10:17:40,962 # X: 92, Y:199
2021-12-03 10:17:40,974 # Released!
2021-12-03 10:17:41,563 # Pressed!
2021-12-03 10:17:41,563 # X: 106, Y:166
2021-12-03 10:17:41,623 # Released!
2021-12-03 10:17:41,959 # Pressed!
2021-12-03 10:17:41,966 # X: 58, Y:250
2021-12-03 10:17:42,355 # Released!
2021-12-03 10:17:42,361 # Pressed!
2021-12-03 10:17:42,367 # X: 122, Y:152
2021-12-03 10:17:42,374 # Released!
2021-12-03 10:17:42,379 # Pressed!
2021-12-03 10:17:42,379 # X: 130, Y:158
2021-12-03 10:17:42,559 # Released!
2021-12-03 10:17:43,153 # Pressed!
2021-12-03 10:17:43,159 # X: 58, Y:121
2021-12-03 10:17:43,783 # Released!
2021-12-03 10:17:44,167 # Pressed!
2021-12-03 10:17:44,168 # X: 34, Y:267
2021-12-03 10:17:44,401 # Released!
2021-12-03 10:17:44,779 # Pressed!
2021-12-03 10:17:44,785 # X: 31, Y:241
2021-12-03 10:17:45,337 # Released!
2021-12-03 10:17:45,667 # Pressed!
2021-12-03 10:17:45,679 # X: 26, Y:46
2021-12-03 10:17:45,685 # X: 25, Y:47
2021-12-03 10:17:45,847 # Released!
2021-12-03 10:17:46,123 # Pressed!
2021-12-03 10:17:46,129 # X: 112, Y:126
2021-12-03 10:17:46,273 # Released!
2021-12-03 10:17:47,548 # Exiting Pyterm
```

</details>

<details><summary>tsl2561</summary>

```
$ BUILD_IN_DOCKER=1 make -C tests/driver_tsl2561/ flash term --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/driver_tsl2561/' 'riot/riotbuild:latest' make     
Building application "tests_driver_tsl2561" for "samr21-xpro" with MCU "samd21".

"make" -C /data/riotbuild/riotbase/boards/samr21-xpro
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/samd21
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/sam0_common
"make" -C /data/riotbuild/riotbase/cpu/sam0_common/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/tsl2561
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  13376	    112	   2428	  15916	   3e2c	/data/riotbuild/riotbase/tests/driver_tsl2561/bin/samr21-xpro/tests_driver_tsl2561.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
/work/riot/RIOT/dist/tools/edbg/edbg.sh flash /work/riot/RIOT/tests/driver_tsl2561/bin/samr21-xpro/tests_driver_tsl2561.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004653 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x4 expected 0xe5, read 0x11
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004653 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming..... done.
Verification..... done.
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-12-03 10:27:04,014 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2021-12-03 10:27:05,018 # Illuminance [lx]: 111
2021-12-03 10:27:05,019 # 
2021-12-03 10:27:05,021 # +-------------------------------------+
2021-12-03 10:27:05,861 # Illuminance [lx]: 110
2021-12-03 10:27:05,862 # 
2021-12-03 10:27:05,865 # +-------------------------------------+
2021-12-03 10:27:07,280 # Illuminance [lx]: 111
2021-12-03 10:27:07,280 # 
2021-12-03 10:27:07,283 # +-------------------------------------+
2021-12-03 10:27:08,693 # Illuminance [lx]: 111
2021-12-03 10:27:08,693 # 
2021-12-03 10:27:08,697 # +-------------------------------------+
2021-12-03 10:27:10,106 # Illuminance [lx]: 96
2021-12-03 10:27:10,106 # 
2021-12-03 10:27:10,109 # +-------------------------------------+
2021-12-03 10:27:11,519 # Illuminance [lx]: 96
2021-12-03 10:27:11,519 # 
2021-12-03 10:27:11,522 # +-------------------------------------+
2021-12-03 10:27:12,932 # Illuminance [lx]: 1
2021-12-03 10:27:12,932 # 
2021-12-03 10:27:12,935 # +-------------------------------------+
2021-12-03 10:27:14,345 # Illuminance [lx]: 97
2021-12-03 10:27:14,345 # 
2021-12-03 10:27:14,348 # +-------------------------------------+
2021-12-03 10:27:15,758 # Illuminance [lx]: 306
2021-12-03 10:27:15,758 # 
2021-12-03 10:27:15,761 # +-------------------------------------+
2021-12-03 10:27:16,802 # Exiting Pyterm
```

</details>

<details><summary>si1145</summary>

```
$ BUILD_IN_DOCKER=1 make -C tests/driver_si114x/ flash term --no-print-directory
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/driver_si114x/' 'riot/riotbuild:latest' make     
Building application "tests_driver_si114x" for "samr21-xpro" with MCU "samd21".

"make" -C /data/riotbuild/riotbase/boards/samr21-xpro
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/samd21
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/sam0_common
"make" -C /data/riotbuild/riotbase/cpu/sam0_common/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/si114x
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  14284	    112	   2436	  16832	   41c0	/data/riotbuild/riotbase/tests/driver_si114x/bin/samr21-xpro/tests_driver_si114x.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] edbg binary successfully built!
/work/riot/RIOT/dist/tools/edbg/edbg.sh flash /work/riot/RIOT/tests/driver_si114x/bin/samr21-xpro/tests_driver_si114x.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800001644 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev B)
Verification...
at address 0x4 expected 0x0d, read 0x79
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800001644 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev B)
Programming..... done.
Verification..... done.
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-12-03 10:28:46,037 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2021-12-03 10:28:47,039 # Initialization successful
2021-12-03 10:28:47,040 # +--------Starting Measurements--------+
2021-12-03 10:28:47,040 # 
2021-12-03 10:28:47,040 # UV index: 0
2021-12-03 10:28:47,040 # IR light [lx]: 261
2021-12-03 10:28:47,041 # Visible light [lx]: 260
2021-12-03 10:28:47,041 # Distance [cnt]: 256
2021-12-03 10:28:47,041 # Response: 0x0e
2021-12-03 10:28:47,041 # 
2021-12-03 10:28:47,042 # +-------------------------------------+
2021-12-03 10:28:48,076 # UV index: 0
2021-12-03 10:28:48,078 # IR light [lx]: 260
2021-12-03 10:28:48,080 # Visible light [lx]: 261
2021-12-03 10:28:48,082 # Distance [cnt]: 256
2021-12-03 10:28:48,083 # Response: 0x0e
2021-12-03 10:28:48,084 # 
2021-12-03 10:28:48,087 # +-------------------------------------+
2021-12-03 10:28:50,092 # UV index: 0
2021-12-03 10:28:50,094 # IR light [lx]: 260
2021-12-03 10:28:50,096 # Visible light [lx]: 261
2021-12-03 10:28:50,098 # Distance [cnt]: 256
2021-12-03 10:28:50,100 # Response: 0x0e
2021-12-03 10:28:50,100 # 
2021-12-03 10:28:50,103 # +-------------------------------------+
2021-12-03 10:28:52,109 # UV index: 0
2021-12-03 10:28:52,110 # IR light [lx]: 260
2021-12-03 10:28:52,112 # Visible light [lx]: 261
2021-12-03 10:28:52,114 # Distance [cnt]: 256
2021-12-03 10:28:52,116 # Response: 0x0e
2021-12-03 10:28:52,116 # 
2021-12-03 10:28:52,119 # +-------------------------------------+
2021-12-03 10:28:54,125 # UV index: 0
2021-12-03 10:28:54,127 # IR light [lx]: 268
2021-12-03 10:28:54,129 # Visible light [lx]: 264
2021-12-03 10:28:54,131 # Distance [cnt]: 256
2021-12-03 10:28:54,132 # Response: 0x0e
2021-12-03 10:28:54,132 # 
2021-12-03 10:28:54,135 # +-------------------------------------+
2021-12-03 10:28:56,141 # UV index: 0
2021-12-03 10:28:56,143 # IR light [lx]: 254
2021-12-03 10:28:56,145 # Visible light [lx]: 260
2021-12-03 10:28:56,147 # Distance [cnt]: 257
2021-12-03 10:28:56,148 # Response: 0x0e
```

</details>

<details><summary>lsm6dsl</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=b-l475e-iot01a -C tests/driver_lsm6dsl flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=b-l475e-iot01a'  -w '/data/riotbuild/riotbase/tests/driver_lsm6dsl/' 'riot/riotbuild:latest' make 'BOARD=b-l475e-iot01a'    
Building application "tests_driver_lsm6dsl" for "b-l475e-iot01a" with MCU "stm32".

[INFO] updating stm32cmsis /data/riotbuild/riotbase/build/stm32/cmsis/l4/.pkg-state.git-downloaded
echo 26ed4846f831f730d852507e178061053e522daf   > /data/riotbuild/riotbase/build/stm32/cmsis/l4/.pkg-state.git-downloaded
[INFO] patch stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/b-l475e-iot01a
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/lsm6dsl
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/frac
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  14660	    112	   2440	  17212	   433c	/data/riotbuild/riotbase/tests/driver_lsm6dsl/bin/b-l475e-iot01a/tests_driver_lsm6dsl.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/driver_lsm6dsl/bin/b-l475e-iot01a/tests_driver_lsm6dsl.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0 (2021-11-22-14:28)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.244825
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 33439 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000830 msp: 0x20000200
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev 4 : 0x1007)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Info : Padding image section 1 at 0x080039b4 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x080039b8 .. 0x08003fff
auto erase enabled
wrote 14776 bytes from file /work/riot/RIOT/tests/driver_lsm6dsl/bin/b-l475e-iot01a/tests_driver_lsm6dsl.elf in 0.894577s (16.130 KiB/s)

verified 14772 bytes in 0.539307s (26.749 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2021-12-02 09:40:02,286 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2021-12-02 09:40:03,291 # Powering up LSM6DSL sensor...
2021-12-02 09:40:03,292 # [SUCCESS]
2021-12-02 09:40:03,292 # 
2021-12-02 09:40:03,293 # Accelerometer x: 0 y: 0 z: 0
2021-12-02 09:40:03,294 # Gyroscope x: 0 y: 0 z: 0
2021-12-02 09:40:03,295 # Temperature [in °C x 100]: 1954 
2021-12-02 09:40:03,296 # 
2021-12-02 09:40:03,705 # Accelerometer x: -6 y: -119 z: 1045
2021-12-02 09:40:03,714 # Gyroscope x: -8 y: -14 z: 5
2021-12-02 09:40:03,719 # Temperature [in °C x 100]: 1965 
2021-12-02 09:40:03,720 # 
2021-12-02 09:40:04,229 # Accelerometer x: -6 y: -117 z: 1047
2021-12-02 09:40:04,238 # Gyroscope x: -6 y: -13 z: 5
2021-12-02 09:40:04,243 # Temperature [in °C x 100]: 1967 
2021-12-02 09:40:04,244 # 
2021-12-02 09:40:04,753 # Accelerometer x: -6 y: -118 z: 1048
2021-12-02 09:40:04,762 # Gyroscope x: -7 y: -13 z: 5
2021-12-02 09:40:04,767 # Temperature [in °C x 100]: 1971 
2021-12-02 09:40:04,767 # 
2021-12-02 09:40:05,276 # Accelerometer x: -5 y: -118 z: 1048
2021-12-02 09:40:05,285 # Gyroscope x: -7 y: -13 z: 5
2021-12-02 09:40:05,290 # Temperature [in °C x 100]: 1977 
```

</details>

Something doens't work with my ccs811 sensor (also on master)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
