### PR TITLE
sys/net/nanocoap: Introduce coap_build_pkt_t and use it

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -75,14 +75,14 @@ static ssize_t _handler_info(coap_pkt_t *pdu,
     return resp_len + slen;
 }
 
-static const coap_resource_t _resources[] = {
+static const gcoap_resource_t _resources[] = {
     { "/node/info",  COAP_GET, _handler_info, NULL },
     { "/sense/hum",  COAP_GET, _handler_dummy, NULL },
     { "/sense/temp", COAP_GET, _handler_dummy, NULL }
 };
 
 static gcoap_listener_t _listener = {
-    .resources     = (coap_resource_t *)&_resources[0],
+    .resources     = _resources,
     .resources_len = ARRAY_SIZE(_resources),
     .next          = NULL
 };

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -57,14 +57,14 @@ static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx
     return text_resp(pdu, buf, len, (char *)ctx, COAP_FORMAT_TEXT);
 }
 
-static const coap_resource_t resources[] = {
+static const gcoap_resource_t resources[] = {
     { "/riot/bar",  COAP_GET, handler_text, "foo" },
     { "/riot/foo",  COAP_GET, handler_text, "bar" },
     { "/riot/info", COAP_GET, handler_info, NULL }
 };
 
 static gcoap_listener_t listener = {
-    .resources     = &resources[0],
+    .resources     = resources,
     .resources_len = ARRAY_SIZE(resources),
     .next          = NULL
 };

--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -56,13 +56,13 @@ static const credman_credential_t credential = {
 };
 #endif
 
-static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
+static ssize_t _encode_link(const gcoap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
-static const coap_resource_t _resources[] = {
+static const gcoap_resource_t _resources[] = {
     { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },
 };
@@ -83,7 +83,7 @@ static gcoap_listener_t _listener = {
 
 
 /* Adds link format params to resource list */
-static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
+static ssize_t _encode_link(const gcoap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context) {
     ssize_t res = gcoap_encode_link(resource, buf, maxlen, context);
     if (res > 0) {

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -55,19 +55,19 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
     *response->cur++ = 0xff;
 
     /* Add actual content */
-    response->cur += coap_blockwise_put_bytes(&slicer, response->cur, block2_intro, sizeof(block2_intro)-1);
-    response->cur += coap_blockwise_put_bytes(&slicer, response->cur, (uint8_t*)RIOT_VERSION, strlen(RIOT_VERSION));
-    response->cur += coap_blockwise_put_char(&slicer, response->cur, ')');
-    response->cur += coap_blockwise_put_bytes(&slicer, response->cur, block2_board, sizeof(block2_board)-1);
-    response->cur += coap_blockwise_put_bytes(&slicer, response->cur, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
-    response->cur += coap_blockwise_put_bytes(&slicer, response->cur, block2_mcu, sizeof(block2_mcu)-1);
-    response->cur += coap_blockwise_put_bytes(&slicer, response->cur, (uint8_t*)RIOT_MCU, strlen(RIOT_MCU));
+    coap_blockwise_put_bytes(&slicer, response, block2_intro, sizeof(block2_intro)-1);
+    coap_blockwise_put_bytes(&slicer, response, (uint8_t*)RIOT_VERSION, strlen(RIOT_VERSION));
+    coap_blockwise_put_char(&slicer, response, ')');
+    coap_blockwise_put_bytes(&slicer, response, block2_board, sizeof(block2_board)-1);
+    coap_blockwise_put_bytes(&slicer, response, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
+    coap_blockwise_put_bytes(&slicer, response, block2_mcu, sizeof(block2_mcu)-1);
+    coap_blockwise_put_bytes(&slicer, response, (uint8_t*)RIOT_MCU, strlen(RIOT_MCU));
     /* To demonstrate individual chars */
-    response->cur += coap_blockwise_put_char(&slicer, response->cur, ' ');
-    response->cur += coap_blockwise_put_char(&slicer, response->cur, 'M');
-    response->cur += coap_blockwise_put_char(&slicer, response->cur, 'C');
-    response->cur += coap_blockwise_put_char(&slicer, response->cur, 'U');
-    response->cur += coap_blockwise_put_char(&slicer, response->cur, '.');
+    coap_blockwise_put_char(&slicer, response, ' ');
+    coap_blockwise_put_char(&slicer, response, 'M');
+    coap_blockwise_put_char(&slicer, response, 'C');
+    coap_blockwise_put_char(&slicer, response, 'U');
+    coap_blockwise_put_char(&slicer, response, '.');
 
     return coap_block2_build_reply(pkt, COAP_CODE_205, response, &slicer);
 }

--- a/examples/suit_update/coap_handler.c
+++ b/examples/suit_update/coap_handler.c
@@ -14,10 +14,10 @@
 #include "suit/transport/coap.h"
 #include "kernel_defines.h"
 
-static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_board_handler(coap_pkt_t *pkt, coap_build_pkt_t *response, void *context)
 {
     (void)context;
-    return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
+    return coap_reply_simple(pkt, COAP_CODE_205, response,
             COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
 }
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -219,6 +219,15 @@ typedef struct {
 } coap_pkt_t;
 
 /**
+ * @brief   CoAP PDU assembly context structure
+ */
+typedef struct {
+    coap_hdr_t *hdr;                                  /**< pointer to raw packet   */
+    uint8_t *cur;                                     /**< current write position  */
+    uint8_t *end;                                     /**< end of the tx buffer    */
+} coap_build_pkt_t;
+
+/**
  * @brief   Resource handler type
  *
  * Functions that implement this must be prepared to be called multiple times
@@ -232,7 +241,7 @@ typedef struct {
  * For POST, PATCH and other non-idempotent methods, this is an additional
  * requirement introduced by the contract of this type.
  */
-typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context);
+typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, coap_build_pkt_t *rsp, void *context);
 
 /**
  * @brief   Coap blockwise request callback descriptor
@@ -464,6 +473,23 @@ static inline void coap_hdr_set_type(coap_hdr_t *hdr, unsigned type)
 
     hdr->ver_t_tkl &= ~0x30;
     hdr->ver_t_tkl |= type << 4;
+}
+
+/**
+ * @brief   Initialize a CoAP response to an incoming packet
+ *
+ * @param[in]   pkt      packet to respond to
+ * @param[out]  response the uninitialized response packet
+ * @param[in]   buf      buffer for the response packet
+ * @param[in]   size     size of the response buffer
+ */
+static inline void coap_init_response(const coap_pkt_t *pkt,
+                                      coap_build_pkt_t *response,
+                                      void *buf, size_t size)
+{
+    response->hdr = buf;
+    response->end = (uint8_t *)buf + size;
+    response->cur = (uint8_t *)buf + coap_get_total_hdr_len(pkt);
 }
 /**@}*/
 
@@ -1611,16 +1637,14 @@ static inline size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum,
  *
  * @param[in]   pkt         packet to reply to
  * @param[in]   code        reply code (e.g., COAP_CODE_204)
- * @param[out]  rbuf        buffer to write reply to
- * @param[in]   rlen        size of @p rbuf
- * @param[in]   payload_len length of payload
+ * @param[out]  response    context to write reply to
  * @param[in]   slicer      slicer to use
  *
  * @returns     size of reply packet on success
  * @returns     <0 on error
  */
 ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,
-                                uint8_t *rbuf, unsigned rlen, unsigned payload_len,
+                                coap_build_pkt_t *response,
                                 coap_block_slicer_t *slicer);
 
 /**
@@ -1653,31 +1677,26 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token,
  *
  * @param[in]   pkt         packet to reply to
  * @param[in]   code        reply code (e.g., COAP_CODE_204)
- * @param[out]  rbuf        buffer to write reply to
- * @param[in]   rlen        size of @p rbuf
- * @param[in]   payload_len length of payload
+ * @param[out]  response    context to write reply to
  *
  * @returns     size of reply packet on success
  * @returns     <0 on error
- * @returns     -ENOSPC if @p rbuf too small
  */
-ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
-                         uint8_t *rbuf, unsigned rlen, unsigned payload_len);
+ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code, coap_build_pkt_t *response);
 
 /**
  * @brief   Handle incoming CoAP request
  *
  * This function will find the correct handler, call it and write the reply
- * into @p resp_buf.
+ * into @p response.
  *
  * @param[in]   pkt             pointer to (parsed) CoAP packet
- * @param[out]  resp_buf        buffer for response
- * @param[in]   resp_buf_len    size of response buffer
+ * @param[out]  response        buffer context for response
  *
  * @returns     size of reply packet on success
  * @returns     <0 on error
  */
-ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len);
+ssize_t coap_handle_req(coap_pkt_t *pkt, coap_build_pkt_t *response);
 
 /**
  * @brief   Pass a coap request to a matching handler
@@ -1686,16 +1705,14 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
  * the handler.
  *
  * @param[in]   pkt             pointer to (parsed) CoAP packet
- * @param[out]  resp_buf        buffer for response
- * @param[in]   resp_buf_len    size of response buffer
+ * @param[out]  response        buffer context for response
  * @param[in]   resources       Array of coap endpoint resources
  * @param[in]   resources_numof length of the coap endpoint resources
  *
  * @returns     size of the reply packet on success
  * @returns     <0 on error
  */
-ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
-                          unsigned resp_buf_len,
+ssize_t coap_tree_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
                           const coap_resource_t *resources,
                           size_t resources_numof);
 
@@ -1811,8 +1828,7 @@ ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c);
  *
  * @param[in]   pkt         packet to reply to
  * @param[in]   code        reply code (e.g., COAP_CODE_204)
- * @param[out]  buf         buffer to write reply to
- * @param[in]   len         size of @p buf
+ * @param[out]  response    response packet
  * @param[in]   ct          content type of payload
  * @param[in]   payload     ptr to payload
  * @param[in]   payload_len length of payload
@@ -1823,16 +1839,16 @@ ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c);
  */
 ssize_t coap_reply_simple(coap_pkt_t *pkt,
                           unsigned code,
-                          uint8_t *buf, size_t len,
+                          coap_build_pkt_t *response,
                           unsigned ct,
-                          const uint8_t *payload, uint8_t payload_len);
+                          const void *payload, uint8_t payload_len);
 
 /**
  * @brief   Reference to the default .well-known/core handler defined by the
  *          application
  */
 extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
-                                                    uint8_t *buf, size_t len,
+                                                    coap_build_pkt_t *response,
                                                     void *context);
 /**@}*/
 

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -823,14 +823,14 @@ void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
  * parts that are outside the current block2 request.
  *
  * @param[in]   slicer      slicer to use
- * @param[in]   bufpos      pointer to the current payload buffer position
+ * @param[out]  pkt         destination packet
  * @param[in]   c           byte array to copy
  * @param[in]   len         length of the byte array
  *
  * @returns     Number of bytes written to @p bufpos
  */
-size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
-                                const uint8_t *c, size_t len);
+size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, coap_build_pkt_t *pkt,
+                                const void *c, size_t len);
 
 /**
  * @brief Add a single character to a block2 reply.
@@ -840,12 +840,12 @@ size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
  * when the character is outside the current block2 request.
  *
  * @param[in]   slicer      slicer to use
- * @param[in]   bufpos      pointer to the current payload buffer position
+ * @param[out]  pkt         destination packet
  * @param[in]   c           character to write
  *
  * @returns     Number of bytes written to @p bufpos
  */
-size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, char c);
+size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, coap_build_pkt_t *pkt, char c);
 
 /**
  * @brief    Block option getter

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -70,17 +70,13 @@ void suit_coap_run(void);
 /**
  * @brief   Coap subtree handler
  *
- * @param[in,out]   pkt     Packet struct containing the request. Is reused for
- *                          the response
- * @param[in]       buf     Buffer to write reply to
- * @param[in]       len     Total length of the buffer associated with the
- *                          request
- * @param[in]       buf     Buffer to write reply to
+ * @param[in,out]   pkt     Packet struct containing the request.
+ * @param[out]      rsp     Packet struct used for the response
+ * @param[in]       ctx     Subtree context
  *
  * @returns     ssize_t     Size of the reply
  */
-ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf,
-                             size_t len, void *context);
+ssize_t coap_subtree_handler(coap_pkt_t *pkt, coap_build_pkt_t *rsp, void *context);
 
 /**
  * @brief   Type for CoAP resource subtrees

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -68,16 +68,16 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu,
                            const sock_udp_ep_t *remote, bool by_mid);
 static int _find_resource(gcoap_socket_type_t tl_type,
                           coap_pkt_t *pdu,
-                          const coap_resource_t **resource_ptr,
+                          const gcoap_resource_t **resource_ptr,
                           gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
 static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
                                                        coap_pkt_t *pdu);
 static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
-                                   const coap_resource_t *resource);
+                                   const gcoap_resource_t *resource);
 
 static int _request_matcher_default(gcoap_listener_t *listener,
-                                    const coap_resource_t **resource,
+                                    const gcoap_resource_t **resource,
                                     coap_pkt_t *pdu);
 
 #if IS_USED(MODULE_GCOAP_DTLS)
@@ -86,7 +86,7 @@ static void _dtls_free_up_session(void *arg);
 #endif
 
 /* Internal variables */
-const coap_resource_t _default_resources[] = {
+const gcoap_resource_t _default_resources[] = {
     { "/.well-known/core", COAP_GET, _well_known_core_handler, NULL },
 };
 
@@ -534,7 +534,7 @@ static void _cease_retransmission(gcoap_request_memo_t *memo) {
 static size_t _handle_req(gcoap_socket_t *sock, coap_pkt_t *pdu, uint8_t *buf,
                           size_t len, sock_udp_ep_t *remote)
 {
-    const coap_resource_t *resource     = NULL;
+    const gcoap_resource_t *resource    = NULL;
     gcoap_listener_t *listener          = NULL;
     sock_udp_ep_t *observer             = NULL;
     gcoap_observe_memo_t *memo          = NULL;
@@ -644,7 +644,7 @@ static size_t _handle_req(gcoap_socket_t *sock, coap_pkt_t *pdu, uint8_t *buf,
 }
 
 static int _request_matcher_default(gcoap_listener_t *listener,
-                                    const coap_resource_t **resource,
+                                    const gcoap_resource_t **resource,
                                     coap_pkt_t *pdu)
 {
     uint8_t uri[CONFIG_NANOCOAP_URI_MAX];
@@ -663,7 +663,7 @@ static int _request_matcher_default(gcoap_listener_t *listener,
     for (size_t i = 0; i < listener->resources_len; i++) {
         *resource = &listener->resources[i];
 
-        int res = coap_match_path(*resource, uri);
+        int res = coap_match_path((coap_resource_t *)*resource, uri);
 
         /* URI mismatch */
         if (res > 0) {
@@ -704,7 +704,7 @@ static int _request_matcher_default(gcoap_listener_t *listener,
  */
 static int _find_resource(gcoap_socket_type_t tl_type,
                           coap_pkt_t *pdu,
-                          const coap_resource_t **resource_ptr,
+                          const gcoap_resource_t **resource_ptr,
                           gcoap_listener_t **listener_ptr)
 {
     int ret = GCOAP_RESOURCE_NO_PATH;
@@ -713,7 +713,7 @@ static int _find_resource(gcoap_socket_type_t tl_type,
     gcoap_listener_t *listener = _coap_state.listeners;
 
     while (listener) {
-        const coap_resource_t *resource;
+        const gcoap_resource_t *resource;
         int res;
 
         /* only makes sense to check if non-UDP transports are supported,
@@ -925,7 +925,7 @@ static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
  * resource[in] -- Resource to match
  */
 static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
-                                   const coap_resource_t *resource)
+                                   const gcoap_resource_t *resource)
 {
     *memo = NULL;
     for (int i = 0; i < CONFIG_GCOAP_OBS_REGISTRATIONS_MAX; i++) {
@@ -1292,7 +1292,7 @@ int gcoap_resp_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code)
 }
 
 int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
-                                                  const coap_resource_t *resource)
+                                                  const gcoap_resource_t *resource)
 {
     gcoap_observe_memo_t *memo = NULL;
 
@@ -1323,7 +1323,7 @@ int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 }
 
 size_t gcoap_obs_send(const uint8_t *buf, size_t len,
-                      const coap_resource_t *resource)
+                      const gcoap_resource_t *resource)
 {
     gcoap_observe_memo_t *memo = NULL;
     _find_obs_memo_resource(&memo, resource);
@@ -1403,7 +1403,7 @@ int gcoap_get_resource_list_tl(void *buf, size_t maxlen, uint8_t cf,
     return (int)pos;
 }
 
-ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
+ssize_t gcoap_encode_link(const gcoap_resource_t *resource, char *buf,
                           size_t maxlen, coap_link_encoder_ctx_t *context)
 {
     size_t path_len = strlen(resource->path);

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1061,11 +1061,11 @@ ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,
     return coap_build_reply(pkt, code, response);
 }
 
-size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, char c)
+size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, coap_build_pkt_t *pkt, char c)
 {
     /* Only copy the char if it is within the window */
     if ((slicer->start <= slicer->cur) && (slicer->cur < slicer->end)) {
-        *bufpos = c;
+        *pkt->cur++ = c;
         slicer->cur++;
         return 1;
     }
@@ -1073,8 +1073,8 @@ size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, cha
     return 0;
 }
 
-size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
-                                const uint8_t *c, size_t len)
+size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, coap_build_pkt_t *pkt,
+                                const void *c, size_t len)
 {
     size_t str_len = 0;    /* Length of the string to copy */
 
@@ -1097,8 +1097,10 @@ size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
     }
 
     /* Only copy the relevant part of the string to the buffer */
-    memcpy(bufpos, c + str_offset, str_len);
+    memcpy(pkt->cur, (const uint8_t *)c + str_offset, str_len);
     slicer->cur += len;
+    pkt->cur += str_len;
+
     return str_len;
 }
 
@@ -1115,13 +1117,12 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, coap_build_pkt_t *
 
     for (unsigned i = 0; i < coap_resources_numof; i++) {
         if (i) {
-            response->cur += coap_blockwise_put_char(&slicer, response->cur, ',');
+            coap_blockwise_put_char(&slicer, response, ',');
         }
-        response->cur += coap_blockwise_put_char(&slicer, response->cur, '<');
         unsigned url_len = strlen(coap_resources[i].path);
-        response->cur += coap_blockwise_put_bytes(&slicer, response->cur,
-                (uint8_t*)coap_resources[i].path, url_len);
-        response->cur += coap_blockwise_put_char(&slicer, response->cur, '>');
+        coap_blockwise_put_char(&slicer, response, '<');
+        coap_blockwise_put_bytes(&slicer, response, coap_resources[i].path, url_len);
+        coap_blockwise_put_char(&slicer, response, '>');
     }
 
     return coap_block2_build_reply(pkt, COAP_CODE_205, response, &slicer);

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -410,7 +410,7 @@ bool coap_has_unprocessed_critical_options(const coap_pkt_t *pkt)
     return false;
 }
 
-ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len)
+ssize_t coap_handle_req(coap_pkt_t *pkt, coap_build_pkt_t *response)
 {
     if (coap_get_code_class(pkt) != COAP_REQ) {
         DEBUG("coap_handle_req(): not a request.\n");
@@ -418,14 +418,12 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
     }
 
     if (pkt->hdr->code == 0) {
-        return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
+        return coap_build_reply(pkt, COAP_CODE_EMPTY, response);
     }
-    return coap_tree_handler(pkt, resp_buf, resp_buf_len, coap_resources,
-                             coap_resources_numof);
+    return coap_tree_handler(pkt, response, coap_resources, coap_resources_numof);
 }
 
-ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
-                          unsigned resp_buf_len,
+ssize_t coap_tree_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
                           const coap_resource_t *resources,
                           size_t resources_numof)
 {
@@ -451,47 +449,43 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
             break;
         }
         else {
-            return resource->handler(pkt, resp_buf, resp_buf_len, resource->context);
+            return resource->handler(pkt, response, resource->context);
         }
     }
 
-    return coap_build_reply(pkt, COAP_CODE_404, resp_buf, resp_buf_len, 0);
+    return coap_build_reply(pkt, COAP_CODE_404, response);
 }
 
 ssize_t coap_reply_simple(coap_pkt_t *pkt,
                           unsigned code,
-                          uint8_t *buf, size_t len,
+                          coap_build_pkt_t *response,
                           unsigned ct,
-                          const uint8_t *payload, uint8_t payload_len)
+                          const void *payload, uint8_t payload_len)
 {
-    uint8_t *payload_start = buf + coap_get_total_hdr_len(pkt);
-    uint8_t *bufpos = payload_start;
+    coap_build_reply(pkt, code, response);
 
-    if (payload_len) {
-        bufpos += coap_put_option_ct(bufpos, 0, ct);
-        *bufpos++ = 0xff;
+    if (payload_len == 0) {
+        return 0;
     }
 
-    ssize_t res = coap_build_reply(pkt, code, buf, len,
-                                   bufpos - payload_start + payload_len);
+    assert(payload);
 
-    if (payload_len && (res > 0)) {
-        assert(payload);
-        memcpy(bufpos, payload, payload_len);
-    }
+    response->cur += coap_put_option_ct(response->cur, 0, ct);
+    *response->cur++ = 0xff;
 
-    return res;
-}
-
-ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
-                         uint8_t *rbuf, unsigned rlen, unsigned payload_len)
-{
-    unsigned tkl = coap_get_token_len(pkt);
-    unsigned len = sizeof(coap_hdr_t) + tkl;
-
-    if ((len + payload_len) > rlen) {
+    if (response->cur + payload_len >= response->end) {
         return -ENOSPC;
     }
+
+    memcpy(response->cur, payload, payload_len);
+    response->cur += payload_len;
+
+    return 0;
+}
+
+ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code, coap_build_pkt_t *response)
+{
+    unsigned tkl = coap_get_token_len(pkt);
 
     /* if code is COAP_CODE_EMPTY (zero), assume Reset (RST) type */
     unsigned type = COAP_TYPE_RST;
@@ -504,14 +498,11 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
         }
     }
 
-    coap_build_hdr((coap_hdr_t *)rbuf, type, pkt->token, tkl, code,
-                   ntohs(pkt->hdr->id));
-    coap_hdr_set_type((coap_hdr_t *)rbuf, type);
-    coap_hdr_set_code((coap_hdr_t *)rbuf, code);
+    coap_build_hdr(response->hdr, type, pkt->token, tkl, code, ntohs(pkt->hdr->id));
+    coap_hdr_set_type(response->hdr, type);
+    coap_hdr_set_code(response->hdr, code);
 
-    len += payload_len;
-
-    return len;
+    return 0;
 }
 
 ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t token_len, unsigned code, uint16_t id)
@@ -1059,15 +1050,15 @@ bool coap_block_finish(coap_block_slicer_t *slicer, uint16_t option)
 }
 
 ssize_t coap_block2_build_reply(coap_pkt_t *pkt, unsigned code,
-                                uint8_t *rbuf, unsigned rlen, unsigned payload_len,
+                                coap_build_pkt_t *response,
                                 coap_block_slicer_t *slicer)
 {
     /* Check if the generated data filled the requested block */
     if (slicer->cur < slicer->start) {
-        return coap_build_reply(pkt, COAP_CODE_BAD_OPTION, rbuf, rlen, 0);
+        return coap_build_reply(pkt, COAP_CODE_BAD_OPTION, response);
     }
     coap_block2_finish(slicer);
-    return coap_build_reply(pkt, code, rbuf, rlen, payload_len);
+    return coap_build_reply(pkt, code, response);
 }
 
 size_t coap_blockwise_put_char(coap_block_slicer_t *slicer, uint8_t *bufpos, char c)
@@ -1111,33 +1102,29 @@ size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
     return str_len;
 }
 
-ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \
-                                             size_t len, void *context)
+ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
+                                             void *context)
 {
     (void)context;
     coap_block_slicer_t slicer;
     coap_block2_init(pkt, &slicer);
-    uint8_t *payload = buf + coap_get_total_hdr_len(pkt);
-    uint8_t *bufpos = payload;
-    bufpos += coap_put_option_ct(bufpos, 0, COAP_FORMAT_LINK);
-    bufpos += coap_opt_put_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &slicer, 1);
 
-    *bufpos++ = 0xff;
+    response->cur += coap_put_option_ct(response->cur, 0, COAP_FORMAT_LINK);
+    response->cur += coap_opt_put_block2(response->cur, COAP_OPT_CONTENT_FORMAT, &slicer, 1);
+    *response->cur++ = 0xff;
 
     for (unsigned i = 0; i < coap_resources_numof; i++) {
         if (i) {
-            bufpos += coap_blockwise_put_char(&slicer, bufpos, ',');
+            response->cur += coap_blockwise_put_char(&slicer, response->cur, ',');
         }
-        bufpos += coap_blockwise_put_char(&slicer, bufpos, '<');
+        response->cur += coap_blockwise_put_char(&slicer, response->cur, '<');
         unsigned url_len = strlen(coap_resources[i].path);
-        bufpos += coap_blockwise_put_bytes(&slicer, bufpos,
+        response->cur += coap_blockwise_put_bytes(&slicer, response->cur,
                 (uint8_t*)coap_resources[i].path, url_len);
-        bufpos += coap_blockwise_put_char(&slicer, bufpos, '>');
+        response->cur += coap_blockwise_put_char(&slicer, response->cur, '>');
     }
 
-    unsigned payload_len = bufpos - payload;
-    return coap_block2_build_reply(pkt, COAP_CODE_205, buf, len, payload_len,
-                                   &slicer);
+    return coap_block2_build_reply(pkt, COAP_CODE_205, response, &slicer);
 }
 
 unsigned coap_get_len(coap_pkt_t *pkt)

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -104,11 +104,10 @@ static inline void _print_download_progress(suit_manifest_t *manifest,
 
 static kernel_pid_t _suit_coap_pid;
 
-ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                             void *context)
+ssize_t coap_subtree_handler(coap_pkt_t *pkt, coap_build_pkt_t *response, void *ctx)
 {
-    coap_resource_subtree_t *subtree = context;
-    return coap_tree_handler(pkt, buf, len, subtree->resources,
+    coap_resource_subtree_t *subtree = ctx;
+    return coap_tree_handler(pkt, response, subtree->resources,
                              subtree->resources_numof);
 }
 
@@ -292,16 +291,16 @@ void suit_coap_run(void)
                   _suit_coap_thread, NULL, "suit_coap");
 }
 
-static ssize_t _version_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+static ssize_t _version_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
                                 void *context)
 {
     (void)context;
-    return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
+    return coap_reply_simple(pkt, COAP_CODE_205, response,
                              COAP_FORMAT_TEXT, (uint8_t *)"NONE", 4);
 }
 
 #ifdef MODULE_RIOTBOOT_SLOT
-static ssize_t _slot_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+static ssize_t _slot_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
                              void *context)
 {
     /* context is passed either as NULL or 0x1 for /active or /inactive */
@@ -314,12 +313,12 @@ static ssize_t _slot_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
         c += riotboot_slot_current();
     }
 
-    return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
+    return coap_reply_simple(pkt, COAP_CODE_205, response,
                              COAP_FORMAT_TEXT, (uint8_t *)&c, 1);
 }
 #endif
 
-static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+static ssize_t _trigger_handler(coap_pkt_t *pkt, coap_build_pkt_t *response,
                                 void *context)
 {
     (void)context;
@@ -339,7 +338,7 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
         code = COAP_CODE_REQUEST_ENTITY_INCOMPLETE;
     }
 
-    return coap_reply_simple(pkt, code, buf, len,
+    return coap_reply_simple(pkt, code, response,
                              COAP_FORMAT_NONE, NULL, 0);
 }
 

--- a/tests/nanocoap_cli/nanocli_server.c
+++ b/tests/nanocoap_cli/nanocli_server.c
@@ -59,11 +59,15 @@ static int _nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize,
         }
         else {
             coap_pkt_t pkt;
+            coap_build_pkt_t response;
+
             if (coap_parse(&pkt, (uint8_t *)buf, res) < 0) {
                 DEBUG("nanocoap: error parsing packet\n");
                 continue;
             }
-            if ((res = coap_handle_req(&pkt, buf, bufsize)) > 0) {
+
+            coap_init_response(&pkt, &response, buf, bufsize);
+            if ((res = coap_handle_req(&pkt, &response)) >= 0) {
                 res = sock_udp_send(&sock, buf, res, &remote);
             }
         }

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -32,7 +32,7 @@
 /* internal value that can be read/written via CoAP */
 static uint8_t internal_value = 0;
 
-static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _value_handler(coap_pkt_t *pkt, coap_build_pkt_t *response, void *context)
 {
     (void) context;
 
@@ -68,8 +68,8 @@ static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *c
         code = COAP_CODE_METHOD_NOT_ALLOWED;
     }
 
-    return coap_reply_simple(pkt, code, buf, len,
-            COAP_FORMAT_TEXT, (uint8_t*)rsp, p);
+    return coap_reply_simple(pkt, code, response,
+                             COAP_FORMAT_TEXT, rsp, p);
 }
 
 /* must be sorted by path (ASCII order) */

--- a/tests/pkg_edhoc_c/responder.c
+++ b/tests/pkg_edhoc_c/responder.c
@@ -58,7 +58,7 @@ static wc_Sha256 _sha_r;
 struct tc_sha256_state_struct _sha_r;
 #endif
 
-ssize_t _edhoc_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+ssize_t _edhoc_handler(coap_pkt_t *pkt, coap_build_pkt_t *response, void *context)
 {
     (void)context;
     ssize_t msg_len = 0;
@@ -76,19 +76,19 @@ ssize_t _edhoc_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
                  edhoc_create_msg2(&_ctx, pkt->payload, pkt->payload_len, msg, sizeof(msg))) >= 0) {
             printf("[responder]: sending msg2 (%d bytes):\n", (int) msg_len);
             print_bstr(msg, msg_len);
-            msg_len = coap_reply_simple(pkt, COAP_CODE_204, buf, len, COAP_FORMAT_OCTET, msg,
+            msg_len = coap_reply_simple(pkt, COAP_CODE_204, response, COAP_FORMAT_OCTET, msg,
                                         msg_len);
         }
         else {
             puts("[responder]: failed to create msg2");
-            coap_reply_simple(pkt, COAP_CODE_404, buf, len, COAP_FORMAT_TEXT, NULL, 0);
+            coap_reply_simple(pkt, COAP_CODE_404, response, COAP_FORMAT_TEXT, NULL, 0);
             return -1;
         }
     }
     else if (_ctx.state == EDHOC_SENT_MESSAGE_2) {
         puts("[responder]: finalize exchange");
         edhoc_resp_finalize(&_ctx, pkt->payload, pkt->payload_len, false, NULL, 0);
-        msg_len = coap_reply_simple(pkt, COAP_CODE_204, buf, len, COAP_FORMAT_OCTET, NULL, 0);
+        msg_len = coap_reply_simple(pkt, COAP_CODE_204, response, COAP_FORMAT_OCTET, NULL, 0);
     }
 
     if (_ctx.state == EDHOC_FINALIZED) {

--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -15,7 +15,7 @@
 
 static riotboot_flashwrite_t _writer;
 
-ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context)
+ssize_t _flashwrite_handler(coap_pkt_t* pkt, coap_build_pkt_t *response, void *context)
 {
     riotboot_flashwrite_t *writer = context;
 
@@ -65,11 +65,10 @@ ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *con
         riotboot_flashwrite_finish(writer);
     }
 
-    ssize_t reply_len = coap_build_reply(pkt, result, buf, len, 0);
-    uint8_t *pkt_pos = (uint8_t*)pkt->hdr + reply_len;
-    pkt_pos += coap_put_block1_ok(pkt_pos, &block1, 0);
+    coap_build_reply(pkt, result, response);
+    response->cur += coap_put_block1_ok(response->cur, &block1, 0);
 
-    return pkt_pos - (uint8_t*)pkt->hdr;
+    return response->cur - (uint8_t*)response->hdr;
 }
 
 /* must be sorted by path (ASCII order) */

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -25,13 +25,13 @@
 /*
  * A test set of dummy resources. The resource handlers are set to NULL.
  */
-static const coap_resource_t resources[] = {
+static const gcoap_resource_t resources[] = {
     { .path = "/act/switch", .methods = (COAP_GET | COAP_POST) },
     { .path = "/sensor/temp", .methods = (COAP_GET) },
     { .path = "/test/info/all", .methods = (COAP_GET) },
 };
 
-static const coap_resource_t resources_second[] = {
+static const gcoap_resource_t resources_second[] = {
     { .path = "/second/part", .methods = (COAP_GET)},
 };
 

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -501,11 +501,14 @@ static void test_nanocoap__server_reply_simple(void)
 {
     uint8_t buf[_BUF_SIZE];
     coap_pkt_t pkt;
+    coap_build_pkt_t response;
     char *payload = "0";
 
     int res = _read_riot_value_req(&pkt, &buf[0]);
 
-    coap_reply_simple(&pkt, COAP_CODE_CONTENT, buf, _BUF_SIZE,
+    coap_init_response(&pkt, &response, buf, sizeof(buf));
+
+    coap_reply_simple(&pkt, COAP_CODE_CONTENT, &response,
                       COAP_FORMAT_TEXT, (uint8_t *)payload, 1);
 
     TEST_ASSERT_EQUAL_INT(0, res);
@@ -551,11 +554,14 @@ static void test_nanocoap__server_reply_simple_con(void)
 {
     uint8_t buf[_BUF_SIZE];
     coap_pkt_t pkt;
+    coap_build_pkt_t response;
     char *payload = "0";
 
     _read_riot_value_req_con(&pkt, &buf[0]);
 
-    coap_reply_simple(&pkt, COAP_CODE_CONTENT, buf, _BUF_SIZE,
+    coap_init_response(&pkt, &response, buf, sizeof(buf));
+
+    coap_reply_simple(&pkt, COAP_CODE_CONTENT, &response,
                       COAP_FORMAT_TEXT, (uint8_t *)payload, 1);
 
     TEST_ASSERT_EQUAL_INT(COAP_TYPE_ACK, coap_get_type(&pkt));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For requests NanoCOAP assembles a `coap_pkt_t` struct, however responses are built using a raw `uint8_t *` and `size_t` pair.
This makes it very hard to extend functionality.

For more flexibility, this introduces a new `coap_rsp_pkt_t` struct that is used to assemble a COAP response.
I did not use `coap_pkt_t` since that assumes an already parsed packet.

The goal is to have a separate payload pointer so that together with #17485 we do not have to copy the payload into the COAP response buffer but can just pass a pointer to it.
This is relevant with large COAP blocks (e.g 1k) via Ethernet or IEEE 802.15.4g.

But this is for a future PR, this PR only converts the `uint8_t *rsp, size_t rsp_len` functions to use `coap_pkt_t *response` instead. Some code was simplified as we no longer need to pass the packet length as return value but can always determine it from the new struct. 

#### TODO

 - [x] convert GCOAP
 - [x] update documentation 

### Testing procedure

<details><summary>examples/suit_update</summary>

```
suit_coap: trigger received
suit_coap: downloading "coap://[2001:db8::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
suit_coap: got manifest with size 495
suit: verifying manifest signature
suit: validated manifest version
)riotboot_hdr_validate: riotboot_hdr magic number invalid
Manifest seq_no: 1646321196, highest available: 1646321023
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 4000 with other slot offset
Comparing manifest offset 82000 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 50244518-6a7c-5ce7-932b-88b318336c82 to 50244518-6a7c-5ce7-932b-88b318336c82 from manifest
validating class id: OK
Comparing manifest offset 4000 with other slot offset
Comparing manifest offset 82000 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x6220de2c
Image start address: 0x00082400
Header chksum: 0x449701f7

suit_coap: rebooting...
----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.04-devel-616-g1a182-nanocoap-coap_rsp_pkt_t)
RIOT SUIT update example application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x6220de2c
Image start address: 0x00082400
Header chksum: 0x449701f7

suit_coap: started.
Starting the shell
> 
```
</details>

<details><summary>tests/riotboot_flashwrite</summary>

```
/home/benpicco/dev/RIOT/dist/tools/ethos/ethos riot0 /dev/ttyACM0 
----> ethos: sending hello.
----> ethos: activating serial pass through.
----> ethos: hello reply received
----> ethos: hello reply received


riotboot-hdr

> 
> 
> 
> riotboot-hdr
Image magic_number: 0x544f4952
Image Version: 0x6220dbfb


Image start address: 0x00004400
Header chksum: 0x7bcb1fbe

> current-slot

> 
> current-slot
Running from slot 0
> ifconfig
ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
pinging node...
PING fe80::649b:87ff:fe4c:4152%riot0(fe80::649b:87ff:fe4c:4152%riot0) 56 data bytes

--- fe80::649b:87ff:fe4c:4152%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 37.085/37.085/37.085/0.000 ms
pinging node succeeded.
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/benpicco/dev/RIOT/tests/riotboot_flashwrite/bin/same54-xpro/tests_riotboot_flashwrite-slot0.1646320636.riot.bin...
creating /home/benpicco/dev/RIOT/tests/riotboot_flashwrite/bin/same54-xpro/tests_riotboot_flashwrite-slot1.1646320636.riot.bin...
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:4152
          inet6 group: ff02::1:ff00:2
          
> _flashwrite_handler(): received data: offset=0 len=64 blockwise=1 more=1
_flashwrite_handler(): init len=64
riotboot_flashwrite: initializing update to target slot 1
_flashwrite_handler(): received data: offset=64 len=64 blockwise=1 more=1
_flashwrite_handler(): received data: offset=128 len=64 blockwise=1 more=1
[…]
_flashwrite_handler(): received data: offset=69952 len=64 blockwise=1 more=1
_flashwrite_handler(): received data: offset=70016 len=24 blockwise=1 more=0
_flashwrite_handler(): finish
WARNING:coap.blockwise-requester:Block1 option completely ignored by server, assuming it knows what it is doing.
reboot
reboot
----> ethos: hello received
Failed to send flush request: Operation not permitted
NETOPT_RX_END_IRQ not implemented by driver
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.04-devel-616-gc798e-nanocoap-coap_rsp_pkt_t)
riotboot_flashwrite test application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x6220dbfc
Image start address: 0x00082400
Header chksum: 0x3bd7ffc6

Starting the shell


> current-slot

> 
> current-slot
Running from slot 1
> ifconfig
ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
pinging node...
PING fe80::649b:87ff:fe4c:4152%riot0(fe80::649b:87ff:fe4c:4152%riot0) 56 data bytes

--- fe80::649b:87ff:fe4c:4152%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 38.856/38.856/38.856/0.000 ms
pinging node succeeded.
compiling /home/benpicco/dev/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/benpicco/dev/RIOT/tests/riotboot_flashwrite/bin/same54-xpro/tests_riotboot_flashwrite-slot0.1646320637.riot.bin...
creating /home/benpicco/dev/RIOT/tests/riotboot_flashwrite/bin/same54-xpro/tests_riotboot_flashwrite-slot1.1646320637.riot.bin...
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:4152
          inet6 group: ff02::1:ff00:2
          
> _flashwrite_handler(): received data: offset=0 len=64 blockwise=1 more=1
_flashwrite_handler(): init len=64
riotboot_flashwrite: initializing update to target slot 0
_flashwrite_handler(): received data: offset=64 len=64 blockwise=1 more=1
_flashwrite_handler(): received data: offset=128 len=64 blockwise=1 more=1
[…]
_flashwrite_handler(): received data: offset=69952 len=64 blockwise=1 more=1
_flashwrite_handler(): received data: offset=70016 len=24 blockwise=1 more=0
_flashwrite_handler(): finish
WARNING:coap.blockwise-requester:Block1 option completely ignored by server, assuming it knows what it is doing.
reboot
reboot
----> ethos: hello received
Failed to send flush request: Operation not permitted
NETOPT_RX_END_IRQ not implemented by driver
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.04-devel-616-gc798e-nanocoap-coap_rsp_pkt_t)
riotboot_flashwrite test application
Running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x6220dbfd
Image start address: 0x00004400
Header chksum: 0x7bd31fc0

Starting the shell


> current-slot

> 
> current-slot
Running from slot 0
> ifconfig
ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
pinging node...
PING fe80::649b:87ff:fe4c:4152%riot0(fe80::649b:87ff:fe4c:4152%riot0) 56 data bytes

--- fe80::649b:87ff:fe4c:4152%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 39.409/39.409/39.409/0.000 ms
pinging node succeeded.
riotboot-invalidate 0
reboot
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:4152
          inet6 group: ff02::1:ff00:2
          
> riotboot-invalidate 0
> reboot
----> ethos: hello received
Failed to send flush request: Operation not permitted
NETOPT_RX_END_IRQ not implemented by driver
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.04-devel-616-gc798e-nanocoap-coap_rsp_pkt_t)
riotboot_flashwrite test application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x6220dbfc
Image start address: 0x00082400
Header chksum: 0x3bd7ffc6

Starting the shell


> current-slot

> 
> current-slot
Running from slot 1
TEST PASSED
```
</details>

<details><summary>examples/gcoap <-> examples/nanocoap_server</summary>

```
> coap get fe80::9483:27ff:feaf:5d66 5683 /riot/ver
coap get fe80::9483:27ff:feaf:5d66 5683 /riot/ver
gcoap_cli: sending msg ID 20789, 15 bytes
--- blockwise start ---
gcoap: response Success, code 2.05, 16 bytes
This is RIOT (Ve
gcoap: response Success, code 2.05, 16 bytes
rsion: 2022.04-d
gcoap: response Success, code 2.05, 16 bytes
evel-74-g23b93-n
gcoap: response Success, code 2.05, 16 bytes
anocoap-coap_rsp
gcoap: response Success, code 2.05, 16 bytes
_pkt_t) running 
gcoap: response Success, code 2.05, 16 bytes
on a native boar
gcoap: response Success, code 2.05, 16 bytes
d with a native 
gcoap: response Success, code 2.05, 4 bytes
MCU.
--- blockwise complete ---
```
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
