### PR TITLE
doc: fix the reference to libcoap removal commit in LOSTANDFOUND.md

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -42,7 +42,7 @@ This way, their names are never removed from the RIOT repository.
 
 # Removed Features
 
-### pkg/libcoap [d83d08f0995a88f399e70a7d07b44dd780082436]
+### pkg/libcoap [e89eebc6bfba61f8f81ed078deff4050941ff3be]
 
 Author:
 - Martine Lenders <mlenders@inf.fu-berlin.de>


### PR DESCRIPTION
### Contribution description

This PR  fixes the the reference to the commit for removing the `libcoap` package in `LOSTANDFOUND.md`.

With PR #17163 for removing the `libcoap` package, the file `LOSTANDFOUND.md` was updated to reference the corresponding commit. However, when the PR was merged, the commit got a different ID. Thus, the reference in `LOSTANDFOUND.md` was wrong.

### Testing procedure

`make doc` with doxygen 1.9.2 or 1.8.17 and check `doc/doxygen/html/md_LOSTANDFOUND.html`

Without the PR, the term in brackets is just a text, with this PR it is a link.
```
pkg/libcoap [d83d08f0995a88f399e70a7d07b44dd780082436]
```

### Issues/PRs references

Found when investigating issue #17063