### PR TITLE
drivers/ethos: remove deprecated USE_ETHOS_FOR_STDIO define

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -34,10 +34,6 @@
 #include "net/eui_provider.h"
 #include "net/ethernet.h"
 
-#ifdef USE_ETHOS_FOR_STDIO
-#error USE_ETHOS_FOR_STDIO is deprecated, use USEMODULE+=stdio_ethos instead
-#endif
-
 #ifdef MODULE_ETHOS_STDIO
 #include "stdio_uart.h"
 #include "isrpipe.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This define was marked as deprecated in #11668 (merged in june 2019) so probably no longer used (and even more since using it triggers a failed build).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Marked as deprecated in #11668

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
