### PR TITLE
boards/common/microbit: fix doxygen grouping

### DIFF
--- a/boards/common/microbit/include/microbit.h
+++ b/boards/common/microbit/include/microbit.h
@@ -8,6 +8,7 @@
 
 /**
  * @defgroup    boards_common_microbit Common microbit LED handling
+ * @ingroup     boards_common
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Otherwise the "Common microbit LED handling" group appears at the top-level modules group:

![image](https://user-images.githubusercontent.com/1375137/147225321-cc2bca40-602f-4e0f-95c8-a804ab0b3f88.png)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just check the generated documentation, the microbit common group has moved under the common boards doxygen group.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
