### PR TITLE
boards/feather-m0: add arduino feature

### DIFF
--- a/boards/feather-m0/Kconfig
+++ b/boards/feather-m0/Kconfig
@@ -20,6 +20,7 @@ config BOARD_FEATHER_M0
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
     select HAS_HIGHLEVEL_STDIO
 
     select HAVE_SAUL_GPIO

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -13,6 +13,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += arduino
 FEATURES_PROVIDED += highlevel_stdio
 
 # This configuration enables modules that are only available when using Kconfig

--- a/boards/feather-m0/include/arduino_board.h
+++ b/boards/feather-m0/include/arduino_board.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-m0
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+#include "periph/pwm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_16,
+    ARDUINO_PIN_17,
+    ARDUINO_PIN_18,
+    ARDUINO_PIN_19,
+    ARDUINO_PIN_20,
+    ARDUINO_PIN_21,
+    ARDUINO_PIN_22,
+    ARDUINO_PIN_23,
+    ARDUINO_PIN_24,
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+    ADC_UNDEF,
+    ARDUINO_A7,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/feather-m0/include/arduino_pinmap.h
+++ b/boards/feather-m0/include/arduino_pinmap.h
@@ -68,18 +68,6 @@ extern "C" {
 #define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (LORA_RST) */
 #define ARDUINO_PIN_7           GPIO_UNDEF       /**< D7 */
 #define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (LORA_CS) */
-#elif defined(BOARD_FEATHER_M0_BLE)
-#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
-#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
-#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (BLE_SWDIO/RST) */
-#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 (BLE_IRQ) */
-#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (BLE_CS) */
-#elif defined(BOARD_FEATHER_M0_LOGGER)
-#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
-#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
-#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (SD CS) */
-#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 (SD CD) */
-#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (Green LED) */
 #else
 #define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
 #define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */

--- a/boards/feather-m0/include/arduino_pinmap.h
+++ b/boards/feather-m0/include/arduino_pinmap.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2021 J. David Ibáñez <jdavid.ibp@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_feather-m0
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      J. David Ibáñez <jdavid.ibp@gmail.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ *
+ * @{
+ */
+
+#define ARDUINO_PIN_0           GPIO_PIN(PA, 11) /**< D0 (RX) */
+#define ARDUINO_PIN_1           GPIO_PIN(PA, 10) /**< D1 (TX) */
+#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
+#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
+#define ARDUINO_PIN_4           GPIO_UNDEF       /**< D4 */
+#define ARDUINO_PIN_5           GPIO_PIN(PA, 15) /**< D5 */
+#define ARDUINO_PIN_6           GPIO_PIN(PA, 20) /**< D6 */
+#define ARDUINO_PIN_7           GPIO_UNDEF       /**< D7 */
+#define ARDUINO_PIN_8           GPIO_UNDEF       /**< D8 */
+#define ARDUINO_PIN_9           GPIO_PIN(PA, 7)  /**< D9 */
+#define ARDUINO_PIN_10          GPIO_PIN(PA, 18) /**< D10 */
+#define ARDUINO_PIN_11          GPIO_PIN(PA, 16) /**< D11 */
+#define ARDUINO_PIN_12          GPIO_PIN(PA, 19) /**< D12 */
+#define ARDUINO_PIN_13          GPIO_PIN(PA, 17) /**< D13 (LED) */
+#define ARDUINO_PIN_14          GPIO_PIN(PA, 2)  /**< D14 (A0) */
+#define ARDUINO_PIN_15          GPIO_PIN(PB, 8)  /**< D15 (A1) */
+#define ARDUINO_PIN_16          GPIO_PIN(PB, 9)  /**< D16 (A2) */
+#define ARDUINO_PIN_17          GPIO_PIN(PA, 4)  /**< D17 (A3) */
+#define ARDUINO_PIN_18          GPIO_PIN(PA, 5)  /**< D18 (A4) */
+#define ARDUINO_PIN_19          GPIO_PIN(PB, 2)  /**< D19 (A5) */
+#define ARDUINO_PIN_20          GPIO_PIN(PA, 22) /**< D20 (I2C SDA) */
+#define ARDUINO_PIN_21          GPIO_PIN(PA, 23) /**< D21 (I2C SCL) */
+#define ARDUINO_PIN_22          GPIO_PIN(PA, 12) /**< D22 (SPI MISO) */
+#define ARDUINO_PIN_23          GPIO_PIN(PB, 10) /**< D23 (SPI MOSI) */
+#define ARDUINO_PIN_24          GPIO_PIN(PB, 11) /**< D24 (SPI SCK) */
+
+#define ARDUINO_PIN_A0          ARDUINO_PIN_14   /**< A0 */
+#define ARDUINO_PIN_A1          ARDUINO_PIN_15   /**< A1 */
+#define ARDUINO_PIN_A2          ARDUINO_PIN_16   /**< A2 */
+#define ARDUINO_PIN_A3          ARDUINO_PIN_17   /**< A3 */
+#define ARDUINO_PIN_A4          ARDUINO_PIN_18   /**< A4 */
+#define ARDUINO_PIN_A5          ARDUINO_PIN_19   /**< A5 */
+#define ARDUINO_PIN_A7          ARDUINO_PIN_9    /**< A7 */
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)  /**< ADC 0 */
+#define ARDUINO_A1              ADC_LINE(2)  /**< ADC 1 */
+#define ARDUINO_A2              ADC_LINE(3)  /**< ADC 2 */
+#define ARDUINO_A3              ADC_LINE(4)  /**< ADC 3 */
+#define ARDUINO_A4              ADC_LINE(5)  /**< ADC 4 */
+#define ARDUINO_A5              ADC_LINE(10) /**< ADC 5 */
+#define ARDUINO_A7              ADC_LINE(7)  /**< ADC 7 */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/feather-m0/include/arduino_pinmap.h
+++ b/boards/feather-m0/include/arduino_pinmap.h
@@ -37,13 +37,8 @@ extern "C" {
 
 #define ARDUINO_PIN_0           GPIO_PIN(PA, 11) /**< D0 (RX) */
 #define ARDUINO_PIN_1           GPIO_PIN(PA, 10) /**< D1 (TX) */
-#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
-#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
-#define ARDUINO_PIN_4           GPIO_UNDEF       /**< D4 */
 #define ARDUINO_PIN_5           GPIO_PIN(PA, 15) /**< D5 */
 #define ARDUINO_PIN_6           GPIO_PIN(PA, 20) /**< D6 */
-#define ARDUINO_PIN_7           GPIO_UNDEF       /**< D7 */
-#define ARDUINO_PIN_8           GPIO_UNDEF       /**< D8 */
 #define ARDUINO_PIN_9           GPIO_PIN(PA, 7)  /**< D9 */
 #define ARDUINO_PIN_10          GPIO_PIN(PA, 18) /**< D10 */
 #define ARDUINO_PIN_11          GPIO_PIN(PA, 16) /**< D11 */
@@ -60,6 +55,38 @@ extern "C" {
 #define ARDUINO_PIN_22          GPIO_PIN(PA, 12) /**< D22 (SPI MISO) */
 #define ARDUINO_PIN_23          GPIO_PIN(PB, 10) /**< D23 (SPI MOSI) */
 #define ARDUINO_PIN_24          GPIO_PIN(PB, 11) /**< D24 (SPI SCK) */
+
+#if defined(BOARD_FEATHER_M0_WIFI)
+#define ARDUINO_PIN_2           GPIO_PIN(PA, 14) /**< D2 (WINC_CHIP_EN) */
+#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (WINC_RST) */
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 (WINC_IRQ) */
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (WINC_CS) */
+#elif defined(BOARD_FEATHER_M0_LORA)
+#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
+#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)  /**< D3 (LORA_IRQ) */
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (LORA_RST) */
+#define ARDUINO_PIN_7           GPIO_UNDEF       /**< D7 */
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (LORA_CS) */
+#elif defined(BOARD_FEATHER_M0_BLE)
+#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
+#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (BLE_SWDIO/RST) */
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 (BLE_IRQ) */
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (BLE_CS) */
+#elif defined(BOARD_FEATHER_M0_LOGGER)
+#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
+#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)  /**< D4 (SD CS) */
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21) /**< D7 (SD CD) */
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)  /**< D8 (Green LED) */
+#else
+#define ARDUINO_PIN_2           GPIO_UNDEF       /**< D2 */
+#define ARDUINO_PIN_3           GPIO_UNDEF       /**< D3 */
+#define ARDUINO_PIN_4           GPIO_UNDEF       /**< D4 */
+#define ARDUINO_PIN_7           GPIO_UNDEF       /**< D7 */
+#define ARDUINO_PIN_8           GPIO_UNDEF       /**< D8 */
+#endif
 
 #define ARDUINO_PIN_A0          ARDUINO_PIN_14   /**< A0 */
 #define ARDUINO_PIN_A1          ARDUINO_PIN_15   /**< A1 */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Adds the **arduino** feature to the **feather-m0** board.

This is a follow up of PR #17335 ; it contains the first 3 commits from that PR rebased and merged.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Use `tests/periph_gpio_arduino` and `tests/sys_arduino_lib`.

`examples/arduino_hello-world` and `tests/sys_arduino` don't work, as discussed in PR #17335 this is to be fixed in a different PR.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This is a follow up of PR #17335 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
