### PR TITLE
pkt/littlefs: Initialize stat buffers before partially writing

### DIFF
--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -396,6 +396,7 @@ static int _fsync(vfs_file_t *filp)
 static int _stat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
 {
     littlefs_desc_t *fs = mountp->private_data;
+    memset(buf, 0, sizeof(*buf));
 
     mutex_lock(&fs->lock);
 
@@ -432,6 +433,7 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
 {
     (void)path;
     littlefs_desc_t *fs = mountp->private_data;
+    memset(buf, 0, sizeof(*buf));
 
     mutex_lock(&fs->lock);
 

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -402,6 +402,7 @@ static int _fsync(vfs_file_t *filp)
 static int _stat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
 {
     littlefs2_desc_t *fs = mountp->private_data;
+    memset(buf, 0, sizeof(*buf));
 
     mutex_lock(&fs->lock);
 
@@ -438,6 +439,7 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
 {
     (void)path;
     littlefs2_desc_t *fs = mountp->private_data;
+    memset(buf, 0, sizeof(*buf));
 
     mutex_lock(&fs->lock);
 


### PR DESCRIPTION
As the global stat and statvfs handlers don't zero the buffer, it's up to the individual FSs to initialize the structs that the caller passes in (typically containing whatever was on the stack). This avoids readers getting stack content when actually the file system does not report anything meaningful.

### Testing procedure

```
$ make -C examples/filesystem all term
main(): This is RIOT! (Version: 2022.04-devel-321-g02109f-littlefs-stat-buffers)
constfs mounted successfully
> format
format
/sda successfully formatted
> mount
mount
/sda successfully mounted
> vfs df
vfs df
Mountpoint              Total         Used    Available     Capacity
/sda                     2048            2         2046       0%
/const                     27           27            0     100%
> 
```

(Unmodified to status before -- we don't have any code that read the uninit'd fields, or it would have shown earlier)

### Issues/PRs references

Noted when reviewing https://github.com/RIOT-OS/RIOT/pull/17634#discussion_r805144779