### PR TITLE
core/include/debug.h: minor fix in debug.h

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -94,7 +94,7 @@ extern "C" {
  *
  * @note Another name for ::DEBUG_PRINT
  */
-#define DEBUG(...) if (ENABLE_DEBUG) { DEBUG_PRINT(__VA_ARGS__); }
+#define DEBUG(...) do { if (ENABLE_DEBUG) { DEBUG_PRINT(__VA_ARGS__); } } while (0)
 
 /**
  * @def DEBUG_PUTS
@@ -102,7 +102,7 @@ extern "C" {
  * @brief Print debug information to stdout using puts(), so no stack size
  *        restrictions do apply.
  */
-#define DEBUG_PUTS(str) if (ENABLE_DEBUG) { puts(str); }
+#define DEBUG_PUTS(str) do { if (ENABLE_DEBUG) { puts(str); } } while (0)
 /** @} */
 
 /**

--- a/cpu/gd32v/periph/timer.c
+++ b/cpu/gd32v/periph/timer.c
@@ -119,7 +119,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* set prescaler */
     dev(tim)->PSC = (((periph_apb_clk(timer_config[tim].bus) * 2) / freq) - 1);
     DEBUG("[timer]: %" PRIu32 "/%lu =  %" PRIu16 "\n",
-          periph_apb_clk(timer_config[tim].bus), freq, dev(tim)->PSC)
+          periph_apb_clk(timer_config[tim].bus), freq, dev(tim)->PSC);
 
     /* generate an update event to apply our configuration */
     dev(tim)->SWEVG = TIMER0_SWEVG_UPG_Msk;

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -573,7 +573,7 @@ void isr_radio(void)
              * ID 204, "Switching between TX and RX causes unwanted emissions")
              */
             _disable();
-            DEBUG("[nrf52840] TX ACK done.")
+            DEBUG("[nrf52840] TX ACK done.");
             _set_ifs_timer(false);
             break;
         default:

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -257,7 +257,7 @@ static int mtd_spi_read_jedec_id(const mtd_spi_nor_t *dev, mtd_jedec_id_t *out)
     uint8_t bank = 0;
     while (buffer[bank] == JEDEC_NEXT_BANK) {
         if (++bank == JEDEC_BANK_MAX) {
-            DEBUG_PUTS("mtd_spi_read_jedec_id: bank out of bounds\n")
+            DEBUG_PUTS("mtd_spi_read_jedec_id: bank out of bounds\n");
             return -1;
         }
     }

--- a/drivers/stmpe811/stmpe811_touch_dev.c
+++ b/drivers/stmpe811/stmpe811_touch_dev.c
@@ -66,7 +66,7 @@ uint8_t _stmpe811_touches(const touch_dev_t *touch_dev, touch_t *touches, size_t
         touches[0].x = pos.y;
         touches[0].y = dev->params.xmax - pos.x;
 
-        DEBUG("X: %i, Y: %i\n", touches[0].x, touches[0].y)
+        DEBUG("X: %i, Y: %i\n", touches[0].x, touches[0].y);
     }
 
     return ret;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -206,7 +206,7 @@ static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *
         } else if (prev_state == NO_SPACE) {
             /* No space in session management. Should not happen. If it occurs,
             we lost track of sessions */
-            DEBUG("gcoap: no space in session management. We lost track of sessions!")
+            DEBUG("gcoap: no space in session management. We lost track of sessions!");
             sock_dtls_session_destroy(sock, &socket.ctx_dtls_session);
         }
 
@@ -993,7 +993,7 @@ static ssize_t _tl_authenticate(gcoap_socket_t *sock, const sock_udp_ep_t *remot
         return 0;
     }
     if (session_state == NO_SPACE) {
-        DEBUG("gcoap: no space in dsm\n")
+        DEBUG("gcoap: no space in dsm\n");
         return -ENOTCONN;
     }
 

--- a/sys/net/dsm/dsm.c
+++ b/sys/net/dsm/dsm.c
@@ -67,7 +67,7 @@ dsm_state_t dsm_store(sock_dtls_t *sock, sock_dtls_session_t *session,
 
     /* no existing session found */
     if (res == 0) {
-        DEBUG("dsm: no existing session found, storing as new session\n")
+        DEBUG("dsm: no existing session found, storing as new session\n");
         sock_dtls_session_get_udp_ep(session, &ep);
         sock_dtls_session_set_udp_ep(&session_slot->session, &ep);
         session_slot->sock = sock;
@@ -76,7 +76,7 @@ dsm_state_t dsm_store(sock_dtls_t *sock, sock_dtls_session_t *session,
 
     /* existing session found and session should be restored */
     if (res == 1 && restore) {
-        DEBUG("dsm: existing session found, restoring\n")
+        DEBUG("dsm: existing session found, restoring\n");
         memcpy(session, &session_slot->session, sizeof(sock_dtls_session_t));
     }
     session_slot->last_used_sec = (uint32_t)(xtimer_now_usec64() / US_PER_SEC);

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -141,7 +141,7 @@ void gnrc_lorawan_mcps_indication(gnrc_lorawan_t *mac, mcps_indication_t *ind)
     }
 
     if (!gnrc_netapi_dispatch_receive(nettype, demux, pkt)) {
-        DEBUG("gnrc_lorawan_netif: unable to forward packet\n")
+        DEBUG("gnrc_lorawan_netif: unable to forward packet\n");
         goto release;
     }
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -141,7 +141,7 @@ int gnrc_tcp_ep_init(gnrc_tcp_ep_t *ep, int family, const uint8_t *addr, size_t 
     TCP_DEBUG_ENTER;
 #ifdef MODULE_GNRC_IPV6
     if (family != AF_INET6) {
-        TCP_DEBUG_ERROR("-EAFNOSUPPORT: Parameter family is not AF_INET6.")
+        TCP_DEBUG_ERROR("-EAFNOSUPPORT: Parameter family is not AF_INET6.");
         TCP_DEBUG_LEAVE;
         return -EAFNOSUPPORT;
     }
@@ -153,7 +153,7 @@ int gnrc_tcp_ep_init(gnrc_tcp_ep_t *ep, int family, const uint8_t *addr, size_t 
         memcpy(ep->addr.ipv6, addr, sizeof(ipv6_addr_t));
     }
     else {
-        TCP_DEBUG_ERROR("-EINVAL: Parameter addr is invalid.")
+        TCP_DEBUG_ERROR("-EINVAL: Parameter addr is invalid.");
         TCP_DEBUG_LEAVE;
         return -EINVAL;
     }
@@ -161,7 +161,7 @@ int gnrc_tcp_ep_init(gnrc_tcp_ep_t *ep, int family, const uint8_t *addr, size_t 
     /* Suppress Compiler Warnings */
     (void) addr;
     (void) addr_size;
-    TCP_DEBUG_ERROR("-EAFNOSUPPORT: No network layer configured.")
+    TCP_DEBUG_ERROR("-EAFNOSUPPORT: No network layer configured.");
     TCP_DEBUG_LEAVE;
     return -EAFNOSUPPORT;
 #endif

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -208,7 +208,7 @@ static int _transition_to(gnrc_tcp_tcb_t *tcb, _gnrc_tcp_fsm_state_t state)
                     /* Check if given port number is in use: return error */
                     if (_is_local_port_in_use(tcb->local_port)) {
                         mutex_unlock(&list->lock);
-                        TCP_DEBUG_ERROR("-EADDRINUSE: Port already used.")
+                        TCP_DEBUG_ERROR("-EADDRINUSE: Port already used.");
                         TCP_DEBUG_LEAVE;
                         return -EADDRINUSE;
                     }

--- a/sys/ut_process/ut_process.c
+++ b/sys/ut_process/ut_process.c
@@ -306,7 +306,7 @@ static int _set_var(const char *var, size_t var_len,
     char prefix = '\0', sep = '\0';
 
     if ((var == NULL) || (var_len == 0)) {
-        DEBUG("ut_process: zero-length variable found\n")
+        DEBUG("ut_process: zero-length variable found\n");
         return -EINVAL;
     }
     value = _find_var(var, var_len, vars, vars_len);


### PR DESCRIPTION
### Contribution description

Since the DEBUG and DEBUG_PUTS macros include semicolons in their definition, using a semicolon after their invocations in other files is unneeded, and certain code inspection programs output this as a code smell/bug. At the same time, a line which doesn't end in a semicolon looks weird in C so I propose this change.