### PR TITLE
cpu/qn908x: migrate ADC periph to ztimer

### DIFF
--- a/cpu/qn908x/Makefile.dep
+++ b/cpu/qn908x/Makefile.dep
@@ -14,4 +14,9 @@ ifneq (,$(filter periph_uart periph_i2c periph_spi,$(USEMODULE)))
   USEMODULE += periph_flexcomm
 endif
 
+ifneq (,$(filter periph_adc,$(USEMODULE)))
+  USEMODULE += ztimer
+  USEMODULE += ztimer_usec
+endif
+
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/qn908x/periph/Kconfig
+++ b/cpu/qn908x/periph/Kconfig
@@ -17,3 +17,10 @@ config MODULE_PERIPH_GPIO_MUX
     depends on TEST_KCONFIG
     help
       Common Pin MUX functions for qn908x CPUs.
+
+config MODULE_PERIPH_ADC
+    bool "ADC peripheral driver"
+    depends on HAS_PERIPH_ADC
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_USEC
+    select MODULE_ZTIMER_PERIPH_TIMER

--- a/cpu/qn908x/periph/adc.c
+++ b/cpu/qn908x/periph/adc.c
@@ -41,7 +41,7 @@
 #include "bitarithm.h"
 #include "cpu.h"
 #include "mutex.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "gpio_mux.h"
 #include "periph/adc.h"
@@ -142,7 +142,7 @@ int adc_init(adc_t line)
         /* Need to wait 100 us before the ADC can be used for sampling. We could
          * in theory avoid this wait since it is only needed before adc_sample()
          * is called but it is short enough that it is safer to include it. */
-        xtimer_usleep(100u);
+        ztimer_sleep(ZTIMER_USEC, 100u);
 
         /* Enable the ADC clock so we can use the ADC. */
         CLOCK_EnableClock(kCLOCK_Adc);
@@ -278,7 +278,7 @@ int32_t adc_sample(adc_t line, adc_res_t res) {
         ADC_CFG_SCAN_INTV(4); /* Switching ADC source every 32 clock cycles. */
 
     /* Need to wait for one ADC cycle before it can be started. */
-    xtimer_usleep(adc_clock_cycle_us[QN908X_ADC_CLOCK]);
+    ztimer_sleep(ZTIMER_USEC, adc_clock_cycle_us[QN908X_ADC_CLOCK]);
 
     /* Configure the destination of the ADC value read from the interrupt. */
     volatile int32_t adc_data = 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR migrates the ADC implementation of the qn908x cpu to ztimer. The missing dependency resolution is also added.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- `tests/periph_adc` should still work on this platform (but I can't test unfortunately). Maybe @iosabi you can give this a try ?

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
