### PR TITLE
usbus/hid: Remove unimplemented function declaration

### DIFF
--- a/sys/include/usb/usbus/hid.h
+++ b/sys/include/usb/usbus/hid.h
@@ -114,13 +114,6 @@ void usbus_hid_init(usbus_t *usbus, usbus_hid_device_t *hid,
 size_t usbus_hid_submit(usbus_hid_device_t *hid, const uint8_t *buf,
                         size_t len);
 
-/**
- * @brief Flush the buffer to the USB host
- *
- * @param[in]   hid      USBUS HID handler context
- */
-void usbus_hid_flush(usbus_hid_device_t *hid);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR removes the declaration for the unimplemented function `usbus_hid_flush`. This function used to be a wrapper for `usbdev_ep_xmit` which I didn't need anymore after chaning parts of the initial USB HID implementation. I forgot to remove this declaration.
