### PR TITLE
sys/ztimer: ztimer_set() return the now value

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -381,8 +381,11 @@ void ztimer_handler(ztimer_clock_t *clock);
  * @param[in]   clock       ztimer clock to operate on
  * @param[in]   timer       timer entry to set
  * @param[in]   val         timer target (relative ticks from now)
+ *
+ * @return The value of @ref ztimer_now() that @p timer was set against
+ *         (`now() + @p val = absolute trigger time`).
  */
-void ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val);
+uint32_t ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val);
 
 /**
  * @brief   Check if a timer is currently active


### PR DESCRIPTION
### Contribution description

This PR makes `ztimer_set` return the `now` value it was set against. This change although an API change should not break anything since the function was returning void, but it should allow estimating the actual value against which the set function was used.

My main motivation for this is that `esp` timer implementation sets a `timer_expire` value that cant be directly translated from `ztimer` to `xtimer`. So I'm open to any other better suggestion on doing such a thing.


### Testing procedure

everything should still build ok! 