### PR TITLE
core: Warn about using irq_enable

### DIFF
--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -53,7 +53,12 @@ MAYBE_INLINE unsigned irq_disable(void);
  *          interpreted as a boolean value. The actual value is only
  *          significant for irq_restore().
  *
- * @see     irq_restore
+ * @warning This function is here primarily for internal use, and for
+ *          compatibility with the Arduino environment (which lacks the
+ *          "disable / restore" concept. Enabling interrupts when a different
+ *          component disabled them can easily cause unintended behavior there.
+ *
+ *          Use @ref irq_restore instead.
  */
 MAYBE_INLINE unsigned irq_enable(void);
 
@@ -63,7 +68,6 @@ MAYBE_INLINE unsigned irq_enable(void);
  *
  * @param[in] state   state to restore
  *
- * @see     irq_enable
  * @see     irq_disable
  */
 MAYBE_INLINE void irq_restore(unsigned state);

--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -168,12 +168,12 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
     int32_t pwm_duty_cycle_abs = pwm_duty_cycle;
     pwm_duty_cycle_abs *= (pwm_duty_cycle < 0) ? -1 : 1;
 
-    irq_disable();
+    unsigned irqstate = irq_disable();
     gpio_write(dev->gpio_dir0, gpio_dir0_value);
     gpio_write(dev->gpio_dir1_or_brake, gpio_dir1_or_brake_value);
     pwm_set(motor_driver_conf->pwm_dev, dev->pwm_channel, \
             (uint16_t)pwm_duty_cycle_abs);
-    irq_enable();
+    irq_restore(irqstate);
 
     motor_driver_cb_t cb = motor_driver_conf->cb;
     if (cb) {
@@ -233,11 +233,11 @@ int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id)
         goto motor_brake_err;
     }
 
-    irq_disable();
+    unsigned irqstate = irq_disable();
     gpio_write(dev->gpio_dir0, gpio_dir0_value);
     gpio_write(dev->gpio_dir1_or_brake, gpio_dir1_or_brake_value);
     pwm_set(motor_driver_conf->pwm_dev, dev->pwm_channel, 0);
-    irq_enable();
+    irq_restore(irqstate);
 
     return 0;
 


### PR DESCRIPTION
### Contribution description

Setting the system in a state with more interrupts enabled than expected by the caller is generally unexpected -- if this were allowed unchecked, many components would need to revisit and tighten their synchronization efforts making them less efficient. (I didn't do a precise check, but I expect that ztimer might *not* tolerate interrupts to be enabled by the callback, especially as that means that unrelated interrupts might manipulate ztimer again).

One offending user was found in the implementations (motor_driver) and changed to use irq_restore. All others have some justification for using enable (eg. it's done in an ISR).

### Testing procedure

* Look at whether you agree with the doc change.
* Test the motor example. (I didn't, and don't have the hardware -- but what could go wrong?).

### Issues/PRs references

This came up looking at the synchronization necessary around Rust code. If arbitrary callbacks can enable interrupts just like that without responsibility, code in critical sections just needs way more severe locking and precautions.

[edit: since when does GitHub accept submissions with plain Enter? Sucks...]