### PR TITLE
sys/xtimer: introduce `xtimer_is_set()`

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -311,6 +311,13 @@ static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
 void xtimer_remove(xtimer_t *timer);
 
 /**
+ * @brief state if an xtimer is currently set (waiting to be expired)
+ *
+ * @param[in] timer ptr to timer structure to work on
+ */
+static inline bool xtimer_is_set(const xtimer_t *timer);
+
+/**
  * @brief Convert microseconds to xtimer ticks
  *
  * @param[in] usec  microseconds

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -324,6 +324,11 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b)
     return (a.ticks64 < b.ticks64);
 }
 
+static inline bool xtimer_is_set(const xtimer_t *timer)
+{
+    return timer->offset || timer->long_offset;
+}
+
 #endif /* !defined(DOXYGEN) */
 
 #ifdef __cplusplus

--- a/tests/xtimer_remove/main.c
+++ b/tests/xtimer_remove/main.c
@@ -23,6 +23,7 @@
 #include "msg.h"
 #include "thread.h"
 #include "xtimer.h"
+#include "test_utils/expect.h"
 
 #define NUMOF (3U)
 
@@ -39,9 +40,11 @@ int main(void)
         for (unsigned int i = 0; i < NUMOF; i++) {
             msg[i].type = i;
             xtimer_set_msg(&timers[i], 100000*(i+1), &msg[i], me);
+            expect(xtimer_is_set(&timers[i]));
         }
 
         xtimer_remove(&timers[n]);
+        expect(!xtimer_is_set(&timers[n]));
 
         unsigned int num = NUMOF-1;
         while(num--) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There are [cases](https://github.com/RIOT-OS/RIOT/pull/17365/commits/6d88a942c4b059158f928093b64eb0c5495c5668#r802579616) where code is using internal xtimer struct members to figure out if a given xtimer is currentlly set. So, provide a function in the public API.

I've added some uses of this function (both ways, on set timers and unset timers) to `xtimer_remove()`.

I consider this addition as an intermediate step, easing migration to ztimer_xtimer_compat.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should be fine.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
