### PR TITLE
tools/zep_dispatch: allow to pin nodes to MAC address

### DIFF
--- a/dist/tools/zep_dispatch/Makefile
+++ b/dist/tools/zep_dispatch/Makefile
@@ -21,6 +21,8 @@ RIOT_INCLUDE += -I$(RIOTBASE)/sys/include
 
 SRCS := $(wildcard *.c)
 SRCS += $(RIOTBASE)/sys/net/link_layer/ieee802154/ieee802154.c
+SRCS += $(RIOTBASE)/sys/fmt/fmt.c
+SRCS += $(RIOTBASE)/sys/net/link_layer/l2util/l2util.c
 
 $(BINARY): $(SRCS)
 	$(CC) $(CFLAGS) $(CFLAGS_EXTRA) $(SRCS) -o $@

--- a/dist/tools/zep_dispatch/example.topo
+++ b/dist/tools/zep_dispatch/example.topo
@@ -1,3 +1,6 @@
+# uncomment to pin node A to a specific MAC address
+# A := BA:7C:18:E4:C0:45:65:AF
+
 # A and B are connected with an ideal link
 A	B
 # A and C are connected with a symmetric link with 10% packet loss

--- a/dist/tools/zep_dispatch/topology.c
+++ b/dist/tools/zep_dispatch/topology.c
@@ -37,6 +37,8 @@ struct edge {
     float weight_b_a;
 };
 
+size_t l2util_addr_from_str(const char *str, uint8_t *out);
+
 static char *_fmt_addr(char *out, size_t out_len, const uint8_t *addr, uint8_t addr_len)
 {
     char *start = out;
@@ -70,9 +72,8 @@ static struct node *_find_or_create_node(list_node_t *nodes, const char *name)
     struct node *node = _find_node_by_name(nodes, name);
 
     if (node == NULL) {
-        node = malloc(sizeof(*node));
+        node = calloc(1, sizeof(*node));
         strncpy(node->name, name, sizeof(node->name) - 1);
-        node->mac_len = 0;
         list_add(nodes, &node->next);
     }
 
@@ -94,6 +95,17 @@ static bool _parse_line(char *line, list_node_t *nodes, list_node_t *edges)
 
     if (a == NULL || b == NULL) {
         return false;
+    }
+
+    /* add node with a defined MAC address */
+    if (strcmp(b, ":=") == 0) {
+        struct node *n = _find_or_create_node(nodes, a);
+        if (n == NULL) {
+            return false;
+        }
+
+        n->mac_len = l2util_addr_from_str(e_ab, n->mac);
+        return true;
     }
 
     if (e_ab == NULL) {
@@ -255,9 +267,16 @@ bool topology_add(topology_t *t, const uint8_t *mac, uint8_t mac_len,
             continue;
         }
 
-        /* abort if node is already in list */
+        /* node is already in the list - either it is connected or MAC was pinned */
         if (memcmp(super->mac, mac, mac_len) == 0) {
-            return true;
+            if (super->addr.sin6_port == addr->sin6_port) {
+                /* abort if node is already connected */
+                return true;
+            } else {
+                /* use pre-allocated node */
+                empty = super;
+                break;
+            }
         }
     }
 

--- a/examples/gnrc_border_router/Makefile.native.conf
+++ b/examples/gnrc_border_router/Makefile.native.conf
@@ -23,3 +23,8 @@ TERMPROG ?= sudo $(RIOTTOOLS)/zep_dispatch/start_network.sh $(TERMPROG_FLAGS)
 
 # -z [::1]:$PORT for each ZEP device
 TERMFLAGS ?= $(patsubst %,-z [::1]:%, $(shell seq $(ZEP_PORT_BASE) $(ZEP_PORT_MAX)))
+
+# set optional ZEP l2 address
+ifneq (,$(ZEP_MAC))
+  TERMFLAGS += --eui64=$(ZEP_MAC)
+endif

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -52,6 +52,10 @@ ZEP_PORT_BASE ?= 17754
 ifeq (1,$(USE_ZEP))
   TERMFLAGS += -z [::1]:$(ZEP_PORT_BASE)
   USEMODULE += socket_zep
+
+  ifneq (,$(ZEP_MAC))
+    TERMFLAGS += --eui64=$(ZEP_MAC)
+  endif
 endif
 
 # Uncomment the following 2 lines to specify static link lokal IPv6 address


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Positions in the topology are handed out first come first serve.
This makes it hard to have a reproducible setup if the ZEP dispatcher is restarted (e.g. to modify the topology) or if a node is restarted.

Fix this by allowing to specify a MAC address for each node.
If a node with a pinned MAC address connects, it will always be assigned to the same topology node.


### Testing procedure

Create a topology file with nodes pinned to specific MAC addresses:

```
A := AA:AA:AA:AA:AA:AA:AA:AA
B := BB:BB:BB:BB:BB:BB:BB:BB
C := CC:CC:CC:CC:CC:CC:CC:CC

A B
B C
```

Run the ZEP dispatcher with this file:

    make -C dist/tools/zep_dispatch TOPOLOGY=test.topo run

Now start three instances of `native` with the set IDs:

    make -C examples/gnrc_networking USE_ZEP=1 ZEP_MAC=AA:AA:AA:AA:AA:AA:AA:AA all term
    make -C examples/gnrc_networking USE_ZEP=1 ZEP_MAC=BB:BB:BB:BB:BB:BB:BB:BB all term
    make -C examples/gnrc_networking USE_ZEP=1 ZEP_MAC=CC:CC:CC:CC:CC:CC:CC:CC all term

Node B should be able to ping it's two neighbors:

```
> ping ff02::1
12 bytes from fe80::cecc:cccc:cccc:cccc%7: icmp_seq=0 ttl=64 rssi=24672 dBm time=0.564 ms
12 bytes from fe80::a8aa:aaaa:aaaa:aaaa%7: icmp_seq=0 ttl=64 rssi=24672 dBm time=0.620 ms (DUP!)
12 bytes from fe80::a8aa:aaaa:aaaa:aaaa%7: icmp_seq=1 ttl=64 rssi=24672 dBm time=0.491 ms
12 bytes from fe80::cecc:cccc:cccc:cccc%7: icmp_seq=1 ttl=64 rssi=24672 dBm time=0.528 ms (DUP!)
12 bytes from fe80::cecc:cccc:cccc:cccc%7: icmp_seq=2 ttl=64 rssi=24672 dBm time=0.509 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 2 duplicates, 0% packet loss
round-trip min/avg/max = 0.491/0.542/0.620 ms
```

Now restart a single node. It should again take it's assigned place in the topology. 

But we can also modify the topology and restart the dispatcher:

```
A := AA:AA:AA:AA:AA:AA:AA:AA
B := BB:BB:BB:BB:BB:BB:BB:BB
C := CC:CC:CC:CC:CC:CC:CC:CC

B C
C A
```

Now B should only reach node C:

```
> ping ff02::1
12 bytes from fe80::cecc:cccc:cccc:cccc%7: icmp_seq=0 ttl=64 rssi=24672 dBm time=0.399 ms
12 bytes from fe80::cecc:cccc:cccc:cccc%7: icmp_seq=1 ttl=64 rssi=24672 dBm time=0.543 ms
12 bytes from fe80::cecc:cccc:cccc:cccc%7: icmp_seq=2 ttl=64 rssi=24672 dBm time=0.474 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.399/0.472/0.543 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
