### PR TITLE
doc: fix libcoap removal commit

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -278,6 +278,7 @@ Author(s):
 Reason for removal:
 - Hardware not available so can't be tested
 
+[d83d08f0995a88f399e70a7d07b44dd780082436]: https://github.com/RIOT-OS/RIOT/commit/d83d08f0995a88f399e70a7d07b44dd780082436
 [cdc252ab7bd4161cc046bf93a3e55995704b24d4]: https://github.com/RIOT-OS/RIOT/commit/cdc252ab7bd4161cc046bf93a3e55995704b24d4
 [ed3887ac5c1e95308c2827bce3cdca8b0f146c22]: https://github.com/RIOT-OS/RIOT/commit/ed3887ac5c1e95308c2827bce3cdca8b0f146c22
 [0e2a62078850e1ecc74db2db4d639cf2d8fb96d3]: https://github.com/RIOT-OS/RIOT/commit/0e2a62078850e1ecc74db2db4d639cf2d8fb96d3

--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -42,7 +42,7 @@ This way, their names are never removed from the RIOT repository.
 
 # Removed Features
 
-### pkg/libcoap [e89eebc6bfba61f8f81ed078deff4050941ff3be]
+### pkg/libcoap [d83d08f0995a88f399e70a7d07b44dd780082436]
 
 Author:
 - Martine Lenders <mlenders@inf.fu-berlin.de>


### PR DESCRIPTION
### Contribution description

This PR is a follow-up of PR #17371. It reverts the commit c558599b2895db141ba089a719df3b503538aac8 and adds the missing reference.

With PR RIOT-OS#17163 for removing `libcoap`, the file `LOSTANDFOUND.md` was updated to reference the commit for removing `libcoap`. The reference was not defined at the end of the file.

### Testing procedure

`make doc` with doxygen 1.9.2 or 1.8.17 and check `doc/doxygen/html/md_LOSTANDFOUND.html`

Without the PR, the term in brackets is just a text, with this PR it is a link.
```
pkg/libcoap [d83d08f0995a88f399e70a7d07b44dd780082436]
```

### Issues/PRs references

Follow-up of PR #17371