### PR TITLE
boards/feather-m0: add arduino feature

### DIFF
--- a/boards/feather-m0/Kconfig
+++ b/boards/feather-m0/Kconfig
@@ -20,4 +20,5 @@ config BOARD_FEATHER_M0
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
     select HAS_HIGHLEVEL_STDIO

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -13,4 +13,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += highlevel_stdio

--- a/boards/feather-m0/include/arduino_board.h
+++ b/boards/feather-m0/include/arduino_board.h
@@ -60,27 +60,6 @@ static const gpio_t arduino_pinmap[] = {
     ARDUINO_PIN_22,
     ARDUINO_PIN_23,
     ARDUINO_PIN_24,
-    ARDUINO_PIN_25,
-    ARDUINO_PIN_26,
-    ARDUINO_PIN_27,
-    ARDUINO_PIN_28,
-    ARDUINO_PIN_29,
-    ARDUINO_PIN_30,
-    ARDUINO_PIN_31,
-    ARDUINO_PIN_32,
-    ARDUINO_PIN_33,
-    ARDUINO_PIN_34,
-    ARDUINO_PIN_35,
-    ARDUINO_PIN_36,
-    ARDUINO_PIN_37,
-    ARDUINO_PIN_38,
-    ARDUINO_PIN_39,
-    ARDUINO_PIN_40,
-    ARDUINO_PIN_41,
-    ARDUINO_PIN_42,
-    ARDUINO_PIN_43,
-    ARDUINO_PIN_44,
-    ARDUINO_PIN_45,
 };
 
 /**
@@ -93,7 +72,7 @@ static const adc_t arduino_analog_map[] = {
     ARDUINO_A3,
     ARDUINO_A4,
     ARDUINO_A5,
-    ARDUINO_A6,
+    ADC_UNDEF,
     ARDUINO_A7,
 };
 

--- a/boards/feather-m0/include/arduino_board.h
+++ b/boards/feather-m0/include/arduino_board.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2021 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-m0
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+#include "periph/pwm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_16,
+    ARDUINO_PIN_17,
+    ARDUINO_PIN_18,
+    ARDUINO_PIN_19,
+    ARDUINO_PIN_20,
+    ARDUINO_PIN_21,
+    ARDUINO_PIN_22,
+    ARDUINO_PIN_23,
+    ARDUINO_PIN_24,
+    ARDUINO_PIN_25,
+    ARDUINO_PIN_26,
+    ARDUINO_PIN_27,
+    ARDUINO_PIN_28,
+    ARDUINO_PIN_29,
+    ARDUINO_PIN_30,
+    ARDUINO_PIN_31,
+    ARDUINO_PIN_32,
+    ARDUINO_PIN_33,
+    ARDUINO_PIN_34,
+    ARDUINO_PIN_35,
+    ARDUINO_PIN_36,
+    ARDUINO_PIN_37,
+    ARDUINO_PIN_38,
+    ARDUINO_PIN_39,
+    ARDUINO_PIN_40,
+    ARDUINO_PIN_41,
+    ARDUINO_PIN_42,
+    ARDUINO_PIN_43,
+    ARDUINO_PIN_44,
+    ARDUINO_PIN_45,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+    ARDUINO_A6,
+    ARDUINO_A7,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/feather-m0/include/arduino_pinmap.h
+++ b/boards/feather-m0/include/arduino_pinmap.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-m0
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PA, 11)
+#define ARDUINO_PIN_1           GPIO_PIN(PA, 10)
+#define ARDUINO_PIN_2           GPIO_PIN(PA, 14)
+#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)
+#define ARDUINO_PIN_5           GPIO_PIN(PA, 15)
+#define ARDUINO_PIN_6           GPIO_PIN(PA, 20)
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)
+#define ARDUINO_PIN_9           GPIO_PIN(PA, 7)
+#define ARDUINO_PIN_10          GPIO_PIN(PA, 18)
+#define ARDUINO_PIN_11          GPIO_PIN(PA, 16)
+#define ARDUINO_PIN_12          GPIO_PIN(PA, 19)
+#define ARDUINO_PIN_13          GPIO_PIN(PA, 17) /* on-board LED */
+#define ARDUINO_PIN_14          GPIO_PIN(PA, 2)
+#define ARDUINO_PIN_15          GPIO_PIN(PB, 8)
+#define ARDUINO_PIN_16          GPIO_PIN(PB, 9)
+#define ARDUINO_PIN_17          GPIO_PIN(PA, 4)
+#define ARDUINO_PIN_18          GPIO_PIN(PA, 5)
+#define ARDUINO_PIN_19          GPIO_PIN(PB, 2)
+#define ARDUINO_PIN_20          GPIO_PIN(PA, 22)
+#define ARDUINO_PIN_21          GPIO_PIN(PA, 23)
+#define ARDUINO_PIN_22          GPIO_PIN(PA, 12)
+#define ARDUINO_PIN_23          GPIO_PIN(PB, 10)
+#define ARDUINO_PIN_24          GPIO_PIN(PB, 11)
+#define ARDUINO_PIN_25          GPIO_PIN(PB, 3)
+#define ARDUINO_PIN_26          GPIO_PIN(PA, 27)
+#define ARDUINO_PIN_27          GPIO_PIN(PA, 28)
+#define ARDUINO_PIN_28          GPIO_PIN(PA, 24)
+#define ARDUINO_PIN_29          GPIO_PIN(PA, 25)
+#define ARDUINO_PIN_30          GPIO_PIN(PB, 22)
+#define ARDUINO_PIN_31          GPIO_PIN(PB, 23)
+#define ARDUINO_PIN_32          GPIO_PIN(PA, 22)
+#define ARDUINO_PIN_33          GPIO_PIN(PA, 23)
+#define ARDUINO_PIN_34          GPIO_PIN(PA, 19)
+#define ARDUINO_PIN_35          GPIO_PIN(PA, 16)
+#define ARDUINO_PIN_36          GPIO_PIN(PA, 18)
+#define ARDUINO_PIN_37          GPIO_PIN(PA, 17)
+#define ARDUINO_PIN_38          GPIO_PIN(PA, 13)
+#define ARDUINO_PIN_39          GPIO_PIN(PA, 21)
+#define ARDUINO_PIN_40          GPIO_PIN(PA, 6)
+#define ARDUINO_PIN_41          GPIO_PIN(PA, 7)
+#define ARDUINO_PIN_42          GPIO_PIN(PA, 3)
+#define ARDUINO_PIN_43          GPIO_PIN(PA, 2)
+#define ARDUINO_PIN_44          GPIO_PIN(PA, 6)
+#define ARDUINO_PIN_45          GPIO_PIN(PA, 7)
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PA, 2)
+#define ARDUINO_PIN_A1          GPIO_PIN(PB, 8)
+#define ARDUINO_PIN_A2          GPIO_PIN(PB, 9)
+#define ARDUINO_PIN_A3          GPIO_PIN(PA, 4)
+#define ARDUINO_PIN_A4          GPIO_PIN(PA, 5)
+#define ARDUINO_PIN_A5          GPIO_PIN(PB, 2)
+#define ARDUINO_PIN_A6          GPIO_PIN(PA, 6)
+#define ARDUINO_PIN_A7          GPIO_PIN(PA, 7)
+/** @ */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(2)
+#define ARDUINO_A2              ADC_LINE(3)
+#define ARDUINO_A3              ADC_LINE(4)
+#define ARDUINO_A4              ADC_LINE(5)
+#define ARDUINO_A5              ADC_LINE(10)
+#define ARDUINO_A6              ADC_LINE(6)
+#define ARDUINO_A7              ADC_LINE(7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/feather-m0/include/arduino_pinmap.h
+++ b/boards/feather-m0/include/arduino_pinmap.h
@@ -31,78 +31,79 @@ extern "C" {
 
 /**
  * @name    Mapping of MCU pins to Arduino pins
+ *
  * @{
  */
-#define ARDUINO_PIN_0           GPIO_PIN(PA, 11)
-#define ARDUINO_PIN_1           GPIO_PIN(PA, 10)
-#define ARDUINO_PIN_2           GPIO_PIN(PA, 14)
-#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)
-#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)
-#define ARDUINO_PIN_5           GPIO_PIN(PA, 15)
-#define ARDUINO_PIN_6           GPIO_PIN(PA, 20)
-#define ARDUINO_PIN_7           GPIO_PIN(PA, 21)
 
-#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)
-#define ARDUINO_PIN_9           GPIO_PIN(PA, 7)
-#define ARDUINO_PIN_10          GPIO_PIN(PA, 18)
-#define ARDUINO_PIN_11          GPIO_PIN(PA, 16)
-#define ARDUINO_PIN_12          GPIO_PIN(PA, 19)
-#define ARDUINO_PIN_13          GPIO_PIN(PA, 17) /* on-board LED */
-#define ARDUINO_PIN_14          GPIO_PIN(PA, 2)
-#define ARDUINO_PIN_15          GPIO_PIN(PB, 8)
-#define ARDUINO_PIN_16          GPIO_PIN(PB, 9)
-#define ARDUINO_PIN_17          GPIO_PIN(PA, 4)
-#define ARDUINO_PIN_18          GPIO_PIN(PA, 5)
-#define ARDUINO_PIN_19          GPIO_PIN(PB, 2)
-#define ARDUINO_PIN_20          GPIO_PIN(PA, 22)
-#define ARDUINO_PIN_21          GPIO_PIN(PA, 23)
-#define ARDUINO_PIN_22          GPIO_PIN(PA, 12)
-#define ARDUINO_PIN_23          GPIO_PIN(PB, 10)
-#define ARDUINO_PIN_24          GPIO_PIN(PB, 11)
-#define ARDUINO_PIN_25          GPIO_PIN(PB, 3)
-#define ARDUINO_PIN_26          GPIO_PIN(PA, 27)
-#define ARDUINO_PIN_27          GPIO_PIN(PA, 28)
-#define ARDUINO_PIN_28          GPIO_PIN(PA, 24)
-#define ARDUINO_PIN_29          GPIO_PIN(PA, 25)
-#define ARDUINO_PIN_30          GPIO_PIN(PB, 22)
-#define ARDUINO_PIN_31          GPIO_PIN(PB, 23)
-#define ARDUINO_PIN_32          GPIO_PIN(PA, 22)
-#define ARDUINO_PIN_33          GPIO_PIN(PA, 23)
-#define ARDUINO_PIN_34          GPIO_PIN(PA, 19)
-#define ARDUINO_PIN_35          GPIO_PIN(PA, 16)
-#define ARDUINO_PIN_36          GPIO_PIN(PA, 18)
-#define ARDUINO_PIN_37          GPIO_PIN(PA, 17)
-#define ARDUINO_PIN_38          GPIO_PIN(PA, 13)
-#define ARDUINO_PIN_39          GPIO_PIN(PA, 21)
-#define ARDUINO_PIN_40          GPIO_PIN(PA, 6)
-#define ARDUINO_PIN_41          GPIO_PIN(PA, 7)
-#define ARDUINO_PIN_42          GPIO_PIN(PA, 3)
-#define ARDUINO_PIN_43          GPIO_PIN(PA, 2)
-#define ARDUINO_PIN_44          GPIO_PIN(PA, 6)
-#define ARDUINO_PIN_45          GPIO_PIN(PA, 7)
+#define ARDUINO_PIN_0           GPIO_PIN(PA, 11) /**< D0 (RX) */
+#define ARDUINO_PIN_1           GPIO_PIN(PA, 10) /**< D1 (TX) */
+#define ARDUINO_PIN_2           GPIO_PIN(PA, 14) /**< D2 */
+#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)  /**< D3 */
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 */
+#define ARDUINO_PIN_5           GPIO_PIN(PA, 15) /**< D5 */
+#define ARDUINO_PIN_6           GPIO_PIN(PA, 20) /**< D6 */
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 */
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 */
+#define ARDUINO_PIN_9           GPIO_PIN(PA, 7)  /**< D9 */
+#define ARDUINO_PIN_10          GPIO_PIN(PA, 18) /**< D10 */
+#define ARDUINO_PIN_11          GPIO_PIN(PA, 16) /**< D11 */
+#define ARDUINO_PIN_12          GPIO_PIN(PA, 19) /**< D12 */
+#define ARDUINO_PIN_13          GPIO_PIN(PA, 17) /**< D13 (LED) */
+#define ARDUINO_PIN_14          GPIO_PIN(PA, 2)  /**< D14 (A0) */
+#define ARDUINO_PIN_15          GPIO_PIN(PB, 8)  /**< D15 (A1) */
+#define ARDUINO_PIN_16          GPIO_PIN(PB, 9)  /**< D16 (A2) */
+#define ARDUINO_PIN_17          GPIO_PIN(PA, 4)  /**< D17 (A3) */
+#define ARDUINO_PIN_18          GPIO_PIN(PA, 5)  /**< D18 (A4) */
+#define ARDUINO_PIN_19          GPIO_PIN(PB, 2)  /**< D19 (A5) */
+#define ARDUINO_PIN_20          GPIO_PIN(PA, 22) /**< D20 */
+#define ARDUINO_PIN_21          GPIO_PIN(PA, 23) /**< D21 */
+#define ARDUINO_PIN_22          GPIO_PIN(PA, 12) /**< D22 */
+#define ARDUINO_PIN_23          GPIO_PIN(PB, 10) /**< D23 */
+#define ARDUINO_PIN_24          GPIO_PIN(PB, 11) /**< D24 */
+#define ARDUINO_PIN_25          GPIO_PIN(PB, 3)  /**< D25 */
+#define ARDUINO_PIN_26          GPIO_PIN(PA, 27) /**< D26 */
+#define ARDUINO_PIN_27          GPIO_PIN(PA, 28) /**< D27 */
+#define ARDUINO_PIN_28          GPIO_PIN(PA, 24) /**< D28 */
+#define ARDUINO_PIN_29          GPIO_PIN(PA, 25) /**< D29 */
+#define ARDUINO_PIN_30          GPIO_PIN(PB, 22) /**< D30 */
+#define ARDUINO_PIN_31          GPIO_PIN(PB, 23) /**< D31 */
+#define ARDUINO_PIN_32          GPIO_PIN(PA, 22) /**< D32 */
+#define ARDUINO_PIN_33          GPIO_PIN(PA, 23) /**< D33 */
+#define ARDUINO_PIN_34          GPIO_PIN(PA, 19) /**< D34 */
+#define ARDUINO_PIN_35          GPIO_PIN(PA, 16) /**< D35 */
+#define ARDUINO_PIN_36          GPIO_PIN(PA, 18) /**< D36 */
+#define ARDUINO_PIN_37          GPIO_PIN(PA, 17) /**< D37 */
+#define ARDUINO_PIN_38          GPIO_PIN(PA, 13) /**< D38 */
+#define ARDUINO_PIN_39          GPIO_PIN(PA, 21) /**< D39 */
+#define ARDUINO_PIN_40          GPIO_PIN(PA, 6)  /**< D40 */
+#define ARDUINO_PIN_41          GPIO_PIN(PA, 7)  /**< D41 */
+#define ARDUINO_PIN_42          GPIO_PIN(PA, 3)  /**< D42 */
+#define ARDUINO_PIN_43          GPIO_PIN(PA, 2)  /**< D43 */
+#define ARDUINO_PIN_44          GPIO_PIN(PA, 6)  /**< D44 */
+#define ARDUINO_PIN_45          GPIO_PIN(PA, 7)  /**< D45 */
 
-#define ARDUINO_PIN_A0          GPIO_PIN(PA, 2)
-#define ARDUINO_PIN_A1          GPIO_PIN(PB, 8)
-#define ARDUINO_PIN_A2          GPIO_PIN(PB, 9)
-#define ARDUINO_PIN_A3          GPIO_PIN(PA, 4)
-#define ARDUINO_PIN_A4          GPIO_PIN(PA, 5)
-#define ARDUINO_PIN_A5          GPIO_PIN(PB, 2)
-#define ARDUINO_PIN_A6          GPIO_PIN(PA, 6)
-#define ARDUINO_PIN_A7          GPIO_PIN(PA, 7)
-/** @ */
+#define ARDUINO_PIN_A0          ARDUINO_PIN_14   /**< A0 */
+#define ARDUINO_PIN_A1          ARDUINO_PIN_15   /**< A1 */
+#define ARDUINO_PIN_A2          ARDUINO_PIN_16   /**< A2 */
+#define ARDUINO_PIN_A3          ARDUINO_PIN_17   /**< A3 */
+#define ARDUINO_PIN_A4          ARDUINO_PIN_18   /**< A4 */
+#define ARDUINO_PIN_A5          ARDUINO_PIN_19   /**< A5 */
+#define ARDUINO_PIN_A6          ARDUINO_PIN_8    /**< A6 */
+#define ARDUINO_PIN_A7          ARDUINO_PIN_9    /**< A7 */
+/** @} */
 
 /**
  * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
-#define ARDUINO_A0              ADC_LINE(0)
-#define ARDUINO_A1              ADC_LINE(2)
-#define ARDUINO_A2              ADC_LINE(3)
-#define ARDUINO_A3              ADC_LINE(4)
-#define ARDUINO_A4              ADC_LINE(5)
-#define ARDUINO_A5              ADC_LINE(10)
-#define ARDUINO_A6              ADC_LINE(6)
-#define ARDUINO_A7              ADC_LINE(7)
+#define ARDUINO_A0              ADC_LINE(0)  /**< ADC 0 */
+#define ARDUINO_A1              ADC_LINE(2)  /**< ADC 1 */
+#define ARDUINO_A2              ADC_LINE(3)  /**< ADC 2 */
+#define ARDUINO_A3              ADC_LINE(4)  /**< ADC 3 */
+#define ARDUINO_A4              ADC_LINE(5)  /**< ADC 4 */
+#define ARDUINO_A5              ADC_LINE(10) /**< ADC 5 */
+#define ARDUINO_A6              ADC_LINE(6)  /**< ADC 6 */
+#define ARDUINO_A7              ADC_LINE(7)  /**< ADC 7 */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/feather-m0/include/arduino_pinmap.h
+++ b/boards/feather-m0/include/arduino_pinmap.h
@@ -37,13 +37,13 @@ extern "C" {
 
 #define ARDUINO_PIN_0           GPIO_PIN(PA, 11) /**< D0 (RX) */
 #define ARDUINO_PIN_1           GPIO_PIN(PA, 10) /**< D1 (TX) */
-#define ARDUINO_PIN_2           GPIO_PIN(PA, 14) /**< D2 */
-#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)  /**< D3 */
-#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 */
+#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
+#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
+#define ARDUINO_PIN_4           GPIO_UNDEF       /**< D4 */
 #define ARDUINO_PIN_5           GPIO_PIN(PA, 15) /**< D5 */
 #define ARDUINO_PIN_6           GPIO_PIN(PA, 20) /**< D6 */
-#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 */
-#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 */
+#define ARDUINO_PIN_7           GPIO_UNDEF       /**< D7 */
+#define ARDUINO_PIN_8           GPIO_UNDEF       /**< D8 */
 #define ARDUINO_PIN_9           GPIO_PIN(PA, 7)  /**< D9 */
 #define ARDUINO_PIN_10          GPIO_PIN(PA, 18) /**< D10 */
 #define ARDUINO_PIN_11          GPIO_PIN(PA, 16) /**< D11 */
@@ -55,32 +55,11 @@ extern "C" {
 #define ARDUINO_PIN_17          GPIO_PIN(PA, 4)  /**< D17 (A3) */
 #define ARDUINO_PIN_18          GPIO_PIN(PA, 5)  /**< D18 (A4) */
 #define ARDUINO_PIN_19          GPIO_PIN(PB, 2)  /**< D19 (A5) */
-#define ARDUINO_PIN_20          GPIO_PIN(PA, 22) /**< D20 */
-#define ARDUINO_PIN_21          GPIO_PIN(PA, 23) /**< D21 */
-#define ARDUINO_PIN_22          GPIO_PIN(PA, 12) /**< D22 */
-#define ARDUINO_PIN_23          GPIO_PIN(PB, 10) /**< D23 */
-#define ARDUINO_PIN_24          GPIO_PIN(PB, 11) /**< D24 */
-#define ARDUINO_PIN_25          GPIO_PIN(PB, 3)  /**< D25 */
-#define ARDUINO_PIN_26          GPIO_PIN(PA, 27) /**< D26 */
-#define ARDUINO_PIN_27          GPIO_PIN(PA, 28) /**< D27 */
-#define ARDUINO_PIN_28          GPIO_PIN(PA, 24) /**< D28 */
-#define ARDUINO_PIN_29          GPIO_PIN(PA, 25) /**< D29 */
-#define ARDUINO_PIN_30          GPIO_PIN(PB, 22) /**< D30 */
-#define ARDUINO_PIN_31          GPIO_PIN(PB, 23) /**< D31 */
-#define ARDUINO_PIN_32          GPIO_PIN(PA, 22) /**< D32 */
-#define ARDUINO_PIN_33          GPIO_PIN(PA, 23) /**< D33 */
-#define ARDUINO_PIN_34          GPIO_PIN(PA, 19) /**< D34 */
-#define ARDUINO_PIN_35          GPIO_PIN(PA, 16) /**< D35 */
-#define ARDUINO_PIN_36          GPIO_PIN(PA, 18) /**< D36 */
-#define ARDUINO_PIN_37          GPIO_PIN(PA, 17) /**< D37 */
-#define ARDUINO_PIN_38          GPIO_PIN(PA, 13) /**< D38 */
-#define ARDUINO_PIN_39          GPIO_PIN(PA, 21) /**< D39 */
-#define ARDUINO_PIN_40          GPIO_PIN(PA, 6)  /**< D40 */
-#define ARDUINO_PIN_41          GPIO_PIN(PA, 7)  /**< D41 */
-#define ARDUINO_PIN_42          GPIO_PIN(PA, 3)  /**< D42 */
-#define ARDUINO_PIN_43          GPIO_PIN(PA, 2)  /**< D43 */
-#define ARDUINO_PIN_44          GPIO_PIN(PA, 6)  /**< D44 */
-#define ARDUINO_PIN_45          GPIO_PIN(PA, 7)  /**< D45 */
+#define ARDUINO_PIN_20          GPIO_PIN(PA, 22) /**< D20 (I2C SDA) */
+#define ARDUINO_PIN_21          GPIO_PIN(PA, 23) /**< D21 (I2C SCL) */
+#define ARDUINO_PIN_22          GPIO_PIN(PA, 12) /**< D22 (SPI MISO) */
+#define ARDUINO_PIN_23          GPIO_PIN(PB, 10) /**< D23 (SPI MOSI) */
+#define ARDUINO_PIN_24          GPIO_PIN(PB, 11) /**< D24 (SPI SCK) */
 
 #define ARDUINO_PIN_A0          ARDUINO_PIN_14   /**< A0 */
 #define ARDUINO_PIN_A1          ARDUINO_PIN_15   /**< A1 */
@@ -88,7 +67,6 @@ extern "C" {
 #define ARDUINO_PIN_A3          ARDUINO_PIN_17   /**< A3 */
 #define ARDUINO_PIN_A4          ARDUINO_PIN_18   /**< A4 */
 #define ARDUINO_PIN_A5          ARDUINO_PIN_19   /**< A5 */
-#define ARDUINO_PIN_A6          ARDUINO_PIN_8    /**< A6 */
 #define ARDUINO_PIN_A7          ARDUINO_PIN_9    /**< A7 */
 /** @} */
 
@@ -102,7 +80,6 @@ extern "C" {
 #define ARDUINO_A3              ADC_LINE(4)  /**< ADC 3 */
 #define ARDUINO_A4              ADC_LINE(5)  /**< ADC 4 */
 #define ARDUINO_A5              ADC_LINE(10) /**< ADC 5 */
-#define ARDUINO_A6              ADC_LINE(6)  /**< ADC 6 */
 #define ARDUINO_A7              ADC_LINE(7)  /**< ADC 7 */
 /** @} */
 

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -35,6 +35,18 @@ extern "C" {
 void stdio_init(void);
 
 /**
+ * @brief Get number of bytes available for reading.
+ *
+ * @return nr of available bytes
+ */
+int stdio_avail(void);
+
+/**
+ * @brief Clear the input buffer
+ */
+void stdio_clear(void);
+
+/**
  * @brief read @p len bytes from stdio uart into @p buffer
  *
  * @param[out]  buffer  buffer to read into

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -51,6 +51,16 @@ void stdio_init(void)
 #endif
 }
 
+int stdio_avail(void)
+{
+    return tsrb_avail(&_cdc_stdio_isrpipe.tsrb);
+}
+
+void stdio_clear(void)
+{
+    tsrb_clear(&_cdc_stdio_isrpipe.tsrb);
+}
+
 ssize_t stdio_read(void* buffer, size_t len)
 {
     (void)buffer;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Adds the arduino feature to the feather-m0 board.

The pins come from https://github.com/adafruit/ArduinoCore-samd/tree/master/variants/feather_m0

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've tested with `tests/periph_gpio_arduino` and `tests/sys_arduino_lib`. Both work.

But `examples/arduino_hello-world` and `tests/sys_arduino` don't work, `Serial` does not print anything.
That's why I'm creating this PR as a draft.
Any help understanding why `Serial` doesn't work with the feather-m0 is much appreciated.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
