### PR TITLE
makefiles/docker.inc.mk: add DOCKER_ENV_VARS_ALWAYS

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -344,6 +344,7 @@ check_no_riot_config() {
     pathspec+=('**/Makefile*')
     pathspec+=('**/*.mk')
     pathspec+=(':!makefiles/kconfig.mk')
+    pathspec+=(':!makefiles/docker.inc.mk')
     git -C "${RIOTBASE}" grep -n "${patterns[@]}" -- "${pathspec[@]}" \
         | error_with_message "Don't push RIOT_CONFIG_* definitions upstream. Rather define configuration via Kconfig"
 }


### PR DESCRIPTION
### Contribution description

This PR adds a potential solution for #14504

This adds a list of variables that should always be passed to docker
since they are commonly set in Makefile/Makefile.include and therefore
can not be checked for their origin.

### Testing procedure

~~This one should carefully be tested, at least so that dependencies do not change with or without this PR. I think `/dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh ` should be ran at least.~~

Kconfig run https://github.com/RIOT-OS/RIOT/pull/17396#issuecomment-1034856703

Test out passing dependency-related variables...

@leandrolanzieri what Kconfig related things should be added as well.

### Issues/PRs references

Partial fix to #14504 