### PR TITLE
gnrc/rpl: auto-init RPL if there is only a single interface

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -28,7 +28,7 @@
 
 void auto_init_gnrc_rpl(void)
 {
-    if (gnrc_netif_highlander()) {
+    if (gnrc_netif_highlander() || gnrc_netif_numof() == 1) {
         gnrc_netif_t *netif = gnrc_netif_iter(NULL);
         if (netif == NULL) {
             /* XXX this is just a work-around ideally this would happen with


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If there is only a single interface, we can auto-init RPL without an additional user supplied define. 
Handle this the same as the `gnrc_netif_highlander()` case. 

### Testing procedure

Run `examples/gnrc_networking`. You now don't have to specify

    CFLAGS=-DCONFIG_GNRC_RPL_DEFAULT_NETIF=7 

anymore to auto-start RPL.

#### master

```
> rpl
RPL not initializied
```

#### this PR

```
> rpl
instance table:	[ ]	
parent table:	[ ]	[ ]	[ ]	
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
