### PR TITLE
tests/pkg_relic: increase stacksize

### DIFF
--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -27,7 +27,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     z1 \
                     #
 
-CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(5*THREAD_STACKSIZE_DEFAULT\)
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(6*THREAD_STACKSIZE_DEFAULT\)
 
 USEPKG += relic
 USEMODULE += embunit


### PR DESCRIPTION
### Contribution description

Bumping relic seems to have increased stack usage, this made the test fail on some BOARDs as showed in release tests, this PR in

### Testing procedure

e.g. on iotlab:

`IOTLAB_NODE=auto BOARD=b-l475e-iot01a make -C tests/pkg_relic/ clean flash test -j`

```
main(): This is RIOT! (Version: 2022.04-devel-1-g102534-pr_test_pkg_relic_stacksize)
.
OK (1 tests)
```

See [here](https://github.com/RIOT-OS/RIOT/runs/4834912248?check_suite_focus=true) for a failed iot-lab run.

### Issues/PRs references

#17161 