### PR TITLE
drivers: only build saul interface if saul module is used + add saul_drivers test application

### DIFF
--- a/drivers/ad7746/Makefile
+++ b/drivers/ad7746/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/adcxx1c/Makefile
+++ b/drivers/adcxx1c/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ads101x/Makefile
+++ b/drivers/ads101x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/adxl345/Makefile
+++ b/drivers/adxl345/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/apds99xx/Makefile
+++ b/drivers/apds99xx/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/bme680/Makefile
+++ b/drivers/bme680/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/bmp180/Makefile
+++ b/drivers/bmp180/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/bmx055/Makefile
+++ b/drivers/bmx055/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/bmx280/Makefile
+++ b/drivers/bmx280/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ccs811/Makefile
+++ b/drivers/ccs811/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/dht/Makefile
+++ b/drivers/dht/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ds18/Makefile
+++ b/drivers/ds18/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ds75lx/Makefile
+++ b/drivers/ds75lx/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/fxos8700/Makefile
+++ b/drivers/fxos8700/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/gp2y10xx/Makefile
+++ b/drivers/gp2y10xx/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/hdc1000/Makefile
+++ b/drivers/hdc1000/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/hm330x/Makefile
+++ b/drivers/hm330x/Makefile
@@ -1,7 +1,1 @@
-SRC := hm330x.c
-
-ifneq (,$(filter saul,$(USEMODULE)))
-  SRC += hm330x_saul.c
-endif
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/hmc5883l/Makefile
+++ b/drivers/hmc5883l/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/hsc/Makefile
+++ b/drivers/hsc/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/hts221/Makefile
+++ b/drivers/hts221/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ili9341/Makefile
+++ b/drivers/ili9341/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_disp_dev.mk

--- a/drivers/ina2xx/Makefile
+++ b/drivers/ina2xx/Makefile
@@ -1,3 +1,1 @@
-MODULE = ina2xx
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/include/lis2dh12.h
+++ b/drivers/include/lis2dh12.h
@@ -37,6 +37,7 @@
 #define LIS2DH12_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "saul.h"
 #include "lis2dh12_registers.h"

--- a/drivers/io1_xplained/Makefile
+++ b/drivers/io1_xplained/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/isl29020/Makefile
+++ b/drivers/isl29020/Makefile
@@ -1,3 +1,1 @@
-MODULE = isl29020
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/itg320x/Makefile
+++ b/drivers/itg320x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/jc42/Makefile
+++ b/drivers/jc42/Makefile
@@ -1,2 +1,1 @@
-MODULE = jc42
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/l3g4200d/Makefile
+++ b/drivers/l3g4200d/Makefile
@@ -1,3 +1,1 @@
-MODULE = l3g4200d
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lis2dh12/Makefile
+++ b/drivers/lis2dh12/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lis3dh/Makefile
+++ b/drivers/lis3dh/Makefile
@@ -1,3 +1,1 @@
-MODULE = lis3dh
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lis3mdl/Makefile
+++ b/drivers/lis3mdl/Makefile
@@ -1,3 +1,1 @@
-MODULE = lis3mdl
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lm75/Makefile
+++ b/drivers/lm75/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lpsxxx/Makefile
+++ b/drivers/lpsxxx/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lsm303dlhc/Makefile
+++ b/drivers/lsm303dlhc/Makefile
@@ -1,3 +1,1 @@
-MODULE = lsm303dlhc
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/lsm6dsl/Makefile
+++ b/drivers/lsm6dsl/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ltc4150/Makefile
+++ b/drivers/ltc4150/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/mag3110/Makefile
+++ b/drivers/mag3110/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/mhz19/Makefile
+++ b/drivers/mhz19/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/mma7660/Makefile
+++ b/drivers/mma7660/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/mma8x5x/Makefile
+++ b/drivers/mma8x5x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/mpl3115a2/Makefile
+++ b/drivers/mpl3115a2/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/mpu9x50/Makefile
+++ b/drivers/mpu9x50/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/opt3001/Makefile
+++ b/drivers/opt3001/Makefile
@@ -1,3 +1,1 @@
-MODULE = opt3001
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/pca9685/Makefile
+++ b/drivers/pca9685/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/pcf857x/Makefile
+++ b/drivers/pcf857x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/ph_oem/Makefile
+++ b/drivers/ph_oem/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/pir/Makefile
+++ b/drivers/pir/Makefile
@@ -1,3 +1,1 @@
-MODULE = pir
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/qmc5883l/Makefile
+++ b/drivers/qmc5883l/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/saul/init_devs/auto_init_hm330x.c
+++ b/drivers/saul/init_devs/auto_init_hm330x.c
@@ -27,11 +27,14 @@
  */
 static hm330x_t hm330x_devs[HM330X_NUMOF];
 
-#if IS_ACTIVE(MODULE_SAUL)
 /**
  * @brief   Number of logical saul devices per physical sensor
  */
+#if IS_USED(MODULE_HM3302)
 #define HM330X_SAUL_DEV_NUM      (6)
+#else
+#define HM330X_SAUL_DEV_NUM      (3)
+#endif
 
 /**
  * @brief   Memory for the SAUL registry entries
@@ -50,17 +53,16 @@ static saul_reg_t saul_entries[HM330X_NUMOF * HM330X_SAUL_DEV_NUM];
 extern const saul_driver_t hm330x_saul_driver_mc_pm_1;
 extern const saul_driver_t hm330x_saul_driver_mc_pm_2p5;
 extern const saul_driver_t hm330x_saul_driver_mc_pm_10;
+#if IS_USED(MODULE_HM3302)
 extern const saul_driver_t hm330x_saul_driver_nc_pm_1;
 extern const saul_driver_t hm330x_saul_driver_nc_pm_2p5;
 extern const saul_driver_t hm330x_saul_driver_nc_pm_10;
-/** @} */
 #endif
+/** @} */
 
 void auto_init_hm330x(void)
 {
-#if IS_ACTIVE(MODULE_SAUL)
     assert(HM330X_INFO_NUM == HM330X_NUMOF);
-#endif
 
     for (unsigned int i = 0; i < HM330X_NUMOF; i++) {
         LOG_DEBUG("[auto_init_saul] initializing hm330x #%u\n", i);
@@ -70,19 +72,19 @@ void auto_init_hm330x(void)
                       i);
             continue;
         }
-    #if IS_ACTIVE(MODULE_SAUL)
         saul_entries[(i * HM330X_SAUL_DEV_NUM)].driver = &hm330x_saul_driver_mc_pm_1;
         saul_entries[(i * HM330X_SAUL_DEV_NUM) + 1].driver = &hm330x_saul_driver_mc_pm_2p5;
         saul_entries[(i * HM330X_SAUL_DEV_NUM) + 2].driver = &hm330x_saul_driver_mc_pm_10;
+#if IS_USED(MODULE_HM3302)
         saul_entries[(i * HM330X_SAUL_DEV_NUM) + 3].driver = &hm330x_saul_driver_nc_pm_1;
         saul_entries[(i * HM330X_SAUL_DEV_NUM) + 4].driver = &hm330x_saul_driver_nc_pm_2p5;
         saul_entries[(i * HM330X_SAUL_DEV_NUM) + 5].driver = &hm330x_saul_driver_nc_pm_10;
+#endif
         /* the physical device is the same for all logical SAUL instances */
         for (unsigned x = 0; x < HM330X_SAUL_DEV_NUM; x++) {
             saul_entries[i * HM330X_SAUL_DEV_NUM + x].dev = &(hm330x_devs[i]);
             saul_entries[i * HM330X_SAUL_DEV_NUM + x].name = hm330x_saul_info[i].name;
             saul_reg_add(&saul_entries[i * HM330X_SAUL_DEV_NUM + x]);
         }
-    #endif
     }
 }

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -251,13 +251,13 @@ void saul_init_devs(void)
         extern void auto_init_scd30(void);
         auto_init_scd30();
     }
-    if (IS_USED(MODULE_SHT2X)) {
-        extern void auto_init_sht2x(void);
-        auto_init_sht2x();
-    }
     if (IS_USED(MODULE_SDP3X)) {
         extern void auto_init_sdp3x(void);
         auto_init_sdp3x();
+    }
+    if (IS_USED(MODULE_SDS011)) {
+        extern void auto_init_sds011(void);
+        auto_init_sds011();
     }
     if (IS_USED(MODULE_SEESAW_SOIL)) {
         extern void auto_init_seesaw_soil(void);
@@ -267,6 +267,10 @@ void saul_init_devs(void)
         extern void auto_init_sgp30(void);
         auto_init_sgp30();
     }
+    if (IS_USED(MODULE_SHT2X)) {
+        extern void auto_init_sht2x(void);
+        auto_init_sht2x();
+    }
     if (IS_USED(MODULE_SHT3X)) {
         extern void auto_init_sht3x(void);
         auto_init_sht3x();
@@ -274,10 +278,6 @@ void saul_init_devs(void)
     if (IS_USED(MODULE_SHTC1)) {
         extern void auto_init_shtc1(void);
         auto_init_shtc1();
-    }
-    if (IS_USED(MODULE_SDS011)) {
-        extern void auto_init_sds011(void);
-        auto_init_sds011();
     }
     if (IS_USED(MODULE_SI1133)) {
         extern void auto_init_si1133(void);

--- a/drivers/scd30/Makefile
+++ b/drivers/scd30/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sdp3x/Makefile
+++ b/drivers/sdp3x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sds011/Makefile
+++ b/drivers/sds011/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/seesaw_soil/Makefile
+++ b/drivers/seesaw_soil/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sgp30/Makefile
+++ b/drivers/sgp30/Makefile
@@ -1,7 +1,1 @@
-SRC := sgp30.c
-
-ifneq (,$(filter saul,$(USEMODULE)))
-  SRC += sgp30_saul.c
-endif
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sht1x/Makefile
+++ b/drivers/sht1x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sht2x/Makefile
+++ b/drivers/sht2x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sht3x/Makefile
+++ b/drivers/sht3x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/shtc1/Makefile
+++ b/drivers/shtc1/Makefile
@@ -1,3 +1,1 @@
-MODULE = shtc1
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/si1133/Makefile
+++ b/drivers/si1133/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/si114x/Makefile
+++ b/drivers/si114x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/si70xx/Makefile
+++ b/drivers/si70xx/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sm_pwm_01c/Makefile
+++ b/drivers/sm_pwm_01c/Makefile
@@ -1,7 +1,1 @@
-SRC := sm_pwm_01c.c
-
-ifneq (,$(filter saul,$(USEMODULE)))
-  SRC += sm_pwm_01c_saul.c
-endif
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/sm_pwm_01c/sm_pwm_01c_saul.c
+++ b/drivers/sm_pwm_01c/sm_pwm_01c_saul.c
@@ -55,12 +55,10 @@ const saul_driver_t sm_pwm_01c_saul_driver_mc_pm_10 = {
     .read = read_mc_pm_10,
     .write = saul_notsup,
     .type = SAUL_SENSE_PM,
-    .subtype = SAUL_SENSE_PM_10,
 };
 
 const saul_driver_t sm_pwm_01c_saul_driver_mc_pm_2p5 = {
     .read = read_mc_pm_2p5,
     .write = saul_notsup,
     .type = SAUL_SENSE_PM,
-    .subtype = SAUL_SENSE_PM_2p5,
 };

--- a/drivers/sps30/Makefile
+++ b/drivers/sps30/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/stmpe811/Makefile
+++ b/drivers/stmpe811/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_touch_dev.mk

--- a/drivers/tcs37727/Makefile
+++ b/drivers/tcs37727/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/tmp00x/Makefile
+++ b/drivers/tmp00x/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/tsl2561/Makefile
+++ b/drivers/tsl2561/Makefile
@@ -1,3 +1,1 @@
-MODULE = tsl2561
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/tsl4531x/Makefile
+++ b/drivers/tsl4531x/Makefile
@@ -1,3 +1,1 @@
-MODULE = tsl4531x
-
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/vcnl40x0/Makefile
+++ b/drivers/vcnl40x0/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/drivers/veml6070/Makefile
+++ b/drivers/veml6070/Makefile
@@ -1,1 +1,1 @@
-include $(RIOTBASE)/Makefile.base
+include $(RIOTMAKE)/driver_with_saul.mk

--- a/makefiles/driver_with_disp_dev.mk
+++ b/makefiles/driver_with_disp_dev.mk
@@ -1,0 +1,12 @@
+MODULE ?= $(shell basename $(CURDIR))
+DISP_DEV_INTERFACE ?= $(MODULE)_disp_dev.c
+
+# by default include all .c files except <module>_disp_dev.c
+SRC = $(filter-out $(DISP_DEV_INTERFACE),$(wildcard *.c))
+
+# only include <module>_disp_dev.c if saul module is used
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  SRC += $(DISP_DEV_INTERFACE)
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/makefiles/driver_with_saul.mk
+++ b/makefiles/driver_with_saul.mk
@@ -1,0 +1,12 @@
+MODULE ?= $(shell basename $(CURDIR))
+SAUL_INTERFACE ?= $(MODULE)_saul.c
+
+# by default include all .c files except <module>_saul.c
+SRC = $(filter-out $(SAUL_INTERFACE),$(wildcard *.c))
+
+# only include <module>_saul.c if saul module is used
+ifneq (,$(filter saul,$(USEMODULE)))
+  SRC += $(SAUL_INTERFACE)
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/makefiles/driver_with_touch_dev.mk
+++ b/makefiles/driver_with_touch_dev.mk
@@ -1,0 +1,12 @@
+MODULE ?= $(shell basename $(CURDIR))
+TOUCH_DEV_INTERFACE ?= $(MODULE)_touch_dev.c
+
+# by default include all .c files except <module>_touch_dev.c
+SRC = $(filter-out $(TOUCH_DEV_INTERFACE),$(wildcard *.c))
+
+# only include <module>_touch_dev.c if saul module is used
+ifneq (,$(filter touch_dev,$(USEMODULE)))
+  SRC += $(TOUCH_DEV_INTERFACE)
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/saul_drivers/Makefile
+++ b/tests/saul_drivers/Makefile
@@ -1,0 +1,52 @@
+BOARD ?= stm32f4discovery
+include ../Makefile.tests_common
+
+# Only build on a subset of boards (one per arch supported and
+# with enough features provided)
+BOARD_WHITELIST ?= \
+    atmega256rfr2-xpro \
+    esp32-wroom-32 \
+    stm32f4discovery \
+    #
+
+# Get the list of drivers with a SAUL interface (without saul periph)
+DRIVERS_DIR = $(RIOTBASE)/drivers
+DRIVERS_WITH_SAUL_PATHS = $(filter-out $(wildcard $(DRIVERS_DIR)/saul/*_saul.c),$(wildcard $(DRIVERS_DIR)/*/*_saul.c))
+DRIVERS ?= $(subst _saul.c,,$(notdir $(DRIVERS_WITH_SAUL_PATHS)))
+USEMODULE += $(DRIVERS)
+
+# Somes drivers with submodules needs special care to select a precise driver variant
+ifneq (,$(filter adcxx1c,$(DRIVERS)))
+  USEMODULE += adc081c
+endif
+ifneq (,$(filter apds99xx,$(DRIVERS)))
+  USEMODULE += apds9960
+endif
+ifneq (,$(filter bme680,$(DRIVERS)))
+  USEMODULE += bme680_i2c
+endif
+ifneq (,$(filter lm75,$(DRIVERS)))
+  USEMODULE += tmp1075
+endif
+ifneq (,$(filter lpsxxx,$(DRIVERS)))
+  USEMODULE += lps22hh
+endif
+ifneq (,$(filter mhz19,$(DRIVERS)))
+  USEMODULE += mhz19_uart
+endif
+ifneq (,$(filter mpu9x50,$(DRIVERS)))
+  USEMODULE += mpu9150
+endif
+ifneq (,$(filter pcf857x,$(DRIVERS)))
+  USEMODULE += pcf8575
+endif
+ifneq (,$(filter si70xx,$(DRIVERS)))
+  USEMODULE += si7021
+endif
+ifneq (,$(filter tmp00x,$(DRIVERS)))
+  USEMODULE += tmp006
+endif
+
+USEMODULE += saul_default
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/saul_drivers/README.md
+++ b/tests/saul_drivers/README.md
@@ -1,0 +1,9 @@
+saul_drivers
+============
+
+This application is only used by the CI to check the build of drivers that
+provide a SAUL interface.
+All such drivers are added automatically to the build along with the
+`saul_default` module. This will check:
+- the build of the saul interface,
+- the build of driver auto initialization.

--- a/tests/saul_drivers/main.c
+++ b/tests/saul_drivers/main.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Build test application for drivers providing a SAUL interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Some drivers already use this build system trick: only build the `<driver>_saul.c` file when `USEMODULE` contains `saul` (for example: hm330x and sgp30). This provides a nice optimization since the file is only built when needed.

This PR generalizes this trick in `driver_with_saul.mk` and make use of it when applicable. This could be even more generalized for drivers with disp_dev or touch_dev interfaces and maybe also netdev.

**warning:** I also don't think that this PR should be merged as-is (but maybe others won't agree) because it allows to completely skip the build of the saul interface if no board pull-in the driver when saul is used. The saul interface won't be built by Murdock. This is related to #6405 (maybe the proposal in https://github.com/RIOT-OS/RIOT/issues/6405#issuecomment-311290141 is enough to workaround the issue)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
