### PR TITLE
usbus: Bind extra USB config

### DIFF
--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -153,6 +153,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief USB peripheral setting to indicate remote wakeup capability.
+ */
+#ifndef CONFIG_USB_REM_WAKEUP
+#define CONFIG_USB_REM_WAKEUP   (0)
+#endif
+
+/**
  * @brief USB device max power draw in mA, between 0 and 500mA
  */
 #ifndef CONFIG_USB_MAX_POWER

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -261,6 +261,9 @@ size_t usbus_fmt_descriptor_conf(usbus_t *usbus)
     if (CONFIG_USB_SELF_POWERED) {
         conf.attributes |= USB_CONF_ATTR_SELF_POWERED;
     }
+    if (CONFIG_USB_REM_WAKEUP) {
+        conf.attributes |= USB_CONF_ATTR_REM_WAKEUP;
+    }
     /* TODO: upper bound */
     /* USB max power is reported in increments of 2 mA */
     conf.max_power = CONFIG_USB_MAX_POWER / 2;
@@ -286,6 +289,7 @@ size_t usbus_fmt_descriptor_dev(usbus_t *usbus)
     desc.max_packet_size = CONFIG_USBUS_EP0_SIZE;
     desc.vendor_id = CONFIG_USB_VID;
     desc.product_id = CONFIG_USB_PID;
+    desc.bcd_device = CONFIG_USB_PRODUCT_BCDVERSION;
     desc.manufacturer_idx = usbus->manuf.idx;
     desc.product_idx = usbus->product.idx;
     desc.serial_idx = usbus->serial.idx;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
While working on a potential qmk_firmware integration, a few inconsistencies were noticed in the resulting USB descriptors.
* Added remote wakeup capability
* Set configured device version

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
TODO: Right now its been tested via wireshark and a heavily modified qmk_firmware branch.
Please do let me know if theres existing test cases to update.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
None.