### PR TITLE
sys/asymcute: remove deprecated CONFIG_ASYMCUTE_BUFSIZE_EXP

### DIFF
--- a/sys/include/net/asymcute.h
+++ b/sys/include/net/asymcute.h
@@ -79,16 +79,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default buffer size for Asymcute client (as exponent of 2^n)
- *
- * @deprecated Use @ref CONFIG_ASYMCUTE_BUFSIZE instead. Will be removed after
- * 2021.04 release.
- */
-#ifndef CONFIG_ASYMCUTE_BUFSIZE_EXP
-#define CONFIG_ASYMCUTE_BUFSIZE_EXP     (7U)
-#endif
-
-/**
  * @brief   Default buffer size used for receive and request buffers
  */
 #ifndef CONFIG_ASYMCUTE_BUFSIZE


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR remove the deprecated (and unused) `CONFIG_ASYMCUTE_BUFSIZE_EXP` define which was marked for removal after 2021.04 release.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
