### PR TITLE
sys/shell: remove deprecated SHELL_NO_{ECHO,PROMPT} defines

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -67,24 +67,6 @@ extern "C" {
 #define CONFIG_SHELL_NO_PROMPT 0
 #endif
 
-/**
- * @brief Set to 1 to disable shell's echo
- * @deprecated This has been replaced by @ref CONFIG_SHELL_NO_ECHO and will be
- *             removed after release 2021.07.
- */
-#ifndef SHELL_NO_ECHO
-#define SHELL_NO_ECHO CONFIG_SHELL_NO_ECHO
-#endif
-
-/**
- * @brief Set to 1 to disable shell's prompt
- * @deprecated This has been replaced by @ref CONFIG_SHELL_NO_PROMPT and will be
- *             removed after release 2021.07.
- */
-#ifndef SHELL_NO_PROMPT
-#define SHELL_NO_PROMPT CONFIG_SHELL_NO_PROMPT
-#endif
-
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

They were advertised for complete removal after 2021.07.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
