### PR TITLE
makefiles: avoid extra "/" when including files from external modules

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -10,7 +10,7 @@
 
 # include external modules dependencies
 # processed before RIOT ones to be evaluated before the 'default' rules.
--include $(EXTERNAL_MODULE_PATHS:%=%/Makefile.dep)
+-include $(EXTERNAL_MODULE_PATHS:%=%Makefile.dep)
 
 # pull dependencies from sys and drivers
 include $(RIOTBASE)/sys/Makefile.dep

--- a/Makefile.include
+++ b/Makefile.include
@@ -578,7 +578,7 @@ include $(RIOTBASE)/sys/Makefile.include
 -include $(PKG_PATHS:%=%Makefile.include)
 
 # include external modules configuration
--include $(EXTERNAL_MODULE_PATHS:%=%/Makefile.include)
+-include $(EXTERNAL_MODULE_PATHS:%=%Makefile.include)
 
 # Deduplicate includes without sorting them
 # see https://stackoverflow.com/questions/16144115/makefile-remove-duplicate-words-without-sorting


### PR DESCRIPTION
### Contribution description
As the `dir` make function considers the last slash as part of the directory-part of a file name, we don't need to add an extra one. From the [function documentation](https://www.gnu.org/software/make/manual/html_node/File-Name-Functions.html):

> The directory-part of the file name is everything up through (and including) the last slash in it. 

Alternatively we can go the other way, and remove the slash from the variable. I took this path because of the natural way make seems to consider directory paths.

### Testing procedure
`tests/external_module_dirs` should work as usual

### Issues/PRs references
Spotted while reviewing #17596