### PR TITLE
sys/evtimer,ztimer: do not depend on ztimer_now64

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -19,6 +19,8 @@ USEMODULE += gnrc_icmpv6_echo
 
 USEMODULE += nanocoap_sock
 
+USEMODULE += xtimer
+
 # include this for nicely formatting the returned internal value
 USEMODULE += fmt
 

--- a/examples/suit_update/main.c
+++ b/examples/suit_update/main.c
@@ -23,7 +23,6 @@
 #include "thread.h"
 #include "irq.h"
 #include "net/nanocoap_sock.h"
-#include "xtimer.h"
 
 #include "shell.h"
 

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -5,6 +5,7 @@ USEMODULE += hashes
 USEMODULE += random
 USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
+USEMODULE += xtimer
 
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -22,6 +22,7 @@
 #include "log.h"
 #include "net/sock/dtls.h"
 #include "net/credman.h"
+#include "xtimer.h"
 
 #if SOCK_HAS_ASYNC
 #include "net/sock/async.h"

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -154,6 +154,7 @@ endif
 
 ifneq (,$(filter uhcpc,$(USEMODULE)))
   USEMODULE += posix_inet
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter netdev_tap,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -745,6 +745,7 @@ endif
 
 ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
   USEMODULE += nanocoap_sock
+  USEMODULE += xtimer
   USEMODULE += sock_util
 endif
 

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -137,6 +137,9 @@ static inline uint32_t evtimer_now_msec(void)
 
 /**
  * @brief   Return the current system time in minutes
+ *
+ * @deprecated wrongly placed convenience function, that
+ *             may not work as expected with ztimer (32 bit)
  */
 static inline uint32_t evtimer_now_min(void)
 {

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -124,7 +124,7 @@ ifneq (,$(filter gnrc_ipv6_auto_subnets,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_nib_rtr_adv_pio_cb
   CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ADV_ROUTER=0
   CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ADD_RIO_IN_LAST_RA=1
-
+  USEMODULE += xtimer
   ifeq (,$(filter gnrc_ipv6_auto_subnets_simple,$(USEMODULE)))
     DEFAULT_MODULE += gnrc_ipv6_auto_subnets_auto_init
     USEMODULE += gnrc_udp

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -26,7 +26,9 @@
 #include "net/gnrc/tx_sync.h"
 #include "net/udp.h"
 #include "utlist.h"
+#ifdef MODULE_XTIMER
 #include "xtimer.h"
+#endif
 
 #include "sock_types.h"
 #include "gnrc_sock_internal.h"

--- a/sys/test_utils/Makefile.dep
+++ b/sys/test_utils/Makefile.dep
@@ -8,4 +8,5 @@ ifneq (,$(filter benchmark_udp,$(USEMODULE)))
   USEMODULE += netutils
   USEMODULE += sema_inv
   USEMODULE += sock_udp
+  USEMODULE += xtimer
 endif

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -34,7 +34,6 @@ endif
 # make evtimer use ztimer_msec as low level timer
 ifneq (,$(filter evtimer_on_ztimer,$(USEMODULE)))
   USEMODULE += ztimer_msec
-  USEMODULE += ztimer_now64
 endif
 
 # "ztimer_xtimer_compat" is a wrapper of the xtimer API on ztimer_used

--- a/tests/driver_encx24j600/Makefile.ci
+++ b/tests/driver_encx24j600/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
+    bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \
     msb-430h \
@@ -15,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    slstk3400a \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \

--- a/tests/evtimer_underflow/Makefile
+++ b/tests/evtimer_underflow/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += evtimer
+USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/evtimer_underflow/main.c
+++ b/tests/evtimer_underflow/main.c
@@ -23,6 +23,7 @@
 #include "evtimer_msg.h"
 #include "thread.h"
 #include "msg.h"
+#include "xtimer.h"
 
 #define WORKER_MSG_QUEUE_SIZE   (8)
 
@@ -45,7 +46,7 @@ static evtimer_msg_event_t events[] = {
 /* This thread will print the drift to stdout once per second */
 void *worker_thread(void *arg)
 {
-    (void) arg;
+    (void)arg;
 
     msg_init_queue(worker_msg_queue, WORKER_MSG_QUEUE_SIZE);
     while (1) {
@@ -58,6 +59,11 @@ void *worker_thread(void *arg)
     }
 }
 
+void sleep_msec(uint16_t t)
+{
+    xtimer_msleep(t);
+}
+
 int main(void)
 {
     evtimer_init_msg(&evtimer);
@@ -67,9 +73,11 @@ int main(void)
                                      THREAD_PRIORITY_MAIN - 1,
                                      THREAD_CREATE_STACKTEST,
                                      worker_thread, NULL, "worker");
+
     while (1) {
         for (unsigned i = 0; i < NEVENTS; i++) {
             evtimer_add_msg(&evtimer, &events[i], pid);
+            sleep_msec(10);
         }
     }
 }

--- a/tests/gnrc_dhcpv6_relay/Makefile.ci
+++ b/tests/gnrc_dhcpv6_relay/Makefile.ci
@@ -10,7 +10,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
+    hifive1 \
+    hifive1b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -20,6 +20,8 @@ USEMODULE += sock_ip
 USEMODULE += gnrc_ipv6
 USEMODULE += ps
 
+USEMODULE += xtimer
+
 CFLAGS += -DTEST_SUITES
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sock_neterr/Makefile.ci
+++ b/tests/gnrc_sock_neterr/Makefile.ci
@@ -8,7 +8,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l011k4 \
+    nucleo-l031k6\
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
+    stm32g0316-disco \
     #

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -20,6 +20,8 @@ USEMODULE += gnrc_sock_check_reuse
 USEMODULE += sock_udp
 USEMODULE += gnrc_ipv6
 USEMODULE += ps
+USEMODULE += xtimer
+
 
 CFLAGS += -DTEST_SUITES
 

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -11,6 +11,8 @@ USEMODULE += gnrc_icmpv6_echo
 
 USEMODULE += sock_udp
 
+USEMODULE += xtimer
+
 USEPKG += microcoap
 
 # include this for printing IP addresses

--- a/tests/riotboot_flashwrite/Makefile.ci
+++ b/tests/riotboot_flashwrite/Makefile.ci
@@ -16,8 +16,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
+    nucleo-l412kb \
     saml10-xpro \
     saml11-xpro \
     slstk3400a \


### PR DESCRIPTION
### Contribution description

evtimer uses 32 bits of msec -> there is no reason to pull ztimer_now64 

### Testing procedure

run evtimer tests `evtimer_mbox, evtimer_msg, evtimer_underflow` with `USEMODULE=evtimer_on_ztimer`

### Issues/PRs references

