### PR TITLE
gnrc/ipv6nib: remove the need for evtimer-minutes

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/abr.h
+++ b/sys/include/net/gnrc/ipv6/nib/abr.h
@@ -41,8 +41,8 @@ extern "C" {
 typedef struct {
     ipv6_addr_t addr;       /**< The address of the border router */
     uint32_t version;       /**< last received version */
-    uint32_t valid_until;   /**< timestamp (in minutes) until which the
-                             *   information is valid */
+    uint32_t valid_until_ms;   /**< timestamp (in ms) until which the information is valid
+                                *   (needs resolution in minutes an 16 bits of them)*/
 } gnrc_ipv6_nib_abr_t;
 
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C) || defined(DOXYGEN)
@@ -116,7 +116,7 @@ bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *abr);
  */
 static inline uint32_t gnrc_ipv6_nib_abr_valid_offset(const gnrc_ipv6_nib_abr_t *abr)
 {
-    return abr->valid_until - evtimer_now_min();
+    return (abr->valid_until_ms - evtimer_now_msec()) / ( MS_PER_SEC * SEC_PER_MIN);
 }
 #endif
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -250,16 +250,17 @@ _nib_abr_entry_t *_handle_abro(const sixlowpan_nd_opt_abr_t *abro)
     if (abr != NULL) {
         uint32_t abro_version = sixlowpan_nd_opt_abr_get_version(abro);
         uint16_t ltime = byteorder_ntohs(abro->ltime);
+        /* correct for default value */
+        ltime = (ltime == 0) ? SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT : ltime;
+
+        uint32_t ltime_ms = MS_PER_SEC * SEC_PER_MIN * ltime;
 
         if (abr->version >= abro_version) {
             abr->version = abro_version;
-            abr->valid_until = evtimer_now_min() + ltime;
+            abr->valid_until_ms = evtimer_now_msec() + ltime_ms;
         }
-        /* correct for default value */
-        ltime = (ltime == 0) ? SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT : ltime;
         _evtimer_add(abr, GNRC_IPV6_NIB_ABR_TIMEOUT, &abr->timeout,
-                     /* UINT16_MAX min < UINT32_MAX ms so no risk of overflow */
-                     MS_PER_SEC * SEC_PER_MIN * ltime);
+                     ltime_ms);
     }
     return abr;
 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -228,8 +228,8 @@ typedef struct {
     ipv6_addr_t addr;               /**< The address of the border router */
     uint32_t version;               /**< last received version of the info of
                                      *   the _nib_abr_entry_t::addr */
-    uint32_t valid_until;           /**< timestamp (in minutes) until which
-                                     *   information is valid */
+    uint32_t valid_until_ms;        /**< timestamp (in ms) until which information is valid
+                                     *   (needs resolution in minutes an 16 bits of them)*/
     evtimer_msg_event_t timeout;    /**< timeout of the information */
     /**
      * @brief   Bitfield marking the prefixes in the NIB's off-link entries

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -37,7 +37,7 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr)
         _nib_release();
         return -ENOMEM;
     }
-    abr->valid_until = 0U;
+    abr->valid_until_ms = 0U;
     /* Associate all existing prefixes in the prefix list of the border router's
      * downstream interface to the authoritative border router so they are
      * advertised in a Router Advertisement with the Authoritative Border Router
@@ -77,7 +77,7 @@ bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *entry)
         if (!ipv6_addr_is_unspecified(&abr->addr)) {
             memcpy(&entry->addr, &abr->addr, sizeof(entry->addr));
             entry->version = abr->version;
-            entry->valid_until = abr->valid_until;
+            entry->valid_until_ms = abr->valid_until_ms;
             break;
         }
     }
@@ -89,13 +89,13 @@ bool gnrc_ipv6_nib_abr_iter(void **state, gnrc_ipv6_nib_abr_t *entry)
 void gnrc_ipv6_nib_abr_print(gnrc_ipv6_nib_abr_t *abr)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    uint32_t now = evtimer_now_min();
 
     printf("%s v%" PRIu32 " expires %" PRIu32 "min\n",
            ipv6_addr_to_str(addr_str, &abr->addr, sizeof(addr_str)),
            abr->version,
-           (abr->valid_until != 0) ? (abr->valid_until - now) :
-                                     SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT);
+           (abr->valid_until_ms != 0) ?
+           gnrc_ipv6_nib_abr_valid_offset(abr) :
+           SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT);
 }
 #else
 typedef int dont_be_pedantic;


### PR DESCRIPTION
### Contribution description

remove the only use of evtimer_now_min()

### Testing procedure

not yet sure

"test/gnrc_ipv6_nib*"

should not fail

### Issues/PRs references

#17357 deprecated the need for min to avoid ztimer_now64
