### PR TITLE
drivers/dose: include board.h

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "board.h"
 #include "dose.h"
 #include "random.h"
 #include "irq.h"
@@ -32,6 +33,10 @@
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+
+#if !defined(DOSE_TIMER_DEV) && IS_ACTIVE(MODULE_DOSE_WATCHDOG)
+#error "DOSE_TIMER_DEV needs to be set by the board"
+#endif
 
 static uint16_t crc16_update(uint16_t crc, uint8_t octet);
 static dose_signal_t state_transit_blocked(dose_t *ctx, dose_signal_t signal);

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -170,8 +170,6 @@ typedef enum {
  */
 #if DOXYGEN
 #define DOSE_TIMER_DEV              TIMER_DEV(…)
-#elif !defined(DOSE_TIMER_DEV) && IS_ACTIVE(MODULE_DOSE_WATCHDOG)
-#error "DOSE_TIMER_DEV needs to be set by the board"
 #endif
 
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`DOSE_TIMER_DEV` is defined in `board.h`, so we have to include it.
It's not included by the header (and should not), so move the check to the .c file.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
