### PR TITLE
sys: factor out US_PER_SEC etc from timex.h into time_units.h

### DIFF
--- a/sys/include/time_units.h
+++ b/sys/include/time_units.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2014 Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_time_units Time unit representations
+ * @brief       Timestamp representation, computation, and conversion
+ * @ingroup     sys
+ *
+ * @{
+ * @file
+ * @brief       Utility header providing time unit defines
+ */
+
+#ifndef TIME_UNITS_H
+#define TIME_UNITS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The number of microseconds per second
+ */
+#define US_PER_SEC          (1000000LU)
+
+/**
+ * @brief The number of seconds per minute
+ */
+#define SEC_PER_MIN         (60LU)
+
+/**
+ * @brief The number of centiseconds per second
+ */
+#define CS_PER_SEC          (100LU)
+
+/**
+ * @brief The number of milliseconds per second
+ */
+#define MS_PER_SEC          (1000LU)
+
+/**
+ * @brief The number of microseconds per millisecond
+ */
+#define US_PER_MS           (1000LU)
+
+/**
+ * @brief The number of microseconds per centisecond
+ */
+#define US_PER_CS  (10000U)
+
+/**
+ * @brief The number of milliseconds per centisecond
+ */
+#define MS_PER_CS  (10U)
+
+/**
+ * @brief The number of nanoseconds per microsecond
+ */
+#define NS_PER_US           (1000LU)
+
+/**
+ * @brief The number of nanoseconds per second
+ */
+#define NS_PER_SEC  (1000000000LLU)
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* TIME_UNITS_H */

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -22,55 +22,11 @@
 
 #include <stdint.h>
 #include <inttypes.h>
+#include "time_units.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief The number of microseconds per second
- */
-#define US_PER_SEC          (1000000LU)
-
-/**
- * @brief The number of seconds per minute
- */
-#define SEC_PER_MIN         (60LU)
-
-/**
- * @brief The number of centiseconds per second
- */
-#define CS_PER_SEC          (100LU)
-
-/**
- * @brief The number of milliseconds per second
- */
-#define MS_PER_SEC          (1000LU)
-
-/**
- * @brief The number of microseconds per millisecond
- */
-#define US_PER_MS           (1000LU)
-
-/**
- * @brief The number of microseconds per centisecond
- */
-#define US_PER_CS  (10000U)
-
-/**
- * @brief The number of milliseconds per centisecond
- */
-#define MS_PER_CS  (10U)
-
-/**
- * @brief The number of nanoseconds per microsecond
- */
-#define NS_PER_US           (1000LU)
-
-/**
- * @brief The number of nanoseconds per second
- */
-#define NS_PER_SEC  (1000000000LLU)
 
 /**
  * @brief The maximum length of the string representation of a timex timestamp


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It itched for a long time that "timex" needs to be included everywhere just to get its convenience defines.
This PR moves those out into "time_units.h". That is included in "timex.h" for backwards compat.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should be enough due to timex.h including time_units.h.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
