### PR TITLE
sys/ztimer: don't access non-existant timer

### DIFF
--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -366,20 +366,23 @@ void ztimer_handler(ztimer_clock_t *clock)
     }
 #endif
 
-    clock->list.offset += clock->list.next->offset;
-    clock->list.next->offset = 0;
+    if (clock->list.next) {
+        clock->list.offset += clock->list.next->offset;
+        clock->list.next->offset = 0;
 
-    ztimer_t *entry = _now_next(clock);
-    while (entry) {
-        DEBUG("ztimer_handler(): trigger %p->%p at %" PRIu32 "\n",
-              (void *)entry, (void *)entry->base.next, clock->ops->now(clock));
-        entry->callback(entry->arg);
-        entry = _now_next(clock);
-        if (!entry) {
-            /* See if any more alarms expired during callback processing */
-            /* This reduces the number of implicit calls to clock->ops->now() */
-            _ztimer_update_head_offset(clock);
+        ztimer_t *entry = _now_next(clock);
+        while (entry) {
+            DEBUG("ztimer_handler(): trigger %p->%p at %" PRIu32 "\n",
+                  (void *)entry, (void *)entry->base.next, clock->ops->now(
+                      clock));
+            entry->callback(entry->arg);
             entry = _now_next(clock);
+            if (!entry) {
+                /* See if any more alarms expired during callback processing */
+                /* This reduces the number of implicit calls to clock->ops->now() */
+                _ztimer_update_head_offset(clock);
+                entry = _now_next(clock);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There is a possible race between triggering and removing a timer, which might lead to reading uninitialized memory.

I triggered the case on native with this patch: https://gist.github.com/18ba849370a64b3562d06776b894caed
It doesn't show on nrf52840dk. I guess this depends on whether an rtt cancel properly clears a possibly pending interrupt.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
