### PR TITLE
cpu/stm32/wl: Model kconfig clocks

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -117,9 +117,6 @@ esp8266-olimex-mod
 
 msbiot
 pyboard
-
-lora-e5-dev
-nucleo-wl55jc
 "}
 
 # This list will force all boards that are not in the TEST_KCONFIG_BOARD_BLOCKLIST

--- a/boards/lora-e5-dev/Kconfig
+++ b/boards/lora-e5-dev/Kconfig
@@ -25,6 +25,10 @@ config BOARD_LORA_E5_DEV
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
     select HAVE_SAUL_GPIO
     select HAVE_LM75A
 
@@ -35,3 +39,5 @@ config LORA_E5_DEV_ENABLE_3P3V
 config LORA_E5_DEV_ENABLE_5V
     bool "LoRa-E5 Development Kit - Enable 5V output"
     default y
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -22,7 +22,7 @@ config USE_CLOCK_PLL
 
 config USE_CLOCK_MSI
     bool "Use direct multi-speed frequency internal oscillator (MSI)"
-    depends on CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    depends on CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config USE_CLOCK_HSE
     bool "Direct High frequency external oscillator (HSE)"
@@ -33,7 +33,7 @@ config USE_CLOCK_HSI
 
 endchoice
 
-if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 choice
 bool "Source clock for PLL" if USE_CLOCK_PLL
 default CLOCK_PLL_SRC_HSE if BOARD_HAS_HSE
@@ -50,7 +50,7 @@ config CLOCK_PLL_SRC_HSI
     bool "Use HSI16 source clock"
 endchoice
 
-endif  # CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+endif  # CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CUSTOM_PLL_PARAMS
     bool "Configure PLL parameters"
@@ -63,10 +63,10 @@ config CLOCK_PLL_M
     default 1 if CPU_FAM_G0
     default 6 if CPU_FAM_G4 && BOARD_HAS_HSE
     default 4 if CPU_FAM_G4
-    default 6 if (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB) && CLOCK_PLL_SRC_MSI
-    default 4 if CPU_FAM_WB && CLOCK_PLL_SRC_HSE
-    default 2 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_MP1
-    range 1 8 if CPU_FAM_G0 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    default 6 if (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL) && CLOCK_PLL_SRC_MSI
+    default 4 if (CPU_FAM_WB || CPU_FAM_WL) && CLOCK_PLL_SRC_HSE
+    default 2 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL || CPU_FAM_MP1
+    range 1 8 if CPU_FAM_G0 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
     range 1 16 if CPU_FAM_G4
 
 config CLOCK_PLL_N
@@ -85,6 +85,7 @@ config CLOCK_PLL_N
     default 90 if CPU_FAM_F4 && CLOCK_MAX_180MHZ
     default 216 if CPU_FAM_F7 && BOARD_HAS_HSE
     default 108 if CPU_FAM_F7
+    default 12 if CPU_FAM_WL
     default 16 if CPU_FAM_WB
     default 30 if CPU_LINE_STM32L4A6XX || CPU_LINE_STM32L4P5XX || CPU_LINE_STM32L4Q5XX || CPU_LINE_STM32L4R5XX || CPU_LINE_STM32L4R7XX || CPU_LINE_STM32L4R9XX || CPU_LINE_STM32L4S5XX || CPU_LINE_STM32L4S7XX || CPU_LINE_STM32L4S9XX
     default 27 if CPU_FAM_L5
@@ -95,7 +96,7 @@ config CLOCK_PLL_N
     range 8 86 if CPU_FAM_G0 || CPU_FAM_L4 || CPU_FAM_L5
     range 50 432 if CPU_FAM_F2 || CPU_FAM_F4 || CPU_FAM_F7
     range 8 127 if CPU_FAM_G4
-    range 6 127 if CPU_FAM_WB
+    range 6 127 if CPU_FAM_WB || CPU_FAM_WL
     range 4 512 if CPU_FAM_MP1
 
 if CPU_FAM_F2 || CPU_FAM_F4 || CPU_FAM_F7 || CPU_FAM_MP1
@@ -138,15 +139,15 @@ config CLOCK_PLL_Q
     range 2 15
 endif  # CPU_FAM_F2 || CPU_FAM_F4 || CPU_FAM_F7 || CPU_FAM_MP1
 
-if CPU_FAM_G0 || CPU_FAM_WB || CPU_FAM_MP1
+if CPU_FAM_G0 || CPU_FAM_WB || CPU_FAM_WL || CPU_FAM_MP1
 config CLOCK_PLL_R
     int "Q: VCO division factor" if CUSTOM_PLL_PARAMS
-    default 2 if CPU_FAM_WB
+    default 2 if CPU_FAM_WB || CPU_FAM_WL
     default 3 if CPU_FAM_MP1
     default 6 if BOARD_HAS_HSE
     default 5
     range 2 8
-endif  # CPU_FAM_G0 || CPU_FAM_WB || CPU_FAM_MP1
+endif  # CPU_FAM_G0 || CPU_FAM_WB || CPU_FAM_WL || CPU_FAM_MP1
 
 if CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 choice
@@ -175,7 +176,7 @@ config CLOCK_PLL_R
     default 8 if PLL_R_DIV_8
 endif  # CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 
-endif  # CPU_FAM_F2 || CPU_FAM_F4 || CPU_FAM_F7 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_MP1
+endif  # CPU_FAM_F2 || CPU_FAM_F4 || CPU_FAM_F7 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL || CPU_FAM_MP1
 
 if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
 config CLOCK_PLL_PREDIV
@@ -288,35 +289,35 @@ config CLOCK_HSISYS_DIV
     default 128 if CLOCK_HSISYS_DIV_128
 endif  # CPU_FAM_G0
 
-if CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+if CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 choice
 bool "Desired MSI clock frequency" if USE_CLOCK_MSI || (USE_CLOCK_PLL && CLOCK_PLL_SRC_MSI)
-default CLOCK_MSI_48MHZ if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+default CLOCK_MSI_48MHZ if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 default CLOCK_MSI_4MHZ
 
 config CLOCK_MSI_65KHZ
     bool "65.536kHz" if CPU_FAM_L0 || CPU_FAM_L1
 
 config CLOCK_MSI_100KHZ
-    bool "100kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "100kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_130KHZ
     bool "131.072kHz" if CPU_FAM_L0 || CPU_FAM_L1
 
 config CLOCK_MSI_200KHZ
-    bool "200kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "200kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_260KHZ
     bool "262.144kHz" if CPU_FAM_L0 || CPU_FAM_L1
 
 config CLOCK_MSI_400KHZ
-    bool "400kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "400kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_520KHZ
     bool "524.288kHz" if CPU_FAM_L0 || CPU_FAM_L1
 
 config CLOCK_MSI_800KHZ
-    bool "800kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "800kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_1MHZ
     bool
@@ -331,19 +332,19 @@ config CLOCK_MSI_4MHZ
     prompt "4MHz"
 
 config CLOCK_MSI_8MHZ
-    bool "8MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "8MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_16MHZ
-    bool "16MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "16MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_24MHZ
-    bool "24MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "24MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_32MHZ
-    bool "32MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "32MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MSI_48MHZ
-    bool "48MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    bool "48MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 endchoice
 
@@ -357,11 +358,11 @@ config CLOCK_MSI
     default 200000 if CLOCK_MSI_200KHZ
     default 400000 if CLOCK_MSI_400KHZ
     default 800000 if CLOCK_MSI_800KHZ
-    default 1000000 if CLOCK_MSI_1MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB)
+    default 1000000 if CLOCK_MSI_1MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL)
     default 1048000 if CLOCK_MSI_1MHZ && (CPU_FAM_L0 || CPU_FAM_L1)
-    default 2000000 if CLOCK_MSI_2MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB)
+    default 2000000 if CLOCK_MSI_2MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL)
     default 2097000 if CLOCK_MSI_2MHZ && (CPU_FAM_L0 || CPU_FAM_L1)
-    default 4000000 if CLOCK_MSI_4MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB)
+    default 4000000 if CLOCK_MSI_4MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL)
     default 4194000 if CLOCK_MSI_4MHZ && (CPU_FAM_L0 || CPU_FAM_L1)
     default 8000000 if CLOCK_MSI_8MHZ
     default 16000000 if CLOCK_MSI_16MHZ
@@ -369,11 +370,11 @@ config CLOCK_MSI
     default 32000000 if CLOCK_MSI_32MHZ
     default 48000000 if CLOCK_MSI_48MHZ
 
-endif  # CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+endif  # CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 
 choice
 bool "APB1 prescaler (division factor of HCLK to produce PCLK1)"
-default CLOCK_APB1_DIV_4 if CPU_FAM_F2 || (CPU_FAM_F4 && CLOCK_MAX_180MHZ) || CPU_FAM_F7 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_U5 || CPU_FAM_WB
+default CLOCK_APB1_DIV_4 if CPU_FAM_F2 || (CPU_FAM_F4 && CLOCK_MAX_180MHZ) || CPU_FAM_F7 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_U5 || CPU_FAM_WB || CPU_FAM_WL
 default CLOCK_APB1_DIV_2 if CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_F4 || CPU_FAM_MP1
 default CLOCK_APB1_DIV_1
 
@@ -405,7 +406,7 @@ config CLOCK_APB1_DIV
 choice
 bool "APB2 prescaler (division factor of HCLK to produce PCLK2)"
 depends on !CPU_FAM_G0 && !CPU_FAM_F0
-default CLOCK_APB2_DIV_2 if CPU_FAM_F2 || (CPU_FAM_F4 && CLOCK_MAX_180MHZ) || CPU_FAM_F7 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_U5 || CPU_FAM_WB || CPU_FAM_MP1
+default CLOCK_APB2_DIV_2 if CPU_FAM_F2 || (CPU_FAM_F4 && CLOCK_MAX_180MHZ) || CPU_FAM_F7 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_U5 || CPU_FAM_WB || CPU_FAM_WL || CPU_FAM_MP1
 default CLOCK_APB2_DIV_1
 
 config CLOCK_APB2_DIV_1
@@ -433,7 +434,7 @@ config CLOCK_APB2_DIV
     default 8 if CLOCK_APB2_DIV_8
     default 16 if CLOCK_APB2_DIV_16
 
-if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB || CPU_FAM_WL
 config CLOCK_ENABLE_MCO
     bool "Enable MCU Clock Output (MCO) on PA8"
 
@@ -453,15 +454,15 @@ config CLOCK_MCO_USE_HSI
 
 config CLOCK_MCO_USE_LSE
     bool "Use LSE as MCO source"
-    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB  || CPU_FAM_WL
 
 config CLOCK_MCO_USE_LSI
     bool "Use LSI as MCO source"
-    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MCO_USE_MSI
     bool "Use MSI as MCO source"
-    depends on CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+    depends on CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB || CPU_FAM_WL
 
 config CLOCK_MCO_USE_SYSCLK
     bool "Use SYSCLK as MCO source"
@@ -490,15 +491,15 @@ config CLOCK_MCO_PRE_16
 
 config CLOCK_MCO_PRE_32
     bool "Divide MCO by 32"
-    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
+    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB && !CPU_FAM_WL
 
 config CLOCK_MCO_PRE_64
     bool "Divide MCO by 64"
-    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
+    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB && !CPU_FAM_WL
 
 config CLOCK_MCO_PRE_128
     bool "Divide MCO by 128"
-    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB
+    depends on !CPU_FAM_G4 && !CPU_FAM_L0 && !CPU_FAM_L1 && !CPU_FAM_L4 && !CPU_FAM_WB && !CPU_FAM_WL
 
 endchoice
 
@@ -513,6 +514,6 @@ config CLOCK_MCO_PRE
     default 128 if CLOCK_MCO_PRE_128
     default 1
 
-endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB
+endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_WB || CPU_FAM_WL
 
 endmenu


### PR DESCRIPTION


### Contribution description

This implements the clock configuration of the stm32wl CPU in Kconfig.
It is largely based off the stm32wb config.
The `lora-e5-dev` board can now indicate that the HSE/LSE should be used.

### Testing procedure

Murdock green and compare what is in the header.

### Issues/PRs references

Part of #14975