### PR TITLE
pkg/uwb-core: fix wrong header include

### DIFF
--- a/pkg/uwb-core/include/uwb_core.h
+++ b/pkg/uwb-core/include/uwb_core.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include "event.h"
 #if IS_USED(MODULE_UWB_CORE_EVENT_THREAD)
-#include "event/thread"
+#include "event/thread.h"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Pretty dumb mistake because of lazy testing on my side.

### Testing procedure

This now compiles:

```
USEMODULE=uwb-core_twr_aloha make -C examples/twr_aloha/ -j
Building application "twr-aloha" for "dwm1001" with MCU "nrf52".

"make" -C /home/francisco/workspace/RIOT/pkg/mynewt-core
"make" -C /home/francisco/workspace/RIOT/pkg/uwb-core
"make" -C /home/francisco/workspace/RIOT/pkg/uwb-dw1000
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/dsp/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_dsp
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/uwb_rng/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_rng
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/rng_math/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_rng_math
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/ -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_twr_aloha
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/twr_ds/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_twr_ds
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/twr_ds_ext/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_twr_ds_ext
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/twr_ss/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_twr_ss
"make" -C /home/francisco/workspace/RIOT/build/pkg/mynewt-core/hw/mcu/nordic/nrf52xxx/src/ -f /home/francisco/workspace/RIOT/pkg/mynewt-core/mynewt-core_nrf5x_hal.mk MODULE=mynewt-core_nrf5x_hal
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/twr_ss_ack/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_twr_ss_ack
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/twr_ss_ext/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_twr_ss_ext
"make" -C /home/francisco/workspace/RIOT/build/pkg/mynewt-core/kernel/os/src -f /home/francisco/workspace/RIOT/pkg/mynewt-core/mynewt-core_os.mk MODULE=mynewt-core_os
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/lib/json/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core_uwb_json
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-dw1000/hw/drivers/uwb/uwb_dw1000/src -f /home/francisco/workspace/RIOT/pkg/uwb-dw1000/uwb-dw1000.mk MODULE=uwb-dw1000
"make" -C /home/francisco/workspace/RIOT/build/pkg/uwb-core/hw/drivers/uwb/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=uwb-core
"make" -C /home/francisco/workspace/RIOT/boards/dwm1001
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/pkg/mynewt-core/contrib
"make" -C /home/francisco/workspace/RIOT/pkg/uwb-core/contrib
"make" -C /home/francisco/workspace/RIOT/pkg/uwb-dw1000/hal
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/event
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/frac
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/periph
"make" -C /home/francisco/workspace/RIOT/cpu/nrf52/vectors
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/sys/ps
"make" -C /home/francisco/workspace/RIOT/sys/sema
"make" -C /home/francisco/workspace/RIOT/cpu/nrf5x_common/periph
"make" -C /home/francisco/workspace/RIOT/sys/shell
"make" -C /home/francisco/workspace/RIOT/sys/shell/commands
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/sys/ztimer
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
   text	   data	    bss	    dec	    hex	filename
  50784	    776	   8552	  60112	   ead0	/home/francisco/workspace/RIOT/examples/twr_aloha/bin/dwm1001/twr-aloha.elf

```


### Issues/PRs references


