### PR TITLE
sys/ztimer: ztimer_now() add warning regarding comparing now() values

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -465,6 +465,9 @@ ztimer_now_t _ztimer_now_extend(ztimer_clock_t *clock);
 /**
  * @brief   Get the current time from a clock
  *
+ * @warning don't compare ztimer_now() values from different clocks. The
+ *          clocks are almost certainly not synchronized.
+ *
  * @param[in]   clock          ztimer clock to operate on
  *
  * @return  Current count on @p clock


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Add another warning to not compare `ztimer_now()` values from different clocks.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
