### PR TITLE
sys: introduce sysclk function to retrieve core clock frequency

### DIFF
--- a/boards/qn9080dk/include/board.h
+++ b/boards/qn9080dk/include/board.h
@@ -29,16 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @name    Clock configuration
- * @{
- */
-#ifndef CLOCK_CORECLOCK
-/* Using 32MHz internal oscillator as default clock source */
-#define CLOCK_CORECLOCK     (32000000ul)
-#endif
-/** @} */
-
-/**
  * @name    LED configuration
  * @{
  */

--- a/boards/qn9080dk/include/periph_conf.h
+++ b/boards/qn9080dk/include/periph_conf.h
@@ -21,12 +21,23 @@
 
 #include <stdint.h>
 
+#include "macros/units.h"
 #include "cpu.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+/* Using 32MHz internal oscillator as default clock source */
+#define CLOCK_CORECLOCK     MHZ(32)     /**< System core clock frequency in Hz */
+#endif
+/** @} */
 
 /**
  * @name ADC configuration

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #define PERIPH_CPU_H
 
 #include <stdint.h>
+#include "sdk_conf.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -23,6 +23,7 @@
 #include <limits.h>
 
 #include "eagle_soc.h"
+#include "cpu_conf.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/fe310/clock.c
+++ b/cpu/fe310/clock.c
@@ -17,13 +17,14 @@
  * @}
  */
 
+#include "clk.h"
 #include "cpu.h"
 #include "periph_conf.h"
 
 #include "vendor/prci_driver.h"
 
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL)
-static uint32_t _cpu_frequency = 0;
+uint32_t cpu_coreclk = 0;
 #endif
 
 void fe310_clock_init(void)
@@ -92,21 +93,10 @@ void fe310_clock_init(void)
         /* Don't use PLL clock source */
         PRCI_REG(PRCI_PLLCFG) &= ~PLL_SEL(PLL_SEL_PLL);
     }
-}
 
-uint32_t cpu_freq(void)
-{
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL)
-    /* Clock frequency with HFROSC cannot be determined precisely from
-       settings */
-    /* If not done already, estimate the CPU frequency */
-    if (_cpu_frequency == 0) {
-        /* Ignore the first run (for icache reasons) */
-        _cpu_frequency = PRCI_measure_mcycle_freq(3000, RTC_FREQ);
-        _cpu_frequency = PRCI_measure_mcycle_freq(3000, RTC_FREQ);
-    }
-    return _cpu_frequency;
-#else
-    return CLOCK_CORECLOCK;
+    /* Ignore the first run (for icache reasons) */
+    cpu_coreclk = PRCI_measure_mcycle_freq(3000, RTC_FREQ);
+    cpu_coreclk = PRCI_measure_mcycle_freq(3000, RTC_FREQ);
 #endif
 }

--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include "clk.h"
 #include "cpu.h"
 #include "periph/init.h"
 #include "periph_conf.h"
@@ -80,7 +81,7 @@ void flash_init(void)
      * by the following formula (Fin is processor/tile-link clock):
      *    Fsck = Fin/(2(div + 1))
      */
-    uint32_t freq = cpu_freq();
+    uint32_t freq = coreclk();
     uint32_t sckdiv = (freq - 1) / (MAX_FLASH_FREQ * 2);
 
     if (sckdiv > SCKDIV_SAFE) {

--- a/cpu/fe310/include/clk_conf.h
+++ b/cpu/fe310/include/clk_conf.h
@@ -113,7 +113,7 @@ extern "C" {
 
 /*
    When using HFROSC input clock, the core clock cannot be computed from settings,
-   call cpu_freq() to get the configured CPU frequency.
+   in this case, coreclk() returns the configured CPU frequency.
  */
 #ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
 #define CONFIG_CLOCK_DESIRED_FREQUENCY     MHZ(320)

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -175,13 +175,6 @@ typedef struct {
  */
 void fe310_clock_init(void);
 
-/**
- * @brief   Get and eventually compute the current CPU core clock frequency
- *
- * @return  the cpu core clock frequency in Hz
- */
-uint32_t cpu_freq(void);
-
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/fe310/periph/i2c.c
+++ b/cpu/fe310/periph/i2c.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include "clk.h"
 #include "cpu.h"
 #include "mutex.h"
 
@@ -69,7 +70,7 @@ void i2c_init(i2c_t dev)
 
     /* Compute prescale: presc = (CORE_CLOCK / (5 * I2C_SPEED)) - 1 */
     uint16_t presc =
-        ((uint16_t)(cpu_freq() / 1000) /
+        ((uint16_t)(coreclk() / 1000) /
          (5 * _fe310_i2c_speed[i2c_config[dev].speed])) - 1;
 
     DEBUG("[i2c] init: computed prescale: %i (0x%02X|0x%02X)\n", presc,

--- a/cpu/fe310/periph/spi.c
+++ b/cpu/fe310/periph/spi.c
@@ -24,6 +24,7 @@
 
 #include <assert.h>
 
+#include "clk.h"
 #include "cpu.h"
 #include "mutex.h"
 #include "periph/spi.h"
@@ -62,7 +63,7 @@ void spi_init(spi_t dev)
     mutex_init(&lock);
 
     for (uint8_t i = 0; i < SPI_CLK_NUMOF; ++i) {
-        _spi_clks_config[i] = SPI_DIV_UP(cpu_freq(), 2 * _spi_clks[i]) - 1;
+        _spi_clks_config[i] = SPI_DIV_UP(coreclk(), 2 * _spi_clks[i]) - 1;
     }
 
     /* trigger pin initialization */

--- a/cpu/fe310/periph/uart.c
+++ b/cpu/fe310/periph/uart.c
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <inttypes.h>
 
+#include "clk.h"
 #include "irq.h"
 #include "cpu.h"
 #include "periph/uart.h"
@@ -87,7 +88,7 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     uart_poweron(dev);
 
     /* Calculate baudrate divisor given current CPU clk rate */
-    uartDiv = cpu_freq() / baudrate;
+    uartDiv = coreclk() / baudrate;
 
     /* Enable UART 8-N-1 at given baudrate */
     _REG32(uart_config[dev].addr, UART_REG_DIV) = uartDiv;

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -16,8 +16,19 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+#include "macros/units.h"
+
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @brief   System core clock in Hz
+ *
+ *  1GHz is an arbitrary value used for compatibility with other platforms.
+ */
+#ifndef CLOCK_CORECLOCK
+#define CLOCK_CORECLOCK     GHZ(1)
 #endif
 
 /**

--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -19,9 +19,3 @@ QUIET ?= 1
 FEATURES_OPTIONAL += periph_timer
 
 include $(RIOTBASE)/Makefile.include
-
-ifeq (native,$(BOARD))
-  # For the native board, CLOCK_CORECLOCK is undefined. But we need
-  # a valid number to get the example compiled
-  CFLAGS += -DCLOCK_CORECLOCK=1000000000
-endif

--- a/examples/blinky/main.c
+++ b/examples/blinky/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 
+#include "clk.h"
 #include "board.h"
 #include "periph_conf.h"
 #include "timex.h"
@@ -41,7 +42,8 @@ static void delay(void)
          * compilers would detect that the loop is only wasting CPU cycles and
          * optimize it out - but here the wasting of CPU cycles is desired.
          */
-        for (volatile uint32_t i = 0; i < CLOCK_CORECLOCK / 20; i++) { }
+        uint32_t loops = coreclk() / 20;
+        for (volatile uint32_t i = 0; i < loops; i++) { }
     }
 }
 

--- a/pkg/openwsn/contrib/leds.c
+++ b/pkg/openwsn/contrib/leds.c
@@ -23,6 +23,7 @@
 #include "leds.h"
 #include "openwsn_leds.h"
 
+#include "clk.h"
 #include "board.h"
 #include "periph/gpio.h"
 
@@ -86,7 +87,8 @@ static void _blink_checked(gpio_t pin)
         /* toggle for ~10s if ztimer is used */
         for (uint8_t i = 0; i < 100; i++) {
             _toggle_checked(pin);
-            for (uint32_t i = 0; i < (CLOCK_CORECLOCK / 50); i++) {
+            uint32_t runs = coreclk() / 50;
+            for (uint32_t i = 0; i < runs; i++) {
                 /* Make sure for loop is not optimized out */
                 __asm__ ("");
             }

--- a/sys/include/clk.h
+++ b/sys/include/clk.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_clk System core clock
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       System core clock utility functions
+ */
+
+#ifndef CLK_H
+#define CLK_H
+
+#include <assert.h>
+#include <stdint.h>
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get the current system core clock frequency in Hz.
+ *
+ * @returns current system core clock frequency in Hz
+ */
+static inline uint32_t coreclk(void) {
+#if defined(CLOCK_CORECLOCK)
+    return CLOCK_CORECLOCK;
+#else
+    extern uint32_t cpu_coreclk;
+    assert(cpu_coreclk != 0);
+    return cpu_coreclk;
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CLK_H */
+/** @} */

--- a/tests/bench_msg_pingpong/main.c
+++ b/tests/bench_msg_pingpong/main.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include "macros/units.h"
 #include "thread.h"
+#include "clk.h"
 
 #include "msg.h"
 #include "xtimer.h"
@@ -80,10 +81,8 @@ int main(void)
     }
 
     printf("{ \"result\" : %"PRIu32, n);
-#ifdef CLOCK_CORECLOCK
     printf(", \"ticks\" : %"PRIu32,
-           (uint32_t)((TEST_DURATION_US/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
-#endif
+           (uint32_t)((TEST_DURATION_US/US_PER_MS) * (coreclk()/KHZ(1)))/n);
     puts(" }");
 
     return 0;

--- a/tests/bench_mutex_pingpong/main.c
+++ b/tests/bench_mutex_pingpong/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 
 #include "macros/units.h"
+#include "clk.h"
 #include "mutex.h"
 #include "thread.h"
 #include "xtimer.h"
@@ -79,10 +80,8 @@ int main(void)
     }
 
     printf("{ \"result\" : %"PRIu32, n);
-#ifdef CLOCK_CORECLOCK
     printf(", \"ticks\" : %"PRIu32,
-           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
-#endif
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (coreclk()/KHZ(1)))/n);
     puts(" }");
 
     return 0;

--- a/tests/bench_sched_nop/main.c
+++ b/tests/bench_sched_nop/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "macros/units.h"
+#include "clk.h"
 #include "thread.h"
 
 #include "xtimer.h"
@@ -53,10 +54,8 @@ int main(void)
     }
 
     printf("{ \"result\" : %"PRIu32, n);
-#ifdef CLOCK_CORECLOCK
     printf(", \"ticks\" : %"PRIu32,
-           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
-#endif
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (coreclk()/KHZ(1)))/n);
     puts(" }");
 
     return 0;

--- a/tests/bench_thread_flags_pingpong/main.c
+++ b/tests/bench_thread_flags_pingpong/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "macros/units.h"
+#include "clk.h"
 #include "thread.h"
 
 #include "thread_flags.h"
@@ -76,10 +77,8 @@ int main(void)
     }
 
     printf("{ \"result\" : %"PRIu32, n);
-#ifdef CLOCK_CORECLOCK
     printf(", \"ticks\" : %"PRIu32,
-           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
-#endif
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (coreclk()/KHZ(1)))/n);
     puts(" }");
 
     return 0;

--- a/tests/bench_thread_yield_pingpong/main.c
+++ b/tests/bench_thread_yield_pingpong/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 
 #include "macros/units.h"
+#include "clk.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -73,10 +74,8 @@ int main(void)
     }
 
     printf("{ \"result\" : %"PRIu32, n);
-#ifdef CLOCK_CORECLOCK
     printf(", \"ticks\" : %"PRIu32,
-           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
-#endif
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (coreclk()/KHZ(1)))/n);
     puts(" }");
 
     return 0;

--- a/tests/leds/main.c
+++ b/tests/leds/main.c
@@ -21,14 +21,11 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include "clk.h"
 #include "board.h"
 #include "periph_conf.h"
 
-#ifdef CLOCK_CORECLOCK
-#define DELAY_SHORT         (CLOCK_CORECLOCK / 50)
-#else
-#define DELAY_SHORT         (500000UL)
-#endif
+#define DELAY_SHORT         (coreclk() / 50)
 #define DELAY_LONG          (DELAY_SHORT * 4)
 
 void dumb_delay(uint32_t delay)

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -37,7 +37,7 @@ BOARDS_TIMER_32kHz := \
     stk3700 \
     #
 
-BOARDS_TIMER_CLOCK_CORECLOCK := \
+BOARDS_TIMER_SYSCLK := \
   cc2538dk \
   openmote-b \
   openmote-cc2538 \
@@ -52,8 +52,8 @@ else ifneq (,$(filter $(BOARDS_TIMER_250kHz),$(BOARD)))
   TIMER_SPEED ?= 250000
 else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
   TIMER_SPEED ?= 32768
-else ifneq (,$(filter $(BOARDS_TIMER_CLOCK_CORECLOCK),$(BOARD)))
-  TIMER_SPEED ?= CLOCK_CORECLOCK
+else ifneq (,$(filter $(BOARDS_TIMER_SYSCLK),$(BOARD)))
+  TIMER_SPEED ?= coreclk\(\)
 endif
 
 TIMER_SPEED ?= 1000000

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "clk.h"
 #include "periph/timer.h"
 
 /**

--- a/tests/periph_uart_mode/main.c
+++ b/tests/periph_uart_mode/main.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "clk.h"
 #include "board.h"
 #include "periph/uart.h"
 #include "periph_conf.h"
@@ -69,7 +70,8 @@ static void _delay(void)
          * compilers would detect that the loop is only wasting CPU cycles and
          * optimize it out - but here the wasting of CPU cycles is desired.
          */
-        for (volatile uint32_t i = 0; i < CLOCK_CORECLOCK / 20; i++) { }
+        uint32_t loops = coreclk() / 20;
+        for (volatile uint32_t i = 0; i < loops; i++) { }
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR introduces the `sysclk()` to get the value of the system core clock frequency. In most situation, this frequency corresponds to the `CLOCK_CORECLOCK` constant. But in some cases, this constant is wrong or not defined:
- with native it's not defined at all so when using CLOCK_CORECLOCK some preprocessor checks are needed
- on fe310, when using the internal oscillator clocks, the constant is not defined but the system clock is computed at runtime. This behavior could be extend to other families: on STM32, one could imagine fine tuning at runtime the trimming value of internal oscillator to get an approximate of a desired clock value (HSI16 or HSI48 - without autotrim - for example).
As an example, doing the following doesn't build on hifive1b:
```
$ CFLAGS=-DCONFIG_USE_CLOCK_HFROSC=1 BUILD_IN_DOCKER=1 BOARD=hifive1b make -C examples/blinky --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=hifive1b' -e 'CFLAGS=-DCONFIG_USE_CLOCK_HFROSC=1'  -w '/data/riotbuild/riotbase/examples/blinky/' 'riot/riotbuild:latest' make     
Building application "blinky" for "hifive1b" with MCU "fe310".

/data/riotbuild/riotbase/examples/blinky/main.c: In function 'delay':
/data/riotbuild/riotbase/examples/blinky/main.c:44:43: error: 'CLOCK_CORECLOCK' undeclared (first use in this function)
   44 |         for (volatile uint32_t i = 0; i < CLOCK_CORECLOCK / 20; i++) { }
      |                                           ^~~~~~~~~~~~~~~
/data/riotbuild/riotbase/examples/blinky/main.c:44:43: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [/data/riotbuild/riotbase/Makefile.base:146: /data/riotbuild/riotbase/examples/blinky/bin/hifive1b/application_blinky/main.o] Error 1
```

So the idea of this PR is to wrap `CLOCK_CORECLOCK` in a static inline function called `sysclk` (suggestions for a better name welcome), inspired by what was done with fe310 and let the cpu implementation define its own version when it cannot be determined at compile time, but only a runtime.
With compiler optimization, using this function has no effect compared to directly using the constant.

All tests, examples, drivers and pkg that are using `CLOCK_CORECLOCK` are adapted to use this function. We could also imagine to use it in the CPU implementations directly (like the fe310).

Last, but not least, I wasn't sure what's the best location for the header `clk.h`. For the moment, it's in `sys/`, before I put it in `core/` but maybe it would be preferable to put it in `cpu/` and in this case, where ? Suggestion welcome.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- Check the firmware sizes are unchanged (maybe not for `tests/driver_ws281x`
- fe310 features (uart, i2c, spi) are still working
- affected test applications are still working
- openwsn is still working

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
