### PR TITLE
net: Add typedef for AF enum

### DIFF
--- a/sys/include/net/af.h
+++ b/sys/include/net/af.h
@@ -24,7 +24,10 @@
 extern "C" {
 #endif
 
-enum {
+/**
+ * @brief   UNIX address family definitions
+ */
+typedef enum {
     AF_UNSPEC = 0,              /**< unspecified address family */
 #define AF_UNSPEC   AF_UNSPEC   /**< unspecified address family (as macro) */
     AF_UNIX,                    /**< local to host (pipes, portals) address family. */
@@ -39,7 +42,7 @@ enum {
     AF_NUMOF,                   /**< maximum number of address families on this system */
 #define AF_NUMOF    AF_NUMOF    /**< maximum number of address families on this system (as macro) */
 #define AF_MAX      AF_NUMOF    /**< alias for @ref AF_NUMOF */
-};
+} unix_af_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This adds a `typedef` to the unix interface family enum.
This is useful as it allows to have the interface family as enum method parameter and then improves compile time type checks.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
