### PR TITLE
ztimer_periodic: make callback function return bool

### DIFF
--- a/sys/event/periodic.c
+++ b/sys/event/periodic.c
@@ -22,7 +22,7 @@
 #include "ztimer/periodic.h"
 #include "event/periodic.h"
 
-static int _event_periodic_callback(void *arg)
+static bool _event_periodic_callback(void *arg)
 {
     event_periodic_t *event_periodic = (event_periodic_t *)arg;
 

--- a/sys/include/ztimer/periodic.h
+++ b/sys/include/ztimer/periodic.h
@@ -66,6 +66,7 @@
 #ifndef ZTIMER_PERIODIC_H
 #define ZTIMER_PERIODIC_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "ztimer.h"
@@ -77,7 +78,7 @@ extern "C" {
 /**
  * @brief Periodic timer stop unless it returns this value
  */
-#define ZTIMER_PERIODIC_KEEP_GOING 0
+#define ZTIMER_PERIODIC_KEEP_GOING true
 
 /**
  * @brief   ztimer periodic structure
@@ -87,7 +88,7 @@ typedef struct {
     ztimer_clock_t *clock;      /**< clock for this timer               */
     uint32_t interval;          /**< interval of this timer             */
     ztimer_now_t last;          /**< last trigger time                  */
-    int (*callback)(void *);    /**< called on each trigger             */
+    bool (*callback)(void *);   /**< called on each trigger             */
     void *arg;                  /**< argument for callback              */
 } ztimer_periodic_t;
 
@@ -100,11 +101,12 @@ typedef struct {
  * @param[in]       clock       the clock to configure this timer on
  * @param[inout]    timer       periodic timer object to initialize
  * @param[in]       callback    function to call on each trigger
+ *                              returns `true` if the timer should keep going
  * @param[in]       arg         argument to pass to callback function
  * @param[in]       interval    period length of this timer instance
  */
 void ztimer_periodic_init(ztimer_clock_t *clock, ztimer_periodic_t *timer,
-                          int (*callback)(void *),
+                          bool (*callback)(void *),
                           void *arg, uint32_t interval);
 
 /**

--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -54,7 +54,7 @@ static void _ztimer_periodic_callback(void *arg)
 }
 
 void ztimer_periodic_init(ztimer_clock_t *clock, ztimer_periodic_t *timer,
-                          int (*callback)(
+                          bool (*callback)(
                               void *), void *arg, uint32_t interval)
 {
     *timer =

--- a/tests/ztimer_periodic/main.c
+++ b/tests/ztimer_periodic/main.c
@@ -41,7 +41,7 @@ static const char *_names[] = { "ZTIMER_MSEC", "ZTIMER_USEC" };
 static uint32_t _intervals[] = { 100, 10000 };
 static uint32_t _max_offsets[] = { 2, 100 };
 
-static int callback(void *arg)
+static bool callback(void *arg)
 {
     _times[_count] = ztimer_now(arg);
 
@@ -58,7 +58,7 @@ static int callback(void *arg)
         mutex_unlock(&_mutex);
     }
 
-    return (_count == REPEAT);
+    return _count < REPEAT;
 }
 
 int main(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The callback function of `ztimer_periodic` is only expected to have two states.
So let it return `true` if the timer should keep repeating, `false` otherwise.


**This is an API change**: Previously users had to return `0` to keep going, now `!0` needs to be returned to keep the timer running. But the meaning of the return value was previously undocumented and the functionality is rather new, I expect there to be not many (if any) users.

### Testing procedure

`tests/ztimer_periodic` still works


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
