### PR TITLE
boards/feather-m0-*: fix Arduino feature in Kconfig

### DIFF
--- a/boards/feather-m0-lora/Kconfig
+++ b/boards/feather-m0-lora/Kconfig
@@ -20,6 +20,7 @@ config BOARD_FEATHER_M0_LORA
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
     select HAS_HIGHLEVEL_STDIO
 
     select HAVE_SAUL_GPIO

--- a/boards/feather-m0-wifi/Kconfig
+++ b/boards/feather-m0-wifi/Kconfig
@@ -20,6 +20,7 @@ config BOARD_FEATHER_M0_WIFI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
     select HAS_HIGHLEVEL_STDIO
 
     select HAVE_SAUL_GPIO


### PR DESCRIPTION
### Contribution description

This PR solves the problem with the `arduino` feature introduced with PR #17401 for the `feather-m0` base board, in the `Kconfig` for derived `feather-m0-*` boards.
 
With PR #17401 the `arduino` feature for the `feather-m0` baseboard was introduced. Since all derived `feather-m0-*` boards with additional hardware modules have all features of the `feather-m0` base board, just `Makefile.features` of the `feather-m0` base board is included by `Makefile.features` of all derived `feather-m0 boards-*`. Thus all derived boards also have this feature.

However, the `Kconfig` file is defined separately for derived `feather-m0-*` boards. In PR #17401, it was forgotten to include the `arduino` feature in the `Kconfig` file for the derived boards. This wasn't realized before merging because the CI didn't trigger an error message.

### Testing procedure

Green CI.

### Issues/PRs references

Fix feature problem introduced with PR #17401 