### PR TITLE
boards/lora-e5-dev: fix default DARWIN port

### DIFF
--- a/boards/lora-e5-dev/Makefile.include
+++ b/boards/lora-e5-dev/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # Setup of programmer and serial is shared between STM32 based boards
 include $(RIOTMAKE)/boards/stm32.inc.mk


### PR DESCRIPTION
### Contribution description

This fixes the default OSX PORT, I don't have OSX but just fixed this for a student running on OSX and it worked. Note that this BOARD is under USB0 on linux, and the new default matches the one for other BOARDs under USB0.

### Testing procedure

- Just checking the code should do
