### PR TITLE
boards/nucleo-f767zi: Fix adc pin config in periph_conf.h

### DIFF
--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -198,12 +198,12 @@ static const eth_conf_t eth_config = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-        {GPIO_PIN(PORT_A, 3), 0, 0},
-        {GPIO_PIN(PORT_C, 0), 0, 1},
-        {GPIO_PIN(PORT_C, 3), 0, 4},
-        {GPIO_PIN(PORT_F, 3), 0, 8},
-        {GPIO_PIN(PORT_F, 5), 0, 11},
-        {GPIO_PIN(PORT_F, 10), 0, 10},
+        {GPIO_PIN(PORT_A, 3), 2, 3},
+        {GPIO_PIN(PORT_C, 0), 2, 10},
+        {GPIO_PIN(PORT_C, 3), 2, 13},
+        {GPIO_PIN(PORT_F, 3), 2, 9},
+        {GPIO_PIN(PORT_F, 5), 2, 15},
+        {GPIO_PIN(PORT_F, 10), 2, 8},
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fix wrong adc pins in periph_conf of nucleo 767zi board for Arduino A0 - A5. Previous configuration was not working and did not match the datasheet description.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

New configuration matches the description in [datasheet](https://www.st.com/resource/en/user_manual/um1974-stm32-nucleo144-boards-mb1137-stmicroelectronics.pdf) page 60. See screenshot for convenience. Was tested with all 6 Pins by a simple voltage divider.

<img width="776" alt="image" src="https://user-images.githubusercontent.com/56831337/150832601-8085d72f-b62c-4824-b2cd-71883bfeb894.png">


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

--