### PR TITLE
nimble/statconn: use errno return values

### DIFF
--- a/pkg/nimble/statconn/include/nimble_statconn.h
+++ b/pkg/nimble/statconn/include/nimble_statconn.h
@@ -50,6 +50,7 @@
 #ifndef NIMBLE_STATCONN_H
 #define NIMBLE_STATCONN_H
 
+#include <errno.h>
 #include <stdint.h>
 
 #include "nimble_netif.h"
@@ -113,16 +114,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Return codes used by the statconn module
- */
-enum {
-    NIMBLE_STATCONN_OK      =  0,   /**< all groovy */
-    NIMBLE_STATCONN_NOSLOT  = -1,   /**< no more connection slot available */
-    NIMBLE_STATCONN_NOTCONN = -2,   /**< given address is not managed */
-    NIMBLE_STATCONN_INUSE   = -3,   /**< given peer is already managed */
-};
-
-/**
  * @brief   Initialize the statconn module
  *
  * @warning This function **must** only be called once. Typically this is done
@@ -148,9 +139,9 @@ void nimble_statconn_eventcb(nimble_netif_eventcb_t cb);
  *
  * @param[in] addr      BLE address of the peer
  *
- * @return  NIMBLE_STATCONN_OK if peer was successfully added
- * @return  NIMBLE_STATCONN_INUSE if the peer address is already in use
- * @return  NIMBLE_STATCONN_NOSLOT if no empty connection slot is available
+ * @return  0 if peer was successfully added
+ * @return  -EALREADY if the peer address is already in use
+ * @return  -ENOMEM if no empty connection slot is available
  */
 int nimble_statconn_add_master(const uint8_t *addr);
 
@@ -159,9 +150,9 @@ int nimble_statconn_add_master(const uint8_t *addr);
  *
  * @param[in] addr      BLE address of the peer
  *
- * @return  NIMBLE_STATCONN_OK if peer was successfully added
- * @return  NIMBLE_STATCONN_INUSE if the peer address is already in use
- * @return  NIMBLE_STATCONN_NOSLOT if no empty connection slot is available
+ * @return  0 if peer was successfully added
+ * @return  -EALREADY if the peer address is already in use
+ * @return  -ENOMEM if no empty connection slot is available
  */
 int nimble_statconn_add_slave(const uint8_t *addr);
 
@@ -170,8 +161,8 @@ int nimble_statconn_add_slave(const uint8_t *addr);
  *
  * @param[in] addr      BLE address of the peer
  *
- * @return  NIMBLE_STATCONN_OK if peer was successfully removed
- * @return  NIMBLE_STATCONN_NOTCONN if given address is not managed
+ * @return  0 if peer was successfully removed
+ * @return  -ENOTCONN if given address is not managed
  */
 int nimble_statconn_rm(const uint8_t *addr);
 

--- a/pkg/nimble/statconn/nimble_statconn.c
+++ b/pkg/nimble/statconn/nimble_statconn.c
@@ -159,19 +159,19 @@ static int _be(uint8_t role, const uint8_t *addr)
     slot_t *s = _get_addr(addr);
     if (s != NULL) {
         mutex_unlock(&_lock);
-        return NIMBLE_STATCONN_INUSE;
+        return -EALREADY;
     }
     s = _get_state(UNUSED);
     if (s == NULL) {
         mutex_unlock(&_lock);
-        return NIMBLE_STATCONN_NOSLOT;
+        return -ENOMEM;
     }
 
     s->state = (role | PENDING);
     memcpy(s->addr, addr, BLE_ADDR_LEN);
     mutex_unlock(&_lock);
     _activate(role);
-    return NIMBLE_STATCONN_OK;
+    return 0;
 }
 
 void nimble_statconn_init(void)
@@ -226,7 +226,7 @@ int nimble_statconn_rm(const uint8_t *addr)
     slot_t *s = _get_addr(addr);
     if (s == NULL) {
         mutex_unlock(&_lock);
-        return NIMBLE_STATCONN_NOTCONN;
+        return -ENOTCONN;
     }
     uint8_t role = (s->state & ROLE_M) ? ROLE_M : ROLE_S;
 
@@ -242,5 +242,5 @@ int nimble_statconn_rm(const uint8_t *addr)
         _activate(ROLE_S);
     }
 
-    return NIMBLE_STATCONN_OK;
+    return 0;
 }

--- a/sys/shell/commands/sc_nimble_statconn.c
+++ b/sys/shell/commands/sc_nimble_statconn.c
@@ -39,7 +39,7 @@ int _nimble_statconn_handler(int argc, char **argv)
     }
 
     if (strncmp(argv[1], "addm", 4) == 0) {
-        if (nimble_statconn_add_master(addr) == NIMBLE_STATCONN_OK) {
+        if (nimble_statconn_add_master(addr) == 0) {
             puts("success: connecting to peer as slave");
         }
         else {
@@ -47,7 +47,7 @@ int _nimble_statconn_handler(int argc, char **argv)
         }
     }
     else if (strncmp(argv[1], "adds", 4) == 0) {
-        if (nimble_statconn_add_slave(addr) == NIMBLE_STATCONN_OK) {
+        if (nimble_statconn_add_slave(addr) == 0) {
             puts("success: connecting to peer as master");
         }
         else {
@@ -55,7 +55,7 @@ int _nimble_statconn_handler(int argc, char **argv)
         }
     }
     else if (strncmp(argv[1], "rm", 2) == 0) {
-        if (nimble_statconn_rm(addr) == NIMBLE_STATCONN_OK) {
+        if (nimble_statconn_rm(addr) == 0) {
             puts("success: closed connection to peer");
         }
         else {


### PR DESCRIPTION
### Contribution description
I recently ported most of the nimble submodules from using custom return values to using `errno` values. This PR applies that same changes to `nimble_statconn` to make this module more coherent to the rest. Should be pretty straight forward...


### Testing procedure
Code review and build test should do the trick.

### Issues/PRs references
none