### PR TITLE
boards/same54-xpro: support for board variation with SST26VF064B flash

### DIFF
--- a/boards/adafruit-itsybitsy-m4/board.c
+++ b/boards/adafruit-itsybitsy-m4/board.c
@@ -40,7 +40,6 @@ static const mtd_spi_nor_params_t _samd51_nor_params = {
     .cs   = SAM0_QSPI_PIN_CS,
     .wp   = SAM0_QSPI_PIN_DATA_2,
     .hold = SAM0_QSPI_PIN_DATA_3,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t samd51_nor_dev = {

--- a/boards/common/weact-f4x1cx/board.c
+++ b/boards/common/weact-f4x1cx/board.c
@@ -40,7 +40,6 @@ static const mtd_spi_nor_params_t _weact_nor_params = {
     .cs   = WEACT_4X1CX_NOR_SPI_CS,
     .wp   = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t weact_nor_dev = {

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -38,7 +38,6 @@ static const mtd_spi_nor_params_t _ikea_tradfri_nor_params = {
     .cs = IKEA_TRADFRI_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t ikea_tradfri_nor_dev = {

--- a/boards/iotlab-m3/mtd.c
+++ b/boards/iotlab-m3/mtd.c
@@ -40,7 +40,6 @@ static const mtd_spi_nor_params_t _mtd_nor_params = {
     .cs   = GPIO_PIN(PORT_A, 11),
     .wp   = GPIO_PIN(PORT_C, 6),
     .hold = GPIO_PIN(PORT_C, 9),
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t mtd_nor_dev = {

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -56,7 +56,6 @@ static const mtd_spi_nor_params_t mulle_nor_params = {
     .wait_32k_erase = 20LU * US_PER_MS,
     .wait_chip_wake_up = 1LU * US_PER_MS,
     .spi = MULLE_NOR_SPI_DEV,
-    .addr_width = 3,
     .mode = SPI_MODE_3,
     .cs = MULLE_NOR_SPI_CS,
     .wp = GPIO_UNDEF,

--- a/boards/nrf52840dk/mtd.c
+++ b/boards/nrf52840dk/mtd.c
@@ -40,7 +40,6 @@ static const mtd_spi_nor_params_t _nrf52840dk_nor_params = {
     .cs = NRF52840DK_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t nrf52840dk_nor_dev = {

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -43,7 +43,6 @@ static const mtd_spi_nor_params_t _pinetime_nor_params = {
     .cs = PINETIME_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t pinetime_nor_dev = {

--- a/boards/qn9080dk/board.c
+++ b/boards/qn9080dk/board.c
@@ -43,7 +43,6 @@ static const mtd_spi_nor_params_t _mtd_nor_params = {
     .cs   = SPI_HWCS(0),  /* GPIO(PORT_A, 3) is used for HWCS(0) on FC2 */
     .wp   = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,  /* 24-bit addresses */
 };
 
 static mtd_spi_nor_t mtd_nor_dev = {

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -24,7 +24,7 @@
 #include "timex.h"
 
 #ifdef MODULE_MTD
-/* N25Q256A */
+/* N25Q256A or SST26VF064B */
 static const mtd_spi_nor_params_t _same54_nor_params = {
     .opcode = &mtd_spi_nor_opcode_default,
     .wait_chip_erase = 240 * US_PER_SEC,
@@ -38,7 +38,6 @@ static const mtd_spi_nor_params_t _same54_nor_params = {
     .cs   = SAM0_QSPI_PIN_CS,
     .wp   = SAM0_QSPI_PIN_DATA_2,
     .hold = SAM0_QSPI_PIN_DATA_3,
-    .addr_width = 4,
 };
 
 static mtd_spi_nor_t same54_nor_dev = {

--- a/boards/serpente/board.c
+++ b/boards/serpente/board.c
@@ -41,7 +41,6 @@ static const mtd_spi_nor_params_t _serpente_nor_params = {
     .cs = SERPENTE_NOR_SPI_CS,
     .wp = GPIO_UNDEF,
     .hold = GPIO_UNDEF,
-    .addr_width = 3,
 };
 
 static mtd_spi_nor_t serpente_nor_dev = {

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -150,6 +150,12 @@ typedef struct {
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
     uint8_t sec_addr_shift;
+    /**
+     * @brief   number of address bytes
+     *
+     * Computed by mtd_spi_nor_init, no need to touch outside the driver.
+     */
+    uint8_t addr_width;
 } mtd_spi_nor_t;
 
 /**

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -113,7 +113,6 @@ typedef struct {
     gpio_t cs;               /**< CS pin GPIO handle */
     gpio_t wp;               /**< Write Protect pin GPIO handle */
     gpio_t hold;             /**< HOLD pin GPIO handle */
-    uint8_t addr_width;      /**< Number of bytes in addresses, usually 3 for small devices */
 } mtd_spi_nor_params_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

New variants of the `same54-xpro` board now come with the SST26VF064B QSPI flash instead of N25Q256A.
This requires some changes:

 - the capacity encoding scheme is different from existing chips
 - Global Block-Protection Unlock is required before the chip accepts writes (but this is only needed once)
 - 8 MiB device instead of 32 MiB, does *only* support 24 bit addressing

To solve the third problem, `addr_width` is not determined at run-time so it does not have to be set by the board anymore.

### Testing procedure

I used `tests/mtd_raw` to test the changes:

#### old same54-xpro

```
2022-02-03 22:03:44,478 # main(): This is RIOT! (Version: 2022.04-devel-223-g9fd1b-drivers/mtd_spi_nor-microchip)
2022-02-03 22:03:44,479 # Manual MTD test
2022-02-03 22:03:44,483 # init MTD_0… OK (32 MiB)
2022-02-03 22:03:44,486 # init MTD_1… OK (256 byte)
> test 0
2022-02-03 22:03:47,197 # test 0
2022-02-03 22:03:47,197 # [START]
2022-02-03 22:03:48,471 # [SUCCESS]
```

#### new same54-xpro

```
> 2022-02-03 22:03:19,956 # main(): This is RIOT! (Version: 2022.04-devel-223-g9fd1b-drivers/mtd_spi_nor-microchip)
2022-02-03 22:03:19,958 # Manual MTD test
2022-02-03 22:03:19,961 # init MTD_0… OK (8 MiB)
2022-02-03 22:03:19,964 # init MTD_1… OK (256 byte)
> test 0
2022-02-03 22:03:24,709 # test 0
2022-02-03 22:03:24,710 # [START]
2022-02-03 22:03:25,978 # [SUCCESS]
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
