### PR TITLE
core/assert: avoid including panic.h with assert.h

### DIFF
--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -20,6 +20,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/assert.c
+++ b/core/assert.c
@@ -16,15 +16,17 @@
 #include <stdio.h>
 
 #include "assert.h"
+#include "panic.h"
 
-#ifdef DEBUG_ASSERT_VERBOSE
-NORETURN void _assert_failure(const char *file, unsigned line)
+__NORETURN void _assert_failure(const char *file, unsigned line)
 {
-    printf("%s:%u => ", file, line); \
-    core_panic(PANIC_ASSERT_FAIL, assert_crash_message); \
+    printf("%s:%u => ", file, line);
+    core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
 }
-#else
-typedef int dont_be_pedantic;
-#endif
+
+__NORETURN void _assert_panic(void)
+{
+    core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
+}
 
 /** @} */

--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -50,10 +50,13 @@ extern "C" {
 
 /**
  * @def __NORETURN
+ * @brief hidden (__) NORETURN definition
  * @internal
+ *
  * Duplicating the definitions of kernel_defines.h as these are unsuitable for
  * system header files like the assert.h.
- * kernel_defines.h would define symbols that are not reserved. */
+ * kernel_defines.h would define symbols that are not reserved.
+ */
 #ifndef __NORETURN
 #ifdef __GNUC__
 #define __NORETURN __attribute__((noreturn))

--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -22,8 +22,6 @@
 #ifndef ASSERT_H
 #define ASSERT_H
 
-#include "panic.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,9 +49,18 @@ extern "C" {
 #endif
 
 /**
- * @brief   the string that is passed to panic in case of a failing assertion
- */
-extern const char assert_crash_message[];
+ * @def __NORETURN
+ * @internal
+ * Duplicating the definitions of kernel_defines.h as these are unsuitable for
+ * system header files like the assert.h.
+ * kernel_defines.h would define symbols that are not reserved. */
+#ifndef __NORETURN
+#ifdef __GNUC__
+#define __NORETURN __attribute__((noreturn))
+#else /*__GNUC__*/
+#define __NORETURN
+#endif /*__GNUC__*/
+#endif /*__NORETURN*/
 
 #ifdef NDEBUG
 #define assert(ignore)((void)0)
@@ -68,8 +75,7 @@ extern const char assert_crash_message[];
  * @param[in] file  The file name of the file the assertion failed in
  * @param[in] line  The code line of @p file the assertion failed in
  */
-NORETURN void _assert_failure(const char *file, unsigned line);
-
+__NORETURN void _assert_failure(const char *file, unsigned line);
 /**
  * @brief    abort the program if assertion is false
  *
@@ -103,10 +109,10 @@ NORETURN void _assert_failure(const char *file, unsigned line);
  */
 #define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, \
                                                           __LINE__))
-#else
-#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, \
-                                                    assert_crash_message))
-#endif
+#else /* DEBUG_ASSERT_VERBOSE */
+__NORETURN void _assert_panic(void);
+#define assert(cond) ((cond) ? (void)0 : _assert_panic())
+#endif /* DEBUG_ASSERT_VERBOSE */
 
 #if !defined __cplusplus
 #if __STDC_VERSION__ >= 201112L

--- a/core/panic.c
+++ b/core/panic.c
@@ -21,10 +21,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#include <string.h>
-#include <stdio.h>
-
-#include "assert.h"
 #include "kernel_defines.h"
 #include "cpu.h"
 #include "irq.h"

--- a/core/panic.c
+++ b/core/panic.c
@@ -43,8 +43,6 @@
 #include "usb_board_reset.h"
 #endif
 
-const char assert_crash_message[] = "FAILED ASSERTION.";
-
 /* flag preventing "recursive crash printing loop" */
 static int crashed = 0;
 

--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -39,6 +39,7 @@
 #include "cpu.h"
 #include "mutex.h"
 #include "byteorder.h"
+#include "panic.h"
 
 #include "cpu_conf_stm32_common.h"
 

--- a/cpu/stm32/periph/i2c_2.c
+++ b/cpu/stm32/periph/i2c_2.c
@@ -42,6 +42,7 @@
 #include "irq.h"
 #include "mutex.h"
 #include "pm_layered.h"
+#include "panic.h"
 
 #include "periph/i2c.h"
 #include "periph/gpio.h"

--- a/drivers/disp_dev/disp_dev.c
+++ b/drivers/disp_dev/disp_dev.c
@@ -20,6 +20,7 @@
 
 #include <assert.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <inttypes.h>
 #include <errno.h>
 

--- a/drivers/saul/init_devs/auto_init_sgp30.c
+++ b/drivers/saul/init_devs/auto_init_sgp30.c
@@ -16,9 +16,7 @@
 
 #include "assert.h"
 #include "log.h"
-#if IS_USED(MODULE_SAUL)
 #include "saul_reg.h"
-#endif
 
 #include "sgp30.h"
 #include "sgp30_params.h"
@@ -28,7 +26,6 @@
  */
 static sgp30_t sgp30_devs[SGP30_NUM];
 
-#if IS_USED(MODULE_SAUL)
 /**
  * @brief   Memory for the SAUL registry entries
  */
@@ -41,7 +38,6 @@ static saul_reg_t saul_entries[SGP30_NUM * 2];
 extern const saul_driver_t sgp30_saul_driver_eco2;
 extern const saul_driver_t sgp30_saul_driver_tvoc;
 /** @} */
-#endif
 
 void auto_init_sgp30(void)
 {
@@ -55,7 +51,6 @@ void auto_init_sgp30(void)
             continue;
         }
 
-#if IS_USED(MODULE_SAUL)
         /* eCO2 */
         saul_entries[(i * 2)].dev = &(sgp30_devs[i]);
         saul_entries[(i * 2)].name = sgp30_saul_info[i].name;
@@ -69,6 +64,5 @@ void auto_init_sgp30(void)
         /* register to saul */
         saul_reg_add(&(saul_entries[(i * 2)]));
         saul_reg_add(&(saul_entries[(i * 2) + 1]));
-#endif
     }
 }

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -13,6 +13,7 @@
 #include "fmt.h"
 #include "net/nanocoap.h"
 #include "hashes/sha256.h"
+#include "kernel_defines.h"
 
 /* internal value that can be read/written via CoAP */
 static uint8_t internal_value = 0;

--- a/examples/suit_update/coap_handler.c
+++ b/examples/suit_update/coap_handler.c
@@ -12,6 +12,7 @@
 
 #include "net/nanocoap.h"
 #include "suit/transport/coap.h"
+#include "kernel_defines.h"
 
 static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
 {

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -31,6 +31,7 @@
 ssize_t write(int fildes, const void *buf, size_t nbyte);
 #endif
 
+#include "kernel_defines.h"
 #include "fmt.h"
 
 static const char _hex_chars[16] = "0123456789ABCDEF";

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -21,6 +21,7 @@
 #define NET_GNRC_IPV6_NIB_PL_H
 
 #include <stdint.h>
+#include <kernel_defines.h>
 
 #if IS_USED(MODULE_EVTIMER)
 #include "evtimer.h"

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -31,6 +31,7 @@
 
 #include "net/ipv6/addr.h"
 #include "timex.h"
+#include <kernel_defines.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/utlist.h
+++ b/sys/include/utlist.h
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /** @brief Version number */
 #define UTLIST_VERSION 1.9.9
+#include <stddef.h>
 
 #include <assert.h>
 

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -25,6 +25,7 @@
 
 #include "fmt.h"
 #include "net/nanocoap.h"
+#include "kernel_defines.h"
 
 #define _MAX_PAYLOAD_LEN  (16)
 

--- a/tests/sys_architecture/main.c
+++ b/tests/sys_architecture/main.c
@@ -23,6 +23,7 @@
 
 #include "assert.h"
 #include "architecture.h"
+#include "kernel_defines.h"
 
 /* On all but 8bit architectures, at least one of the following should be
  * misaligned */


### PR DESCRIPTION
### Contribution description

remove panic.h include from assert.h

since assert.h is a stdlib header it should follow the rules for stdlib headers (one of them being only define marcos that the header is used for and have every thing else in _<n/Name> and __<n/Name>

### Testing procedure

successful ci-run  (avoid something depending on  `panic.h` being included by `assert.h`

The remove me has a patched hello-world example:
for the non assert code path:
```
DEVHELP=0 CFLAGS=-DNDEBUG make flash term
```
for the panic assert code path:
```
DEVHELP=1 make flash term
```
for the verbose assert code path:
```
DEVHELP=1 CFLAGS=-DDEBUG_ASSERT_VERBOSE make flash term
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
