### PR TITLE
makefiles/kconfig: add board & CPU config variables

### DIFF
--- a/boards/adafruit-clue/Makefile.features
+++ b/boards/adafruit-clue/Makefile.features
@@ -12,7 +12,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/adafruit-itsybitsy-m4/Makefile.features
+++ b/boards/adafruit-itsybitsy-m4/Makefile.features
@@ -17,5 +17,5 @@ FEATURES_PROVIDED += periph_usbdev
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/adafruit-itsybitsy-m4.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/adafruit-itsybitsy-m4.config
 endif

--- a/boards/adafruit-itsybitsy-nrf52/Makefile.features
+++ b/boards/adafruit-itsybitsy-nrf52/Makefile.features
@@ -12,7 +12,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/arduino-nano-33-ble/Makefile.features
+++ b/boards/arduino-nano-33-ble/Makefile.features
@@ -12,7 +12,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/bastwan/Makefile.features
+++ b/boards/bastwan/Makefile.features
@@ -19,5 +19,5 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/bastwan.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/bastwan.config
 endif

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -13,4 +13,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += riotboot
 
 # iotlab boards provide a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/iotlab/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/iotlab/clock.config

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -15,7 +15,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/weact-f4x1cx/Makefile.features
+++ b/boards/common/weact-f4x1cx/Makefile.features
@@ -14,4 +14,4 @@ FEATURES_PROVIDED += periph_usbdev
 FEATURES_PROVIDED += highlevel_stdio
 
 # weact-f4x1cx boards provide a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/weact-f4x1cx/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/weact-f4x1cx/clock.config

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # f4vi1 provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/f4vi1/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/f4vi1/clock.config

--- a/boards/feather-nrf52840/Makefile.features
+++ b/boards/feather-nrf52840/Makefile.features
@@ -12,7 +12,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # msbiot provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/msbiot/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/msbiot/clock.config

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -22,5 +22,5 @@ FEATURES_PROVIDED += periph_uart
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/mulle.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/mulle.config
 endif

--- a/boards/nrf52840-mdk-dongle/Makefile.features
+++ b/boards/nrf52840-mdk-dongle/Makefile.features
@@ -11,7 +11,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840dongle/Makefile.features
+++ b/boards/nrf52840dongle/Makefile.features
@@ -15,7 +15,7 @@ FEATURES_PROVIDED += highlevel_stdio
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
+  KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/common/nrf52/nrf52_bootloader.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/pinetime/Makefile.features
+++ b/boards/pinetime/Makefile.features
@@ -9,7 +9,7 @@ FEATURES_PROVIDED += vdd_lc_filter_reg1
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/pinetime.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/pinetime.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/pyboard/Makefile.features
+++ b/boards/pyboard/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # pyboard provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/pyboard/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/pyboard/clock.config

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -8,7 +8,7 @@ FEATURES_PROVIDED += vdd_lc_filter_reg1
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/ruuvitag.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/ruuvitag.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/stm32f723e-disco/Makefile.features
+++ b/boards/stm32f723e-disco/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # stm32f723e-disco provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/stm32f723e-disco/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/stm32f723e-disco/clock.config

--- a/boards/stm32f746g-disco/Makefile.features
+++ b/boards/stm32f746g-disco/Makefile.features
@@ -13,4 +13,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # stm32f746g-disco provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/stm32f746g-disco/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/stm32f746g-disco/clock.config

--- a/boards/stm32f769i-disco/Makefile.features
+++ b/boards/stm32f769i-disco/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # stm32f769i-disco provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/stm32f769i-disco/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/stm32f769i-disco/clock.config

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -8,7 +8,7 @@ FEATURES_PROVIDED += vdd_lc_filter_reg1
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/thingy52.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/thingy52.config
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/ublox-c030-u201/Makefile.features
+++ b/boards/ublox-c030-u201/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # ublox-c030-u201 provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/ublox-c030-u201/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/ublox-c030-u201/clock.config

--- a/boards/weact-f401cc/Makefile.features
+++ b/boards/weact-f401cc/Makefile.features
@@ -3,4 +3,4 @@ CPU_MODEL = stm32f401cc
 include $(RIOTBOARD)/common/weact-f4x1cx/Makefile.features
 
 # weact-f401cc provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/weact-f401cc/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/weact-f401cc/clock.config

--- a/boards/weact-f401ce/Makefile.features
+++ b/boards/weact-f401ce/Makefile.features
@@ -3,4 +3,4 @@ CPU_MODEL = stm32f401ce
 include $(RIOTBOARD)/common/weact-f4x1cx/Makefile.features
 
 # weact-f401ce provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/weact-f401ce/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/weact-f401ce/clock.config

--- a/boards/weact-f411ce/Makefile.features
+++ b/boards/weact-f411ce/Makefile.features
@@ -3,4 +3,4 @@ CPU_MODEL = stm32f411ce
 include $(RIOTBOARD)/common/weact-f4x1cx/Makefile.features
 
 # weact-f411ce provides a custom default Kconfig clock configuration
-KCONFIG_ADD_CONFIG += $(RIOTBOARD)/weact-f411ce/clock.config
+KCONFIG_BOARD_CONFIG += $(RIOTBOARD)/weact-f411ce/clock.config

--- a/boards/yarm/Makefile.features
+++ b/boards/yarm/Makefile.features
@@ -18,5 +18,5 @@ FEATURES_PROVIDED += riotboot
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(BOARDDIR)/yarm.config
+  KCONFIG_BOARD_CONFIG += $(BOARDDIR)/yarm.config
 endif

--- a/cpu/atxmega/Makefile.features
+++ b/cpu/atxmega/Makefile.features
@@ -17,5 +17,5 @@ FEATURES_PROVIDED += periph_timer periph_timer_periodic
 # Add atxmega configurations. This configuration enables modules that are only available when
 # using Kconfig module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/atxmega/atxmega.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/atxmega/atxmega.config
 endif

--- a/cpu/cc2538/Makefile.features
+++ b/cpu/cc2538/Makefile.features
@@ -19,5 +19,5 @@ include $(RIOTCPU)/cortexm_common/Makefile.features
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/cc2538/cc2538.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/cc2538/cc2538.config
 endif

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -43,5 +43,5 @@ FEATURES_PROVIDED += no_idle_thread
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/cortexm_common/cortexm_common.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/cortexm_common/cortexm_common.config
 endif

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -38,5 +38,5 @@ include $(RIOTCPU)/cortexm_common/Makefile.features
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1,$(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/efm32/efm32.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/efm32/efm32.config
 endif

--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -37,5 +37,5 @@ include $(RIOTCPU)/cortexm_common/Makefile.features
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/kinetis/kinetis.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/kinetis/kinetis.config
 endif

--- a/cpu/lpc1768/Makefile.features
+++ b/cpu/lpc1768/Makefile.features
@@ -12,5 +12,5 @@ include $(RIOTCPU)/cortexm_common/Makefile.features
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/lpc1768/lpc1768.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/lpc1768/lpc1768.config
 endif

--- a/cpu/lpc23xx/Makefile.features
+++ b/cpu/lpc23xx/Makefile.features
@@ -11,5 +11,5 @@ include $(RIOTCPU)/arm7_common/Makefile.features
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/lpc23xx/lpc23xx.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/lpc23xx/lpc23xx.config
 endif

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -32,5 +32,5 @@ endif
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/native/native.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/native/native.config
 endif

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -31,5 +31,5 @@ include $(RIOTCPU)/cortexm_common/Makefile.features
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/sam0_common/sam0_common.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/sam0_common/sam0_common.config
 endif

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -58,11 +58,11 @@ ifneq (,$(filter $(CPU_MODEL),$(STM32_WITH_MPU)))
   FEATURES_PROVIDED += cortexm_mpu
 endif
 
-# Add stm32 configs after including cortexm_common so stm32 takes precendence
+include $(RIOTCPU)/cortexm_common/Makefile.features
+
+# Add stm32 configs after including cortexm_common so stm32 takes precedence
 # This configuration enables modules that are only available when using Kconfig
 # module modelling
 ifeq (1, $(TEST_KCONFIG))
-  KCONFIG_ADD_CONFIG += $(RIOTCPU)/stm32/stm32.config
+  KCONFIG_CPU_CONFIG += $(RIOTCPU)/stm32/stm32.config
 endif
-
-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -61,13 +61,17 @@ KCONFIG_OUT_DEP = $(KCONFIG_OUT_CONFIG).d
 # Add configurations to merge, in ascendent priority (i.e. a file overrides the
 # previous ones).
 #
-# KCONFIG_ADD_CONFIG holds a list of .config files that are merged for the
-# initial configuration. This allows to split configurations in common files
-# and share them among boards or cpus.
+# KCONFIG_CPU_CONFIG, KCONFIG_BOARD_CONFIG and KCONFIG_ADD_CONFIG hold a lists
+# of .config files that are merged for the initial configuration. This allows
+# to split configurations in common files and share them among boards or cpus.
+# Files are merged from more generic to more specific.
 # This file will contain application default configurations used for Kconfig Test
+MERGE_SOURCES += $(KCONFIG_CPU_CONFIG)
+MERGE_SOURCES += $(KCONFIG_BOARD_CONFIG)
 MERGE_SOURCES += $(KCONFIG_ADD_CONFIG)
 MERGE_SOURCES += $(wildcard $(KCONFIG_APP_CONFIG))
 MERGE_SOURCES += $(wildcard $(KCONFIG_USER_CONFIG))
+
 MERGE_SOURCES += $(KCONFIG_GENERATED_ENV_CONFIG)
 
 # Create directory to place generated files


### PR DESCRIPTION
### Contribution description
This introduces `KCONFIG_BOARD_CONFIG` and `KCONFIG_CPU_CONFIG` variable for boards and CPUs (including common directories) to add default configuration files to be merged. The current approach, as it uses `Makefile.features`, would include boards first, not allowing them to override CPU configurations.

Documentation on this is added as well.

### Testing procedure
- You can check that for a board like `stm32f769i-disco`, which has configuration files from different sources (board, stm32, cortexm_common), now the order is the correct: 1st the arch, 2nd the cpu, 3rd the board. This can be seen by printing `MERGE_SOURCES` from `makefiles/kconfig.mk` and building with `TEST_KCONFIG=1`.
- Read the docs
- Green CI

### Issues/PRs references
Found in #17349
