### PR TITLE
periph_can,candev: socketcan pkg for native, candev test cleanup

### DIFF
--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -9,6 +9,7 @@ ifneq (,$(filter mtd,$(USEMODULE)))
 endif
 
 ifneq (,$(filter periph_can,$(FEATURES_USED)))
+  USEPKG += libsocketcan
   ifeq ($(OS),Linux)
     CFLAGS += -DCAN_DLL_NUMOF=2
   endif

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -6,7 +6,10 @@ ifeq ($(BUILDOSXNATIVE),1)
 endif
 
 ifneq (,$(filter periph_can,$(USEMODULE)))
-  LINKFLAGS += -lsocketcan
+  ifeq (,$(filter libsocketcan,$(USEPKG)))
+    # link system libsocketcan if not using the provided package
+    LINKFLAGS += -lsocketcan
+  endif
 endif
 
 TOOLCHAINS_SUPPORTED = gnu llvm afl

--- a/pkg/libsocketcan/Kconfig
+++ b/pkg/libsocketcan/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) ML!PA Consulting GmbH
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config PACKAGE_LIBSOCKETCAN
+    bool "libsocketcan2 32bit for native Linux builds"
+    depends on BOARD_NATIVE

--- a/pkg/libsocketcan/Makefile
+++ b/pkg/libsocketcan/Makefile
@@ -1,0 +1,9 @@
+PKG_NAME=libsocketcan
+PKG_URL=https://git.pengutronix.de/git/tools/libsocketcan
+PKG_VERSION=077def398ad303043d73339112968e5112d8d7c8
+PKG_LICENSE=LGPL-2.1
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/libsocketcan/Makefile.include
+++ b/pkg/libsocketcan/Makefile.include
@@ -1,0 +1,1 @@
+NATIVEINCLUDES += -I"$(PKGDIRBASE)/libsocketcan/include"

--- a/pkg/libsocketcan/Makefile.libsocketcan
+++ b/pkg/libsocketcan/Makefile.libsocketcan
@@ -1,0 +1,9 @@
+MODULE=libsocketcan
+
+CFLAGS += -Wno-strict-prototypes
+CFLAGS += -Wno-pointer-arith
+CFLAGS += -Wno-old-style-definition
+
+SRC += libsocketcan.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/libsocketcan/doc.txt
+++ b/pkg/libsocketcan/doc.txt
@@ -1,0 +1,16 @@
+/**
+ * @defgroup pkg_libsocketcan   Socketcan library
+ * @ingroup  pkg
+ * @ingroup  sys_serialization
+ * @brief    Provides libsocketcan for native 32bit linux builds when not available otherwise
+ *
+ * # Introduction
+ *
+ * "This library allows you to control some basic functions in SocketCAN from userspace."
+ *
+ * # License
+ *
+ * Licensed under LGPL 2.1.
+ *
+ * @see      https://git.pengutronix.de/cgit/tools/libsocketcan
+ */

--- a/tests/candev/Makefile
+++ b/tests/candev/Makefile
@@ -1,21 +1,7 @@
-BOARD ?= nucleo-f767zi
-
 include ../Makefile.tests_common
 
 USEMODULE += shell
 USEMODULE += can
 USEMODULE += isrpipe
-
-
-# define the CAN driver you want to use here
-CAN_DRIVER ?= MCP2515
-
-ifeq ($(CAN_DRIVER), PERIPH_CAN)
-	FEATURES_REQUIRED += periph_can
-else ifeq ($(CAN_DRIVER), MCP2515)
-	USEMODULE += mcp2515
-else ifeq ($(CAN_DRIVER), CAN_ALT)
-	# other can modules can be defined here
-endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/candev/Makefile.board.dep
+++ b/tests/candev/Makefile.board.dep
@@ -1,0 +1,14 @@
+ifneq (,$(filter native,$(BOARD)))
+  CAN_DRIVER ?= PERIPH_CAN
+endif
+
+# define the CAN driver you want to use here
+CAN_DRIVER ?= MCP2515
+
+ifeq ($(CAN_DRIVER), PERIPH_CAN)
+  FEATURES_REQUIRED += periph_can
+else ifeq ($(CAN_DRIVER), MCP2515)
+  USEMODULE += mcp2515
+else ifeq ($(CAN_DRIVER), CAN_ALT)
+  # other can modules can be defined here
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

- add libsocketcan as a package to resolve its reduced availability (Ubuntu dropped it for i386 builds)
- allow switching between OS provided and package provided libsocketcan for cpu/native
- make tests/candev more readable

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

On Ubuntu 20.04 with libsocketcan2:amd64 available, libsocketcan-dev available, libsocketcan2:i386 unavailable.

In `tests/candev`:

- `make -j BOARD=native CAN_DRIVER=PERIPH_CAN` should fail
- `make -j BOARD=native CAN_DRIVER=PERIPH_CAN USEPKG=libsocketcan` should build
- `sudo modprobe vcan; sudo ip link add dev vcan0 type vcan; sudo ip link set up dev vcan0` should create a virtual can device
- install can-utils for the OS
- run the native build, run `candump vcan0` in another terminal
- run `receive` in the native build's terminal
- run `cansend vcan0 1234567f#123456` in another terminal -> both candump and the native build's terminal should show similar output
- run `send 1 2 3 4` in the native build's terminal -> candump should show the data

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
