### PR TITLE
core/thread doc: Point to helper function

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -444,7 +444,7 @@ const char *thread_getname(kernel_pid_t pid);
  *
  * Only works if the thread was created with the flag THREAD_CREATE_STACKTEST.
  *
- * @param[in] stack the stack you want to measure. Try `thread_get_active()->stack_start`
+ * @param[in] stack the stack you want to measure. Try `thread_get_stackstart(thread_get_active())`
  *
  * @return          the amount of unused space of the thread's stack
  */


### PR DESCRIPTION
### Contribution description

In #16818 a helper to access a thread's `stack_start` member was introduced.

The documentation of `thread_measure_stack_free` still used the member access rather than the new method.

### Testing procedure

* Look at diff