### PR TITLE
tools/zep_dispatch: basic dual-stack support

### DIFF
--- a/dist/tools/zep_dispatch/main.c
+++ b/dist/tools/zep_dispatch/main.c
@@ -51,7 +51,7 @@ static void _send_flat(void *ctx, void *buffer, size_t len,
             /* remove client if sending fails */
         }
         else if (sendto(sock, buffer, len, 0, (struct sockaddr *)addr, sizeof(*addr)) < 0) {
-            inet_ntop(AF_INET6, &addr->sin6_addr, addr_str, INET6_ADDRSTRLEN);
+            inet_ntop(src_addr->sin6_family, &addr->sin6_addr, addr_str, INET6_ADDRSTRLEN);
             printf("removing [%s]:%d\n", addr_str, ntohs(addr->sin6_port));
             prev->next = n->next;
             free(n);
@@ -63,7 +63,7 @@ static void _send_flat(void *ctx, void *buffer, size_t len,
 
     /* if the client new, add it to the broadcast list */
     if (!known_node) {
-        inet_ntop(AF_INET6, &src_addr->sin6_addr, addr_str, INET6_ADDRSTRLEN);
+        inet_ntop(src_addr->sin6_family, &src_addr->sin6_addr, addr_str, INET6_ADDRSTRLEN);
         printf("adding [%s]:%d\n", addr_str, ntohs(src_addr->sin6_port));
         zep_client_t *client = malloc(sizeof(zep_client_t));
         memcpy(&client->addr, src_addr, sizeof(*src_addr));
@@ -101,7 +101,7 @@ static void dispatch_loop(int sock, dispatch_cb_t dispatch, void *ctx)
         ssize_t bytes_in = recvfrom(sock, buffer, sizeof(buffer), 0,
                                     (struct sockaddr *)&src_addr, &addr_len);
 
-        if (bytes_in <= 0 || addr_len != sizeof(src_addr)) {
+        if (bytes_in <= 0) {
             continue;
         }
 
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
     }
 
     struct addrinfo hint = {
-        .ai_family   = AF_INET6,
+        .ai_family   = AF_UNSPEC,
         .ai_socktype = SOCK_DGRAM,
         .ai_protocol = IPPROTO_UDP,
         .ai_flags    = AI_NUMERICHOST,


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Murdock does not support IPv6 on link-local interfaces.
Therefore in order to being able to use ZEP dispatcher in automated tests on CI, we have to add dual-stack support.


### Testing procedure

Make ZEP dispatcher listen on an IPv4 address

    zep_dispatch 127.0.0.1 17754

Patch the `gnrc_networking` example to use IPv4 for ZEP

```patch
diff --git a/examples/gnrc_networking/Makefile b/examples/gnrc_networking/Makefile
index fcdcc3fb55..784d1fcaa8 100644
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -47,7 +47,7 @@ USE_ZEP ?= 0
 # set the ZEP port for native
 ZEP_PORT_BASE ?= 17754
 ifeq (1,$(USE_ZEP))
-  TERMFLAGS += -z [::1]:$(ZEP_PORT_BASE)
+  TERMFLAGS += -z 127.0.0.1:$(ZEP_PORT_BASE)
   USEMODULE += socket_zep
 endif
```

And start two `native` instances with ZEP:

    make -C examples/gnrc_networking USE_ZEP=1 all term

They are detected by the dispatcher

```
entering loop…
adding [0.0.0.0]:46934
adding [0.0.0.0]:60951
```

And can ping each other

```
main(): This is RIOT! (Version: 2022.01-devel-1563-g1b71cc-zep_dispatch-ipv4)
RIOT network stack example application
All up, running the shell now
> ping ff02::1
12 bytes from fe80::6cea:621a:16db:37bd%7: icmp_seq=0 ttl=64 rssi=0 dBm time=0.615 ms
12 bytes from fe80::6cea:621a:16db:37bd%7: icmp_seq=1 ttl=64 rssi=0 dBm time=0.581 ms
12 bytes from fe80::6cea:621a:16db:37bd%7: icmp_seq=2 ttl=64 rssi=0 dBm time=0.428 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.428/0.541/0.615 ms
```


### Issues/PRs references

split off #17353
