### PR TITLE
sys/can: migrate to ztimer

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -399,14 +399,16 @@ ifneq (,$(filter can,$(USEMODULE)))
 endif
 
 ifneq (,$(filter can_isotp,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer
+  USEMODULE += ztimer_usec
   USEMODULE += gnrc_pktbuf
 endif
 
 ifneq (,$(filter conn_can,$(USEMODULE)))
   USEMODULE += can
   USEMODULE += can_mbox
-  USEMODULE += xtimer
+  USEMODULE += ztimer
+  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter entropy_source_%,$(USEMODULE)))

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 
 #include "thread.h"
+#include "ztimer.h"
 #include "can/device.h"
 #include "can/common.h"
 #include "can/pkt.h"
@@ -146,7 +147,7 @@ static int power_down(candev_dev_t *candev_dev)
     }
 
 #ifdef MODULE_CAN_PM
-    xtimer_remove(&candev_dev->pm_timer);
+    ztimer_remove(ZTIMER_USEC, &candev_dev->pm_timer);
     candev_dev->last_pm_update = 0;
 #endif
 
@@ -171,15 +172,15 @@ static void pm_reset(candev_dev_t *candev_dev, uint32_t value)
 
     if (value == 0) {
         candev_dev->last_pm_value = 0;
-        xtimer_remove(&candev_dev->pm_timer);
+        ztimer_remove(ZTIMER_USEC, &candev_dev->pm_timer);
         return;
     }
 
     if (candev_dev->last_pm_update == 0 ||
-            value > (candev_dev->last_pm_value - (xtimer_now_usec() - candev_dev->last_pm_update))) {
+            value > (candev_dev->last_pm_value - (ztimer_now(ZTIMER_USEC) - candev_dev->last_pm_update))) {
         candev_dev->last_pm_value = value;
-        candev_dev->last_pm_update = xtimer_now_usec();
-        xtimer_set(&candev_dev->pm_timer, value);
+        candev_dev->last_pm_update = ztimer_now(ZTIMER_USEC);
+        ztimer_set(ZTIMER_USEC, &candev_dev->pm_timer, value);
     }
 }
 #endif

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -28,7 +28,7 @@ extern "C" {
 #include "sched.h"
 
 #ifdef MODULE_CAN_PM
-#include "xtimer.h"
+#include "ztimer.h"
 #endif
 #ifdef MODULE_CAN_TRX
 #include "can/can_trx.h"
@@ -79,7 +79,7 @@ typedef struct candev_dev {
     uint32_t tx_wakeup_timeout;     /**< Min timeout loaded when a frame is sent */
     uint32_t last_pm_update;   /**< time when the pm was updated */
     uint32_t last_pm_value;    /**< last pm timer value set */
-    xtimer_t pm_timer;         /**< timer for power management */
+    ztimer_t pm_timer;         /**< timer for power management */
 #endif
 } candev_dev_t;
 

--- a/sys/include/can/isotp.h
+++ b/sys/include/can/isotp.h
@@ -28,7 +28,7 @@ extern "C" {
 #include "can/can.h"
 #include "can/common.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "net/gnrc/pktbuf.h"
 
 #ifndef CAN_ISOTP_BS
@@ -110,8 +110,8 @@ struct isotp {
     struct isotp_fc_options txfc;  /**< tx flow control options (defined remotely) */
     struct tpcon tx;               /**< transmit state */
     struct tpcon rx;               /**< receive state */
-    xtimer_t tx_timer;             /**< timer for tx operations */
-    xtimer_t rx_timer;             /**< timer for rx operations */
+    ztimer_t tx_timer;             /**< timer for tx operations */
+    ztimer_t rx_timer;             /**< timer for rx operations */
     can_reg_entry_t entry;         /**< entry containing ifnum and upper layer msg system */
     uint32_t tx_gap;               /**< transmit gap from fc (in us) */
     uint8_t tx_wft;                /**< transmit wait counter */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As the title says, this PR migrates the CAN stack to ztimer. The changes are pretty straight forward.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- I don't have any hardware to test this, so would appreciate if someone could test. Maybe @vincent-d ?

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
