### PR TITLE
core (largely doc): Differentiate message types from thread flags

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -15,9 +15,20 @@
  * ========
  * IPC messages consist of a sender PID, a type, and some content. The sender
  * PID will be set by the IPC internally and is not required to be set by the
- * user. The type helps the receiver to multiplex different message types and
- * should be set to a system-wide unique value. The content can either be
- * provided as a 32-bit integer or a pointer.
+ * user. The type helps the receiver to multiplex different message types.
+ * The content can either be provided as a 32-bit integer or a pointer.
+ *
+ * Some message types are predefined; for example, @ref
+ * GNRC_NETAPI_MSG_TYPE_RCV & co are defined. These are fixed in the sense that
+ * registering for a particular set of messages (for the above, e.g. @ref
+ * gnrc_netreg_register) will use these message types. Threads that do nothing
+ * to receive such messages can safely use the same numbers for other purposes.
+ * The predefined types use non-conflicting ranges (e.g. `0x02NN`) to avoid
+ * ruling out simultaneous use of different components in the same thread.
+ *
+ * In general, threads may consider it an error to send them a message they did
+ * not request. Best practice is to log (but otherwise ignore) unexpected
+ * messages.
  *
  * Blocking vs non-blocking
  * ========================

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -39,7 +39,7 @@
  * Usually, if it is only of interest that an event occurred, but not how many
  * of them, thread flags should be considered.
  *
- * Note that some flags (currently the three most significant bits) are used by
+ * Note that some flags (currently the two most significant bits) are used by
  * core functions and should not be set by the user. They can be waited for.
  *
  * This API is optional and must be enabled by adding "core_thread_flags" to USEMODULE.

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -41,6 +41,9 @@
  *
  * Note that some flags (currently the two most significant bits) are used by
  * core functions and should not be set by the user. They can be waited for.
+ * Unlike @ref core_msg "messages" (which are only ever sent when requested),
+ * these flags can be set unprompted. (For example, @ref THREAD_FLAG_MSG_WAITING
+ * is set on a thread automatically with every message sent there).
  *
  * This API is optional and must be enabled by adding "core_thread_flags" to USEMODULE.
  *

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -101,6 +101,19 @@ extern "C" {
  * @see xtimer_set_timeout_flag
  */
 #define THREAD_FLAG_TIMEOUT         (1u << 14)
+
+/**
+ * @brief Comprehensive set of all predefined flags
+ *
+ * This bit mask is set for all thread flag bits that are predefined in RIOT.
+ * Flags within this set may be set on a thread by the operating system without
+ * the thread soliciting them (though not all are; for example, @ref
+ * THREAD_FLAG_TIMEOUT is not).
+ *
+ * When using custom flags, asserting that they are not in this set can help
+ * avoid conflict with future additions to the predefined flags.
+ */
+#define THREAD_FLAG_PREDEFINED_MASK (THREAD_FLAG_MSG_WAITING | THREAD_FLAG_TIMEOUT)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

How to make sure own thread flags or message types do not conflict with preexisting ones (especially with the lack of a comprehensive of predefined ones for the latter) is difficult from the current documentation; this change set:

* clarifies that flags *will* be set by the OS without solicitation,
  * and adds a single define against which custom use can be checked; and
* states that messages are *not* set by the OS willy-nilly, and that system-wide uniqueness of numbers is not really necessary (but just a good practice by the standard library)

(and fixes an obsolete number in the process).

### Testing procedure

* Agree with the changes to the docs
* Watch nothing break in the tests from an added define

### Issues/PRs references

This contains clean-up from https://github.com/RIOT-OS/RIOT/pull/7717