### PR TITLE
tools/cpy2remed: Addition of new programmer for nucleo boards

### DIFF
--- a/boards/nucleo-l552ze-q/Makefile.include
+++ b/boards/nucleo-l552ze-q/Makefile.include
@@ -1,2 +1,8 @@
+#variable needed by cpy2remed PROGRAMMER
+#it contains name of ST-Link removable media
+DIR_NAME_AT_REMED = "NODE_L552ZE"
+
+PROGRAMMERS_SUPPORTED += cpy2remed
+
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-l552ze-q/doc.txt
+++ b/boards/nucleo-l552ze-q/doc.txt
@@ -36,6 +36,8 @@ of Flash.
 
 ## Flashing the device
 
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-L552ZE-Q board includes an on-board ST-LINK programmer and can be
 flashed using OpenOCD.
 @note The upstream version of OpenOCD doesn't contain yet support for this board,
@@ -64,6 +66,19 @@ and debug via GDB by simply typing
 ```
 make BOARD=nucleo-l552ze-q debug
 ```
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l552ze-q PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
 ## Accessing RIOT shell
 

--- a/dist/tools/cpy2remed/cpy2remed.sh
+++ b/dist/tools/cpy2remed/cpy2remed.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+#cpy2remed - copy to removable media
+#$1 contains generated hexfile
+#$2 contains directory name for this particular nucleo board which could be
+#   set in the board makefile.include using variable DIR_NAME_AT_REMED
+
+HEXFILE="$1"
+DEV_DIR="$2"
+
+REMED_MOUNT_PATH="${REMED_MOUNT_PATH:-/media/$USER/$DEV_DIR/}"
+
+cp "$HEXFILE" "$REMED_MOUNT_PATH"

--- a/makefiles/tools/cpy2remed.inc.mk
+++ b/makefiles/tools/cpy2remed.inc.mk
@@ -1,0 +1,6 @@
+
+FLASHER ?= $(RIOTTOOLS)/cpy2remed/cpy2remed.sh
+
+FLASHFILE ?= $(HEXFILE)
+
+FFLAGS ?= $(FLASHFILE) $(DIR_NAME_AT_REMED)


### PR DESCRIPTION
### Contribution description

This PR adds a new programmer to the Nucleo boards with an on-board ST-LINK debugger. On-board ST-LINK provides removable media to which program image file in HEX format could be copied for programing. Introduced **_cpy2remed_** (copy two removable media) script automates programming process.

OpenOCD programmer could utilize ST-LINK, but in my opinion, more straightforward method without installing additional software could be beneficial for users not familiar with micro-controllers.

### Testing procedure
Currently, programmer was tested on STM Nucleo-L552ZE-Q board; however, all Nucleo boards with ST-LINK should work after a minor enhancement - add **DIR_NAME_AT_REMED**  variable to the **_Makefile.include_** file.

Go to RIOT/examples/blinky and run command:
```
make BOARD=nucleo-l552ze-q PROGRAMMER=cpy2remed flash
```
After a while, the green LED (LD1) should start blinking.

Changes in documentation can be observed using commands:
```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l552-q.html
```
### Issues/PRs references

N/A