### PR TITLE
make: remove deprecation warnings raised with old flasher tools vars

### DIFF
--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -2,12 +2,6 @@ BOSSA_VERSION ?= 1.9
 FLASHFILE ?= $(BINFILE)
 FLASHER ?= $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)/bossac
 
-# Warn about deprecated variables
-ifneq (,$(FFLAGS_OPTS))
-  $(warning Warning! FFLAGS_OPTS is deprecated use BOSSA_FLAGS_OPTS)
-  BOSSA_FLAGS_OPTS ?= $(FFLAGS_OPTS)
-endif
-
 BOSSA_FLAGS_OPTS ?=
 
 # Only use ROM_OFFSET with Bossa version 1.9

--- a/makefiles/tools/cc2538-bsl.inc.mk
+++ b/makefiles/tools/cc2538-bsl.inc.mk
@@ -3,12 +3,6 @@ FLASHFILE ?= $(CC2538_BSL_FLASHFILE)
 CC2538_BSL ?= $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
 PROG_BAUD ?= 500000	# default value in cc2538-bsl
 
-# Warn about deprecated variables
-ifneq (,$(FFLAGS_OPTS))
-  $(warning Warning! FFLAGS_OPTS is deprecated use CC2538_BSL_FLAGS_OPTS)
-  CC2538_BSL_FLAGS_OPTS ?= $(FFLAGS_OPTS)
-endif
-
 CC2538_BSL_FLAGS_OPTS ?=
 CC2538_BSL_FLAGS  = $(if $(IMAGE_OFFSET), -a $(shell printf "0x%08x" $$(($(IMAGE_OFFSET) + $(ROM_START_ADDR)))))
 CC2538_BSL_FLAGS += -p "$(PROG_DEV)" $(CC2538_BSL_FLAGS_OPTS) --write-erase -v -b $(PROG_BAUD) $(FLASHFILE)

--- a/makefiles/tools/dfu-util.inc.mk
+++ b/makefiles/tools/dfu-util.inc.mk
@@ -10,12 +10,6 @@ _ROM_ADDR_WITH_OFFSET ?= $(shell printf "0x%x" $$(($(ROM_START_ADDR) + $(ROM_OFF
 FLASH_ADDR ?= $(if $(ROM_OFFSET),$(_ROM_ADDR_WITH_OFFSET),$(ROM_START_ADDR))
 DFU_USE_DFUSE ?= 0
 
-# Warn about deprecated variables
-ifneq (,$(FFLAGS_OPTS))
-  $(warning Warning! FFLAGS_OPTS is deprecated use DFU_UTIL_FLAGS_OPTS)
-  DFU_UTIL_FLAGS_OPTS ?= $(FFLAGS_OPTS)
-endif
-
 # Optional flasher flags
 DFU_UTIL_FLAGS_OPTS ?=
 

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -9,17 +9,6 @@ DEBUGGER_FLAGS ?= debug $(ELFFILE)
 DEBUGSERVER_FLAGS ?= debug-server
 RESET_FLAGS ?= reset
 
-# Warn about deprecated variables
-ifneq (,$(DEBUG_ADAPTER))
-  $(warning Warning! DEBUG_ADAPTER is deprecated use OPENOCD_DEBUG_ADAPTER)
-  OPENOCD_DEBUG_ADAPTER ?= $(DEBUG_ADAPTER)
-endif
-
-ifneq (,$(PRE_FLASH_CHECK_SCRIPT))
-  $(warning Warning! PRE_FLASH_CHECK_SCRIPT is deprecated use OPENOCD_PRE_FLASH_CHECK_SCRIPT)
-  OPENOCD_PRE_FLASH_CHECK_SCRIPT ?= $(PRE_FLASH_CHECK_SCRIPT)
-endif
-
 ifneq (,$(OPENOCD_DEBUG_ADAPTER))
   include $(RIOTMAKE)/tools/openocd-adapters/$(OPENOCD_DEBUG_ADAPTER).inc.mk
   OPENOCD_ADAPTER_INIT += -c 'transport select $(OPENOCD_TRANSPORT)'

--- a/makefiles/tools/pyocd.inc.mk
+++ b/makefiles/tools/pyocd.inc.mk
@@ -3,12 +3,6 @@ DEBUGGER ?= $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 DEBUGSERVER ?= $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 RESET ?= $(RIOTBASE)/dist/tools/pyocd/pyocd.sh
 
-# Warn about deprecated variables
-ifneq (,$(FLASH_TARGET_TYPE))
-  $(warning Warning! FLASH_TARGET_TYPE is deprecated use PYOCD_FLASH_TARGET_TYPE)
-  PYOCD_FLASH_TARGET_TYPE ?= $(FLASH_TARGET_TYPE)
-endif
-
 PYOCD_FLASH_TARGET_TYPE ?=
 FLASHFILE ?= $(HEXFILE)
 FFLAGS ?= flash $(FLASHFILE)

--- a/makefiles/tools/uf2conv.inc.mk
+++ b/makefiles/tools/uf2conv.inc.mk
@@ -1,11 +1,5 @@
 FLASHFILE ?= $(HEXFILE)
 
-# Warn about deprecated variables
-ifneq (,$(FFLAGS_OPTS))
-  $(warning Warning! FFLAGS_OPTS is deprecated use UF2CONV_FLAGS)
-  UF2CONV_FLAGS ?= $(FFLAGS_OPTS)
-endif
-
 FLASHER ?= $(RIOTTOOLS)/uf2/uf2conv.py
 FFLAGS  ?= $(UF2CONV_FLAGS) $(FLASHFILE)
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Make variables used for flasher tools were refactored (mostly renamed with tools specific namespaces) beginning of 2021 and deprecation warnings were added at that moment.

This PR removes all the deprecation warnings and the support for the old variables names.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Can't find the old PRs related

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
