### PR TITLE
tests/pkg_mbedtls: improve entropy test case and doc

### DIFF
--- a/tests/pkg_mbedtls/Makefile
+++ b/tests/pkg_mbedtls/Makefile
@@ -3,9 +3,6 @@ include ../Makefile.tests_common
 USEPKG += mbedtls
 USEMODULE += mbedtls_entropy
 
-# entropy test keeps failing on this board due to low entropy
-TEST_ON_CI_BLACKLIST += samr21-xpro
-
 # Increase stack size of main thread.
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
 

--- a/tests/pkg_mbedtls/main.c
+++ b/tests/pkg_mbedtls/main.c
@@ -30,16 +30,35 @@ int main(void)
 {
     puts("mbedtls test\n");
 
-    /* Execute built-in tests */
+    /* Execute built-in tests SHA-2xx tests */
     mbedtls_sha256_self_test(1);
+
+    bool adc_noise_single_entropy = false;
+    /* NOTE, the following express needs adjustment when further entropy
+       sources added by RIOT */
+#if IS_USED(MODULE_MBEDTLS_ENTROPY_SOURCE_ADC) && !IS_USED(MODULE_MBEDTLS_ENTROPY_SOURCE_HWRNG)
+    /* If the adc noise entropy source is compiled and is the only source
+       utilized with the mbedtls entropy module, indicate it */
+    adc_noise_single_entropy = true;
+#endif
+    /* Used by the testrunner to ignore potential test failures it the case of
+       a single adc noise entropy source */
+    printf("adc_noise_single_entropy: %d\n", adc_noise_single_entropy);
+
+    /* Initializes available entropy sources */
+    entropy_mbedtls_riot_init();
+
+    /* Execute mbedtls built-in entropy tests*/
     mbedtls_entropy_self_test(1);
 
-    /* Execute convenience functions */
+    /* Execute convenience entropy functions */
     unsigned char out[4];
-    entropy_mbedtls_riot_init();
+    /* This function requires entropy_mbedtls_riot_init() beforehand */
     entropy_mbedtls_riot_retrieve(out, sizeof(out));
+    /* Clears the internal context again */
     entropy_mbedtls_riot_uninit();
 
+    /* This function does not require initialization */
     entropy_mbedtls_riot_get(out, sizeof(out));
 
     return 0;

--- a/tests/pkg_mbedtls/tests/01-run.py
+++ b/tests/pkg_mbedtls/tests/01-run.py
@@ -17,7 +17,16 @@ def testfunc(child):
     child.expect_exact('SHA-256 test #1: passed')
     child.expect_exact('SHA-256 test #2: passed')
     child.expect_exact('SHA-256 test #3: passed')
-    child.expect_exact('ENTROPY test: passed')
+
+    # If the adc noise module is not a single entropy source, the ENTROPY test
+    # should succeed. Otherwise, if the adc noise module is the only entropy
+    # source, ignore a test failure which might be introduced by improver ADC
+    # configurations or properties. This still allows us to execute this test
+    # regardless of configuration specifics.
+    child.expect(r'adc_noise_single_entropy: (\d+)\r\n')
+    adc_noise_single_entropy = int(child.match.group(1))
+    if adc_noise_single_entropy == 0:
+        child.expect_exact('ENTROPY test: passed')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description
*tests/pkg_mbedtls* failed the entropy tests on some boards (compare [this](https://github.com/RIOT-OS/RIOT/pull/15671#issuecomment-1020920722) and [this](https://github.com/RIOT-OS/RIOT/pull/15671#issuecomment-1022361502) comment).

This PR applies the following changes:
- Indicate when `adc noise` is the only source for the mbedtls entropy module. In this case, it can occur that the test fails due to improper ADC configurations and hardware properties.
- The testrunner checks for the occurrence of "adc_noise_single_entropy" and does not wait for a successful entropy test result in this case.
- Remove CI blacklisting introduced in #17588.

### Testing procedure
- Execute *tests/pkg_mbedtls* on boards (`samr21-xpro` and `nucleo-l152re` in particular) and native using  `make test`.
- CI passes execution on hardware.

### Issues/PRs references

#15671, #17588
