### PR TITLE
boards: unify user button defines

### DIFF
--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -84,9 +84,12 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button pin configuration
+ * @{
  */
-#define BTN_B1_PIN          GPIO_PIN(PORT_B, 2)
+#define BTN0_PIN            GPIO_PIN(PORT_B, 2)     /**< User button pin */
+#define BTN0_MODE           GPIO_IN_PU              /**< User button pin mode */
+/** @} */
 
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO

--- a/boards/b-l072z-lrwan1/include/gpio_params.h
+++ b/boards/b-l072z-lrwan1/include/gpio_params.h
@@ -55,8 +55,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     },
     {
         .name = "Button(B1 User)",
-        .pin = BTN_B1_PIN,
-        .mode = GPIO_IN_PU
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE
     },
 };
 

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -47,9 +47,12 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button pin configuration
+ * @{
  */
-#define BTN_B1_PIN          GPIO_PIN(PORT_C, 13)
+#define BTN0_PIN            GPIO_PIN(PORT_C, 13)    /**< User button pin */
+#define BTN0_MODE           GPIO_IN_PU              /**< User button pin mode */
+/** @} */
 
 /**
  * @name    HTS221 temperature/humidity sensor configuration

--- a/boards/b-l475e-iot01a/include/gpio_params.h
+++ b/boards/b-l475e-iot01a/include/gpio_params.h
@@ -47,8 +47,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     },
     {
         .name = "Button(B1 User)",
-        .pin = BTN_B1_PIN,
-        .mode = GPIO_IN_PU,
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     }
 };

--- a/boards/pyboard/include/board.h
+++ b/boards/pyboard/include/board.h
@@ -42,9 +42,12 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button pin configuration
+ * @{
  */
-#define BTN_B1_PIN          GPIO_PIN(PORT_B, 3)
+#define BTN0_PIN            GPIO_PIN(PORT_B, 3)     /**< User button pin */
+#define BTN0_MODE           GPIO_IN_PU              /**< User button pin mode */
+/** @} */
 
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and stdio

--- a/boards/pyboard/include/gpio_params.h
+++ b/boards/pyboard/include/gpio_params.h
@@ -40,8 +40,8 @@ static const saul_gpio_params_t saul_gpio_params[] =
     },
     {
         .name = "Button(B1 User)",
-        .pin = BTN_B1_PIN,
-        .mode = GPIO_IN_PU,
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
     }
 };

--- a/boards/ublox-c030-u201/include/board.h
+++ b/boards/ublox-c030-u201/include/board.h
@@ -56,9 +56,12 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button pin configuration
+ * @{
  */
-#define BTN_B1_PIN          GPIO_PIN(PORT_C, 13)
+#define BTN0_PIN            GPIO_PIN(PORT_C, 13)    /**< User button pin */
+#define BTN0_MODE           GPIO_IN                 /**< User button pin mode */
+/** @} */
 
 /**
  * @name    si7034 temperature sensor configuration

--- a/boards/ublox-c030-u201/include/gpio_params.h
+++ b/boards/ublox-c030-u201/include/gpio_params.h
@@ -51,8 +51,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     },
     {
         .name = "Button(B1 User)",
-        .pin = BTN_B1_PIN,
-        .mode = GPIO_IN,
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
     },
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There are a few boards that define there user button as `BTN_B1_PIN` without defining the GPIO mode. This is not compatible with the `tests/buttons` application which expects the defines to be called `BTNx_PIN` and `BTNx_MODE`.

This PR renamed these defines to make them compatible and testable with `tests/buttons`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/buttons` now works with `b-l072z-rwan1`, `b-l475e-iot01a`, `pyboard` and `ublox-c030-u201`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that when working on #17410 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
