### PR TITLE
boards/feather-m0: sx127x params only valid for lora variant

### DIFF
--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -59,9 +59,11 @@ extern "C" {
  * @{
  **/
 #define SX127X_PARAM_SPI                SPI_DEV(0)
+#if defined(BOARD_FEATHER_M0_LORA)
 #define SX127X_PARAM_SPI_NSS            GPIO_PIN(PA, 6)
 #define SX127X_PARAM_RESET              GPIO_PIN(PA, 8)
 #define SX127X_PARAM_DIO0               GPIO_PIN(PA, 9)
+#endif
 #define SX127X_PARAM_DIO1               GPIO_UNDEF
 #define SX127X_PARAM_DIO2               GPIO_UNDEF
 #define SX127X_PARAM_DIO3               GPIO_UNDEF


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In the `feather-m0` board the `sx127x` pin parameters are hardcoded for the
`feather-m0-lora` variant, but this is not compatible with other configurations.

For example in the feather-m0 adalogger `PA06` and `PA08` are used for the
SD card. When combined with the RFM95W FeatherWing the IRQ/CS/RST pins
must be wired, and then the sx127x pins must be configured to match the
wiring (which will be necessarily different from the lora variant configuration).

With the proposed change the pin configuration only applies to the `feather-m0-lora`
variant. If a different configuration is used, the pins must be defined somewhere else.
This change fixes a preprocessor redefined error:

```
error: "SX127X_PARAM_SPI_NSS" redefined [-Werror]
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I've tested `tests/driver_sx127x` with two Feathers M0 Adalogger plus
the RFM95W FeatherWing, with the wiring as show in the picture below.


![98717263-21d68580-238d-11eb-99a4-666474dc43d4](https://user-images.githubusercontent.com/596769/151346827-d6db80f7-cd09-4149-9b12-644b6a300a41.jpg)

Then configured the pins with CFLAGS:

```
-DSX127X_PARAM_SPI_NSS="GPIO_PIN(PA, 18)"
-DSX127X_PARAM_RESET="GPIO_PIN(PA, 16)"
-DSX127X_PARAM_DIO0="GPIO_PIN(PA, 20)"
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.