### PR TITLE
fs/constfs: omit leading '/' in readdir() 

### DIFF
--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -282,7 +282,8 @@ static int constfs_readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
     if (fp->path == NULL) {
         return -EIO;
     }
-    size_t len = strnlen(fp->path, VFS_NAME_MAX + 1);
+    const char *filename = fp->path[0] == '/' ? fp->path + 1 : fp->path;
+    size_t len = strnlen(filename, VFS_NAME_MAX + 1);
     if (len > VFS_NAME_MAX) {
         /* name does not fit in vfs_dirent_t buffer */
         /* skipping past the broken entry */
@@ -291,7 +292,7 @@ static int constfs_readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
         return -EAGAIN;
     }
     /* copy the string, including terminating null */
-    memcpy(&entry->d_name[0], fp->path, len + 1);
+    memcpy(&entry->d_name[0], filename, len + 1);
     entry->d_ino = filenum;
     ++filenum;
     dirp->private_data.value = filenum;

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -544,6 +544,8 @@ int _ls_handler(int argc, char **argv)
         } else if (stat.st_mode & S_IFREG) {
             printf("%s\t%lu B\n", entry.d_name, stat.st_size);
             ++nfiles;
+        } else {
+            printf("%s\n", entry.d_name);
         }
     }
     if (ret == 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This aligns ConstFS readdir() implementation more with POSIX.


### Testing procedure

```
main(): This is RIOT! (Version: 2022.04-devel-288-g28fa5)
constfs mounted successfully
> ls /const
ls /const
hello-world	14 B
hello-riot	13 B
total 2 files
> cat /const/hello-world
cat /const/hello-world
Hello World!
```


### Issues/PRs references

#14635
