### PR TITLE
cpu/atxmega/include/cpu_conf: ztimer64 arithmetic idle stack fix

### DIFF
--- a/cpu/atxmega/include/cpu_conf.h
+++ b/cpu/atxmega/include/cpu_conf.h
@@ -41,7 +41,7 @@ extern "C" {
  * to avoid not printing of debug in interrupts
  */
 #ifndef THREAD_STACKSIZE_IDLE
-#ifdef MODULE_XTIMER
+#if MODULE_XTIMER || MODULE_ZTIMER64
 /* xtimer's 64 bit arithmetic doesn't perform well on 8 bit archs. In order to
  * prevent a stack overflow when an timer triggers while the idle thread is
  * running, we have to increase the stack size then


### PR DESCRIPTION
### Contribution description

While cleaning up all xtimer users in `cpu` I noticed we missed this in #16928. I don't have a BOARD to test, put I think the change is straight forward enough.

### Testing procedure

`tests/ztimer64_msg` on a atxmega, maybe @maribu?

### Issues/PRs references

Cleanup from #16928 