### PR TITLE
net/gnrc/pkt: Fix ISO C++ compatibility

### DIFF
--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -210,7 +210,7 @@ static inline gnrc_pktsnip_t *gnrc_pkt_prepend(gnrc_pktsnip_t *pkt,
 static inline gnrc_pktsnip_t *gnrc_pkt_delete(gnrc_pktsnip_t *pkt,
                                               gnrc_pktsnip_t *snip)
 {
-    list_node_t list = { .next = (list_node_t *)pkt };
+    list_node_t list = { (list_node_t *)pkt };
 
     list_remove(&list, (list_node_t *)snip);
     return (gnrc_pktsnip_t *)list.next;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Currently this header can't be included from C++ files when building for native:
```
/data/riotbuild/riotproject/RIOT/sys/include/net/gnrc/pkt.h: In function ‘gnrc_pktsnip_t* gnrc_pkt_delete(gnrc_pktsnip_t*, gnrc_pktsnip_t*)’:
/data/riotbuild/riotproject/RIOT/sys/include/net/gnrc/pkt.h:213:26: error: C++ designated initializers only available with ‘-std=c++2a’ or ‘-std=gnu++2a’ [-Werror=pedantic]
  213 |     list_node_t list = { .next = (list_node_t *)pkt };
      |                          ^
cc1plus: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotproject/RIOT/Makefile.base:166: /data/riotbuild/riotproject/sock_udp_example_cpp/bin/native/sock_udp_base_cpp/sock_udp_base.o] Error 1
make[1]: *** [/data/riotbuild/riotproject/RIOT/Makefile.base:31: ALL--/data/riotbuild/riotproject/modules/sock_udp_base_cpp] Error 2
make[1]: *** Waiting for unfinished jobs....
```
This doesn't happen with other compilers like `gcc-arm-none-eabi`.

I know the code change makes the code less readable. If you have better ideas on fixing it, I am happy for suggestions. We could also think about removing the ISO C++ requirement from the compiler flags for `native`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
