### PR TITLE
sys/lora: remove deprecated LORA_PAYLOAD_CRC_ON_DEFAULT define

### DIFF
--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -132,7 +132,7 @@ static void sx126x_init_default_config(sx126x_t *dev)
     sx126x_set_lora_mod_params(dev, &dev->mod_params);
 
     dev->pkt_params.pld_len_in_bytes = 0;
-    dev->pkt_params.crc_is_on = LORA_PAYLOAD_CRC_ON_DEFAULT;
+    dev->pkt_params.crc_is_on = !IS_ACTIVE(CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT);
     dev->pkt_params.header_type = (
         IS_ACTIVE(CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT) ? true : false
         );

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -179,7 +179,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_bandwidth(dev, CONFIG_LORA_BW_DEFAULT);
     sx127x_set_spreading_factor(dev, CONFIG_LORA_SF_DEFAULT);
     sx127x_set_coding_rate(dev, CONFIG_LORA_CR_DEFAULT);
-    sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
+    sx127x_set_crc(dev, !IS_ACTIVE(CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT));
     sx127x_set_freq_hop(dev, IS_ACTIVE(CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT) ? true : false);
     sx127x_set_hop_period(dev, CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
     sx127x_set_fixed_header_len_mode(dev, IS_ACTIVE(CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT) ?

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -177,17 +177,11 @@ extern "C" {
 #define CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
 #endif
 
-/** @brief Enable/disable payload CRC, optional
- *
- * @deprecated Use inverse `CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT` instead.
- * Will be removed after 2021.04 release.
+/**
+* @brief    Enable/disable payload CRC, optional
 */
-#ifndef LORA_PAYLOAD_CRC_ON_DEFAULT
-#if IS_ACTIVE(CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT)
-#define LORA_PAYLOAD_CRC_ON_DEFAULT                 (false)
-#else
-#define LORA_PAYLOAD_CRC_ON_DEFAULT                 (true)
-#endif
+#ifdef DOXYGEN
+#define CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT
 #endif
 
 /** @brief Configure payload length


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

And use the inverse `CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT` instead as advertised by the doc.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `tests/sx126x` and `tests/sx127x` are still working as expected

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

`LORA_PAYLOAD_CRC_ON_DEFAULT` was marked for removal in #15007

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
