### PR TITLE
tools/compile_commands: Update --clangd set

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -288,8 +288,7 @@ if __name__ == '__main__':
                         help='Drop the given flag, if present (repeatable)')
     parser.add_argument('--clangd', default=False, action='store_const', const=True,
                         help='Shorthand for --add-built-in-includes --add-libstdxx-includes ' +
-                             '--filter-out=-Wformat-truncation --filter-out=-Wformat-overflow ' +
-                             '--filter-out=-mno-thumb-interwork')
+                             'and some CFLAG adjustments throughy --filter-out')
     _args = parser.parse_args()
     if _args.clangd:
         _args.add_built_in_includes = True
@@ -297,5 +296,7 @@ if __name__ == '__main__':
         _args.filter_out = ['-Wformat-truncation', '-Wformat-overflow', '-mno-thumb-interwork',
                             # Only even included for versions of GCC that support it
                             '-malign-data=natural',
+                            # Only supported starting with clang 11
+                            '-msmall-data-limit=8',
                             ]
     generate_compile_commands(_args)

--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -228,6 +228,9 @@ def generate_module_compile_commands(path, state, args):
         except ValueError:
             pass
 
+    if args.clangd:
+        cdetails.cflags.append('-Wno-unknown-warning-option')
+
     c_extra_includes = []
     cxx_extra_includes = []
 
@@ -288,12 +291,13 @@ if __name__ == '__main__':
                         help='Drop the given flag, if present (repeatable)')
     parser.add_argument('--clangd', default=False, action='store_const', const=True,
                         help='Shorthand for --add-built-in-includes --add-libstdxx-includes ' +
-                             'and some CFLAG adjustments throughy --filter-out')
+                             'and some CFLAG adjustments throughy --filter-out, and ignores ' +
+                             'unknown warning flags')
     _args = parser.parse_args()
     if _args.clangd:
         _args.add_built_in_includes = True
         _args.add_libstdcxx_includes = True
-        _args.filter_out = ['-Wformat-truncation', '-Wformat-overflow', '-mno-thumb-interwork',
+        _args.filter_out = ['-mno-thumb-interwork',
                             # Only even included for versions of GCC that support it
                             '-malign-data=natural',
                             # Only supported starting with clang 11


### PR DESCRIPTION
### Contribution description

The --clangd adjustments showed to be faulty by not being acceptable for Rust's bindgen when used on RISC-V builds. This fixes things by

* adding `-msmall-data-limit=8` to the clangd filter-out list (the option *is* supported by clang, but only in versions more recent than the libclang shipped with current riotdocker), and
* replacing all the `-Wformat-truncation` etc. warning filter-outs with an added `-Wno-unknown-warning-option` flag.

Its documentation is adjusted to no longer exhaustively list what is done, but to give an overview.

### Testing procedure

* My main use case is covered in re-runs of #17491, which now passes. (Before, it failed complaining about `-msmall-data-limit=8`).
* I don't know how else compile_commands is used, any ideas for extra testing or whether it's necessary?

(I'd think that the Rust tests are a good cover already, because they use it extensively, and even (when executing tests) compare some generated versions of structs to see whether parties agree on struct sizes, which is one of the important areas where messing with CFLAGS can go wrong)

### Issues/PRs references

The need for this became apparent when testing, in #17491, the combination of the recently merged RISC-V support for Rust with updates to the latest riot-sys crate (which drops a few workarounds that were thought to be disused already, but are placed better here anyway).

The `-Wno-unknown-warning-option` does not actually stem from that change, but from revisiting the warning list.