### PR TITLE
{disp,touch}_dev: improve Kconfig at different levels

### DIFF
--- a/boards/stm32f429i-disc1/Kconfig
+++ b/boards/stm32f429i-disc1/Kconfig
@@ -29,5 +29,7 @@ config BOARD_STM32F429I_DISC1
     select BOARD_HAS_LSE
 
     select HAVE_SAUL_GPIO
+    select HAVE_ILI9341
+    select HAVE_STMPE811_I2C
 
 source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/drivers/stmpe811/Kconfig
+++ b/drivers/stmpe811/Kconfig
@@ -15,6 +15,18 @@ config MODULE_STMPE811
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
 
+config HAVE_STMPE811_I2C
+    bool
+    select MODULE_STMPE811_I2C if MODULE_TOUCH_DEV
+    help
+      Indicates that an STMPE811 over I2C touch panel is present.
+
+config HAVE_STMPE811_SPI
+    bool
+    select MODULE_STMPE811_SPI if MODULE_TOUCH_DEV
+    help
+      Indicates that an STMPE811 over SPI touch panel is present.
+
 choice
     bool "STMPE811 Touchscreen Controller"
     optional

--- a/drivers/stmpe811/Kconfig
+++ b/drivers/stmpe811/Kconfig
@@ -5,8 +5,10 @@
 # directory for more details.
 #
 
-config MODULE_STMPE811
+menuconfig MODULE_STMPE811
     bool
+    prompt "STMPE811 Touchscreen Controller" if !(MODULE_TOUCH_DEV && HAVE_STMPE811)
+    default (MODULE_TOUCH_DEV && HAVE_STMPE811)
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
     depends on TEST_KCONFIG
@@ -15,36 +17,44 @@ config MODULE_STMPE811
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
 
-config HAVE_STMPE811_I2C
-    bool
-    select MODULE_STMPE811_I2C if MODULE_TOUCH_DEV
-    help
-      Indicates that an STMPE811 over I2C touch panel is present.
+if MODULE_STMPE811
 
-config HAVE_STMPE811_SPI
-    bool
-    select MODULE_STMPE811_SPI if MODULE_TOUCH_DEV
+choice STMPE811_VARIANT
+    bool "Model"
+    default MODULE_STMPE811_I2C if HAVE_STMPE811_I2C
+    default MODULE_STMPE811_SPI if HAVE_STMPE811_SPI
     help
-      Indicates that an STMPE811 over SPI touch panel is present.
-
-choice
-    bool "STMPE811 Touchscreen Controller"
-    optional
-    depends on TEST_KCONFIG
-    help
-        The driver supports both STMPE811 connected either via SPI or
+        The driver supports both stmpe811 connected either via SPI or
         I2C bus. Select one combination.
 
 config MODULE_STMPE811_I2C
     bool "STMPE811 on I2C"
     depends on HAS_PERIPH_I2C
     select MODULE_PERIPH_I2C
-    select MODULE_STMPE811
 
 config MODULE_STMPE811_SPI
     bool "STMPE811 on SPI"
     depends on HAS_PERIPH_SPI
+    depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_SPI
-    select MODULE_STMPE811
-
+    select MODULE_PERIPH_GPIO
 endchoice
+
+endif # MODULE_STMPE811
+
+config HAVE_STMPE811
+    bool
+    help
+      Indicates that an STMPE811 is present.
+
+config HAVE_STMPE811_I2C
+    bool
+    select HAVE_STMPE811
+    help
+      Indicates that an STMPE811 over I2C touch panel is present.
+
+config HAVE_STMPE811_SPI
+    bool
+    select HAVE_STMPE811
+    help
+      Indicates that an STMPE811 over SPI touch panel is present.

--- a/drivers/stmpe811/Kconfig
+++ b/drivers/stmpe811/Kconfig
@@ -9,13 +9,11 @@ config MODULE_STMPE811
     bool
     depends on HAS_PERIPH_GPIO
     depends on HAS_PERIPH_GPIO_IRQ
-    depends on HAS_PERIPH_I2C
     depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
-    depends on TEST_KCONFIG
 
 choice
     bool "STMPE811 Touchscreen Controller"

--- a/tests/disp_dev/app.config.test
+++ b/tests/disp_dev/app.config.test
@@ -1,0 +1,3 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_DISP_DEV=y

--- a/tests/driver_stmpe811/app.config.test
+++ b/tests/driver_stmpe811/app.config.test
@@ -1,3 +1,3 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
-CONFIG_MODULE_STMPE811_I2C=y
+CONFIG_MODULE_STMPE811=y

--- a/tests/touch_dev/Makefile
+++ b/tests/touch_dev/Makefile
@@ -4,6 +4,7 @@ include ../Makefile.tests_common
 DISABLE_MODULE += test_utils_interactive_sync
 
 USEMODULE += touch_dev
-USEMODULE += xtimer
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/touch_dev/app.config.test
+++ b/tests/touch_dev/app.config.test
@@ -1,0 +1,5 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TOUCH_DEV=y
+CONFIG_MODULE_ZTIMER=y
+CONFIG_MODULE_ZTIMER_MSEC=y

--- a/tests/touch_dev/main.c
+++ b/tests/touch_dev/main.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "touch_dev.h"
 
@@ -77,7 +77,7 @@ int main(void)
             printf("X: %i, Y:%i\n", touches[0].x, touches[0].y);
         }
 
-        xtimer_msleep(10);
+        ztimer_sleep(ZTIMER_MSEC, 10);
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR improves the Kconfig support around disp/touch_dev at several levels:
- add an app.config.test in related test applications (`tests/disp_dev` and `tests/touch_dev`)
- add missing `HAVE_` with the stmpe811 touch device (and also does some cleanup there)
- extend the stm32f429i-disc1 board Kconfig to declare it has an ili9341 compatible display and stmpe811 touch panel
- migrate the `tests/touch_dev` app to ztimer (since I was on it)
- add `tests/disp_dev` and `tests/touch_dev` apps to the list of apps tested on Murdock with Kconfig. That should help with #17437 and #17448.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that there were missing Kconfig options in stm32f429i-disc1 when working on #17448 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
