### PR TITLE
examples: add basic gpio example with toggle command

### DIFF
--- a/examples/gpio/Makefile
+++ b/examples/gpio/Makefile
@@ -1,0 +1,24 @@
+# name of your application
+APPLICATION = gpio
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Enable shell
+USEMODULE += shell
+
+# Use a peripheral timer for the delay, if available
+FEATURES_OPTIONAL += periph_gpio
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/gpio/README.md
+++ b/examples/gpio/README.md
@@ -1,0 +1,13 @@
+GPIO
+=======
+
+This is a basic example that toggles the value of a given GPIO pin.
+The user interface is through the `toggle <pin_number>` shell command.
+Example usage:
+
+```bash
+> toggle 26
+```
+
+This is mostly useful for beginners who are to starting to experiment with
+RIOT and may want to test the GPIO interface.

--- a/examples/gpio/main.c
+++ b/examples/gpio/main.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 Geovane Fedrecheski
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       GPIO toggle application
+ *
+ * @author      Geovane Fedrecheski <geonnave@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "shell.h"
+#include "periph/gpio.h"
+
+static int _toggle_handler(int argc, char **argv)
+{
+    /* These parameters are not used, avoid a warning during build */
+    (void)argc;
+    (void)argv;
+
+    uint8_t pin_number;
+
+    if (argc == 2) {
+        pin_number = atoi(argv[1]);
+        printf("dbg> pin_number: %d\n", pin_number);
+        gpio_t pin = GPIO_PIN(1, pin_number);
+        gpio_init(pin, GPIO_OUT);
+        gpio_toggle(pin);
+        return 0;
+    }
+    else {
+        printf("usage: %s <pin_number>\n", argv[0]);
+        return 1;
+    }
+}
+
+static const shell_command_t shell_commands[] = {
+    { "toggle", "Toggle gpio value at specified pin", _toggle_handler },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Example GPIO application");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

I figured there was no example code for gpio, so I am proposing one. Goals are:
- exemplify how to import and initialize gpio peripheral
- expose `gpio_toggle` as a shell command

### Testing procedure

1. build and flash the project onto a board
2. access the board's shell
3. type `toggle X` where X is a valid GPIO pin for that board


### Issues/PRs references

n/a.
