### PR TITLE
doc: C2Rust does not need patching any more.

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -126,16 +126,20 @@ This encompass both components needed for riot-sys and for the later installatio
 
 Installing **C2Rust** is special because
 it can only be built using a particular nightly version
-(as explained in its [introduction post])
-and needs some patches applied:
+(as explained in its [introduction post]):
 
 ```shell
 $ rustup install nightly-2019-12-05
 $ rustup component add --toolchain nightly-2019-12-05 rustfmt rustc-dev
-$ git clone https://github.com/chrysn-pull-requests/c2rust -b for-riot
+$ git clone https://github.com/immunant/c2rust
 $ cd c2rust
+$ git reset --hard 6674d785
 $ cargo +nightly-2019-12-05 install --locked --path c2rust
 ```
+
+The `git reset` step pins C2Rust to the version at time of writing.
+It is expected that later versions of C2Rust would work just as well,
+but they may need a more recent nightly Rust.
 
 [cargo]: https://doc.rust-lang.org/cargo/
 [**rustup**, installed as described on its website]: https://rustup.rs/


### PR DESCRIPTION
### Contribution description

C2Rust has accepted most of the patches in the current for-riot; what's left needs riot-sys fixes anyway on the long run.

### Testing procedure

* Look at the docs.

For full testing:

* Install C2Rust as documented (replacing any old C2Rust installation)
* Build any of the Rust examples (ideally rust-gcoap as it has the largest coverage) on native and a cortex-m board (and on a RISC-V board if overtaken by #17520)

### Issues/PRs references

A sibling PR on riotdocker is https://github.com/RIOT-OS/riotdocker/pull/173.

### Status

This is on hold as a draft because it still depends on two things:

* [x] The no-llvm-asm branch of riot-wrappers to be merged, released and the Cargo.lock files here to be updated to use it, and
* [x] the sibling riotdocker PR that performs the same steps under automation. (That, in turn, will need to wait for the release to have completed).

[edit: Finish incomplete sentence, cross-link to sibling PR; turned into bulled list after first blocker is resolved].