### PR TITLE
cpu/riscv_common: fix undeclared memory region linker error

### DIFF
--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -35,8 +35,8 @@ SECTIONS
   __stack_size     = DEFINED(__stack_size) ? __stack_size : 256;
 
   /* Populate information about rom size */
-  _srom = ORIGIN(rom);
-  _erom = ORIGIN(rom) + LENGTH(rom);
+  _srom = ORIGIN(flash);
+  _erom = ORIGIN(flash) + LENGTH(flash);
 
   .init           :
   {
@@ -220,5 +220,5 @@ SECTIONS
 
   .end_fw (NOLOAD) : ALIGN(4) {
     _end_fw = . ;
-  } > rom
+  } > flash
 }


### PR DESCRIPTION
Since commit 3a11b1fbd280b2b46ef0a8011bead180800f83c2 (#16972) building RIOT applications with `BOARD=hifive1` causes the following linker warning to be emitted on my system:

	/opt/rv32imc/lib/gcc/riscv32-unknown-elf/10.2.0/../../../../riscv32-unknown-elf/bin/ld:riscv_base.ld:220: warning: memory region `rom' not declared

This is due to the fact that the RISC-V linker script doesn't have a rom memory region. While many other ARM-based boards have a rom memory region defined in the linker script, the corresponding region name in the RISC-V linker script is flash and rom is not declared as a memory region hence the warning.

I think this was accidentally overlooked in 3a11b1fbd280b2b46ef0a8011bead180800f83c2. It is fixed in this commit by replacing the rom region with the flash region. The linker script identifiers (e.g. _srom and _erom) are not renamed.

@Ollrogge can you confirm that the changes proposed here are aligned with 3a11b1fbd280b2b46ef0a8011bead180800f83c2?