### PR TITLE
sys/ztimer64: PRIu64 requires stdio before inttypes

### DIFF
--- a/sys/ztimer64/ztimer64.c
+++ b/sys/ztimer64/ztimer64.c
@@ -23,6 +23,8 @@
  */
 #include <assert.h>
 #include <stdint.h>
+/* stdio.h needs to be included before inttypes.h (newlibc) */
+#include <stdio.h>
 #include <inttypes.h>
 
 #include "ztimer64.h"
@@ -294,9 +296,7 @@ void ztimer64_clock_print(const ztimer64_clock_t *clock)
     const ztimer64_base_t *entry = clock->first;
 
     while (entry) {
-        printf("0x%08x:%" PRIu64 "\n", (unsigned)entry,
-               entry->target);
-
+        printf("0x%08x:%" PRIu64 "\n", (unsigned)entry, entry->target);
         entry = entry->next;
     }
     puts("");


### PR DESCRIPTION
### Contribution description

adds stdio.h include in front of inttypes.h fixes:
```
ztimer64.c:298:26: error: expected ')' before 'PRIu64'
  298 |         printf("0x%08x:%" PRIu64 "\n", (unsigned)entry, entry->target);
```

### Testing procedure

```
examples/hello-world$ USEMODULE=ztimer64_msec BOARD=nucleo-f767zi make clean all
```

with master:
```
ztimer64.c:298:26: error: expected ')' before 'PRIu64'
  298 |         printf("0x%08x:%" PRIu64 "\n", (unsigned)entry, entry->target);
```

with PR:
SUCCESS

### Issues/PRs references

https://github.com/mirror/newlib-cygwin/blob/d079ab4d37ca37cef04e43aa333ab2b53c81699d/newlib/libc/include/inttypes.h#L216
