### PR TITLE
gnrc/nib: only enable RTR_ADV on RA if MULTIHOP_P6C is enabled

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -817,7 +817,9 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     evtimer_del(&_nib_evtimer, &netif->ipv6.search_rtr.event);
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     if (gnrc_netif_is_6ln(netif) && !gnrc_netif_is_6lbr(netif)) {
-        _set_rtr_adv(netif);
+        if (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)) {
+            _set_rtr_adv(netif);
+        }
         /* but re-fetch information from router in time */
         _evtimer_add(netif, GNRC_IPV6_NIB_SEARCH_RTR,
                      &netif->ipv6.search_rtr, (next_timeout >> 2) * 3);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When a 6LR receives a Router Advertisement on it's 6Lo interface, it will automatically start sending router advertisements on that interface.

If the 6LoWPAN link is used as an uplink to a downstream network on another interface with `gnrc_ipv6_auto_subnets`, this is not the intended behavior. 


### Testing procedure

Follow the instructions in #17594

The upstream 6Lo interface on the 6LR node should no longer have the `RTR_ADV` set automatically:

```
2022-04-13 00:35:30,130 # Iface  7  HWaddr: 3A:F1  Channel: 26  NID: 0x23  PHY: O-QPSK 
2022-04-13 00:35:30,134 #           Long HWaddr: AA:CC:F4:7B:67:C4:BA:F1 
2022-04-13 00:35:30,137 #            State: IDLE 
2022-04-13 00:35:30,142 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2022-04-13 00:35:30,144 #           6LO  IPHC  
2022-04-13 00:35:30,147 #           Source address length: 8
2022-04-13 00:35:30,149 #           Link type: wireless
2022-04-13 00:35:30,155 #           inet6 addr: fe80::a8cc:f47b:67c4:baf1  scope: link  VAL
2022-04-13 00:35:30,162 #           inet6 addr: 2001:16b8:4508:22f4:a8cc:f47b:67c4:baf1  scope: global  VAL
2022-04-13 00:35:30,165 #           inet6 group: ff02::2
2022-04-13 00:35:30,168 #           inet6 group: ff02::1
2022-04-13 00:35:30,172 #           inet6 group: ff02::1:ffc4:baf1
2022-04-13 00:35:30,172 #           
2022-04-13 00:35:30,175 #           Statistics for Layer 2
2022-04-13 00:35:30,179 #             RX packets 264  bytes 25779
2022-04-13 00:35:30,183 #             TX packets 64 (Multicast: 48)  bytes 0
2022-04-13 00:35:30,187 #             TX succeeded 38 errors 0
2022-04-13 00:35:30,189 #           Statistics for IPv6
2022-04-13 00:35:30,193 #             RX packets 50  bytes 5295
2022-04-13 00:35:30,197 #             TX packets 24 (Multicast: 8)  bytes 3679
2022-04-13 00:35:30,200 #             TX succeeded 24 errors 0
2022-04-13 00:35:30,201 # 
2022-04-13 00:35:30,202 # Iface  6 
2022-04-13 00:35:30,206 #           Long HWaddr: AA:CC:F4:7B:67:C4:A1:F1 
2022-04-13 00:35:30,209 #           MTU:65535  HL:64  RTR  
2022-04-13 00:35:30,211 #           RTR_ADV  
2022-04-13 00:35:30,213 #           Link type: wired
2022-04-13 00:35:30,219 #           inet6 addr: fe80::a8cc:f47b:67c4:a1f1  scope: link  VAL
2022-04-13 00:35:30,226 #           inet6 addr: 2001:16b8:4508:22f6:a8cc:f47b:67c4:a1f1  scope: global  VAL
2022-04-13 00:35:30,229 #           inet6 group: ff02::2
2022-04-13 00:35:30,232 #           inet6 group: ff02::1
2022-04-13 00:35:30,236 #           inet6 group: ff02::1:ffc4:a1f1
2022-04-13 00:35:30,236 #           
2022-04-13 00:35:30,239 #           Statistics for Layer 2
2022-04-13 00:35:30,243 #             RX packets 9  bytes 624
2022-04-13 00:35:30,247 #             TX packets 28 (Multicast: 0)  bytes 3991
2022-04-13 00:35:30,250 #             TX succeeded 0 errors 0
2022-04-13 00:35:30,253 #           Statistics for IPv6
2022-04-13 00:35:30,256 #             RX packets 9  bytes 624
2022-04-13 00:35:30,261 #             TX packets 28 (Multicast: 13)  bytes 3991
2022-04-13 00:35:30,264 #             TX succeeded 28 errors 0
2022-04-13 00:35:30,264 # 
```

### Issues/PRs references
