### PR TITLE
tests/senml: do no include saul_default

### DIFF
--- a/tests/senml_cbor/main.c
+++ b/tests/senml_cbor/main.c
@@ -104,7 +104,7 @@ void test_senml_encode(void)
     fmt_bytes_hex(result, cbor_buf, len);
 
     /* Compare hex result */
-    TEST_ASSERT_EQUAL_INT(2 * len, sizeof expect - 1);
+    TEST_ASSERT_EQUAL_INT(2 * len, sizeof(expect) - 1);
     TEST_ASSERT_EQUAL_INT(0, strncmp(expect, result, len));
 }
 

--- a/tests/senml_saul/Makefile
+++ b/tests/senml_saul/Makefile
@@ -1,6 +1,5 @@
 include ../Makefile.tests_common
 
-USEMODULE += saul_default
 USEMODULE += senml_saul
 USEMODULE += fmt
 USEMODULE += embunit

--- a/tests/senml_saul/main.c
+++ b/tests/senml_saul/main.c
@@ -39,7 +39,7 @@ void test_senml_encode(void)
     fmt_bytes_hex(result, cbor_buf, len);
 
     /* Compare hex result */
-    TEST_ASSERT_EQUAL_INT(2 * len, sizeof expect - 1);
+    TEST_ASSERT_EQUAL_INT(2 * len, sizeof(expect) - 1);
     TEST_ASSERT_EQUAL_INT(0, strncmp(expect, result, len));
 }
 


### PR DESCRIPTION
### Contribution description

Seems like my last test of #16384 was too old since an error sneaked in, the saul tests expect there to be no saul device present... so do not include saul-default.

### Testing procedure

```
EXTERNAL_BOARD_DIRS= RYOT_CI=1 BOARD=samr21-xpro make -C tests/senml_saul/ flash test -j
Building application "tests_senml_saul" for "samr21-xpro" with MCU "samd21".

"make" -C /home/francisco/workspace/RIOT/pkg/nanocbor/ 
"make" -C /home/francisco/workspace/RIOT/build/pkg/nanocbor/src -f /home/francisco/workspace/RIOT/Makefile.base MODULE=nanocbor
"make" -C /home/francisco/workspace/RIOT/boards/samr21-xpro
"make" -C /home/francisco/workspace/RIOT/core
"make" -C /home/francisco/workspace/RIOT/cpu/samd21
"make" -C /home/francisco/workspace/RIOT/drivers
"make" -C /home/francisco/workspace/RIOT/sys
"make" -C /home/francisco/workspace/RIOT/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT/drivers/saul
"make" -C /home/francisco/workspace/RIOT/sys/auto_init
"make" -C /home/francisco/workspace/RIOT/sys/embunit
"make" -C /home/francisco/workspace/RIOT/sys/fmt
"make" -C /home/francisco/workspace/RIOT/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT/sys/malloc_thread_safe
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common
"make" -C /home/francisco/workspace/RIOT/cpu/samd21/periph
"make" -C /home/francisco/workspace/RIOT/cpu/sam0_common/periph
"make" -C /home/francisco/workspace/RIOT/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT/cpu/samd21/vectors
"make" -C /home/francisco/workspace/RIOT/sys/phydat
"make" -C /home/francisco/workspace/RIOT/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT/sys/saul_reg
"make" -C /home/francisco/workspace/RIOT/sys/senml
"make" -C /home/francisco/workspace/RIOT/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT/sys/tsrb
"make" -C /home/francisco/workspace/RIOT/cpu/cortexm_common/periph
   text	   data	    bss	    dec	    hex	filename
  14612	    140	   2772	  17524	   4474	/home/francisco/workspace/RIOT/tests/senml_saul/bin/samr21-xpro/tests_senml_saul.elf
rsync --chmod=ugo=rwX /home/francisco/workspace/RIOT/tests/senml_saul/bin/samr21-xpro/tests_senml_saul.bin ci@ci-riot-tribe.saclay.inria.fr:/builds/boards/bin/samr21-xpro_flashfile.bin
ssh ci@ci-riot-tribe.saclay.inria.fr 'IMAGE_OFFSET= BOARD=samr21-xpro QUIET=1 make --no-print-directory -C /builds/boards flash-only FLASHFILE=/builds/boards/bin/samr21-xpro_flashfile.bin'
/builds/boards/RIOT/dist/tools/edbg/edbg.sh flash /builds/boards/bin/samr21-xpro_flashfile.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004957 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x4 expected 0xb1, read 0xb5
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004957 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming..... done.
Verification..... done.
Done flashing
r
ssh -t ci@ci-riot-tribe.saclay.inria.fr 'BOARD=samr21-xpro QUIET=1 make --no-print-directory -C /builds/boards cleanterm' 
/builds/boards/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-samr21-xpro" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/riot/tty-samr21-xpro
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2022.04-devel-345-ga0ec1-pr_senml_saul_default)
.
OK (1 tests)
```
### Issues/PRs references

Spotted in #16789 
