### PR TITLE
cord_ep_standalone: add a fire-and-forget version of cord_ep_register()

### DIFF
--- a/sys/include/net/cord/ep_standalone.h
+++ b/sys/include/net/cord/ep_standalone.h
@@ -71,6 +71,26 @@ void cord_ep_standalone_run(void);
 void cord_ep_standalone_reg_cb(cord_ep_standalone_cb_t cb);
 
 /**
+ * @brief   Provide the RD address and initiate EP registration
+ *
+ *
+ * This is a fire and forget version of cord_ep_register().
+ * It returns immediately.
+ * The background thread attempts to register to the given RD address.
+ * The success status can be obtained by the registered calback function.
+ *
+ * @see cord_ep_register()
+ *
+ * @pre                     @p remote != NULL
+ *
+ * @param[in] remote    remote endpoint of the target RD
+ * @param[in] regif     registration interface resource of the RD, it will be
+ *                      discovered automatically when set to NULL
+ *
+ */
+void cord_ep_standalone_register(sock_udp_ep_t *remote, char *regif);
+
+/**
  * @brief   Signal the cord_ep thread about connection status change
  *
  * @note    This function should not be called by a user, but it is called from

--- a/sys/include/net/cord/ep_standalone.h
+++ b/sys/include/net/cord/ep_standalone.h
@@ -77,7 +77,7 @@ void cord_ep_standalone_reg_cb(cord_ep_standalone_cb_t cb);
  * This is a fire and forget version of cord_ep_register().
  * It returns immediately.
  * The background thread attempts to register to the given RD address.
- * The success status can be obtained by the registered calback function.
+ * The success status can be obtained by the registered callback function.
  *
  * @see cord_ep_register()
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description


This PR adds a the function `void cord_ep_standalone_register(sock_udp_ep_t *remote, char *regif)` to the submodule `cord_ep_standalone`. 
It uses the background thread of the standalone module, so the function operates asynchronously.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

In the example `examples/cord_ep`, put the following code before the `shell_run()` call.

Replace `CONFIG_RD_PORT` with the port number of the RD, and `CONFIG_RD_ADDR` with the IPv6 address of the RD (as string constant). 

The node should register with the RD on startup, and a success message should show up tin the node's terminal.

```
    /* register endpoint at RD */
    sock_udp_ep_t remote;
    ipv6_addr_t addr;
    remote.family = AF_INET6;
    remote.netif = SOCK_ADDR_ANY_NETIF;
    if (ipv6_addr_from_str(&addr, CONFIG_RD_ADDR) == NULL) {
        puts("unable to parse RD address");
    }
    memcpy(remote.addr.ipv6, &addr.u8[0], sizeof(addr.u8));
    remote.port = CONFIG_RD_PORT;
    cord_ep_standalone_register(&remote, NULL);
```
When testing on `native`, I had to replace `SOCK_ADDR_ANY_NETIF` with the actual interface id, too. I have used the IPv6 address of the `tapbr` interface.