### PR TITLE
gnrc/ipv6_auto_subnets: init RPL root when adding a prefix

### DIFF
--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -729,6 +729,9 @@ static inline int gnrc_netif_ipv6_group_to_l2_group(gnrc_netif_t *netif,
  * @param[in] pref      Preferred lifetime of the prefix in seconds
  *
  * @return  >= 0, on success
+ *          The returned value is the index of the newly created address
+ *          based on the prefix and the interfaces IID in the interface's
+ *          address array.
  * @return  -ENOMEM, when no space for new addresses (or its solicited nodes
  *          multicast address) is left on the interface
  */

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -301,7 +301,10 @@ static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t 
               new_prefix_len, downstream->pid);
 
         /* first remove old prefix if the prefix changed */
-        _remove_old_prefix(downstream, &new_prefix, new_prefix_len, &ext_opts);
+        if (_remove_old_prefix(downstream, &new_prefix, new_prefix_len, &ext_opts)) {
+            /* if the prefix did not change, there is nothing to do here */
+            continue;
+        }
 
         /* configure subnet on downstream interface */
         idx = gnrc_netif_ipv6_add_prefix(downstream, &new_prefix, new_prefix_len,

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -306,6 +306,10 @@ static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t 
         /* configure subnet on downstream interface */
         idx = gnrc_netif_ipv6_add_prefix(downstream, &new_prefix, new_prefix_len,
                                          valid_ltime, pref_ltime);
+        if (idx < 0) {
+            DEBUG("auto_subnets: adding prefix to %u failed\n", downstream->pid);
+            continue;
+        }
 
         /* start advertising subnet */
         gnrc_ipv6_nib_change_rtr_adv_iface(downstream, true);
@@ -320,9 +324,7 @@ static void _configure_subnets(uint8_t subnets, uint8_t start_idx, gnrc_netif_t 
         }
 
         /* configure RPL root if applicable */
-        if (idx >= 0) {
-            gnrc_rpl_configure_root(downstream, &downstream->ipv6.addrs[idx]);
-        }
+        gnrc_rpl_configure_root(downstream, &downstream->ipv6.addrs[idx]);
     }
 
     /* immediately send an RA with RIO */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently there is no way to initialize a RPL root from the shell in the same way as with automatic prefix configuration.
This changes the `nib prefix add` command to use the same mechanism as `uhcpc` and `dhcpv6` when adding a new prefix.

I also added this to the `ipv6_auto_subnets` as this was missing there before.

To avoid conflicts with heterogeneous downstream networks (wired and wireless downstream) I added a check to only initialize RPL on a wireless interface.

### Testing procedure


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
