### PR TITLE
sys/arduino: add assertion to gpio handling

### DIFF
--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -32,6 +32,7 @@ extern "C" {
 
 void pinMode(int pin, int mode)
 {
+    assert(gpio_is_valid(arduino_pinmap[pin]));
     gpio_mode_t m = GPIO_OUT;
 
     if (mode == INPUT) {
@@ -46,11 +47,13 @@ void pinMode(int pin, int mode)
 
 void digitalWrite(int pin, int state)
 {
+    assert(gpio_is_valid(arduino_pinmap[pin]));
     gpio_write(arduino_pinmap[pin], state);
 }
 
 int digitalRead(int pin)
 {
+    assert(gpio_is_valid(arduino_pinmap[pin]));
     if (gpio_read(arduino_pinmap[pin])) {
         return HIGH;
     }


### PR DESCRIPTION
### Contribution description

This PR add assertion to GPIO handling to the Arduino module to avoid system lock if an Arduino pin is used that is defined as `GPIO_UNDEF`

Not all boards that provide a Arduino pin layout break out all GPIOs. A good example are the Adafruit `feather-m0` boards. For such boards, GPIO pins that are not broken out have to be defined as `GPIO_UNDEF` to preserve the Arduino pin layout. However, GPIO functions lead to a complete system lock on `feather-m0` boards if a pin is used that is defined as `GPIO_UNDEF`. Therefore, at least an assert should blow up in that case.

### Testing procedure

Compile and flash
```
make BOARD=feather-m0 -C tests/periph_gpio_arduino flash term
```
Execute
```
toggle 13
toggle 3
```
After the second command, the system hangs without this PR. With this PR, the second command should lead to an assert with PR. 
 
### Issues/PRs references

Found when testing PR #17401