### PR TITLE
cpu/esp: change dynamic SSID option handling

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1401,11 +1401,11 @@ Furthermore, the following configuration parameters have to be defined:
 
 <center>
 
-Parameter          | Default                   | Description
-:------------------|:--------------------------|:------------
-ESP_WIFI_SSID      | "RIOT_AP"                 | SSID of the AP to be used.
-ESP_WIFI_PASS      | -                         | Passphrase used for the AP as clear text (max. 64 chars).
-ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
+Parameter           | Default                   | Description
+:-------------------|:--------------------------|:------------
+#ESP_WIFI_SSID      | "RIOT_AP"                 | SSID of the AP to be used.
+#ESP_WIFI_PASS      | -                         | Passphrase used for the AP as clear text (max. 64 chars).
+#ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
 
 </center>
 
@@ -1452,15 +1452,19 @@ following configuration parameters have to be defined:
 
 <center>
 
-Parameter          | Default   | Description
-:------------------|:----------|:------------
-ESP_WIFI_SSID      | "RIOT_AP" | SSID of the AP to be used.
-ESP_WIFI_EAP_ID    | none      | Optional anonymous identity used in phase 1 (outer) EAP authentication. If it is not defined, the user name defined for phase 2 (inner) EAP authentication is used as identity in phase 1.
-ESP_WIFI_EAP_USER  | none      | User name used in phase 2 (inner) EAP authentication.
-ESP_WIFI_EAP_PASS  | none      | Password used in phase 2 (inner) EAP authentication.
-ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
+Parameter           | Default   | Description
+:-------------------|:----------|:------------
+#ESP_WIFI_SSID      | "RIOT_AP" | SSID of the AP to be used.
+ESP_WIFI_EAP_ID     | none      | Optional anonymous identity used in phase 1 (outer) EAP authentication.[1]
+ESP_WIFI_EAP_USER   | none      | User name used in phase 2 (inner) EAP authentication.
+ESP_WIFI_EAP_PASS   | none      | Password used in phase 2 (inner) EAP authentication.
+#ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
 
-</center>
+</center><br>
+
+[1] If the optional anonymous identy `ESP_WIFI_EAP_ID` is not defined, the user
+name `ESP_WIFI_EAP_USER` defined for phase 2 (inner) EAP authentication is used
+as identity in phase 1.
 
 These configuration parameter definitions, as well as enabling the `esp_wifi`
 module, can be done either in the makefile of the project or at make command

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1499,14 +1499,20 @@ The following parameters can be configured:
 Parameter                 | Default                   | Description
 :-------------------------|:--------------------------|:-------------
 #ESP_WIFI_SSID            | "RIOT_AP"                 | Static SSID definition for the SoftAP
-#ESP_WIFI_AP_PREFIX       | "RIOT_AP_"                | Optional prefix for dynamic SSID, if used, the node will create the SSID based on the prefix + mac address (e.g.: "RIOT_AP_aabbccddeeff"). This is disabled by default and `ESP_WIFI_SSID` is used, define this to enable the usage of the SSID prefix.
-#ESP_WIFI_PASS            | none                      | The password for the WiFi SoftAP network interface. If no password is provided, the interface will be "open", otherwise it uses WPA2-PSK authentication mode.
-#ESP_WIFI_SSID_HIDDEN     | 0                         | Whether the SoftAP SSID should be hidden.
+#ESP_WIFI_PASS            | none                      | The password for the WiFi SoftAP network interface.[1]
+#ESP_WIFI_SSID_DYNAMIC    | 0                         | Defines whether dynamic SSID is used for the SoftAP [2].
+#ESP_WIFI_SSID_HIDDEN     | 0                         | Defines whether the SoftAP SSID should be hidden.
 #ESP_WIFI_MAX_CONN        | 4                         | The maximum number of connections for the SoftAP.
 #ESP_WIFI_BEACON_INTERVAL | 100                       | The beacon interval time in milliseconds for the SoftAP.
 #ESP_WIFI_STACKSIZE       | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
 
-</center>
+</center><br>
+
+[1] If no password is provided, the interface will be "open", otherwise it
+    uses WPA2-PSK authentication mode.<br>
+[2] If #ESP_WIFI_SSID_DYNAMIC is set to 1, a dynamic SSID is generated for the
+    SoftAP by extending the defined SSID (`ESP_WIFI_SSID`) with the MAC address
+    of the SoftAP interface used, e.g.: `RIOT_AP_aabbccddeeff`
 
 These configuration parameter definitions, as well as enabling the `esp_wifi_ap`
 module, can be done either in the makefile of the project or at make command
@@ -1514,7 +1520,7 @@ line, for example:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_ap \
-CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1 \
+CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1' \
 make -C examples/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -759,14 +759,20 @@ The following parameters can be configured:
 Parameter                 | Default                   | Description
 :-------------------------|:--------------------------|:-------------
 #ESP_WIFI_SSID            | "RIOT_AP"                 | Static SSID definition for the SoftAP
-#ESP_WIFI_AP_PREFIX       | "RIOT_AP_"                | Optional prefix for dynamic SSID, if used, the node will create the SSID based on the prefix + mac address (e.g.: "RIOT_AP_aabbccddeeff"). This is disabled by default and `ESP_WIFI_SSID` is used, define this to enable the usage of the SSID prefix.
-#ESP_WIFI_PASS            | none                      | The password for the WiFi SoftAP network interface. If no password is provided, the interface will be "open", otherwise it uses WPA2-PSK authentication mode.
-#ESP_WIFI_SSID_HIDDEN     | 0                         | Whether the SoftAP SSID should be hidden.
+#ESP_WIFI_PASS            | none                      | The password for the WiFi SoftAP network interface.[1]
+#ESP_WIFI_SSID_DYNAMIC    | 0                         | Defines whether dynamic SSID is used for the SoftAP [2].
+#ESP_WIFI_SSID_HIDDEN     | 0                         | Defines whether the SoftAP SSID should be hidden.
 #ESP_WIFI_MAX_CONN        | 4                         | The maximum number of connections for the SoftAP.
 #ESP_WIFI_BEACON_INTERVAL | 100                       | The beacon interval time in milliseconds for the SoftAP.
 #ESP_WIFI_STACKSIZE       | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
 
-</center>
+</center><br>
+
+[1] If no password is provided, the interface will be "open", otherwise it
+    uses WPA2-PSK authentication mode.<br>
+[2] If #ESP_WIFI_SSID_DYNAMIC is set to 1, a dynamic SSID is generated for the
+    SoftAP by extending the defined SSID (`ESP_WIFI_SSID`) with the MAC address
+    of the SoftAP interface used, e.g.: `RIOT_AP_aabbccddeeff`
 
 These configuration parameter definitions, as well as enabling the `esp_wifi_ap`
 module, can be done either in the makefile of the project or at make command
@@ -774,7 +780,7 @@ line, for example:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_ap \
-CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1 \
+CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1' \
 make -C examples/gnrc_networking BOARD=...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -919,13 +919,13 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
     }
 
 #if defined(MCU_ESP8266) || defined(MODULE_ESP_WIFI_AP)
-#ifdef ESP_WIFI_AP_PREFIX
+#if IS_ACTIVE(ESP_WIFI_SSID_DYNAMIC)
     uint8_t mac[ETHERNET_ADDR_LEN];
     esp_wifi_get_mac(ESP_MAC_WIFI_SOFTAP, mac);
-    sprintf((char*)wifi_config_ap.ap.ssid, "%s%02x%02x%02x%02x%02x%02x",
-            ESP_WIFI_AP_PREFIX, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    sprintf((char*)wifi_config_ap.ap.ssid, "%s_%02x%02x%02x%02x%02x%02x",
+            ESP_WIFI_SSID, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
     wifi_config_ap.ap.ssid_len = strlen((char*)wifi_config_ap.ap.ssid);
-#endif /* ESP_WIFI_AP_PREFIX */
+#endif /* IS_ACTIVE(ESP_WIFI_SSID_DYNAMIC) */
     /* set the SoftAP configuration */
     result = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config_ap);
     if (result != ESP_OK) {

--- a/cpu/esp_common/esp-wifi/esp_wifi_params.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_params.h
@@ -44,25 +44,29 @@
 /**
  * @brief   SSID of the AP to be used.
  */
-#if !defined(ESP_WIFI_SSID) && !defined(ESP_WIFI_AP_PREFIX)
+#ifndef ESP_WIFI_SSID
 #define ESP_WIFI_SSID       "RIOT_AP"
-#endif
-
-/**
- * @brief   Prefix to be used as part of the SSID (e.g.: RIOT_AP_aabbccddeeff)
- */
-#if !defined(ESP_WIFI_SSID) && !defined(ESP_WIFI_AP_PREFIX) || defined(DOXYGEN)
-#define ESP_WIFI_AP_PREFIX "RIOT_AP_"
 #endif
 
 /**
  * @brief   Passphrase used for the AP as clear text (max. 64 chars).
  */
-#ifdef DOXYGEN
+#ifndef ESP_WIFI_PASS
 #define ESP_WIFI_PASS       "ThisistheRIOTporttoESP"
 #endif
 
 #if defined(MODULE_ESP_WIFI_AP) || defined(DOXYGEN)
+
+/**
+ * @brief   Use dynamic SSID for the SoftAP
+ *
+ * If set to 1, the SSID for the SoftAP is generated dynamically by extending
+ * the defined SSID (`ESP_WIFI_SSID`) with the MAC address of the SoftAP
+ * interface used, e.g.: `RIOT_AP_aabbccddeeff`
+ */
+#ifndef ESP_WIFI_SSID_DYNAMIC
+#define ESP_WIFI_SSID_DYNAMIC   0
+#endif
 
 /**
  * @brief   Whether SoftAP SSID should be hidden.


### PR DESCRIPTION
### Contribution description

This PR simplifies the definition of the option to use dynamic SSIDs for the SoftAP, especially with regard to the migration to `Kconfig`.

The semantics of defining a separate SSID prefix string that overrides the already defined SSID and enables the dynamic SSID generation with that prefix exactly when and only when it is set, made the handling of the parameter definition unnecessarily difficult and hard to understand.

Defining a boolean option that just enables the dynamic SSID generation, which then simply reuses the defined SSID as a prefix, makes it much more understandable and easier to handle, especially with respect to Kconfig.

This PR removes the configuration parameter `ESP_WIFI_PREFIX` and introduces the boolean configuration parameter `ESP_WIFI_SSID_DYNAMIC` which is defined as 0 by default. If set to 1, the already defined `ESP_WIFI_SSID` is used as prefix to generate a dynamic SSID by extending it with the MAC address of the SoftAP interface used, e.g.: `RIOT_AP_aabbccddeeff`

### Testing procedure

Compile and flash test application
```
USEMODULE=esp_wifi_ap \
CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1'  \
make -C examples/gnrc_networking BOARD=esp32-wroom-32 flash
```
with and without ` -DESP_WIFI_SSID_DYNAMIC=1` in `CFLAGS` and use any WiFi device to check the used SSID.

Without  ` -DESP_WIFI_SSID_DYNAMIC=1`, the SSID of the SoftAP should be `RIOT_AP`, with ` -DESP_WIFI_SSID_DYNAMIC=1`, the SSID of the SoftAP should be something like `RIOT_AP_<mac>`

### Issues/PRs references
