### PR TITLE
sys/net/application_layer/sock_dns: add pseudomodule auto_init_sock_dns

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -24,6 +24,15 @@ ifneq (,$(filter auto_init_gnrc_netif,$(USEMODULE)))
   USEMODULE += gnrc_netif_init_devs
 endif
 
+ifneq (,$(filter auto_init_sock_dns,$(USEMODULE)))
+  ifneq (,$(filter ipv4,$(USEMODULE)))
+    USEMODULE += ipv4_addr
+  endif
+  ifneq (,$(filter ipv6,$(USEMODULE)))
+    USEMODULE += ipv6_addr
+  endif
+endif
+
 ifneq (,$(filter congure_%,$(USEMODULE)))
   USEMODULE += congure
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -319,4 +319,10 @@ void auto_init(void)
         extern void benchmark_udp_auto_init(void);
         benchmark_udp_auto_init();
     }
+
+    if (IS_USED(MODULE_AUTO_INIT_SOCK_DNS)) {
+        LOG_DEBUG("Auto init sock_dns.\n");
+        extern void auto_init_sock_dns(void);
+        auto_init_sock_dns();
+    }
 }

--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -18,6 +18,7 @@
  * @brief   DNS sock definitions
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
 
 #ifndef NET_SOCK_DNS_H
@@ -34,6 +35,41 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef MODULE_AUTO_INIT_SOCK_DNS
+/**
+ * @brief IP version of the address provided with CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR
+ */
+#ifndef CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION
+    /* IPv6 is preferred */
+    #if defined(SOCK_HAS_IPV6)
+        #define CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION 6
+    #elif defined(SOCK_HAS_IPV4)
+        #define CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION 4
+    #else
+        #error "Neither IPv4 nor IPv6 included in build"
+    #endif
+#endif
+
+/**
+ * @brief Address of the DNS server
+ */
+#ifndef CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR
+    /* Default to Google Public DNS */
+    #if CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION == 6
+        #define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR "2001:4860:4860::8888"
+    #elif CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION == 4
+        #define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR "8.8.8.8"
+    #endif
+#endif
+
+/**
+ * @brief Port of the DNS server
+ */
+#ifndef CONFIG_AUTO_INIT_SOCK_DNS_SERVER_PORT
+#define CONFIG_AUTO_INIT_SOCK_DNS_SERVER_PORT SOCK_DNS_PORT
+#endif
+#endif /* MODULE_AUTO_INIT_SOCK_DNS */
 
 /**
  * @name DNS defines

--- a/sys/net/application_layer/sock_dns/dns.c
+++ b/sys/net/application_layer/sock_dns/dns.c
@@ -12,11 +12,14 @@
  * @file
  * @brief   sock DNS client implementation
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Hendrik van Essen <hendrik.ve@fu-berlin.de>
  * @}
  */
 
 #include <errno.h>
 #include <string.h>
+
+#include <arpa/inet.h>
 
 #include "net/dns.h"
 #include "net/dns/msg.h"
@@ -24,10 +27,43 @@
 #include "net/sock/dns.h"
 
 /* min domain name length is 1, so minimum record length is 7 */
-#define DNS_MIN_REPLY_LEN   (unsigned)(sizeof(dns_hdr_t ) + 7)
+#define DNS_MIN_REPLY_LEN   (unsigned)(sizeof(dns_hdr_t) + 7)
 
 /* global DNS server UDP endpoint */
 sock_udp_ep_t sock_dns_server;
+
+#ifdef MODULE_AUTO_INIT_SOCK_DNS
+void auto_init_sock_dns(void)
+{
+    assert(   CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION == 4
+           || CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION == 6);
+
+    assert(   CONFIG_AUTO_INIT_SOCK_DNS_SERVER_PORT > 0
+           && CONFIG_AUTO_INIT_SOCK_DNS_SERVER_PORT <= 0xffff);
+
+    switch (CONFIG_AUTO_INIT_SOCK_DNS_IP_VERSION) {
+#ifdef SOCK_HAS_IPV4
+    case 4:
+        inet_pton(AF_INET, CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR,
+                  sock_dns_server.addr.ipv4);
+        sock_dns_server.family = AF_INET;
+        break;
+#endif
+#ifdef SOCK_HAS_IPV6
+    case 6:
+        inet_pton(AF_INET6, CONFIG_AUTO_INIT_SOCK_DNS_SERVER_ADDR,
+                  sock_dns_server.addr.ipv6);
+        sock_dns_server.family = AF_INET6;
+        break;
+#endif
+    default:
+        assert(0);
+        return;
+    }
+
+    sock_dns_server.port = CONFIG_AUTO_INIT_SOCK_DNS_SERVER_PORT;
+}
+#endif /* MODULE_AUTO_INIT_SOCK_DNS */
 
 int sock_dns_query(const char *domain_name, void *addr_out, int family)
 {


### PR DESCRIPTION
### Contribution description

This PR adds the pseudomodule `auto_init_sock_dns` to `sock_dns` such that the DNS server can be set automatically.

### Testing procedure

You can test this by adding `USEMODULE += auto_init_sock_dns` to the makefile of `tests/gnrc_sock_dns`. When running the program with a terminal and execute `dns server` it will immediatly return `DNS server: [2001:4860:4860::8888]:53` showing that a DNS server is alredy set up automatically.