### PR TITLE
doc/boards/rpi-pico: Addition of section concerning shell access

### DIFF
--- a/boards/rpi-pico/doc.txt
+++ b/boards/rpi-pico/doc.txt
@@ -112,7 +112,7 @@ but limited to educational purposes. Afterwards run:
 make BOARD=rpi-pico PROGRAMMER=jlink flash
 ```
 
-## Accesing RIOT shell
+## Accessing RIOT shell
 
 This board's default access to RIOT shell is via UART (UART0 TX - pin 1, UART0 RX - pin 2).
 

--- a/boards/rpi-pico/doc.txt
+++ b/boards/rpi-pico/doc.txt
@@ -114,7 +114,7 @@ make BOARD=rpi-pico PROGRAMMER=jlink flash
 
 ## Accesing RIOT shell
 
-This board's default access to RIOT shell is via UART (UART0 TX - pin 1, UART0 RX - pin 2). 
+This board's default access to RIOT shell is via UART (UART0 TX - pin 1, UART0 RX - pin 2).
 
 The default baud rate is 115 200.
 

--- a/boards/rpi-pico/doc.txt
+++ b/boards/rpi-pico/doc.txt
@@ -112,6 +112,20 @@ but limited to educational purposes. Afterwards run:
 make BOARD=rpi-pico PROGRAMMER=jlink flash
 ```
 
+## Accesing RIOT shell
+
+This board's default access to RIOT shell is via UART (UART0 TX - pin 1, UART0 RX - pin 2). 
+
+The default baud rate is 115 200.
+
+The simplest way to connect to the shell is the execution of the command:
+
+```
+make BOARD=rpi-pico term
+```
+
+@warning Raspberry Pi Pico board is not 5V tolerant. Use voltage divider or logic level shifter when connecting to 5V UART.
+
 ## On-Chip Debugging
 
 There are currently (June 2021) few hardware options for debugging the Raspberry Pi Pico:


### PR DESCRIPTION
### Contribution description

This PR adds to Raspberry Pi Pico board documentation section concerning accessing RIOT shell.
Information in description accordingly to the Issue [17453](https://github.com/RIOT-OS/RIOT/issues/17453).

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__rpi__pico.html
```

### Issues/PRs references

See Issue  [#17453](https://github.com/RIOT-OS/RIOT/issues/17453).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
