### PR TITLE
sys/cpp11-compat: use new/delete operators from sys/cpp_new_delete

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -337,6 +337,7 @@ ifneq (,$(filter log_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
+  USEMODULE += cpp_new_delete
   USEMODULE += xtimer
   USEMODULE += timex
   FEATURES_REQUIRED += cpp

--- a/sys/cpp11-compat/cppsupport.cpp
+++ b/sys/cpp11-compat/cppsupport.cpp
@@ -106,22 +106,6 @@ void __verbose_terminate_handler()
      Elegant Invention
  */
 
-void* operator new(std::size_t size) {
-    return std::malloc(size);
-}
-
-void* operator new[](std::size_t size) {
-    return std::malloc(size);
-}
-
-void operator delete(void* ptr) noexcept {
-    std::free(ptr);
-}
-
-void operator delete[](void* ptr) noexcept {
-    std::free(ptr);
-}
-
 /* Optionally you can override the 'nothrow' versions as well.
    This is useful if you want to catch failed allocs with your
    own debug code, or keep track of heap usage for example,

--- a/sys/cpp11-compat/cppsupport.cpp
+++ b/sys/cpp11-compat/cppsupport.cpp
@@ -27,15 +27,6 @@ extern "C" {
 }
 
 /**
- * @brief DSO handle
- *
- * This symbol is used by dynamic shared objects to identify them, but it is
- * somehow pulled in as a dependency by the compiler-generated global (static)
- * constructor code.
- */
-void *__dso_handle __attribute__((weak)) = NULL;
-
-/**
  * @brief Definition of a pure virtual function
  *
  * Calling this function is an error.

--- a/sys/cpp_new_delete/cppsupport.cpp
+++ b/sys/cpp_new_delete/cppsupport.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup cpp_new_delete
+ * @{
+ *
+ * @file
+ * @brief C++ runtime support functions
+ *
+ * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#include <stdlib.h>
+
+/**
+ * @brief DSO handle
+ *
+ * This symbol is used by dynamic shared objects to identify them, but it is
+ * somehow pulled in as a dependency by the compiler-generated global (static)
+ * constructor code.
+ */
+void *__dso_handle __attribute__((weak)) = NULL;
+
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR provides code deduplication as well as the ability for an application to use (re)defined `new`/`delete` operators without requiring `libstdc++`.

1. The `sys/cpp11-compat` module (re)defines the `new`/`delete` operators but depends on `libstdc++` even for `new`/`delete` operators that don't need `libtsdc++`. Module `sys/cpp_new_delete` provides these operators for platforms that don't have the `libstdc++`. Since these operators in `sys/cpp11-compat` are just wrappers for standard `malloc`/`free` functions like in `sys/cpp_new_delete`, the `new`/`delete` operators that don't need `libstdc++` are used from `sys/cpp_new_delete`. Only the `new`/`delete` operators that require the `libstd++` are left in `sys/cpp11-compat`.
    
    So it is sufficient for the use of the (re)defined `new`/`delete` operators that an application uses the module `sys/cpp_new_delete` instead of `sys/cpp11-compat` and thus also works on platforms without `libstdc++`.

2. On ARM platforms, `__dso_handle` is used for dynamic shared objects. But it is also required if global static objects are used. To avoid that `sys/cpp11_compat` is required only for using the (re)defined `new`/`delete` operators, `__dso_handle` is moved to module `sys/cpp_new_delete`

### Testing procedure

Green CI.

### Issues/PRs references

Uses the module introduced by PR #17464 