### PR TITLE
sys/net/gnrc: Enable v6 when sockets are requested

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -431,6 +431,7 @@ ifneq (,$(filter gnrc,$(USEMODULE)))
   endif
   ifneq (,$(filter sock_udp, $(USEMODULE)))
     USEMODULE += gnrc_sock_udp
+    USEMODULE += gnrc_ipv6
   endif
   ifneq (,$(filter sock_tcp, $(USEMODULE)))
     USEMODULE += gnrc_sock_tcp


### PR DESCRIPTION
### Contribution description

When GNRC UDP sockets are requested to be built, but nothing else pulls in IPv6, quite a few things start breaking:

```
.../RIOT/sys/net/gnrc/sock/udp/gnrc_sock_udp.c: In function ‘sock_udp_recv_buf_aux’:                                             
.../RIOT/sys/net/gnrc/sock/udp/gnrc_sock_udp.c:255:11: error: ‘memcmp’ specified b
ound 16 exceeds source size 12 [-Werror=stringop-overread]                                     
  255 |          (memcmp(&sock->remote.addr, &tmp.addr, sizeof(ipv6_addr_t)) != 0)))) {        
      |           ^~~~~~~~
```

or (if that were fixed)

```
.../RIOT/sys/net/gnrc/transport_layer/udp/gnrc_udp.c: In function ‘_receive’:     
.../RIOT/sys/net/gnrc/transport_layer/udp/gnrc_udp.c:113:42: error: ‘GNRC_NETTYPE_IPV6’ undeclared (first use in this function); did you mean ‘GNRC_NETTYPE_UDP’?                
  113 |     ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);                                 |                                          ^~~~~~~~~~~~~~~~~                             
      |                                          GNRC_NETTYPE_UDP      
```

All these look a lot like UDP sockets in GNRC are not supposed to be used with v6 off (why should one), but the build system needs to reflect that.

### Testing procedure

In default example, add `USEMODULE += sntp` and build on native.

### Alternatives

* There may be the intention for GNRC sockets to work in a v6-less setup. I don't plan to contribute to any such setup, but if intended, that would be a valid fix.
* There may be a better / more generic place to set this.
* This may be needed not only for `sock_udp` but any sock (probably not async, not sure that makes sense even without another sock).