### PR TITLE
pkg/arduino_adafruit_sensor: add Adafruit Unified Sensor Driver as package

### DIFF
--- a/pkg/Kconfig
+++ b/pkg/Kconfig
@@ -6,6 +6,7 @@
 #
 menu "Packages"
 
+rsource "arduino_adafruit_sensor/Kconfig"
 rsource "arduino_sdi_12/Kconfig"
 rsource "c25519/Kconfig"
 rsource "cayenne-lpp/Kconfig"

--- a/pkg/arduino_adafruit_sensor/Kconfig
+++ b/pkg/arduino_adafruit_sensor/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config PACKAGE_ARDUINO_ADAFRUIT_SENSOR
+    bool "Arduino Adafruit Unified Sensor Driver package"
+    depends on TEST_KCONFIG
+    select MODULE_ARDUINO

--- a/pkg/arduino_adafruit_sensor/Makefile
+++ b/pkg/arduino_adafruit_sensor/Makefile
@@ -1,0 +1,9 @@
+PKG_NAME=arduino_adafruit_sensor
+PKG_URL=https://github.com/adafruit/Adafruit_Sensor
+PKG_VERSION=334044cc0bd087ff93629cef9ae8efc14e88ec73
+PKG_LICENSE=Apache-2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/arduino_adafruit_sensor/Makefile.dep
+++ b/pkg/arduino_adafruit_sensor/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += arduino
+FEATURES_REQUIRED += cpp
+
+USEMODULE += arduino

--- a/pkg/arduino_adafruit_sensor/Makefile.include
+++ b/pkg/arduino_adafruit_sensor/Makefile.include
@@ -1,0 +1,2 @@
+CFLAGS += "-DARDUINO = 100"
+INCLUDES += -I$(PKGDIRBASE)/arduino_adafruit_sensor

--- a/pkg/arduino_adafruit_sensor/doc.txt
+++ b/pkg/arduino_adafruit_sensor/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup pkg_adafruit_sensor Adafruit Unified Sensor Driver
+ * @ingroup  pkg
+ * @brief    Adafruit Unified Sensor Driver
+ * @see      https://github.com/adafruit/Adafruit_Sensor
+ */

--- a/pkg/arduino_adafruit_sensor/patches/0001-remove_include_Print_h.patch
+++ b/pkg/arduino_adafruit_sensor/patches/0001-remove_include_Print_h.patch
@@ -1,0 +1,24 @@
+From 66fe43c08e09331b1810a37c7b0edbedc212f871 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Sun, 2 Jan 2022 12:38:18 +0100
+Subject: [PATCH 1/3] remove_include_Print_h
+
+---
+ Adafruit_Sensor.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Adafruit_Sensor.h b/Adafruit_Sensor.h
+index 087eda5..77b70e1 100755
+--- a/Adafruit_Sensor.h
++++ b/Adafruit_Sensor.h
+@@ -24,7 +24,6 @@
+ #include <stdint.h>
+ #elif ARDUINO >= 100
+ #include "Arduino.h"
+-#include "Print.h"
+ #else
+ #include "WProgram.h"
+ #endif
+-- 
+2.17.1
+

--- a/pkg/arduino_adafruit_sensor/patches/0002-add_F_for_string_literals.patch
+++ b/pkg/arduino_adafruit_sensor/patches/0002-add_F_for_string_literals.patch
@@ -1,0 +1,24 @@
+From 0bc3004057327195bff710cd85961f97dfe4a38f Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Sun, 2 Jan 2022 13:58:33 +0100
+Subject: [PATCH 2/3] add_F_for_string_literals
+
+---
+ Adafruit_Sensor.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Adafruit_Sensor.cpp b/Adafruit_Sensor.cpp
+index 2a4513e..5b82a10 100644
+--- a/Adafruit_Sensor.cpp
++++ b/Adafruit_Sensor.cpp
+@@ -1,5 +1,7 @@
+ #include "Adafruit_Sensor.h"
+ 
++#define F(string_literal)       (string_literal)
++
+ /**************************************************************************/
+ /*!
+     @brief  Prints sensor information to serial console
+-- 
+2.17.1
+

--- a/pkg/arduino_adafruit_sensor/patches/0003-add_include_string_h.patch
+++ b/pkg/arduino_adafruit_sensor/patches/0003-add_include_string_h.patch
@@ -1,0 +1,25 @@
+From a72b5fb7f3003ee738706f1949c365860e06e3f0 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Sun, 2 Jan 2022 14:12:38 +0100
+Subject: [PATCH 3/3] add_include_string_h
+
+---
+ Adafruit_Sensor.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Adafruit_Sensor.h b/Adafruit_Sensor.h
+index 77b70e1..6844bca 100755
+--- a/Adafruit_Sensor.h
++++ b/Adafruit_Sensor.h
+@@ -28,6 +28,8 @@
+ #include "WProgram.h"
+ #endif
+ 
++#include <string.h>
++
+ /* Constants */
+ #define SENSORS_GRAVITY_EARTH (9.80665F) /**< Earth's gravity in m/s^2 */
+ #define SENSORS_GRAVITY_MOON (1.6F)      /**< The moon's gravity in m/s^2 */
+-- 
+2.17.1
+

--- a/tests/pkg_arduino_adafruit_sensor/Makefile
+++ b/tests/pkg_arduino_adafruit_sensor/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEPKG += arduino_adafruit_sensor
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_arduino_adafruit_sensor/Makefile.ci
+++ b/tests/pkg_arduino_adafruit_sensor/Makefile.ci
@@ -1,0 +1,6 @@
+BOARD_INSUFFICIENT_MEMORY := \
+  arduino-duemilanove \
+  arduino-uno \
+  arduino-nano \
+  nucleo-l011k4 \
+  #

--- a/tests/pkg_arduino_adafruit_sensor/app.config.test
+++ b/tests/pkg_arduino_adafruit_sensor/app.config.test
@@ -1,0 +1,3 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_PACKAGE_ARDUINO_ADAFRUIT_SENSOR=y

--- a/tests/pkg_arduino_adafruit_sensor/main.cpp
+++ b/tests/pkg_arduino_adafruit_sensor/main.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Gunar Schorcht <gunar@schorcht.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief    Tests the Adafruit Unified Sensor Drive
+ *
+ * @author   Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "Adafruit_Sensor.h"
+
+class ADXL345 : public Adafruit_Sensor
+{
+    public:
+        bool getEvent(sensors_event_t *) { return false; };
+        void getSensor(sensor_t *sensor);
+};
+
+void ADXL345::getSensor(sensor_t *s)
+{
+    memset(s, 0, sizeof(sensor_t));
+    strncpy(s->name, "ADXL345", ARRAY_SIZE(s->name) - 1);
+    s->version = 1;
+    s->sensor_id = 12345;
+    s->type = SENSOR_TYPE_ACCELEROMETER;
+    s->min_delay = 0;
+    s->min_value = -156.9064F; /* -16g = 156.9064 m/s^2  */
+    s->max_value = 156.9064F;  /*  16g = 156.9064 m/s^2  */
+    s->resolution = 0.03923F;  /*  4mg = 0.0392266 m/s^2 */
+}
+
+int main(void)
+{
+    ADXL345 adxl345;
+    adxl345.printSensorDetails();
+}

--- a/tests/pkg_arduino_adafruit_sensor/tests/01-run.py
+++ b/tests/pkg_arduino_adafruit_sensor/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 Gunar Schorchtr <gunar@schorcht.net>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('------------------------------------')
+    child.expect_exact('Sensor:       ADXL345')
+    child.expect_exact('Type:         Acceleration (m/s2)')
+    child.expect_exact('Driver Ver:   1')
+    child.expect_exact('Unique ID:    12345')
+    child.expect_exact('Min Value:    -156.90')
+    child.expect_exact('Max Value:    156.90')
+    child.expect_exact('Resolution:   0.03')
+    child.expect_exact('------------------------------------')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR provides the [Adafruit Unified Sensor Driver](https://github.com/adafruit/Adafruit_Sensor) as package.

There are a number of Adafruit sensor drivers which all use a common base class `Adafruit_Sensor` from the [Adafruit Unified Sensor Driver](https://github.com/adafruit/Adafruit_Sensor). To support such drivers, the Adafruit Unified Sensor Driver is provided as package.

Adafruit sensor driver for ST LSM9DS0 will be provided as separat PR as package for demonstration and testing.

PR #12518 will be rebased for testing to have an Adafruit sensor driver for a sensor for which there is a native driver in RIOT.

### Testing procedure

Use a board that provides the `arduino` feature and flash
```
BOARD=... make -C tests/pkg_arduino_adafruit_sensor flash test
```
PR #12518 can be used as a more complex test for using the package.

### Issues/PRs references

Prerequisite for PR #12518