### PR TITLE
driver/css811: fix read status

### DIFF
--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -300,15 +300,6 @@ int ccs811_read_iaq(const ccs811_t *dev,
         return _error_code(dev, data[CCS811_ALG_DATA_ERROR_ID]);
     }
 
-    /*
-     * check whether new data are ready to read; if not, latest values read
-     * from sensor are used and error code CCS811_ERROR_NO_NEW_DATA is returned
-     */
-    if (!(data[CCS811_ALG_DATA_STATUS] & CCS811_STATUS_DATA_RDY)) {
-        DEBUG_DEV("no new data", dev);
-        res = -CCS811_ERROR_NO_NEW_DATA;
-    }
-
     /* if *iaq* is not NULL return IAQ sensor values */
     if (iaq_tvoc) {
         *iaq_tvoc  = data[CCS811_ALG_DATA_TVOC_HB] << 8;

--- a/drivers/include/ccs811.h
+++ b/drivers/include/ccs811.h
@@ -144,8 +144,7 @@ int ccs811_init (ccs811_t *dev, const ccs811_params_t *params);
  *
  * @note
  * - If the function is called and no new data are available, the function
- *   returns the results of the last measurement and the error code
- *   #CCS811_ERROR_NO_NEW_DATA.
+ *   returns the results of the last measurement.
  * - The data-ready status function #ccs811_data_ready or the data-ready
  *   interrupt (#CCS811_INT_DATA_READY) can be used to determine whether
  *   new data are available.
@@ -160,8 +159,6 @@ int ccs811_init (ccs811_t *dev, const ccs811_params_t *params);
  * @param[out] raw_v    Voltage across the sensor measured (0..1023 = 1.65 V)
  *
  * @retval  CCS811_OK                on success and new data are returned
- * @retval  CCS811_ERROR_NO_NEW_DATA when no new data are available and last
- *                                   measurement results are returned.
  * @retval  CCS811_ERROR_*           otherwise, see #ccs811_error_codes_t.
  */
 int ccs811_read_iaq (const ccs811_t *dev,

--- a/drivers/include/ccs811.h
+++ b/drivers/include/ccs811.h
@@ -140,7 +140,7 @@ int ccs811_init (ccs811_t *dev, const ccs811_params_t *params);
  *
  * The function reads the IAQ sensor values (TVOC and eCO2) and/or the raw
  * sensor data. For either \p iaq_tvoc2, \p iaq_eco2, \p raw_i, or \p raw_v
- * also ```NULL``` can be passed, if their value are not of interest.
+ * also `NULL` can be passed, if their value are not of interest.
  *
  * @note
  * - If the function is called and no new data are available, the function
@@ -150,7 +150,7 @@ int ccs811_init (ccs811_t *dev, const ccs811_params_t *params);
  *   new data are available.
  * - In #CCS811_MODE_250MS, only RAW data are available. In
  *   that case, the function fails with error_code #CCS811_ERROR_NO_IAQ_DATA
- *   if \p iaq_tvoc and \p iaq_eco2 parameters are not ```NULL```.
+ *   if \p iaq_tvoc and \p iaq_eco2 parameters are not `NULL`.
  *
  * @param[in]  dev      Device descriptor of CCS811 device to read from
  * @param[out] iaq_tvoc TVOC total volatile organic compound (0..1187 ppb)

--- a/tests/driver_ccs811/README.md
+++ b/tests/driver_ccs811/README.md
@@ -9,9 +9,9 @@ sensor can be used for periodic polling.
 
 The test application demonstrates the use of the CCS811 using
 
-- data-ready status function ```ccs811_data_ready``` to wait for new data and
+- data-ready status function `ccs811_data_ready` to wait for new data and
 - default configuration parameters, that is, the measurement mode
-  ```CCS811_MODE_1S``` with one measurement per second.
+  `CCS811_MODE_1S` with one measurement per second.
 
-Please refer ```$(RIOTBASE)/tests/driver_ccs811_full``` to learn how
+Please refer `$(RIOTBASE)/tests/driver_ccs811_full` to learn how
 to use the CCS811 with interrupts.

--- a/tests/driver_ccs811/main.c
+++ b/tests/driver_ccs811/main.c
@@ -14,12 +14,12 @@
  *
  * The test application demonstrates the use of the CCS811 using
  *
- * - data-ready status function ```ccs811_data_ready``` to wait for
+ * - data-ready status function `ccs811_data_ready` to wait for
  *   new data and
  * - default configuration parameters, that is, the measurement mode
- *   ```CCS811_MODE_1S``` with one measurement per second.
+ *   `CCS811_MODE_1S` with one measurement per second.
  *
- * Please refer ```$(RIOTBASE)/tests/driver_ccs811_full``` to learn how
+ * Please refer `$(RIOTBASE)/tests/driver_ccs811_full` to learn how
  * to use the CCS811 with interrupts.
  */
 

--- a/tests/driver_ccs811_full/README.md
+++ b/tests/driver_ccs811_full/README.md
@@ -10,18 +10,19 @@ sensor can be used with interrupts.
 ## Usage
 
 The test application demonstrates the use of the CCS811 and pseudomodule
-```ccs811_full``` using
+`ccs811_full` using
 
-- data-ready interrupt ```CCS811_INT_DATA_READY``` and
+- data-ready interrupt `CCS811_INT_DATA_READY` and
 - default configuration parameters, that is, the measurement mode
-  ```CCS811_MODE_1S``` with one measurement per second.
+  `CCS811_MODE_1S` with one measurement per second.
 
 The default configuration parameter for the interrupt pin has to be
 overridden according to the hardware configuration by defining
-```CCS811_PARAM_INT_PIN``` before ```ccs811_params.h``` is included, e.g.,
-
-    #define CCS811_PARAM_INT_PIN     (GPIO_PIN(0, 7))
-
+`CCS811_PARAM_INT_PIN` before `ccs811_params.h` is included, e.g.,
+```
+#define CCS811_PARAM_INT_PIN     (GPIO_PIN(0, 7))
+```
 or via the `CFLAGS` variable in the make command.
-
-    CFLAGS="-DCCS811_PARAM_INT_PIN=\(GPIO_PIN\(0,7\)\)" make -C tests/driver_ccs811 BOARD=...
+```
+CFLAGS="-DCCS811_PARAM_INT_PIN=GPIO_PIN\(0,7\)" make -C tests/driver_ccs811_full BOARD=...
+```

--- a/tests/driver_ccs811_full/main.c
+++ b/tests/driver_ccs811_full/main.c
@@ -13,21 +13,21 @@
  * @file
  *
  * The test application demonstrates the use of the CCS811 and pseudomodule
- * ```ccs811_full``` using
+ * `ccs811_full` using
  *
- * - data-ready interrupt ```CCS811_INT_DATA_READY``` and
+ * - data-ready interrupt `CCS811_INT_DATA_READY` and
  * - default configuration parameters, that is, the measurement mode
- *   ```CCS811_MODE_1S``` with one measurement per second.
+ *   `CCS811_MODE_1S` with one measurement per second.
  *
  * The default configuration parameter for the interrupt pin has to be
  * overridden according to the hardware configuration by defining
- * ```CCS811_PARAM_INT_PIN``` before ```ccs811_params.h``` is included, e.g.,
+ * `CCS811_PARAM_INT_PIN` before `ccs811_params.h` is included, e.g.,
  * ```
  * #define CCS811_PARAM_INT_PIN     (GPIO_PIN(0, 7))
  * ```
  * or via the CFLAGS variable in the make command.
  * ```
- * CFLAGS="-DCCS811_PARAM_INT_PIN=\(GPIO_PIN\(0,7\)\)" make -C tests/driver_ccs811 BOARD=...
+ * CFLAGS="-DCCS811_PARAM_INT_PIN=GPIO_PIN\(0,7\)" make -C tests/driver_ccs811_full BOARD=...
  * ```
  */
 


### PR DESCRIPTION
### Contribution description

PR #16215 fixed the handling of the error returned by function `ccs811_read_iaq`. After this change, however, the test applications didn't work anymore for me because of a bug in the driver function `ccs811_read_iaq`. 

The `DATA_RDY` flag in the `STATUS` register which is part of the `ALG_RESULT_DATA` register set is already cleared when the `ALG_RESULT_DATA` register set, although it was definitely set before when checking for new data with the `ccs811_data_ready` function or the interrupt due to new data. So it seems that the `DATA_RDY` is cleared as soon as the reading of the `ALG_RESULT_DATA` register set starts. Thus the `DATA_RDY`  can't be checked in the resulting data. Therefore the function always returned `CCS811_ERROR_NO_NEW_DATA` and the test applications worked before PR #16215 with the bug because function `ccs811_read_iaq` didn't return `CCS811_OK`.

This PR fixes the wrong behaviour of the driver.

### Testing procedure

Compile and run at least `test/driver_ccs811` application.

### Issues/PRs references

Solves the the problem popped up with PR #16215.