### PR TITLE
drivers/mtd_flashpage: add mtd_flashpage_t type

### DIFF
--- a/drivers/include/mtd_flashpage.h
+++ b/drivers/include/mtd_flashpage.h
@@ -34,16 +34,25 @@ extern "C"
  * @brief   Macro helper to initialize a mtd_t with flash-age driver
  */
 #define MTD_FLASHPAGE_INIT_VAL(_pages_per_sector) { \
-    .driver = &mtd_flashpage_driver, \
-    .sector_count = FLASHPAGE_NUMOF, \
-    .pages_per_sector = _pages_per_sector,\
-    .page_size = FLASHPAGE_SIZE / _pages_per_sector,\
+    .base = {                                       \
+        .driver = &mtd_flashpage_driver,            \
+        .sector_count = FLASHPAGE_NUMOF,            \
+        .pages_per_sector = _pages_per_sector,      \
+        .page_size = FLASHPAGE_SIZE / _pages_per_sector, \
+    },                                              \
 }
 
 /**
  * @brief   Flashpage MTD device operations table
  */
 extern const mtd_desc_t mtd_flashpage_driver;
+
+/**
+ * @brief    MTD flashpage descriptor
+ */
+typedef struct {
+    mtd_dev_t base;     /**< MTD generic device */
+} mtd_flashpage_t;
 
 #ifdef __cplusplus
 }

--- a/sys/fido2/ctap/ctap_mem.c
+++ b/sys/fido2/ctap/ctap_mem.c
@@ -28,7 +28,8 @@
 /**
  * @brief   MTD device descriptor initialized with flash-page driver
  */
-static mtd_dev_t _mtd_dev = MTD_FLASHPAGE_INIT_VAL(CTAP_FLASH_PAGES_PER_SECTOR);
+static mtd_flashpage_t _mtd_flash_dev = MTD_FLASHPAGE_INIT_VAL(CTAP_FLASH_PAGES_PER_SECTOR);
+static mtd_dev_t *_mtd_dev = &_mtd_flash_dev.base;
 
 /**
  * @brief   Max amount of resident keys that can be stored
@@ -49,7 +50,7 @@ int fido2_ctap_mem_init(void)
 {
     int ret;
 
-    ret = mtd_init(&_mtd_dev);
+    ret = mtd_init(_mtd_dev);
 
     if (ret < 0) {
         return ret;
@@ -64,7 +65,7 @@ int fido2_ctap_mem_init(void)
 
 static unsigned _amount_of_flashpages(void)
 {
-    return _mtd_dev.sector_count * _mtd_dev.pages_per_sector;
+    return _mtd_dev->sector_count * _mtd_dev->pages_per_sector;
 }
 
 int fido2_ctap_mem_read(void *buf, uint32_t page, uint32_t offset, uint32_t len)
@@ -73,7 +74,7 @@ int fido2_ctap_mem_read(void *buf, uint32_t page, uint32_t offset, uint32_t len)
 
     int ret;
 
-    ret = mtd_read_page(&_mtd_dev, buf, page, offset, len);
+    ret = mtd_read_page(_mtd_dev, buf, page, offset, len);
 
     if (ret < 0) {
         return CTAP1_ERR_OTHER;
@@ -89,14 +90,14 @@ int fido2_ctap_mem_write(const void *buf, uint32_t page, uint32_t offset, uint32
     int ret;
 
     if (!_flash_is_erased(page, offset, len)) {
-        ret = mtd_write_page(&_mtd_dev, buf, page, offset, len);
+        ret = mtd_write_page(_mtd_dev, buf, page, offset, len);
 
         if (ret < 0) {
             return CTAP1_ERR_OTHER;
         }
     }
     else {
-        ret = mtd_write_page_raw(&_mtd_dev, buf, page, offset, len);
+        ret = mtd_write_page_raw(_mtd_dev, buf, page, offset, len);
 
         if (ret < 0) {
             return CTAP1_ERR_OTHER;

--- a/tests/mtd_flashpage/main.c
+++ b/tests/mtd_flashpage/main.c
@@ -36,8 +36,8 @@
 #endif
 #define TEST_ADDRESS0       (FLASHPAGE_NUMOF - 1)
 
-static mtd_dev_t _dev = MTD_FLASHPAGE_INIT_VAL(8);
-static mtd_dev_t *dev = &_dev;
+static mtd_flashpage_t _dev = MTD_FLASHPAGE_INIT_VAL(8);
+static mtd_dev_t *dev = &_dev.base;
 
 static void setup(void)
 {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This introduces a `mtd_flashpage_t` to make mtd_flashpage behave more like other MTD implementations.

### Testing procedure

The generated code of `tests/sys_fido2_ctap` does not change.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
