### PR TITLE
subsystems: Initial exploration

### DIFF
--- a/dist/codetopics/codeowners.ttl
+++ b/dist/codetopics/codeowners.ttl
@@ -1,0 +1,5 @@
+@prefix ont: <ontology.ttl#>.
+@prefix topic: <topcis.ttl#>.
+@prefix user: <runtime-mappings.ttl#user->.
+
+topic:board-microbit-v2 ont:codeowner user:chrysn.

--- a/dist/codetopics/export.py
+++ b/dist/codetopics/export.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+"""Just a quick hack to get a .ttl file with sane prefixes for tools like
+https://skos-play.sparna.fr/skos-testing-tool/,
+https://skos-play.sparna.fr/play/ or
+http://owlgred.lumii.lv/online_visualization"""
+
+import rdflib
+import glob
+
+g = rdflib.Graph()
+for f in glob.glob('*.ttl'):
+    g.load(open(f), format="turtle")
+
+with open('/home/chrysn/Downloads/all.ttl', 'wb') as outfile:
+    g.serialize(outfile, format='turtle')

--- a/dist/codetopics/issues.ttl
+++ b/dist/codetopics/issues.ttl
@@ -1,0 +1,52 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ont: <ontology.ttl#>.
+@prefix : <#>.
+
+# We may not even need to track these; the labeler also doesn't touch them.
+
+:concepts a skos:ConceptScheme;
+  dct:title "RIOT issue and PR concepts";
+  rdfs:comment "An organization structure of issues and pull requests of the RIOT-OS code base.";
+  skos:hasTopConcept :type.
+
+# Copied over the "Type" as an example; "State", "Reviewed", "Process", "Release notes", "Waiting for", "Community", "Discussion", "Impact" and "CI" would match well, not sure about "TF" and "PR-award-nominee".
+#
+# Not sure if we'd even generate them from our labels (might be convenient to
+# have a single source of truth in labels).
+
+:type a skos:Concept;
+    skos:inScheme :concepts;
+    ont:color "#ffff66";
+    skos:prefLabel "Type".
+:type-bug a skos:Concept;
+    skos:inScheme :concepts;
+    skos:broader :type;
+    skos:prefLabel "bug";
+    skos:scopeNote "The issue reports a bug / The PR fixes a bug (including spelling errors)".
+:type-cleanup a skos:Concept;
+    skos:inScheme :concepts;
+    skos:broader :type;
+    skos:prefLabel "cleanup";
+    skos:scopeNote "The issue proposes a clean-up / The PR cleans-up parts of the codebase / documentation".
+:type-enhancement a skos:Concept;
+    skos:inScheme :concepts;
+    skos:broader :type;
+    skos:prefLabel "enhancement";
+    skos:scopeNote "The issue suggests enhanceable parts / The PR enhances parts of the codebase / documentation".
+:type-new-feature a skos:Concept;
+    skos:inScheme :concepts;
+    skos:broader :type;
+    skos:prefLabel "new feature";
+    skos:scopeNote "The issue requests / The PR implemements a new feature for RIOT".
+:type-question a skos:Concept;
+    skos:inScheme :concepts;
+    skos:broader :type;
+    skos:prefLabel "question";
+    skos:scopeNote "The issue poses a question regarding usage of RIOT".
+:type-tracking a skos:Concept;
+    skos:inScheme :concepts;
+    skos:broader :type;
+    skos:prefLabel "tracking";
+    skos:scopeNote "The issue tracks and organizes the sub-tasks of a larger effort".

--- a/dist/codetopics/ontology.ttl
+++ b/dist/codetopics/ontology.ttl
@@ -1,0 +1,17 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+@prefix ont: <#>.
+
+ont:doxygroup a rdf:Property;
+  rdfs:comment "The group in RIOT's doxygen that a concept is identified with. This can be turned into a URI with additional information about RIOT's current public documentation base URI and doxygen's name mangling rules.";
+  rdfs:domain skos:Concept;
+  rdfs:range xsd:string.
+
+ont:color a rdf:Property;
+  rdfs:comment "Color the concept (and its narrower concepts, unless overridden) have when represented visually, eg. on GitHub";
+  rdfs:domain skos:Concept;
+  rdfs:range xsd:string. # Is there an XSD data type for these, and if yes, do we have to reiterate it each time the property is used?

--- a/dist/codetopics/runtime-mappings.ttl
+++ b/dist/codetopics/runtime-mappings.ttl
@@ -1,0 +1,18 @@
+@prefix topic: <topcis.ttl#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix issues: <issues.ttl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix : <#>.
+@prefix user: <#user->.
+
+# These are not expected to be kept in code, but associated to issues somehow, possibly via GitHub tags.
+
+<https://github.com/RIOT-OS/RIOT/pull/16234> dct:subject topic:board-microbit-v2, issues:type-enhancement.
+
+# As are these (if we need them at all)
+
+:riot-members a foaf:Group;
+  foaf:member user:daniel-k. #, ..., ...
+
+user:daniel-k foaf:account <https://github.com/daniel-k>.
+user:chrysn foaf:account <https://github.com/chrysn>.

--- a/dist/codetopics/topics.ttl
+++ b/dist/codetopics/topics.ttl
@@ -1,0 +1,56 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ont: <ontology.ttl#>.
+@prefix : <#>.
+
+:code-topics a skos:ConceptScheme;
+  dct:title "RIOT code topics";
+  rdfs:comment "An organization structure of concepts for different parts of the RIOT-OS code base. Concepts in this structure are often related to particular files or folders of RIOT code. Code topics are often assigned to issues or PRs, but can also be linked to the documentation pages";
+  skos:hasTopConcept :all-code. # It may alternatively be useful to do go for the second-level directly.
+
+:all-code a skos:Concept; skos:prefLabel "RIOT-OS"; skos:inScheme :code-topics.
+
+:board a skos:Concept; skos:prefLabel "Board"; skos:inScheme :code-topics;
+  skos:scopeNote "This encompasses both groups of boards ('boards/common') and individual boards ('boards/*' except common)";
+  ont:doxygroup "boards";
+  skos:broader :all-code.
+
+# Keeping this inbetween rather than having it as a skos:Collection is "clearly not a best practice" (https://www.w3.org/TR/2009/NOTE-skos-primer-20090818/#seccollections), but let's still try for simple.
+:board-implementation a skos:Concept; skos:prefLabel "Named board"; skos:inScheme :code-topics;
+  skos:broader :board.
+
+:board-group a skos:Concept; skos:prefLabel "Common board group"; skos:inScheme :code-topics;
+  skos:broader :board.
+
+# We may manage to automate them from the file structure.
+
+:board-common-atxmega a skos:Concept; skos:prefLabel "ATXmega boards"; skos:inScheme :code-topics;
+  skos:broader :board-group.
+
+# These we should generate from the file structure, maybe even likewise with drivers.
+
+# first one
+:board-6lowpan-clicker a skos:Concept; skos:inScheme :code-topics;
+  skos:broader :board-implementation;
+  ont:glob "boards/6lowpan-clicker".
+
+# fits in the first 
+:board-atxmega-a1-xplained a skos:Concept; skos:inScheme :code-topics;
+  skos:broader :board-implementation;
+  ont:glob "boards/atxmega-a1-xplained";
+  ont:doxygroup "boards_atxmega-a1-xplained"; # Can we get this one automatically? Probably by looking for defgroup in ../../boards/.../doc.txt
+  skos:broader :board-common-atxmega. # Can we get these automatically? Is 'broader' really the right relation here, or would skos:Collection be better?
+
+# part of the runtime-mappings.ttl example
+:board-microbit-v2 a skos:Concept; skos:inScheme :code-topics;
+  skos:broader :board-implementation;
+  ont:glob "boards/microbit-v2";
+  ont:doxygroup "boards_microbit_v2";
+  skos:broader :board-common-microbit.
+
+
+# These are just a few things kept around to memorize that the SKOS terms for this exist
+
+# or even go for skosxl? probably overkill (maybe the below already is)
+:GNRC a skos:Concept; skos:prefLabel "Generic (GNRC) network stack"; skos:altLabel "GNRC"; skos:inScheme :code-topics.


### PR DESCRIPTION
### Contribution description

This is some initial modelling I'm playing around with to eventually have all data available to describe subsystems, their designated experts, and how these map to PRs. Eventually, that should unify the assignments currently done in `./.github/labeler.yml` and `./CODEOWNERS`.

This is all rather early, and I expect much of what's currently in here to change its shape or go away completely eventually; I'm posting this as a Draft PR to allow others to peek into what is going on.

### Testing procedure

TBD; will largely interact with CI

### Issues/PRs references

See discussions staring at the 2021 summit.