### PR TITLE
boards/samr34-xpro: add minimal support for WLR089 Xplained Pro

### DIFF
--- a/boards/samr34-xpro/doc.txt
+++ b/boards/samr34-xpro/doc.txt
@@ -1,0 +1,40 @@
+/**
+@defgroup    boards_samr34-xpro Microchip SAM R34 Xplained Pro
+@ingroup     boards
+@brief       Support for the Microchip SAM R34 Xplained Pro and WLR089 Xplained Pro
+
+## Overview
+
+The `SAMR34 Xplained Pro` is a compact evaluation board by Microchip featuring a
+SAMR34J18 SoC. The SoC includes a SAML21 ARM Cortex-M0+ micro-controller
+bundled with Semtech's SX1276, a 868/915 MHz LoRa compatible radio.
+For programming the MCU comes with 40Kb of RAM and 256Kb of flash memory.
+
+## Hardware
+
+![samr34-xpro image](https://www.microchip.com/content/dam/mchp/mrt-dam/devtools/3072-180605-wpd-dm320111-2.jpg)
+
+An evaluation board for the radio certified WLR089 module exists as the WLR089 Xplained Pro, it is compatible with the `samr34-xpro`.
+
+![wlr089-xpro](https://www.microchip.com/content/dam/mchp/mrt-dam/devtools/3411-264438-1598368489-c14679-200616-wsg-ev23m25a-wlr089-explained-pro-evaluation-board.jpg)
+
+
+### MCU
+| MCU        | SAMR34J18B            |
+|:---------- |:--------------------- |
+| Family     | ARM Cortex-M0+        |
+| Vendor     | Atmel                 |
+| RAM        | 32 kiB + 8 kiB battery RAM |
+| Flash      | 256 KiB               |
+| Frequency  | up to 48MHz           |
+| FPU        | no                    |
+| Timers     | 6 (3xTC (8,16,32 bit), 3xTCC (16 bit)) |
+| ADCs       | 1x 12-bit (8 channels)|
+| UARTs      | max 5 (shared with SPI and I2C) |
+| SPIs       | max 5 (see UART)      |
+| I2Cs       | max 5 (see UART)      |
+| Vcc        | 1.8V - 3.6V           |
+| Datasheet  | [Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/SAMR34-R35-Low-Power-LoRa-Sub-GHz-SiP-Data-Sheet-DS70005356B.pdf) |
+| Board Manual | [SAM R34 XPro](https://www.microchip.com/en-us/development-tool/DM320111)<br>[WLR089 XPro](https://www.microchip.com/en-us/development-tool/EV23M25A)|
+
+ */

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    boards_samr34-xpro Microchip SAM R34 Xplained Pro
- * @ingroup     boards
- * @brief       Support for the Microchip SAM R34 Xplained Pro board.
+ * @ingroup     boards_samr34-xpro
  * @{
  *
  * @file
@@ -32,50 +30,50 @@ extern "C" {
  * @name Semtech SX1276 configuration
  * @{
  */
-#define SX127X_PARAM_SPI                    (SPI_DEV(0))
-#define SX127X_PARAM_SPI_NSS                GPIO_PIN(1, 31)       /* D10 */
-#define SX127X_PARAM_RESET                  GPIO_PIN(1, 15)       /* A0 */
-#define SX127X_PARAM_DIO0                   GPIO_PIN(1, 16)      /* D2 */
-#define SX127X_PARAM_DIO1                   GPIO_PIN(0, 11)       /* D3 */
-#define SX127X_PARAM_DIO2                   GPIO_PIN(0, 12)       /* D4 */
-#define SX127X_PARAM_DIO3                   GPIO_PIN(1, 17)       /* D5 */
-#define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
+#define SX127X_PARAM_SPI                    SPI_DEV(0)            /**< internal SPI */
+#define SX127X_PARAM_SPI_NSS                GPIO_PIN(1, 31)       /**< D10 */
+#define SX127X_PARAM_RESET                  GPIO_PIN(1, 15)       /**< A0  */
+#define SX127X_PARAM_DIO0                   GPIO_PIN(1, 16)       /**< D2  */
+#define SX127X_PARAM_DIO1                   GPIO_PIN(0, 11)       /**< D3  */
+#define SX127X_PARAM_DIO2                   GPIO_PIN(0, 12)       /**< D4  */
+#define SX127X_PARAM_DIO3                   GPIO_PIN(1, 17)       /**< D5  */
+#define SX127X_PARAM_PASELECT               SX127X_PA_RFO         /**< no boost */
 /** @}*/
 
 /**
  * @name Board specific configuration
  *  @{
  */
-#define TCXO_PWR_PIN                        GPIO_PIN(PA, 9)
-#define TX_OUTPUT_SEL_PIN                   GPIO_PIN(PA, 13)
+#define TCXO_PWR_PIN                        GPIO_PIN(PA, 9)     /**< 32 MHz oscillator for radio enable */
+#define TX_OUTPUT_SEL_PIN                   GPIO_PIN(PA, 13)    /**< BAND_SEL */
 /** @}*/
 
 /**
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED_PORT                    PORT->Group[0]
+#define LED_PORT                    PORT->Group[0]                      /**< GPIO port      */
 
-#define LED0_PIN                    GPIO_PIN(PA, 18)
-#define LED0_MASK                   (1 << 18)
-#define LED0_ON                     (LED_PORT.OUTCLR.reg = LED0_MASK)
-#define LED0_OFF                    (LED_PORT.OUTSET.reg = LED0_MASK)
-#define LED0_TOGGLE                 (LED_PORT.OUTTGL.reg = LED0_MASK)
+#define LED0_PIN                    GPIO_PIN(PA, 18)                    /**< GPIO pin       */
+#define LED0_MASK                   (1 << 18)                           /**< GPIO pin mask  */
+#define LED0_ON                     (LED_PORT.OUTCLR.reg = LED0_MASK)   /**< enable LED     */
+#define LED0_OFF                    (LED_PORT.OUTSET.reg = LED0_MASK)   /**< disable LED    */
+#define LED0_TOGGLE                 (LED_PORT.OUTTGL.reg = LED0_MASK)   /**< toggle LED     */
 
-#define LED1_PIN                    GPIO_PIN(PA, 19)
-#define LED1_MASK                   (1 << 19)
-#define LED1_ON                     (LED_PORT.OUTCLR.reg = LED1_MASK)
-#define LED1_OFF                    (LED_PORT.OUTSET.reg = LED1_MASK)
-#define LED1_TOGGLE                 (LED_PORT.OUTTGL.reg = LED1_MASK)
+#define LED1_PIN                    GPIO_PIN(PA, 19)                    /**< GPIO pin       */
+#define LED1_MASK                   (1 << 19)                           /**< GPIO pin mask  */
+#define LED1_ON                     (LED_PORT.OUTCLR.reg = LED1_MASK)   /**< enable LED     */
+#define LED1_OFF                    (LED_PORT.OUTSET.reg = LED1_MASK)   /**< disable LED    */
+#define LED1_TOGGLE                 (LED_PORT.OUTTGL.reg = LED1_MASK)   /**< toggle LED     */
 /** @} */
 
 /**
  * @name    BTN0 (SW0 Button) pin definitions
  * @{
  */
-#define BTN0_PORT                   PORT->Group[0]
-#define BTN0_PIN                    GPIO_PIN(PA, 28)
-#define BTN0_MODE                   GPIO_IN_PU
+#define BTN0_PORT                   PORT->Group[0]                      /**< GPIO port      */
+#define BTN0_PIN                    GPIO_PIN(PA, 28)                    /**< GPIO pin       */
+#define BTN0_MODE                   GPIO_IN_PU                          /**< Pull Up GPIO   */
 /** @} */
 
 /**

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -13357,6 +13357,7 @@ drivers/sx127x/include/sx127x_registers\.h:[0-9]+: warning: Member SX127X_RNG_RE
 drivers/sx127x/include/sx127x_registers\.h:[0-9]+: warning: Member SX127X_RNG_REG_MODEM_CONFIG2 \(macro definition\) of file sx127x_registers\.h is not documented\.
 drivers/sx127x/include/sx127x_registers\.h:[0-9]+: warning: Member VERSION_SX1272 \(macro definition\) of file sx127x_registers\.h is not documented\.
 drivers/sx127x/include/sx127x_registers\.h:[0-9]+: warning: Member VERSION_SX1276 \(macro definition\) of file sx127x_registers\.h is not documented\.
+drivers/sx127x/include/sx127x_registers\.h:[0-9]+: warning: Member VERSION_SX1276_WLR089 \(macro definition\) of file sx127x_registers\.h is not documented\.
 drivers/tcs37727/include/tcs37727\-internal\.h:[0-9]+: warning: Member B_COEF_IF \(macro definition\) of file tcs37727\-internal\.h is not documented\.
 drivers/tcs37727/include/tcs37727\-internal\.h:[0-9]+: warning: Member CT_COEF_IF \(macro definition\) of file tcs37727\-internal\.h is not documented\.
 drivers/tcs37727/include/tcs37727\-internal\.h:[0-9]+: warning: Member CT_OFFSET_IF \(macro definition\) of file tcs37727\-internal\.h is not documented\.

--- a/drivers/sx127x/include/sx127x_registers.h
+++ b/drivers/sx127x/include/sx127x_registers.h
@@ -558,6 +558,7 @@ extern "C" {
 /* Version */
 #define SX127X_REG_VERSION                                           (0x42)
 #define VERSION_SX1276                                               (0x12)
+#define VERSION_SX1276_WLR089                                        (0x13)
 #define VERSION_SX1272                                               (0x22)
 
 /* Additional settings */

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -53,7 +53,7 @@ int sx127x_check_version(const sx127x_t *dev)
     }
     DEBUG("[sx127x] SX1272 transceiver detected\n");
 #else /* MODULE_SX1276) */
-    if (version != VERSION_SX1276) {
+    if (version != VERSION_SX1276 && version != VERSION_SX1276_WLR089) {
         DEBUG("[sx127x] sx1276 test failed, invalid version number: %d\n",
               version);
         return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The [ WLR089 Xplained Pro](https://www.microchip.com/en-us/development-tool/EV23M25A)  is pretty much identical to the [SAM R34 Xplained Pro](https://www.microchip.com/en-us/development-tool/DM320111) - this adds a `doc.txt` to clarify that.

The only notable difference so far is, that the device ID returned by the sx1276 radio is `0x13` instead of `0x12`.
It works when adjusting the check accordingly.

### Testing procedure

@firas-hamdi ran `examples/gnrc_lorawan` and `tests/driver_sx127x`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
