### PR TITLE
pkg: fix documentation on includes

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           =
+PROJECT_NAME           = "RIOT OS"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/pkg/doc.txt
+++ b/pkg/doc.txt
@@ -13,12 +13,10 @@
  * Using packages
  * ==============
  * To add a package to the list of compiled modules you have to add it to the
- * `USEPKG` macro in your application's Makefile. If the package provides
- * header files you might need to update the `INCLUDE` macro, too:
+ * `USEPKG` macro in your application's Makefile:
  *
  * ~~~~~~~~ {.mk}
  * USEPKG += <pkg_name>
- * INCLUDE += $(RIOTPKG)/<pkg_name>/...
  * ~~~~~~~~
  *
  * When the package can be built out-of-source, the source code of external
@@ -52,6 +50,14 @@
  *    apply the patch and how to build the package as a RIOT module.
  *    A rough template for several methods of acquiring a package is provided in
  *    `pkg/Makefile.git` and `pkg/Makefile.http`.
+ *
+ * If your port or the package provide header files, you need to update the
+ * `INCLUDES` variable in the package's `Makefile.include`:
+ *
+ * ~~~~~~~~ {.mk}
+ * INCLUDES += -I$(RIOTPKG)/<pkg_name>/include # headers provided by the port
+ * INCLUDES += -I$(PKGDIRBASE)/<pkg_name> # headers provided by the package
+ * ~~~~~~~~
  *
  * Patch files can be included in a `patches` directory in the package dir.
  * These are applied to the upstream package to make it build with RIOT.

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -839,8 +839,6 @@ ifneq (,$(filter fido2_ctap,$(USEMODULE)))
   USEPKG += tinycbor
   USEPKG += micro-ecc
 
-  INCLUDE += $(RIOTPKG)/tinycbor
-
   USEMODULE += mtd_flashpage
   USEMODULE += mtd_write_page
   USEMODULE += ztimer_msec


### PR DESCRIPTION
### Contribution description

Documentation on how to handle package includes is misleading (maybe outdated?), as it indicates to manually include package's header files in the application Makefile. This is no longer needed.

This PR fixes the documentation, and removes an unnecessary include in `Makefile.dep`.

I'm also piggybacking 6257442e4e7054e8c42834c5f56527a617474882 which assigns a project name to our documentation, because currently I see "My Project" as the top level label. I can split this though if needed.

### Testing procedure
- Build and read the docs
- Verify that `tests/sys_fido2_ctap` still compiles

### Issues/PRs references
Found while reviewing #17435
