### PR TITLE
sys/ztimer64/util.c: fix ztimer64_set_timeout_flag [backport 2022.01]

### DIFF
--- a/sys/ztimer64/util.c
+++ b/sys/ztimer64/util.c
@@ -131,7 +131,7 @@ void ztimer64_set_timeout_flag_at(ztimer64_clock_t *clock, ztimer64_t *t,
     t->callback = _set_timeout_flag_callback;
     t->arg = thread_get_active();
     thread_flags_clear(THREAD_FLAG_TIMEOUT);
-    ztimer64_set(clock, t, target);
+    ztimer64_set_at(clock, t, target);
 }
 #endif
 


### PR DESCRIPTION
# Backport of #17561

### Contribution description

`ztimer64_set_timeout_flag_at` should use `ztimer_set_at` to be consistent with absolute timeouts.

### Testing procedure

Cherry-picked from #17365 where `ztimer64` is used for `xtimer` compat module. With this commit `test/thread_flags` and `test/event_wait_timeout` pass

```
BOARD=native make -C tests/event_wait_timeout flash test -j
Building application "tests_event_wait_timeout" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/event
"make" -C /home/francisco/workspace/RIOT/sys/frac
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/ztimer
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
   text	   data	    bss	    dec	    hex	filename
  37867	    640	  56048	  94555	  1715b	/home/francisco/workspace/RIOT/tests/event_wait_timeout/bin/native/tests_event_wait_timeout.elf
r
/home/francisco/workspace/RIOT/tests/event_wait_timeout/bin/native/tests_event_wait_timeout.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.04-devel-119-gde50d-pr_ztimer64_flag)
[START] event_wait_timeout test application.

waiting for event with 10ms timeout...
event_wait time out after 10038us
waiting for event with 10ms timeout (using uint64)...
event_wait time out after 10045us
finished: 4/4 events and 4/4 timeouts recorded
[SUCCESS]

```

```
make -C tests/thread_flags flash test -j
Building application "tests_thread_flags" for "native" with MCU "native".

"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/native
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/boards/native/drivers
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/div
"make" -C /home/francisco/workspace/RIOT/sys/frac
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/cpu/native/periph
"make" -C /home/francisco/workspace/RIOT/cpu/native/stdio_native
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/ztimer
"make" -C /home/francisco/workspace/RIOT/sys/ztimer64
   text	   data	    bss	    dec	    hex	filename
  37361	    612	  60164	  98137	  17f59	/home/francisco/workspace/RIOT/tests/thread_flags/bin/native/tests_thread_flags.elf
r
/home/francisco/workspace/RIOT/tests/thread_flags/bin/native/tests_thread_flags.elf /dev/ttyACM0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.04-devel-144-g6d6ec-ztimer_xtimer_compat_64)
START
thread(): waiting for 0x1...
main(): setting flag 0x0001
thread(): received flags: 0x0001
thread(): waiting for 0x1 || 0x64...
main(): setting flag 0x0064
thread(): received flags: 0x0064
thread(): waiting for 0x2 && 0x4...
main(): setting flag 0x0001
main(): setting flag 0x0008
main(): setting flag 0x0002
main(): setting flag 0x0004
thread(): received flags: 0x0006
thread(): waiting for any flag, one by one
thread(): received flags: 0x0001
thread(): waiting for any flag, one by one
thread(): received flags: 0x0008
main: setting 100ms timeout...
main: timeout triggered. time passed: 100057us
main: setting 100ms timeout (using uint64)...
main: timeout triggered. time passed: 100066us
SUCCESS
```


