### PR TITLE
[treewide] lora: use int16_t for RSSI value [backport 2022.01]

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -372,7 +372,7 @@ static int _atwinc15x0_get(netdev_t *netdev, netopt_t opt, void *val,
             return sizeof(uint16_t);
 
         case NETOPT_RSSI:
-            assert(max_len == sizeof(int8_t));
+            assert(max_len == sizeof(int16_t));
             _rssi_info_ready = false;
             /* trigger the request current RSSI (asynchronous function) */
             if (m2m_wifi_req_curr_rssi() != M2M_SUCCESS) {
@@ -384,8 +384,8 @@ static int _atwinc15x0_get(netdev_t *netdev, netopt_t opt, void *val,
                 ztimer_sleep(ZTIMER_MSEC, ATWINC15X0_WAIT_TIME_MS);
             }
             /* return the RSSI */
-            *((int8_t *)val) = dev->rssi;
-            return sizeof(int8_t);
+            *((int16_t *)val) = dev->rssi;
+            return sizeof(int16_t);
 
         default:
             return netdev_eth_get(netdev, opt, val, max_len);

--- a/drivers/include/net/netdev/lora.h
+++ b/drivers/include/net/netdev/lora.h
@@ -32,7 +32,7 @@ extern "C" {
  * @brief   Received LoRa packet status information
  */
 typedef struct {
-    uint8_t rssi;           /**< RSSI of a received packet */
+    int16_t rssi;           /**< RSSI of a received packet */
     int8_t snr;             /**< S/N ratio */
 } netdev_lora_rx_info_t;
 

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -291,9 +291,9 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
         return sizeof(netopt_enable_t);
 
     case NETOPT_RSSI:
-        assert(max_len >= sizeof(int8_t));
+        assert(max_len >= sizeof(int16_t));
         sx126x_get_rssi_inst(dev, ((int16_t *)val));
-        return sizeof(int8_t);
+        return sizeof(int16_t);
 
     default:
         break;

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -345,9 +345,9 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
         return sizeof(netopt_enable_t);
 
     case NETOPT_RSSI:
-        assert(max_len >= sizeof(int8_t));
-        *((int8_t *)val) = sx127x_read_rssi(dev);
-        return sizeof(int8_t);
+        assert(max_len >= sizeof(int16_t));
+        *((int16_t *)val) = sx127x_read_rssi(dev);
+        return sizeof(int16_t);
 
     default:
         break;

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -205,8 +205,8 @@ void SX127XStartCad(void)
 int16_t SX127XRssi(RadioModems_t modem)
 {
     (void)modem;
-    int8_t rssi;
-    loramac_netdev_ptr->driver->get(loramac_netdev_ptr, NETOPT_RSSI, &rssi, sizeof(int8_t));
+    int16_t rssi;
+    loramac_netdev_ptr->driver->get(loramac_netdev_ptr, NETOPT_RSSI, &rssi, sizeof(int16_t));
     return rssi;
 }
 

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -772,7 +772,7 @@ typedef enum {
     NETOPT_LINK_CHECK,
 
     /**
-     * @brief (int8_t) Received Signal Strength Indicator (RSSI)
+     * @brief (int16_t) Received Signal Strength Indicator (RSSI)
      *
      * The RSSI is an indicator for the received field strength in wireless
      * channels. It is often represented as the ratio of received power to

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -607,7 +607,6 @@ static void _netif_list(netif_t *iface)
     uint16_t u16;
     int16_t i16;
     uint8_t u8;
-    int8_t i8;
     int res;
     netopt_state_t state;
     unsigned line_thresh = 1;
@@ -639,9 +638,9 @@ static void _netif_list(netif_t *iface)
     if (res >= 0) {
         printf(" NID: 0x%" PRIx16 " ", u16);
     }
-    res = netif_get_opt(iface, NETOPT_RSSI, 0, &i8, sizeof(i8));
+    res = netif_get_opt(iface, NETOPT_RSSI, 0, &i16, sizeof(i16));
     if (res >= 0) {
-        printf(" RSSI: %d ", i8);
+        printf(" RSSI: %d ", i16);
     }
 #ifdef MODULE_GNRC_NETIF_CMD_LORA
     res = netif_get_opt(iface, NETOPT_BANDWIDTH, 0, &u8, sizeof(u8));


### PR DESCRIPTION
# Backport of #17497

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The RSSI values reported by LoRa transceiver can be less than -127.
Therefore, `int8_t` is not enough. This commit defines the RSSI of
`netdev_lora_rx_info` as `int16_t` and adapt the drivers accordingly
(sx126x, sx127x).

BTW, the `sx126x` was writing an `int16_t` into an `int8_t`. :man_shrugging:. It's indirectly fixed by this commit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Check that the RSSI values reported by the LoRa radios (sx126x, sx127x) are right (negative values, starting from around -140). Use `tests/driver_sx127x` and `test/drivers_sx126x` for that.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #17451

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
