### PR TITLE
sys/ztimer64: make _del_entry_from_list() safe for uninit ztimer64_t

### DIFF
--- a/sys/ztimer64/ztimer64.c
+++ b/sys/ztimer64/ztimer64.c
@@ -128,6 +128,9 @@ static int _add_entry_to_list(ztimer64_clock_t *clock, ztimer64_base_t *entry)
 static int _del_entry_from_list(ztimer64_clock_t *clock, ztimer64_base_t *entry)
 {
     DEBUG("_del_entry_from_list()\n");
+    if (!clock->first) {
+        return 0;
+    }
     assert(_is_set((ztimer64_t *)entry));
     if (clock->first == entry) {
         /* special case: removing first entry */

--- a/tests/unittests/tests-ztimer64/tests-ztimer64-core.c
+++ b/tests/unittests/tests-ztimer64/tests-ztimer64-core.c
@@ -198,6 +198,24 @@ static void test_ztimer64_checkpoint(void)
     TEST_ASSERT_EQUAL_INT(2 * ZTIMER64_CHECKPOINT_INTERVAL + UINT32_MAX, now64);
 }
 
+static void test_ztimer64_set_uninitialized(void)
+{
+    /* regression test for setting an uninitialized ztimer64 on an empty clock */
+    ztimer_mock_t zmock;
+    ztimer_clock_t *z = &zmock.super;
+    ztimer64_clock_t z64mock;
+    ztimer64_clock_t *z64 = &z64mock;
+
+    memset(&zmock, '\0', sizeof(ztimer_mock_t));
+    memset(&z64mock, '\0', sizeof(ztimer64_clock_t));
+    /* ztimer base clock is already extended to 32bit */
+    ztimer_mock_init(&zmock, 32);
+    ztimer64_clock_init(z64, z);
+
+    ztimer64_t timer = { .base.target = 1 };
+    ztimer64_set(z64, &timer, 0);
+}
+
 Test *tests_ztimer64_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -206,6 +224,7 @@ Test *tests_ztimer64_tests(void)
         new_TestFixture(test_ztimer64_set_0),
         new_TestFixture(test_ztimer64_set_at),
         new_TestFixture(test_ztimer64_checkpoint),
+        new_TestFixture(test_ztimer64_set_uninitialized),
     };
 
     EMB_UNIT_TESTCALLER(ztimer64_tests, setup, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

ztimer64's `_is_set()` might return true on uninitialized timer structs. e.g., `ztimer64_set()` would then call `_del_entry_from_list()`, which expects the clock's list to be non-empty.
This might cause a NULL dereference.

This PR adds an early out to `_del_entry_from_list()` to handle that case.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

There's a regression test. Revert 7b9a6850a3fc11b22d202229edd6a9af8df9d3b3 to see the unittests crash.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
