### PR TITLE
cpu/esp: migrate to ztimer

### DIFF
--- a/cpu/esp32/Makefile
+++ b/cpu/esp32/Makefile
@@ -1,6 +1,8 @@
 # Define the module that is built:
 MODULE = cpu
 
+SRC = irq_arch.c startup.c syscalls.c
+
 # Add a list of subdirectories, that should also be built:
 DIRS += $(RIOTCPU)/esp_common
 DIRS += periph
@@ -12,6 +14,10 @@ endif
 
 ifneq (, $(filter esp_freertos, $(USEMODULE)))
     DIRS += freertos
+endif
+
+ifneq (,$(filter esp_wifi% esp_eth, $(USEMODULE)))
+    SRC += esp_ztimer.c
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -16,7 +16,7 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
   USEMODULE += esp_idf_eth_phy
   USEMODULE += netdev_eth
   USEMODULE += netopt
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
@@ -55,7 +55,7 @@ endif
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
   ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
     USEMODULE += core_thread_flags
-    USEMODULE += xtimer
+    USEMODULE += ztimer_msec
     USEMODULE += periph_i2c_hw
   else
     # PLEASE NOTE: because of the very poor and faulty hardware implementation

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1212,7 +1212,7 @@ Possible wake-up sources for the _Light-sleep_ mode are:
   `ESP_PM_WUP_UART1`)
 
 @note Since the digital core (MCU) is stalled during _Light-sleep_, it
-is not possible timers like `periph_timer` or `xtimer` as wake-up source.
+is not possible to use timers like `periph_timer` or `ztimer` as wake-up source.
 
 @warning
 Since only level interrupts are supported in _Light-sleep_ mode,
@@ -1569,7 +1569,7 @@ The following parameters are defined for ESP-NOW nodes. These parameters can be 
 
 Parameter               | Default                   | Description
 :-----------------------|:--------------------------|:-----------
-ESP_NOW_SCAN_PERIOD     | 10000000UL                | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
+ESP_NOW_SCAN_PERIOD_MS  | 10000UL                   | Defines the period in ms at which an node scans for other nodes in its range. The default period is 10 s.
 ESP_NOW_SOFT_AP_PASS    | "ThisistheRIOTporttoESP"  | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
 ESP_NOW_CHANNEL         | 6                         | Defines the channel that is used as the broadcast medium by all nodes together.
 ESP_NOW_KEY             | NULL                      | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type `uint8_t[16]` and has to be exactly 16 bytes long.

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -32,7 +32,8 @@
 #include "net/ethernet.h"
 #include "net/netdev/eth.h"
 
-#include "xtimer.h"
+#include "timex.h"
+#include "ztimer.h"
 
 #include "esp_common.h"
 #include "esp_attr.h"
@@ -43,6 +44,7 @@
 
 #include "esp32/esp_event_loop.h"
 
+#include "board.h"
 #if !defined(EMAC_PHY_SMI_MDC_PIN) || !defined(EMAC_PHY_SMI_MDIO_PIN)
 #error Board definition does not provide EMAC configuration
 #endif
@@ -50,7 +52,7 @@
 #define SYSTEM_EVENT_ETH_RX_DONE    (SYSTEM_EVENT_MAX + 1)
 #define SYSTEM_EVENT_ETH_TX_DONE    (SYSTEM_EVENT_MAX + 2)
 
-#define EMAC_PHY_CLOCK_DELAY        (500 * USEC_PER_MSEC) /* given in us */
+#define EMAC_PHY_CLOCK_DELAY_MS     (500)
 
 #ifdef EMAC_PHY_LAN8720
 #include "eth_phy/phy_lan8720.h"
@@ -130,7 +132,7 @@ static void _esp_eth_phy_power_enable_gpio(bool enable)
     gpio_init(EMAC_PHY_POWER_PIN, GPIO_OUT);
     gpio_write(EMAC_PHY_POWER_PIN, enable);
 
-    xtimer_usleep (USEC_PER_MSEC);
+    ztimer_sleep(ZTIMER_MSEC, 1);
 
     if (enable) {
         EMAC_ETHERNET_PHY_CONFIG.phy_power_enable(true);
@@ -171,7 +173,7 @@ static int _esp_eth_init(netdev_t *netdev)
      * after activating clock logic it can take some time before we can
      * enable EMAC
      */
-    xtimer_usleep (EMAC_PHY_CLOCK_DELAY);
+    ztimer_sleep(ZTIMER_MSEC, EMAC_PHY_CLOCK_DELAY_MS);
 
     if (ret == ESP_OK && (ret = esp_eth_enable()) != ESP_OK) {
         LOG_TAG_ERROR("esp_eth", "enable failed");

--- a/cpu/esp32/esp_ztimer.c
+++ b/cpu/esp32/esp_ztimer.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       ETS timer to xtimer mapper
+ * @brief       ETS timer to ztimer mapper
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  *
@@ -29,24 +29,25 @@
 
 #include "esp_attr.h"
 #include "irq_arch.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 
 #include "rom/ets_sys.h"
 
-struct _ets_to_xtimer {
+struct _ets_to_ztimer {
     ETSTimer   *ets_timer;
-    xtimer_t   xtimer;
+    ztimer_t   ztimer;
 };
 
-/* maximum number of ETS timer to xtimer mapper objects */
+/* maximum number of ETS timer to ztimer mapper objects */
 /* TODO tune the value */
 #define ETS_TO_TIMER_NUM 40
 
-/* table of ETS timer to xtimer mapper objects */
-static struct _ets_to_xtimer _ets_to_xtimer_map[ETS_TO_TIMER_NUM] = {};
+/* table of ETS timer to ztimer mapper objects */
+static struct _ets_to_ztimer _ets_to_ztimer_map[ETS_TO_TIMER_NUM] = {};
 
 /**
- * @brief   Get the ETS timer to xtimer mapper object for the given timer.
+ * @brief   Get the ETS timer to ztimer mapper object for the given timer.
  *
  * If there is no object, the function registers a new one and returns it.
  * If there is no more object available, it returns NULL.
@@ -54,47 +55,47 @@ static struct _ets_to_xtimer _ets_to_xtimer_map[ETS_TO_TIMER_NUM] = {};
  * @param   pointer to the ETS timer
  * @return  pointer to the mapper object or NULL in case of error
  */
-struct _ets_to_xtimer* _ets_to_xtimer_get(ETSTimer *timer)
+struct _ets_to_ztimer* _ets_to_ztimer_get(ETSTimer *timer)
 {
     /* search for an existing mapper object */
     for (int i = 0; i < ETS_TO_TIMER_NUM; i++) {
-        if (_ets_to_xtimer_map[i].ets_timer == timer) {
-            return &_ets_to_xtimer_map[i];
+        if (_ets_to_ztimer_map[i].ets_timer == timer) {
+            return &_ets_to_ztimer_map[i];
         }
     }
     /* search for a free mapper object */
     for (int i = 0; i < ETS_TO_TIMER_NUM; i++) {
-        if (_ets_to_xtimer_map[i].ets_timer == NULL) {
-            _ets_to_xtimer_map[i].ets_timer = timer;
-            return &_ets_to_xtimer_map[i];
+        if (_ets_to_ztimer_map[i].ets_timer == NULL) {
+            _ets_to_ztimer_map[i].ets_timer = timer;
+            return &_ets_to_ztimer_map[i];
         }
     }
-    LOG_TAG_ERROR("esp_xtimer", "There is no free ETS timer to xtimer mapper "
+    LOG_TAG_ERROR("esp_ztimer", "There is no free ETS timer to ztimer mapper "
                   "object available\n");
     return NULL;
 }
 
 /**
- * @brief   Free the ETS timer to xtimer mapper object for the given timer.
+ * @brief   Free the ETS timer to ztimer mapper object for the given timer.
  * @param   pointer to the ETS timer
  */
-void _ets_to_xtimer_free(ETSTimer *timer)
+void _ets_to_ztimer_free(ETSTimer *timer)
 {
     /* search for an existing mapper object */
     for (int i = 0; i < ETS_TO_TIMER_NUM; i++) {
-        if (_ets_to_xtimer_map[i].ets_timer == timer) {
-            _ets_to_xtimer_map[i].ets_timer = NULL;
+        if (_ets_to_ztimer_map[i].ets_timer == timer) {
+            _ets_to_ztimer_map[i].ets_timer = NULL;
             return;
         }
     }
-    DEBUG("%s There is no ETS timer to xtimer for ETS timer %p\n",
+    DEBUG("%s There is no ETS timer to ztimer for ETS timer %p\n",
           __func__, timer);
 }
 
-/* xtimer call back function, distributes ets_timer callbacks */
-void IRAM_ATTR _ets_to_xtimer_callback (void *arg)
+/* ztimer call back function, distributes ets_timer callbacks */
+void IRAM_ATTR _ets_to_ztimer_callback (void *arg)
 {
-    struct _ets_to_xtimer* e2xt = (struct _ets_to_xtimer*)arg;
+    struct _ets_to_ztimer* e2xt = (struct _ets_to_ztimer*)arg;
 
     assert(arg != NULL);
     assert(e2xt->ets_timer != NULL);
@@ -115,22 +116,22 @@ void ets_timer_setfn(ETSTimer *ptimer, ETSTimerFunc *pfunc, void *parg)
 {
     DEBUG("%s timer=%p pfunc=%p parg=%p\n", __func__, ptimer, pfunc, parg);
 
-    struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(ptimer);
+    struct _ets_to_ztimer* e2xt = _ets_to_ztimer_get(ptimer);
 
     assert(e2xt != NULL);
 
     e2xt->ets_timer->timer_func = pfunc;
     e2xt->ets_timer->timer_arg  = parg;
 
-    e2xt->xtimer.callback = &_ets_to_xtimer_callback;
-    e2xt->xtimer.arg = (void*)e2xt;
+    e2xt->ztimer.callback = &_ets_to_ztimer_callback;
+    e2xt->ztimer.arg = (void*)e2xt;
 }
 
 void ets_timer_done(ETSTimer *ptimer)
 {
     DEBUG("%s timer=%p\n", __func__, ptimer);
 
-    struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(ptimer);
+    struct _ets_to_ztimer* e2xt = _ets_to_ztimer_get(ptimer);
 
     assert(e2xt != NULL);
 
@@ -142,31 +143,35 @@ void ets_timer_arm_us(ETSTimer *timer, uint32_t tmout, bool repeat)
 {
     DEBUG("%s timer=%p tmout=%u repeat=%d\n", __func__, timer, tmout, repeat);
 
-    struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(timer);
+    struct _ets_to_ztimer* e2xt = _ets_to_ztimer_get(timer);
 
     assert(e2xt != NULL);
-    assert(e2xt->xtimer.callback != NULL);
+    assert(e2xt->ztimer.callback != NULL);
 
-    xtimer_set(&e2xt->xtimer, tmout);
+    tmout = (tmout + 500) / 1000;
+    uint32_t now = ztimer_set(ZTIMER_MSEC, &e2xt->ztimer, tmout);
 
-    e2xt->ets_timer->timer_expire = e2xt->xtimer.start_time + e2xt->xtimer.offset;
-    e2xt->ets_timer->timer_period = repeat ? tmout : 0;
+    /* Note: this is approximating the expiry time since for very short timeout
+             this might be set to a minimum value that guarantees the ISR
+             being executed */
+    e2xt->ets_timer->timer_expire = (now + tmout) * 1000;
+    e2xt->ets_timer->timer_period = repeat ? (tmout * 1000) : 0;
 }
 
 void ets_timer_arm(ETSTimer *timer, uint32_t tmout, bool repeat)
 {
-    ets_timer_arm_us(timer, tmout * USEC_PER_MSEC, repeat);
+    ets_timer_arm_us(timer, tmout * US_PER_MS, repeat);
 }
 
 void ets_timer_disarm(ETSTimer *timer)
 {
     DEBUG("%s timer=%p\n", __func__, timer);
 
-    struct _ets_to_xtimer* e2xt = _ets_to_xtimer_get(timer);
+    struct _ets_to_ztimer* e2xt = _ets_to_ztimer_get(timer);
 
     assert(e2xt != NULL);
 
-    xtimer_remove(&e2xt->xtimer);
+    ztimer_remove(ZTIMER_MSEC, &e2xt->ztimer);
 }
 
 void ets_timer_init(void)

--- a/cpu/esp32/periph/Kconfig.i2c
+++ b/cpu/esp32/periph/Kconfig.i2c
@@ -21,7 +21,8 @@ config MODULE_ESP_I2C_SW
 config MODULE_ESP_I2C_HW
     bool "Hardware"
     select MODULE_CORE_THREAD_FLAGS
-    select MODULE_XTIMER
+    select MODULE_ZTIMER
+    select MODULE_ZTIMER_MSEC
     select MODULE_PERIPH_I2C_HW
 
 endchoice

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -672,11 +672,11 @@ static const uint32_t transfer_int_mask = I2C_TRANS_COMPLETE_INT_ENA
                                         | I2C_TIME_OUT_INT_ENA;
 
 /* at I2C_SPEED_NORMAL a transfer takes at most 33 byte * 9 clock cycles * 1/100000 s */
-#define I2C_TRANSFER_TIMEOUT    3000
+#define I2C_TRANSFER_TIMEOUT_MS    3
 
 #define I2C_THREAD_FLAG BIT     (0)
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 void _i2c_transfer_timeout (void *arg)
 {
@@ -713,10 +713,10 @@ static void _i2c_transfer (i2c_t dev)
     _i2c_hw[dev].regs->int_clr.val  = transfer_int_mask;
 
     /* set a timer for the case the I2C hardware gets stuck */
-    xtimer_t i2c_timeout = {};
+    ztimer_t i2c_timeout = {};
     i2c_timeout.callback = _i2c_transfer_timeout;
     i2c_timeout.arg = (void*)(uintptr_t)dev;
-    xtimer_set(&i2c_timeout, I2C_TRANSFER_TIMEOUT);
+    ztimer_set(ZTIMER_MSEC, &i2c_timeout, I2C_TRANSFER_TIMEOUT_MS);
 
     /* start execution of commands in command pipeline registers */
     _i2c_bus[dev].pid = thread_getpid();
@@ -726,7 +726,7 @@ static void _i2c_transfer (i2c_t dev)
 
     /* wait for transfer results and remove timeout timer*/
     thread_flags_wait_one(I2C_THREAD_FLAG);
-    xtimer_remove(&i2c_timeout);
+    ztimer_remove(ZTIMER_MSEC, &i2c_timeout);
 
     /* returned from transmission */
     DEBUG("%s results=%08x\n", __func__, _i2c_bus[dev].results);

--- a/cpu/esp32/periph/pm.c
+++ b/cpu/esp32/periph/pm.c
@@ -26,7 +26,6 @@
 #include "gpio_arch.h"
 #include "rtt_arch.h"
 #include "syscalls.h"
-#include "xtimer.h"
 
 #include "periph/rtc.h"
 #include "rom/rtc.h"

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -40,7 +40,6 @@
 #include "esp_common.h"
 #include "irq_arch.h"
 #include "syscalls.h"
-#include "xtimer.h"
 
 #define RTC_PLL_480M    480 /* PLL with 480 MHz at maximum */
 #define RTC_PLL_320M    320 /* PLL with 480 MHz at maximum */
@@ -74,6 +73,7 @@
 #define HW_TIMER_CLK_DIV      (rtc_clk_apb_freq_get() / 1000000)
 #define HW_TIMER_CORRECTION   (RTC_PLL_320M / CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 #define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION << 1, 5))
+#define HW_TIMER_FREQUENCY    (1000000UL) /* only 1MHz is supported */
 
 struct hw_timer_regs_t {
     /* see Technical Reference, section 17.4 */
@@ -198,7 +198,7 @@ int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
           __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  HW_TIMER_NUMOF, -1);
-    CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);
+    CHECK_PARAM_RET (freq == HW_TIMER_FREQUENCY, -1);
     CHECK_PARAM_RET (cb   != NULL, -1);
 
     if (timers[dev].initialized) {
@@ -367,6 +367,7 @@ void IRAM timer_stop(tim_t dev)
 #define HW_TIMER_DELTA_MAX    0x00ffffff  /* in us */
 #define HW_TIMER_DELTA_MASK   0x00ffffff
 #define HW_TIMER_DELTA_RSHIFT 24
+#define HW_TIMER_FREQUENCY    (1000000UL) /* only 1MHz is supported */
 
 #define HW_TIMER_CORRECTION   (RTC_PLL_480M / CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 #define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION, 5))
@@ -442,7 +443,7 @@ int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     DEBUG("%s dev=%u freq=%u cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  HW_TIMER_NUMOF, -1);
-    CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);
+    CHECK_PARAM_RET (freq == HW_TIMER_FREQUENCY, -1);
     CHECK_PARAM_RET (cb   != NULL, -1);
 
     if (timers[dev].initialized) {

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -182,7 +182,7 @@ uint32_t system_get_time(void)
 
 uint32_t system_get_time_ms(void)
 {
-    return system_get_time_64() / USEC_PER_MSEC;
+    return system_get_time_64() / US_PER_MS;
 }
 
 uint64_t system_get_time_64(void)

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -828,7 +828,7 @@ be overridden by [application-specific board configurations](#esp8266_applicatio
 
 Parameter | Default | Description
 :---------|:--------|:-----------
-#ESP_NOW_SCAN_PERIOD | 10000000UL | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
+#ESP_NOW_SCAN_PERIOD_MS | 10000UL | Defines the period in ms at which an node scans for other nodes in its range. The default period is 10 s.
 #ESP_NOW_SOFT_AP_PASS | "ThisistheRIOTporttoESP" | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
 #ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
 #ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type `uint8_t[16]` and has to be exactly 16 bytes long.

--- a/cpu/esp8266/ld/esp8266.riot-os.ld
+++ b/cpu/esp8266/ld/esp8266.riot-os.ld
@@ -242,7 +242,7 @@ SECTIONS
     *freertos/*(.literal .text .literal.* .text.*)
     *freertos_common/*(.literal .text .literal.* .text.*)
     *periph/*(.literal .text .literal.* .text.*)
-    *xtimer/*(.literal .text .literal.* .text.*)
+    *ztimer/*(.literal .text .literal.* .text.*)
 
     *libhal.a:clock.o(.literal .text .literal.* .text.*)
     *libhal.a:int_asm--set_intclear.o(.literal .text .literal.* .text.*)

--- a/cpu/esp8266/periph/timer.c
+++ b/cpu/esp8266/periph/timer.c
@@ -26,7 +26,6 @@
 #include "debug.h"
 #include "log.h"
 
-#include "xtimer.h"
 #include "periph/timer.h"
 
 #include "esp/common_macros.h"
@@ -49,6 +48,7 @@
 #define HW_TIMER_DELTA_MASK   0x00ffffff
 #define HW_TIMER_DELTA_RSHIFT 24
 #define HW_TIMER_CORRECTION   2             /* overhead in us */
+#define HW_TIMER_FREQUENCY    (1000000UL)   /* only 1MHz is supported */
 
 #define HW_TIMER_CLOCK             (APB_CLK_FREQ)
 
@@ -121,7 +121,7 @@ int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
           __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  HW_TIMER_NUMOF, -1);
-    CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);
+    CHECK_PARAM_RET (freq == HW_TIMER_FREQUENCY, -1);
     CHECK_PARAM_RET (cb   != NULL, -1);
 
     if (timers[dev].initialized) {
@@ -317,6 +317,7 @@ void timer_print_config(void)
 #define OS_TIMER_DELTA_MASK   0x0000ffff
 #define OS_TIMER_DELTA_RSHIFT 16
 #define OS_TIMER_CORRECTION   4
+#define OS_TIMER_FREQUENCY    (1000000UL) /* only 1MHz is supported */
 
 extern void os_timer_arm_us(os_timer_t *ptimer, uint32_t time, bool repeat_flag);
 
@@ -385,7 +386,7 @@ int timer_init (tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     DEBUG("%s dev=%u freq=%u cb=%p arg=%p\n", __func__, dev, freq, cb, arg);
 
     CHECK_PARAM_RET (dev  <  OS_TIMER_NUMOF, -1);
-    CHECK_PARAM_RET (freq == XTIMER_HZ_BASE, -1);
+    CHECK_PARAM_RET (freq == OS_TIMER_FREQUENCY, -1);
     CHECK_PARAM_RET (cb   != NULL, -1);
 
     if (timers[dev].initialized) {

--- a/cpu/esp8266/syscalls.c
+++ b/cpu/esp8266/syscalls.c
@@ -21,6 +21,7 @@
 #include "esp_attr.h"
 #include "esp_common.h"
 #include "sdk/sdk.h"
+#include "timex.h"
 
 #ifdef MODULE_ESP_IDF_HEAP
 #include "esp_heap_caps.h"
@@ -66,7 +67,7 @@ uint32_t system_get_time(void)
 
 uint32_t system_get_time_ms(void)
 {
-    return system_get_time() / USEC_PER_MSEC;
+    return system_get_time() / US_PER_MS;
 }
 
 void IRAM_ATTR syscalls_init_arch(void)

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -83,5 +83,5 @@ endif
 
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   USEMODULE += netopt
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
 endif

--- a/cpu/esp_common/esp-now/doc.txt
+++ b/cpu/esp_common/esp-now/doc.txt
@@ -34,7 +34,7 @@ The following parameters are defined for ESP-NOW nodes.
 
 Parameter | Default | Description
 :---------|:--------|:-----------
-ESP_NOW_SCAN_PERIOD | 10000000UL | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
+ESP_NOW_SCAN_PERIOD_MS | 10000UL | Defines the period in ms at which an node scans for other nodes in its range. The default period is 10 s.
 ESP_NOW_SOFT_AP_PASS | "ThisistheRIOTporttoESP" | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
 ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
 ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type ```uint8_t[16]``` and has to be exactly 16 bytes long.

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 
 #include "net/gnrc.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "esp_common.h"
 #include "esp_attr.h"
@@ -91,7 +91,7 @@ static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, const uint8
 
 #if ESP_NOW_UNICAST
 
-static xtimer_t _esp_now_scan_peers_timer;
+static ztimer_t _esp_now_scan_peers_timer;
 static bool _esp_now_scan_peers_done = false;
 
 #define ESP_NOW_APS_BLOCK_SIZE 8 /* has to be power of two */
@@ -117,7 +117,7 @@ static void IRAM_ATTR esp_now_scan_peers_done(void)
     uint16_t ap_num;
 
     ret = esp_wifi_scan_get_ap_num(&ap_num);
-    DEBUG("wifi_scan_get_ap_num ret=%d num=%d\n", ret ,ap_num);
+    DEBUG("wifi_scan_get_ap_num ret=%d num=%d\n", ret, ap_num);
 
     if (ret == ESP_OK && ap_num) {
         uint32_t state;
@@ -173,7 +173,7 @@ static void esp_now_scan_peers_start(void)
     /* start the scan */
     esp_wifi_scan_start(&scan_cfg, false);
     /* set the time for next scan */
-    xtimer_set(&_esp_now_scan_peers_timer, esp_now_params.scan_period);
+    ztimer_set(ZTIMER_MSEC, &_esp_now_scan_peers_timer, esp_now_params.scan_period);
 }
 
 static void IRAM_ATTR esp_now_scan_peers_timer_cb(void* arg)

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -44,12 +44,12 @@
 #endif
 
 /**
- * @brief   Period in microseconds at which an ESP-NOW node scans for other
+ * @brief   Period in milliseconds at which an ESP-NOW node scans for other
  *          ESP-NOW nodes in its range.
  * @ingroup cpu_esp_common_conf
  */
-#ifndef ESP_NOW_SCAN_PERIOD
-#define ESP_NOW_SCAN_PERIOD     (10000000UL)
+#ifndef ESP_NOW_SCAN_PERIOD_MS
+#define ESP_NOW_SCAN_PERIOD_MS     (10000UL)
 #endif
 
 /**
@@ -92,7 +92,7 @@
  */
 #ifndef ESP_NOW_PARAMS
 #define ESP_NOW_PARAMS   { .key = ESP_NOW_KEY, \
-                           .scan_period = ESP_NOW_SCAN_PERIOD, \
+                           .scan_period = ESP_NOW_SCAN_PERIOD_MS, \
                            .softap_pass = ESP_NOW_SOFT_AP_PASS, \
                            .channel = ESP_NOW_CHANNEL \
                          }

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -25,7 +25,6 @@
 #include "net/ethernet.h"
 #include "net/netdev/eth.h"
 #include "od.h"
-#include "xtimer.h"
 
 #include "esp_common.h"
 #include "esp_attr.h"
@@ -49,6 +48,7 @@
 #include "esp_wifi_netdev.h"
 
 #include "log.h"
+#include "board.h"
 
 #define ESP_WIFI_DEBUG(f, ...) \
         DEBUG("[esp_wifi] %s: " f "\n", __func__, ## __VA_ARGS__)

--- a/cpu/esp_common/freertos/portable.c
+++ b/cpu/esp_common/freertos/portable.c
@@ -22,7 +22,7 @@
 #include "freertos/FreeRTOS.h"
 
 uint32_t xPortGetTickRateHz(void) {
-    return MSEC_PER_SEC / portTICK_PERIOD_MS;
+    return MS_PER_SEC / portTICK_PERIOD_MS;
 }
 
 BaseType_t xPortInIsrContext(void)

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -21,7 +21,10 @@
 #include "log.h"
 #include "syscalls.h"
 #include "thread.h"
-#include "xtimer.h"
+#if defined(MODULE_ESP_WIFI_ANY) || defined(MODULE_ESP_ETH)
+#include "ztimer.h"
+#endif
+#include "timex.h"
 
 #ifdef MCU_ESP32
 #include "soc/soc.h"
@@ -134,14 +137,14 @@ void vTaskDelay( const TickType_t xTicksToDelay )
 {
     DEBUG("%s xTicksToDelay=%d\n", __func__, xTicksToDelay);
 #if defined(MODULE_ESP_WIFI_ANY)
-    uint64_t us = xTicksToDelay * MHZ / xPortGetTickRateHz();
-    xtimer_usleep(us);
+     uint64_t ms = xTicksToDelay * MS_PER_SEC / xPortGetTickRateHz();
+     ztimer_sleep(ZTIMER_MSEC, ms);
 #endif
 }
 
 TickType_t xTaskGetTickCount (void)
 {
-    return system_get_time() / USEC_PER_MSEC / portTICK_PERIOD_MS;
+    return system_get_time() / US_PER_MS / portTICK_PERIOD_MS;
 }
 
 void vTaskEnterCritical( portMUX_TYPE *mux )

--- a/cpu/esp_common/freertos/timers.c
+++ b/cpu/esp_common/freertos/timers.c
@@ -19,28 +19,29 @@
 #include "esp_common.h"
 #include "esp_attr.h"
 #include "log.h"
-#include "xtimer.h"
+#include "ztimer.h"
+#include "timex.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/timers.h"
 
 typedef struct {
-    xtimer_t    xtimer;         /* xtimer object */
+    ztimer_t    ztimer;         /* ztimer object */
     const char* name;           /* FreeRTOS timer name */
     uint32_t    period;         /* in us */
     bool        autoreload;     /* FreeRTOS timer reload indicator */
     const void* timerid;        /* FreeRTOS timer id */
     TimerCallbackFunction_t cb; /* FreeRTOS callback function */
-} freertos_xtimer_t;
+} freertos_ztimer_t;
 
-static void IRAM_ATTR _xtimer_callback (void *arg)
+static void IRAM_ATTR _ztimer_callback (void *arg)
 {
     assert(arg != NULL);
 
-    freertos_xtimer_t* timer = (freertos_xtimer_t*)arg;
+    freertos_ztimer_t* timer = (freertos_ztimer_t*)arg;
 
     if (timer->autoreload) {
-        xtimer_set(&timer->xtimer, timer->period);
+        ztimer_set(ZTIMER_MSEC, &timer->ztimer, timer->period);
     }
 
     if (timer->cb) {
@@ -54,21 +55,21 @@ TimerHandle_t xTimerCreate (const char * const pcTimerName,
                             void * const pvTimerID,
                             TimerCallbackFunction_t pxCallbackFunction)
 {
-    freertos_xtimer_t* timer = malloc(sizeof(freertos_xtimer_t));
+    freertos_ztimer_t* timer = malloc(sizeof(freertos_ztimer_t));
     if (timer == NULL) {
         return NULL;
     }
 
     /* FreeRTOS timer parameter */
     timer->name = pcTimerName;
-    timer->period = xTimerPeriod * portTICK_PERIOD_MS * USEC_PER_MSEC;
+    timer->period = xTimerPeriod * portTICK_PERIOD_MS;
     timer->autoreload = uxAutoReload;
     timer->timerid = pvTimerID;
     timer->cb = pxCallbackFunction;
 
-    /* xtimer parameter */
-    timer->xtimer.callback = _xtimer_callback;
-    timer->xtimer.arg = timer;
+    /* ztimer parameter */
+    timer->ztimer.callback = _ztimer_callback;
+    timer->ztimer.arg = timer;
 
     DEBUG("%s %p %s %d %u\n", __func__, timer, pcTimerName, xTimerPeriod, uxAutoReload);
     return timer;
@@ -79,8 +80,8 @@ BaseType_t xTimerDelete(TimerHandle_t xTimer, TickType_t xBlockTime)
     DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
-    freertos_xtimer_t* timer = (freertos_xtimer_t*)xTimer;
-    xtimer_remove(&timer->xtimer);
+    freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
+    ztimer_remove(ZTIMER_MSEC, &timer->ztimer);
     free(timer);
 
     return pdTRUE;
@@ -91,8 +92,8 @@ BaseType_t xTimerStart (TimerHandle_t xTimer, TickType_t xBlockTime)
     DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
-    freertos_xtimer_t* timer = (freertos_xtimer_t*)xTimer;
-    xtimer_set(&timer->xtimer, timer->period);
+    freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
+    ztimer_set(ZTIMER_MSEC, &timer->ztimer, timer->period);
 
     return pdTRUE;
 }
@@ -102,8 +103,8 @@ BaseType_t xTimerStop  (TimerHandle_t xTimer, TickType_t xBlockTime)
     DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
-    freertos_xtimer_t* timer = (freertos_xtimer_t*)xTimer;
-    xtimer_remove(&timer->xtimer);
+    freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
+    ztimer_remove(ZTIMER_MSEC, &timer->ztimer);
 
     return pdTRUE;
 }
@@ -113,8 +114,8 @@ BaseType_t xTimerReset (TimerHandle_t xTimer, TickType_t xBlockTime)
     DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
-    freertos_xtimer_t* timer = (freertos_xtimer_t*)xTimer;
-    xtimer_set(&timer->xtimer, xBlockTime * portTICK_PERIOD_MS * USEC_PER_MSEC);
+    freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
+    ztimer_set(ZTIMER_MSEC, &timer->ztimer, xBlockTime * portTICK_PERIOD_MS * US_PER_MS);
 
     return pdTRUE;
 }
@@ -123,7 +124,7 @@ void *pvTimerGetTimerID(const TimerHandle_t xTimer)
 {
     assert(xTimer != NULL);
 
-    freertos_xtimer_t* timer = (freertos_xtimer_t*)xTimer;
+    freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
     return (void*)timer->timerid;
 }
 

--- a/cpu/esp_common/include/freertos/timers.h
+++ b/cpu/esp_common/include/freertos/timers.h
@@ -14,15 +14,13 @@
 #ifndef DOXYGEN
 
 #include "freertos/FreeRTOS.h"
-#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef void* TimerHandle_t;
-
-#define TimerCallbackFunction_t  xtimer_callback_t
+typedef void (*TimerCallbackFunction_t)(void*);
 #define tmrTIMER_CALLBACK        TimerCallbackFunction_t
 
 TimerHandle_t xTimerCreate (const char * const pcTimerName,


### PR DESCRIPTION
### Contribution description

`esp` has a couple of uses of `xtimer` that can't be directly translated to `ztimer`, so it seems better to do it in its own PR. I also don't have hardware to tests so would appreciate if maybe @gschorcht could complement murdock's testing.

The most delicate change is https://github.com/fjmolinas/RIOT/blob/6a736e4cdfb57ee446050d8fd0c455f120dd381c/cpu/esp32/esp_ztimer.c#L153-L157 since this is not a direct translation, so depending on how sensitive this value is some adjustment might be needed, thougts @gschorcht?

### Testing procedure

- All `esp` tests should pass
- Murdock tests should pass

### Issues/PRs references

depends on #17385
part of #16903 