### PR TITLE
pkg/fatfs_vfs: support FF_FS_TINY=0

### DIFF
--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -1,6 +1,8 @@
 INCLUDES += -I$(PKGDIRBASE)
 INCLUDES += -I$(RIOTPKG)/fatfs/fatfs_diskio/mtd/include
 INCLUDES += -I$(RIOTPKG)/fatfs/vendor/include
+# native overwrites all INCLUDES
+NATIVEINCLUDES += -I$(RIOTPKG)/fatfs/vendor/include
 
 DIRS += $(RIOTBASE)/pkg/fatfs/fatfs_diskio/mtd
 

--- a/pkg/fatfs/doc.txt
+++ b/pkg/fatfs/doc.txt
@@ -5,3 +5,18 @@
  * @brief    Provides FAT file system support
  * @see      http://elm-chan.org/fsw/ff/00index_e.html
  */
+
+# Compile-Time options
+
+ - `FATFS_FFCONF_OPT_FS_READONLY`: This option switches read-only configuration.
+                                   Read-only configuration removes writing API functions.
+
+ - `FATFS_FFCONF_OPT_USE_FASTSEEK`: Enables faster seek at the cost of some per-fd RAM.
+
+ - `FATFS_FFCONF_OPT_FS_TINY`: Memory optimisations. Disabling this will increase FS performance
+                               at the cost of higher per-FD RAM usage (+512 byte/fd) as well as
+                               increased stack usage.
+
+ - `FATFS_FFCONF_OPT_FS_EXFAT`: enables support for exFAT
+
+ - `FATFS_FFCONF_OPT_USE_LFN`: enables support for long file names

--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -87,6 +87,11 @@ static int _format(vfs_mount_t *mountp)
     }
 #endif
 
+    /* make sure the volume has been initialized */
+    if (_init(mountp)) {
+        return -EINVAL;
+    }
+
     const MKFS_PARM param = {
         .fmt = CONFIG_FATFS_FORMAT_TYPE,
     };

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -99,14 +99,21 @@ extern "C" {
  */
 #ifdef MODULE_FATFS_VFS
 #include "ffconf.h"
+
 #if FF_FS_TINY
 #define _FATFS_FILE_CACHE               (0)
 #else
 #define _FATFS_FILE_CACHE               FF_MAX_SS
 #endif
 
+#if FF_USE_FASTSEEK
+#define _FATFS_FILE_SEEK_PTR             (4)
+#else
+#define _FATFS_FILE_SEEK_PTR             (0)
+#endif
+
 #define FATFS_VFS_DIR_BUFFER_SIZE       (44)
-#define FATFS_VFS_FILE_BUFFER_SIZE      (72 + _FATFS_FILE_CACHE)
+#define FATFS_VFS_FILE_BUFFER_SIZE      (72 + _FATFS_FILE_CACHE + _FATFS_FILE_SEEK_PTR)
 #else
 #define FATFS_VFS_DIR_BUFFER_SIZE       (1)
 #define FATFS_VFS_FILE_BUFFER_SIZE      (1)

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -98,8 +98,15 @@ extern "C" {
  * @{
  */
 #ifdef MODULE_FATFS_VFS
+#include "ffconf.h"
+#if FF_FS_TINY
+#define _FATFS_FILE_CACHE               (0)
+#else
+#define _FATFS_FILE_CACHE               FF_MAX_SS
+#endif
+
 #define FATFS_VFS_DIR_BUFFER_SIZE       (44)
-#define FATFS_VFS_FILE_BUFFER_SIZE      (72)
+#define FATFS_VFS_FILE_BUFFER_SIZE      (72 + _FATFS_FILE_CACHE)
 #else
 #define FATFS_VFS_DIR_BUFFER_SIZE       (1)
 #define FATFS_VFS_FILE_BUFFER_SIZE      (1)


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For increased performance it can be desireable to disable the tiny option.
The config option enables a per-file cache which increases the size of `fatfs_file_desc_t`.


### Testing procedure

Build with 

    CFLAGS += -DFATFS_FFCONF_OPT_FS_TINY=0
    CFLAGS += -DFATFS_FFCONF_OPT_USE_FASTSEEK=1


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
