### PR TITLE
sys/ztimer: add convenience functions for sleeping

### DIFF
--- a/cpu/stm32/periph/adc_f3.c
+++ b/cpu/stm32/periph/adc_f3.c
@@ -143,13 +143,7 @@ int adc_init(adc_t line)
     if (!(dev(line)->CR & ADC_CR_ADEN)) {
         /* Enable ADC internal voltage regulator and wait for startup period */
         dev(line)->CR |= ADC_CR_ADVREGEN;
-#if IS_USED(MODULE_ZTIMER_USEC)
-        ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
-#else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
-#endif
+        ztimer_sleep_usecs_relaxed(ADC_T_ADCVREG_STUP_US);
 
         if (dev(line)->DIFSEL & (1 << adc_config[line].chan)) {
             /* Configure calibration for differential inputs */

--- a/cpu/stm32/periph/adc_l4.c
+++ b/cpu/stm32/periph/adc_l4.c
@@ -147,13 +147,7 @@ int adc_init(adc_t line)
 
         /* enable ADC internal voltage regulator and wait for startup period */
         dev(line)->ADC_CR_REG |= (ADC_CR_ADVREGEN);
-#if IS_USED(MODULE_ZTIMER_USEC)
-        ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
-#else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
-#endif
+        ztimer_sleep_usecs_relaxed(ADC_T_ADCVREG_STUP_US);
 
         /* configure calibration for single ended input */
         dev(line)->ADC_CR_REG &= ~(ADC_CR_ADCALDIF);

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -83,13 +83,7 @@ int adc_init(adc_t line)
 
         /* enable ADC internal voltage regulator and wait for startup period */
         ADC->CR |= (ADC_CR_ADVREGEN);
-#if IS_USED(MODULE_ZTIMER_USEC)
-        ztimer_sleep(ZTIMER_USEC, ADC_T_ADCVREG_STUP_US);
-#else
-        /* to avoid using ZTIMER_USEC unless already included round up the
-           internal voltage regulator start up to 1ms */
-        ztimer_sleep(ZTIMER_MSEC, 1);
-#endif
+        ztimer_sleep_usecs_relaxed(ADC_T_ADCVREG_STUP_US);
 
         /* ´start automatic calibration and wait for it to complete */
         ADC->CR |= ADC_CR_ADCAL;

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -829,6 +829,16 @@ static inline void _ztimer_sleep_scale_down(ztimer_clock_t *clock,
 }
 
 /**
+ * @name        Sleep functions with relaxed requirements
+ *
+ * Use these functions to automatically select the most suitable (in terms of
+ * resolution) clock out of the given clocks automatically. This may result
+ * in a significantly reduced resolution and longer sleeps that requested.
+ * However, sleeps are rounded up to sleep at least the requested duration.
+ *
+ * @{
+ */
+/**
  * @brief       Sleep at least for the given amount of microseconds with relaxed
  *              requirements
  * @param[in]   usecs       Number of microseconds to sleep
@@ -899,6 +909,8 @@ static inline void ztimer_sleep_secs_relaxed(uint32_t secs)
         _ztimer_sleep_scale_up(ZTIMER_USEC, secs, US_PER_SEC);
     }
 }
+/** @} */ /* Group relaxed sleep functions */
+
 /** @} */
 
 #ifdef __cplusplus

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -112,38 +112,19 @@ static inline uint32_t xtimer_now_usec(void)
     return ztimer_now(ZTIMER_USEC);
 }
 
-static inline void _ztimer_sleep_scale(ztimer_clock_t *clock, uint32_t time,
-                                       uint32_t scale)
+static inline uint64_t xtimer_now_usec64(void)
 {
-    const uint32_t max_sleep = UINT32_MAX / scale;
-
-    while (time > max_sleep) {
-        ztimer_sleep(clock, max_sleep * scale);
-        time -= max_sleep;
-    }
-
-    ztimer_sleep(clock, time * scale);
+    return ztimer_now(ZTIMER_USEC);
 }
 
 static inline void xtimer_sleep(uint32_t seconds)
 {
-    /* TODO: use ZTIMER_SEC */
-    if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
-        _ztimer_sleep_scale(ZTIMER_MSEC, seconds, MS_PER_SEC);
-    }
-    else {
-        _ztimer_sleep_scale(ZTIMER_USEC, seconds, US_PER_SEC);
-    }
+    ztimer_sleep_secs_relaxed(seconds);
 }
 
 static inline void xtimer_msleep(uint32_t milliseconds)
 {
-    if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
-        ztimer_sleep(ZTIMER_MSEC, milliseconds);
-    }
-    else {
-        _ztimer_sleep_scale(ZTIMER_USEC, milliseconds, US_PER_MS);
-    }
+    ztimer_sleep_msecs_relaxed(milliseconds);
 }
 
 static inline void xtimer_usleep(uint32_t microseconds)
@@ -153,7 +134,7 @@ static inline void xtimer_usleep(uint32_t microseconds)
 
 static inline void xtimer_nanosleep(uint32_t nanoseconds)
 {
-    ztimer_sleep(ZTIMER_USEC, nanoseconds / NS_PER_US);
+    _ztimer_sleep_scale_down(ZTIMER_USEC, nanoseconds, NS_PER_US);
 }
 
 static inline void xtimer_tsleep32(xtimer_ticks32_t ticks)


### PR DESCRIPTION
### Contribution description

This adds three additional wrapper-convenience functions for when drivers have relaxed requirements and don't want to pull in additional clocks, but rather use whatever clock is available.

The xtimer compat code and the STM32 ADC drivers are added as the first users of the new convenience API.

### Testing procedure

Sleeping for minimum durations specified in usecs, msecs, and secs should work now regardless of which ztimer clocks are available, as long at least one is present. If multiple options are present, the most suitable clock should be used.

### Issues/PRs references

None