### PR TITLE
sys/ztimer64: default select ztimer64_init

### DIFF
--- a/sys/ztimer64/Makefile.dep
+++ b/sys/ztimer64/Makefile.dep
@@ -4,17 +4,22 @@
 USEMODULE += ztimer
 USEMODULE += ztimer64
 
-ifneq (,$(filter ztimer64_usec,$(USEMODULE)))
+ifneq (,$(filter auto_init_ztimer64,$(USEMODULE)))
+  USEMODULE += ztimer64_init
+endif
+ifneq (,$(filter ztimer64_%,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_ztimer64
+  DEFAULT_MODULE += ztimer64_init
+endif
+
+ifneq (,$(filter ztimer64_usec,$(USEMODULE)))
   USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter ztimer64_msec,$(USEMODULE)))
-  DEFAULT_MODULE += auto_init_ztimer64
   USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter ztimer64_sec,$(USEMODULE)))
-  DEFAULT_MODULE += auto_init_ztimer64
   USEMODULE += ztimer_sec
 endif


### PR DESCRIPTION
### Contribution description

Cherry-picked from #17367, currently, ztimer64_init is not selected. This fixes it while still allowing to disable it.

### Testing procedure

- in master
```
USEMODULE=ztimer64_usec make -C examples/hello-world/ info-modules | grep ztimer64_init
#empty
```

- this pr
```
USEMODULE=ztimer64_usec make -C examples/hello-world/ info-modules | grep ztimer64_init
ztimer64_init
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
