### PR TITLE
tests/*: remove uneeded xtimer_init

### DIFF
--- a/tests/driver_motor_driver/main.c
+++ b/tests/driver_motor_driver/main.c
@@ -112,8 +112,6 @@ void motion_control(void)
 
 int main(void)
 {
-    xtimer_init();
-
     motion_control();
 
     return 0;

--- a/tests/thread_priority_inversion/main.c
+++ b/tests/thread_priority_inversion/main.c
@@ -90,7 +90,6 @@ kernel_pid_t pid_high;
 
 int main(void)
 {
-    xtimer_init();
     mutex_init(&res_mtx);
     puts("This is a scheduling test for Priority Inversion");
 


### PR DESCRIPTION
### Contribution description

This PR removes explicit calls to `xtimer-init()` in tests not disabling `auto-init`.

### Testing procedure

- Green Murdock

### Issues/PRs references

Split from #17365 