### PR TITLE
doc: fix missing or non matching arguments in Doxygen documentation

### DIFF
--- a/drivers/include/can/candev.h
+++ b/drivers/include/can/candev.h
@@ -63,7 +63,7 @@ typedef struct candev candev_t;
  * @brief   Event callback for signaling event to upper layers
  *
  * @param[in] dev           CAN device descriptor
- * @param[in] type          type of the event
+ * @param[in] event         type of the event
  * @param[in] arg           event argument
  */
 typedef void (*candev_event_cb_t)(candev_t *dev, candev_event_t event, void *arg);

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -289,7 +289,8 @@ typedef struct netdev netdev_t;
 /**
  * @brief   Event callback for signaling event to upper layers
  *
- * @param[in] type          type of the event
+ * @param[in] dev           pointer to the device descriptor
+ * @param[in] event         type of the event
  */
 typedef void (*netdev_event_cb_t)(netdev_t *dev, netdev_event_t event);
 

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -104,6 +104,7 @@ typedef struct cipher_interface_st {
                    uint8_t *plain_block);
 } cipher_interface_t;
 
+/** Pointer type to BlockCipher-Interface for the Cipher-Algorithms */
 typedef const cipher_interface_t *cipher_id_t;
 
 /**

--- a/sys/include/net/cord/ep_standalone.h
+++ b/sys/include/net/cord/ep_standalone.h
@@ -45,7 +45,7 @@ typedef enum {
  * The registered callback function is executed in the context of the dedicated
  * standalone RD endpoint's thread.
  *
- * @param[in] t         type of event
+ * @param[in] event     type of event
  */
 typedef void(*cord_ep_standalone_cb_t)(cord_ep_standalone_event_t event);
 

--- a/sys/include/net/sock/async/types.h
+++ b/sys/include/net/sock/async/types.h
@@ -154,7 +154,7 @@ typedef struct sock_udp sock_udp_t;     /**< forward declare for async */
  * @param[in] arg   Argument provided when setting the callback using
  *                  @ref sock_udp_set_cb(). May be NULL.
  */
-typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type,
+typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t flags,
                               void *arg);
 #endif  /* defined(MODULE_SOCK_UDP) || defined(DOXYGEN) */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR provides minor Doxygen documentation fixes that are reported locally when running `make static-test`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Check the generated documentation on Circle CI
- Issues are not reported anymore when running Doxygen (1.9.1 locally):

<details><summary>this PR</summary>

```
$ make static-test 
./dist/tools/ci/static_tests.sh
Running "./dist/tools/whitespacecheck/check.sh master" ✓
Running "./dist/tools/licenses/check.sh" ✓
Running "./dist/tools/licenses/check.sh" ✓
Running "./dist/tools/doccheck/check.sh" ✓
Running "./dist/tools/externc/check.sh" ✓
Required command 'vera++' for './dist/tools/vera++/check.sh' not found in PATH •
Running "./dist/tools/coccinelle/check.sh" ✓
Running "./dist/tools/flake8/check.sh" ✓
Running "./dist/tools/headerguards/check.sh" ✓
Running "./dist/tools/buildsystem_sanity_check/check.sh" ✓
Running "./dist/tools/feature_resolution/check.sh" ✓
Command output:

	Running test blacklist-failure
	Success
	Running test blacklist-optional
	Success
	Running test blacklist-success
	Success
	Running test complex-failure
	Success
	Running test complex-success
	Success
	Running test conflict-failure
	Success
	Running test conflict-optional
	Success
	Running test conflict-success
	Success
	Running test empty
	Success
	Running test required-any-corner-case
	Success
	Running test required-any-fail
	Success
	Running test required-any-order
	Success
	Running test required-any-reuse-optional
	Success
	Running test required-any-reuse-required
	Success
	Running test trivial-failure
	Success
	Running test trivial-success
	Success

Running "./dist/tools/boards_supported/check.sh" ✓
Command output:

	6lowpan-clicker acd52832 adafruit-clue adafruit-itsybitsy-m4 adafruit-itsybitsy-nrf52 airfy-beacon alientek-pandora arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-nano-33-ble arduino-nano-33-iot arduino-uno arduino-zero atmega1284p atmega256rfr2-xpro atmega328p atmega328p-xplained-mini atxmega-a1-xplained atxmega-a1u-xpro atxmega-a3bu-xplained avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a b-u585i-iot02a bastwan blackpill blackpill-128kib bluepill bluepill-128kib bluepill-stm32f030c8 calliope-mini cc1312-launchpad cc1350-launchpad cc1352-launchpad cc1352p-launchpad cc2538dk cc2650-launchpad cc2650stk derfmega128 derfmega256 dwm1001 e104-bt5010a-tb e104-bt5011a-tb e180-zg120b-tb ek-lm4f120xl esp32-ethernet-kit-v1_0 esp32-ethernet-kit-v1_1 esp32-ethernet-kit-v1_2 esp32-heltec-lora32-v2 esp32-mh-et-live-minikit esp32-olimex-evb esp32-ttgo-t-beam esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 feather-m0 feather-m0-lora feather-m0-wifi feather-nrf52840 firefly frdm-k22f frdm-k64f frdm-kl43z frdm-kw41z hamilton hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lora-e5-dev lsn50 maple-mini mbed_lpc1768 mcb2388 mega-xplained microbit microbit-v2 microduino-corerf msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840-mdk-dongle nrf52840dk nrf52840dongle nrf52dk nrf6310 nrf9160dk nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-g070rb nucleo-g071rb nucleo-g431rb nucleo-g474re nucleo-l011k4 nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l412kb nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nucleo-l552ze-q nucleo-wl55jc nz32-sc151 olimexino-stm32 omote opencm904 openlabs-kw41z-mini openlabs-kw41z-mini-256kib openmote-b openmote-cc2538 p-l496g-cell02 p-nucleo-wb55 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-wifire pinetime pyboard qn9080dk reel remote-pa remote-reva remote-revb rpi-pico ruuvitag samd10-xmini samd20-xpro samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeedstudio-gd32 seeeduino_arch-pro seeeduino_xiao sensebox_samd21 serpente slstk3400a slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff sodaq-sara-sff spark-core stk3200 stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f429i-disco stm32f469i-disco stm32f4discovery stm32f723e-disco stm32f746g-disco stm32f769i-disco stm32g0316-disco stm32l0538-disco stm32l476g-disco stm32mp157c-dk2 teensy31 telosb thingy52 ublox-c030-u201 udoo usb-kw41z waspmote-pro weact-f401cc weact-f401ce weact-f411ce wemos-zero yarm yunjia-nrf51822 z1 zigduino

Running "./dist/tools/codespell/check.sh" ✓
Running "./dist/tools/uncrustify/uncrustify.sh --check" ✓
Command output:

	All files are uncrustified!

Running "./dist/tools/shellcheck/check.sh" ✓

```

</details>

<details><summary>master</summary>

```
$ make static-test 
./dist/tools/ci/static_tests.sh
Running "./dist/tools/whitespacecheck/check.sh master" ✓
Running "./dist/tools/licenses/check.sh" ✓
Running "./dist/tools/licenses/check.sh" ✓
Running "./dist/tools/doccheck/check.sh" x
Command output:

	ERROR: Doxygen generates the following warnings:
	sys/include/crypto/ciphers.h:107: warning: Member cipher_id_t (typedef) of file ciphers.h is not documented.
	drivers/include/can/candev.h:65: warning: argument 'type' of command @param is not found in the argument list of candev_event_cb_t(candev_t *dev, candev_event_t event, void *arg)
	drivers/include/can/candev.h:69: warning: The following parameter of candev_event_cb_t(candev_t *dev, candev_event_t event, void *arg) is not documented:
	sys/include/net/cord/ep_standalone.h:45: warning: argument 't' of command @param is not found in the argument list of cord_ep_standalone_cb_t(cord_ep_standalone_event_t event)
	sys/include/net/cord/ep_standalone.h:50: warning: The following parameter of cord_ep_standalone_cb_t(cord_ep_standalone_event_t event) is not documented:
	drivers/include/net/netdev.h:292: warning: argument 'type' of command @param is not found in the argument list of netdev_event_cb_t(netdev_t *dev, netdev_event_t event)
	drivers/include/net/netdev.h:294: warning: The following parameters of netdev_event_cb_t(netdev_t *dev, netdev_event_t event) are not documented:
	sys/include/net/sock/async/types.h:144: warning: argument 'flags' of command @param is not found in the argument list of sock_udp_cb_t(sock_udp_t *sock, sock_async_flags_t type, void *arg)
	sys/include/net/sock/async/types.h:157: warning: The following parameter of sock_udp_cb_t(sock_udp_t *sock, sock_async_flags_t type, void *arg) is not documented:

Running "./dist/tools/externc/check.sh" ✓
Required command 'vera++' for './dist/tools/vera++/check.sh' not found in PATH •
Running "./dist/tools/coccinelle/check.sh" ✓
Running "./dist/tools/flake8/check.sh" ✓
Running "./dist/tools/headerguards/check.sh" ✓
Running "./dist/tools/buildsystem_sanity_check/check.sh" ✓
Running "./dist/tools/feature_resolution/check.sh" ✓
Command output:

	Running test blacklist-failure
	Success
	Running test blacklist-optional
	Success
	Running test blacklist-success
	Success
	Running test complex-failure
	Success
	Running test complex-success
	Success
	Running test conflict-failure
	Success
	Running test conflict-optional
	Success
	Running test conflict-success
	Success
	Running test empty
	Success
	Running test required-any-corner-case
	Success
	Running test required-any-fail
	Success
	Running test required-any-order
	Success
	Running test required-any-reuse-optional
	Success
	Running test required-any-reuse-required
	Success
	Running test trivial-failure
	Success
	Running test trivial-success
	Success

Running "./dist/tools/boards_supported/check.sh" ✓
Command output:

	6lowpan-clicker acd52832 adafruit-clue adafruit-itsybitsy-m4 adafruit-itsybitsy-nrf52 airfy-beacon alientek-pandora arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano arduino-nano-33-ble arduino-nano-33-iot arduino-uno arduino-zero atmega1284p atmega256rfr2-xpro atmega328p atmega328p-xplained-mini atxmega-a1-xplained atxmega-a1u-xpro atxmega-a3bu-xplained avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a b-u585i-iot02a bastwan blackpill blackpill-128kib bluepill bluepill-128kib bluepill-stm32f030c8 calliope-mini cc1312-launchpad cc1350-launchpad cc1352-launchpad cc1352p-launchpad cc2538dk cc2650-launchpad cc2650stk derfmega128 derfmega256 dwm1001 e104-bt5010a-tb e104-bt5011a-tb e180-zg120b-tb ek-lm4f120xl esp32-ethernet-kit-v1_0 esp32-ethernet-kit-v1_1 esp32-ethernet-kit-v1_2 esp32-heltec-lora32-v2 esp32-mh-et-live-minikit esp32-olimex-evb esp32-ttgo-t-beam esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 feather-m0 feather-m0-lora feather-m0-wifi feather-nrf52840 firefly frdm-k22f frdm-k64f frdm-kl43z frdm-kw41z hamilton hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lora-e5-dev lsn50 maple-mini mbed_lpc1768 mcb2388 mega-xplained microbit microbit-v2 microduino-corerf msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840-mdk-dongle nrf52840dk nrf52840dongle nrf52dk nrf6310 nrf9160dk nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-g070rb nucleo-g071rb nucleo-g431rb nucleo-g474re nucleo-l011k4 nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l412kb nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nucleo-l552ze-q nucleo-wl55jc nz32-sc151 olimexino-stm32 omote opencm904 openlabs-kw41z-mini openlabs-kw41z-mini-256kib openmote-b openmote-cc2538 p-l496g-cell02 p-nucleo-wb55 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-wifire pinetime pyboard qn9080dk reel remote-pa remote-reva remote-revb rpi-pico ruuvitag samd10-xmini samd20-xpro samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeedstudio-gd32 seeeduino_arch-pro seeeduino_xiao sensebox_samd21 serpente slstk3400a slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff sodaq-sara-sff spark-core stk3200 stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f429i-disco stm32f469i-disco stm32f4discovery stm32f723e-disco stm32f746g-disco stm32f769i-disco stm32g0316-disco stm32l0538-disco stm32l476g-disco stm32mp157c-dk2 teensy31 telosb thingy52 ublox-c030-u201 udoo usb-kw41z waspmote-pro weact-f401cc weact-f401ce weact-f411ce wemos-zero yarm yunjia-nrf51822 z1 zigduino

Running "./dist/tools/codespell/check.sh" ✓
Running "./dist/tools/uncrustify/uncrustify.sh --check" ✓
Command output:

	All files are uncrustified!

Running "./dist/tools/shellcheck/check.sh" ✓
make: *** [makefiles/tests.inc.mk:3: static-test] Error 1
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
