### PR TITLE
boards/p-l496g-cell02: add riotboot feature

### DIFF
--- a/boards/p-l496g-cell02/Kconfig
+++ b/boards/p-l496g-cell02/Kconfig
@@ -23,6 +23,9 @@ config BOARD_P_L496G_CELL02
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
 
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
     # Clock configuration
     select BOARD_HAS_LSE
 

--- a/boards/p-l496g-cell02/Makefile.features
+++ b/boards/p-l496g-cell02/Makefile.features
@@ -11,3 +11,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As the title says.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `tests/riotboot` works on p-l496g-cell02:

<details>

```
$ make BOARD=p-l496g-cell02 -C tests/riotboot flash test
make: Entering directory '/work/riot/RIOT/tests/riotboot'
Building application "tests_riotboot" for "p-l496g-cell02" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/p-l496g-cell02
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/boards/p-l496g-cell02
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/malloc_thread_safe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot0.1641217693.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  14480	    132	   2380	  16992	   4260	/work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot0-extended.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08000000
Open On-Chip Debugger 0.11.0-dirty (2022-01-03-14:47)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.236915
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 46709 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       halted

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080003a8 msp: 0x20000200
Info : device idcode = 0x20006461 (STM32L49/L4Axx - Rev B : 0x2000)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Warn : Adding extra erase range, 0x08080c00 .. 0x08080fff
auto erase enabled
wrote 527360 bytes from file /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot0-extended.bin in 22.347906s (23.045 KiB/s)

verified 527360 bytes in 15.062105s (34.192 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x61d2fe9d

compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot1.1641217694.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot1.1641217694.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08080800
Open On-Chip Debugger 0.11.0-dirty (2022-01-03-14:47)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Warn : Transport "hla_swd" was already selected
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.235333
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 42167 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       halted

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000408 msp: 0x20000200
Info : device idcode = 0x20006461 (STM32L49/L4Axx - Rev B : 0x2000)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Info : Padding image section 0 at 0x08084514 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08084518 .. 0x080847ff
auto erase enabled
wrote 15640 bytes from file /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot1.1641217694.riot.bin in 0.932985s (16.371 KiB/s)

verified 15636 bytes in 0.507071s (30.113 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=1
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x61d2fe9e
Image start address: 0x08080c00
Header chksum: 0x9d75121b

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x08001400
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001400
slot 1: metadata: 0x8080800 image: 0x08080c00
> 
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot0.1641217695.riot.bin...
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot0.1641217695.riot.bin
### Flashing Target ###
Binfile detected, adding ROM base address: 0x08000000
Flashing with IMAGE_OFFSET: 0x08001000
Open On-Chip Debugger 0.11.0-dirty (2022-01-03-14:47)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Warn : Transport "hla_swd" was already selected
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.238497
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
Info : starting gdb server for stm32l4x.cpu on 0
Info : Listening on port 45539 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       halted

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000408 msp: 0x20000200
Info : device idcode = 0x20006461 (STM32L49/L4Axx - Rev B : 0x2000)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Info : Padding image section 0 at 0x08004d14 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08004d18 .. 0x08004fff
auto erase enabled
wrote 15640 bytes from file /work/riot/RIOT/tests/riotboot/bin/p-l496g-cell02/tests_riotboot-slot0.1641217695.riot.bin in 0.934231s (16.349 KiB/s)

verified 15636 bytes in 0.517756s (29.492 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
Error executing event examine-end on target stm32l4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:37: Error: wrong # args: should be "expr expression"
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 288
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32l4x.cfg", line 108
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 37
shutdown command invoked
Done flashing


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.

> 
> curslotnr
curslotnr
Current slot=0
> curslothdr
curslothdr
Image magic_number: 0x544f4952
Image Version: 0x61d2fe9f
Image start address: 0x08001400
Header chksum: 0xad711a14

> getslotaddr 0
getslotaddr 0
Slot 0 address=0x08001400
> dumpaddrs
dumpaddrs
slot 0: metadata: 0x8001000 image: 0x08001400
slot 1: metadata: 0x8080800 image: 0x08080c00
> 
TEST PASSED
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
