### PR TITLE
sys/net/sock: add sock_udp_sendv() API

### DIFF
--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -573,14 +573,15 @@ int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf)
 }
 #endif /* defined(MODULE_LWIP_SOCK_UDP) || defined(MODULE_LWIP_SOCK_IP) */
 
-ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
-                       int proto, const struct _sock_tl_ep *remote, int type)
+ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
+                        int proto, const struct _sock_tl_ep *remote, int type)
 {
     ip_addr_t remote_addr;
     struct netconn *tmp;
-    struct netbuf *buf;
+    struct netbuf *buf = NULL;
+    size_t payload_len = 0;
     int res;
-    err_t err;
+    err_t err= ERR_OK;
     u16_t remote_port = 0;
 
 #if LWIP_IPV6
@@ -598,11 +599,19 @@ ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
     }
 
     buf = netbuf_new();
-    if ((buf == NULL) || (netbuf_alloc(buf, len) == NULL) ||
-        (netbuf_take(buf, data, len) != ERR_OK)) {
+    if (netbuf_alloc(buf, iolist_size(snips)) == NULL) {
         netbuf_delete(buf);
         return -ENOMEM;
     }
+
+    for (const iolist_t *snip = snips; snip != NULL; snip = snip->iol_next) {
+        if (pbuf_take_at(buf->p, snip->iol_base, snip->iol_len, payload_len) != ERR_OK) {
+            netbuf_delete(buf);
+            return -ENOMEM;
+        }
+        payload_len += snip->iol_len;
+    }
+
     if ((conn == NULL) && (remote != NULL)) {
         if ((res = _create(type, proto, 0, &tmp)) < 0) {
             netbuf_delete(buf);
@@ -625,13 +634,13 @@ ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
         netbuf_delete(buf);
         return -ENOTCONN;
     }
-    res = len;  /* set for non-TCP calls */
+    res = payload_len;  /* set for non-TCP calls */
     if (remote != NULL) {
         err = netconn_sendto(tmp, buf, &remote_addr, remote_port);
     }
 #if LWIP_TCP
     else if (tmp->type & NETCONN_TCP) {
-        err = netconn_write_partly(tmp, data, len, 0, (size_t *)(&res));
+        err = netconn_write_partly(tmp, buf->p->payload, buf->p->len, 0, (size_t *)(&res));
     }
 #endif /* LWIP_TCP */
     else {

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -163,18 +163,17 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
     return (ssize_t)buf->ptr->len;
 }
 
-ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
-                          const sock_udp_ep_t *remote, sock_udp_aux_tx_t *aux)
+ssize_t sock_udp_sendv_aux(sock_udp_t *sock, const iolist_t *snips,
+                           const sock_udp_ep_t *remote, sock_udp_aux_tx_t *aux)
 {
     (void)aux;
     assert((sock != NULL) || (remote != NULL));
-    assert((len == 0) || (data != NULL)); /* (len != 0) => (data != NULL) */
 
     if ((remote != NULL) && (remote->port == 0)) {
         return -EINVAL;
     }
-    return lwip_sock_send((sock) ? sock->base.conn : NULL, data, len, 0,
-                          (struct _sock_tl_ep *)remote, NETCONN_UDP);
+    return lwip_sock_sendv((sock) ? sock->base.conn : NULL, snips, 0,
+                           (struct _sock_tl_ep *)remote, NETCONN_UDP);
 }
 
 #ifdef SOCK_HAS_ASYNC

--- a/pkg/lwip/include/lwip/sock_internal.h
+++ b/pkg/lwip/include/lwip/sock_internal.h
@@ -56,8 +56,19 @@ int lwip_sock_get_addr(struct netconn *conn, struct _sock_tl_ep *ep, u8_t local)
 #if defined(MODULE_LWIP_SOCK_UDP) || defined(MODULE_LWIP_SOCK_IP)
 int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf);
 #endif
-ssize_t lwip_sock_send(struct netconn *conn, const void *data, size_t len,
-                       int proto, const struct _sock_tl_ep *remote, int type);
+ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
+                        int proto, const struct _sock_tl_ep *remote, int type);
+static inline ssize_t lwip_sock_send(struct netconn *conn,
+                                     const void *data, size_t len,
+                                     int proto, const struct _sock_tl_ep *remote, int type)
+{
+    iolist_t snip = {
+        .iol_base = (void *)data,
+        .iol_len  = len,
+    };
+
+    return lwip_sock_sendv(conn, &snip, proto, remote, type);
+}
 /**
  * @}
  */

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -141,6 +141,10 @@ ifneq (,$(filter sntp,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter sock_%,$(USEMODULE)))
+  USEMODULE += iolist
+endif
+
 ifneq (,$(filter netdev_ieee802154,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += random

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -103,6 +103,8 @@
 #define NET_SOCK_H
 
 #include <stdint.h>
+#include <stddef.h>
+#include "iolist.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -605,6 +605,43 @@ static inline ssize_t sock_udp_recv_buf(sock_udp_t *sock,
 }
 
 /**
+ * @brief   Sends a UDP message to remote end point with non-continous payload
+ *
+ * @pre `((sock != NULL || remote != NULL))`
+ *
+ * @param[in] sock      A UDP sock object. May be `NULL`.
+ *                      A sensible local end point should be selected by the
+ *                      implementation in that case.
+ * @param[in] snips     List of payload chunks, will be processed in order.
+ *                      May be `NULL`.
+ * @param[in] remote    Remote end point for the sent data.
+ *                      May be `NULL`, if @p sock has a remote end point.
+ *                      sock_udp_ep_t::family may be AF_UNSPEC, if local
+ *                      end point of @p sock provides this information.
+ *                      sock_udp_ep_t::port may not be 0.
+ * @param[out] aux      Auxiliary data about the transmission.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @return  The number of bytes sent on success.
+ * @return  -EADDRINUSE, if `sock` has no local end-point or was `NULL` and the
+ *          pool of available ephemeral ports is depleted.
+ * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_udp_ep_t::family of
+ *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
+ *          reachable.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::netif of @p remote is not a valid
+ *          interface or contradicts the given local interface (i.e.
+ *          neither the local end point of `sock` nor remote are assigned to
+ *          `SOCK_ADDR_ANY_NETIF` but are nevertheless different.
+ * @return  -EINVAL, if sock_udp_ep_t::port of @p remote is 0.
+ * @return  -ENOMEM, if no memory was available to send @p data.
+ * @return  -ENOTCONN, if `remote == NULL`, but @p sock has no remote end point.
+ */
+ssize_t sock_udp_sendv_aux(sock_udp_t *sock, const iolist_t *snips,
+                           const sock_udp_ep_t *remote, sock_udp_aux_tx_t *aux);
+
+/**
  * @brief   Sends a UDP message to remote end point
  *
  * @pre `((sock != NULL || remote != NULL)) && (if (len != 0): (data != NULL))`
@@ -639,8 +676,18 @@ static inline ssize_t sock_udp_recv_buf(sock_udp_t *sock,
  * @return  -ENOMEM, if no memory was available to send @p data.
  * @return  -ENOTCONN, if `remote == NULL`, but @p sock has no remote end point.
  */
-ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
-                          const sock_udp_ep_t *remote, sock_udp_aux_tx_t *aux);
+static inline ssize_t sock_udp_send_aux(sock_udp_t *sock,
+                                        const void *data, size_t len,
+                                        const sock_udp_ep_t *remote,
+                                        sock_udp_aux_tx_t *aux)
+{
+    const iolist_t snip = {
+        .iol_base = (void *)data,
+        .iol_len  = len,
+    };
+
+    return sock_udp_sendv_aux(sock, &snip, remote, aux);
+}
 
 /**
  * @brief   Sends a UDP message to remote end point
@@ -680,6 +727,45 @@ static inline ssize_t sock_udp_send(sock_udp_t *sock,
                                     const sock_udp_ep_t *remote)
 {
     return sock_udp_send_aux(sock, data, len, remote, NULL);
+}
+
+/**
+ * @brief   Sends a UDP message to remote end point with non-continous payload
+ *
+ * @pre `((sock != NULL || remote != NULL))`
+ *
+ * @param[in] sock      A UDP sock object. May be `NULL`.
+ *                      A sensible local end point should be selected by the
+ *                      implementation in that case.
+ * @param[in] snips     List of payload chunks, will be processed in order.
+ *                      May be `NULL`.
+ * @param[in] remote    Remote end point for the sent data.
+ *                      May be `NULL`, if @p sock has a remote end point.
+ *                      sock_udp_ep_t::family may be AF_UNSPEC, if local
+ *                      end point of @p sock provides this information.
+ *                      sock_udp_ep_t::port may not be 0.
+ *
+ * @return  The number of bytes sent on success.
+ * @return  -EADDRINUSE, if `sock` has no local end-point or was `NULL` and the
+ *          pool of available ephemeral ports is depleted.
+ * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_udp_ep_t::family of
+ *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
+ *          reachable.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::netif of @p remote is not a valid
+ *          interface or contradicts the given local interface (i.e.
+ *          neither the local end point of `sock` nor remote are assigned to
+ *          `SOCK_ADDR_ANY_NETIF` but are nevertheless different.
+ * @return  -EINVAL, if sock_udp_ep_t::port of @p remote is 0.
+ * @return  -ENOMEM, if no memory was available to send @p data.
+ * @return  -ENOTCONN, if `remote == NULL`, but @p sock has no remote end point.
+ */
+static inline ssize_t sock_udp_sendv(sock_udp_t *sock,
+                                     const iolist_t *snips,
+                                     const sock_udp_ep_t *remote)
+{
+    return sock_udp_sendv_aux(sock, snips, remote, NULL);
 }
 
 #include "sock_types.h"

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -1288,6 +1288,38 @@ static void test_sock_udp_send6__socketed(void)
     expect(_check_net());
 }
 
+static void test_sock_udp_sendv6__socketed(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_LOCAL };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR6_REMOTE };
+    static const sock_udp_ep_t local = { .addr = { .ipv6 = _TEST_ADDR6_LOCAL },
+                                         .family = AF_INET6,
+                                         .netif = _TEST_NETIF,
+                                         .port = _TEST_PORT_LOCAL };
+    static const sock_udp_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_REMOTE },
+                                          .family = AF_INET6,
+                                          .port = _TEST_PORT_REMOTE };
+
+    const iolist_t tail = {
+        .iol_base = "EFGH",
+        .iol_len  = sizeof("EFGH"),
+    };
+
+    const iolist_t head = {
+        .iol_next = (void *)&tail,
+        .iol_base = "ABCD",
+        .iol_len  = sizeof("ABCD") - 1,
+    };
+
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(sizeof("ABCDEFGH") == sock_udp_sendv(&_sock, &head, NULL));
+    expect(_check_6packet(&src_addr, &dst_addr, _TEST_PORT_LOCAL,
+                         _TEST_PORT_REMOTE, "ABCDEFGH", sizeof("ABCDEFGH"),
+                         _TEST_NETIF, false));
+    xtimer_usleep(1000);    /* let GNRC stack finish */
+    expect(_check_net());
+}
+
 static void test_sock_udp_send6__socketed_other_remote(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_LOCAL };
@@ -1531,6 +1563,7 @@ int main(void)
     CALL(test_sock_udp_send6__socketed_no_netif());
     CALL(test_sock_udp_send6__socketed_no_local());
     CALL(test_sock_udp_send6__socketed());
+    CALL(test_sock_udp_sendv6__socketed());
     CALL(test_sock_udp_send6__socketed_other_remote());
     CALL(test_sock_udp_send6__unsocketed_no_local_no_netif());
     CALL(test_sock_udp_send6__unsocketed_no_netif());


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Both GNRC and LWIP support the notion of packet snips/slices: A packet does not have to be in continuous memory.
This is useful when e.g. sending a blockwise CoAP message where the CoAP header can be a small buffer and the CoAP block payload can be just a pointer into a larger buffer (possibly on ROM).

However, the sock API completely throws this out of the window by only allowing a single payload buffer in `sock_udp_send()`.
This means we need another buffer to copy the payload and the header into, artificially doubling memory requirements and introducing an unnecessary copy step. 

Fix this by introducing a new `sock_udp_sendv()` function. This allows to specify an array of payload chunks instead of a single buffer. `sock_udp_send()` is now simple a wrapper around the new function.

#### Implemented for

 - [x] GNRC
 - [x] LWIP
 - [x] OpenWSN

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
