### PR TITLE
drivers/periph_spi: spi_init_with_gpio_mode mode by reference

### DIFF
--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -192,7 +192,7 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
 }
 
 #ifdef MODULE_PERIPH_SPI_GPIO_MODE
-int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode)
+int spi_init_with_gpio_mode(spi_t bus, const spi_gpio_mode_t* mode)
 {
     assert(bus < SPI_NUMOF);
 
@@ -203,17 +203,17 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode)
     return ret;
 #else
     if (gpio_is_valid(spi_config[bus].mosi_pin)) {
-        ret += gpio_init(spi_config[bus].mosi_pin, mode.mosi);
+        ret += gpio_init(spi_config[bus].mosi_pin, mode->mosi);
         gpio_init_af(spi_config[bus].mosi_pin, spi_config[bus].mosi_af);
     }
 
     if (gpio_is_valid(spi_config[bus].miso_pin)) {
-        ret += gpio_init(spi_config[bus].miso_pin, mode.miso);
+        ret += gpio_init(spi_config[bus].miso_pin, mode->miso);
         gpio_init_af(spi_config[bus].miso_pin, spi_config[bus].miso_af);
     }
 
     if (gpio_is_valid(spi_config[bus].sclk_pin)) {
-        ret += gpio_init(spi_config[bus].sclk_pin, mode.sclk);
+        ret += gpio_init(spi_config[bus].sclk_pin, mode->sclk);
         gpio_init_af(spi_config[bus].sclk_pin, spi_config[bus].sclk_af);
     }
     return ret;

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -324,12 +324,13 @@ typedef struct {
  * @brief   Initialize MOSI/MISO/SCLK pins with adapted GPIO modes
  *
  * @param[in]   bus     SPI device that is used with the given CS line
- * @param[in]   mode    a struct containing the 3 modes to use on each pin
+ * @param[in]   mode    a pointer to a truct containing the 3 modes to use on
+ *                      each pin
  *
  * @retval  0           success
  * @retval  <0          error
  */
-int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode);
+int spi_init_with_gpio_mode(spi_t bus, const spi_gpio_mode_t* mode);
 #endif
 
 /**

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -350,7 +350,7 @@ static int _init_spi(sx127x_t *dev)
         .miso = (SX127X_DIO_PULL_MODE),
         .sclk = (GPIO_OUT | SX127X_DIO_PULL_MODE),
     };
-    res += spi_init_with_gpio_mode(dev->params.spi, gpio_modes);
+    res += spi_init_with_gpio_mode(dev->params.spi, &gpio_modes);
 #endif
 
     if (res != SPI_OK) {


### PR DESCRIPTION
### Contribution description

When the `spi_init_with_gpio_mode` was added I'm not sure why but we passed the mode by value, as its a structure it makes more sense to pass it by reference.

### Testing procedure

The code should be the same. This is only used to minimize power consumption on BOARDS including an `sx127x`. I think a compilation check should be enough.

### Issues/PRs references

Split from #17233 
