### PR TITLE
sys/pm_layered: allow board.h to set PM_BLOCKER_INITIAL

### DIFF
--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -20,6 +20,7 @@
 
 #include <assert.h>
 
+#include "board.h"
 #include "atomic_utils.h"
 #include "irq.h"
 #include "periph/pm.h"


### PR DESCRIPTION
### Contribution description

This PR includes `board.h` in `pm_layered`. This allow boards to save energy by selecting an appropriate `PM_BLOCKER_INITIAL` value.

I'm currently working on the `efm32` family. Every peripheral requiring a certain PM mode blocks it during power-on of the peripheral in question. Thus, setting `PM_BLOCKER_INITIAL` to `0x0` would result in a system that's entering the right PM mode depending whether a certain peripheral is used or not.

### Testing procedure


### Issues/PRs references

