### PR TITLE
boards/p-nucleo-wb55: update documentation

### DIFF
--- a/boards/p-nucleo-wb55/doc.txt
+++ b/boards/p-nucleo-wb55/doc.txt
@@ -98,8 +98,8 @@ Implementation Status
 |                  | RTC               | yes     |         |
 |                  | RNG               | yes     |         |
 |                  | Timer             | yes     | TIM2    |
-|                  | WDT               | no      |         |
-|                  | USB               | no      |         |
+|                  | WDT               | yes     |         |
+|                  | USB               | yes     |         |
 |                  | PWM               | no      |         |
 |                  | AES               | no      |         |
 

--- a/boards/p-nucleo-wb55/doc.txt
+++ b/boards/p-nucleo-wb55/doc.txt
@@ -1,6 +1,6 @@
 /**
 @defgroup    boards_p-nucleo-wb55 STM32 p-nucleo-wb55
-@ingroup     boards_common_nucleo
+@ingroup     boards
 @brief       Support for the STM32 p-nucleo-wb55
 
 Hardware

--- a/boards/p-nucleo-wb55/doc.txt
+++ b/boards/p-nucleo-wb55/doc.txt
@@ -45,11 +45,7 @@ Flashing the device
 -------------------
 
 The ST p-nucleo-wb55 board includes an on-board ST-LINK programmer and can be
-flashed using OpenOCD.
-
-@note The latest release of OpenOCD doesn't contain support for this board,
-so a recent development version must be built from source to be able to flash
-this board.
+flashed using OpenOCD (use version 0.11.0 at least).
 
 To flash this board, just use the following command:
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR improves a bit the documentation of this board:
- use the main `boards` Doxygen group as parent group: the board is listed with all other boards (for the moment it's listed alone under a common nucleo group and is difficult to find)
- update the notes about the OpenOCD version to use to flash this board. It's supported in 0.11.0 release, so just mention it as a minimal requirement
- add new features supported: Watchdog is supported, according to the STM32 features and USB support was added recently in #17281

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check the documentation

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
