### PR TITLE
makefiles: remove PCF857x pseudomodule definitions

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -174,12 +174,6 @@ NO_PSEUDOMODULES += netdev_ieee802154_submac
 # print ascii representation in function od_hex_dump()
 PSEUDOMODULES += od_string
 
-# include variants of PCF857X drivers as pseudo modules
-PSEUDOMODULES += pcf857x_irq
-PSEUDOMODULES += pcf8574
-PSEUDOMODULES += pcf8574a
-PSEUDOMODULES += pcf8575
-
 # add all pseudo random number generator variants as pseudomodules
 PSEUDOMODULES += prng_%
 


### PR DESCRIPTION
### Contribution description

As the title says, the PCF7857x pseudomodule definitions that were accidentally added by PR #10430 are removed.

The pseudomodules used by the PCF7857x driver are correctly defined by the `Makfefile.include` of the driver. However, by mistake they were left in `makefiles/pseudomodules.mk` when the very old PR was rebased to the current master. That is, they were only leftovers that have been overseen after rebasing an squashing dozens of fixup commits.

### Testing procedure

Compilation in Murdock succeed.

### Issues/PRs references

Added with PR #10430 