### PR TITLE
cpu/esp: revert the change for default definition of ESP_WIFI_PASS

### DIFF
--- a/cpu/esp_common/esp-wifi/esp_wifi_params.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_params.h
@@ -51,7 +51,7 @@
 /**
  * @brief   Passphrase used for the AP as clear text (max. 64 chars).
  */
-#ifndef ESP_WIFI_PASS
+#ifdef DOXYGEN
 #define ESP_WIFI_PASS       "ThisistheRIOTporttoESP"
 #endif
 


### PR DESCRIPTION
### Contribution description

This PR reverts a change made as part of PR #17415.

Previously, the default value for `ESP_WIFI_PASS` was intentionally defined only when `DOXYGEN` is also defined to allow `ESP_WIFI_PASS` to be left undefined for using APs without authentication. As part of PR #17415 the definition was changed to always define a default value for `EPS_WIFI_PASS`.  This made it impossible to use APs without authentication. This PR reverts this change.

The change in PR #17415 that is undone by this PR was supposedly a correction and  was made in preparation for the migration to `Kconfig`. There are no other changes in PR #17415 affected by this change. 

### Testing procedure

It is a very small fix back to the former definition (comment https://github.com/RIOT-OS/RIOT/pull/17415/files#r771905996). There are no functional or other changes affected by this change. Therefore, green CI should be sufficient.

### Issues/PRs references

Fixes a bug introduced with PR #174153