### PR TITLE
murdock: prioritize job collection over build jobs

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -376,7 +376,7 @@ get_compile_jobs() {
 
     get_apps | \
         maybe_filter_changed_apps | \
-        dwqc ${DWQ_ENV} -s \
+        dwqc ${DWQ_ENV} --queue default-first -s \
         ${DWQ_JOBID:+--subjob} \
         "$0 get_app_board_toolchain_pairs \${1} $0 compile"
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Previously, the fanned out job collection would add it's jobs to the
"default" queue, competing with build jobs. This could lead to a
situation where job collection would take very long or even time out.

This PR choses "default-first" as queue for the fan-out. Workers are
expected to add that queue *before* "default", so its jobs get processed
first.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
