### PR TITLE
cpu: remove unused `xtimer.h` headers

### DIFF
--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -12,7 +12,6 @@ USEMODULE += sam0_common_periph
 ifneq (,$(filter sam0_eth,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += netopt
-  USEMODULE += xtimer
   USEMODULE += iolist
   FEATURES_REQUIRED += periph_eth
 endif

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -24,7 +24,6 @@
 #include <errno.h>
 
 #include "bitarithm.h"
-#include "xtimer.h"
 #include "cpu.h"
 #include "cpu_conf.h"
 #include "periph/pm.h"


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

Green murdock.
