### PR TITLE
pkg/ccn-ndn: migrate to ztimer

### DIFF
--- a/pkg/ccn-lite/Makefile.dep
+++ b/pkg/ccn-lite/Makefile.dep
@@ -4,3 +4,5 @@ USEMODULE += evtimer
 USEMODULE += random
 USEMODULE += timex
 USEMODULE += posix_headers
+USEMODULE += ztimer64_usec
+USEMODULE += div

--- a/pkg/ccn-lite/patches/0002-src-ccnl-migrate-from-xtimer-to-ztimer64.patch
+++ b/pkg/ccn-lite/patches/0002-src-ccnl-migrate-from-xtimer-to-ztimer64.patch
@@ -1,0 +1,83 @@
+From 3fe4a5842357bd14651d4cc0860da00c0649c182 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Thu, 9 Dec 2021 15:25:22 +0100
+Subject: [PATCH 1/2] src/ccnl%: migrate from xtimer to ztimer64
+
+---
+ src/ccnl-core/src/ccnl-os-time.c  | 8 +++++---
+ src/ccnl-riot/src/ccn-lite-riot.c | 8 ++++----
+ 2 files changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/src/ccnl-core/src/ccnl-os-time.c b/src/ccnl-core/src/ccnl-os-time.c
+index 21b4afb6..0087b9dc 100644
+--- a/src/ccnl-core/src/ccnl-os-time.c
++++ b/src/ccnl-core/src/ccnl-os-time.c
+@@ -38,12 +38,14 @@ struct ccnl_timer_s *eventqueue;
+ 
+ 
+ #if defined(CCNL_RIOT) && !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__linux__))
+-#include <xtimer.h>
++#include <ztimer64.h>
++#include <timex.h>
++#include <div.h>
+ 
+ int gettimeofday(struct timeval *__restrict __p, void *__restrict __tz)
+ {
+     (void) __tz;
+-    uint64_t now = xtimer_now_usec64();
++    uint64_t now = ztimer64_now(ZTIMER64_USEC);
+     __p->tv_sec = div_u64_by_1000000(now);
+     __p->tv_usec = now - (__p->tv_sec * US_PER_SEC);
+ 
+@@ -108,7 +110,7 @@ timestamp(void)
+         cp[5] = '\0';
+     else while (strlen(cp) < 5)
+         strcat(cp, "0");
+-        
++
+     return ts;
+ }
+ 
+diff --git a/src/ccnl-riot/src/ccn-lite-riot.c b/src/ccnl-riot/src/ccn-lite-riot.c
+index 33ca23cf..678e8301 100644
+--- a/src/ccnl-riot/src/ccn-lite-riot.c
++++ b/src/ccnl-riot/src/ccn-lite-riot.c
+@@ -32,7 +32,7 @@
+ #include "sched.h"
+ #include "random.h"
+ #include "timex.h"
+-#include "xtimer.h"
++#include "ztimer64.h"
+ #include "net/gnrc/netreg.h"
+ #include "net/gnrc/netif.h"
+ #include "net/gnrc/netif/hdr.h"
+@@ -464,7 +464,7 @@ ccnl_start(void)
+     return ccnl_event_loop_pid;
+ }
+ 
+-static xtimer_t _wait_timer;
++static ztimer64_t _wait_timer;
+ static msg_t _timeout_msg;
+ int
+ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
+@@ -480,7 +480,7 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
+ 
+         /* TODO: receive from socket or interface */
+         _timeout_msg.type = CCNL_MSG_TIMEOUT;
+-        xtimer_set_msg64(&_wait_timer, timeout, &_timeout_msg, thread_getpid());
++        ztimer64_set_msg(ZTIMER64_USEC, &_wait_timer, timeout, &_timeout_msg, thread_getpid());
+         msg_t m;
+         msg_receive(&m);
+         if (m.type == GNRC_NETAPI_MSG_TYPE_RCV) {
+@@ -500,7 +500,7 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
+                 gnrc_pktbuf_release(pkt);
+                 continue;
+             }
+-            xtimer_remove(&_wait_timer);
++            ztimer64_remove(ZTIMER64_USEC, &_wait_timer);
+             break;
+         }
+         else if (m.type == CCNL_MSG_TIMEOUT) {
+-- 
+2.30.2
+

--- a/pkg/ccn-lite/patches/0003-src-ccnl-riot-move-late-initialization-of-evtimer.patch
+++ b/pkg/ccn-lite/patches/0003-src-ccnl-riot-move-late-initialization-of-evtimer.patch
@@ -1,0 +1,32 @@
+From 21139f10cbc2b7f2613503e9013f3b861ea74889 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 10 Dec 2021 16:53:41 +0100
+Subject: [PATCH 2/2] src/ccnl-riot: move late initialization of evtimer
+
+---
+ src/ccnl-riot/src/ccn-lite-riot.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ccnl-riot/src/ccn-lite-riot.c b/src/ccnl-riot/src/ccn-lite-riot.c
+index 678e8301..fde0a441 100644
+--- a/src/ccnl-riot/src/ccn-lite-riot.c
++++ b/src/ccnl-riot/src/ccn-lite-riot.c
+@@ -360,7 +360,6 @@ void
+     char *spref;
+ 
+     msg_init_queue(_msg_queue, CCNL_QUEUE_SIZE);
+-    evtimer_init_msg(&ccnl_evtimer);
+     struct ccnl_relay_s *ccnl = (struct ccnl_relay_s*) arg;
+ 
+     while(!ccnl->halt_flag) {
+@@ -449,6 +448,7 @@ void
+ kernel_pid_t
+ ccnl_start(void)
+ {
++    evtimer_init_msg(&ccnl_evtimer);
+     loopback_face = ccnl_get_face_or_create(&ccnl_relay, -1, NULL, 0);
+     loopback_face->flags |= CCNL_FACE_FLAGS_STATIC;
+ 
+-- 
+2.30.2
+

--- a/pkg/ndn-riot/Makefile.dep
+++ b/pkg/ndn-riot/Makefile.dep
@@ -1,7 +1,7 @@
 USEMODULE += ndn-encoding
 USEMODULE += gnrc
 USEMODULE += gnrc_nettype_ndn
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 USEMODULE += random
 USEMODULE += hashes
 USEPKG += micro-ecc

--- a/pkg/ndn-riot/patches/0005-use-ztimer_msec-instead-of-xtimer.patch
+++ b/pkg/ndn-riot/patches/0005-use-ztimer_msec-instead-of-xtimer.patch
@@ -1,0 +1,256 @@
+From b5cf1b1f24584666df472166104139f7627424e9 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Thu, 9 Dec 2021 15:17:13 +0100
+Subject: [PATCH] use ztimer_msec instead of xtimer
+
+---
+ app.c | 12 ++++++------
+ app.h |  4 ++--
+ cs.h  |  2 --
+ fib.h |  1 -
+ l2.c  | 13 +++++++------
+ ndn.c |  1 -
+ pit.c | 12 +++++++-----
+ pit.h |  4 ++--
+ 8 files changed, 24 insertions(+), 25 deletions(-)
+
+diff --git a/app.c b/app.c
+index bc4718d..8e5598a 100644
+--- a/app.c
++++ b/app.c
+@@ -225,8 +225,8 @@ int ndn_app_run(ndn_app_t* handle)
+                       msg.sender_pid, handle->id);
+                 return NDN_APP_STOP;
+
+-            case MSG_XTIMER:
+-                DEBUG("ndn_app: XTIMER msg received from thread %"
++            case MSG_ZTIMER:
++                DEBUG("ndn_app: ZTIMER msg received from thread %"
+                       PRIkernel_pid " (pid=%" PRIkernel_pid ")\n",
+                       msg.sender_pid, handle->id);
+
+@@ -299,7 +299,7 @@ static inline void _release_sched_cb_table(ndn_app_t* handle)
+         DEBUG("ndn_app: remove scheduler cb entry (pid=%"
+               PRIkernel_pid ")\n", handle->id);
+         DL_DELETE(handle->_scb_table, entry);
+-        xtimer_remove(&entry->timer);
++        ztimer_remove(ZTIMER_USEC, &entry->timer);
+         free(entry);
+     }
+ }
+@@ -380,14 +380,14 @@ int ndn_app_schedule(ndn_app_t* handle, ndn_app_sched_cb_t cb, void* context,
+     if (entry == NULL) return -1;
+
+     // initialize the timer
+-    entry->timer = (xtimer_t) {0};
++    entry->timer = (ztimer_t) {0};
+
+     // initialize the msg struct
+-    entry->timer_msg.type = MSG_XTIMER;
++    entry->timer_msg.type = MSG_ZTIMER;
+     entry->timer_msg.content.ptr = (char*)(&entry->timer_msg);
+
+     // set a timer to send a message to the app thread
+-    xtimer_set_msg(&entry->timer, timeout, &entry->timer_msg, handle->id);
++    ztimer_set_msg(ZTIMER_USEC, &entry->timer, timeout, &entry->timer_msg, handle->id);
+
+     return 0;
+ }
+diff --git a/app.h b/app.h
+index c357692..21666d9 100644
+--- a/app.h
++++ b/app.h
+@@ -23,7 +23,7 @@
+ #include "encoding/name.h"
+ #include "forwarding-strategy.h"
+
+-#include <xtimer.h>
++#include <ztimer.h>
+ #include <net/gnrc/pktbuf.h>
+ #include "sched.h"
+
+@@ -95,7 +95,7 @@ typedef struct _sched_cb_entry {
+     struct _sched_cb_entry *next;
+     ndn_app_sched_cb_t cb;
+     void* context;
+-    xtimer_t timer;
++    ztimer_t timer;
+     msg_t timer_msg;
+ } _sched_cb_entry_t;
+
+diff --git a/cs.h b/cs.h
+index 01edf2b..c544cf8 100644
+--- a/cs.h
++++ b/cs.h
+@@ -22,8 +22,6 @@
+
+ #include "encoding/shared-block.h"
+
+-//#include <xtimer.h>
+-
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git a/fib.h b/fib.h
+index 5e190d2..cdf70aa 100644
+--- a/fib.h
++++ b/fib.h
+@@ -23,7 +23,6 @@
+ #include "encoding/shared-block.h"
+ #include "face-table.h"
+
+-#include <xtimer.h>
+ #include "sched.h"
+
+ #ifdef __cplusplus
+diff --git a/l2.c b/l2.c
+index a0546b5..817c210 100644
+--- a/l2.c
++++ b/l2.c
+@@ -20,7 +20,8 @@
+ #include "encoding/shared-block.h"
+ #include "ndn.h"
+
+-#include <xtimer.h>
++#include <timex.h>
++#include <ztimer.h>
+ #include <net/gnrc/netif/hdr.h>
+ #include <debug.h>
+
+@@ -59,7 +60,7 @@ typedef struct _l2_frag_block {
+ typedef struct _l2_frag_entry {
+     struct _l2_frag_entry* prev;
+     struct _l2_frag_entry* next;
+-    xtimer_t timer;
++    ztimer_t timer;
+     msg_t timer_msg;
+     uint8_t* netif_hdr;
+     size_t netif_hdr_len;
+@@ -69,13 +70,13 @@ typedef struct _l2_frag_entry {
+ } _l2_frag_entry_t;
+
+ //TODO: use larger timeout value in non-test environment
+-#define NDN_L2_FRAG_MAX_LIFETIME    (10U * US_PER_SEC)
++#define NDN_L2_FRAG_MAX_LIFETIME    (10U * MS_PER_SEC)
+
+ static _l2_frag_entry_t* _l2_frag_list;
+
+ static void _release_l2_frag_entry(_l2_frag_entry_t* entry) {
+     DL_DELETE(_l2_frag_list, entry);
+-    xtimer_remove(&entry->timer);
++    ztimer_remove(ZTIMER_USEC, &entry->timer);
+     _l2_frag_block_t *blk, *tmp;
+     LL_FOREACH_SAFE(entry->frags, blk, tmp) {
+         free(blk->data);
+@@ -155,7 +156,7 @@ ndn_shared_block_t* ndn_l2_frag_receive(kernel_pid_t iface,
+         entry->id = id;
+
+         // initialize timer
+-        entry->timer = (xtimer_t) {0};
++        entry->timer = (ztimer_t) {0};
+         entry->timer_msg.type = NDN_L2_FRAG_MSG_TYPE_TIMEOUT;
+         entry->timer_msg.content.ptr = (char*)(&entry->timer_msg);
+
+@@ -166,7 +167,7 @@ ndn_shared_block_t* ndn_l2_frag_receive(kernel_pid_t iface,
+     assert(entry != NULL);
+
+     // set (reset) timer
+-    xtimer_set_msg(&entry->timer, NDN_L2_FRAG_MAX_LIFETIME,
++    ztimer_set_msg(ZTIMER_USEC, &entry->timer, NDN_L2_FRAG_MAX_LIFETIME,
+                    &entry->timer_msg, ndn_pid);
+
+     if ((entry->frags_map & seq_map) != 0) {
+diff --git a/ndn.c b/ndn.c
+index 3db7411..d370d0b 100644
+--- a/ndn.c
++++ b/ndn.c
+@@ -36,7 +36,6 @@
+ #include <net/gnrc/netreg.h>
+ #include <thread.h>
+ #include <timex.h>
+-#include <xtimer.h>
+
+ #define GNRC_NDN_STACK_SIZE        (THREAD_STACKSIZE_DEFAULT)
+ #define GNRC_NDN_PRIO              (THREAD_PRIORITY_MAIN - 3)
+diff --git a/pit.c b/pit.c
+index 692105e..dc1698c 100644
+--- a/pit.c
++++ b/pit.c
+@@ -28,6 +28,8 @@
+ #define ENABLE_DEBUG 1
+ #include <debug.h>
+ #include <utlist.h>
++#include <timex.h>
++#include <ztimer.h>
+
+ #include <assert.h>
+ #include <stdlib.h>
+@@ -120,7 +122,7 @@ int ndn_pit_add(kernel_pid_t face_id, int face_type, ndn_shared_block_t* si,
+                 DEBUG("ndn: add to existing pit entry (face=%"
+                       PRIkernel_pid ")\n", face_id);
+                 /* reset timer */
+-                xtimer_set_msg(&entry->timer, lifetime, &entry->timer_msg,
++                ztimer_set_msg(ZTIMER_USEC, &entry->timer, lifetime, &entry->timer_msg,
+                                ndn_pid);
+ 		// overwrite forwarding strategy
+ 		entry->forwarding_strategy = strategy;
+@@ -155,14 +157,14 @@ int ndn_pit_add(kernel_pid_t face_id, int face_type, ndn_shared_block_t* si,
+ 	*pit_entry = entry;
+
+     /* initialize the timer */
+-    entry->timer = (xtimer_t) {0};
++    entry->timer = (ztimer_t) {0};
+
+     /* initialize the msg struct */
+     entry->timer_msg.type = NDN_PIT_MSG_TYPE_TIMEOUT;
+     entry->timer_msg.content.ptr = (char*)(&entry->timer_msg);
+
+     /* set a timer to send a message to ndn thread */
+-    xtimer_set_msg(&entry->timer, lifetime, &entry->timer_msg, ndn_pid);
++    ztimer_set_msg(ZTIMER_USEC, &entry->timer, lifetime, &entry->timer_msg, ndn_pid);
+
+     // set forwarding strategy
+     entry->forwarding_strategy = strategy;
+@@ -175,7 +177,7 @@ void ndn_pit_release(ndn_pit_entry_t *entry)
+ {
+     assert(_pit != NULL);
+     DL_DELETE(_pit, entry);
+-    xtimer_remove(&entry->timer);
++    ztimer_remove(ZTIMER_USEC, &entry->timer);
+     ndn_shared_block_release(entry->shared_pi);
+     free(entry->face_list);
+     free(entry);
+@@ -253,7 +255,7 @@ int ndn_pit_match_data(ndn_shared_block_t* sd, kernel_pid_t iface)
+ 	    DEBUG("ndn: found matching pit entry for data\n");
+
+             DL_DELETE(_pit, entry);
+-            xtimer_remove(&entry->timer);
++            ztimer_remove(ZTIMER_USEC, &entry->timer);
+
+ 	    // invoke forwarding strategy trigger if available
+ 	    if (entry->forwarding_strategy->before_satisfy_interest) {
+diff --git a/pit.h b/pit.h
+index 3384a4c..91664e0 100644
+--- a/pit.h
++++ b/pit.h
+@@ -24,7 +24,7 @@
+ #include "face-table.h"
+
+ #include "sched.h"
+-#include <xtimer.h>
++#include <ztimer.h>
+
+ #ifdef __cplusplus
+ extern "C" {
+@@ -39,7 +39,7 @@ typedef struct ndn_pit_entry {
+     struct ndn_pit_entry *prev;
+     struct ndn_pit_entry *next;
+     ndn_shared_block_t *shared_pi;  /**< shared TLV block of the pending interest */
+-    xtimer_t timer;                 /**< xtimer struct */
++    ztimer_t timer;                 /**< ztimer struct */
+     msg_t timer_msg;                /**< special message to indicate timeout event */
+
+     // List of incoming faces
+--
+2.30.2
+


### PR DESCRIPTION

### Contribution description

This PR migrate the `ndn-riot` and `ccn-lite` package to RIOT. With migrating `ccn-lite` I also ran into a bug where the `evtimer` was actually initialized later than the event were added to it. I'm not sure why but this issue only triggered when testing on `iotlab-m3` with `evtimer_on_ztimer`.

### Testing procedure

<details><summary>examples/ccn-lite-relay</summary>

```
2021-12-10 16:57:56,827 # help
2021-12-10 16:57:56,828 # Command              Description
2021-12-10 16:57:56,828 # ---------------------------------------
2021-12-10 16:57:56,829 # reboot               Reboot the node
2021-12-10 16:57:56,830 # version              Prints current RIOT_VERSION
2021-12-10 16:57:56,830 # pm                   interact with layered PM subsystem
2021-12-10 16:57:56,831 # ps                   Prints information about running threads.
2021-12-10 16:57:56,832 # ifconfig             Configure network interfaces
2021-12-10 16:57:56,833 # ccnl_open            opens an interface or socket
2021-12-10 16:57:56,833 # ccnl_int             sends an interest
2021-12-10 16:57:56,843 # ccnl_cs              shows CS or creates content and populates it
2021-12-10 16:57:56,844 # ccnl_fib             shows or modifies the CCN-Lite FIB
ccnl_cs /riot/peter/schmerzl Hello World! Hello RIOT!
2021-12-10 16:58:08,091 # ccnl_cs /riot/peter/schmerzl Hello World! Hello RIOT!
```

```
2021-12-10 16:58:06,198 # help
2021-12-10 16:58:06,199 # Command              Description
2021-12-10 16:58:06,200 # ---------------------------------------
2021-12-10 16:58:06,200 # reboot               Reboot the node
2021-12-10 16:58:06,201 # version              Prints current RIOT_VERSION
2021-12-10 16:58:06,215 # pm                   interact with layered PM subsystem
2021-12-10 16:58:06,216 # ps                   Prints information about running threads.
2021-12-10 16:58:06,216 # ifconfig             Configure network interfaces
2021-12-10 16:58:06,217 # ccnl_open            opens an interface or socket
2021-12-10 16:58:06,218 # ccnl_int             sends an interest
2021-12-10 16:58:06,219 # ccnl_cs              shows CS or creates content and populates it
2021-12-10 16:58:06,219 # ccnl_fib             shows or modifies the CCN-Lite FIB
ccnl_fib add /riot/peter/schmerzl ff:ff:ff:ff:ff:ff
2021-12-10 16:58:28,166 # ccnl_fib add /riot/peter/schmerzl ff:ff:ff:ff:ff:ff
> ccnl_int /riot/peter/schmerzl
2021-12-10 16:58:34,229 # ccnl_int /riot/peter/schmerzl
> 2021-12-10 16:58:34,245 # PKTDUMP: data received:
2021-12-10 16:58:34,246 # ~~ SNIP  0 - size:  24 byte, type: GNRC_NETTYPE_CCN_CHUNK (2)
2021-12-10 16:58:34,247 # Content is: Hello World! Hello RIOT!
2021-12-10 16:58:34,247 # ~~ PKT    -  1 snips, total size:  24 byte
2021-12-10 17:02:48,625 # Exiting Pyterm
```
</details>

NOTE: to reproduce the issue mentioned on master `USEMODULE=ztimer_usec BOARD=iotlab-m3 make -C examples/ccn-lite-relay/ clean flash term -j` would see the device harfault after 30s.

<details><summary>examples/ndn-ping</summary>

```
2021-12-10 17:08:41,778 # reboot
2021-12-10 17:08:41,779 # main(): This is RIOT! (Version: 2022.01-devel-1134-gb77b2-pr_pkg_ztimer_migrate)
2021-12-10 17:08:41,780 # All up, running the shell now
ndnping server /test 12345
2021-12-10 17:08:49,425 # ndnping server /test 12345
2021-12-10 17:08:49,426 # server (pid=1): start
2021-12-10 17:08:49,427 # ndn: ADD_FACE message received from pid 1
2021-12-10 17:08:49,427 # server (pid=1): register prefix "/test"
2021-12-10 17:08:49,428 # ndn: ADD_FIB message received from pid 1
2021-12-10 17:08:49,429 # server (pid=1): enter app run loop
2021-12-10 17:09:16,368 # ndn: RCV message received from pid 2
2021-12-10 17:09:16,369 # ndn: add new pit entry (face=2)
2021-12-10 17:09:16,384 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:16,385 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:16,385 # ndn: send to app face 1
2021-12-10 17:09:16,386 # server (pid=1): interest received, name=/test/%14%A6%ED%8E
2021-12-10 17:09:16,592 # server (pid=1): send data to NDN thread, name=/test/%14%A6%ED%8E/9
2021-12-10 17:09:16,593 # ndn: DATA message received from pid 1
2021-12-10 17:09:16,594 # ndn: found matching pit entry for data
2021-12-10 17:09:16,595 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:16,596 # ndn: send data to netdev face 2
2021-12-10 17:09:16,596 # server (pid=1): return to the app
2021-12-10 17:09:18,383 # ndn: RCV message received from pid 2
2021-12-10 17:09:18,384 # ndn: add new pit entry (face=2)
2021-12-10 17:09:18,384 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:18,385 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:18,385 # ndn: send to app face 1
2021-12-10 17:09:18,385 # server (pid=1): interest received, name=/test/%BB%93%29-
2021-12-10 17:09:18,592 # server (pid=1): send data to NDN thread, name=/test/%BB%93%29-/9
2021-12-10 17:09:18,593 # ndn: DATA message received from pid 1
2021-12-10 17:09:18,594 # ndn: found matching pit entry for data
2021-12-10 17:09:18,595 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:18,596 # ndn: send data to netdev face 2
2021-12-10 17:09:18,597 # server (pid=1): return to the app
2021-12-10 17:09:20,384 # ndn: RCV message received from pid 2
2021-12-10 17:09:20,384 # ndn: add new pit entry (face=2)
2021-12-10 17:09:20,399 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:20,400 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:20,401 # ndn: send to app face 1
2021-12-10 17:09:20,402 # server (pid=1): interest received, name=/test/%FB%AF%1Bx
2021-12-10 17:09:20,608 # server (pid=1): send data to NDN thread, name=/test/%FB%AF%1Bx/9
2021-12-10 17:09:20,609 # ndn: DATA message received from pid 1
2021-12-10 17:09:20,610 # ndn: found matching pit entry for data
2021-12-10 17:09:20,612 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:20,613 # ndn: send data to netdev face 2
2021-12-10 17:09:20,615 # server (pid=1): return to the app
2021-12-10 17:09:22,400 # ndn: RCV message received from pid 2
2021-12-10 17:09:22,400 # ndn: add new pit entry (face=2)
2021-12-10 17:09:22,401 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:22,402 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:22,403 # ndn: send to app face 1
2021-12-10 17:09:22,403 # server (pid=1): interest received, name=/test/%FC%26%C0%01
2021-12-10 17:09:22,608 # server (pid=1): send data to NDN thread, name=/test/%FC%26%C0%01/9
2021-12-10 17:09:22,609 # ndn: DATA message received from pid 1
2021-12-10 17:09:22,609 # ndn: found matching pit entry for data
2021-12-10 17:09:22,610 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:22,611 # ndn: send data to netdev face 2
2021-12-10 17:09:22,612 # server (pid=1): return to the app
2021-12-10 17:09:24,399 # ndn: RCV message received from pid 2
2021-12-10 17:09:24,399 # ndn: add new pit entry (face=2)
2021-12-10 17:09:24,415 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:24,415 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:24,416 # ndn: send to app face 1
2021-12-10 17:09:24,416 # server (pid=1): interest received, name=/test/%00%EC%BE%0F
2021-12-10 17:09:24,623 # server (pid=1): send data to NDN thread, name=/test/%00%EC%BE%0F/9
2021-12-10 17:09:24,624 # ndn: DATA message received from pid 1
2021-12-10 17:09:24,624 # ndn: found matching pit entry for data
2021-12-10 17:09:24,624 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:24,625 # ndn: send data to netdev face 2
2021-12-10 17:09:24,625 # server (pid=1): return to the app
```

```
2021-12-10 17:09:15,361 # ndnping client /test 5
2021-12-10 17:09:15,362 # client (pid=1): start
2021-12-10 17:09:15,363 # ndn: ADD_FACE message received from pid 1
2021-12-10 17:09:15,364 # client (pid=1): schedule first interest in 1 sec
2021-12-10 17:09:15,364 # client (pid=1): enter app run loop
2021-12-10 17:09:16,370 # client (pid=1): in sched callback, count=1
2021-12-10 17:09:16,371 # client (pid=1): express interest, name=/test/%14%A6%ED%8E
2021-12-10 17:09:16,371 # ndn: INTEREST message received from pid 1
2021-12-10 17:09:16,372 # ndn: add new pit entry (face=1)
2021-12-10 17:09:16,373 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:16,374 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:16,374 # ndn: send to netdev face 2
2021-12-10 17:09:16,375 # client (pid=1): schedule next interest in 2 sec
2021-12-10 17:09:16,594 # ndn: RCV message received from pid 2
2021-12-10 17:09:16,594 # ndn: found matching pit entry for data
2021-12-10 17:09:16,595 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:16,596 # ndn: send data to app face 1
2021-12-10 17:09:16,597 # client (pid=1): data received, name=/test/%14%A6%ED%8E/9
2021-12-10 17:09:16,597 # client (pid=1): content=E6EA21E6
2021-12-10 17:09:16,817 # client (pid=1): signature valid
2021-12-10 17:09:18,369 # client (pid=1): in sched callback, count=2
2021-12-10 17:09:18,370 # client (pid=1): express interest, name=/test/%BB%93%29-
2021-12-10 17:09:18,370 # ndn: INTEREST message received from pid 1
2021-12-10 17:09:18,370 # ndn: add new pit entry (face=1)
2021-12-10 17:09:18,371 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:18,385 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:18,385 # ndn: send to netdev face 2
2021-12-10 17:09:18,385 # client (pid=1): schedule next interest in 2 sec
2021-12-10 17:09:18,609 # ndn: RCV message received from pid 2
2021-12-10 17:09:18,610 # ndn: found matching pit entry for data
2021-12-10 17:09:18,611 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:18,612 # ndn: send data to app face 1
2021-12-10 17:09:18,612 # client (pid=1): data received, name=/test/%BB%93%29-/9
2021-12-10 17:09:18,613 # client (pid=1): content=E12F02AE
2021-12-10 17:09:18,833 # client (pid=1): signature valid
2021-12-10 17:09:20,386 # client (pid=1): in sched callback, count=3
2021-12-10 17:09:20,387 # client (pid=1): express interest, name=/test/%FB%AF%1Bx
2021-12-10 17:09:20,388 # ndn: INTEREST message received from pid 1
2021-12-10 17:09:20,388 # ndn: add new pit entry (face=1)
2021-12-10 17:09:20,389 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:20,390 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:20,391 # ndn: send to netdev face 2
2021-12-10 17:09:20,392 # client (pid=1): schedule next interest in 2 sec
2021-12-10 17:09:20,610 # ndn: RCV message received from pid 2
2021-12-10 17:09:20,611 # ndn: found matching pit entry for data
2021-12-10 17:09:20,613 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:20,614 # ndn: send data to app face 1
2021-12-10 17:09:20,616 # client (pid=1): data received, name=/test/%FB%AF%1Bx/9
2021-12-10 17:09:20,616 # client (pid=1): content=C9638558
2021-12-10 17:09:20,833 # client (pid=1): signature valid
2021-12-10 17:09:22,386 # client (pid=1): in sched callback, count=4
2021-12-10 17:09:22,387 # client (pid=1): express interest, name=/test/%FC%26%C0%01
2021-12-10 17:09:22,387 # ndn: INTEREST message received from pid 1
2021-12-10 17:09:22,388 # ndn: add new pit entry (face=1)
2021-12-10 17:09:22,389 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:22,390 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:22,401 # ndn: send to netdev face 2
2021-12-10 17:09:22,402 # client (pid=1): schedule next interest in 2 sec
2021-12-10 17:09:22,625 # ndn: RCV message received from pid 2
2021-12-10 17:09:22,626 # ndn: found matching pit entry for data
2021-12-10 17:09:22,627 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:22,628 # ndn: send data to app face 1
2021-12-10 17:09:22,628 # client (pid=1): data received, name=/test/%FC%26%C0%01/9
2021-12-10 17:09:22,629 # client (pid=1): content=BD5AA9E3
2021-12-10 17:09:22,833 # client (pid=1): signature valid
2021-12-10 17:09:24,401 # client (pid=1): in sched callback, count=5
2021-12-10 17:09:24,401 # client (pid=1): express interest, name=/test/%00%EC%BE%0F
2021-12-10 17:09:24,401 # ndn: INTEREST message received from pid 1
2021-12-10 17:09:24,402 # ndn: add new pit entry (face=1)
2021-12-10 17:09:24,402 # ndn: invoke forwarding strategy trigger: after_receive_interest
2021-12-10 17:09:24,403 # ndn: in default strategy trigger: after_receive_interest
2021-12-10 17:09:24,403 # ndn: send to netdev face 2
2021-12-10 17:09:24,403 # client (pid=1): schedule next interest in 2 sec
2021-12-10 17:09:24,625 # ndn: RCV message received from pid 2
2021-12-10 17:09:24,625 # ndn: found matching pit entry for data
2021-12-10 17:09:24,625 # ndn: forwarding strategy does not have trigger: before_satisfy_interest
2021-12-10 17:09:24,626 # ndn: send data to app face 1
2021-12-10 17:09:24,626 # client (pid=1): data received, name=/test/%00%EC%BE%0F/9
2021-12-10 17:09:24,626 # client (pid=1): content=D7C33BAA
2021-12-10 17:09:24,849 # client (pid=1): signature valid
2021-12-10 17:09:26,401 # client (pid=1): in sched callback, count=6
2021-12-10 17:09:26,402 # client (pid=1): stop the app
2021-12-10 17:09:26,402 # client (pid=1): returned from app run loop
2021-12-10 17:09:26,403 # ndn: REMOVE_FACE message received from pid 1
```
</details>