### PR TITLE
sys/arduino: add Serial over stdio support

### DIFF
--- a/boards/common/arduino-mkr/include/arduino_board.h
+++ b/boards/common/arduino-mkr/include/arduino_board.h
@@ -29,6 +29,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   On-board serial port mapping, stdio is used for Serial
+ */
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
+
+/**
  * @brief   Look-up table for the Arduino's digital pins
  */
 static const gpio_t arduino_pinmap[] = {

--- a/boards/feather-m0/include/arduino_board.h
+++ b/boards/feather-m0/include/arduino_board.h
@@ -32,6 +32,13 @@ extern "C" {
 #define ARDUINO_LED         (13)
 
 /**
+ * @brief   On-board serial port mapping, stdio is used for Serial
+ */
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
+
+/**
  * @brief   Look-up table for the Arduino's digital pins
  */
 static const gpio_t arduino_pinmap[] = {

--- a/boards/sodaq-autonomo/include/arduino_board.h
+++ b/boards/sodaq-autonomo/include/arduino_board.h
@@ -35,7 +35,9 @@ extern "C" {
 /**
  * @brief   On-board serial port mapping
  */
-#define ARDUINO_UART_DEV         UART_DEV(0)
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
 
 /**
  * @brief   Look-up table for the Arduino's digital pins

--- a/boards/sodaq-explorer/include/arduino_board.h
+++ b/boards/sodaq-explorer/include/arduino_board.h
@@ -34,7 +34,9 @@ extern "C" {
 /**
  * @brief   On-board serial port mapping
  */
-#define ARDUINO_UART_DEV         UART_DEV(0)
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
 
 /**
  * @brief   Look-up table for the Arduino's digital pins

--- a/boards/sodaq-one/include/arduino_board.h
+++ b/boards/sodaq-one/include/arduino_board.h
@@ -34,7 +34,9 @@ extern "C" {
 /**
  * @brief   On-board serial port mapping
  */
-#define ARDUINO_UART_DEV         UART_DEV(0)
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
 
 /**
  * @brief   Look-up table for the Arduino's digital pins

--- a/boards/sodaq-sara-aff/include/arduino_board.h
+++ b/boards/sodaq-sara-aff/include/arduino_board.h
@@ -34,7 +34,9 @@ extern "C" {
 /**
  * @brief   On-board serial port mapping
  */
-#define ARDUINO_UART_DEV         UART_DEV(0)
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
 
 /**
  * @brief   Look-up table for the Arduino's digital pins

--- a/boards/sodaq-sara-sff/include/arduino_board.h
+++ b/boards/sodaq-sara-sff/include/arduino_board.h
@@ -34,7 +34,9 @@ extern "C" {
 /**
  * @brief   On-board serial port mapping
  */
-#define ARDUINO_UART_DEV         UART_DEV(0)
+#ifndef ARDUINO_UART_DEV
+#define ARDUINO_UART_DEV    UART_UNDEF
+#endif
 
 /**
  * @brief   Look-up table for the Arduino's digital pins

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -10,6 +10,9 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   USEMODULE += fmt
   USEMODULE += ztimer_usec
   USEMODULE += ztimer_msec
+  ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+    USEMODULE += arduino_serial_stdio
+  endif
 endif
 
 ifneq (,$(filter arduino_pwm,$(FEATURES_USED)))

--- a/sys/arduino/Kconfig
+++ b/sys/arduino/Kconfig
@@ -34,3 +34,8 @@ config MODULE_ARDUINO_PWM
     depends on MODULE_ARDUINO
     depends on TEST_KCONFIG
     select MODULE_PERIPH_PWM
+
+config MODULE_ARDUINO_SERIAL_STDIO
+    bool "Use STDIO as Serial"
+    depends on MODULE_ARDUINO
+    depends on TEST_KCONFIG

--- a/sys/arduino/Kconfig
+++ b/sys/arduino/Kconfig
@@ -39,3 +39,4 @@ config MODULE_ARDUINO_SERIAL_STDIO
     bool "Use STDIO as Serial"
     depends on MODULE_ARDUINO
     depends on TEST_KCONFIG
+    default y if MODULE_STDIO_CDC_ACM

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -26,3 +26,4 @@ INCLUDES += -I$(RIOTBASE)/sys/arduino/include
 CXXEXFLAGS += -std=c++11
 
 PSEUDOMODULES += arduino_pwm
+PSEUDOMODULES += arduino_serial_stdio

--- a/tests/sys_arduino/app.config.test
+++ b/tests/sys_arduino/app.config.test
@@ -1,0 +1,3 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_ARDUINO=y


### PR DESCRIPTION
### Contribution description

This PR provides the support for using the `Serial` over `stdio_*`

On Arduino boards, the `Serial` object uses
- either an UART interface connected to an USB interface via an additional ATmega chip (class `HardwareSerial`)
- or directly the USB CDC interface (class `_Serial`).

However, the `Serial` object in RIOT always uses the UART interface defined by `ARDUINO_UART_DEV`, usually `UART_DEV(0)`. Therefore `Serial` does not work for boards like `feather-m0` and `arduino-mkr` which use the USB CDC interface directly. Since the STDIO already uses the USB CDC interface for such boards with the help of the module `stdio_cdc_acm`, it is possible to realize the `Serial` object for such boards on top of the STDIO.

For this purpose the module `arduino_serial_stdio` is introduced. If this module is enabled AND the `ARDUINO_UART_DEV` is defined as `UART_UNDEF`, the STDIO is used for `Serial`. This allows either the use of the STDIO or the use of a UART interface if defined by `ARDUINO_UART_DEV`.

The module `arduino_serial_stdio` is automatically enabled for boards using `stdio_cdc_acm`. However, to actually use `Serial` via STDIO, `ARDUINO_UART_DEV` have to be defined additionally `UART_UNDEF`. This is done by this PR for
- `feather-m0`
- `arduino-mkr`.

For `sodaq` boards the situation is unclear, since `ARDUINO_UART_DEV` is explicitly defined for these boards and it is not clear whether this is intentional.

The use of `Serial` over STDIO requires that the used `stdio` backend implements the `stdio_available` function that was introduced by PR #17446.

### Testing procedure

1. Use either a `feather-m0` or an `arduino-mkr` board and use the following example to test:
    ```
    make BOARD=arduino-mkr1000 -C examples/arduino_hello-world flash term
    make BOARD=feather-m0 -C examples/arduino_hello-world flash term
    ```
    Enter a string should be echoed as expected.
2. Use any other board that uses `std_uart`, for example `esp32-wroom` and do the same:
    ```
    CFLAGS='-DARDUINO_UART_DEV=UART_UNDEF' USEMODULE=arduino_serial_stdio \
    make BOARD=esp32-wroom-32 -C examples/arduino_hello-world flash term
    ```
    Enter a string should be echoed as expected.

### Issues/PRs references

Depends on PR #17446.
