### PR TITLE
tests/periph_uart_nonblocking: migrate to ztimer

### DIFF
--- a/tests/periph_uart_nonblocking/Makefile
+++ b/tests/periph_uart_nonblocking/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_uart_nonblocking
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_uart_nonblocking/app.config.test
+++ b/tests/periph_uart_nonblocking/app.config.test
@@ -2,4 +2,4 @@
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_PERIPH_UART=y
 CONFIG_MODULE_PERIPH_UART_NONBLOCKING=y
-CONFIG_MODULE_XTIMER=y
+CONFIG_ZTIMER_USEC=y

--- a/tests/periph_uart_nonblocking/main.c
+++ b/tests/periph_uart_nonblocking/main.c
@@ -19,14 +19,15 @@
  */
 
 #include <stdio.h>
-#include <xtimer.h>
+#include "ztimer.h"
+#include "periph_conf.h"
 
 #define LINE_DELAY_MS   100
 
 static inline uint32_t puts_delay(const char* str)
 {
     puts(str);
-    xtimer_usleep(LINE_DELAY_MS * 1000);
+    ztimer_sleep(ZTIMER_USEC, LINE_DELAY_MS * 1000);
     return LINE_DELAY_MS * 1000;
 }
 
@@ -46,7 +47,7 @@ int main(void)
     _irq_disabled_print();
 
     uint32_t total_us = 0;
-    xtimer_ticks32_t counter = xtimer_now();
+    uint32_t counter = ztimer_now(ZTIMER_USEC);
 
     /* Richard Stallman and the Free Software Foundation
        claim no copyright on this song. */
@@ -72,9 +73,9 @@ int main(void)
     total_us += puts_delay("You'll be free, hackers, you'll be free.");
     total_us += puts_delay("");
 
-    counter.ticks32 = xtimer_now().ticks32 - counter.ticks32;
+    counter = ztimer_now(ZTIMER_USEC) - counter;
 
-    printf("== printed in %" PRIu32 "/%" PRIu32 " µs ==\n", xtimer_usec_from_ticks(counter), total_us);
+    printf("== printed in %" PRIu32 "/%" PRIu32 " µs ==\n", counter, total_us);
 
     puts("[SUCCESS]");
 


### PR DESCRIPTION
### Contribution description

This PR migrates the `periph_uart_nonblocking` to use `ztimer`, avoiding accessing `xtimer` internals.

### Testing procedure

- Green Murdock
- ` make -C tests/periph_uart_nonblocking/ flash test -j`
```
main(): This is RIOT! (Version: 2022.04-devel-126-g621d8-pr_xtimer_init_in_test)

puts with disabled interrupts and a full transmit buffer

Join us now and share the software;
You'll be free, hackers, you'll be free.
Join us now and share the software;
You'll be free, hackers, you'll be free.

Hoarders can get piles of money,
That is true, hackers, that is true.
But they cannot help their neighbors;
That's not good, hackers, that's not good.

When we have enough free software
At our call, hackers, at our call,
We'll kick out those dirty licenses
Ever more, hackers, ever more.

Join us now and share the software;
You'll be free, hackers, you'll be free.
Join us now and share the software;
You'll be free, hackers, you'll be free.

== printed in 2103389/2100000 µs ==
[SUCCESS]
```