### PR TITLE
makefiles/dependency_resolution: add outer loop for DEFAULT_MODULE deps 

### DIFF
--- a/makefiles/default_modules.deps.mk
+++ b/makefiles/default_modules.deps.mk
@@ -1,0 +1,3 @@
+# This files contains dependencies for default modules. They are parsed at the
+# end of the dependency loop. They MAY inlcude new modules, but this modules
+# MUST NOT have dependencies themselfs.

--- a/makefiles/default_modules.deps.mk
+++ b/makefiles/default_modules.deps.mk
@@ -1,3 +1,11 @@
 # This files contains dependencies for default modules. They are parsed at the
 # end of the dependency loop. They MAY inlcude new modules, but this modules
 # MUST NOT have dependencies themselfs.
+
+ifneq (,$(filter auto_init_ztimer,$(USEMODULE)))
+  USEMODULE += ztimer_init
+endif
+
+ifneq (,$(filter auto_init_saul,$(USEMODULE)))
+  USEMODULE += saul_init_devs
+endif

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -1,10 +1,5 @@
 DEFAULT_MODULE += board cpu core core_init core_msg core_panic sys
 
-DEFAULT_MODULE += auto_init
-
-# Initialize all used peripherals by default
-DEFAULT_MODULE += periph_init
-
 # Include potentially added default modules by the board
 -include $(BOARDDIR)/Makefile.default
 

--- a/makefiles/dependency_resolution.inc.mk
+++ b/makefiles/dependency_resolution.inc.mk
@@ -35,14 +35,26 @@ NEW_STATE := $(USEMODULE) $(USEPKG) $(FEATURES_USED)
 ifneq ($(OLD_STATE),$(NEW_STATE))
   include $(RIOTMAKE)/dependency_resolution.inc.mk
 else
+  # Include late allowing them to have been disabled during dependency resolution
+  DEFAULT_MODULE += auto_init periph_init
+  USEMODULE += $(filter-out $(DISABLE_MODULE),auto_init periph_init)
+
   # If module auto_init is not used, silently disable all of its submodules
   ifeq (,$(filter auto_init,$(USEMODULE)))
     DISABLE_MODULE += auto_init_%
   endif
 
-  # add default modules again, as $(DEFAULT_MODULE) might have been extended
-  # during dependency processing
+  # If module periph_init is not used, silently disable all of its submodules
+  ifeq (,$(filter periph_init,$(USEMODULE)))
+    DISABLE_MODULE += periph_init_%
+  endif
+
+  # Add default modules again, as $(DEFAULT_MODULE) might have been extended
+  # during dependency resolution
   USEMODULE += $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE))
+
+  # Include eventual dependencies for default modules
+  include $(RIOTMAKE)/default_modules.deps.mk
 
   # Sort and de-duplicate used modules and default modules for readability
   USEMODULE := $(sort $(USEMODULE))

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -10,32 +10,30 @@ PERIPH_FEATURES := $(filter periph_%,$(FEATURES_USED))
 USEMODULE += $(PERIPH_FEATURES)
 
 # Add all USED periph_% init modules unless they are blacklisted
-ifneq (,$(filter periph_init, $(USEMODULE)))
-  PERIPH_IGNORE_MODULES := \
-    periph_init% \
-    periph_common \
-    periph_flexcomm \
-    periph_gpio_mux \
-    periph_i2c_hw \
-    periph_i2c_sw \
-    periph_rtc_ms \
-    periph_mcg \
-    periph_wdog \
-    periph_flash \
-    periph_rtc_rtt \
-    periph_rtt_hw_rtc \
-    periph_rtt_hw_sys \
-    periph_clic \
-    periph_coretimer \
-    periph_plic \
-    periph_spi_on_qspi
-    #
-  PERIPH_MODULES := $(filter-out $(PERIPH_IGNORE_MODULES),\
-                                 $(filter periph_%,$(USEMODULE)))
-  # Use simple expansion to avoid USEMODULE referencing itself
-  PERIPH_INIT_MODULES := $(subst periph_,periph_init_,$(PERIPH_MODULES))
-  DEFAULT_MODULE += $(PERIPH_INIT_MODULES)
-endif
+PERIPH_IGNORE_MODULES := \
+  periph_init% \
+  periph_common \
+  periph_flexcomm \
+  periph_gpio_mux \
+  periph_i2c_hw \
+  periph_i2c_sw \
+  periph_rtc_ms \
+  periph_mcg \
+  periph_wdog \
+  periph_flash \
+  periph_rtc_rtt \
+  periph_rtt_hw_rtc \
+  periph_rtt_hw_sys \
+  periph_clic \
+  periph_coretimer \
+  periph_plic \
+  periph_spi_on_qspi
+  #
+PERIPH_MODULES := $(filter-out $(PERIPH_IGNORE_MODULES),\
+                               $(filter periph_%,$(USEMODULE)))
+# Use simple expansion to avoid USEMODULE referencing itself
+PERIPH_INIT_MODULES := $(subst periph_,periph_init_,$(PERIPH_MODULES))
+DEFAULT_MODULE += $(PERIPH_INIT_MODULES)
 
 # select cpu_check_address pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cpu_check_address, $(FEATURES_USED))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -88,10 +88,6 @@ ifneq (,$(filter base64url,$(USEMODULE)))
   USEMODULE += base64
 endif
 
-ifneq (,$(filter auto_init_saul,$(USEMODULE)))
-  USEMODULE += saul_init_devs
-endif
-
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer
@@ -119,10 +115,6 @@ ifneq (,$(filter dhcpv6_relay,$(USEMODULE)))
   USEMODULE += event
   USEMODULE += sock_async_event
   USEMODULE += sock_udp
-endif
-
-ifneq (,$(filter auto_init_dhcpv6_relay,$(USEMODULE)))
-  USEMODULE += dhcpv6_relay
 endif
 
 ifneq (,$(filter dns_%,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -115,6 +115,7 @@ ifneq (,$(filter dhcpv6_client,$(USEMODULE)))
 endif
 
 ifneq (,$(filter dhcpv6_relay,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_dhcpv6_relay
   USEMODULE += event
   USEMODULE += sock_async_event
   USEMODULE += sock_udp

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -7,9 +7,6 @@ ifneq (,$(filter ztimer,$(USEMODULE)))
   USEMODULE += ztimer_core
   USEMODULE += ztimer_convert_frac
   USEMODULE += ztimer_convert_shift
-  ifneq (,$(filter auto_init_ztimer,$(USEMODULE)))
-    USEMODULE += ztimer_init
-  endif
   DEFAULT_MODULE += auto_init_ztimer
   DEFAULT_MODULE += ztimer_init
 endif

--- a/tests/gnrc_dhcpv6_relay/Makefile
+++ b/tests/gnrc_dhcpv6_relay/Makefile
@@ -4,7 +4,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 export TAP ?= tap0
 
-USEMODULE += auto_init_dhcpv6_relay
+USEMODULE += dhcpv6_relay
 USEMODULE += event_thread
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_netif_single          # Only one interface used and it makes


### PR DESCRIPTION
### Contribution description

Some DEFAULT_MODULEs in tree have dependencies of their own. This is
usually done for aliases of init modules, and do not have dependencies
themselves.

This adds the final stage to dependency resolutions where DEFAULT_MODULEs
dependencies MAY be included. These included modules MUST NOT have
dependencies themselves.

This allows for modules to disable DEFAULT_MODULEs during dependencies
resolution independent of the inclusion order.

auto_init and periph_init modules are moved to this outer-loop, allowing
therefore for modules to disable them during the dependency resolution

### Testing procedure

Dependencies should not have changed.

### Issues/PRs references

Could be used by #17584
