### PR TITLE
tests/ieee802154_hal: fix default RNG selection

### DIFF
--- a/tests/ieee802154_hal/app.config.test.native
+++ b/tests/ieee802154_hal/app.config.test.native
@@ -3,4 +3,4 @@ CONFIG_MODULE_SOCKET_ZEP=y
 # Should be autoselecting the MODULE_PRNG_HWRNG if possible
 # Since the makefile cannot we have to override until end of migration
 # Remove when TEST_KCONFIG is complete
-CONFIG_MODULE_PRNG_TINYMT32=y
+CONFIG_MODULE_PRNG_MUSL_LCG=y


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

#16932 introduced `app.config.test.native` but back when that PR was created the default was still tinymt32.
Now the default is musl lcg - this must also be reflected by Kconfig.


### Testing procedure

Fixes CI build

```
-- running on worker riotbuild-0 thread 3, build number 9661.
make: Entering directory '/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/tests/ieee802154_hal'
make: Leaving directory '/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/tests/ieee802154_hal'
make: Entering directory '/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/tests/ieee802154_hal'
Building application "tests_ieee802154_hal" for "native" with MCU "native".

sha1sum /tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/build/tests_ieee802154_hal.elf > /tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/build/test-input-hash.sha1
   text	   data	    bss	    dec	    hex	filename
  60744	   8945	  49492	 119181	  1d18d	/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/build/tests_ieee802154_hal.elf
make: Leaving directory '/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/tests/ieee802154_hal'
make: Entering directory '/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/tests/ieee802154_hal'
Building application "tests_ieee802154_hal" for "native" with MCU "native".

sha1sum /tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/build/tests_ieee802154_hal.elf > /tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/build/test-input-hash.sha1
   text	   data	    bss	    dec	    hex	filename
  60304	   8945	  49476	 118725	  1cfc5	/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/build/tests_ieee802154_hal.elf
make: Leaving directory '/tmp/dwq.0.915265949079789/4a5d8cd9d792a713bd5ebbf844208c96/tests/ieee802154_hal'
Hashes of binaries with and without Kconfig mismatch for tests/ieee802154_hal
Please check that all used modules are modelled in Kconfig and enabled
43c43
< prng_musl_lcg
---
> prng_tinymt32
51a52
> tinymt32
-- build directory size: 84K
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
