### PR TITLE
murdock: don't run can_fast_ci_run if `FULL_BUILD==1`

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -665,6 +665,11 @@ static_tests() {
 
 build_filter_status() {
     echo "--- can_fast_ci_run:"
+    if [ $FULL_BUILD -eq 1 ]; then
+        echo "--- doing full build."
+        return
+    fi
+
     dist/tools/ci/can_fast_ci_run.py ${CFCR_ARGS} --explain --json --changed-boards --changed-apps
     if [ -n "$MURDOCK_TEST_CHANGE_FILTER" ]; then
         echo MURDOCK_TEST_CHANGE_FILTER=$MURDOCK_TEST_CHANGE_FILTER


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The fast build script seems to have broken nightlies, as those don't have a base branch configured:

```
-- running on worker breeze thread 5, build number 213193.
--- can_fast_ci_run:
usage: can_fast_ci_run.py [-h] [--explain] [--debug] [--riotbase RIOTBASE]
                          [--upstreambranch UPSTREAMBRANCH] [--changed-boards]
                          [--changed-apps] [--json]
can_fast_ci_run.py: error: argument --upstreambranch: expected one argument
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
