### PR TITLE
cpu/native/netdev_tap: Add to netdev_register

### DIFF
--- a/cpu/native/include/netdev_tap.h
+++ b/cpu/native/include/netdev_tap.h
@@ -59,8 +59,10 @@ typedef struct {
  *
  * @param dev       the preallocated netdev_tap device handle to setup
  * @param params    initialization parameters
+ * @param index     Index of @p params in a global parameter struct array.
+ *                  If initialized manually, pass a unique identifier instead.
  */
-void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params);
+void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params, int index);
 
 #ifdef __cplusplus
 }

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -290,10 +290,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     return res;
 }
 
-void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params) {
+void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params, int index) {
     dev->netdev.driver = &netdev_driver_tap;
     strncpy(dev->tap_name, *(params->tap_name), IFNAMSIZ - 1);
     dev->tap_name[IFNAMSIZ - 1] = '\0';
+    netdev_register(&dev->netdev, NETDEV_TAP, index);
 }
 
 static void _tap_isr(int fd, void *arg) {

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -323,6 +323,7 @@ typedef enum {
     NETDEV_CC2420,
     NETDEV_ETHOS,
     NETDEV_SLIPDEV,
+    NETDEV_TAP,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_netdev_tap.c
+++ b/pkg/lwip/init_devs/auto_init_netdev_tap.c
@@ -33,7 +33,7 @@ static netdev_tap_t netdev_taps[NETIF_TAP_NUMOF];
 static void auto_init_netdev_tap(void)
 {
     for (unsigned i = 0; i < NETIF_TAP_NUMOF; i++) {
-        netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i]);
+        netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i], i);
         if (lwip_add_ethernet(&netif[i], &netdev_taps[i].netdev) == NULL) {
             DEBUG("Could not add netdev_tap device\n");
             return;

--- a/sys/net/gnrc/netif/init_devs/auto_init_netdev_tap.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_netdev_tap.c
@@ -38,7 +38,7 @@ void auto_init_netdev_tap(void)
         LOG_DEBUG("[auto_init_netif] initializing netdev_tap #%u on TAP %s\n",
                   i, *(p->tap_name));
 
-        netdev_tap_setup(&netdev_tap[i], p);
+        netdev_tap_setup(&netdev_tap[i], p, i);
         gnrc_netif_ethernet_create(&_netif[i], _netdev_eth_stack[i], TAP_MAC_STACKSIZE,
                                    TAP_MAC_PRIO, "gnrc_netdev_tap",
                                    &netdev_tap[i].netdev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This adds the `netdev_tap` device to `netdev_register`. This is convenient for testing.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
N/A
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
N/A
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
