### PR TITLE
sys/vfs: add vfs_default, configure default fs for same54-xpro

### DIFF
--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -14,4 +14,10 @@ ifneq (,$(filter periph_can,$(FEATURES_USED)))
   endif
 endif
 
+# default to using littlefs2 on the virtual flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif
+
 USEMODULE += native_drivers

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -49,25 +49,25 @@ mtd_dev_t *mtd0 = &mtd0_dev.base;
 #if defined(MODULE_LITTLEFS)
 
 #include "fs/littlefs_fs.h"
-VFS_AUTO_MOUNT(littlefs, VFS_MTD(mtd0_dev), "/", 0);
+VFS_AUTO_MOUNT(littlefs, VFS_MTD(mtd0_dev), "/nvm", 0);
 
 /* littlefs2 support */
 #elif defined(MODULE_LITTLEFS2)
 
 #include "fs/littlefs2_fs.h"
-VFS_AUTO_MOUNT(littlefs2, VFS_MTD(mtd0_dev), "/", 0);
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(mtd0_dev), "/nvm", 0);
 
 /* spiffs support */
 #elif defined(MODULE_SPIFFS)
 
 #include "fs/spiffs_fs.h"
-VFS_AUTO_MOUNT(spiffs, VFS_MTD(mtd0_dev), "/", 0);
+VFS_AUTO_MOUNT(spiffs, VFS_MTD(mtd0_dev), "/nvm", 0);
 
 /* FAT support */
 #elif defined(MODULE_FATFS_VFS)
 
 #include "fs/fatfs.h"
-VFS_AUTO_MOUNT(fatfs, VFS_MTD(mtd0_dev), "/", 0);
+VFS_AUTO_MOUNT(fatfs, VFS_MTD(mtd0_dev), "/nvm", 0);
 
 #endif
 #endif /* MODULE_VFS */

--- a/boards/same54-xpro/Makefile.dep
+++ b/boards/same54-xpro/Makefile.dep
@@ -16,3 +16,9 @@ endif
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sam0_eth
 endif
+
+# default to using littlefs2 on the external flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -61,6 +61,11 @@ static mtd_at24cxxx_t at24mac_dev = {
     .params = at24cxxx_params,
 };
 mtd_dev_t *mtd1 = (mtd_dev_t *)&at24mac_dev;
+
+#ifdef MODULE_VFS_DEFAULT
+#include "fs/littlefs2_fs.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(same54_nor_dev), "/nvm", 0);
+#endif
 #endif /* MODULE_MTD */
 
 void board_init(void)

--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -30,8 +30,6 @@ USEMODULE += mtd
 
 # Use VFS
 USEMODULE += vfs
-# the example demonstrates manual file system mounting, disable auto-mount
-DISABLE_MODULE += vfs_auto_mount
 
 # Use a file system
 # USEMODULE += littlefs

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -217,8 +217,39 @@ PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
 PSEUDOMODULES += vdd_lc_filter_%
+## @defgroup pseudomodule_vfs_auto_format vfs_auto_format
+## @brief Format mount points at startup unless they can be mounted
+##
+## When this module is active, mount points configured through the @ref
+## pseudomodule_vfs_auto_mount module that can not be mounted at startup are
+## formatted and, if that operation is successful, attempted to mount again.
+##
+## Beware that this may be a harmful procedure in case a bug that corrupts a
+## filesystem coincides with a bug that sends the device into a reboot loop.
 PSEUDOMODULES += vfs_auto_format
+
+## @defgroup pseudomodule_vfs_auto_mount vfs_auto_mount
+## @brief Mount file systems at startup
+##
+## When this module is active, mount points specified through
+## @ref VFS_AUTO_MOUNT are mounted at their designated mount points at startup.
+## These mount points can be specified by the application, or are provided by
+## some boards if the @ref pseudomodule_vfs_default module is active.
 PSEUDOMODULES += vfs_auto_mount
+
+## @defgroup pseudomodule_vfs_default vfs_default
+## @brief Enable default assignments of a board's devices to VFS mount points
+##
+## When this module is active, boards with additional flash storage will
+## automatically mount (and possibly format, if @ref
+## pseudomodule_vfs_auto_format is enabled) their flash devices with a file
+## system that is common for that board (or at least common for this board
+## within RIOT).
+##
+## Boards will generally mount to `/nvm` unless they have several storage
+## backends.
+PSEUDOMODULES += vfs_default
+
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -498,12 +498,16 @@ ifneq (,$(filter devfs,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += vfs
+  DEFAULT_MODULE += vfs_auto_mount
+endif
+
 ifneq (,$(filter vfs,$(USEMODULE)))
   USEMODULE += posix_headers
   ifeq (native, $(BOARD))
     USEMODULE += native_vfs
   endif
-  DEFAULT_MODULE += vfs_auto_mount
 endif
 
 ifneq (,$(filter sock_async_event,$(USEMODULE)))

--- a/sys/vfs/Kconfig
+++ b/sys/vfs/Kconfig
@@ -10,10 +10,14 @@ config MODULE_VFS
     depends on TEST_KCONFIG
     select MODULE_POSIX_HEADERS
 
+config MODULE_VFS_DEFAULT
+    bool "Use default (board specific) file systems and mount points"
+    depends on MODULE_VFS
+    imply MODULE_VFS_AUTO_MOUNT
+
 config MODULE_VFS_AUTO_MOUNT
     bool "Automatically mount configured file systems"
     depends on MODULE_VFS
-    default y
 
 config MODULE_VFS_AUTO_FORMAT
     bool "Automatically format configured file systems if mount fails"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a `vfs_default` pseudo-module that works analogous to the `netdev_default` module and let's a board specify a default file system and mount point.

As an example I configured littlefs2 for the external flash on the `same54-xpro` which gets mounted to `/nvm`.

### Testing procedure

Add 

    USEMODULE += vfs_default

to any application (e.g. `examples/gnrc_networking`). You now have a file system! (and a `ls` command) 

Add the

    USEMODULE += vfs_auto_format

module if you want to automatically create the file system too. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
