### PR TITLE
gnrc_sixlowpan: allow to build with gnrc_sixlowpan_ctx disabled 

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -101,6 +101,7 @@ PSEUDOMODULES += gnrc_sixlowpan_frag_hint
 PSEUDOMODULES += gnrc_sixlowpan_frag_sfr_stats
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc
 PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
+PSEUDOMODULES += gnrc_sixlowpan_no_ctx
 PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_udp_cmd
 PSEUDOMODULES += gnrc_sock_async

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -213,7 +213,7 @@ extern "C" {
  * @see [RFC 6775, section 8.1](https://tools.ietf.org/html/rfc6775#section-8.1)
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C
-#if CONFIG_GNRC_IPV6_NIB_6LR
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LR) && IS_USED(MODULE_GNRC_SIXLOWPAN_CTX)
 #define CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C             1
 #else
 #define CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C             0

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -75,6 +75,7 @@ typedef struct {
     uint16_t ltime;
 } gnrc_sixlowpan_ctx_t;
 
+#if IS_USED(MODULE_GNRC_SIXLOWPAN_CTX) || DOXYGEN
 /**
  * @brief   Gets a context matching the given IPv6 address best with its prefix.
  *
@@ -94,6 +95,19 @@ gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_lookup_addr(const ipv6_addr_t *addr);
  * @return  NULL if there is no such context.
  */
 gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_lookup_id(uint8_t id);
+#else
+static inline gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_lookup_addr(const ipv6_addr_t *addr)
+{
+    (void)addr;
+    return NULL;
+}
+
+static inline gnrc_sixlowpan_ctx_t *gnrc_sixlowpan_ctx_lookup_id(uint8_t id)
+{
+    (void)id;
+    return NULL;
+}
+#endif /* IS_USED(MODULE_GNRC_SIXLOWPAN_CTX) */
 
 /**
  * @brief   Updates (or adds if currently not registered) a context

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -246,8 +246,10 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_iphc,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
   USEMODULE += gnrc_sixlowpan
-  USEMODULE += gnrc_sixlowpan_ctx
   USEMODULE += gnrc_sixlowpan_iphc_nhc
+  ifeq (,$(filter gnrc_sixlowpan_no_ctx,$(USEMODULE)))
+    USEMODULE += gnrc_sixlowpan_ctx
+  endif
 endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -307,7 +307,7 @@ uint32_t _handle_6co(const icmpv6_hdr_t *icmpv6,
         bf_set(abr->ctxs, cid);
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
-#else   /* MODULE_GNRC_SIXLOWPAN_CTX */
+#elif IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C) /* MODULE_GNRC_SIXLOWPAN_CTX */
     (void)abr;
 #endif  /* MODULE_GNRC_SIXLOWPAN_CTX */
     return ltime * SEC_PER_MIN * MS_PER_SEC;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This allows to disable the `gnrc_sixlowpan_ctx ` module. This is useful if no compression contexts are desired.
It is an easy workaround for the issue that `CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C` is not checked per-interface and thus having a non-6Lo host behind a 6Lo node does not work, but since compression contexts are an optional feature, it should be possible to disable them.

### Testing procedure

Everything should still work with

    USEMODULE += gnrc_sixlowpan_no_ctx

In my case I have:

<details><summary>same54-xpro (border router)</summary>

```
Iface  8  HWaddr: FC:C2:3D:0D:02:E3
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::fec2:3dff:fe0d:2e3  scope: link  VAL
          inet6 addr: fc23::fec2:3dff:fe0d:2e3  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff0d:2e3

          Statistics for Layer 2
            RX packets 82  bytes 26502
            TX packets 20 (Multicast: 9)  bytes 1588
            TX succeeded 20 errors 0
          Statistics for IPv6
            RX packets 52  bytes 12644
            TX packets 20 (Multicast: 9)  bytes 1308
            TX succeeded 20 errors 0

Iface  7  HWaddr: 42:BB  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK

          Long HWaddr: BA:4C:F0:1D:6E:42:42:BB
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR
          RTR_ADV  6LO  IPHC
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::b84c:f01d:6e42:42bb  scope: link  VAL
          inet6 addr: fc23:0:4000:0:b84c:f01d:6e42:42bb  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff42:42bb

          Statistics for Layer 2
            RX packets 6  bytes 276
            TX packets 6 (Multicast: 4)  bytes 248
            TX succeeded 6 errors 0
          Statistics for IPv6
            RX packets 6  bytes 372
            TX packets 6 (Multicast: 4)  bytes 364
            TX succeeded 6 errors 0

Iface  6  HWaddr: 42:BA  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK

          Long HWaddr: BA:4C:F0:1D:6E:42:42:BA
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR
          RTR_ADV  6LO  IPHC
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::b84c:f01d:6e42:42ba  scope: link  VAL
          inet6 addr: fc23:0:8000:0:b84c:f01d:6e42:42ba  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff42:42ba

          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 11 (Multicast: 11)  bytes 437
            TX succeeded 11 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 11 (Multicast: 11)  bytes 668
            TX succeeded 11 errors 0

> nib route
fc23::/32 dev #8
fc23:0:4000::/34 dev #7
fc23:0:8000::/34 dev #6
fc23:0:6000::/35 via fe80::204:2519:1801:c905 dev #7
default* via fe80::215:5dff:fe25:93a2 dev #8
``` 
</details>

<details><summary>samr21-xpro (6LR)</summary>

```
Iface  7
          Long HWaddr: E6:1E:5E:72:34:2C:D0:7B
          MTU:65535  HL:64  RTR
          RTR_ADV
          Link type: wired
          inet6 addr: fe80::e41e:5e72:342c:d07b  scope: link  VAL
          inet6 addr: fc23:0:6000:0:e41e:5e72:342c:d07b  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff2c:d07b

          Statistics for Layer 2
            RX packets 1  bytes 64
            TX packets 1 (Multicast: 0)  bytes 64
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 1  bytes 64
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0

Iface  6  HWaddr: 49:05  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK

          Long HWaddr: 00:04:25:19:18:01:C9:05
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR
          RTR_ADV  6LO  IPHC
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::204:2519:1801:c905  scope: link  VAL
          inet6 addr: fc23:0:4000:0:204:2519:1801:c905  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff01:c905

          Statistics for Layer 2
            RX packets 4  bytes 344
            TX packets 5 (Multicast: 2)  bytes 358
            TX succeeded 5 errors 0
          Statistics for IPv6
            RX packets 4  bytes 344
            TX packets 5 (Multicast: 2)  bytes 400
            TX succeeded 5 errors 0

> nib route
fc23:0:6000::/35 dev #7
default via fe80::b84c:f01d:6e42:42bb dev #6
``` 
</details>

<details><summary>samd21-xpro (IPv6 node)</summary>

```
Iface  5
          Long HWaddr: BA:8C:00:6A:14:6B:3C:55
          MTU:65535  HL:64  RTR

          Link type: wired
          inet6 addr: fe80::b88c:6a:146b:3c55  scope: link  VAL
          inet6 addr: fc23:0:6000:0:b88c:6a:146b:3c55  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff6b:3c55

          Statistics for Layer 2
            RX packets 1  bytes 104
            TX packets 3 (Multicast: 0)  bytes 176
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 1  bytes 104
            TX packets 3 (Multicast: 3)  bytes 176
            TX succeeded 3 errors 0

> nib route
fc23:0:6000::/35 dev #5
default* via fe80::e41e:5e72:342c:d07b dev #5
``` 
</details>

##### ping between samd21-xpro and same54-xpro via SLIP and IEEE 802.15.4
```
> ping fc23::fec2:3dff:fe0d:2e3
12 bytes from fc23::fec2:3dff:fe0d:2e3: icmp_seq=0 ttl=63 time=74.689 ms
12 bytes from fc23::fec2:3dff:fe0d:2e3: icmp_seq=1 ttl=63 time=73.410 ms
12 bytes from fc23::fec2:3dff:fe0d:2e3: icmp_seq=2 ttl=63 time=74.046 ms

--- fc23::fec2:3dff:fe0d:2e3 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 73.410/74.048/74.689 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
