### PR TITLE
cpu/riscv_common: Enable Rust applications

### DIFF
--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -12,7 +12,7 @@ config CPU_ARCH_RISCV
     select HAS_NEWLIB
     select HAS_PERIPH_CORETIMER
     select HAS_PICOLIBC if '$(RIOT_CI_BUILD)' != '1'
-    #select HAS_RUST_TARGET
+    select HAS_RUST_TARGET
     select HAS_SSP
 
     select MODULE_MALLOC_THREAD_SAFE if TEST_KCONFIG

--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -8,7 +8,7 @@ FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += libstdcpp
 FEATURES_PROVIDED += newlib
 FEATURES_PROVIDED += periph_coretimer
-#FEATURES_PROVIDED += rust_target
+FEATURES_PROVIDED += rust_target
 FEATURES_PROVIDED += ssp
 
 # RISC-V toolchain on CI does not work properly with picolibc yet

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -11,7 +11,9 @@ CARGO_COMPILE_COMMANDS_FLAGS = --clang
 $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" APPLICATION_BLOBS="$(BLOBS)" \
 	  "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk compile-commands
+	@# replacement addresses https://github.com/rust-lang/rust-bindgen/issues/1555
 	$(Q)$(RIOTTOOLS)/compile_commands/compile_commands.py $(CARGO_COMPILE_COMMANDS_FLAGS) $(BINDIR) \
+	  | sed 's/"riscv-none-embed"/"riscv32"/g' \
 	  | $(LAZYSPONGE) $@
 
 

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -241,6 +241,11 @@ DOCKER_APPDIR = $(DOCKER_RIOTPROJECT)/$(BUILDRELPATH)
 # Directory mapping in docker and directories environment variable configuration
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(ETC_LOCALTIME),/etc/localtime,ro)
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(RIOTBASE),$(DOCKER_RIOTBASE))
+# Selective components of Cargo to ensure crates are not re-downloaded (and
+# subsequently rebuilt) on every run. Not using all of ~/.cargo as ~/.cargo/bin
+# would be run by Cargo and that'd be very weird.
+DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(HOME)/.cargo/registry,$(DOCKER_BUILD_ROOT)/.cargo/registry)
+DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(HOME)/.cargo/git,$(DOCKER_BUILD_ROOT)/.cargo/git)
 DOCKER_VOLUMES_AND_ENV += -e 'RIOTBASE=$(DOCKER_RIOTBASE)'
 DOCKER_VOLUMES_AND_ENV += -e 'CCACHE_BASEDIR=$(DOCKER_RIOTBASE)'
 


### PR DESCRIPTION
### Contribution description

This is largely just stating it works.

It contains a workaround for
https://github.com/rust-lang/rust-bindgen/issues/1555 (withouot which
bindgen would fail, with little information helping remedy the cause)

[edit: added] Note that the actual RUST_TARGET referred to in "HAS_RUST_TARGET" has already been set since the introduction to Rust (so that experimentation could be done when forcing one's way around the features); only now it is used. When any other targets than riscv32imac are supported, `makefiles/arch/riscv.inc.mk` will need adjustments both on the CFLAGS and RUST_TARGET side.

### Testing procedure

* Take a RISC-V board, run one of the Rust examples or tests.

(I did it with a hifive1 and rust-hello).

Even though I thought I had all the right and matching compilers, things did not work for me when building from my Debian environment -- I blame it on the weird way C2Rust is installed here. In the docker images, all works fine, so despite my reluctance I'm doing tests `BUILD_IN_DOCKER=1`.

### Status

~~This is marked as a Draft PR while I'm doing a bit more testing, and also I don't want to clog CI right now.~~

Ready for experimentation as long as CI says it's good.