### PR TITLE
cpu/esp32: add clear bus during init to the I2C software implementation

### DIFF
--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -210,6 +210,16 @@ void i2c_init(i2c_t dev)
         gpio_init(_i2c_bus[dev].sda, GPIO_IN_OD_PU)) {
         return;
     }
+
+    /* clear the bus by sending 10 clock pulses while SDA is LOW */
+    gpio_set(i2c_config[dev].scl);
+    gpio_set(i2c_config[dev].sda);
+    gpio_clear(i2c_config[dev].sda);
+    for (int i = 0; i < 20; i++) {
+        gpio_toggle(i2c_config[dev].scl);
+    }
+    gpio_set(i2c_config[dev].sda);
+
 #else /* MCU_ESP32 */
     /*
      * Due to critical timing required by the I2C software implementation,
@@ -226,8 +236,8 @@ void i2c_init(i2c_t dev)
      * When I2C_CLOCK_STRETCH is 0 (disabled), SCL is instead an always driven
      * output GPIO with no pull-up.
      */
-    if (gpio_init(_i2c_bus[dev].scl, I2C_CLOCK_STRETCH ? GPIO_IN_PU : GPIO_OUT)
-        || gpio_init(_i2c_bus[dev].sda, GPIO_IN_PU)) {
+    if (gpio_init(_i2c_bus[dev].scl, I2C_CLOCK_STRETCH ? GPIO_IN_PU : GPIO_OUT) ||
+        gpio_init(_i2c_bus[dev].sda, GPIO_IN_PU)) {
         return;
     }
 #endif /* MCU_ESP32 */

--- a/drivers/aip31068/Makefile.dep
+++ b/drivers/aip31068/Makefile.dep
@@ -1,8 +1,3 @@
 FEATURES_REQUIRED += periph_i2c
 
 USEMODULE += xtimer
-
-ifeq (esp32,$(CPU))
-  # necessary to fix driver initialization on esp32
-  USEMODULE += esp_i2c_hw
-endif


### PR DESCRIPTION
### Contribution description

This PR adds a clear bus mechanism to the I2C software implementation, which is executed during initialization.

On the ESP32 it it often not possible with the I2C software implementation to communicate with an AIP31068 based LCD module.  Therefore, the I2C hardware implementation is enabled when the AIP31068 driver is used. The timing of the two implementations seems to be almost identical. The only difference is that the hardware implementation clears the bus before each access by sending 10 clock pulses on the SCL line while the SDA is held LOW. Using the same mechanism during the I2C initialization for the software implementation solves the communication problem with the AIP31068.

Because the I2C hardware implementation is more buggy than stable and the AIP31068 driver is the only module that used the I2C hardware implementation, this special dependency is removed with this fix.

### Testing procedure
```
make BOARD=esp32-wroom-32 -C tests/driver_aip31068/ flash term
```
should work stable.

### Issues/PRs references

The problem popped up when migrating makefile dependencies to Kconfig in PR #17232.