### PR TITLE
tests/malloc: fix counting bugs

### DIFF
--- a/tests/malloc/main.c
+++ b/tests/malloc/main.c
@@ -84,7 +84,7 @@ static void free_memory(struct node *head)
 
     while (head) {
         if (head->ptr) {
-            if (total > CHUNK_SIZE) {
+            if (total >= CHUNK_SIZE) {
                 total -= CHUNK_SIZE;
                 freed++;
             }


### PR DESCRIPTION
### Contribution description

There is a corner cases in which the counting of allocated memory
previously was wrong: When the allocation of the chunk succeeded but the
allocation of the next struct  node fails. This was relatively unlikely
to happen, as the chunk size was much bigger than the memory required by
the struct node. But it happens on the ESP32 boards resulting in failing
nightlies. This fixes the issue.

### Testing procedure

The test should now succeed on both ESP32 and non ESP32 boards.

### Issues/PRs references

None