### PR TITLE
boards/nrf9160dk: fix LED macros

### DIFF
--- a/boards/nrf9160dk/include/board.h
+++ b/boards/nrf9160dk/include/board.h
@@ -54,20 +54,20 @@ extern "C" {
 
 #define LED_PORT            (NRF_P0_S) /**< Default LED PORT */
 
-#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK) /**< LED0 ON macro */
-#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK) /**< LED0 OFF macro */
+#define LED0_ON             (LED_PORT->OUTSET = LED0_MASK) /**< LED0 ON macro */
+#define LED0_OFF            (LED_PORT->OUTCLR = LED0_MASK) /**< LED0 OFF macro */
 #define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK) /**< LED0 toggle macro */
 
-#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK) /**< LED1 ON macro */
-#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK) /**< LED1 OFF macro */
+#define LED1_ON             (LED_PORT->OUTSET = LED1_MASK) /**< LED1 ON macro */
+#define LED1_OFF            (LED_PORT->OUTCLR = LED1_MASK) /**< LED1 OFF macro */
 #define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK) /**< LED1 toggle macro */
 
-#define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK) /**< LED2 ON macro */
-#define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK) /**< LED2 OFF macro */
+#define LED2_ON             (LED_PORT->OUTSET = LED2_MASK) /**< LED2 ON macro */
+#define LED2_OFF            (LED_PORT->OUTCLR = LED2_MASK) /**< LED2 OFF macro */
 #define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK) /**< LED2 toggle macro */
 
-#define LED3_ON             (LED_PORT->OUTCLR = LED3_MASK) /**< LED3 ON macro */
-#define LED3_OFF            (LED_PORT->OUTSET = LED3_MASK) /**< LED3 OFF macro */
+#define LED3_ON             (LED_PORT->OUTSET = LED3_MASK) /**< LED3 ON macro */
+#define LED3_OFF            (LED_PORT->OUTCLR = LED3_MASK) /**< LED3 OFF macro */
 #define LED3_TOGGLE         (LED_PORT->OUT   ^= LED3_MASK) /**< LED3 toggle macro */
 /** @} */
 


### PR DESCRIPTION
### Contribution description
LED macros were inverted, so `LEDn_ON` would turn the LED off and `LEDn_OFF` would turn it on.
From the board [HW user guide](https://infocenter.nordicsemi.com/pdf/nRF9160_DK_HW_User_Guide_v1.0.0.pdf) (p. 25): 
> The LEDs are active high, meaning that writing a logical one ('1') to the output pin will illuminate the LED.

I confirmed this locally.

### Testing procedure
- Using `tests/leds` you should see one LED blinking at a time and the rest off. On master the the rest of the LEDs are on.

### Issues/PRs references
#16650
