### PR TITLE
boards/nucleo-l552ze-q doc: Improvements to documentation

### DIFF
--- a/boards/nucleo-l552ze-q/doc.txt
+++ b/boards/nucleo-l552ze-q/doc.txt
@@ -3,6 +3,37 @@
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-L552ZE-Q
 
+## Overview
+
+The Nucleo-L552ZE-Q is a board from ST's Nucleo family supporting ARM Cortex-M33
+STM32L552ZE ultra-low-pawer microcontroller with TrustZone, 256kB or RAM and 512Kb
+of Flash.
+
+## Hardware
+
+![Nucleo144 L552ZE-Q](https://www.st.com/bin/ecommerce/api/image.PF267817.en.feature-description-include-personalized-no-cpn-large.jpg)
+
+### MCU
+
+| MCU          | STM32L552ZE                  |
+|:-------------|:-----------------------------|
+| Family       | ARM Cortex-M33               |
+| Vendor       | ST Microelectronics          |
+| RAM          | 256Kb                        |
+| Flash        | 512Kb                        |
+| Frequency    | up tp 110MHz                 |
+| FPU          | yes                          |
+| TrustZone    | yes                          |
+| Timers       | 16                           |
+| UARTs        | 6 (3xUSART, 2xUART, 1xLPUART)|
+| I2cs         | 4                            |
+| SPIs         | 3                            |
+| CAN          | 1                            |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l552ze.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00346336-stm32l552xx-and-stm32l562xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0264-stm32-cortexm33-mcus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/dm00615305-stm32l5-nucleo-144-board-mb1361-stmicroelectronics.pdf)|
+
 ## Flashing the device
 
 The ST Nucleo-L552ZE-Q board includes an on-board ST-LINK programmer and can be
@@ -33,6 +64,20 @@ and debug via GDB by simply typing
 ```
 make BOARD=nucleo-l552ze-q debug
 ```
+
+## Accessing RIOT shell
+
+Default RIOT shell access utilize VCP (Virtual COM Port) via USB interface,
+provided by integrated ST-LINK programmer. ST-LINK is connected to the
+microcontroller LPUART1.
+
+The default baud rate is 115 200.
+
+If a physical connection to LPUART1 is needed, connect UART interface to pins
+PG7 (LPUART1 TX) and PG8 (LPUART1 RX).
+
+@note Accordingly to the [MCU Datasheet](https://www.st.com/resource/en/datasheet/stm32l552ze.pdf)
+PG7 and PG8 pins are 5V tolerant (see table 21, page 108).
 
 ## Supported Toolchains
 


### PR DESCRIPTION
### Contribution description
Improvements to STM Nucleo L552ZE-QE documentation:

- Add board image,
- Add MCU table - similar to those, for example for, Nucleo F103RB, F302R8 or F446RE,
- Add information concerning accessing RIOT shell (see Issue #17453) 

### Testing procedure

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l552ze-q.html
```

### Issues/PRs references

Issue #17453
