### PR TITLE
tests: Fix thread return with local message queue

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -375,6 +375,9 @@ unsigned msg_avail(void);
  *                  not be NULL.
  * @param[in] num   Number of ``msg_t`` structures in array.
  *                  **MUST BE POWER OF TWO!**
+ *
+ * If array resides on the stack, the containing stack frame must never be
+ * left, not even if it is the current thread's entry function.
  */
 void msg_init_queue(msg_t *array, int num);
 

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -109,12 +109,13 @@ void print_register(char reg, int num_bytes)
 
 char rx_handler_stack[THREAD_STACKSIZE_MAIN];
 
+static msg_t _msg_q[1];
+
 /* RX handler that waits for a message from the ISR */
 void *nrf24l01p_rx_handler(void *arg)
 {
     (void)arg;
-    msg_t msg_q[1];
-    msg_init_queue(msg_q, 1);
+    msg_init_queue(_msg_q, 1);
     unsigned int pid = thread_getpid();
     char rx_buf[NRF24L01P_MAX_DATA_LENGTH];
 

--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -129,10 +129,11 @@ static void test1(void)
     puts("first: end");
 }
 
+static msg_t _sema_thread_queue[SEMAPHORE_MSG_QUEUE_SIZE];
+
 static void *priority_sema_thread(void *name)
 {
-    msg_t msg_queue[SEMAPHORE_MSG_QUEUE_SIZE];
-    msg_init_queue(msg_queue, SEMAPHORE_MSG_QUEUE_SIZE);
+    msg_init_queue(_sema_thread_queue, SEMAPHORE_MSG_QUEUE_SIZE);
     sem_wait(&s1);
     printf("Thread '%s' woke up.\n", (const char *) name);
     return NULL;
@@ -176,11 +177,12 @@ void test2(void)
     }
 }
 
+static msg_t _one_two_queue[SEMAPHORE_MSG_QUEUE_SIZE];
+
 static void *test3_one_two_thread(void *arg)
 {
-    msg_t msg_queue[SEMAPHORE_MSG_QUEUE_SIZE];
     (void)arg;
-    msg_init_queue(msg_queue, SEMAPHORE_MSG_QUEUE_SIZE);
+    msg_init_queue(_one_two_queue, SEMAPHORE_MSG_QUEUE_SIZE);
     sem_wait(&s1);
     puts("Thread 1 woke up after waiting for s1.");
     sem_wait(&s2);
@@ -188,11 +190,12 @@ static void *test3_one_two_thread(void *arg)
     return NULL;
 }
 
+static msg_t _two_one_queue[SEMAPHORE_MSG_QUEUE_SIZE];
+
 static void *test3_two_one_thread(void *arg)
 {
-    msg_t msg_queue[SEMAPHORE_MSG_QUEUE_SIZE];
     (void)arg;
-    msg_init_queue(msg_queue, SEMAPHORE_MSG_QUEUE_SIZE);
+    msg_init_queue(_two_one_queue, SEMAPHORE_MSG_QUEUE_SIZE);
     sem_wait(&s2);
     puts("Thread 2 woke up after waiting for s2.");
     sem_wait(&s1);

--- a/tests/thread_msg_block_w_queue/main.c
+++ b/tests/thread_msg_block_w_queue/main.c
@@ -52,13 +52,14 @@ void *sender_thread(void *arg)
     return NULL;
 }
 
+static msg_t _msg_q[1];
+
 int main(void)
 {
     msg_t msg;
     p_recv = thread_getpid();
 
-    msg_t msg_q[1];
-    msg_init_queue(msg_q, 1);
+    msg_init_queue(_msg_q, 1);
 
     p_send = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,


### PR DESCRIPTION
### Contribution description

When a message queue is configured from the stack, that main function
must never return -- otherwise, during sched_task_exit (which the
thread's function "returns" to), message senders might still send
messages into already freed stack space (which would be reused by
sched_task_exit).

[new] A follow-up commit adds a line on this to the msg_init_queue documentation.

Most occurrences of queue initialization throughout RIOT are either static or followed by an endless loop without breaks / returns; the few examples not matching either pattern are fixed here.

### Testing procedure

I don't see any way to make the fixed behavior actually happen; this is more about best practice. (Especially given that sched_task_exit currently starts with a debug statement followed by `irq_disable`, so the message would need to hit right into the execution of debug printing).

The two altered tesets that don't depend on hardware can be and were successfully run (in tests/thread_msg_block_w_queue and tests/posix_semaphore) on native.

### Issues/PRs references

This came up when nailing down the safety criteria of `msg_init_queue` in Rust.

[edit: see [new]]