### PR TITLE
sys/ztimer: fix backend selection

### DIFF
--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -99,5 +99,7 @@ ifneq (,$(filter ztimer_msec ztimer_sec,$(USEMODULE)))
     else
       USEMODULE += ztimer_periph_timer
     endif
+  else
+    USEMODULE += ztimer_periph_timer
   endif
 endif


### PR DESCRIPTION
### Contribution description
With the introduction of `ztimer_no_periph_rtt` in #17284 `ztimer_msec` and `ztimer_sec` don't fallback to `ztimer_periph_timer` when the pseudomodule is active. This adds the fallback selection again.

### Testing procedure
- Something like `BOARD=samr21-xpro USEMODULE="ztimer_msec ztimer_no_periph_rtt" make -C examples/hello-world/` should work with this PR, but fails on master due to lack of backend selection.

### Issues/PRs references
#17284
