### PR TITLE
sys/Makefile.dep: fix event periodic dependency

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -525,8 +525,8 @@ ifneq (,$(filter event_timeout,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter event_periodic_timeout,$(USEMODULE)))
-  USEMODULE += event_timeout
+ifneq (,$(filter event_periodic,$(USEMODULE)))
+  USEMODULE += event_timeout_ztimer
   USEMODULE += ztimer_periodic
 endif
 


### PR DESCRIPTION
### Contribution description

It seems in the original PR the dependency was not adapted to the name change. Also this module depends on ztimer, there is no need for `event_timeout`.

### Testing procedure

- green murdock
