### PR TITLE
sys/vfs: provide vfs_fsync()

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -219,6 +219,19 @@ static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
     return (ssize_t)bw;
 }
 
+static int _fsync(vfs_file_t *filp)
+{
+    fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
+
+    FRESULT res = f_sync(&fd->file);
+
+    if (res != FR_OK) {
+        return fatfs_err_to_errno(res);
+    }
+
+    return 0;
+}
+
 static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 {
     fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
@@ -469,6 +482,7 @@ static const vfs_file_ops_t fatfs_file_ops = {
     .write = _write,
     .lseek = _lseek,
     .fstat = _fstat,
+    .fsync = _fsync,
 };
 
 static const vfs_dir_ops_t fatfs_dir_ops = {

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -377,6 +377,22 @@ static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
     return littlefs_err_to_errno(ret);
 }
 
+static int _fsync(vfs_file_t *filp)
+{
+    littlefs_desc_t *fs = filp->mp->private_data;
+    lfs_file_t *fp = _get_lfs_file(filp);
+
+    mutex_lock(&fs->lock);
+
+    DEBUG("littlefs: fsync: filp=%p, fp=%p\n",
+          (void *)filp, (void *)fp);
+
+    int ret = lfs_file_sync(&fs->fs, fp);
+    mutex_unlock(&fs->lock);
+
+    return littlefs_err_to_errno(ret);
+}
+
 static int _stat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
 {
     littlefs_desc_t *fs = mountp->private_data;
@@ -519,6 +535,7 @@ static const vfs_file_ops_t littlefs_file_ops = {
     .read = _read,
     .write = _write,
     .lseek = _lseek,
+    .fsync = _fsync,
 };
 
 static const vfs_dir_ops_t littlefs_dir_ops = {

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -383,6 +383,22 @@ static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
     return littlefs_err_to_errno(ret);
 }
 
+static int _fsync(vfs_file_t *filp)
+{
+    littlefs2_desc_t *fs = filp->mp->private_data;
+    lfs_file_t *fp = _get_lfs_file(filp);
+
+    mutex_lock(&fs->lock);
+
+    DEBUG("littlefs: fsync: filp=%p, fp=%p\n",
+          (void *)filp, (void *)fp);
+
+    int ret = lfs_file_sync(&fs->fs, fp);
+    mutex_unlock(&fs->lock);
+
+    return littlefs_err_to_errno(ret);
+}
+
 static int _stat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
 {
     littlefs2_desc_t *fs = mountp->private_data;
@@ -525,6 +541,7 @@ static const vfs_file_ops_t littlefs_file_ops = {
     .read = _read,
     .write = _write,
     .lseek = _lseek,
+    .fsync = _fsync,
 };
 
 static const vfs_dir_ops_t littlefs_dir_ops = {

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -332,6 +332,15 @@ static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
     return spiffs_err_to_errno(SPIFFS_lseek(&fs_desc->fs, filp->private_data.value, off, s_whence));
 }
 
+static int _fsync(vfs_file_t *filp)
+{
+    spiffs_desc_t *fs_desc = filp->mp->private_data;
+
+    int ret = SPIFFS_fflush(&fs_desc->fs, filp->private_data.value);
+
+    return spiffs_err_to_errno(ret);
+}
+
 static int _fstat(vfs_file_t *filp, struct stat *buf)
 {
     spiffs_desc_t *fs_desc = filp->mp->private_data;
@@ -514,6 +523,7 @@ static const vfs_file_ops_t spiffs_file_ops = {
     .write = _write,
     .lseek = _lseek,
     .fstat = _fstat,
+    .fsync = _fsync,
 };
 
 static const vfs_dir_ops_t spiffs_dir_ops = {

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -440,6 +440,17 @@ struct vfs_file_ops {
      * @return <0 on error
      */
     ssize_t (*write) (vfs_file_t *filp, const void *src, size_t nbytes);
+
+    /**
+     * @brief Synchronize a file on storage
+     *        Any pending writes are written out to storage.
+     *
+     * @param[in]  filp     pointer to open file
+     *
+     * @return 0 on success
+     * @return <0 on error
+     */
+    int (*fsync) (vfs_file_t *filp);
 };
 
 /**
@@ -738,6 +749,17 @@ ssize_t vfs_read(int fd, void *dest, size_t count);
  * @return <0 on error
  */
 ssize_t vfs_write(int fd, const void *src, size_t count);
+
+/**
+ * @brief Synchronize a file on storage
+ *        Any pending writes are written out to storage.
+ *
+ * @param[in]  fd       fd number obtained from vfs_open
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int vfs_fsync(int fd);
 
 /**
  * @brief Open a directory for reading with readdir


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

All file systems provide a means to flush pending data to storage without closing the filedescriptor.
Expose this function via VFS.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
