### PR TITLE
boards/iotlab-m3: add MTD definition

### DIFF
--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -5,4 +5,8 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lps331ap
 endif
 
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_spi_nor
+endif
+
 USEMODULE += boards_common_iotlab

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -33,7 +33,7 @@
 
 | Device            | ID            | Supported     | Comments              |
 |:----------------- |:------------- |:------------- |:--------------------- |
-| MCU               | [STM23F103REY](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/CD00171190.pdf) | partly    | Energy saving modes not fully utilized |
+| MCU               | [STM32F103REY](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/CD00171190.pdf) | partly    | Energy saving modes not fully utilized |
 | Low-level driver  | GPIO          | yes           |                       |
 |                   | PWM           | no            | periph config missing |
 |                   | UART          | yes           |                       |
@@ -48,6 +48,7 @@
 | Gyroscope         | LSM303DLHC    | yes           |                       |
 | Pressure Sensor   | LPS331AP      | yes           |                       |
 | Light Sensor      | ISL29020      | yes           |                       |
+| SPI Flash         | N25Q128       | yes           |                       |
 
 ## Toolchains
 

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -27,6 +27,7 @@
 #include "cpu.h"
 #include "periph_conf.h"
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,6 +64,14 @@ extern "C" {
  */
 #define LSM303DLHC_PARAM_ACC_PIN   GPIO_PIN(PORT_B, 12)
 #define LSM303DLHC_PARAM_MAG_PIN   GPIO_PIN(PORT_B, 2)
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+extern mtd_dev_t *mtd0;     /**< SPI NOR Flash device */
+#define MTD_0     mtd0      /**< Indicate presence of MTD device */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -46,7 +46,24 @@ static const spi_conf_t spi_config[] = {
         .rx_dma   = DMA_STREAM_UNDEF,
         .rx_dma_chan = 1,
 #endif
-    }
+    },
+#ifdef MODULE_MTD
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_UNDEF,
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = DMA_STREAM_UNDEF,
+        .tx_dma_chan = 1,
+        .rx_dma   = DMA_STREAM_UNDEF,
+        .rx_dma_chan = 1,
+#endif
+    },
+#endif
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)

--- a/boards/iotlab-m3/mtd.c
+++ b/boards/iotlab-m3/mtd.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_iotlab-m3
+ * @{
+ *
+ * @file
+ * @brief       MTD configuration for the iotlab-m3 board
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "mtd.h"
+#include "mtd_spi_nor.h"
+#include "periph/gpio.h"
+#include "timex.h"
+
+#ifdef MODULE_MTD
+/* N25Q128A13E1240F */
+static const mtd_spi_nor_params_t _mtd_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase   = 240 * US_PER_SEC,
+    .wait_64k_erase    = 700 * US_PER_MS,
+    .wait_sector_erase = 250 * US_PER_MS,
+    .wait_chip_wake_up = 1 * US_PER_MS,
+    .clk  = MHZ(54),
+    .flag = SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_64K,
+    .spi  = SPI_DEV(1),
+    .mode = SPI_MODE_0,
+    .cs   = GPIO_PIN(PORT_A, 11),
+    .wp   = GPIO_PIN(PORT_C, 6),
+    .hold = GPIO_PIN(PORT_C, 9),
+    .addr_width = 3,
+};
+
+static mtd_spi_nor_t mtd_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = 256,
+        .pages_per_sector = 16,
+    },
+    .params = &_mtd_nor_params,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd_nor_dev;
+#endif /* MODULE_MTD */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The board comes with a 16 MiB SPI-NOR flash (N25Q128).
Provide the needed MTD definitions to support it.


### Testing procedure

If you have an account on the IoT Lab you can create a [new experiment](https://www.iot-lab.info/testbed/dashboard). 
Select a `m3` node, e.g. in `grenoble` and select the firmware to flash. If you need to re-flash the firmware, make sure to reload the page before each flashing of a new firmware as otherwise the flash process will hang.

Connect with `ssh` to `grenoble.iot-lab.info` and connect to your node with `nc m3-$NODE 20000` where `$NODE` is the node ID of the node that was assigned to you.

This way you can flash e.g. `tests/mtd_raw`:

```
main(): This is RIOT! (Version: 2022.01-devel-964-g83291)
Manual MTD test
init MTD_0… OK (16 MiB)

> test 0
[START]
[SUCCESS]

> info
mtd devices: 1
 -=[ MTD_0 ]=-
sectors: 4096
pages per sector: 16
page size: 256
total: 16 MiB
```

`tests/pkg_littlefs2` with `CFLAGS += -DCONFIG_USE_HARDWARE_MTD=1`:

```
START
main(): This is RIOT! (Version: 2022.01-devel-965-gf2ebb-boards/iotlab-m3-mtd)
........
OK (8 tests)
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
