### PR TITLE
sys/crypto: remove deprecated CIPHER_AES_128

### DIFF
--- a/pkg/ndn-riot/patches/0006-replace-deprecated-CIPHER_AES_128-by-CIPHER_AES.patch
+++ b/pkg/ndn-riot/patches/0006-replace-deprecated-CIPHER_AES_128-by-CIPHER_AES.patch
@@ -1,0 +1,34 @@
+From a69fe71eb8e915db21bda6879ce0f8b768e5982d Mon Sep 17 00:00:00 2001
+From: Alexandre Abadie <alexandre.abadie@inria.fr>
+Date: Fri, 7 Jan 2022 17:20:46 +0100
+Subject: [PATCH] replace deprecated CIPHER_AES_128 by CIPHER_AES
+
+---
+ encoding/data.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/encoding/data.c b/encoding/data.c
+index 6abf186..afebde4 100644
+--- a/encoding/data.c
++++ b/encoding/data.c
+@@ -437,7 +437,7 @@ ndn_shared_block_t* ndn_data_encrypt_with_ccm(ndn_block_t* name,
+ 
+     // Initiate cipher
+     cipher_t cipher;
+-    if (cipher_init(&cipher, CIPHER_AES_128, key, key_len) < 0) {
++    if (cipher_init(&cipher, CIPHER_AES, key, key_len) < 0) {
+         DEBUG("ndn_encoding: cannot init ccm cipher for encryption\n");
+         return NULL;
+     }
+@@ -1027,7 +1027,7 @@ ndn_shared_block_t* ndn_data_decrypt_with_ccm(ndn_block_t* block,
+ 
+     // Initiate cipher
+     cipher_t cipher;
+-    if (cipher_init(&cipher, CIPHER_AES_128, key, key_len) < 0) {
++    if (cipher_init(&cipher, CIPHER_AES, key, key_len) < 0) {
+         DEBUG("ndn_encoding: cannot init ccm cipher for decryption\n");
+         return NULL;
+     }
+-- 
+2.32.0
+

--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -72,7 +72,6 @@ static const cipher_interface_t aes_interface = {
     aes_decrypt
 };
 
-const cipher_id_t CIPHER_AES_128 = &aes_interface;
 const cipher_id_t CIPHER_AES = &aes_interface;
 
 static const u32 Te0[256] = {

--- a/sys/fido2/ctap/ctap_crypto.c
+++ b/sys/fido2/ctap/ctap_crypto.c
@@ -196,7 +196,7 @@ int fido2_ctap_crypto_aes_ccm_enc(uint8_t *out, size_t out_len,
     cipher_t cipher;
     int ret;
 
-    ret = cipher_init(&cipher, CIPHER_AES_128, key, key_len);
+    ret = cipher_init(&cipher, CIPHER_AES, key, key_len);
 
     if (ret != 1) {
         return CTAP1_ERR_OTHER;

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -108,14 +108,6 @@ typedef struct cipher_interface_st {
 typedef const cipher_interface_t *cipher_id_t;
 
 /**
- * @brief AES_128 cipher id
- *
- * @deprecated Use @ref CIPHER_AES instead. Will be removed after 2021.07
- * release.
- */
-extern const cipher_id_t CIPHER_AES_128;
-
-/**
  * @brief AES cipher id
  */
 extern const cipher_id_t CIPHER_AES;

--- a/tests/sys_crypto_aes_ccm/tests-crypto-modes-ccm-128.c
+++ b/tests/sys_crypto_aes_ccm/tests-crypto-modes-ccm-128.c
@@ -2186,7 +2186,7 @@ static void test_encrypt_op(const uint8_t *key, uint8_t key_len,
     TEST_ASSERT_MESSAGE(sizeof(data) >= output_expected_len,
                         "Output buffer too small");
 
-    err = cipher_init(&cipher, CIPHER_AES_128, key, key_len);
+    err = cipher_init(&cipher, CIPHER_AES, key, key_len);
     TEST_ASSERT_EQUAL_INT(1, err);
 
     len = cipher_encrypt_ccm(&cipher, adata, adata_len,
@@ -2214,7 +2214,7 @@ static void test_decrypt_op(const uint8_t *key, uint8_t key_len,
     TEST_ASSERT_MESSAGE(sizeof(data) >= output_expected_len,
                         "Output buffer too small");
 
-    err = cipher_init(&cipher, CIPHER_AES_128, key, key_len);
+    err = cipher_init(&cipher, CIPHER_AES, key, key_len);
     TEST_ASSERT_EQUAL_INT(1, err);
 
     len = cipher_decrypt_ccm(&cipher, adata, adata_len,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR removes the definition and use of CIPHER_AES_128 which is deprecated and marked for removal after 2021.07.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
