### PR TITLE
sys/benchmark: fix divide by zero if runs < 1000

### DIFF
--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -26,7 +26,7 @@
 void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
 {
     uint32_t full = (time / runs);
-    uint32_t div  = (time - (full * runs)) / (runs / 1000);
+    uint32_t div  = (time - (full * runs)) * 1000 / runs;
 
     uint32_t per_sec = (uint32_t)(((uint64_t)US_PER_SEC * runs) / time);
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If runs < 1000, `runs / 1000` will result in 0 - which causes a division by 0.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
