### PR TITLE
pkg/littlefs*: align readdir() with documentation

### DIFF
--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -493,8 +493,7 @@ static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
     int ret = lfs_dir_read(&fs->fs, dir, &info);
     if (ret >= 0) {
         entry->d_ino = info.type;
-        entry->d_name[0] = '/';
-        strncpy(entry->d_name + 1, info.name, VFS_NAME_MAX - 1);
+        strncpy(entry->d_name, info.name, VFS_NAME_MAX - 1);
     }
 
     mutex_unlock(&fs->lock);

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -499,8 +499,7 @@ static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
     int ret = lfs_dir_read(&fs->fs, dir, &info);
     if (ret >= 0) {
         entry->d_ino = info.type;
-        entry->d_name[0] = '/';
-        strncpy(entry->d_name + 1, info.name, VFS_NAME_MAX - 1);
+        strncpy(entry->d_name, info.name, VFS_NAME_MAX - 1);
     }
 
     mutex_unlock(&fs->lock);

--- a/tests/pkg_littlefs/main.c
+++ b/tests/pkg_littlefs/main.c
@@ -288,8 +288,8 @@ static void tests_littlefs_readdir(void)
     int nb_files = 0;
     do {
         res = vfs_readdir(&dirp, &entry);
-        if (res == 1 && (strcmp("/test0.txt", &(entry.d_name[0])) == 0 ||
-                         strcmp("/test1.txt", &(entry.d_name[0])) == 0)) {
+        if (res == 1 && (strcmp("test0.txt", &(entry.d_name[0])) == 0 ||
+                         strcmp("test1.txt", &(entry.d_name[0])) == 0)) {
             nb_files++;
         }
     } while (res == 1);
@@ -305,7 +305,7 @@ static void tests_littlefs_readdir(void)
     nb_files = 0;
     do {
         res = vfs_readdir(&dirp, &entry);
-        if (res == 1 && strcmp("/test2.txt", &(entry.d_name[0])) == 0) {
+        if (res == 1 && strcmp("test2.txt", &(entry.d_name[0])) == 0) {
             nb_files++;
         }
     } while (res == 1);

--- a/tests/pkg_littlefs2/main.c
+++ b/tests/pkg_littlefs2/main.c
@@ -288,8 +288,8 @@ static void tests_littlefs_readdir(void)
     int nb_files = 0;
     do {
         res = vfs_readdir(&dirp, &entry);
-        if (res == 1 && (strcmp("/test0.txt", &(entry.d_name[0])) == 0 ||
-                         strcmp("/test1.txt", &(entry.d_name[0])) == 0)) {
+        if (res == 1 && (strcmp("test0.txt", &(entry.d_name[0])) == 0 ||
+                         strcmp("test1.txt", &(entry.d_name[0])) == 0)) {
             nb_files++;
         }
     } while (res == 1);
@@ -305,7 +305,7 @@ static void tests_littlefs_readdir(void)
     nb_files = 0;
     do {
         res = vfs_readdir(&dirp, &entry);
-        if (res == 1 && strcmp("/test2.txt", &(entry.d_name[0])) == 0) {
+        if (res == 1 && strcmp("test2.txt", &(entry.d_name[0])) == 0) {
             nb_files++;
         }
     } while (res == 1);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`readdir()` should only output the name of the file, but littleFS adds a leading `/`.

Neither FAT nor Linux will exhibit this behavior. (SPIFFS does not support directories)

        struct dirent *entry;
        DIR *dir = opendir(".");
        while ((entry = readdir(dir))) {
                printf("%s\n", entry->d_name);
        }

This results in surprising failures of code that expects filenames to match that was tested on a different FS, when suddenly there is a `/` in front of the filename.

### Testing procedure

#### before

```
> ls /
/.
/..
/test
total 3 files
> ls /test
/.
/..
/0.cnk
/1.cnk
total 4 files
```

#### with this patch

```
> ls /
.
..
test
total 3 files
> ls /test
.
..
0.cnk
1.cnk
total 4 files
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
