### PR TITLE
drivers/stmpe811: improve interrupt callback management

### DIFF
--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -118,17 +118,6 @@ static int _read_burst(const stmpe811_t *dev, uint8_t reg, void *buf, size_t len
 }
 #endif /* bus mode selection */
 
-static void _gpio_irq(void *arg)
-{
-    const stmpe811_t *dev = (const stmpe811_t *)arg;
-
-    assert(dev);
-
-    if (dev->cb) {
-        dev->cb(dev->cb_arg);
-    }
-}
-
 static int _soft_reset(const stmpe811_t *dev)
 {
     if (_write_reg(dev, STMPE811_SYS_CTRL1, STMPE811_SYS_CTRL1_SOFT_RESET ) < 0) {
@@ -191,8 +180,6 @@ int stmpe811_init(stmpe811_t *dev, const stmpe811_params_t *params, stmpe811_eve
                   void *arg)
 {
     dev->params = *params;
-    dev->cb = cb;
-    dev->cb_arg = arg;
     dev->prev_x = 0;
     dev->prev_y = 0;
 
@@ -295,7 +282,7 @@ int stmpe811_init(stmpe811_t *dev, const stmpe811_params_t *params, stmpe811_eve
 
     if (gpio_is_valid(dev->params.int_pin)) {
         DEBUG("[stmpe811] init: configuring touchscreen interrupt\n");
-        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, _gpio_irq, dev);
+        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, arg);
 
         /* Enable touchscreen interrupt */
         ret += _write_reg(dev, STMPE811_INT_EN, STMPE811_INT_EN_TOUCH_DET);

--- a/drivers/stmpe811/stmpe811_touch_dev.c
+++ b/drivers/stmpe811/stmpe811_touch_dev.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 
 #include "kernel_defines.h"
+#include "periph/gpio.h"
 
 #include "stmpe811.h"
 #include "stmpe811_touch_dev.h"
@@ -77,8 +78,9 @@ void _stmpe811_set_event_callback(const touch_dev_t *touch_dev, touch_event_cb_t
     stmpe811_t *dev = (stmpe811_t *)touch_dev;
     assert(dev);
 
-    dev->cb = (stmpe811_event_cb_t)cb;
-    dev->cb_arg = arg;
+    if (gpio_is_valid(dev->params.int_pin)) {
+        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, arg);
+    }
 }
 
 const touch_dev_driver_t stmpe811_touch_dev_driver = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Inspired by https://github.com/RIOT-OS/RIOT/pull/17448#discussion_r779749191

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `tests/driver_stmpe811` and ` tests/touch_dev` should still work (I'll be able to test later)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Inspired by @benpicco's review in #17448

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
