### PR TITLE
cpu/atmega_common: Remember CTC mode with timer_periodic

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -219,11 +219,12 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
     if (channel == 0) {
         if (flags & TIM_FLAG_RESET_ON_MATCH) {
             /* enable CTC mode */
-            ctx[tim].dev->CRB |= (1 << 3);
+            ctx[tim].mode |= (1 << 3);
         } else {
             /* disable CTC mode */
-            ctx[tim].dev->CRB &= (1 << 3);
+            ctx[tim].mode &= (1 << 3);
         }
+        ctx[tim].dev->CRB = ctx[tim].mode;
     } else {
         assert((flags & TIM_FLAG_RESET_ON_MATCH) == 0);
         res = -1;


### PR DESCRIPTION
### Contribution description

On `cpu/atmega_common` the `periph_timer_periodic` implementation does not keep correct counting mode with `TIM_FLAG_RESET_ON_MATCH`. This PR fixes this issue.


### Testing procedure

To reproduce:
1. Create a periodic timeout with `TIM_FLAG_RESET_ON_MATCH` set.
2. Stop the timer.
3. Start/Resume the timer.
4. Now the counting mode is restored to its initial value (without CTC mode enabled), resulting in a timeout miss. The implementation falsely waits until the timer overflows instead of the desired periodic counter top value.

### Description of the fix

The `timer_start()` function sets the counting mode to `ctx[tim].mode`, as initialized in `timer_init()`. To preserve `TIM_FLAG_RESET_ON_MATCH`, `timer_set_periodic()` now also updates `ctx[tim].mode`.
