### PR TITLE
boards/feather-m0*: base board definition in Kconfig

### DIFF
--- a/boards/feather-m0-lora/Kconfig
+++ b/boards/feather-m0-lora/Kconfig
@@ -10,19 +10,7 @@ config BOARD
 config BOARD_FEATHER_M0_LORA
     bool
     default y
-    select CPU_MODEL_SAMD21G18A
-    select HAS_PERIPH_ADC
-    select HAS_PERIPH_I2C
-    select HAS_PERIPH_PWM
-    select HAS_PERIPH_RTC
-    select HAS_PERIPH_RTT
-    select HAS_PERIPH_SPI
-    select HAS_PERIPH_TIMER
-    select HAS_PERIPH_UART
-    select HAS_PERIPH_USBDEV
-    select HAS_ARDUINO
-    select HAS_HIGHLEVEL_STDIO
+    select BOARD_FEATHER_M0_BASE
+    select HAVE_SX1276
 
-    select HAVE_SAUL_GPIO
-
-source "$(RIOTBOARD)/common/samdx1-arduino-bootloader/Kconfig"
+source "$(RIOTBOARD)/feather-m0/Kconfig.feather-m0-base"

--- a/boards/feather-m0-wifi/Kconfig
+++ b/boards/feather-m0-wifi/Kconfig
@@ -10,19 +10,7 @@ config BOARD
 config BOARD_FEATHER_M0_WIFI
     bool
     default y
-    select CPU_MODEL_SAMD21G18A
-    select HAS_PERIPH_ADC
-    select HAS_PERIPH_I2C
-    select HAS_PERIPH_PWM
-    select HAS_PERIPH_RTC
-    select HAS_PERIPH_RTT
-    select HAS_PERIPH_SPI
-    select HAS_PERIPH_TIMER
-    select HAS_PERIPH_UART
-    select HAS_PERIPH_USBDEV
-    select HAS_ARDUINO
-    select HAS_HIGHLEVEL_STDIO
+    select BOARD_FEATHER_M0_BASE
+    select HAVE_ATWINC15X0
 
-    select HAVE_SAUL_GPIO
-
-source "$(RIOTBOARD)/common/samdx1-arduino-bootloader/Kconfig"
+source "$(RIOTBOARD)/feather-m0/Kconfig.feather-m0-base"

--- a/boards/feather-m0/Kconfig
+++ b/boards/feather-m0/Kconfig
@@ -10,19 +10,6 @@ config BOARD
 config BOARD_FEATHER_M0
     bool
     default y
-    select CPU_MODEL_SAMD21G18A
-    select HAS_PERIPH_ADC
-    select HAS_PERIPH_I2C
-    select HAS_PERIPH_PWM
-    select HAS_PERIPH_RTC
-    select HAS_PERIPH_RTT
-    select HAS_PERIPH_SPI
-    select HAS_PERIPH_TIMER
-    select HAS_PERIPH_UART
-    select HAS_PERIPH_USBDEV
-    select HAS_ARDUINO
-    select HAS_HIGHLEVEL_STDIO
+    select BOARD_FEATHER_M0_BASE
 
-    select HAVE_SAUL_GPIO
-
-source "$(RIOTBOARD)/common/samdx1-arduino-bootloader/Kconfig"
+rsource "Kconfig.feather-m0-base"

--- a/boards/feather-m0/Kconfig.feather-m0-base
+++ b/boards/feather-m0/Kconfig.feather-m0-base
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_FEATHER_M0_BASE
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
+    select HAS_HIGHLEVEL_STDIO
+
+    select HAVE_SAUL_GPIO
+
+source "$(RIOTBOARD)/common/samdx1-arduino-bootloader/Kconfig"


### PR DESCRIPTION
### Contribution description

This PR introduces a base board definition in Kconfig for all `feather-m0*` boards.

Derived `feather-m0-*` boards have all features of the `feather-m0` base board and `Makefile.features` of derived `feather-m0-*` boards just include `Makefile.features` of the `feather-m0` base board. Therefore a base board definition is introduced in Kconfig for all `feather-m0*` boards.

Such a base board definition in Kconfig helps to avoid problems as introduced with PR #17401 and fixed with PR #17444.

### Testing procedure

Green CI.

### Issues/PRs references
