### PR TITLE
nimble: fix nimble_scanner regression bugs

### DIFF
--- a/pkg/nimble/autoconn/nimble_autoconn.c
+++ b/pkg/nimble/autoconn/nimble_autoconn.c
@@ -300,7 +300,9 @@ int nimble_autoconn_update(const nimble_autoconn_params_t *params,
     nimble_scanner_cfg_t scan_params;
     scan_params.itvl_ms = params->scan_itvl;
     scan_params.win_ms = params->scan_win;
-    scan_params.flags = NIMBLE_SCANNER_FILTER_DUPS;
+    scan_params.flags = NIMBLE_SCANNER_PASSIVE
+                        | NIMBLE_SCANNER_FILTER_DUPS
+                        | NIMBLE_SCANNER_PHY_1M;
 
     /* set the advertising parameters used */
     _adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;

--- a/pkg/nimble/rpble/nimble_rpble.c
+++ b/pkg/nimble/rpble/nimble_rpble.c
@@ -304,7 +304,9 @@ int nimble_rpble_param_update(const nimble_rpble_cfg_t *cfg)
     nimble_scanner_cfg_t scan_params = { 0 };
     scan_params.itvl_ms = cfg->scan_itvl_ms;
     scan_params.win_ms = cfg->scan_win_ms;
-    scan_params.flags = (NIMBLE_SCANNER_PASSIVE | NIMBLE_SCANNER_FILTER_DUPS);
+    scan_params.flags = NIMBLE_SCANNER_PASSIVE
+                        | NIMBLE_SCANNER_FILTER_DUPS
+                        | NIMBLE_SCANNER_PHY_1M;
     nimble_scanner_init(&scan_params, _on_scan_evt);
 
     /* start to look for parents */

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -159,7 +159,8 @@ static inline bool nimble_scanner_is_active(void)
  *
  *          If there is an active scanning process, it will be restarted.
  *
- * @param[in]  duration_ms  duration of scanning procedure in ms
+ * @param[in]  duration_ms  duration of scanning procedure in ms, set to
+ *                          BLE_HS_FOREVER to scan without time limit
  */
 void nimble_scanner_set_scan_duration(int32_t duration_ms);
 

--- a/pkg/nimble/scanner/nimble_scanner.c
+++ b/pkg/nimble/scanner/nimble_scanner.c
@@ -103,13 +103,16 @@ int nimble_scanner_start(void)
         const struct ble_gap_ext_disc_params *coded =
             (_scan_flags & NIMBLE_SCANNER_PHY_CODED) ? &_scan_params : NULL;
 
+        int32_t dur = (_scan_duration == BLE_HS_FOREVER) ? 0
+                                                         : _scan_duration / 10;
+
         int res = ble_gap_ext_disc(nimble_riot_own_addr_type,
-                                   _scan_duration / 10, 0, dups,
+                                   dur, 0, dups,
                                    BLE_HCI_SCAN_FILT_NO_WL, limited,
                                    uncoded, coded,
                                    _on_scan_evt, NULL);
 #else
-        int res = ble_gap_disc(nimble_riot_own_addr_type, 0,
+        int res = ble_gap_disc(nimble_riot_own_addr_type, _scan_duration,
                                &_scan_params, _on_scan_evt, NULL);
 #endif
         if (res != 0) {


### PR DESCRIPTION
### Contribution description
follow up on #16843: some things were missed :-)

This PR fixes regressions introduced by #16843: 
- setting the scan duration in the `nimble_scanner` was faulty: `BLE_HS_FOREVER` was never applied correctly when using extended advertisements and the delay was never applied to legacy advertisements in the first place
- for `nimble_autoconn` and `nimble_rpble` the scanning did not work anymore, as we forgot to set the `NIMBLE_SCANNER_PHY_1M` flag...

### Testing procedure
- use `tests/nimble_autoconn_gnrc` and `tests/nimble_rpble` examples to verify that nodes successfully connect to one another
- the `nimble_scanner_set_duration()` function is nowhere used in the RIOT codebase (its initial PR did not provide a test with it...), so I'd say manual code review should suffice for now.

### Issues/PRs references
fixes regressions of #16843
