### PR TITLE
cpu/nrf52-9160: add periph_spi_init_gpio

### DIFF
--- a/cpu/nrf52/Kconfig
+++ b/cpu/nrf52/Kconfig
@@ -17,6 +17,7 @@ config CPU_FAM_NRF52
     select HAS_CORTEXM_MPU
     select HAS_CPU_NRF52
     select HAS_PERIPH_I2C_RECONFIGURE
+    select HAS_PERIPH_SPI_GPIO_MODE
 
 ## CPU Models
 config CPU_MODEL_NRF52805XXAA

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -32,5 +32,9 @@ ifneq (,$(filter saul_nrf_vddh,$(USEMODULE)))
   FEATURES_REQUIRED += periph_adc
 endif
 
+ifneq (,$(filter periph_spi,$(USEMODULE)))
+  USEMODULE += periph_spi_gpio_mode
+endif
+
 include $(RIOTCPU)/nrf5x_common/Makefile.dep
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -24,6 +24,7 @@ FEATURES_PROVIDED += ble_nimble_netif
 FEATURES_PROVIDED += cortexm_mpu
 
 FEATURES_PROVIDED += periph_i2c_reconfigure
+FEATURES_PROVIDED += periph_spi_gpio_mode
 
 # On top of the default 1Mbit PHY mode, all nrf52 support the 2MBit PHY mode,
 # and the 52840 does further support the coded PHYs

--- a/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
@@ -135,11 +135,35 @@ void spi_init(spi_t bus)
     spi_init_pins(bus);
 }
 
+int spi_init_with_gpio_mode(spi_t bus, const spi_gpio_mode_t* mode)
+{
+    assert(bus < SPI_NUMOF);
+
+    if (gpio_is_valid(spi_config[bus].mosi)) {
+        gpio_init(spi_config[bus].miso, mode->mosi);
+    }
+
+    if (gpio_is_valid(spi_config[bus].miso)) {
+        gpio_init(spi_config[bus].mosi, mode->miso);
+    }
+
+    if (gpio_is_valid(spi_config[bus].sclk)) {
+        /* clk_pin will be muxed during acquire / release */
+        gpio_init(spi_config[bus].sclk, mode->sclk);
+    }
+
+    return 0;
+}
+
 void spi_init_pins(spi_t bus)
 {
-    gpio_init(spi_config[bus].sclk, GPIO_OUT);
-    gpio_init(spi_config[bus].mosi, GPIO_OUT);
-    gpio_init(spi_config[bus].miso, GPIO_IN);
+    const spi_gpio_mode_t gpio_modes = {
+        .mosi = GPIO_OUT,
+        .sclk = GPIO_OUT,
+        .miso = GPIO_IN,
+    };
+    spi_init_with_gpio_mode(bus, &gpio_modes);
+
     /* select pins for the SPI device */
     SPI_SCKSEL = spi_config[bus].sclk;
     SPI_MOSISEL = spi_config[bus].mosi;

--- a/cpu/nrf9160/Kconfig
+++ b/cpu/nrf9160/Kconfig
@@ -14,6 +14,7 @@ config CPU_FAM_NRF9160
     select HAS_PERIPH_GPIO_IRQ
     select HAS_PERIPH_TIMER_PERIODIC
     select HAS_PERIPH_UART_MODECFG
+    select HAS_PERIPH_SPI_GPIO_MODE
 
 ## CPU Models
 config CPU_MODEL_NRF9160
@@ -38,5 +39,6 @@ config HAS_CPU_NRF9160
         Indicates that the current cpu is 'nrf9160'.
 
 rsource "vectors/Kconfig"
+rsource "periph/Kconfig"
 
 source "$(RIOTCPU)/nrf5x_common/Kconfig"

--- a/cpu/nrf9160/Makefile.dep
+++ b/cpu/nrf9160/Makefile.dep
@@ -1,4 +1,8 @@
 USEMODULE += nrf9160_vectors
 
+ifneq (,$(filter periph_spi,$(USEMODULE)))
+  USEMODULE += periph_spi_gpio_mode
+endif
+
 include $(RIOTCPU)/nrf5x_common/Makefile.dep
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/nrf9160/Makefile.features
+++ b/cpu/nrf9160/Makefile.features
@@ -1,4 +1,6 @@
 CPU_CORE = cortex-m33
 CPU_FAM  = nrf9160
 
+FEATURES_PROVIDED += periph_spi_gpio_mode
+
 include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf9160/periph/Kconfig
+++ b/cpu/nrf9160/periph/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Inria
+# Copyright (c) 2022 Inria
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
@@ -7,25 +7,12 @@
 
 if TEST_KCONFIG
 
-config MODULE_PERIPH_UART_NONBLOCKING
-    depends on HAS_PERIPH_UART_NONBLOCKING
-    depends on MODULE_PERIPH_UART
-    select MODULE_TSRB
-
 config MODULE_PERIPH_SPI
     depends on HAS_PERIPH_SPI
-    select MODULE_PERIPH_GPIO_IRQ if CPU_MODEL_NRF52832XXAA && HAS_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_SPI_GPIO_MODE if MODULE_PERIPH_SPI && HAS_PERIPH_SPI_GPIO_MODE
 
 config MODULE_SAUL_NRF_VDDH
     bool "Internal Voltage Sensor"
     depends on HAS_PERIPH_ADC
-    select MODULE_PERIPH_ADC
 
 endif # TEST_KCONFIG
-
-config HAVE_SAUL_NRF_VDDH
-    bool
-    select MODULE_SAUL_NRF_VDDH if MODULE_SAUL_DEFAULT
-    help
-        Indicates that internal voltage sensor is present.


### PR DESCRIPTION
### Contribution description

This PR allows nrf52-9160 to init spi with pull-up/pull-downs. The motivation was to be able to get rid of the use of `soft-spi` code in #17233, used in init just because spi was not able to set pull-up, but many platforms can.

### Testing procedure

Tested on a dwm1001 with an sdcard attached:

```
2022-02-04 09:41:23,859 # help
2022-02-04 09:41:23,861 # Command              Description
2022-02-04 09:41:23,865 # ---------------------------------------
2022-02-04 09:41:23,869 # mount                mount flash filesystem
2022-02-04 09:41:23,873 # format               format flash file system
2022-02-04 09:41:23,877 # umount               unmount flash filesystem
2022-02-04 09:41:23,881 # cat                  print the content of a file
2022-02-04 09:41:23,885 # tee                  write a string in a file
2022-02-04 09:41:23,888 # reboot               Reboot the node
2022-02-04 09:41:23,892 # version              Prints current RIOT_VERSION
2022-02-04 09:41:23,897 # pm                   interact with layered PM subsystem
2022-02-04 09:41:23,903 # ps                   Prints information about running threads.
2022-02-04 09:41:23,907 # vfs                  virtual file system operations
2022-02-04 09:41:23,910 # ls                   list files
> mount
2022-02-04 09:41:25,958 # mount
2022-02-04 09:41:25,995 # Error while mounting /sda...try format
format
2022-02-04 09:41:28,779 # format
2022-02-04 09:41:28,863 # /sda successfully formatted
> mount
2022-02-04 09:41:30,564 # mount
2022-02-04 09:41:30,592 # /sda successfully mounted
2022-02-04 09:41:37,598 # ls
2022-02-04 09:41:37,599 # ls <path>
2022-02-04 09:41:37,601 # list files in <path>
> ls /sda
2022-02-04 09:41:39,624 # ls /sda
2022-02-04 09:41:39,643 # /.
2022-02-04 09:41:39,643 # /..
2022-02-04 09:41:39,643 # total 2 files
> tee /sda/test.txt "hello"
2022-02-04 09:42:02,741 # tee /sda/test.txt "hello"
> REBOOT
2022-02-04 09:42:05,454 # REBOOT
2022-02-04 09:42:05,457 # shell: command not found: REBOOT
> reboot
2022-02-04 09:42:07,013 # reboot
2022-02-04 09:42:07,021 # main(): This is RIOT! (Version: 2022.04-devel-228-g7c5aa-pr_spi_gpio_mode_nrf)
2022-02-04 09:42:07,023 # constfs mounted successfully
2022-02-04 09:42:31,224 # mount
2022-02-04 09:42:31,268 # /sda successfully mounted
ls /sda
2022-02-04 09:42:32,874 # ls /sda
2022-02-04 09:42:32,893 # /.
2022-02-04 09:42:32,893 # /..
2022-02-04 09:42:32,902 # /test.txt
2022-02-04 09:42:32,903 # total 3 files
cat /sda/test.txt
2022-02-04 09:42:35,125 # cat /sda/test.txt
2022-02-04 09:42:36,745 # hello> cat /sda/test.txt
2022-02-04 09:42:37,944 # hello> cat /sda/test.txt
```

### Issues/PRs references

Split from #17233 