### PR TITLE
tests/pkg_ucglib: add missing function declaration

### DIFF
--- a/tests/pkg_ucglib/Makefile
+++ b/tests/pkg_ucglib/Makefile
@@ -20,6 +20,7 @@ endif
 
 # features depend on output type
 ifeq ($(TEST_OUTPUT),2)
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=48*1024
   USEMODULE += ucglib_sdl
 endif
 

--- a/tests/pkg_ucglib/main.c
+++ b/tests/pkg_ucglib/main.c
@@ -61,6 +61,10 @@
 
 #include "logo.h"
 
+#if TEST_OUTPUT == TEST_OUTPUT_SDL
+int ucg_sdl_get_key(void);
+#endif
+
 int main(void)
 {
     uint32_t screen = 0;


### PR DESCRIPTION
### Contribution description

From testing #17309 I ran into an issue with SDL function declarations, this declares the missign funciton

### Testing procedure

`TEST_OUTPUT=2 make -C tests/pkg_ucglib/ flash term` compiles and works on native.
