### PR TITLE
drivers/rtt_rtc: select rtc_utils

### DIFF
--- a/drivers/rtt_rtc/Kconfig
+++ b/drivers/rtt_rtc/Kconfig
@@ -10,5 +10,6 @@ config MODULE_RTT_RTC
     depends on HAS_PERIPH_RTT
     depends on TEST_KCONFIG
     select MODULE_PERIPH_RTT
+    select MODULE_RTC_UTILS
     help
         Basic RTC implementation based on a RTT.

--- a/drivers/rtt_rtc/Makefile.dep
+++ b/drivers/rtt_rtc/Makefile.dep
@@ -2,3 +2,5 @@
 ifeq (,$(UNIT_TESTS))
   FEATURES_REQUIRED += periph_rtt
 endif
+
+USEMODULE += rtc_utils

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -52,7 +52,7 @@ ifneq (,$(filter periph_%, $(USEMODULE)))
 endif
 
 # include rtc_utils if periph_rtc is used
-ifneq (,$(filter periph_rtc, $(USEMODULE)))
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += rtc_utils
 endif
 


### PR DESCRIPTION
### Contribution description

Spotted by @emmanuelsearch during release tests, if compiling only the `rtt_rtc` module with the mock then there is a missing dependency against `rtc_utils`.

### Testing procedure

master

```
make -C tests/unittests/ tests-rtt_rtc
Building application "tests_unittests" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT2/boards/native
"make" -C /home/francisco/workspace/RIOT2/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/native
"make" -C /home/francisco/workspace/RIOT2/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/native/stdio_native
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/drivers/rtt_rtc
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/embunit
"make" -C /home/francisco/workspace/RIOT2/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT2/sys/ztimer
"make" -C /home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/rtt_rtc/rtt_rtc.o: in function `rtc_set_time':
/home/francisco/workspace/RIOT2/drivers/rtt_rtc/rtt_rtc.c:126: undefined reference to `rtc_tm_normalize'
/usr/bin/ld: /home/francisco/workspace/RIOT2/drivers/rtt_rtc/rtt_rtc.c:132: undefined reference to `rtc_mktime'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/rtt_rtc/rtt_rtc.o: in function `rtc_get_time':
/home/francisco/workspace/RIOT2/drivers/rtt_rtc/rtt_rtc.c:166: undefined reference to `rtc_localtime'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/rtt_rtc/rtt_rtc.o: in function `rtc_set_alarm':
/home/francisco/workspace/RIOT2/drivers/rtt_rtc/rtt_rtc.c:185: undefined reference to `rtc_mktime'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/tests-rtt_rtc/tests-rtt_rtc.o: in function `test_set_alarm_set_time':
/home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c:180: undefined reference to `rtc_tm_compare'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c:187: undefined reference to `rtc_tm_compare'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c:200: undefined reference to `rtc_tm_compare'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/tests-rtt_rtc/tests-rtt_rtc.o: in function `_alarm_cb':
/home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c:75: undefined reference to `rtc_tm_compare'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/tests-rtt_rtc/tests-rtt_rtc.o: in function `test_set_alarm_short':
/home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c:141: undefined reference to `rtc_tm_compare'
/usr/bin/ld: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/tests-rtt_rtc/tests-rtt_rtc.o:/home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c:148: more undefined references to `rtc_tm_compare' follow
collect2: error: ld returned 1 exit status
make: *** [/home/francisco/workspace/RIOT2/tests/unittests/../../Makefile.include:694: /home/francisco/workspace/RIOT2/tests/unittests/bin/native/tests_unittests.elf] Error 1
```

pr

```
make -C tests/unittests/ tests-rtt_rtc
Building application "tests_unittests" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT2/boards/native
"make" -C /home/francisco/workspace/RIOT2/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/native
"make" -C /home/francisco/workspace/RIOT2/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/native/stdio_native
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/drivers/rtt_rtc
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/embunit
"make" -C /home/francisco/workspace/RIOT2/sys/rtc_utils
"make" -C /home/francisco/workspace/RIOT2/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT2/sys/ztimer
"make" -C /home/francisco/workspace/RIOT2/tests/unittests/tests-rtt_rtc
   text	   data	    bss	    dec	    hex	filename
  38511	    684	  51960	  91155	  16413	/home/francisco/workspace/RIOT2/tests/unittests/bin/native/tests_unittests.elf
```
