### PR TITLE
drivers/mtd_sdcard: support unaligned reads & writes

### DIFF
--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -55,7 +55,8 @@ typedef struct {
  *          the sector first.
  *          Attention: an erase call will therefore NOT touch the content,
  *          so enable this feature to ensure overriding the data.
- *          This feature is currently not supported.
+ *
+ *          This feature requires the `mtd_write_page` module.
  */
 #ifdef DOXYGEN
 #define CONFIG_MTD_SDCARD_ERASE

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -28,6 +28,9 @@
 
 #include <inttypes.h>
 #include <errno.h>
+#include <string.h>
+
+#define MIN(a, b) ((a) > (b) ? (b) : (a))
 
 static int mtd_sdcard_init(mtd_dev_t *dev)
 {
@@ -47,80 +50,92 @@ static int mtd_sdcard_init(mtd_dev_t *dev)
     return -EIO;
 }
 
-static int mtd_sdcard_read(mtd_dev_t *dev, void *buff, uint32_t addr,
-                           uint32_t size)
-{
-    DEBUG("mtd_sdcard_read: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
-    mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
-    sd_rw_response_t err;
-    sdcard_spi_read_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
-                           buff, SD_HC_BLOCK_SIZE,
-                           size / SD_HC_BLOCK_SIZE, &err);
-
-    if (err == SD_RW_OK) {
-        return 0;
-    }
-    return -EIO;
-}
-
 static int mtd_sdcard_read_page(mtd_dev_t *dev, void *buff, uint32_t page,
                                 uint32_t offset, uint32_t size)
 {
+    sd_rw_response_t err;
+    mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
+
     DEBUG("mtd_sdcard_read_page: page:%" PRIu32 " offset:%" PRIu32 " size:%" PRIu32 "\n",
           page, offset, size);
 
-    if (offset) {
+    if (offset || size % SD_HC_BLOCK_SIZE) {
+#if IS_USED(MODULE_MTD_WRITE_PAGE)
+        if (dev->work_area == NULL) {
+            DEBUG("mtd_sdcard_read_page: no work area\n");
+            return -ENOTSUP;
+        }
+
+        sdcard_spi_read_blocks(mtd_sd->sd_card, page,
+                               dev->work_area, SD_HC_BLOCK_SIZE,
+                               1, &err);
+        if (err != SD_RW_OK) {
+            return -EIO;
+        }
+
+        size = MIN(size, SD_HC_BLOCK_SIZE - offset);
+        DEBUG("mtd_sdcard_read_page: read %" PRIu32 " bytes at offset %" PRIu32 "\n",
+              size, offset);
+        memcpy(buff, (uint8_t *)dev->work_area + offset, size);
+        return size;
+#else
         return -ENOTSUP;
+#endif
     }
 
-    mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
-    sd_rw_response_t err;
-    int res = sdcard_spi_read_blocks(mtd_sd->sd_card, page,
-                                     buff, SD_HC_BLOCK_SIZE,
-                                     size / SD_HC_BLOCK_SIZE, &err);
-
+    sdcard_spi_read_blocks(mtd_sd->sd_card, page,
+                           buff, SD_HC_BLOCK_SIZE,
+                           size / SD_HC_BLOCK_SIZE, &err);
     if (err != SD_RW_OK) {
         return -EIO;
     }
-    return res * SD_HC_BLOCK_SIZE;
-}
-
-static int mtd_sdcard_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
-                            uint32_t size)
-{
-    DEBUG("mtd_sdcard_write: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
-    mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
-    sd_rw_response_t err;
-    sdcard_spi_write_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
-                            buff, SD_HC_BLOCK_SIZE,
-                            size / SD_HC_BLOCK_SIZE, &err);
-
-    if (err == SD_RW_OK) {
-        return 0;
-    }
-    return -EIO;
+    return size;
 }
 
 static int mtd_sdcard_write_page(mtd_dev_t *dev, const void *buff, uint32_t page,
                                  uint32_t offset, uint32_t size)
 {
+    sd_rw_response_t err;
+    mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
+
     DEBUG("mtd_sdcard_write_page: page:%" PRIu32 " offset:%" PRIu32 " size:%" PRIu32 "\n",
           page, offset, size);
 
-    if (offset) {
-        return -ENOTSUP;
-    }
+    if (offset || size % SD_HC_BLOCK_SIZE) {
+#if IS_USED(MODULE_MTD_WRITE_PAGE)
+        if (dev->work_area == NULL) {
+            DEBUG("mtd_sdcard_write_page: no work area\n");
+            return -ENOTSUP;
+        }
 
-    mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
-    sd_rw_response_t err;
-    int res = sdcard_spi_write_blocks(mtd_sd->sd_card, page,
-                                     buff, SD_HC_BLOCK_SIZE,
-                                     size / SD_HC_BLOCK_SIZE, &err);
+        sdcard_spi_read_blocks(mtd_sd->sd_card, page,
+                               dev->work_area, SD_HC_BLOCK_SIZE,
+                               1, &err);
+        if (err != SD_RW_OK) {
+            return -EIO;
+        }
+
+        size = MIN(size, SD_HC_BLOCK_SIZE - offset);
+        DEBUG("mtd_sdcard_write_page: write %" PRIu32 " bytes at offset %" PRIu32 "\n",
+              size, offset);
+        memcpy((uint8_t *)dev->work_area + offset, buff, size);
+        sdcard_spi_write_blocks(mtd_sd->sd_card, page,
+                                dev->work_area, SD_HC_BLOCK_SIZE,
+                                1, &err);
+#else
+        return -ENOTSUP;
+#endif
+    } else {
+        sdcard_spi_write_blocks(mtd_sd->sd_card, page,
+                                buff, SD_HC_BLOCK_SIZE,
+                                size / SD_HC_BLOCK_SIZE, &err);
+    }
 
     if (err != SD_RW_OK) {
+        printf("err: %d\n", err);
         return -EIO;
     }
-    return res * SD_HC_BLOCK_SIZE;
+    return size;
 }
 
 static int mtd_sdcard_erase(mtd_dev_t *dev,
@@ -150,6 +165,34 @@ static int mtd_sdcard_power(mtd_dev_t *dev, enum mtd_power_state power)
     return -ENOTSUP; /* currently not supported */
 }
 
+static int mtd_sdcard_read(mtd_dev_t *dev, void *buff, uint32_t addr,
+                           uint32_t size)
+{
+    int res = mtd_sdcard_read_page(dev, buff, addr / SD_HC_BLOCK_SIZE,
+                                   addr % SD_HC_BLOCK_SIZE, size);
+    if (res < 0) {
+        return res;
+    }
+    if (res == (int)size) {
+        return 0;
+    }
+    return -EOVERFLOW;
+}
+
+static int mtd_sdcard_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
+                            uint32_t size)
+{
+    int res =  mtd_sdcard_write_page(dev, buff, addr / SD_HC_BLOCK_SIZE,
+                                     addr % SD_HC_BLOCK_SIZE, size);
+    if (res < 0) {
+        return res;
+    }
+    if (res == (int)size) {
+        return 0;
+    }
+    return -EOVERFLOW;
+}
+
 const mtd_desc_t mtd_sdcard_driver = {
     .init = mtd_sdcard_init,
     .read = mtd_sdcard_read,
@@ -158,5 +201,4 @@ const mtd_desc_t mtd_sdcard_driver = {
     .write_page = mtd_sdcard_write_page,
     .erase = mtd_sdcard_erase,
     .power = mtd_sdcard_power,
-    .flags = MTD_DRIVER_FLAG_DIRECT_WRITE,
 };

--- a/tests/mtd_raw/Makefile
+++ b/tests/mtd_raw/Makefile
@@ -7,6 +7,9 @@ USEMODULE += od
 USEMODULE += mtd
 USEMODULE += mtd_write_page
 
+# enable true erase if MTD is an SD card
+CFLAGS += -DCONFIG_MTD_SDCARD_ERASE=1
+
 # Sometimes fails. See #16130.
 TEST_ON_CI_BLACKLIST += esp32-wroom-32
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This allows to use SD card as a MTD backed even if users want to do unaligned reads and writes (e.g. SPIFFS, FlashDB). 


### Testing procedure

The `test` command from `tests/mtd_raw` should now work on SD cards. 

<details><summary>master</summary>

```
main(): This is RIOT! (Version: 2022.04-devel-401-g130eb42)
Manual MTD test
init MTD_0… OK (8 MiB)
init MTD_1… OK (256 byte)
init MTD_2… OK (15247 MiB)
> test 2
[START]
tests/mtd_raw/main.c:432 => failed condition
*** RIOT kernel panic:
CONDITION FAILED.

*** halted.
```
</details>

<details><summary>this PR</summary>

```
 main(): This is RIOT! (Version: 2022.04-devel-221-g91ca7-drivers/mtd_sdcard-unaligned)
Manual MTD test
init MTD_0… OK (0 byte)
init MTD_1… OK (256 byte)
init MTD_2… OK (15247 MiB)
> test 2
[START]
[SUCCESS]
```
</details>

If the SD card is not configured by the board, this requires adding some manual SD card config, e.g. for `same54-xpro` on EXT2:

```patch
diff --git a/tests/mtd_raw/Makefile b/tests/mtd_raw/Makefile
index 37a8d97fe6..2f1a770f45 100644
--- a/tests/mtd_raw/Makefile
+++ b/tests/mtd_raw/Makefile
@@ -7,6 +7,10 @@ USEMODULE += od
 USEMODULE += mtd
 USEMODULE += mtd_write_page
 
+USEMODULE += mtd_sdcard
+CFLAGS += -DSDCARD_SPI_PARAM_SPI="SPI_DEV(1)" -DSDCARD_SPI_PARAM_CS="GPIO_PIN(2,6)"      \
+          -DSDCARD_SPI_PARAM_CLK="GPIO_PIN(2,5)" -DSDCARD_SPI_PARAM_MOSI="GPIO_PIN(2,4)" \
+          -DSDCARD_SPI_PARAM_MISO="GPIO_PIN(2,7)"
 # enable true erase if MTD is an SD card
 CFLAGS += -DCONFIG_MTD_SDCARD_ERASE=1
 
diff --git a/tests/mtd_raw/main.c b/tests/mtd_raw/main.c
index 71681634b4..40979097bf 100644
--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -31,6 +31,28 @@
 #include "macros/units.h"
 #include "test_utils/expect.h"
 
+#include "mtd_sdcard.h"
+#include "sdcard_spi_params.h"
+
+/* SD card devices are provided by drivers/sdcard_spi/sdcard_spi.c */
+extern sdcard_spi_t sdcard_spi_devs[ARRAY_SIZE(sdcard_spi_params)];
+
+/* Configure MTD device for the first SD card */
+static mtd_sdcard_t mtd_sdcard_dev = {
+    .base = {
+        .driver = &mtd_sdcard_driver
+    },
+    .sd_card = &sdcard_spi_devs[0],
+    .params = &sdcard_spi_params[0],
+};
+
+static mtd_dev_t *mtd_sd = &mtd_sdcard_dev.base;
+
+#define MTD_2   mtd_sd
+
+#undef MTD_NUMOF
+#define MTD_NUMOF 3
+
 #ifndef MTD_NUMOF
 #ifdef MTD_0
 #define MTD_NUMOF 1
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
