### PR TITLE
cpu/esp: integrate CPU clock frequency selection in Kconfig

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -81,11 +81,6 @@ config HAS_PERIPH_ADC_CTRL
     help
         Indicates that an ESP32 ADC controller peripheral is present.
 
-config HAS_ESP_SPI_RAM
-    bool
-    help
-        Indicates that the a RAM is present on the SPI bus.
-
 ## Common CPU symbols
 config CPU_CORE
     default "xtensa-lx6" if CPU_CORE_XTENSA_LX6

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 HAW Hamburg
+#               2021 Gunar Schorcht
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
@@ -98,21 +99,36 @@ config CPU_MODEL
 config CPU
     default "esp32" if CPU_FAM_ESP32
 
-menu "ESP32 configurations"
+menu "ESP32 specific configurations"
     depends on TEST_KCONFIG
     depends on HAS_ARCH_ESP32
 
-config MODULE_ESP_SPI_RAM
-    bool "SPI RAM support"
-    select MODULE_ESP_IDF_HEAP
-    depends on HAS_ESP_SPI_RAM
-    select MODULE_ESP_IDF_HEAP
-    help
-      Say y to use external SPI RAM connected through the FSPI interface.
+    choice
+        bool "CPU clock frequency"
+        default ESP32_DEFAULT_CPU_FREQ_MHZ_80
 
-config MODULE_ESP_JTAG
-    bool "Enable JTAG debugging interface"
-    depends on HAS_ESP_JTAG
+        config ESP32_DEFAULT_CPU_FREQ_MHZ_2
+            bool "2 MHz"
+        config ESP32_DEFAULT_CPU_FREQ_MHZ_40
+            bool "40 MHz"
+        config ESP32_DEFAULT_CPU_FREQ_MHZ_80
+            bool "80 MHz"
+        config ESP32_DEFAULT_CPU_FREQ_MHZ_160
+            bool "160 MHz"
+        config ESP32_DEFAULT_CPU_FREQ_MHZ_240
+            bool "240 MHz"
+    endchoice
+
+    config MODULE_ESP_SPI_RAM
+        bool "SPI RAM support"
+        depends on HAS_ESP_SPI_RAM
+        select MODULE_ESP_IDF_HEAP
+        help
+            Say y to use external SPI RAM connected through the FSPI interface.
+
+    config MODULE_ESP_JTAG
+        bool "Enable JTAG debugging interface"
+        depends on HAS_ESP_JTAG
 
 endmenu
 

--- a/cpu/esp32/include/sdk_conf.h
+++ b/cpu/esp32/include/sdk_conf.h
@@ -29,15 +29,34 @@ extern "C" {
 #endif
 
 /**
-* @name    Clock configuration
-* @{
-*/
+ * @name    Clock configuration
+ * @{
+ */
+
+#ifndef DOXYGEN
+/* Mapping of Kconfig defines to the respective enumeration values */
+#if CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ_2
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   2
+#elif CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ_40
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   40
+#elif CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ_80
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   80
+#elif CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ_160
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   160
+#elif CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ_240
+#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   240
+#endif
+#endif
+
 /**
  * @brief   Defines the CPU frequency [values = 2, 40, 80, 160 and 240]
  */
 #ifndef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ
 #define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ   80
 #endif
+/**
+ * @brief   Mapping configured ESP32 default clock to CLOCK_CORECLOCK define
+ */
 #define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 /** @} */
 
@@ -58,16 +77,6 @@ extern "C" {
  */
 #ifndef CONFIG_LOG_DEFAULT_LEVEL
 #define CONFIG_LOG_DEFAULT_LEVEL    LOG_LEVEL
-#endif
-
-/**
- * ESP32 specific configuration
- *
- * CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ can be overridden by an application
- * specific SDK configuration file.
- */
-#ifndef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ
-#define CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ       80
 #endif
 
 /**

--- a/cpu/esp8266/Kconfig
+++ b/cpu/esp8266/Kconfig
@@ -64,6 +64,22 @@ config CPU_MODEL
 config CPU
     default "esp8266" if CPU_FAM_ESP8266
 
+menu "ESP8266 specific configurations"
+    depends on TEST_KCONFIG
+    depends on HAS_ARCH_ESP8266
+
+    choice
+        bool "CPU clock frequency"
+        default ESP8266_CPU_FREQUENCY_80
+
+        config ESP8266_CPU_FREQUENCY_80
+            bool "80 MHz"
+        config ESP8266_CPU_FREQUENCY_160
+            bool "160 MHz"
+    endchoice
+
+endmenu
+
 source "$(RIOTCPU)/esp_common/Kconfig"
 
 config MODULE_ESP_I2C_SW

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -33,6 +33,16 @@ extern "C" {
 * @name    Clock configuration
 * @{
 */
+
+#ifndef DOXYGEN
+/* Mapping of Kconfig defines to the respective enumeration values */
+#if CONFIG_ESP8266_CPU_FREQUENCY_80
+#define ESP8266_CPU_FREQUENCY   80
+#elif CONFIG_ESP8266_CPU_FREQUENCY_160
+#define ESP8266_CPU_FREQUENCY   160
+#endif
+#endif
+
 /**
  * @brief   Defines the CPU frequency in MHz
  *
@@ -41,6 +51,10 @@ extern "C" {
 #ifndef ESP8266_CPU_FREQUENCY
 #define ESP8266_CPU_FREQUENCY   (80)
 #endif
+
+/**
+ * @brief   Mapping configured ESP8266 default clock to CLOCK_CORECLOCK define
+ */
 #define CLOCK_CORECLOCK         (1000000UL * ESP8266_CPU_FREQUENCY)
 /** @} */
 


### PR DESCRIPTION
### Contribution description

As the title says, this PR integrates CPU clock frequency selection in `Kconfig`.

Futhermore, it contains a small fix which removes the duplicate of `HAS_ESP_SPI_RAM` feature definition (https://github.com/RIOT-OS/RIOT/commit/f01e0804ffefb72a4e56e44ddb10e1e5f19c1799)

### Testing procedure

1. Compilation has to succeed.
2. Use commands:
   ```
   TEST_KCONFIG=1 make BOARD=esp32-wroom-32 -C tests/shell menuconfig
   TEST_KCONFIG=1 make BOARD=esp8266-esp-12x -C tests/shell menuconfig
   ```
   The CPU clock frequency should be selectable in ESP32 and ESP8266 specific configurations.

### Issues/PRs references
