### PR TITLE
sys/net/sock: introduce SOCK_HAS_IPV4

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -107,6 +107,9 @@ ifneq (,$(filter skald, $(USEMODULE)))
 endif
 
 ifneq (,$(filter sock sock_%,$(USEMODULE)))
+  ifneq (,$(filter ipv4,$(USEMODULE)))
+    CFLAGS += -DSOCK_HAS_IPV4
+  endif
   ifneq (,$(filter ipv6,$(USEMODULE)))
     CFLAGS += -DSOCK_HAS_IPV6
   endif

--- a/tests/unittests/tests-sock_util/Makefile.include
+++ b/tests/unittests/tests-sock_util/Makefile.include
@@ -4,3 +4,5 @@ USEMODULE += gnrc_ipv6
 USEMODULE += ipv4_addr
 USEMODULE += ipv6_addr
 USEMODULE += posix_headers
+# GNRC has no support for IPv4, still force it on for the unit test
+USEMODULE += ipv4


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Add a define analogous to `SOCK_HAS_IPV6` so we can skip compilation of IPv4 related code if only IPv6 is used.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
