### PR TITLE
sys/net/nanocoap: introduce `nanocoap_sock_*()`, use in suit/transport/coap

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -590,6 +590,7 @@ endif
 
 ifneq (,$(filter nanocoap_sock,$(USEMODULE)))
   USEMODULE += sock_udp
+  USEMODULE += sock_util
 endif
 
 ifneq (,$(filter nanocoap_%,$(USEMODULE)))

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -183,16 +183,16 @@ extern "C" {
  * @{
  */
 /**
- * @brief    Timeout in seconds for a response to a confirmable request
+ * @brief    Timeout in milliseconds for a response to a confirmable request
  *
  * This value is for the response to the *initial* confirmable message. The
  * timeout doubles for subsequent retries. To avoid synchronization of resends
  * across hosts, the actual timeout is chosen randomly between
- * @ref CONFIG_COAP_ACK_TIMEOUT and
- * (@ref CONFIG_COAP_ACK_TIMEOUT * @ref CONFIG_COAP_RANDOM_FACTOR_1000 / 1000).
+ * @ref CONFIG_COAP_ACK_TIMEOUT_MS and
+ * (@ref CONFIG_COAP_ACK_TIMEOUT_MS * @ref CONFIG_COAP_RANDOM_FACTOR_1000 / 1000).
  */
-#ifndef CONFIG_COAP_ACK_TIMEOUT
-#define CONFIG_COAP_ACK_TIMEOUT        (2U)
+#ifndef CONFIG_COAP_ACK_TIMEOUT_MS
+#define CONFIG_COAP_ACK_TIMEOUT_MS     (2000U)
 #endif
 
 /**
@@ -202,7 +202,7 @@ extern "C" {
  * ([RFC 7252, section 4.2](https://tools.ietf.org/html/rfc7252#section-4.2))
  * multiplied by 1000, to avoid floating point arithmetic.
  *
- * See @ref CONFIG_COAP_ACK_TIMEOUT
+ * See @ref CONFIG_COAP_ACK_TIMEOUT_MS
  */
 #ifndef CONFIG_COAP_RANDOM_FACTOR_1000
 #define CONFIG_COAP_RANDOM_FACTOR_1000      (1500)

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -233,6 +233,19 @@ extern "C" {
 #define COAP_BLOCKWISE_SZX_MAX  (7)
 /** @} */
 
+/**
+ * @brief Coap block-wise-transfer size SZX
+ */
+typedef enum {
+    COAP_BLOCKSIZE_16 = 0,
+    COAP_BLOCKSIZE_32,
+    COAP_BLOCKSIZE_64,
+    COAP_BLOCKSIZE_128,
+    COAP_BLOCKSIZE_256,
+    COAP_BLOCKSIZE_512,
+    COAP_BLOCKSIZE_1024,
+} coap_blksize_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -531,7 +531,7 @@ extern "C" {
  * In normal operations the timeout between retransmissions doubles. When
  * CONFIG_GCOAP_NO_RETRANS_BACKOFF is defined this doubling does not happen.
  *
- * @see CONFIG_COAP_ACK_TIMEOUT
+ * @see CONFIG_COAP_ACK_TIMEOUT_MS
  */
 #define CONFIG_GCOAP_NO_RETRANS_BACKOFF
 #endif

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -702,7 +702,7 @@ typedef struct gcoap_listener gcoap_listener_t;
  */
 typedef int (*gcoap_request_matcher_t)(gcoap_listener_t *listener,
                                        const coap_resource_t **resource,
-                                       const coap_pkt_t *pdu);
+                                       coap_pkt_t *pdu);
 
 /**
  * @brief   A modular collection of resources for a server

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -151,6 +151,21 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief    Maximum length of a CoAP header for a blockwise message
+ */
+#ifndef CONFIG_NANOCOAP_BLOCK_HEADER_MAX
+#define CONFIG_NANOCOAP_BLOCK_HEADER_MAX   (64)
+#endif
+
+/**
+ * @brief    Work buffer size for blockwise operation
+ *
+ * @param[in] blksize   CoAP blocksize
+ */
+#define NANOCOAP_BLOCKWISE_BUF(blksize)    (CONFIG_NANOCOAP_BLOCK_HEADER_MAX \
+                                           + (0x1 << (blksize + 4)))
+
+/**
  * @name coap_opt_finish() flag parameter values
  *
  * Directs packet/buffer updates when user finishes adding options

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -888,7 +888,7 @@ int coap_get_blockopt(coap_pkt_t *pkt, uint16_t option, uint32_t *blknum, unsign
  * @brief    Check whether any of the packet's options that are critical
  *
  * (i.e must be understood by the receiver, indicated by a 1 in the option number's least
- * significant bit) were not accessed since the packet was parsed.)
+ * significant bit) were not accessed since the packet was parsed.
  *
  * Call this in a server on requests after all their option processing has happened,
  * and stop processing the request if it returns true, returning a 4.02 Bad Option response.

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -226,6 +226,20 @@ typedef struct {
 typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context);
 
 /**
+ * @brief   Coap blockwise request callback descriptor
+ *
+ * @param[in] arg      Pointer to be passed as arguments to the callback
+ * @param[in] offset   Offset of received data
+ * @param[in] buf      Pointer to the received data
+ * @param[in] len      Length of the received data
+ * @param[in] more     -1 for no option, 0 for last block, 1 for more blocks
+ *
+ * @returns    0       on success
+ * @returns   -1       on error
+ */
+typedef int (*coap_blockwise_cb_t)(void *arg, size_t offset, uint8_t *buf, size_t len, int more);
+
+/**
  * @brief   Method flag type
  *
  * Must be large enough to contain all @ref nanocoap_method_flags "CoAP method flags"

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -245,7 +245,23 @@ int nanocoap_get_blockwise_url(const char *url,
  * @returns     length of response on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len);
+ssize_t nanocoap_sock_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len);
+
+/**
+ * @brief   Simple synchronous CoAP request
+ *
+ * @param[in,out]   pkt     Packet struct containing the request. Is reused for
+ *                          the response
+ * @param[in]       local   Local UDP endpoint, may be NULL
+ * @param[in]       remote  remote UDP endpoint
+ * @param[in]       len     Total length of the buffer associated with the
+ *                          request
+ *
+ * @returns     length of response on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
+                         sock_udp_ep_t *remote, size_t len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -140,6 +140,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   nanocoap socket type
+ *
+ */
+typedef sock_udp_t nanocoap_sock_t;
+
+/**
  * @brief   Start a nanocoap server instance
  *
  * This function only returns if there's an error binding to @p local, or if
@@ -163,15 +169,15 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
  * @returns     0 on success
  * @returns     <0 on error
  */
-int nanocoap_connect(sock_udp_t *sock, sock_udp_ep_t *local,
-                     sock_udp_ep_t *remote);
+int nanocoap_sock_connect(nanocoap_sock_t *sock, sock_udp_ep_t *local,
+                          sock_udp_ep_t *remote);
 
 /**
  * @brief   Close a CoAP client socket
  *
  * @param[in]  sock     CoAP UDP socket
  */
-static inline void nanocoap_close(sock_udp_t *sock)
+static inline void nanocoap_sock_close(nanocoap_sock_t *sock)
 {
     sock_udp_close(sock);
 }
@@ -187,8 +193,8 @@ static inline void nanocoap_close(sock_udp_t *sock)
  * @returns     length of response payload on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_get(sock_udp_t *sock, const char *path, void *buf,
-                     size_t len);
+ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf,
+                          size_t len);
 
 /**
  * @brief    Performs a blockwise coap get request on a socket.
@@ -208,9 +214,9 @@ ssize_t nanocoap_get(sock_udp_t *sock, const char *path, void *buf,
  * @returns     -1         if failed to fetch the url content
  * @returns      0         on success
  */
-int nanocoap_get_blockwise(sock_udp_t *sock, const char *path,
-                           coap_blksize_t blksize, void *work_buf,
-                           coap_blockwise_cb_t callback, void *arg);
+int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
+                                coap_blksize_t blksize, void *work_buf,
+                                coap_blockwise_cb_t callback, void *arg);
 
 /**
  * @brief    Performs a blockwise coap get request to the specified url.
@@ -219,7 +225,8 @@ int nanocoap_get_blockwise(sock_udp_t *sock, const char *path,
  * block-wise-transfer. A coap_blockwise_cb_t will be called on each received
  * block.
  *
- * @param[in]   url        Absolute URL pointer to source path (i.e. not containing a fragment identifier)
+ * @param[in]   url        Absolute URL pointer to source path (i.e. not containing
+ *                         a fragment identifier)
  * @param[in]   blksize    sender suggested SZX for the COAP block request
  * @param[in]   work_buf   Work buffer, must be `NANOCOAP_BLOCKWISE_BUF(blksize)` bytes
  * @param[in]   callback   callback to be executed on each received block
@@ -245,7 +252,7 @@ int nanocoap_get_blockwise_url(const char *url,
  * @returns     length of response on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_sock_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len);
+ssize_t nanocoap_sock_request(nanocoap_sock_t *sock, coap_pkt_t *pkt, size_t len);
 
 /**
  * @brief   Simple synchronous CoAP request
@@ -262,6 +269,20 @@ ssize_t nanocoap_sock_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len);
  */
 ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
                          sock_udp_ep_t *remote, size_t len);
+
+/**
+ * @brief   Simple synchronous CoAP (confirmable) get
+ *
+ * @param[in]   remote  remote UDP endpoint
+ * @param[in]   path    remote path
+ * @param[out]  buf     buffer to write response to
+ * @param[in]   len     length of @p buffer
+ *
+ * @returns     length of response payload on success
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, void *buf,
+                     size_t len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -154,9 +154,32 @@ extern "C" {
 int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
 
 /**
+ * @brief   Create a CoAP client socket
+ *
+ * @param[out]  sock    CoAP UDP socket
+ * @param[in]   local   Local UDP endpoint, may be NULL
+ * @param[in]   remote  remote UDP endpoint
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+int nanocoap_connect(sock_udp_t *sock, sock_udp_ep_t *local,
+                     sock_udp_ep_t *remote);
+
+/**
+ * @brief   Close a CoAP client socket
+ *
+ * @param[in]  sock     CoAP UDP socket
+ */
+static inline void nanocoap_close(sock_udp_t *sock)
+{
+    sock_udp_close(sock);
+}
+
+/**
  * @brief   Simple synchronous CoAP (confirmable) get
  *
- * @param[in]   remote  remote UDP endpoint
+ * @param[in]   sock    socket to use for the request
  * @param[in]   path    remote path
  * @param[out]  buf     buffer to write response to
  * @param[in]   len     length of @p buffer
@@ -164,24 +187,22 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
  * @returns     length of response payload on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, uint8_t *buf,
+ssize_t nanocoap_get(sock_udp_t *sock, const char *path, void *buf,
                      size_t len);
 
 /**
  * @brief   Simple synchronous CoAP request
  *
+ * @param[in]       sock    socket to use for the request
  * @param[in,out]   pkt     Packet struct containing the request. Is reused for
  *                          the response
- * @param[in]       local   Local UDP endpoint, may be NULL
- * @param[in]       remote  remote UDP endpoint
  * @param[in]       len     Total length of the buffer associated with the
  *                          request
  *
  * @returns     length of response on success
  * @returns     <0 on error
  */
-ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
-                         sock_udp_ep_t *remote, size_t len);
+ssize_t nanocoap_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -191,6 +191,49 @@ ssize_t nanocoap_get(sock_udp_t *sock, const char *path, void *buf,
                      size_t len);
 
 /**
+ * @brief    Performs a blockwise coap get request on a socket.
+ *
+ * This function will fetch the content of the specified resource path via
+ * block-wise-transfer. A coap_blockwise_cb_t will be called on each received
+ * block.
+ *
+ * @param[in]   sock       socket to use for the request
+ * @param[in]   path       pointer to source path
+ * @param[in]   blksize    sender suggested SZX for the COAP block request
+ * @param[in]   work_buf   Work buffer, must be `NANOCOAP_BLOCKWISE_BUF(blksize)` bytes
+ * @param[in]   callback   callback to be executed on each received block
+ * @param[in]   arg        optional function arguments
+ *
+ * @returns     -EINVAL    if an invalid url is provided
+ * @returns     -1         if failed to fetch the url content
+ * @returns      0         on success
+ */
+int nanocoap_get_blockwise(sock_udp_t *sock, const char *path,
+                           coap_blksize_t blksize, void *work_buf,
+                           coap_blockwise_cb_t callback, void *arg);
+
+/**
+ * @brief    Performs a blockwise coap get request to the specified url.
+ *
+ * This function will fetch the content of the specified resource path via
+ * block-wise-transfer. A coap_blockwise_cb_t will be called on each received
+ * block.
+ *
+ * @param[in]   url        Absolute URL pointer to source path (i.e. not containing a fragment identifier)
+ * @param[in]   blksize    sender suggested SZX for the COAP block request
+ * @param[in]   work_buf   Work buffer, must be `NANOCOAP_BLOCKWISE_BUF(blksize)` bytes
+ * @param[in]   callback   callback to be executed on each received block
+ * @param[in]   arg        optional function arguments
+ *
+ * @returns     -EINVAL    if an invalid url is provided
+ * @returns     -1         if failed to fetch the url content
+ * @returns      0         on success
+ */
+int nanocoap_get_blockwise_url(const char *url,
+                               coap_blksize_t blksize, void *work_buf,
+                               coap_blockwise_cb_t callback, void *arg);
+
+/**
  * @brief   Simple synchronous CoAP request
  *
  * @param[in]       sock    socket to use for the request

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -137,6 +137,7 @@ typedef enum {
  *
  * @param[in]   url        url pointer to source path
  * @param[in]   blksize    sender suggested SZX for the COAP block request
+ * @param[in]   work_buf   Work buffer, must be NANOCOAP_BLOCKWISE_BUF(blksize) bytes
  * @param[in]   callback   callback to be executed on each received block
  * @param[in]   arg        optional function arguments
  *
@@ -145,7 +146,7 @@ typedef enum {
  * @returns      0         on success
  */
 int suit_coap_get_blockwise_url(const char *url,
-                               coap_blksize_t blksize,
+                               coap_blksize_t blksize, void *work_buf,
                                coap_blockwise_cb_t callback, void *arg);
 
 /**

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -91,35 +91,9 @@ typedef const struct {
 } coap_resource_subtree_t;
 
 /**
- * @brief   Coap blockwise request callback descriptor
- *
- * @param[in] arg      Pointer to be passed as arguments to the callback
- * @param[in] offset   Offset of received data
- * @param[in] buf      Pointer to the received data
- * @param[in] len      Length of the received data
- * @param[in] more     -1 for no option, 0 for last block, 1 for more blocks
- *
- * @returns    0       on success
- * @returns   -1       on error
- */
-typedef int (*coap_blockwise_cb_t)(void *arg, size_t offset, uint8_t *buf, size_t len, int more);
-
-/**
  * @brief   Reference to the coap resource subtree
  */
 extern const coap_resource_subtree_t coap_resource_subtree_suit;
-
-/**
- * @brief Coap block-wise-transfer size SZX
- */
-typedef enum {
-    COAP_BLOCKSIZE_32 = 1,
-    COAP_BLOCKSIZE_64,
-    COAP_BLOCKSIZE_128,
-    COAP_BLOCKSIZE_256,
-    COAP_BLOCKSIZE_512,
-    COAP_BLOCKSIZE_1024,
-} coap_blksize_t;
 
 /**
  * @brief Coap block-wise-transfer size used for SUIT
@@ -127,27 +101,6 @@ typedef enum {
 #ifndef CONFIG_SUIT_COAP_BLOCKSIZE
 #define CONFIG_SUIT_COAP_BLOCKSIZE  COAP_BLOCKSIZE_64
 #endif
-
-/**
- * @brief    Performs a blockwise coap get request to the specified url.
- *
- * This function will fetch the content of the specified resource path via
- * block-wise-transfer. A coap_blockwise_cb_t will be called on each received
- * block.
- *
- * @param[in]   url        url pointer to source path
- * @param[in]   blksize    sender suggested SZX for the COAP block request
- * @param[in]   work_buf   Work buffer, must be NANOCOAP_BLOCKWISE_BUF(blksize) bytes
- * @param[in]   callback   callback to be executed on each received block
- * @param[in]   arg        optional function arguments
- *
- * @returns     -EINVAL    if an invalid url is provided
- * @returns     -1         if failed to fetch the url content
- * @returns      0         on success
- */
-int suit_coap_get_blockwise_url(const char *url,
-                               coap_blksize_t blksize, void *work_buf,
-                               coap_blockwise_cb_t callback, void *arg);
 
 /**
  * @brief   Trigger a SUIT udate

--- a/sys/net/application_layer/Kconfig.coap
+++ b/sys/net/application_layer/Kconfig.coap
@@ -18,15 +18,15 @@ menuconfig KCONFIG_COAP
 
 if KCONFIG_COAP
 
-config COAP_ACK_TIMEOUT
-    int "Timeout in seconds for a response to a confirmable request"
-    default 2
+config COAP_ACK_TIMEOUT_MS
+    int "Timeout in milliseconds for a response to a confirmable request"
+    default 2000
     help
         This value is for the response to the initial confirmable message. The
         timeout doubles for subsequent retries. To avoid synchronization of
         resends across hosts, the actual timeout is chosen randomly between
-        @ref CONFIG_COAP_ACK_TIMEOUT and
-        (@ref CONFIG_COAP_ACK_TIMEOUT * @ref CONFIG_COAP_RANDOM_FACTOR_1000 / 1000).
+        @ref CONFIG_COAP_ACK_TIMEOUT_MS and
+        (@ref CONFIG_COAP_ACK_TIMEOUT_MS * @ref CONFIG_COAP_RANDOM_FACTOR_1000 / 1000).
         The default of 2 seconds is taken from
         [RFC 7252, section 4.8](https://tools.ietf.org/html/rfc7252#section-4.8).
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -66,7 +66,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 static void _expire_request(gcoap_request_memo_t *memo);
 static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu,
                            const sock_udp_ep_t *remote, bool by_mid);
-static int _find_resource(const coap_pkt_t *pdu,
+static int _find_resource(coap_pkt_t *pdu,
                           const coap_resource_t **resource_ptr,
                           gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
@@ -77,7 +77,7 @@ static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
 
 static int _request_matcher_default(gcoap_listener_t *listener,
                                     const coap_resource_t **resource,
-                                    const coap_pkt_t *pdu);
+                                    coap_pkt_t *pdu);
 
 #if IS_USED(MODULE_GCOAP_DTLS)
 static void _on_sock_dtls_evt(sock_dtls_t *sock, sock_async_flags_t type, void *arg);
@@ -538,7 +538,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     gcoap_observe_memo_t *memo          = NULL;
     gcoap_observe_memo_t *resource_memo = NULL;
 
-    switch (_find_resource((const coap_pkt_t *)pdu, &resource, &listener)) {
+    switch (_find_resource(pdu, &resource, &listener)) {
         case GCOAP_RESOURCE_WRONG_METHOD:
             return gcoap_response(pdu, buf, len, COAP_CODE_METHOD_NOT_ALLOWED);
         case GCOAP_RESOURCE_NO_PATH:
@@ -640,7 +640,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 
 static int _request_matcher_default(gcoap_listener_t *listener,
                                     const coap_resource_t **resource,
-                                    const coap_pkt_t *pdu)
+                                    coap_pkt_t *pdu)
 {
     uint8_t uri[CONFIG_NANOCOAP_URI_MAX];
     int ret = GCOAP_RESOURCE_NO_PATH;
@@ -696,7 +696,7 @@ static int _request_matcher_default(gcoap_listener_t *listener,
  *        code didn't match and `GCOAP_RESOURCE_NO_PATH` if no matching
  *        resource was found.
  */
-static int _find_resource(const coap_pkt_t *pdu,
+static int _find_resource(coap_pkt_t *pdu,
                           const coap_resource_t **resource_ptr,
                           gcoap_listener_t **listener_ptr)
 {

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -47,7 +47,7 @@
 #define NO_IMMEDIATE_REPLY (-1)
 
 /* End of the range to pick a random timeout */
-#define TIMEOUT_RANGE_END (CONFIG_COAP_ACK_TIMEOUT * CONFIG_COAP_RANDOM_FACTOR_1000 / 1000)
+#define TIMEOUT_RANGE_END (CONFIG_COAP_ACK_TIMEOUT_MS * CONFIG_COAP_RANDOM_FACTOR_1000 / 1000)
 
 /* Internal functions */
 static void *_event_loop(void *arg);
@@ -472,9 +472,9 @@ static void _on_resp_timeout(void *arg) {
 #else
         unsigned i        = CONFIG_COAP_MAX_RETRANSMIT - memo->send_limit;
 #endif
-        uint32_t timeout  = ((uint32_t)CONFIG_COAP_ACK_TIMEOUT << i) * MS_PER_SEC;
+        uint32_t timeout  = (uint32_t)CONFIG_COAP_ACK_TIMEOUT_MS << i;
 #if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
-        uint32_t end = ((uint32_t)TIMEOUT_RANGE_END << i) * MS_PER_SEC;
+        uint32_t end = (uint32_t)TIMEOUT_RANGE_END << i;
         timeout = random_uint32_range(timeout, end);
 #endif
         event_timeout_set(&memo->resp_evt_tmout, timeout);
@@ -1158,9 +1158,9 @@ ssize_t gcoap_req_send(const uint8_t *buf, size_t len,
             }
             if (memo->msg.data.pdu_buf) {
                 memo->send_limit  = CONFIG_COAP_MAX_RETRANSMIT;
-                timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT * MS_PER_SEC;
+                timeout           = (uint32_t)CONFIG_COAP_ACK_TIMEOUT_MS;
 #if CONFIG_COAP_RANDOM_FACTOR_1000 > 1000
-                timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END * MS_PER_SEC);
+                timeout = random_uint32_range(timeout, TIMEOUT_RANGE_END);
 #endif
                 memo->state = GCOAP_MEMO_RETRANSMIT;
             }

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -49,7 +49,7 @@ ssize_t nanocoap_request(sock_udp_t *sock, coap_pkt_t *pkt, size_t len)
 
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */
-    uint32_t timeout = CONFIG_COAP_ACK_TIMEOUT * US_PER_SEC;
+    uint32_t timeout = CONFIG_COAP_ACK_TIMEOUT_MS * US_PER_MS;
 
     /* add 1 for initial transmit */
     unsigned tries_left = CONFIG_COAP_MAX_RETRANSMIT + 1;

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -188,10 +188,14 @@ int nanocoap_get_blockwise(sock_udp_t *sock, const char *path,
             return -1;
         }
 
-        /* no block option in response - direcly use paylaod */
+        /* no block option in response - directly use paylaod */
         if (!coap_get_block2(&pkt, &block2)) {
             block2.more = 0;
             block2.offset = 0;
+        }
+
+        if (coap_has_unprocessed_critical_options(&pkt)) {
+            return -ENOTSUP;
         }
 
         res = callback(arg, block2.offset, pkt.payload, pkt.payload_len,

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -358,8 +358,9 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     if (0) {}
 #ifdef MODULE_SUIT_TRANSPORT_COAP
     else if (strncmp(manifest->urlbuf, "coap://", 7) == 0) {
+        uint8_t buffer[NANOCOAP_BLOCKWISE_BUF(CONFIG_SUIT_COAP_BLOCKSIZE)];
         res = suit_coap_get_blockwise_url(manifest->urlbuf, CONFIG_SUIT_COAP_BLOCKSIZE,
-                                          suit_storage_helper,
+                                          buffer, suit_storage_helper,
                                           manifest);
     }
 #endif

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -37,6 +37,7 @@
 
 #ifdef MODULE_SUIT_TRANSPORT_COAP
 #include "suit/transport/coap.h"
+#include "net/nanocoap_sock.h"
 #endif
 #include "suit/transport/mock.h"
 
@@ -359,9 +360,9 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
 #ifdef MODULE_SUIT_TRANSPORT_COAP
     else if (strncmp(manifest->urlbuf, "coap://", 7) == 0) {
         uint8_t buffer[NANOCOAP_BLOCKWISE_BUF(CONFIG_SUIT_COAP_BLOCKSIZE)];
-        res = suit_coap_get_blockwise_url(manifest->urlbuf, CONFIG_SUIT_COAP_BLOCKSIZE,
-                                          buffer, suit_storage_helper,
-                                          manifest);
+        res = nanocoap_get_blockwise_url(manifest->urlbuf, CONFIG_SUIT_COAP_BLOCKSIZE,
+                                         buffer, suit_storage_helper,
+                                         manifest);
     }
 #endif
 #ifdef MODULE_SUIT_TRANSPORT_MOCK

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -29,11 +29,13 @@
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 extern int nanotest_client_cmd(int argc, char **argv);
+extern int nanotest_client_url_cmd(int argc, char **argv);
 extern int nanotest_server_cmd(int argc, char **argv);
 static int _list_all_inet6(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
     { "client", "CoAP client", nanotest_client_cmd },
+    { "url", "CoAP client URL request", nanotest_client_url_cmd },
     { "server", "CoAP server", nanotest_server_cmd },
     { "inet6", "IPv6 addresses", _list_all_inet6 },
     { NULL, NULL, NULL }

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -33,6 +33,8 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
 {
     ipv6_addr_t addr;
     sock_udp_ep_t remote;
+    sock_udp_t sock;
+    ssize_t res;
 
     remote.family = AF_INET6;
 
@@ -74,7 +76,11 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
         return 0;
     }
 
-    return nanocoap_request(pkt, NULL, &remote, len);
+    nanocoap_connect(&sock, NULL, &remote);
+    res = nanocoap_request(&sock, pkt, len);
+    nanocoap_close(&sock);
+
+    return res;
 }
 
 int nanotest_client_cmd(int argc, char **argv)

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -86,7 +86,7 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
 int nanotest_client_cmd(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
-    char *method_codes[] = {"get", "post", "put"};
+    const char *method_codes[] = {"get", "post", "put"};
     unsigned buflen = 128;
     uint8_t buf[buflen];
     coap_pkt_t pkt;
@@ -166,4 +166,51 @@ int nanotest_client_cmd(int argc, char **argv)
     printf("usage: %s <get|post|put> <addr>[%%iface] <port> <path> [data]\n",
            argv[0]);
     return 1;
+}
+
+static int _blockwise_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
+{
+    (void)arg;
+    (void)more;
+
+    printf("offset %03u: ", (unsigned)offset);
+    for (unsigned i = 0; i < len; ++i) {
+        putchar(buf[i]);
+    }
+    puts("");
+
+    return 0;
+}
+
+int nanotest_client_url_cmd(int argc, char **argv)
+{
+    /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
+    const char *method_codes[] = {"get", "post", "put"};
+
+    if (argc < 3) {
+        goto error;
+    }
+
+    int code_pos = -1;
+    for (size_t i = 0; i < ARRAY_SIZE(method_codes); i++) {
+        if (strcmp(argv[1], method_codes[i]) == 0) {
+            code_pos = i;
+            break;
+        }
+    }
+    if (code_pos == -1) {
+        goto error;
+    }
+
+    if (code_pos != 0) {
+        printf("TODO: implement %s request\n", method_codes[code_pos]);
+        return -1;
+    }
+
+    uint8_t buffer[NANOCOAP_BLOCKWISE_BUF(COAP_BLOCKSIZE_32)];
+    return  nanocoap_get_blockwise_url(argv[2], COAP_BLOCKSIZE_32, buffer,
+                                       _blockwise_cb, NULL);
+error:
+    printf("usage: %s <get|post|put> <url> [data]\n", argv[0]);
+    return -1;
 }

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -33,8 +33,6 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
 {
     ipv6_addr_t addr;
     sock_udp_ep_t remote;
-    sock_udp_t sock;
-    ssize_t res;
 
     remote.family = AF_INET6;
 
@@ -76,11 +74,7 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str
         return 0;
     }
 
-    nanocoap_connect(&sock, NULL, &remote);
-    res = nanocoap_request(&sock, pkt, len);
-    nanocoap_close(&sock);
-
-    return res;
+    return nanocoap_request(pkt, NULL, &remote, len);
 }
 
 int nanotest_client_cmd(int argc, char **argv)

--- a/tests/pkg_edhoc_c/initiator.c
+++ b/tests/pkg_edhoc_c/initiator.c
@@ -98,19 +98,13 @@ static int _parse_ipv6_addr(char *addr_str, ipv6_addr_t *addr, uint16_t *netif)
 static ssize_t _send(coap_pkt_t *pkt, size_t len, ipv6_addr_t *addr, uint16_t netif, uint16_t port)
 {
     sock_udp_ep_t remote;
-    sock_udp_t sock;
-    ssize_t res;
 
     remote.family = AF_INET6;
     remote.port = port;
     remote.netif = netif;
     memcpy(&remote.addr.ipv6[0], addr->u8, sizeof(addr->u8));
 
-    nanocoap_connect(&sock, NULL, &remote);
-    res = nanocoap_request(&sock, pkt, len);
-    nanocoap_close(&sock);
-
-    return res;
+    return nanocoap_request(pkt, NULL, &remote, len);
 }
 
 static ssize_t _build_coap_pkt(coap_pkt_t *pkt, uint8_t *buf, ssize_t buflen,

--- a/tests/pkg_edhoc_c/initiator.c
+++ b/tests/pkg_edhoc_c/initiator.c
@@ -98,13 +98,19 @@ static int _parse_ipv6_addr(char *addr_str, ipv6_addr_t *addr, uint16_t *netif)
 static ssize_t _send(coap_pkt_t *pkt, size_t len, ipv6_addr_t *addr, uint16_t netif, uint16_t port)
 {
     sock_udp_ep_t remote;
+    sock_udp_t sock;
+    ssize_t res;
 
     remote.family = AF_INET6;
     remote.port = port;
     remote.netif = netif;
     memcpy(&remote.addr.ipv6[0], addr->u8, sizeof(addr->u8));
 
-    return nanocoap_request(pkt, NULL, &remote, len);
+    nanocoap_connect(&sock, NULL, &remote);
+    res = nanocoap_request(&sock, pkt, len);
+    nanocoap_close(&sock);
+
+    return res;
 }
 
 static ssize_t _build_coap_pkt(coap_pkt_t *pkt, uint8_t *buf, ssize_t buflen,


### PR DESCRIPTION
### Contribution description

This refactors the nanocoap API to not open/close a socket for each request, to allow for socket re-use and align it more with what SUIT does.
As a result, we can remove the copy of `_nanocoap_request()` from SUIT.

The timeout handling differs a bit: In SUIT `CONFIG_COAP_ACK_TIMEOUT` is used as a timeout for the whole request (for all retransmissions combined) whereas nanocoap uses it as the initial timeout for the first request and then doubles the timeout.

I kept the nanocoap behavior, but changed the timeout to milliseconds so lower initial values can be used.

As a next step, this also moves `suit_coap_get_blockwise()` to `nanocoap_get_blockwise()` so it can be used outside SUIT.

### Testing procedure

`examples/suit_update` still works

<details><summary>make BOARD=same54-xpro  test-with-config</summary>

First, run

    sudo dist/tools/ethos/setup_network.sh riot0 2001:db8::/64

```
> riotboot-hdr
Image magic_number: 0x544f4952
Image Version: 0x61d60952
Image start address: 0x00082400
Header chksum: 0xf04d2cd2

> ifconfig
ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
pinging node...
PING fe80::649b:87ff:fe4c:4152%riot0(fe80::649b:87ff:fe4c:4152%riot0) 56 data bytes

--- fe80::649b:87ff:fe4c:4152%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 37.730/37.730/37.730/0.000 ms
pinging node succeeded.
suit
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:4152
          inet6 group: ff02::1:ff00:2
          
> suit
Usage: suit <manifest url>
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417043.riot.bin...
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417043.riot.bin...
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.1641417043.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.1641417043.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417043.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot0.1641417043.riot.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417043.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot1.1641417043.riot.bin"
aiocoap-client -m POST "coap://[fe80::649b:87ff:fe4c:4152%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin" && \
	echo "Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update."
Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update.
> suit: received URL: "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
Unable to validate signature: -2
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417041.riot.bin...
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417041.riot.bin...
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.1641417041.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.1641417041.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.1641417041.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417041.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417041.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot0.1641417041.riot.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417041.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot1.1641417041.riot.bin"
aiocoap-client -m POST "coap://[fe80::649b:87ff:fe4c:4152%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417041.bin" && \
	echo "Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update."
Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update.
suit_parse() failed. res=-6
suit: received URL: "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417041.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417041.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1641417041, highest available: 1641417042
seq_nr <= running image
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417043.riot.bin...
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417043.riot.bin...
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.1641417043.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.1641417043.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417043.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot0.1641417043.riot.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417043.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot1.1641417043.riot.bin"
aiocoap-client -m POST "coap://[fe80::649b:87ff:fe4c:4152%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin" && \
	echo "Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update."
Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update.
)suit_parse() failed. res=-5
suit: received URL: "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417043.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1641417043, highest available: 1641417042
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 4000 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 50244518-6a7c-5ce7-932b-88b318336c82 to 50244518-6a7c-5ce7-932b-88b318336c82 from manifest
validating class id: OK
Comparing manifest offset 4000 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 0
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x61d60953
Image start address: 0x00004400
Header chksum: 0x304a4ccb

suit_coap: rebooting...


----> ethos: hello received
Failed to send flush request: Operation not permitted
current-slot
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.01-devel-1477-gd72ff-nanocoap-suit)
RIOT SUIT update example application
Running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x61d60953
Image start address: 0x00004400
Header chksum: 0x304a4ccb

suit_coap: started.
Starting the shell
> 
> 
> ifconfig
current-slot
Running from slot 0
> ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
pinging node...
PING fe80::649b:87ff:fe4c:4152%riot0(fe80::649b:87ff:fe4c:4152%riot0) 56 data bytes

--- fe80::649b:87ff:fe4c:4152%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 39.213/39.213/39.213/0.000 ms
pinging node succeeded.
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417044.riot.bin...
creating /home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417044.riot.bin...
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.1641417044.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.1641417044.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.1641417044.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417044.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot0.1641417044.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot0.1641417044.riot.bin"
published "/home/benpicco/dev/RIOT/examples/suit_update/bin/same54-xpro/suit_update-slot1.1641417044.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-slot1.1641417044.riot.bin"
aiocoap-client -m POST "coap://[fe80::649b:87ff:fe4c:4152%riot0]/suit/trigger" \
	--payload "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417044.bin" && \
	echo "Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update."
Triggered [fe80::649b:87ff:fe4c:4152%riot0] to update.
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:4152
          inet6 group: ff02::1:ff00:2
          
> suit: received URL: "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417044.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/same54-xpro/suit_update-riot.suit_signed.1641417044.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1641417044, highest available: 1641417043
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 4000 with other slot offset
Comparing manifest offset 82000 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 50244518-6a7c-5ce7-932b-88b318336c82 to 50244518-6a7c-5ce7-932b-88b318336c82 from manifest
validating class id: OK
Comparing manifest offset 4000 with other slot offset
Comparing manifest offset 82000 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x61d60954
Image start address: 0x00082400
Header chksum: 0xf0552cd4

suit_coap: rebooting...


----> ethos: hello received
Failed to send flush request: Operation not permitted
current-slot
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.01-devel-1477-gd72ff-nanocoap-suit)
RIOT SUIT update example application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x61d60954
Image start address: 0x00082400
Header chksum: 0xf0552cd4

suit_coap: started.
Starting the shell
> 
> 
> ifconfig
current-slot
Running from slot 1
> ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
pinging node...
PING fe80::649b:87ff:fe4c:4152%riot0(fe80::649b:87ff:fe4c:4152%riot0) 56 data bytes

--- fe80::649b:87ff:fe4c:4152%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 37.470/37.470/37.470/0.000 ms
pinging node succeeded.
TEST PASSED
```
</details>


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
