### PR TITLE
Add RTC time change notifications

### DIFF
--- a/drivers/periph_common/Kconfig.rtc
+++ b/drivers/periph_common/Kconfig.rtc
@@ -7,6 +7,11 @@
 
 if USEMODULE_PERIPH_RTC
 
+config PERIPH_RTC_SETTER_CALLBACK
+    bool "Support for RTC time change callback"
+    help
+        Provides a time change callback for RTC
+
 endif #MODULE_PERIPH_RTC
 
 # TODO: this module is actually just an artifact from the way periph_init_%

--- a/drivers/rtt_rtc/rtt_rtc.c
+++ b/drivers/rtt_rtc/rtt_rtc.c
@@ -215,11 +215,26 @@ void rtt_rtc_settimeofday(uint32_t s, uint32_t us)
 {
     /* disable alarm to prevent race condition */
     rtt_clear_alarm();
+
+#ifdef MODULE_PERIPH_RTC_SETTER_CALLBACK
+    struct tm tm_after;
+    rtc_localtime(s, &tm_after);
+    uint32_t s_before;
+    uint32_t us_before;
+    rtt_rtc_gettimeofday(&s_before, &us_before);
+    struct tm tm_before;
+    rtc_localtime(s_before, &tm_before);
+#endif /* MODULE_PERIPH_RTC_SETTER_CALLBACK */
+
     uint32_t now = ((uint64_t)us * RTT_SECOND) / US_PER_SEC;
     rtc_now      = s;
     rtt_set_counter(now);
     /* calculate next wake-up period */
     _update_alarm(0);
+
+#ifdef MODULE_PERIPH_RTC_SETTER_CALLBACK
+    rtc_setter_callback(&tm_before, us_before, &tm_after, us);
+#endif /* MODULE_PERIPH_RTC_SETTER_CALLBACK */
 }
 
 void rtt_rtc_gettimeofday(uint32_t *s, uint32_t *us)

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -626,6 +626,10 @@ ifneq (,$(filter tiny_strerror_as_strerror,$(USEMODULE)))
   USEMODULE += tiny_strerror
 endif
 
+ifneq (,$(filter sys_bus_rtc, $(USEMODULE)))
+  USEMODULE += periph_rtc_setter_callback
+endif
+
 # include ztimer dependencies
 ifneq (,$(filter ztimer ztimer_% %ztimer,$(USEMODULE)))
   include $(RIOTBASE)/sys/ztimer/Makefile.dep

--- a/sys/bus/sys_bus_rtc.c
+++ b/sys/bus/sys_bus_rtc.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_bus
+ * @{
+ *
+ * @file
+ * @brief       RTC event bus
+ *
+ * @author      Daniel Lockau <daniel.lockau@ml-pa.com>
+ * @}
+ */
+
+#include "periph/rtc.h"
+#include "sys/bus.h"
+#include "timex.h"
+
+/**
+ * @brief Compute millisecond difference between two time stamps
+ *
+ * Internal function.
+ */
+int32_t sys_bus_rtc_compute_diff_ms(
+        struct tm *tm_before, uint32_t us_before,
+        struct tm *tm_after, uint32_t us_after)
+{
+    assert(us_before < US_PER_SEC);
+    assert(us_after < US_PER_SEC);
+
+    uint32_t s_before = rtc_mktime(tm_before);
+    uint32_t s_after = rtc_mktime(tm_after);
+
+    /* default content is out of range special value INT32_MIN */
+    int32_t diff_ms = RTC_EVENT_OUT_OF_RANGE;
+
+    /* calculate time difference if in range */
+    if (((s_after > s_before) ? (s_after - s_before) : (s_before - s_after))
+            < (INT32_MAX / MS_PER_SEC)) {
+        diff_ms = ((int32_t)(s_after - s_before) * (int32_t)MS_PER_SEC)
+            + ((int32_t)(us_after - us_before) / (int32_t)US_PER_MS);
+    }
+
+    return diff_ms;
+}
+
+#ifdef MODULE_SYS_BUS_RTC
+
+/**
+ * @brief Setter callback for use with @ref rtc_set_time_with_callback
+ *
+ * Internal function.
+ */
+void rtc_setter_callback(
+        struct tm *tm_before, uint32_t us_before,
+        struct tm *tm_after, uint32_t us_after)
+{
+    int32_t diff_ms = sys_bus_rtc_compute_diff_ms(tm_before, us_before,
+            tm_after, us_after);
+
+    /* post result on a non-zero millisecond difference */
+    if (diff_ms != 0) {
+        msg_bus_post(sys_bus_get(SYS_BUS_RTC), SYS_BUS_RTC_EVENT_TIME_CHANGE,
+                     (void *)(uintptr_t)diff_ms);
+    }
+}
+
+#endif /* MODULE_SYS_BUS_RTC */

--- a/sys/include/rtc_utils.h
+++ b/sys/include/rtc_utils.h
@@ -92,6 +92,61 @@ void rtc_localtime(uint32_t time, struct tm *t);
  */
 bool rtc_tm_valid(const struct tm *t);
 
+#if defined(MODULE_PERIPH_RTC_SETTER_CALLBACK) || DOXYGEN
+/**
+ * @brief Time change callback for user implementation
+ *
+ * This callback allows an application or module to react
+ * to changes of the RTC. On execution of the callback,
+ * the RTC time has already been changed.
+ *
+ * Available after loading the module `periph_rtc_setter_callback`.
+ * On loading of the module, this callback must be implemented,
+ * either by another module or the user's application.
+ *
+ * The callback will only be executed if the RTC is set
+ * through @ref rtc_set_time_with_callback.
+ *
+ * @param[in] tm_before     Date and time before the update
+ * @param[in] us_before     The microsecond part of the time
+ *                          before the update
+ * @param[in] tm_after      Date and time after the update
+ * @param[in] us_after      The microsecond part of the time
+ *                          after the update
+ *
+ * @return                  The calculated time difference,
+ *                          intended for testing
+ */
+extern void rtc_setter_callback(
+        struct tm *tm_before, uint32_t us_before,
+        struct tm *tm_after, uint32_t us_after);
+
+/**
+ * @brief Wrapper for @ref rtc_set_time, adding a callback execution
+ *
+ * Available after loading the module `periph_rtc_setter_callback`.
+ *
+ * The supplied callback will be executed just after the time
+ * change happened.
+ *
+ * @param[in] time          The input struct to @ref rtc_set_time
+ *
+ * @return                  The return value of @ref rtc_set_time
+ */
+int rtc_set_time_with_callback(struct tm *time);
+
+/**
+ * @brief Automatic choice of @ref rtc_set_time implementation
+ *
+ * @ref rtc_set_time_with_callback will be used when loading
+ * the module `periph_rtc_setter_callback`. @ref rtc_set_time
+ * will be used otherwise.
+ */
+#define RTC_SET_TIME rtc_set_time_with_callback
+#else
+#define RTC_SET_TIME rtc_set_time
+#endif /* MODULE_PERIPH_RTC_SETTER_CALLBACK */
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/sys/bus.h
+++ b/sys/include/sys/bus.h
@@ -36,6 +36,9 @@ typedef enum {
 #if MODULE_SYS_BUS_POWER
     SYS_BUS_POWER,      /**< Events related to system power */
 #endif
+#if MODULE_SYS_BUS_RTC
+    SYS_BUS_RTC,        /**< Events related to the real time clock */
+#endif
     SYS_BUS_NUMOF       /**< Number of enabled system buses */
 } sys_bus_t;
 
@@ -50,6 +53,29 @@ typedef enum {
 
     /* add more if needed, but not more than 32 */
 } sys_bus_power_event_t;
+
+/**
+ * @brief RTC Bus Events
+ */
+typedef enum {
+    /**
+     * @brief Time change event
+     *
+     * The content of the time change event is a
+     * int32_t holding the time difference between
+     * old and new wall time in milliseconds. This
+     * covers a range of about +-24.85 days and should
+     * be apt for most applications.
+     *
+     * The value of INT32_MIN is not used for communicating
+     * a time difference. It does instead indicate any
+     * positive or negative out-of-range event which has
+     * to be resolved differently by the application.
+     */
+    SYS_BUS_RTC_EVENT_TIME_CHANGE,
+
+    /* add more if needed, but not more than 32 */
+} sys_bus_rtc_event_t;
 
 /**
  * @brief The System Bus array - do not use directly

--- a/sys/include/sys/bus.h
+++ b/sys/include/sys/bus.h
@@ -55,6 +55,11 @@ typedef enum {
 } sys_bus_power_event_t;
 
 /**
+ * @brief Indicates positive or negative out-of-range event
+ */
+#define RTC_EVENT_OUT_OF_RANGE INT32_MIN
+
+/**
  * @brief RTC Bus Events
  */
 typedef enum {

--- a/sys/shell/cmds/rtc.c
+++ b/sys/shell/cmds/rtc.c
@@ -129,7 +129,7 @@ static int _rtc_settime(char **argv)
 
     _parse_time(argv, &now);
 
-    if (rtc_set_time(&now) < 0) {
+    if (RTC_SET_TIME(&now) == -1) {
         puts("rtc: error setting time");
         return 1;
     }

--- a/tests/periph/rtc/Makefile
+++ b/tests/periph/rtc/Makefile
@@ -4,6 +4,8 @@ FEATURES_REQUIRED += periph_rtc
 FEATURES_OPTIONAL += periph_rtc_ms
 FEATURES_OPTIONAL += periph_rtc_mem
 
+USEMODULE += periph_rtc_setter_callback
+
 DISABLE_MODULE += periph_init_rtc
 
 USEMODULE += xtimer

--- a/tests/periph/rtc/tests/01-run.py
+++ b/tests/periph/rtc/tests/01-run.py
@@ -13,6 +13,7 @@ from testrunner import run
 
 BOARD = os.getenv('BOARD', 'native')
 DATE_PATTERN = r'\d{4}\-\d{2}\-\d{2} \d{2}\:\d{2}\:\d{2}'
+TIMEDIFF_PATTERN = r'-?\d{1,12}'
 
 
 def testfunc(child):
@@ -27,6 +28,12 @@ def testfunc(child):
     clock_value = child.match.group(1)
     assert clock_set == clock_value
     assert clock_reboot != clock_value
+
+    child.expect(r'Resetting clock to   ({})'.format(DATE_PATTERN))
+    child.expect(r'    Time change of   ({}) milliseconds'.format(TIMEDIFF_PATTERN))
+    time_change_value = child.match.group(1)
+    # some RTC implementations are millisecond accurate
+    assert abs(int(time_change_value) - 42000) < 10
 
     child.expect(r'  Setting alarm to   ({})'.format(DATE_PATTERN))
     alarm_set = child.match.group(1)

--- a/tests/unittests/tests-sys_bus/Makefile
+++ b/tests/unittests/tests-sys_bus/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-sys_bus/Makefile.include
+++ b/tests/unittests/tests-sys_bus/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += sys_bus_rtc

--- a/tests/unittests/tests-sys_bus/tests-sys_bus.c
+++ b/tests/unittests/tests-sys_bus/tests-sys_bus.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include "embUnit.h"
+
+#include "periph/rtc.h"
+
+extern int32_t sys_bus_rtc_compute_diff_ms(
+        const struct tm *tm_before, uint32_t us_before,
+        const struct tm *tm_after, uint32_t us_after);
+
+static void test_sys_bus_rtc_compute_diff_ms(void)
+{
+    /* zero */
+    struct tm tm_before;
+    struct tm tm_after;
+    rtc_localtime(1000, &tm_before);
+    rtc_localtime(1000, &tm_after);
+    TEST_ASSERT_EQUAL_INT(0, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 0));
+    rtc_localtime(0, &tm_before);
+    rtc_localtime(0, &tm_after);
+    TEST_ASSERT_EQUAL_INT(0, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 1234, &tm_after, 1234));
+
+    /* positive, within range */
+    rtc_localtime(100, &tm_before);
+    rtc_localtime(10000, &tm_after);
+    TEST_ASSERT_EQUAL_INT(9900000, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 1234, &tm_after, 1234));
+    TEST_ASSERT_EQUAL_INT(9899999, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 1234, &tm_after, 0));
+    TEST_ASSERT_EQUAL_INT(9900001, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 1234));
+    TEST_ASSERT_EQUAL_INT(9900123, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 123400));
+    rtc_localtime((INT32_MAX / 1000) + 99, &tm_after);
+    TEST_ASSERT_EQUAL_INT(2147482123, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 123400));
+
+    /* negative, within range */
+    rtc_localtime(10000, &tm_before);
+    rtc_localtime(100, &tm_after);
+    TEST_ASSERT_EQUAL_INT(-9900000, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 1234, &tm_after, 1234));
+    TEST_ASSERT_EQUAL_INT(-9899999, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 1234));
+    TEST_ASSERT_EQUAL_INT(-9900001, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 1234, &tm_after, 0));
+    TEST_ASSERT_EQUAL_INT(-9900123, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 123400, &tm_after, 0));
+    rtc_localtime((INT32_MAX / 1000) + 99, &tm_before);
+    TEST_ASSERT_EQUAL_INT(-2147482123, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 123400, &tm_after, 0));
+
+    /* positive, out of range */
+    rtc_localtime(100, &tm_before);
+    rtc_localtime((INT32_MAX / 1000) + 100, &tm_after);
+    TEST_ASSERT_EQUAL_INT(RTC_EVENT_OUT_OF_RANGE, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 123400));
+    rtc_localtime(0, &tm_before);
+    TEST_ASSERT_EQUAL_INT(RTC_EVENT_OUT_OF_RANGE, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 0, &tm_after, 123400));
+
+    /* negative, out of range */
+    rtc_localtime((INT32_MAX / 1000) + 100, &tm_before);
+    rtc_localtime(100, &tm_after);
+    TEST_ASSERT_EQUAL_INT(RTC_EVENT_OUT_OF_RANGE, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 123400, &tm_after, 0));
+    rtc_localtime(0, &tm_after);
+    TEST_ASSERT_EQUAL_INT(RTC_EVENT_OUT_OF_RANGE, sys_bus_rtc_compute_diff_ms(
+                    &tm_before, 123400, &tm_after, 0));
+}
+
+Test *tests_sys_bus_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_sys_bus_rtc_compute_diff_ms),
+    };
+
+    EMB_UNIT_TESTCALLER(sys_bus_tests, NULL, NULL, fixtures);
+
+    return (Test *)&sys_bus_tests;
+}
+
+void tests_sys_bus(void)
+{
+    TESTS_RUN(tests_sys_bus_tests());
+}
+/** @} */

--- a/tests/unittests/tests-sys_bus/tests-sys_bus.h
+++ b/tests/unittests/tests-sys_bus/tests-sys_bus.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``sys_bus`` module
+ *
+ * @author      Daniel Lockau <daniel.lockau@ml-pa.com>
+ */
+
+#ifndef TESTS_SYS_BUS_H
+#define TESTS_SYS_BUS_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_sys_bus(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_SYS_BUS_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Relating to real (wall clock) time is required in many applications. Knowing about shifts in real time due to setting the clock can be crucial in some application contexts and building up a monitoring within the application can be considered too expensive. Applications also can may have several sources for changing the system's wall time, e.g. the console, a GNSS module or NTP.

As all sources for time changes to the wall time will use the periph/rtc or drivers/rtt_rtc APIs, we propose to add time change notifications to the time setter API functions within those modules. Notifications are distributed to subscribers through a system bus for RTC events.

To enable queuing of multiple additive time change events, we propose to add the amount of time difference created between old wall time and new wall time events as `int32_t` content in milliseconds to each message. This enables communication of time differences in milliseconds within about +-24.8 days and an out of range special value (`INT32_MIN`). One might instead consider a singleton to signal larger time differences as multiple queuing is quite improbable. However, wall time changes of more than 24 days are also quite improbable in a running system and by enabling queuing of multiple additive changes we can achieve consistency within that period even if the application shows some misbehavior.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- the unit test for periph/rtc was extended to test the time difference computation
- the test for periph/rtc was extended to test the time change notifications

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
