### PR TITLE
cpu/stm32: remove invalid family symbols used in Kconfig

### DIFF
--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -45,23 +45,23 @@ orsource "kconfigs/*/Kconfig.lines"
 orsource "kconfigs/*/Kconfig.models"
 
 choice
-	prompt "ReaDout Protection level"
-	default RDP0
-	help
-	Set minimum running RDP level.
-	RDP0 is full debug permissions, RDP1 disables read from Flash but
-	otherwise leaves debug enabled, RDP2 disables JTAG completely. If
-	there is a mismatch between desired RDP level here and RDP level
-	set on the chip, early cpu init will hang.  This ensures production
-	devices with the wrong RDP level, by fault or malace intent, will
-	not run.  See cpu manual for further details on RDP.
+    prompt "ReaDout Protection level"
+    default RDP0
+    help
+    Set minimum running RDP level.
+    RDP0 is full debug permissions, RDP1 disables read from Flash but
+    otherwise leaves debug enabled, RDP2 disables JTAG completely. If
+    there is a mismatch between desired RDP level here and RDP level
+    set on the chip, early cpu init will hang.  This ensures production
+    devices with the wrong RDP level, by fault or malace intent, will
+    not run.  See cpu manual for further details on RDP.
 depends on (CPU_FAM_F1 || CPU_FAM_F2 || CPU_FAM_F3 || CPU_FAM_F4 || CPU_FAM_F7)
 config RDP0
-	bool "RDP0"
+    bool "RDP0"
 config RDP1
-	bool "RDP1"
+    bool "RDP1"
 config RDP2
-	bool "RDP2"
+    bool "RDP2"
 endchoice
 
 if TEST_KCONFIG

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -55,7 +55,7 @@ choice
 	set on the chip, early cpu init will hang.  This ensures production
 	devices with the wrong RDP level, by fault or malace intent, will
 	not run.  See cpu manual for further details on RDP.
-depends on (CPU_FAM_F1 || CPU_FAM_F2 || CPU_FAM_F3 || CPU_FAM_F4 || CPU_FAM_F5 || CPU_FAM_F6 || CPU_FAM_F7)
+depends on (CPU_FAM_F1 || CPU_FAM_F2 || CPU_FAM_F3 || CPU_FAM_F4 || CPU_FAM_F7)
 config RDP0
 	bool "RDP0"
 config RDP1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR is a simple cleanup of stm32 Kconfig where some invalid family symbols are used: `CPU_FAM_F5` and `CPU_FAM_F6`. Obviously F5 and F6 families don't exist.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that while trying to understand why there's a difference between Kconfig/no kconfig builds on stm32u5 in #17410 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
