### PR TITLE
makefiles/libc/newlibc: allow toolchains with nano version only

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -94,11 +94,9 @@ ifeq (1,$(USE_NEWLIB_NANO))
                                                     $(NEWLIB_INCLUDE_DIR)/newlib/nano \
                                                     $(NEWLIB_INCLUDE_DIR)/nano))
 
-  ifeq (,$(NEWLIB_NANO_INCLUDE_DIR))
-    $(error USE_NEWLIB_NANO==1 but nano include folder not found!)
+  ifneq (,$(NEWLIB_NANO_INCLUDE_DIR))
+     # newlib-nano overrides newlib.h and its include dir should therefore go before
+     # the regular system include dirs.
+     INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
   endif
-
-  # newlib-nano overrides newlib.h and its include dir should therefore go before
-  # the regular system include dirs.
-  INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
 endif


### PR DESCRIPTION
### Contribution description

With this PR it becomes possible to use toolchains that provide `newlib-nano` and use `nano.specs` but do not have a separate directory for the newlib version of `newlib.h` because they are only intended to use the nano version.

`makefiles/libc/newlib.mk` assumes that a toolchain which provides the `newlib-nano` provides both the normal version and the nano version of the `newlib`. The nano version of `newlib.h` is therefore stored in its own include directory.  This is necessary for toolchains which allow to use both the normal and the nano version, e.g. for ARM and RISC-V.

However, if the toolchain provides `newlib_nano` but only allows the use of the nano version, it will only have the nano version of `newlib.h` and no separate directory for it, e.g. for ESP32.

To still be able to use such toolchains with `newlib_nano`, the check is changed so that the setting of the `-isystem` option depends on the existence of the separate directory.

### Testing procedure

Green CI.

### Issues/PRs references
