### PR TITLE
drivers: migrate xtimer64 and xtimer/ticks users to ztimer

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -28,7 +28,8 @@
 #include "periph/spi.h"
 #include "nvram-spi.h"
 #include "nvram.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 #include "vfs.h"
 #include "fs/devfs.h"
 #include "mtd_spi_nor.h"
@@ -115,7 +116,7 @@ void board_init(void)
 
 
     /* NVRAM requires xtimer for timing */
-    xtimer_init();
+    ztimer_init();
 
     /* Initialize NVRAM */
     status = mulle_nvram_init();

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -66,7 +66,6 @@
 
 #include "mutex.h"
 #include "periph/gpio.h"
-#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/ltc4150/Kconfig
+++ b/drivers/ltc4150/Kconfig
@@ -12,7 +12,7 @@ config MODULE_LTC4150
     depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
-    select MODULE_XTIMER
+    select ZTIMER64_USEC
     help
         Driver for the Linear Tech LTC4150 Coulomb Counter (a.k.a. battery
         gauge sensor or power consumption sensor).

--- a/drivers/ltc4150/Makefile.dep
+++ b/drivers/ltc4150/Makefile.dep
@@ -1,3 +1,3 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq
-USEMODULE += xtimer
+USEMODULE += ztimer64_usec

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -22,7 +22,8 @@
 #include <string.h>
 
 #include "ltc4150.h"
-#include "xtimer.h"
+#include "ztimer64.h"
+#include "timex.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -44,7 +45,7 @@ static void pulse_cb(void *_dev)
         dir = LTC4150_CHARGE;
     }
 
-    now = xtimer_now_usec64();
+    now = ztimer64_now(ZTIMER64_USEC);
 
     if (dev->params.recorders) {
         assert(dev->params.recorder_data);
@@ -101,7 +102,7 @@ int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
 
 int ltc4150_reset_counters(ltc4150_dev_t *dev)
 {
-    uint64_t now = xtimer_now_usec64();
+    uint64_t now = ztimer64_now(ZTIMER64_USEC);
 
     if (!dev) {
         return -EINVAL;

--- a/drivers/ltc4150/ltc4150_last_minute.c
+++ b/drivers/ltc4150/ltc4150_last_minute.c
@@ -20,7 +20,8 @@
 #include <string.h>
 
 #include "ltc4150.h"
-#include "xtimer.h"
+#include "ztimer64.h"
+#include "timex.h"
 
 static void init_or_reset(ltc4150_dev_t *dev, uint64_t now_usec, void *arg);
 static void pulse(ltc4150_dev_t *dev, ltc4150_dir_t dir, uint64_t now_usec,
@@ -87,7 +88,7 @@ int ltc4150_last_minute_charge(ltc4150_dev_t *dev,
     }
 
     gpio_irq_disable(dev->params.interrupt);
-    update_ringbuffer(d, xtimer_now_usec64());
+    update_ringbuffer(d, ztimer64_now(ZTIMER64_USEC));
     ltc4150_pulses2c(dev, charged, discharged, d->charged, d->discharged);
     gpio_irq_enable(dev->params.interrupt);
 

--- a/drivers/nrf24l01p/Makefile.dep
+++ b/drivers/nrf24l01p/Makefile.dep
@@ -1,4 +1,4 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_spi
-USEMODULE += xtimer
+USEMODULE += ztimer_usec

--- a/drivers/nvram_spi/Kconfig
+++ b/drivers/nvram_spi/Kconfig
@@ -11,4 +11,4 @@ config MODULE_NVRAM_SPI
     depends on TEST_KCONFIG
     select MODULE_NVRAM
     select MODULE_PERIPH_SPI
-    select MODULE_XTIMER
+    select ZTIMER_USEC

--- a/drivers/nvram_spi/Makefile.dep
+++ b/drivers/nvram_spi/Makefile.dep
@@ -1,3 +1,3 @@
 FEATURES_REQUIRED += periph_spi
 USEMODULE += nvram
-USEMODULE += xtimer
+USEMODULE += ztimer_usec

--- a/drivers/nvram_spi/nvram-spi.c
+++ b/drivers/nvram_spi/nvram-spi.c
@@ -14,7 +14,7 @@
 #include "byteorder.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 /**
  * @ingroup     drivers_nvram
@@ -42,7 +42,7 @@ typedef enum {
 
 /** @brief Delay to wait between toggling CS pin, on most chips this can probably be
  * removed. */
-#define NVRAM_SPI_CS_TOGGLE_TICKS xtimer_ticks_from_usec(1)
+#define NVRAM_SPI_CS_TOGGLE_US      1
 
 /**
  * @brief Copy data from system memory to NVRAM.
@@ -140,7 +140,7 @@ static int nvram_spi_write(nvram_t *dev, const uint8_t *src, uint32_t dst, size_
     /* Enable writes */
     spi_transfer_byte(spi_dev->spi, spi_dev->cs, false, NVRAM_SPI_CMD_WREN);
     /* Make sure we have a minimum gap between transfers */
-    xtimer_spin(NVRAM_SPI_CS_TOGGLE_TICKS);
+    ztimer_spin(ZTIMER_USEC, NVRAM_SPI_CS_TOGGLE_US);
     /* Write command and address */
     spi_transfer_byte(spi_dev->spi, spi_dev->cs, true, NVRAM_SPI_CMD_WRITE);
     spi_transfer_bytes(spi_dev->spi, spi_dev->cs, true,
@@ -200,7 +200,7 @@ static int nvram_spi_write_9bit_addr(nvram_t *dev, const uint8_t *src, uint32_t 
     /* Enable writes */
     spi_transfer_byte(spi_dev->spi, spi_dev->cs, false, NVRAM_SPI_CMD_WREN);
     /* Insert needed delay between transactions */
-    xtimer_spin(NVRAM_SPI_CS_TOGGLE_TICKS);
+    ztimer_spin(ZTIMER_USEC, NVRAM_SPI_CS_TOGGLE_US);
     /* Write command and address */
     spi_transfer_byte(spi_dev->spi, spi_dev->cs, true, cmd);
     spi_transfer_byte(spi_dev->spi, spi_dev->cs, true, addr);

--- a/drivers/pir/Kconfig
+++ b/drivers/pir/Kconfig
@@ -12,7 +12,7 @@ config MODULE_PIR
     depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
-    select MODULE_XTIMER
+    select ZTIMER64_USEC
 
 config HAVE_PIR
     bool

--- a/drivers/pir/Makefile.dep
+++ b/drivers/pir/Makefile.dep
@@ -1,3 +1,3 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq
-USEMODULE += xtimer
+USEMODULE += ztimer64_usec

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -24,7 +24,7 @@
 #include "irq.h"
 #include "thread.h"
 #include "msg.h"
-#include "xtimer.h"
+#include "ztimer64.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -50,7 +50,7 @@ int pir_init(pir_t *dev, const pir_params_t *params)
     dev->active = false;
     dev->accum_active_time = 0;
     dev->start_active_time = 0;
-    dev->last_read_time = xtimer_now_usec64();
+    dev->last_read_time = ztimer64_now(ZTIMER64_USEC);
 
     gpio_mode_t gpio_mode;
     if (dev->p.active_high) {
@@ -74,7 +74,7 @@ pir_event_t pir_get_status(const pir_t *dev)
 
 int pir_get_occupancy(pir_t *dev, int16_t *occup) {
     int irq_state = irq_disable();
-    uint64_t now = xtimer_now_usec64();
+    uint64_t now = ztimer64_now(ZTIMER64_USEC);
     uint64_t total_time = now - dev->last_read_time;
     if (total_time == 0) {
         irq_restore(irq_state);
@@ -145,7 +145,7 @@ static void pir_callback(void *arg)
     DEBUG("pir_callback: %p\n", arg);
     pir_t *dev = (pir_t*) arg;
     bool pin_now = gpio_read(dev->p.gpio);
-    uint64_t now = xtimer_now_usec64();
+    uint64_t now = ztimer64_now(ZTIMER64_USEC);
 
     /* We were busy counting */
     if (dev->active) {

--- a/drivers/si1133/Kconfig
+++ b/drivers/si1133/Kconfig
@@ -10,4 +10,4 @@ config MODULE_SI1133
     depends on HAS_PERIPH_I2C
     depends on TEST_KCONFIG
     select MODULE_PERIPH_I2C
-    select MODULE_XTIMER
+    select ZTIMER_USEC

--- a/drivers/si1133/Makefile.dep
+++ b/drivers/si1133/Makefile.dep
@@ -1,2 +1,2 @@
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 FEATURES_REQUIRED += periph_i2c

--- a/tests/driver_ltc4150/Makefile
+++ b/tests/driver_ltc4150/Makefile
@@ -4,6 +4,7 @@ BOARD ?= msba2
 
 USEMODULE += fmt_table
 USEMODULE += ltc4150
+USEMODULE += ztimer_usec
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/driver_ltc4150/main.c
+++ b/tests/driver_ltc4150/main.c
@@ -25,7 +25,8 @@
 #include "led.h"
 #include "ltc4150.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 
 typedef struct {
     uint64_t last_usec;
@@ -96,8 +97,7 @@ static void pulse_cb(ltc4150_dev_t *dev, ltc4150_dir_t dir, uint64_t now_usec,
  */
 static void spin(uint32_t seconds)
 {
-    uint32_t till = xtimer_now_usec() + US_PER_SEC * seconds;
-    while (xtimer_now_usec() < till) { }
+    ztimer_spin(ZTIMER_USEC, US_PER_SEC * seconds);
 }
 
 /**
@@ -110,14 +110,14 @@ static void *busy_thread(void *arg)
         /* one minute of ~0% CPU usage */
         LED0_OFF;
         LED1_OFF;
-        xtimer_sleep(60);
+        ztimer_sleep(ZTIMER_USEC, 60 * US_PER_SEC);
         change_of_load_level = 1;
 
         /* one minute of ~50% CPU usage */
         for (unsigned i = 0; i < 30; i++) {
             LED0_OFF;
             LED1_OFF;
-            xtimer_sleep(1);
+            ztimer_sleep(ZTIMER_USEC, 1 * US_PER_SEC);
             LED0_ON;
             LED1_ON;
             spin(1);

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 USEMODULE += nrf24l01p
 
 # set default device parameters in case they are undefined

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -41,7 +41,7 @@
 #include "nrf24l01p_settings.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "shell.h"
 #include "shell_commands.h"
 #include "thread.h"
@@ -231,7 +231,7 @@ int cmd_send(int argc, char **argv)
     /* trigger transmitting */
     nrf24l01p_transmit(&nrf24l01p_0);
     /* wait while data is pysically transmitted  */
-    xtimer_usleep(DELAY_DATA_ON_AIR);
+    ztimer_sleep(ZTIMER_USEC, DELAY_DATA_ON_AIR);
     /* get status of the transceiver */
     status = nrf24l01p_get_status(&nrf24l01p_0);
     if (status < 0) {

--- a/tests/driver_nvram_spi/Makefile
+++ b/tests/driver_nvram_spi/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += nvram_spi
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 
 # set default device parameters in case they are undefined
 TEST_NVRAM_SPI_DEV           ?= SPI_DEV\(0\)

--- a/tests/driver_nvram_spi/app.config.test
+++ b/tests/driver_nvram_spi/app.config.test
@@ -1,4 +1,4 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_NVRAM_SPI=y
-CONFIG_MODULE_XTIMER=y
+CONFIG_ZTIMER_USEC=y

--- a/tests/driver_nvram_spi/main.c
+++ b/tests/driver_nvram_spi/main.c
@@ -23,7 +23,8 @@
 #include <ctype.h>
 
 #include "board.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 #include "periph/spi.h"
 #include "nvram-spi.h"
 
@@ -137,7 +138,7 @@ int main(void)
     puts("!!! This test will erase everything on the NVRAM !!!");
     puts("!!! Unplug/reset/halt device now if this is not acceptable !!!");
     puts("Waiting for 10 seconds before continuing...");
-    xtimer_sleep(start_delay);
+    ztimer_sleep(ZTIMER_USEC, start_delay * US_PER_SEC);
 
     puts("Reading current memory contents...");
     for (i = 0; i < TEST_NVRAM_SPI_SIZE; ++i) {

--- a/tests/driver_pir/Makefile.ci
+++ b/tests/driver_pir/Makefile.ci
@@ -7,5 +7,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega328p-xplained-mini \
     nucleo-f031k6 \
     nucleo-l011k4 \
+    samd10-xmini \
     stm32f030f4-demo \
     #

--- a/tests/driver_pir/main.c
+++ b/tests/driver_pir/main.c
@@ -23,7 +23,8 @@
 #include <stdio.h>
 
 #include "thread.h"
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 #include "pir.h"
 #include "pir_params.h"
 
@@ -76,7 +77,7 @@ int main(void)
     while (1) {
         printf("Status: %s\n", pir_get_status(&dev) == PIR_STATUS_INACTIVE ?
                "inactive" : "active");
-        xtimer_usleep(1000 * 1000);
+        ztimer_sleep(ZTIMER_USEC, 1 * US_PER_SEC);
     }
 #else
    thread_create(

--- a/tests/driver_si1133/Makefile
+++ b/tests/driver_si1133/Makefile
@@ -2,6 +2,5 @@ include ../Makefile.tests_common
 
 # required modules
 USEMODULE += si1133
-USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_si1133/app.config.test
+++ b/tests/driver_si1133/app.config.test
@@ -1,4 +1,3 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_SI1133=y
-CONFIG_MODULE_XTIMER=y

--- a/tests/driver_si1133/main.c
+++ b/tests/driver_si1133/main.c
@@ -23,7 +23,6 @@
 
 #include "si1133.h"
 #include "si1133_params.h"
-#include "xtimer.h"
 #include "board.h"
 
 /* Helper macro to define _si1133_strerr */

--- a/tests/events/Makefile.board.dep
+++ b/tests/events/Makefile.board.dep
@@ -1,0 +1,7 @@
+# mulle will always select ztimer through requiring nvram_spi module
+# because of order of inclusion 'make' depency resolution will still select
+# xtimer while 'Kconfig' wont, so early require 'ztimer_usec'
+# for 'make' to avoid this
+ifneq (,$(filter mulle,$(BOARD)))
+  USEMODULE += ztimer_usec
+endif


### PR DESCRIPTION
### Contribution description

This PR takes care of the user's of xtimer which can't be directly changed to ztimer with the coccinelle script.

### Testing procedure

I don't have any of the hardware sadly... but I tagged people that are susceptible to having the hardware, it will at least document what was and not tested.

- [ ]  `tests/driver_pir` @maribu ?
- [ ]  `tests/driver_si1133` @iosabi  ?
- [ ] `tests/driver_nrf24l01p` @PeterKietzmann  ?
- [ ] `tests/driver_mtd_nvram_spi` AFAIK there is one `mulle` in FU so maybe @miri64 ? or @jnohlgard?
- [ ] `tests/driver_ltc4150` @maribu 

### Issues/PRs references

Part of #13667 and #17111