### PR TITLE
ieee802154 / tests/unittests: fix all-asan reported errors

### DIFF
--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -182,7 +182,8 @@ int ieee802154_get_src(const uint8_t *mhr, uint8_t *src, le_uint16_t *src_pan)
 
     tmp = mhr[1] & IEEE802154_FCF_SRC_ADDR_MASK;
     if (tmp != IEEE802154_FCF_SRC_ADDR_VOID) {
-        if (!(mhr[0] & IEEE802154_FCF_PAN_COMP)) {
+        if (!(mhr[0] & IEEE802154_FCF_PAN_COMP) &&
+            (tmp != IEEE802154_FCF_SRC_ADDR_RESV)) {
             src_pan->u8[0] = mhr[offset++];
             src_pan->u8[1] = mhr[offset++];
         }

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -608,15 +608,19 @@ static void test_ieee802154_get_src_dst2_src0(void)
 
 static void test_ieee802154_get_src_dst2_src0_pancomp(void)
 {
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
     const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP,
                             IEEE802154_FCF_DST_ADDR_SHORT |
                             IEEE802154_FCF_SRC_ADDR_VOID,
-                            TEST_UINT8 };
+                            TEST_UINT8,
+                            /* source PAN is dest. PAN due to compression */
+                            exp_pan.u8[0], exp_pan.u8[1] };
     uint8_t res_addr;
     le_uint16_t res_pan;
 
     TEST_ASSERT_EQUAL_INT(0,
                           ieee802154_get_src(mhr, &res_addr, &res_pan));
+    TEST_ASSERT_EQUAL_INT(exp_pan.u16, res_pan.u16);
 }
 
 static void test_ieee802154_get_src_dst2_src2(void)
@@ -729,15 +733,19 @@ static void test_ieee802154_get_src_dst8_src0(void)
 
 static void test_ieee802154_get_src_dst8_src0_pancomp(void)
 {
+    const le_uint16_t exp_pan = byteorder_htols(TEST_UINT16 + 1);
     const uint8_t mhr[] = { IEEE802154_FCF_PAN_COMP,
                             IEEE802154_FCF_DST_ADDR_LONG |
                             IEEE802154_FCF_SRC_ADDR_VOID,
-                            TEST_UINT8 };
+                            TEST_UINT8,
+                            /* source PAN is dest. PAN due to compression */
+                            exp_pan.u8[0], exp_pan.u8[1] };
     uint8_t res_addr;
     le_uint16_t res_pan;
 
     TEST_ASSERT_EQUAL_INT(0,
                           ieee802154_get_src(mhr, &res_addr, &res_pan));
+    TEST_ASSERT_EQUAL_INT(exp_pan.u16, res_pan.u16);
 }
 
 static void test_ieee802154_get_src_dst8_src2(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
In current master, when running `make -C tests/unittests all-asan tests-ieee802154` and the `make -C tests/unittests test`, the address sanitizer reports several stack-buffer overflows within `sys/net/link_layer/ieee802154/ieee802154.c`. While some of these errors are indeed too short test vectors within the unittests, it also revealed a parser bug in `ieee802154_get_src()`, when it tries to read a PAN ID for a source address in reserved mode (which is unspecified behavior and also reported by the function with an `-EINVAL` as such, but it still tries to read the PAN ID which is not there).  
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
make -C tests/unittests all-asan tests-ieee802154
make -C tests/unittests test
```

should succeed for this PR's HEAD.

```sh
make -C tests/unittests tests-ieee802154
make -C tests/unittests test
```

should suceed on each commit of this PR.

(note that `test` needs to be run in a separate instance of `make`, since it has not `tests-ieee802154` as a dependency and thus tries to run the test before it is built)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
