### PR TITLE
cpu/sam0_common: add missing MUX definitions

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -147,7 +147,12 @@ typedef enum {
     GPIO_MUX_F = 0x5,       /**< select peripheral function F */
     GPIO_MUX_G = 0x6,       /**< select peripheral function G */
     GPIO_MUX_H = 0x7,       /**< select peripheral function H */
+    GPIO_MUX_I = 0x8,       /**< select peripheral function I */
+    GPIO_MUX_J = 0x9,       /**< select peripheral function J */
+    GPIO_MUX_K = 0xa,       /**< select peripheral function K */
     GPIO_MUX_L = 0xb,       /**< select peripheral function L */
+    GPIO_MUX_M = 0xc,       /**< select peripheral function M */
+    GPIO_MUX_N = 0xd,       /**< select peripheral function N */
 } gpio_mux_t;
 #endif
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds the missing PINMUX modes to the enum.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
