### PR TITLE
sys/saul_reg: remove deprecated saul_reg_rm function

### DIFF
--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -70,26 +70,6 @@ extern saul_reg_t *saul_reg;
 int saul_reg_add(saul_reg_t *dev);
 
 /**
- * @brief   Unregister a device from the SAUL registry
- *
- * @warning   Removing the device at runtime can send applications that have
- *            looked up that device into invalid states, and should thus be
- *            avoided.
- *
- * @warning   This function must only be used by drivers that advise developers
- *            using them on how to prevent race conditions when using SAUL.
- *
- * @deprecated This function will be removed soon as it is practically unusable
- *             for the above reasons.
- *
- * @param[in] dev       pointer to a registry entry
- *
- * @return      0 on success
- * @return      -ENODEV if device was not found in the registry
- */
-int saul_reg_rm(saul_reg_t *dev);
-
-/**
  * @brief   Find a device by its position in the registry
  *
  * @param[in] pos       position to look up

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -53,29 +53,6 @@ int saul_reg_add(saul_reg_t *dev)
     return 0;
 }
 
-int saul_reg_rm(saul_reg_t *dev)
-{
-    saul_reg_t *tmp = saul_reg;
-
-    if (saul_reg == NULL || dev == NULL) {
-        return -ENODEV;
-    }
-    if (saul_reg == dev) {
-        saul_reg = dev->next;
-        return 0;
-    }
-    while (tmp->next && (tmp->next != dev)) {
-        tmp = tmp->next;
-    }
-    if (tmp->next == dev) {
-        tmp->next = dev->next;
-    }
-    else {
-        return -ENODEV;
-    }
-    return 0;
-}
-
 saul_reg_t *saul_reg_find_nth(int pos)
 {
     saul_reg_t *tmp = saul_reg;

--- a/tests/unittests/tests-saul_reg/tests-saul_reg.c
+++ b/tests/unittests/tests-saul_reg/tests-saul_reg.c
@@ -166,52 +166,6 @@ static void test_reg_find_type_and_name(void)
     TEST_ASSERT_NULL(dev);
 }
 
-static void test_reg_rm(void)
-{
-    int res;
-
-    TEST_ASSERT_EQUAL_INT(5, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S3", last()->name);
-
-    res = saul_reg_rm(&s3b);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(4, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S3", last()->name);
-
-    res = saul_reg_rm(&s3a);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(3, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
-
-    res = saul_reg_rm(&s1);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(2, count());
-    TEST_ASSERT_EQUAL_STRING("S0", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
-
-    res = saul_reg_rm(&s1);
-    TEST_ASSERT_EQUAL_INT(-ENODEV, res);
-
-    res = saul_reg_rm(NULL);
-    TEST_ASSERT_EQUAL_INT(-ENODEV, res);
-
-    TEST_ASSERT_EQUAL_INT(2, count());
-
-    res = saul_reg_rm(&s0);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(1, count());
-    TEST_ASSERT_EQUAL_STRING("S2", saul_reg->name);
-    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
-
-    res = saul_reg_rm(&s2);
-    TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(0, count());
-    TEST_ASSERT_NULL(saul_reg);
-}
-
 Test *tests_saul_reg_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -221,7 +175,6 @@ Test *tests_saul_reg_tests(void)
         new_TestFixture(test_reg_find_type),
         new_TestFixture(test_reg_find_name),
         new_TestFixture(test_reg_find_type_and_name),
-        new_TestFixture(test_reg_rm)
     };
 
     EMB_UNIT_TESTCALLER(pkt_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This function was deprecated in #10605 without a clear removal date. The PR was merged end of May 2020 so I think the grace period is enough.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Remove a function marked as deprecated in #10605

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
