### PR TITLE
makefiles/docker.inc.mk: pass TEST_KCONFIG

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -66,6 +66,7 @@ export DOCKER_ENV_VARS += \
   SCANBUILD_OUTPUTDIR \
   SIZE \
   TOOLCHAIN \
+  TEST_KCONFIG \
   UNDEF \
   #
 


### PR DESCRIPTION
### Contribution description

This PR passes `TEST_KCONFIG` to docker to allow building with kconfig.

### Testing procedure

Build with `TEST_KCONFIG` in docker, it now works. For example, this would have wrongly built-in master:

```
TEST_KCONFIG=1 BUILD_IN_DOCKER=1 BOARD=esp8266-esp-12x make -C examples/gnrc_networking clean all -j
```