### PR TITLE
dist/tools/genconfig: add error on hidden symbols

### DIFF
--- a/dist/tools/kconfiglib/genconfig.py
+++ b/dist/tools/kconfiglib/genconfig.py
@@ -173,6 +173,9 @@ def check_config_symbols(kconf):
                 if rng is not None:
                     msg = "   Check that the value is in the correct range:"
                     msg += "[{} - {}] {}\n".format(rng[0], rng[1], rng[2])
+            elif not sym.visibility:
+                msg = "   The symbol is not visible, either it is not "
+                msg += "configurable or its prompt is hidden."
 
             log_error(msg)
 


### PR DESCRIPTION
### Contribution description
This extends the error messages to check if a symbol could not be set due to its visibility.

### Testing procedure
One can quickly test this by trying to enable a hidden symbol. For example, in `tests/kconfig/Kconfig` defining:

```
config HIDDEN_SYMBOL
    bool
```

And trying to enable it in `tests/kconfig/app.config`: `CONFIG_HIDDEN_SYMBOL=y`. When calling `make menuconfig` for instance, you should see this new error message.

### Issues/PRs references
None
