### PR TITLE
drivers/at: remove deprecated AT_SEND_ECHO define

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -174,7 +174,7 @@ int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout)
     uart_write(dev->uart, (const uint8_t *)command, cmdlen);
     uart_write(dev->uart, (const uint8_t *)CONFIG_AT_SEND_EOL, AT_SEND_EOL_LEN);
 
-    if (AT_SEND_ECHO) {
+    if (!IS_ACTIVE(CONFIG_AT_SEND_SKIP_ECHO)) {
         if (at_expect_bytes(dev, command, timeout)) {
             return -1;
         }

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -99,20 +99,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Enable/disable the expected echo after an AT command is sent.
- *
- * @deprecated Use inverse @ref CONFIG_AT_SEND_SKIP_ECHO instead.
- * Will be removed after 2021.01 release.
- */
-#ifndef AT_SEND_ECHO
-#if IS_ACTIVE(CONFIG_AT_SEND_SKIP_ECHO)
-#define AT_SEND_ECHO 0
-#else
-#define AT_SEND_ECHO 1
-#endif
-#endif
-
-/**
  * @brief 1st end of line character received (S3 aka CR character for a modem).
  */
 #ifndef AT_RECV_EOL_1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This define is deprecated and was marked for removal after 2021.01.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- Echo is sent by default (as before)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Remove a define marked as deprecated in #14019

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
