### PR TITLE
murdock: fix exit -> return in subfunction

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -585,7 +585,7 @@ basename_list () {
 update_changed_modules() {
     # early out if there's no base commit info
     if [ -z "${CI_BASE_COMMIT}" ]; then
-        exit 0
+        return 0
     fi
 
     # early out if a full build is requested


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fix exit -> return in a subfunction, turning an early out into a full script exit.
This is probably what's keeping the nightly builds empty.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
