### PR TITLE
cpu/kinetis/include: fix xtimer backend timer selection

### DIFF
--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -500,7 +500,7 @@ enum {
 #ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       RTT_MAX_FREQUENCY
 #endif
-#if IS_USED(PERIPH_RTT)
+#if IS_USED(MODULE_PERIPH_RTT)
 /* On kinetis periph_rtt is built on top on an LPTIMER so if used it
    will conflict with xtimer, if a LPTIMER backend and RTT are needed
    consider using ztimer */

--- a/tests/periph_rtt_min/Makefile
+++ b/tests/periph_rtt_min/Makefile
@@ -11,15 +11,10 @@ RIOT_TERMINAL ?= socat
 include $(RIOTBASE)/Makefile.include
 
 # use highest possible RTT_FREQUENCY for boards that allow it
-ifneq (,$(filter stm32 nrf5%,$(CPU)))
+ifneq (,$(filter stm32 nrf5% sam% kinetis efm32 fe310,$(CPU)))
   RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
   CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
 endif
 
-# kinetis rtt runs at 1Hz, reduce samples to speed up the test
-ifneq (,$(filter kinetis,$(CPU)))
-  SAMPLES ?= 64
-else
-  SAMPLES ?= 1024
-endif
+SAMPLES ?= 1024
 CFLAGS += -DSAMPLES=$(SAMPLES)


### PR DESCRIPTION

### Contribution description

While testing #17357 I had the test fail on `frdm-kw41z`, while investigating I realized there was a wrong define and that the rtt callback was not cleared.

I also added a fix to the rtt_min_offset test which was not updated since now kinetis runs at 32khz.

### Testing procedure

`USEMODULE=evtimer_on_ztimer BOARD=frdm-kw41z make -C tests/evtimer_msg/ flash test -j` now passes

```
main(): This is RIOT! (Version: 2022.01-devel-1233-gbf0546-pr_kinetis_fix_rtt)
Testing generic evtimer
This should list 2 items
ev #1 offset=999
ev #2 offset=500
This should list 4 items
ev #1 offset=659
ev #2 offset=341
ev #3 offset=500
ev #4 offset=2454
Are the reception times of all 4 msgs close to the supposed values?
At   3854 ms received msg 0: "#2 supposed to be 3854"
.At   4195 ms received msg 1: "#0 supposed to be 4195"
.At   4695 ms received msg 2: "#1 supposed to be 4695"
.At   7149 ms received msg 3: "#3 supposed to be 7149"
.
All tests successful
```

- `BOARD=usb-kw41z make -C tests/periph_rtt_min/ flash term -j` default samples are used.

```
START
main(): This is RIOT! (Version: 2022.01-devel-1233-gbf0546-pr_kinetis_fix_rtt)
Evaluate RTT_MIN_OFFSET over 1024 samples
Sample 0
Sample 1
Sample 2
....
Sample 1021
Sample 1022
Sample 1023

RTT_MIN_OFFSET for usb-kw41z over 1024 samples: 1

```

