### PR TITLE
tests/periph_timer_periodic: spice up test

### DIFF
--- a/tests/periph_timer_periodic/tests/01-run.py
+++ b/tests/periph_timer_periodic/tests/01-run.py
@@ -17,13 +17,24 @@ PRECISION = float(os.getenv("TEST_PERIPH_TIMER_PERIODIC_PRECISION", "0"))
 
 def testfunc(child):
     child.expect_exact('TEST START')
-    start = time.time()
+    while True:
+        child.expect(r"Running iteration (\d+) of (\d+)\r\n")
+        iteration = int(child.match.group(1))
+        last_iteration = int(child.match.group(2))
+        start = time.time()
+        for i in range(12):
+            child.expect(r"\[(\d+)\] tick\r\n")
+            chan = int(child.match.group(1))
+            assert chan == 0, "Only channel 0 should tick"
+        child.expect("Cycles:\r\n")
+        end = time.time()
+        # test should run 10 cycles with 25ms each
+        elapsed = end - start
+        assert elapsed > 0.25 * (1 - PRECISION), "=< 0.25s ({})".format(elapsed)
+        assert elapsed < 0.40 * (1 + PRECISION), "=> 0.40s ({})".format(elapsed)
+        if iteration == last_iteration:
+            break
     child.expect_exact('TEST SUCCEEDED')
-    end = time.time()
-    # test should run 10 cycles with 25ms each
-    elapsed = end - start
-    assert elapsed > 0.25 * (1 - PRECISION), "=< 0.25s ({})".format(elapsed)
-    assert elapsed < 0.40 * (1 + PRECISION), "=> 0.40s ({})".format(elapsed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

The test should detect some bugs regarding incorrect behavior regarding `timer_start()` not resuming periodic timers as expected.

### Testing procedure

The test should still pass (hopefully) for all non-AVR boards, but fail on AVR due to the bug fixed in https://github.com/RIOT-OS/RIOT/pull/17387

### Issues/PRs references

Used to test https://github.com/RIOT-OS/RIOT/pull/17387