### PR TITLE
cpu/esp32: support CPU clocks 2 MHz and 40 MHz

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -851,7 +851,7 @@ Beside the I2C hardware implementation, a I2C bit-banging protocol software impl
 used. This implementation allows bus speeds up to 1 Mbps (`I2C_SPEED_FAST_PLUS`). It can be
 activated by adding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-USEMODULE += esp_i2c_hw
+USEMODULE += esp_i2c_sw
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 to application's makefile. The Disadvantage of the software implementation is that it uses busy
 waiting.


### PR DESCRIPTION
### Contribution description

This PR provides some small changes for SPI and I2C (software and hardware implementation) to support CPU clock frequencies of 2 MHz and 40 MHz. The advantage of using a CPU clock frequency of 40 MHz or 2 MHz is that the power consumption is reduced to the half or even one third of the power consumption with a CPU clock frequency of 80 MHz.

So far the ESP32 port supports the CPU clock frequencies 80 MHz, 160 MHz and 240 MHz. The CPU clock of 80 MHz is the default setting. With all these CPU clock frequencies, an APB clock of 80 MHz is used for peripherals. However, for CPU clock frequencies of 40 MHz and 2 MHz, an APB frequency of 40 MHz and 2 MHz, respectively, is used. To support these CPU clock frequencies some changes were necessary for the peripherals that use APB clocks. 

### Limits

With a CPU frequency and APB clock frequency of 2 MHz, possible peripheral clock frequencies are of course very limited.
| CPU clock | APB clock | SPI CLK | I2C SCL<br>software impl. | I2C SCL<br>hardware impl. |
|-----------:|-----------:|:------------------|:-------------------|:-------------------|
| 2 MHz   | 2 MHz   | max. 1 MHz | max. 19 kHz   | max. 30 kHz   |
| 40 MHz | 40 MHz | max. 20 MHz | max. 308 kHz | max. 385 kHz |

Because of the limits for a CPU clock frequency of 2 MHz, an assert blows up for:
- `SPI_CLK_5MHz` and `SPI_CLK_10MHz`
- `I2C_SPEED_FAST` and above for I2C hardware implementation

### Testing procedure

1. SPI Test

    Use an `esp32-wroom-32` board and connect an logic analyzer to `SPI_DEV(0):CLK` (GPIO pin 18).
    Compile test application for different CPU clock frequencies using command
    ```
    USEMODULE='esp_log_startup' CFLAGS='-DCONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ=<mhz>'  \
    make BOARD=esp32-wroom-32 -C tests/periph_spi  flash term
    ```
    with `<mhz>` = 2 | 40 | 80. Used CPU and APB clock frequency can be observed in the log outputs.
    ```
    Used clocks in Hz: CPU=2000000 APB=2000000 XTAL=40000000 FAST=8000000 SLOW=150000
    ```
    Execute following commands and measure the clock frequency:
    ```
    init 0 0 4 0 5
    send hello

    init 0 0 2 0 5
    send hello

    init 0 0 0 0 5
    send hello
    ```
    The SPI clock frequencies should be 10 MHz, 1 MHz, 100 kHz.
    For a CPU clock frequency of 2 MHz, an assert should blow up for the first SPI init command because 10 MHz can't be supported with an APB clock frequency of 2 MHz.  
        
2. I2C hardware implementation
 
    Use an `esp32-wroom-32` board and connect any I2C device, I used LIS3MDL for my tests. Connect a logic analyzer to the IC2_DEV(0):SCL pin (GPIO pin 22).
    Compile test application for different CPU clock frequencies an different IC2 modes using command
    ```
    USEMODULE='esp_log_startup esp_i2c_hw' \
    CFLAGS='-DCONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ=<mhz>  -DI2C0_SPEED=<i2c_mode>' \
    make BOARD=esp32-wroom-32 -C tests/periph_spi  flash term
    ```
    with `<mhz>` = 2 | 40 | 80 and `<i2c_mode>` = `I2C_SPEED_LOW`, `I2C_SPEED_NORMAL`, `I2C_SPEED_FAST` and measure the clock speeds. For `<mhz>` = 2 the maximum clock speed is about 19 kHz, for  `<mhz>` = 40 it is about 308 kHz.

3. I2C hardware implementation

    Use an `esp32-wroom-32` board and connect any I2C device, I used LIS3MDL for my tests. Connect a logic analyzer to the IC2_DEV(0):SCL pin (GPIO pin 22).
    Compile test application for different CPU clock frequencies an different IC2 modes using command
    ```
    USEMODULE='esp_log_startup esp_i2c_hw' \
    CFLAGS='-DCONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ=<mhz>  -DI2C0_SPEED=<i2c_mode>' \
    make BOARD=esp32-wroom-32 -C tests/periph_spi  flash term
    ```
    with `<mhz>` = 2 | 40 | 80 and `<i2c_mode>` = `I2C_SPEED_LOW`, `I2C_SPEED_NORMAL`, `I2C_SPEED_FAST` and measure the clock speeds.
    
    For `<mhz>` = 2 the maximum clock speed is about 30 kHz and `I2C_SPEED_FAST` should blow up an assert.

### Issues/PRs references

Affects or is affected by the implementation in PR #16727.