### PR TITLE
sys/loramac: remove deprecated LORAMAC_DEFAULT_PUBLIC_NETWORK

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -378,7 +378,7 @@ void _init_loramac(semtech_loramac_t *mac,
 
     semtech_loramac_set_dr(mac, CONFIG_LORAMAC_DEFAULT_DR);
     semtech_loramac_set_adr(mac, IS_ACTIVE(CONFIG_LORAMAC_DEFAULT_ADR));
-    semtech_loramac_set_public_network(mac, LORAMAC_DEFAULT_PUBLIC_NETWORK);
+    semtech_loramac_set_public_network(mac, !IS_ACTIVE(CONFIG_LORAMAC_DEFAULT_PRIVATE_NETWORK));
     semtech_loramac_set_class(mac, CONFIG_LORAMAC_DEFAULT_DEVICE_CLASS);
     semtech_loramac_set_tx_port(mac, CONFIG_LORAMAC_DEFAULT_TX_PORT);
     semtech_loramac_set_tx_mode(mac, CONFIG_LORAMAC_DEFAULT_TX_MODE);

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -146,23 +146,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default network type (public or private)
- *
- * This configuration sets the sync word for LoRaWAN communication. This should
- * be in concordance with the gateway configuration. Public networks use `0x34`
- * while private networks use `0x12` as sync word.
- * @deprecated Use inverse @ref CONFIG_LORAMAC_DEFAULT_PRIVATE_NETWORK instead.
- * Will be removed after 2021.04 release.
- */
-#ifndef LORAMAC_DEFAULT_PUBLIC_NETWORK
-#if IS_ACTIVE(CONFIG_LORAMAC_DEFAULT_PRIVATE_NETWORK)
-#define LORAMAC_DEFAULT_PUBLIC_NETWORK          (false)
-#else
-#define LORAMAC_DEFAULT_PUBLIC_NETWORK          (true)
-#endif
-#endif
-
-/**
  * @brief   Default datarate index
  *
  * Data rate combines two aspects, Bandwidth (BW) and Spreading Factor (SF). BW

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -92,8 +92,8 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac)
 
     dev->driver->set(dev, NETOPT_CODING_RATE, &cr, sizeof(cr));
 
-    uint8_t syncword = LORAMAC_DEFAULT_PUBLIC_NETWORK ? LORA_SYNCWORD_PUBLIC
-                                                      : LORA_SYNCWORD_PRIVATE;
+    uint8_t syncword = IS_ACTIVE(CONFIG_LORAMAC_DEFAULT_PRIVATE_NETWORK) ? LORA_SYNCWORD_PRIVATE
+                                                                         : LORA_SYNCWORD_PUBLIC;
 
     dev->driver->set(dev, NETOPT_SYNCWORD, &syncword, sizeof(syncword));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

And use inverse `CONFIG_LORAMAC_DEFAULT_PRIVATE_NETWORK` instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `examples/gnrc_lorawan` and `tests/pkg_semtech-loramac` are still working (untested yet)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

`LORAMAC_DEFAULT_PUBLIC_NETWORK` was marked for removal after 2021.04 in  #15507

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
