### PR TITLE
cpu/cc2538/rtt: fix rtt_set_counter

### DIFF
--- a/cpu/cc2538/periph/rtt.c
+++ b/cpu/cc2538/periph/rtt.c
@@ -92,7 +92,7 @@ uint32_t rtt_get_counter(void)
 void rtt_set_counter(uint32_t counter)
 {
     rtt_alarm -= rtt_offset;
-    rtt_offset = _rtt_get_counter() + counter;
+    rtt_offset = _rtt_get_counter() - counter;
     rtt_alarm += rtt_offset;
 
     /* re-set the overflow callback */


### PR DESCRIPTION
### Contribution description

RTT test was failing on `cc2538` looks like the `set-counter` function was wrong, this should fix it.

### Testing procedure

The test now passes

```
main(): This is RIOT! (Version: 2022.04-devel-54-g8c8ab-pr_cc2538_set_counter)

RIOT RTT low-level driver test
RTT configuration:
RTT_MAX_VALUE: 0xffffffff
RTT_FREQUENCY: 32768

Testing the tick conversion
Trying to convert 1 to seconds and back
Trying to convert 256 to seconds and back
Trying to convert 65536 to seconds and back
Trying to convert 16777216 to seconds and back
Trying to convert 2147483648 to seconds and back
All ok

Initializing the RTT driver
This test will now display 'Hello' every 5 seconds

RTT now: 4283511575
Setting RTT timer to 1337
RTT now: 1337
rtt_set_counter() PASSED
Setting initial alarm to now + 5 s (165177)
rtt_get_alarm() PASSED
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```