### PR TITLE
drivers/sdcard_spi: replace GPIO_UNDEF by SPI_CS_UNDEF

### DIFF
--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -364,7 +364,7 @@ static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, uint32_t r
 
     do {
         uint8_t read_byte = 0;
-        read_byte = spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true,
+        read_byte = spi_transfer_byte(card->params.spi_dev, SPI_CS_UNDEF, true,
                                       SD_CARD_DUMMY_BYTE);
         if (read_byte == token) {
             DEBUG("_wait_for_token: [MATCH]\n");
@@ -553,7 +553,7 @@ static inline uint8_t _wait_for_r1(sdcard_spi_t *card, uint32_t retry_us)
 
 void _select_card_spi(sdcard_spi_t *card)
 {
-    spi_acquire(card->params.spi_dev, GPIO_UNDEF,
+    spi_acquire(card->params.spi_dev, SPI_CS_UNDEF,
                 SD_CARD_SPI_MODE, card->spi_clk);
     gpio_clear(card->params.cs);
 }
@@ -588,7 +588,7 @@ static inline int _sw_spi_rxtx_byte(sdcard_spi_t *card, uint8_t out, uint8_t *in
 
 static inline int _hw_spi_rxtx_byte(sdcard_spi_t *card, uint8_t out, uint8_t *in)
 {
-    *in = spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true, out);
+    *in = spi_transfer_byte(card->params.spi_dev, SPI_CS_UNDEF, true, out);
     return 1;
 }
 
@@ -726,7 +726,7 @@ static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, uint8_t token, co
                                            int size)
 {
 
-    spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true, token);
+    spi_transfer_byte(card->params.spi_dev, SPI_CS_UNDEF, true, token);
 
     if (_transfer_bytes(card, data, 0, size) == size) {
 
@@ -735,7 +735,7 @@ static sd_rw_response_t _write_data_packet(sdcard_spi_t *card, uint8_t token, co
 
         if (_transfer_bytes(card, crc, 0, sizeof(crc)) == sizeof(crc)) {
 
-            uint8_t data_response = spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF,
+            uint8_t data_response = spi_transfer_byte(card->params.spi_dev, SPI_CS_UNDEF,
                                                       true, SD_CARD_DUMMY_BYTE);
 
             DEBUG("_write_data_packet: DATA_RESPONSE: 0x%02x\n", data_response);
@@ -817,7 +817,7 @@ static inline int _write_blocks(sdcard_spi_t *card, uint8_t cmd_idx, int bladdr,
         /* if this is a multi-block write it is needed to issue a stop
            command */
         if (cmd_idx == SD_CMD_25) {
-            spi_transfer_byte(card->params.spi_dev, GPIO_UNDEF, true,
+            spi_transfer_byte(card->params.spi_dev, SPI_CS_UNDEF, true,
                               SD_DATA_TOKEN_CMD_25_STOP);
             DEBUG("_write_blocks: write multi (%d) blocks: [OK]\n", nbl);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is a partial takeover of #6486: it addresses the `sdcard_spi` driver related changes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock is enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Partial takeover of #6486

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
