### PR TITLE
makefiles: use C++14 standard by default for C++ compilations

### DIFF
--- a/cpu/esp32/vendor/esp-idf/nvs_flash/Makefile
+++ b/cpu/esp32/vendor/esp-idf/nvs_flash/Makefile
@@ -3,7 +3,6 @@ MODULE=esp_idf_nvs_flash
 include $(RIOTBASE)/Makefile.base
 
 CFLAGS   += -DESP_PLATFORM
-CXXFLAGS += -std=c++11
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(ESP32_SDK_DIR)/components/nvs_flash/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/spi_flash/include

--- a/cpu/esp8266/vendor/esp-idf/nvs_flash/src/Makefile
+++ b/cpu/esp8266/vendor/esp-idf/nvs_flash/src/Makefile
@@ -3,6 +3,5 @@ MODULE=esp_idf_nvs_flash
 include $(RIOTBASE)/Makefile.base
 
 CFLAGS += -DESP_PLATFORM -DNVS_CRC_HEADER_FILE=\"crc.h\"
-CXXFLAGS += -std=c++11
 INCLUDES += -I$(ESP8266_RTOS_SDK_DIR)/components/nvs_flash/include
 INCLUDES += -I$(ESP8266_RTOS_SDK_DIR)/components/util/include

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -45,6 +45,12 @@ OPTIONAL_CFLAGS += -Wold-style-definition
 CXXUWFLAGS += -std=%
 CXXUWFLAGS += -Wstrict-prototypes -Wold-style-definition
 
+ifeq ($(filter -std=%,$(CXXEXFLAGS)),)
+  ifeq ($(shell $(CC) -std=c++14 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CXXEXFLAGS += -std=c++14
+  endif
+endif
+
 ifeq ($(LTO),1)
   $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto

--- a/pkg/arduino_api/Makefile.include
+++ b/pkg/arduino_api/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(PKGDIRBASE)/arduino_api/api
-
-CXXEXFLAGS += -std=c++11

--- a/pkg/flatbuffers/Makefile.include
+++ b/pkg/flatbuffers/Makefile.include
@@ -7,8 +7,5 @@ ifneq (0,$(shell which flatc > /dev/null 2>&1 ; echo $$?))
   $(call target-export-variables,all,FLATC)
 endif
 
-# This module requires cpp11 support
-CXXEXFLAGS += -std=c++11
-
 # This package is a header only package, so there's nothing to build
 PSEUDOMODULES += flatbuffers

--- a/pkg/talking_leds/Makefile.include
+++ b/pkg/talking_leds/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(PKGDIRBASE)/talking_leds/src
-
-CXXEXFLAGS += -std=c++11

--- a/pkg/utensor/Makefile.include
+++ b/pkg/utensor/Makefile.include
@@ -11,7 +11,3 @@ ifeq (llvm,$(TOOLCHAIN))
   CXXEXFLAGS += -Wno-unused-variable
   CXXEXFLAGS += -Wno-shift-count-negative
 endif
-
-ifneq (native,$(BOARD))
-  CXXEXFLAGS += -std=c++11
-endif

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -20,9 +20,4 @@ endif
 # include the Arduino headers
 INCLUDES += -I$(RIOTBASE)/sys/arduino/include
 
-# Arduino provices C++11, which is not enabled by default in Ubuntu's avr-gcc
-# package, which is __horrible__ out of date. However, we cannot simply ignore
-# all Ubuntu users and instead simply manually enable C++11 support
-CXXEXFLAGS += -std=c++11
-
 PSEUDOMODULES += arduino_pwm

--- a/sys/cpp11-compat/Makefile
+++ b/sys/cpp11-compat/Makefile
@@ -1,4 +1,1 @@
-# This module requires cpp 11
-CXXEXFLAGS += -std=c++11
-
 include $(RIOTBASE)/Makefile.base

--- a/sys/cpp11-compat/cppsupport.cpp
+++ b/sys/cpp11-compat/cppsupport.cpp
@@ -119,4 +119,18 @@ void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
     std::free(ptr);
 }
 
+/* end of tinynew.cpp */
+
+/* additional delete operators required by C++14 */
+
+void operator delete (void* ptr, std::size_t,
+                      const std::nothrow_t&) noexcept {
+    std::free(ptr);
+}
+
+void operator delete[] (void* ptr, std::size_t,
+                        const std::nothrow_t&) noexcept {
+    std::free(ptr);
+}
+
 /** @} */

--- a/sys/cpp_new_delete/Makefile
+++ b/sys/cpp_new_delete/Makefile
@@ -1,3 +1,1 @@
 include $(RIOTBASE)/Makefile.base
-
-CXXFLAGS += -std=c++11

--- a/sys/cpp_new_delete/new_delete.cpp
+++ b/sys/cpp_new_delete/new_delete.cpp
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <stdlib.h>
@@ -35,6 +37,14 @@ void operator delete(void *ptr) {
     free(ptr);
 }
 
+void operator delete(void *ptr, size_t) noexcept {
+    free(ptr);
+}
+
 void operator delete[](void *ptr) {
+    free(ptr);
+}
+
+void operator delete [](void *ptr, size_t) noexcept {
     free(ptr);
 }

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -1,9 +1,5 @@
 include ../Makefile.tests_common
 
-# If you want to add some extra flags when compile c++ files, add these flags
-# to CXXEXFLAGS variable
-CXXEXFLAGS += -std=c++11
-
 # nucleo-f303k8 doesn't have enough RAM to run the test so we reduce the stack
 # size for every thread
 ifneq (,$(filter nucleo-f303k8 nucleo-f334r8,$(BOARD)))

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -1,9 +1,5 @@
 include ../Makefile.tests_common
 
-# If you want to add some extra flags when compile c++ files, add these flags
-# to CXXEXFLAGS variable
-CXXEXFLAGS += -std=c++11
-
 USEMODULE += cpp11-compat
 USEMODULE += xtimer
 

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -1,9 +1,5 @@
 include ../Makefile.tests_common
 
-# If you want to add some extra flags when compile c++ files, add these flags
-# to CXXEXFLAGS variable
-CXXEXFLAGS += -std=c++11
-
 USEMODULE += cpp11-compat
 USEMODULE += xtimer
 USEMODULE += timex


### PR DESCRIPTION
### Contribution description

The GCC version of all used toolchains supports at least C++14. Option `-std=c++14` is therefore set by default for C++ compilations.

### Testing procedure

Green CI.

### Issues/PRs references
