### PR TITLE
sys/ztimer: ztimer_remove report success

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -408,8 +408,14 @@ unsigned ztimer_is_set(const ztimer_clock_t *clock, const ztimer_t *timer);
  *
  * @param[in]   clock       ztimer clock to operate on
  * @param[in]   timer       timer entry to remove
+ *
+ * @retval  true    The timer was removed (and thus its callback neither was nor
+ *                  will be called by ztimer).
+ * @retval  false   The timer fired previously or is not set on the @p clock
+ *                  at all.
+ *
  */
-void ztimer_remove(ztimer_clock_t *clock, ztimer_t *timer);
+bool ztimer_remove(ztimer_clock_t *clock, ztimer_t *timer);
 
 /**
  * @brief   Post a message after a delay

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -365,6 +365,9 @@ struct ztimer_clock {
 
 /**
  * @brief   main ztimer callback handler
+ *
+ * This gets called by clock implementations, and must only be called by them
+ * with interrupts disabled.
  */
 void ztimer_handler(ztimer_clock_t *clock);
 

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -37,7 +37,7 @@
 #include "debug.h"
 
 static void _add_entry_to_list(ztimer_clock_t *clock, ztimer_base_t *entry);
-static void _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry);
+static bool _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry);
 static void _ztimer_update(ztimer_clock_t *clock);
 static void _ztimer_print(const ztimer_clock_t *clock);
 static uint32_t _ztimer_update_head_offset(ztimer_clock_t *clock);
@@ -68,18 +68,20 @@ unsigned ztimer_is_set(const ztimer_clock_t *clock, const ztimer_t *timer)
     return res;
 }
 
-void ztimer_remove(ztimer_clock_t *clock, ztimer_t *timer)
+bool ztimer_remove(ztimer_clock_t *clock, ztimer_t *timer)
 {
+    bool was_removed = false;
     unsigned state = irq_disable();
 
     if (_is_set(clock, timer)) {
         _ztimer_update_head_offset(clock);
-        _del_entry_from_list(clock, &timer->base);
+        was_removed = _del_entry_from_list(clock, &timer->base);
 
         _ztimer_update(clock);
     }
 
     irq_restore(state);
+    return was_removed;
 }
 
 uint32_t ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val)
@@ -232,8 +234,10 @@ static uint32_t _ztimer_update_head_offset(ztimer_clock_t *clock)
     return now;
 }
 
-static void _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry)
+static bool _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry)
 {
+    bool was_removed = false;
+
     DEBUG("_del_entry_from_list()\n");
     ztimer_base_t *list = &clock->list;
 
@@ -254,6 +258,7 @@ static void _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry)
                 list_entry->offset += entry->offset;
             }
 
+            was_removed = true;
             /* reset the entry's next pointer so _is_set() considers it unset */
             entry->next = NULL;
             break;
@@ -268,6 +273,8 @@ static void _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry)
         pm_unblock(clock->block_pm_mode);
     }
 #endif
+
+    return was_removed;
 }
 
 static ztimer_t *_now_next(ztimer_clock_t *clock)


### PR DESCRIPTION
### Contribution description

An application that set a timer and removes it could previously not reliably tell whether the timer fired without keeping track in an atomic (or otherwise synchronized) variable. This introduces a return value to ztimer_remove that allows building applications that do something precisely once (that is, to do whatever cleanup the timeout's callback would do if it had been called.

This is particularly pressing for Rust code, as the language is very picky about closures declared to run exactly once really being called only once. (And while leaking something is generally considered OK there language-wise, on an embedded system the leakage typically means that some mutex is forever locked).

The alternative for the user is to disable interrupts, query ztimer_is_set, and then to remove the timer. That's cumbersome and likely to be done subtly wrong (by not disabling interrupts and creating a race condition).

A second commit encodes an assumption made in the added ztimer_remove documentation in the ztimer_handler documentation.

### Testing procedure

I wouldn't know how to force the corner cases in which this performs visibly different from just clearing and setting, so unless someone has a better idea I'm testing this by running the unit tests and the existing ztimer tests.

Oddly, ztimer_periodic fails on native -- which is a bit odd as there is nothing obvious that can have broken things. Still investigating, and happy to take any clues.

### Impact

#### API

Returning something where previously void was returned is not usually considered a breaking API change in RIOT; not even the wrappers for Rust care (although technically it's a breaking change there for users of riot-sys, but I'm not even counting these any more).

#### Code size

When built for particle-xenon, code size in tests stays the same except in test_ztimer_msg (which is weird because ztimer_remove is not linked there. Probably just taking different optimization paths now, where larger jumps result from a different sequence of functions in ROM). Generally, the code of tests does differ, but somehow the compiler seems to make the most out of the changes.

#### Performance

No tests were done; unless there is register pressure in ztimer_remove this should take at most a few cycles per ztimer_remove.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/16413

Helps resolving: https://github.com/RIOT-OS/RIOT/issues/14390

There was previous discussion there, which I followed where it's not about installing training wheels on ztimers (which may be a good idea but would go into a separate PR).