### PR TITLE
boards/stm32f723e-disco: use connect_assert_srst with openocd

### DIFF
--- a/boards/stm32f723e-disco/Makefile.include
+++ b/boards/stm32f723e-disco/Makefile.include
@@ -9,3 +9,7 @@ OPENOCD_DEBUG_ADAPTER ?= stlink
 
 # openocd programmer is supported
 PROGRAMMERS_SUPPORTED += openocd
+
+# The board can become un-flashable after some execution or after being plugged,
+# use connect_assert_srst to always be able to flash or reset the board.
+OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR enables the `connect_assert_srst` of OpenOCD `reset_config` command with the `stm32f723e-disco` board. After being plugged the first time, the first flash attempt always fails on master. With this PR it works.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Flashing works reliably:

<details><summary>this PR (just after the board is plugged)</summary>

```
$ make BOARD=stm32f723e-disco -C examples/hello-world/ flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/stm32f723e-disco/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0+dev-00546-g5795f4d3e (2021-12-23-10:48)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 2000 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.235263
Info : stm32f7x.cpu: Cortex-M7 r1p1 processor detected
Info : stm32f7x.cpu: target has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f7x.cpu on 0
Info : Listening on port 43471 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f7x.cpu       hla_target little stm32f7x.cpu       reset

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000880 msp: 0x20000200
Info : device id = 0x10006452
Info : flash size = 512 kbytes
auto erase enabled
wrote 16384 bytes from file /work/riot/RIOT/examples/hello-world/bin/stm32f723e-disco/hello-world.elf in 0.626095s (25.555 KiB/s)

verified 10068 bytes in 0.083516s (117.726 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
```

</details>

<details><summary>master (just after the board is plugged)</summary>

```
$ make BOARD=stm32f723e-disco -C examples/hello-world/ flash-only --no-print-directory 
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/stm32f723e-disco/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0+dev-00546-g5795f4d3e (2021-12-23-10:48)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
Info : clock speed 2000 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.233136
Error: Cortex-M PARTNO 0x0 is unrecognized
Warn : target stm32f7x.cpu examination failed
Info : starting gdb server for stm32f7x.cpu on 0
Info : Listening on port 41639 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f7x.cpu       hla_target little stm32f7x.cpu       unknown

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Error: Cortex-M PARTNO 0x0 is unrecognized
TARGET: stm32f7x.cpu - Not halted
make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:807: flash-only] Error 1
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
