### PR TITLE
cpu/esp_common: change esp_now key param

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1536,7 +1536,7 @@ be used simultaneously.
 
 @warning
 The SoftAP may or may not be at all reliable sometimes, this is a known
-problem with the Wi-Fi network interface, even on the official ESP-IDF.
+problem with the Wi-Fi network interface, even with the official ESP-IDF.
 The problem is that the AP doesn't cache multicast data for connected
 stations, and if stations connected to the AP are power save enabled,
 they may experience multicast packet loss. This affects RIOT, because
@@ -1549,50 +1549,76 @@ for more information.
 
 ## ESP-NOW Network Interface {#esp32_esp_now_network_interface}
 
-With ESP-NOW, the ESP32 provides a connectionless communication technology,
+With ESP-NOW, the ESP MCUs provide a connectionless communication technology,
 featuring short packet transmission. It applies the IEEE802.11 Action Vendor
 frame technology, along with the IE function developed by Espressif, and CCMP
 encryption technology, realizing a secure, connectionless communication
 solution.
 
-The RIOT port for ESP32 implements in module `esp_now` a `netdev`
+The RIOT port for ESP MCUs implements with module `esp_now` a `netdev`
 driver which uses ESP-NOW to provide a link layer interface to a meshed network
-of ESP32 nodes. In this network, each node can send short packets with up to
+of ESP nodes. In this network, each node can send short packets with up to
 250 data bytes to all other nodes that are visible in its range.
 
-@note Module `esp_now`module is not enabled automatically if the
-`netdev_default` module is used. Instead, the application has to add the
-`esp_now` module in its makefile when needed.<br>
+@note Module `esp_now` is enabled automatically if the `netdev_default` module
+is used and no other interface is defined as default `netdev`. If it is not
+enabled as default `netdev`, it can be enabled by using the `esp_now` module
+if needed.
+<br>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_now
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For ESP-NOW, ESP32 nodes are used in WiFi SoftAP + Station mode to advertise
-their SSID and become visible to other ESP32 nodes. The SSID of an ESP32 node
+For ESP-NOW, ESP nodes are used in WiFi SoftAP + Station mode to advertise
+their SSID and become visible to other ESP nodes. The SSID of an ESP node
 is the concatenation of the prefix `RIOT_ESP_` with the MAC address of its
-SoftAP WiFi interface. The driver periodically scans all visible ESP32 nodes.
+SoftAP WiFi interface. The driver periodically scans all visible ESP nodes.
 
-The following parameters are defined for ESP-NOW nodes. These parameters can be overridden by
-[application-specific board configurations](#esp32_application_specific_board_configuration).
+The following configuration parameters are defined for ESP-NOW nodes.
+These parameters can be overridden by [application-specific board configurations]
+(#esp32_application_specific_board_configuration).
 
 <center>
 
-Parameter               | Default                   | Description
-:-----------------------|:--------------------------|:-----------
-ESP_NOW_SCAN_PERIOD_MS  | 10000UL                   | Defines the period in ms at which an node scans for other nodes in its range. The default period is 10 s.
-ESP_NOW_SOFT_AP_PASS    | "ThisistheRIOTporttoESP"  | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
-ESP_NOW_CHANNEL         | 6                         | Defines the channel that is used as the broadcast medium by all nodes together.
-ESP_NOW_KEY             | NULL                      | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type `uint8_t[16]` and has to be exactly 16 bytes long.
+Parameter               | Default        | Description
+:-----------------------|:---------------|:-----------
+#ESP_NOW_SCAN_PERIOD_MS | 10000UL        | Scan interval for peer nodes in ms
+#ESP_NOW_SOFT_AP_PASS   | "This is RIOT" | Passphrase for the SoftAP interface as clear text [1]
+#ESP_NOW_CHANNEL        | 6              | Channel used for ESP-NOW in the 2.4 GHz band [2]
+#ESP_NOW_KEY            | ""             | 128-bit key used for encrypted communication [3]
+</center><br>
 
-</center>
+1. The passphrase is used for the SoftAP interface of ESP-NOW nodes. It
+   is defined as a string with a maximum of 64 characters and must be the
+   same for all nodes in the network.
 
-@note The ESP-NOW network interface (module `esp_now`) and the
-[Wifi network interface](#esp32_wifi_network_interface) (module `esp_wifi` or `esp_wifi_enterprise`)
-can be used simultaneously, for example, to realize a border router for
-a mesh network which uses ESP-NOW.
-In this case the ESP-NOW interface must use the same channel as the AP of the
-infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled with
-the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
+2. The channel is in the range of 1 to 13. Please note that in some regions
+   not all 13 channels may be used for regulatory reasons. Select a channel
+   that is allowed in your region.
+   If ESP-NOW is used together with an infrastructure WiFi network, the
+   channel must be the same as used by the AP of the infrastructure WiFi.
+
+3. The key has to be defined to enable encrypted communication between ESP-NOW
+   nodes. The key is 16 bytes long and is defined by a string of 8-bit hex
+   values separated by spaces, for example:
+   ```
+   "0f 1e 2d 3c 4b 5a 69 78 87 96 a5 b4 c3 d2 e1 f0"
+   ```
+   An empty string for this parameter means that the encryption is not used.
+   If less than 16 bytes are defined by the string, the remaining bytes of
+   the key are filled with 0.
+
+@note
+- If encrypted communication is used, a maximum of 6 nodes can
+  communicate with each other, while in unencrypted mode, up to
+  20 nodes can communicate.<br>
+- ESP-NOW network interface (module `esp_now`) and the
+  [Wifi network interface](#esp32_wifi_network_interface) (module `esp_wifi`
+  or `esp_wifi_enterprise`) can be used simultaneously, for example, to
+  realize a border router for a mesh network which uses ESP-NOW.
+  In this case, the ESP-NOW interface must use the same channel as the AP of
+  the infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled
+  with the channel of the AP as the value for the #ESP_NOW_CHANNEL parameter.
 
 [Back to table of contents](#esp32_toc)
 

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -749,7 +749,7 @@ the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
 
 ## WiFi SoftAP Network Interface {#esp8266_wifi_ap_network_interface}
 
-The RIOT port for the ESP8266 supports a `netdev` interface for the ESP32 WiFi
+The RIOT port for the ESP8266 supports a `netdev` interface for the ESP8266 WiFi
 SoftAP mode. Module `esp_wifi_ap` has to be enabled to use it.
 
 The following parameters can be configured:
@@ -803,53 +803,76 @@ Refer to the SDK documentation from Espressif on [AP Sleep](https://docs.espress
 
 ## ESP-NOW Network Interface {#esp8266_esp_now_network_interface}
 
-With ESP-NOW, the ESP8266 provides a connectionless communication technology,
+With ESP-NOW, the ESP MCUs provide a connectionless communication technology,
 featuring short packet transmission. It applies the IEEE802.11 Action Vendor
 frame technology, along with the IE function developed by Espressif, and CCMP
 encryption technology, realizing a secure, connectionless communication
 solution.
 
-The RIOT port for ESP8266 implements in module `esp_now` a `netdev` driver
-which uses ESP-NOW to provide a link layer interface to a meshed network of
-ESP8266 nodes. In this network, each node can send short packets with up to
+The RIOT port for ESP MCUs implements with module `esp_now` a `netdev`
+driver which uses ESP-NOW to provide a link layer interface to a meshed network
+of ESP nodes. In this network, each node can send short packets with up to
 250 data bytes to all other nodes that are visible in its range.
 
-@note Module `esp_now` is not enabled automatically if the `netdev_default`
-module is used. Instead, the application has to add the `esp_now` module in
-its makefile when needed.<br>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@note Module `esp_now` is enabled automatically if the `netdev_default` module
+is used and no other interface is defined as default `netdev`. If it is not
+enabled as default `netdev`, it can be enabled by using the `esp_now` module
+if needed.
+<br>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_now
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For ESP-NOW, ESP8266 nodes are used in WiFi SoftAP + Station mode to advertise
-their SSID and become visible to other ESP8266 nodes. The SSID of an ESP8266
-node is the concatenation of the prefix `RIOT_ESP_` with the MAC address of
-its SoftAP WiFi interface. The driver periodically scans all visible ESP8266
-nodes.
+For ESP-NOW, ESP nodes are used in WiFi SoftAP + Station mode to advertise
+their SSID and become visible to other ESP nodes. The SSID of an ESP node
+is the concatenation of the prefix `RIOT_ESP_` with the MAC address of its
+SoftAP WiFi interface. The driver periodically scans all visible ESP nodes.
 
-The following parameters are defined for ESP-NOW nodes. These parameters can
-be overridden by [application-specific board configurations](#esp8266_application_specific_board_configuration).
+The following configuration parameters are defined for ESP-NOW nodes.
+These parameters can be overridden by [application-specific board configurations]
+(#esp8266_application_specific_board_configuration).
 
 <center>
 
-Parameter | Default | Description
-:---------|:--------|:-----------
-#ESP_NOW_SCAN_PERIOD_MS | 10000UL | Defines the period in ms at which an node scans for other nodes in its range. The default period is 10 s.
-#ESP_NOW_SOFT_AP_PASS | "ThisistheRIOTporttoESP" | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
-#ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
-#ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type `uint8_t[16]` and has to be exactly 16 bytes long.
+Parameter               | Default        | Description
+:-----------------------|:---------------|:-----------
+#ESP_NOW_SCAN_PERIOD_MS | 10000UL        | Scan interval for peer nodes in ms
+#ESP_NOW_SOFT_AP_PASS   | "This is RIOT" | Passphrase for the SoftAP interface as clear text [1]
+#ESP_NOW_CHANNEL        | 6              | Channel used for ESP-NOW in the 2.4 GHz band [2]
+#ESP_NOW_KEY            | ""             | 128-bit key used for encrypted communication [3]
+</center><br>
 
-</center>
+1. The passphrase is used for the SoftAP interface of ESP-NOW nodes. It
+   is defined as a string with a maximum of 64 characters and must be the
+   same for all nodes in the network.
 
-@note The ESP-NOW network interface (module `esp_now`) and the
-[Wifi network interface](#esp8266_wifi_network_interface) (module `esp_wifi`)
-can be used simultaneously, for example, to realize a border router for
-a mesh network which uses ESP-NOW.
-In this case the ESP-NOW interface must use the same channel as the AP of the
-infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled with
-the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
+2. The channel is in the range of 1 to 13. Please note that in some regions
+   not all 13 channels may be used for regulatory reasons. Select a channel
+   that is allowed in your region.
+   If ESP-NOW is used together with an infrastructure WiFi network, the
+   channel must be the same as used by the AP of the infrastructure WiFi.
 
-[Back to table of contents](#esp8266_toc)
+3. The key has to be defined to enable encrypted communication between ESP-NOW
+   nodes. The key is 16 bytes long and is defined by a string of 8-bit hex
+   values separated by spaces, for example:
+   ```
+   "0f 1e 2d 3c 4b 5a 69 78 87 96 a5 b4 c3 d2 e1 f0"
+   ```
+   An empty string for this parameter means that the encryption is not used.
+   If less than 16 bytes are defined by the string, the remaining bytes of
+   the key are filled with 0.
+
+@note
+- If encrypted communication is used, a maximum of 6 nodes can
+  communicate with each other, while in unencrypted mode, up to
+  20 nodes can communicate.<br>
+- ESP-NOW network interface (module `esp_now`) and the
+  [Wifi network interface](#esp8266_wifi_network_interface) (module `esp_wifi`)
+  can be used simultaneously, for example, to
+  realize a border router for a mesh network which uses ESP-NOW.
+  In this case, the ESP-NOW interface must use the same channel as the AP of
+  the infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled
+  with the channel of the AP as the value for the #ESP_NOW_CHANNEL parameter.
 
 # Preconfigured Devices {#esp8266_preconfigured_devices}
 

--- a/cpu/esp_common/esp-now/doc.txt
+++ b/cpu/esp_common/esp-now/doc.txt
@@ -15,38 +15,78 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
 
-This module realizes a netdev interface using Espressif's ESP-NOW technology which uses the built-in WiFi module.
+This module realizes a netdev interface using Espressif's ESP-NOW technology
+which uses the built-in WiFi module.
 
-With ESP-NOW, the ESP nodes (ESP32 and ESP8266) provide a connectionless communication technology, featuring short packet transmission. It applies the IEEE802.11 Action Vendor frame technology, along with the IE function developed by Espressif, and CCMP encryption technology, realizing a secure, connectionless communication solution.
+With ESP-NOW, the ESP MCUs provide a connectionless communication technology,
+featuring short packet transmission. It applies the IEEE802.11 Action Vendor
+frame technology, along with the IE function developed by Espressif, and CCMP
+encryption technology, realizing a secure, connectionless communication
+solution.
 
-The RIOT port for ESP implements in module ```esp_now``` a ```netdev``` driver which uses ESP-NOW to provide a link layer interface to a meshed network of ESP nodes. In this network, each node can send short packets with up to 250 data bytes to all other nodes that are visible in its range.
+The RIOT port for ESP MCUs implements with module `esp_now` a `netdev`
+driver which uses ESP-NOW to provide a link layer interface to a meshed network
+of ESP nodes. In this network, each node can send short packets with up to
+250 data bytes to all other nodes that are visible in its range.
 
-@note Due to symbol conflicts in the ```esp_idf_wpa_supplicant_crypto``` module used by the ```esp_now``` with RIOT's ```crypto``` and ```hashes``` modules, ESP-NOW cannot be used for application that use these modules. Therefore, the module ```esp_now``` is not enabled automatically if the ```netdev_default``` module is used. Instead, the application has to add the ```esp_now``` module in its makefile when needed.<br>
-```
+@note Module `esp_now` is enabled automatically if the `netdev_default` module
+is used and no other interface is defined as default `netdev`. If it is not
+enabled as default `netdev`, it can be enabled by using the `esp_now` module
+if needed.
+<br>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_now
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For ESP-NOW, ESP nodes are used in WiFi SoftAP + Station mode to advertise their SSID and become visible to other ESP nodes. The SSID of an ESP node is the concatenation of the prefix ```RIOT_ESP_``` with the MAC address of its SoftAP WiFi interface. The driver periodically scans all visible ESP nodes.
+For ESP-NOW, ESP nodes are used in WiFi SoftAP + Station mode to advertise
+their SSID and become visible to other ESP nodes. The SSID of an ESP node
+is the concatenation of the prefix `RIOT_ESP_` with the MAC address of its
+SoftAP WiFi interface. The driver periodically scans all visible ESP nodes.
 
-The following parameters are defined for ESP-NOW nodes.
+The following configuration parameters are defined for ESP-NOW nodes.
+These parameters can be overridden by [application-specific board configurations]
+(#esp8266_application_specific_board_configuration).
 
 <center>
 
-Parameter | Default | Description
-:---------|:--------|:-----------
-ESP_NOW_SCAN_PERIOD_MS | 10000UL | Defines the period in ms at which an node scans for other nodes in its range. The default period is 10 s.
-ESP_NOW_SOFT_AP_PASS | "ThisistheRIOTporttoESP" | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
-ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
-ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type ```uint8_t[16]``` and has to be exactly 16 bytes long.
+Parameter               | Default        | Description
+:-----------------------|:---------------|:-----------
+#ESP_NOW_SCAN_PERIOD_MS | 10000UL        | Scan interval for peer nodes in ms
+#ESP_NOW_SOFT_AP_PASS   | "This is RIOT" | Passphrase for the SoftAP interface as clear text [1]
+#ESP_NOW_CHANNEL        | 6              | Channel used for ESP-NOW in the 2.4 GHz band [2]
+#ESP_NOW_KEY            | ""             | 128-bit key used for encrypted communication [3]
+</center><br>
 
-</center>
+1. The passphrase is used for the SoftAP interface of ESP-NOW nodes. It
+   is defined as a string with a maximum of 64 characters and must be the
+   same for all nodes in the network.
 
-@note The ESP-NOW network interface (module `esp_now`) and the
-Wifi network interface (module `esp_wifi`)
-can be used simultaneously, for example, to realize a border router for
-a mesh network which uses ESP-NOW.
-In this case the ESP-NOW interface must use the same channel as the AP of the
-infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled with
-the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
+2. The channel is in the range of 1 to 13. Please note that in some regions
+   not all 13 channels may be used for regulatory reasons. Select a channel
+   that is allowed in your region.
+   If ESP-NOW is used together with an infrastructure WiFi network, the
+   channel must be the same as used by the AP of the infrastructure WiFi.
+
+3. The key has to be defined to enable encrypted communication between ESP-NOW
+   nodes. The key is 16 bytes long and is defined by a string of 8-bit hex
+   values separated by spaces, for example:
+   ```
+   "0f 1e 2d 3c 4b 5a 69 78 87 96 a5 b4 c3 d2 e1 f0"
+   ```
+   An empty string for this parameter means that the encryption is not used.
+   If less than 16 bytes are defined by the string, the remaining bytes of
+   the key are filled with 0.
+
+@note
+- If encrypted communication is used, a maximum of 6 nodes can
+  communicate with each other, while in unencrypted mode, up to
+  20 nodes can communicate.<br>
+- ESP-NOW network interface (module `esp_now`) and the
+  [Wifi network interface](#esp8266_wifi_network_interface) (module `esp_wifi`)
+  can be used simultaneously, for example, to
+  realize a border router for a mesh network which uses ESP-NOW.
+  In this case, the ESP-NOW interface must use the same channel as the AP of
+  the infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled
+  with the channel of the AP as the value for the #ESP_NOW_CHANNEL parameter.
 
  */

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -65,7 +65,7 @@
 static esp_now_netdev_t _esp_now_dev = { 0 };
 static const netdev_driver_t _esp_now_driver;
 
-static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, const uint8_t* key)
+static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, const char* key)
 {
     if (esp_now_is_peer_exist(bssid)) {
         return false;
@@ -77,7 +77,30 @@ static bool _esp_now_add_peer(const uint8_t* bssid, uint8_t channel, const uint8
     peer.channel = channel;
     peer.ifidx = ESP_IF_WIFI_AP;
 
-    if (esp_now_params.key) {
+    if (esp_now_params.key && strlen(esp_now_params.key)) {
+        const char *key = esp_now_params.key;
+        const char *end = key + strlen(key);
+        char *next;
+        long int byte;
+        int i = 0;
+
+        memset(peer.lmk, 0, ESP_NOW_KEY_LEN);
+
+        while ((key < end) && (i < ESP_NOW_KEY_LEN)) {
+            byte = strtol(key, &next, 16);
+            key = next;
+            peer.lmk[i] = byte;
+            i++;
+        }
+
+        DEBUG("esp_now_key: "
+              "%02x %02x %02x %02x %02x %02x %02x %02x "
+              "%02x %02x %02x %02x %02x %02x %02x %02x\n",
+              peer.lmk[0], peer.lmk[1], peer.lmk[2], peer.lmk[3],
+              peer.lmk[4], peer.lmk[5], peer.lmk[6], peer.lmk[7],
+              peer.lmk[8], peer.lmk[9], peer.lmk[10], peer.lmk[11],
+              peer.lmk[12], peer.lmk[13], peer.lmk[14], peer.lmk[15]);
+
         peer.encrypt = true;
         memcpy(peer.lmk, esp_now_params.key, ESP_NOW_KEY_LEN);
     }

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -44,25 +44,38 @@
 #endif
 
 /**
- * @brief   Period in milliseconds at which an ESP-NOW node scans for other
- *          ESP-NOW nodes in its range.
+ * @brief   Scan interval for peer nodes in ms.
  * @ingroup cpu_esp_common_conf
+ *
+ * Each node searches for other nodes in its range with the defined interval.
  */
 #ifndef ESP_NOW_SCAN_PERIOD_MS
 #define ESP_NOW_SCAN_PERIOD_MS  (10000UL)
 #endif
 
 /**
- * @brief   Passphrase used for the SoftAP interface of for all ESP-NOW nodes.
+ * @brief   Passphrase used for the SoftAP interface for all ESP-NOW nodes.
  * @ingroup cpu_esp_common_conf
+ *
+ * The passphrase is used for the SoftAP interface of ESP-NOW nodes. It
+ * is defined as a string with a maximum of 64 characters and must be the
+ * same for all nodes in the network.
  */
 #ifndef ESP_NOW_SOFT_AP_PASS
 #define ESP_NOW_SOFT_AP_PASS    "This is RIOT-OS"
 #endif
 
 /**
- * @brief   Channel used as broadcast medium by all ESP-NOW nodes together
+ * @brief   Channel used for ESP-NOW in the 2.4 GHz band
  * @ingroup cpu_esp_common_conf
+ *
+ * The channel is in the range of 1 to 13. If ESP-NOW is used together with
+ * an infrastructure WiFi network (module `esp_wifi` or `esp_wifi_enterprise`),
+ * e.g. to realize a border router, the channel must be the same as used by
+ * the AP of the infrastructure WiFi.
+ *
+ * @note In some regions not all 13 channels may be used for regulatory
+ * reasons. Select a channel that is allowed in your region.
  */
 #ifndef ESP_NOW_CHANNEL
 #define ESP_NOW_CHANNEL         (6)

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -49,7 +49,7 @@
  * @ingroup cpu_esp_common_conf
  */
 #ifndef ESP_NOW_SCAN_PERIOD_MS
-#define ESP_NOW_SCAN_PERIOD_MS     (10000UL)
+#define ESP_NOW_SCAN_PERIOD_MS  (10000UL)
 #endif
 
 /**
@@ -57,7 +57,7 @@
  * @ingroup cpu_esp_common_conf
  */
 #ifndef ESP_NOW_SOFT_AP_PASS
-#define ESP_NOW_SOFT_AP_PASS    "ThisistheRIOTporttoESP"
+#define ESP_NOW_SOFT_AP_PASS    "This is RIOT-OS"
 #endif
 
 /**

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -69,20 +69,25 @@
 #endif
 
 /**
- * @brief   Key used for the communication between ESP-NOW nodes
+ * @brief   128-bit key used for encrypted communication
  * @ingroup cpu_esp_common_conf
  *
  * The key has to be defined to enable encrypted communication between ESP-NOW
- * nodes. The key has to be of type *uint8_t [16]* and has to be exactly
- * 16 bytes long. If the key is NULL (the default) communication is not
- * encrypted.
+ * nodes. The key is 16 bytes long and is defined by a string of 8-bit hex
+ * values separated by spaces, for example:
+ * ```
+ * "0f 1e 2d 3c 4b 5a 69 78 87 96 a5 b4 c3 d2 e1 f0"
+ * ```
+ * An empty string for this parameter means that the encryption is not used.
+ * If less than 16 bytes are defined by the string, the remaining bytes of
+ * the key are filled with 0.
  *
- * Please note: If encrypted communication is used, a maximum of 6 nodes can
- * communicate with each other, while in unencrypted mode, up to 20 nodes can
- * communicate.
+ * @note:   If encrypted communication is used, a maximum of 6 nodes can
+ *          communicate with each other, while in unencrypted mode, up to
+ *          20 nodes can communicate.
  */
 #ifndef ESP_NOW_KEY
-#define ESP_NOW_KEY             (NULL)
+#define ESP_NOW_KEY             ""
 #endif
 
 /** @} */
@@ -103,7 +108,8 @@
  */
 typedef struct
 {
-    const uint8_t* key;      /**< key of type uint8_t [16] or NULL (no encryption) */
+    const char* key;         /**< Key string with 16 hex values separated by
+                                  spaces, empty string means no encryption */
     uint32_t scan_period;    /**< Period at which the node scans for other nodes */
     const char* softap_pass; /**< Passphrase used for the SoftAP interface */
     uint8_t channel;         /**< Channel used for ESP-NOW nodes */


### PR DESCRIPTION
### Contribution description

This PR changes the way the 128-bit key for encrypted ESP-NOW communication is defined.

The 128-bit key for encrypted ESP-NOW communication is defined by a 16-byte array of type `uint8_t [16]` specified by the `ESP_NOW_KEY` configuration parameter in RIOT. By default, this configuration parameter is specified as `NULL` (no encryption). While it easy to define the key as static initializer in C
```
#define ESP_NOW_KEY { 0x0f, 0x1e, ... }
```
it is not possible to define such static initializer in `Kconfig`. Therefore, in regard to the migration to Kconfig, the key is now defined as a string with hex values separated by spaces
```
#define ESP_NOW_KEY "0f 1e ..."
```
which is easy to implement in Kconfig.

The documentation is updated accordingly as well as fixed and improved a bit.

The PR includes the fix in PR #17420 (commit https://github.com/RIOT-OS/RIOT/pull/17419/commits/87a72e4dfe57098516234fac3d7fef294287e7c1) which is skipped once PR #17420 is merged and this PR is rebased.

### Testing procedure

1. Set `ENABLE_DEBUG` in `cpu/esp_common/esp_now_netdev.c`.
2. Compile and flash `example/gnrc_networking` for two nodes as follows:
    ```
    CFLAGS='-DESP_NOW_KEY=\"0f\ 1e\ 2d\ 3c\ 4b\ 5a\ 69\ 78\ 87\ 96\ a5\ b4\ c3\ d2\ e1\ f0\"' \
    make BOARD=esp32-wroom-32 -C examples/gnrc_networking PORT=/dev/ttyUSB<0|1> flash term
    ```
3. Once the nodes have found each other and are connected, the output should look something like this.
    ```
    _esp_system_event_handler WiFi scan done
    wifi_scan_get_ap_num ret=0 num=2
    wifi_scan_get_aps ret=0 num=2
    esp_now_key: 0f 1e 2d 3c 4b 5a 69 78 87 96 a5 b4 c3 d2 e1 f0
    esp_now_add_peer node 30:ae:a4:41:60:f9 added with return value 0
    associated peers total=1, encrypted=1
    ```
4. Ping the node from one node (optional), e.g. 
    ```
    ping6 fe80::32ae:a4ff:fe41:60f9
    ```
    In this example the LLUA is used as generated from the MAC address that was given in the output in step 3:
    ```
    esp_now_add_peer node 30:ae:a4:41:60:f9 added with return value 0
    ```
### Issues/PRs references

Depends on PR #17420