### PR TITLE
pkg/driver_bme680/kconfig: remove prompt and depend on driver module

### DIFF
--- a/pkg/driver_bme680/Kconfig
+++ b/pkg/driver_bme680/Kconfig
@@ -6,11 +6,15 @@
 #
 
 config PACKAGE_DRIVER_BME680
-    bool "BME680 sensor driver package"
+    bool
     depends on TEST_KCONFIG
+    depends on MODULE_BME680
     select MODULE_DRIVER_BME680_CONTRIB
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
+    help
+      BME680 sensor library, written and maintained by Bosch Sensortec. This is
+      needed by RIOT BME680 driver.
 
 config MODULE_DRIVER_BME680_CONTRIB
     bool


### PR DESCRIPTION
### Contribution description
As indicated by @gschorcht [here](https://github.com/RIOT-OS/RIOT/commit/18c937ab697a1c8bc178dc7268b6991f9824da11#r61736966), the BME680 package cannot be used by itself, but is needed for RIOT BME680 driver. The user should not select this directly, so we remove the prompt and additionally add a dependency on the driver.

### Testing procedure
- Check menuconfig, the package should not be selectable.
- Green CI, the test application should work as usual.

### Issues/PRs references
#15466
