### PR TITLE
boards/cc1352-launchpad doc: adding information concerning shell acccess

### DIFF
--- a/boards/cc1352-launchpad/doc.txt
+++ b/boards/cc1352-launchpad/doc.txt
@@ -9,6 +9,8 @@
 2. [Hardware](#cc1352_launchpad_hardware)
 3. [Board pinout](#cc1352_launcpad_pinout)
 4. [Flashing the Device](#cc1352_launchpad_flashing)
+5. [Accessing RIOT shell](#cc1352_launchpad_shell)
+6. [More information](#cc1352_launchpad_moreinfo)
 
 ## <a name="cc1352_launchpad_overview"> Overview </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
 
@@ -62,6 +64,22 @@ export PROGRAMMER=openocd
 ```
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
+
+## <a name="cc1352_launchpad_shell"> Accessing RIOT shell </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
+
+Default RIOT shell access utilize XDS110 debug probe integrated with launchpad board.
+It provides virtual serials via USB interface - for connecting to RIOT shell, use
+the first one.
+
+If a physical connection to UART is needed, disconnect jumpers RXD and TXD joining
+cc1352 microcontroller with XDS110 and connect UART to pin RXD/DIO12 and TXD/DIO13.
+
+The default baud rate is 115 200 - in both connection types.
+
+@warning Launchpad cc1352 board is not 5V tolerant. Use voltage divider or logic
+level shifter when connecting to 5V UART.
+
+## <a name="cc1352_launchpad_moreinfo"> More information </a> &nbsp;[[TOC]](#cc1352_launchpad_toc)
 
 For detailed information about CC1352R1 MCUs as well as configuring, compiling
 RIOT and installation of flashing tools for CC1352R1 boards,


### PR DESCRIPTION
### Contribution description

This PR adds to TI CC1352 Launchpad board documentation section concerning accessing RIOT shell.
The description is provided according to the Issue [#17453](https://github.com/RIOT-OS/RIOT/issues/17453).

I noticed that in all CCXXXX boards, there are some problems with HTML tags in headers generated by doxygen 1.9.1,
used in the official documentation at the project web page, for example [cc1352-launchad](https://doc.riot-os.org/group__boards__cc1352__launchpad.html).  In my environment using older doxygen 1.8.13, this problem is not observed. 

Are there plans for updating doxygen or temporarily, these links should be removed from the documentation? 

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__cc1352__launchpad.html
```

### Issues/PRs references
See also #17453 

