### PR TITLE
gnrc/netif: convert to ztimer

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -137,6 +137,7 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += l2util
   USEMODULE += fmt
+  USEMODULE += ztimer_msec
   ifneq (,$(filter netdev_ieee802154_submac,$(USEMODULE)))
     USEMODULE += gnrc_netif_pktq
   endif

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -41,8 +41,8 @@
 #include "fmt.h"
 #include "log.h"
 #include "sched.h"
-#if IS_USED(MODULE_XTIMER) || IS_USED(MODULE_ZTIMER_XTIMER_COMPAT)
-#include "xtimer.h"
+#if IS_USED(MODULE_ZTIMER)
+#include "ztimer.h"
 #endif
 
 #include "net/gnrc/netif.h"
@@ -1370,7 +1370,7 @@ bool gnrc_netif_ipv6_wait_for_global_address(gnrc_netif_t *netif,
     /* wait for global address */
     msg_t m;
     while (!has_global) {
-        if (xtimer_msg_receive_timeout(&m, timeout_ms * US_PER_MS) < 0) {
+        if (ztimer_msg_receive_timeout(ZTIMER_MSEC, &m, timeout_ms) < 0) {
             DEBUG_PUTS("gnrc_netif: timeout waiting for prefix");
             break;
         }
@@ -1867,7 +1867,7 @@ static void *_gnrc_netif_thread(void *args)
     /* now let rest of GNRC use the interface */
     gnrc_netif_release(netif);
 #if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
-    xtimer_ticks32_t last_wakeup = xtimer_now();
+    uint32_t last_wakeup = ztimer_now(ZTIMER_USEC);
 #endif
 
     while (1) {
@@ -1893,13 +1893,14 @@ static void *_gnrc_netif_thread(void *args)
                 DEBUG("gnrc_netif: GNRC_NETDEV_MSG_TYPE_SND received\n");
                 _send(netif, msg.content.ptr, false);
 #if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
-                xtimer_periodic_wakeup(
+                ztimer_periodic_wakeup(
+                        ZTIMER_USEC,
                         &last_wakeup,
                         CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US
                     );
                 /* override last_wakeup in case last_wakeup +
                  * CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US was in the past */
-                last_wakeup = xtimer_now();
+                last_wakeup = ztimer_now(ZTIMER_USEC);
 #endif
                 break;
             case GNRC_NETAPI_MSG_TYPE_SET:

--- a/tests/driver_at86rf215/Makefile.ci
+++ b/tests/driver_at86rf215/Makefile.ci
@@ -31,4 +31,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     telosb \
     waspmote-pro \
     zigduino \
+    z1
     #

--- a/tests/gnrc_netif_ipv6_wait_for_global_address/main.c
+++ b/tests/gnrc_netif_ipv6_wait_for_global_address/main.c
@@ -27,7 +27,7 @@
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/raw.h"
 #include "net/netdev_test.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define TEST_NETIF_NUMOF    2
 #define TEST_NETIF_PRIO     3
@@ -54,7 +54,7 @@ static void tear_down(void)
 
 static void *_adder_thread(void *netif)
 {
-    xtimer_msleep(10);
+    ztimer_sleep(ZTIMER_MSEC, 10);
     gnrc_netif_ipv6_addr_add(netif, &_test_addr, 64,
                              GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
     return NULL;
@@ -74,16 +74,16 @@ static void _assert_wait_blocks(gnrc_netif_t *add_netif,
                                 gnrc_netif_t *wait_netif,
                                 bool success)
 {
-    uint32_t now = xtimer_now_usec();
+    uint32_t now = ztimer_now(ZTIMER_MSEC);
     uint32_t timeout = 20;
 
     _add_delayed_addr(add_netif);
     TEST_ASSERT(gnrc_netif_ipv6_wait_for_global_address(wait_netif,
                                                         timeout) == success);
     if (success) {
-        TEST_ASSERT(((xtimer_now_usec() - now) / US_PER_MS) < timeout);
+        TEST_ASSERT((ztimer_now(ZTIMER_MSEC) - now) < timeout);
     } else {
-        TEST_ASSERT(((xtimer_now_usec() - now) / US_PER_MS) >= timeout);
+        TEST_ASSERT((ztimer_now(ZTIMER_MSEC) - now) >= timeout);
     }
 }
 


### PR DESCRIPTION
### Contribution description

This converts gnrc_netif.c to use ztimer instead of xtimer.

### Testing procedure

I think the test in tests ` tests/gnrc_netif_ipv6_wait_for_global_address` should be sufficient:

```Shellsession
koen@zometeen ~/dev/RIOT-dev $ make -C tests/gnrc_netif_ipv6_wait_for_global_address/ term
make: Entering directory '/home/koen/dev/RIOT-dev/tests/gnrc_netif_ipv6_wait_for_global_address'
/home/koen/dev/RIOT-dev/tests/gnrc_netif_ipv6_wait_for_global_address/bin/native/tests_gnrc_netif_ipv6_wait_for_global_address.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
s
START
....
OK (4 tests)
```


### Issues/PRs references

On the list of #17111 