### PR TITLE
sys/stdio: add optional function stdio_available

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -152,6 +152,7 @@ PSEUDOMODULES += sock_udp
 PSEUDOMODULES += socket_zep_hello
 PSEUDOMODULES += soft_uart_modecfg
 PSEUDOMODULES += stdin
+PSEUDOMODULES += stdio_available
 PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_uart_rx

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -37,6 +37,7 @@ endif
 ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
   USEMODULE += isrpipe
   USEMODULE += stdio_uart
+  USEMODULE += stdio_available
 endif
 
 ifneq (,$(filter stdio_uart,$(USEMODULE)))

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -17,6 +17,7 @@ endif
 ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
   USEMODULE += usbus_cdc_acm
   USEMODULE += isrpipe
+  USEMODULE += stdio_available
 endif
 
 ifneq (,$(filter stdio_rtt,$(USEMODULE)))

--- a/sys/Kconfig.stdio
+++ b/sys/Kconfig.stdio
@@ -53,6 +53,11 @@ config MODULE_STDIO_UART_RX
     help
         Reception when using UART-based STDIO needs to be enabled.
 
+config MODULE_STDIO_AVAILABLE
+    bool
+    help
+        Indicates that the implementation supports function stdio_available
+
 config MODULE_PRINTF_FLOAT
     bool "Float support in printf"
 

--- a/sys/Kconfig.stdio
+++ b/sys/Kconfig.stdio
@@ -49,6 +49,7 @@ config MODULE_STDIO_UART_RX
     bool
     depends on MODULE_STDIO_UART
     select MODULE_ISRPIPE
+    select MODULE_STDIO_AVAILABLE
     default y if MODULE_STDIN
     help
         Reception when using UART-based STDIO needs to be enabled.

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -25,6 +25,8 @@
 
 #include <unistd.h>
 
+#include "kernel_defines.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +35,18 @@ extern "C" {
  * @brief initialize the module
  */
 void stdio_init(void);
+
+#if IS_USED(MODULE_STDIO_AVAILABLE) || DOXYGEN
+/**
+ * @brief   Get the number of bytes available for reading from stdio.
+ *
+ * @warning This function is only available if the implementation supports
+ *          it and the @c stdio_available module is enabled.
+ *
+ * @return  number of available bytes
+ */
+int stdio_available(void);
+#endif
 
 /**
  * @brief read @p len bytes from stdio uart into @p buffer

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -67,6 +67,13 @@ void stdio_init(void)
 #endif
 }
 
+#if IS_USED(MODULE_STDIO_AVAILABLE)
+int stdio_available(void)
+{
+    return tsrb_avail(&stdio_uart_isrpipe.tsrb);
+}
+#endif
+
 ssize_t stdio_read(void* buffer, size_t count)
 {
 #ifdef MODULE_STDIO_UART_RX

--- a/sys/usb/usbus/cdc/acm/Kconfig
+++ b/sys/usb/usbus/cdc/acm/Kconfig
@@ -58,5 +58,6 @@ config MODULE_STDIO_CDC_ACM
     bool "CDC ACM"
     depends on MODULE_USBUS_CDC_ACM
     select MODULE_ISRPIPE
+    select MODULE_STDIO_AVAILABLE
 
 endchoice

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -51,6 +51,13 @@ void stdio_init(void)
 #endif
 }
 
+#if IS_USED(MODULE_STDIO_AVAILABLE)
+int stdio_available(void)
+{
+    return tsrb_avail(&_cdc_stdio_isrpipe.tsrb);
+}
+#endif
+
 ssize_t stdio_read(void* buffer, size_t len)
 {
     (void)buffer;


### PR DESCRIPTION
### Contribution description

This PR provides the definition of an additional `stdio` function to check how many bytes are available for reading.

A number of `stdio` backend implementations allow to check the number of bytes available for reading before calling the blocking `stdio_read`. This helps to implement non-blocking functionalities while waiting for `stdin`.

This PR provides the implementation for
```
stdio_uart
stdio_cdc_acm
```

### Testing procedure

Green CI.

### Issues/PRs references

Follow-up of PR #17335
Required for PR #17447 