### PR TITLE
doc: add RIOT root doxygen example path

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -855,7 +855,7 @@ EXCLUDE_SYMBOLS        = *CMSIS* \
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = ../../
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/pkg/driver_bme680/doc.txt
+++ b/pkg/driver_bme680/doc.txt
@@ -3,4 +3,6 @@
  * @ingroup  pkg
  * @brief    Provides the Bosch Sensortec's BME680 gas sensor API
  * @see      https://github.com/BoschSensortec/BME680_driver
+ *
+ * @include pkg/driver_bme680/README.md
  */

--- a/pkg/u8g2/doc.txt
+++ b/pkg/u8g2/doc.txt
@@ -15,4 +15,6 @@
  * to your makefile.
  * 48kB is enough for the test other uses may need more or may
  * need this to be applied to other threads using `THREAD_STACKSIZE_DEFAULT`
+ *
+ * @include pkg/u8g2/README.md
  */

--- a/pkg/ucglib/doc.txt
+++ b/pkg/ucglib/doc.txt
@@ -3,4 +3,6 @@
  * @ingroup  pkg
  * @brief    Provides a color graphics library for OLED and LCD displays
  * @see      https://github.com/olikraus/ucglib
+ *
+ * @include pkg/ucglib/README.md
  */

--- a/pkg/uwb-dw1000/README.md
+++ b/pkg/uwb-dw1000/README.md
@@ -1,0 +1,34 @@
+# Decawave uwb-dw1000 RIOT Port
+
+The distribution https://github.com/decawave/uwb-core contains the
+device driver implementation for the Decawave Impulse Radio-Ultra
+Wideband (IR-UWB) transceiver(s). The driver includes hardware abstraction
+layers (HAL), media access control (MAC) layer, Ranging Services (RNG).
+
+## Abstraction details
+
+uwb-dw1000 is meant as a hardware and architecture agnostic driver. It
+was developed with MyNewt as its default OS, but its abstractions are
+well defined which makes it easy to use with another OS.
+
+A porting layer DPL (Decawave Porting Layer) has been implemented that
+wraps around OS functionalities and modules: mutex, semaphores, threads,
+etc.. In most cases the mapping is direct although some specific
+functionalities might not be supported. This layer is found in the uwb-core
+pkg.
+
+A hardware abstraction layer is defined under `hal` which wraps around
+modules such as: periph_gpio, periph_spi, etc.
+
+Since the library was used on top of mynewt most configuration values
+are prefixed with `MYNEWT_VAL_%`, all configurations can be found under
+`pkg/uwb-dw1000/include/syscfg`.
+
+## Todos
+
+The uwb-dw1000 can be used to provide a netdev driver for the dw1000
+module.
+
+uwb-dw1000 repository uses fixed length arrays to keep track of the
+devices that are present. This port uses linked list but some of the
+upstream code is not compatible with this.

--- a/pkg/uwb-dw1000/doc.txt
+++ b/pkg/uwb-dw1000/doc.txt
@@ -3,39 +3,6 @@
  * @ingroup  pkg
  * @brief    uwb-core driver for Decawave DW1000 transceiver
  * @see      https://github.com/Decawave/uwb-dw1000
+ *
+ * @include pkg/ucglib/README.md
  */
-
-# Decawave uwb-dw1000 RIOT Port
-
-The distribution https://github.com/decawave/uwb-core contains the
-device driver implementation for the Decawave Impulse Radio-Ultra
-Wideband (IR-UWB) transceiver(s). The driver includes hardware abstraction
-layers (HAL), media access control (MAC) layer, Ranging Services (RNG).
-
-## Abstraction details
-
-uwb-dw1000 is meant as a hardware and architecture agnostic driver. It
-was developed with MyNewt as its default OS, but its abstractions are
-well defined which makes it easy to use with another OS.
-
-A porting layer DPL (Decawave Porting Layer) has been implemented that
-wraps around OS functionalities and modules: mutex, semaphores, threads,
-etc.. In most cases the mapping is direct although some specific
-functionalities might not be supported. This layer is found in the uwb-core
-pkg.
-
-A hardware abstraction layer is defined under `hal` which wraps around
-modules such as: periph_gpio, periph_spi, etc.
-
-Since the library was used on top of mynewt most configuration values
-are prefixed with `MYNEWT_VAL_%`, all configurations can be found under
-`pkg/uwb-dw1000/include/syscfg`.
-
-## Todos
-
-The uwb-dw1000 can be used to provide a netdev driver for the dw1000
-module.
-
-uwb-dw1000 repository uses fixed length arrays to keep track of the
-devices that are present. This port uses linked list but some of the
-upstream code is not compatible with this.


### PR DESCRIPTION
### Contribution description
add RIOT root to Doxygen example path
and include some Readme.md with their respective doc.txt  

sadly we can't use `@includedoc` or `@include{doc}` until Doxygen 1.9.2 
see https://github.com/doxygen/doxygen/pull/8395

### Testing procedure

read
and
check circleci: doc-build artifact 

eg
https://15379-7370241-gh.circle-artifacts.com/0/doc/group__pkg__u8g2.html
vs
https://doc.riot-os.org/group__pkg__u8g2.html

### Issues/PRs references

#10815
