### PR TITLE
doc: Improve C++ documentation

### DIFF
--- a/doc.txt
+++ b/doc.txt
@@ -16,6 +16,13 @@
  */
 
 /**
+ * @defgroup cpp C++
+ * @brief    C++ Support in RIOT-OS
+ *
+ * This group contains all C++ related modules for easier reference.
+ */
+
+/**
  * @defgroup utils Utilities
  * @brief Utilities and helper functionality
  *

--- a/doc/doxygen/src/using-cpp.md
+++ b/doc/doxygen/src/using-cpp.md
@@ -40,11 +40,13 @@ RIOT Modules in C++                                              {#cpp-in-riot}
 RIOT modules should be written in C, so that boards/platforms without or partial
 C++ support can still use these modules. However, external modules, packages,
 and modules that require C++ support anyway (e.g. the Arduino compatibility
-features) can be written in C++. These modules/packages have to depend on the
+features) can be written in C++. Also, some modules might be designed as
+compatibility layer for C++ or provide convenient access to RIOT-OS' features
+using C++ APIs.  These modules/packages have to depend on the
 `cpp` feature (`FEATURES_REQUIRED += cpp`) and possibly the `libstdcpp`
 feature using their `Makefile.dep`.
 
 See Also                                                            {#see-also}
 ========
 
-@ref sys_c11_atomics_cpp_compat, @ref cpp11-compat
+Reference @ref cpp for a list of C++ modules.

--- a/sys/cpp11-compat/doc.txt
+++ b/sys/cpp11-compat/doc.txt
@@ -9,5 +9,5 @@
 /**
  * @defgroup  cpp11-compat  C++11 wrapper for RIOT
  * @brief     drop in replacement to enable C++11-like thread, mutex and condition_variable
- * @ingroup   sys
+ * @ingroup   cpp
  */

--- a/sys/cxx_ctor_guards/doc.txt
+++ b/sys/cxx_ctor_guards/doc.txt
@@ -1,6 +1,6 @@
 /**
 @defgroup   sys_cxx_ctor_guards     C++ constructor guards for static instances
-@ingroup    sys
+@ingroup    cpp
 @brief      C++ constructor guards for thread-safe initialization of static
             instances
 

--- a/sys/include/c11_atomics_compat.hpp
+++ b/sys/include/c11_atomics_compat.hpp
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    sys_c11_atomics_cpp_compat C++ compatibility with C11 atomics
- * @ingroup     sys
+ * @ingroup     cpp
  * @brief       C++ compatibility of default C11 atomics types
  *
  * This module provides opaque `typedef`s for each standard C11 atomic type with


### PR DESCRIPTION
## Move C++ modules in a new menu tree and improve the description.

### Contribution description

This should make it easier for C++ developers to find C++ related modules in RIOT-OS.

### Issues/PRs references

#17066 and other C++ related additions can then be better placed in the documentation.