### PR TITLE
kconfig explore all allowed boards on all apps

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -178,6 +178,20 @@ get_supported_kconfig_board_app() {
     if is_in_list "${board}" "${TEST_KCONFIG_BOARD_BLOCKLIST}"; then
         return 1
     fi
+
+    # On nightlies run all possible kconfig tests on all boards
+    # Normally we don't want to do this as it adds quite a bit to build time
+    # and the subset of boards we are testing for are pretty good at catching
+    # any bugs...
+    # This will be over one day, I promise.
+    if [ ${NIGHTLY} -eq 1 ]; then
+        if is_in_list "${appdir}" "${TEST_KCONFIG_ENFORCE_APP_GROUPS}"; then
+            return 0
+        fi
+        if [ -f "${appdir}/app.config.test" ]; then
+            return 0
+        fi
+    fi
     if is_in_list "${appdir}" "${TEST_KCONFIG_TEST_ALLOWLIST}"; then
         return 0
     fi

--- a/boards/ublox-c030-u201/Makefile.dep
+++ b/boards/ublox-c030-u201/Makefile.dep
@@ -4,7 +4,3 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   # USEMODULE += si7034 # TODO: add when si70xx driver is updated
 endif
-
-ifneq (,$(filter vfs,$(USEMODULE)))
-  USEMODULE += mtd_sdcard
-endif


### PR DESCRIPTION
### Contribution description

Run all non-blockisted boards for every kconfig enabled app only during nightlies.
This should find any corner cases slipping through the regular testing (currently only one on the ublox-c030-u201 board due to incorrect makefile modelling).  This should also have no impact on regular CI times, only the nightly will be longer (since it will eventually double the jobs).

### Testing procedure

Check to see that the removeme commit, forcing nightly, tests a board that would not normally be tested for kconfig.


### Issues/PRs references


