### PR TITLE
doc: Fix C2Rust installation procedure

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -125,7 +125,7 @@ $ rustup component add --toolchain nightly-2019-12-05 rustfmt rustc-dev
 $ cargo +nightly-2019-12-05 install c2rust
 $ git clone https://github.com/chrysn-pull-requests/c2rust -b for-riot
 $ cd c2rust
-$ cargo +nightly-2019-12-05 install --path c2rust
+$ cargo +nightly-2019-12-05 install --locked --path c2rust
 ```
 
 [cargo]: https://doc.rust-lang.org/cargo/


### PR DESCRIPTION
### Contribution description

The `--locked` is required since dependencies increased their MSRV to
something later than C2Rust's fixed nightly. That was already reflected
in the riotdocker installation steps, but not here where the line was
taken from upstream's docs.

### Testing procedure

Look at built docs.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/17492