### PR TITLE
vfs: Initialize stat buffers so FSs don't have to

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -307,8 +307,6 @@ static int _fstat(vfs_file_t *filp, struct stat *buf)
     FILINFO fi;
     FRESULT res;
 
-    memset(buf, 0, sizeof(*buf));
-
     res = f_stat(fs_desc->abs_path_str_buff, &fi);
 
     if (res != FR_OK) {

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -227,7 +227,6 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
         return -EFAULT;
     }
     spiffs_desc_t *fs_desc = mountp->private_data;
-    memset(buf, 0, sizeof(*buf));
 
     uint32_t total;
     uint32_t used;
@@ -346,8 +345,6 @@ static int _fstat(vfs_file_t *filp, struct stat *buf)
     spiffs_desc_t *fs_desc = filp->mp->private_data;
     spiffs_stat stat;
     s32_t ret;
-
-    memset(buf, 0, sizeof(*buf));
 
     ret = SPIFFS_fstat(&fs_desc->fs, filp->private_data.value, &stat);
 

--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -144,7 +144,6 @@ static int constfs_statvfs(vfs_mount_t *mountp, const char *restrict path, struc
     }
     constfs_t *fs = mountp->private_data;
     /* clear out the stat buffer first */
-    memset(buf, 0, sizeof(*buf));
     buf->f_bsize = sizeof(uint8_t); /* block size */
     buf->f_frsize = sizeof(uint8_t); /* fundamental block size */
     fsblkcnt_t f_blocks = 0;
@@ -309,8 +308,7 @@ static int constfs_closedir(vfs_DIR *dirp)
 
 static void _constfs_write_stat(const constfs_file_t *fp, struct stat *restrict buf)
 {
-    /* clear out the stat buffer first */
-    memset(buf, 0, sizeof(*buf));
+    /* buffer is cleared by vfs already */
     buf->st_nlink = 1;
     buf->st_mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
     buf->st_size = fp->size;

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -328,7 +328,6 @@ static int socket_close(vfs_file_t *filp)
 static inline int socket_fstat(vfs_file_t *filp, struct stat *buf)
 {
     (void)filp;
-    memset(buf, 0, sizeof(struct stat));
     buf->st_mode |= (S_IFSOCK | S_IRWXU | S_IRWXG | S_IRWXO);
     buf->st_blksize = SOCKET_BLKSIZE;
     return 0;

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -200,6 +200,7 @@ int vfs_fstat(int fd, struct stat *buf)
         /* driver does not implement fstat() */
         return -EINVAL;
     }
+    memset(buf, 0, sizeof(*buf));
     return filp->f_op->fstat(filp, buf);
 }
 
@@ -214,6 +215,7 @@ int vfs_fstatvfs(int fd, struct statvfs *buf)
         return res;
     }
     vfs_file_t *filp = &_vfs_open_files[fd];
+    memset(buf, 0, sizeof(*buf));
     if (filp->mp->fs->fs_op->fstatvfs == NULL) {
         /* file system driver does not implement fstatvfs() */
         if (filp->mp->fs->fs_op->statvfs != NULL) {
@@ -753,6 +755,7 @@ int vfs_stat(const char *restrict path, struct stat *restrict buf)
         atomic_fetch_sub(&mountp->open_files, 1);
         return -EPERM;
     }
+    memset(buf, 0, sizeof(*buf));
     res = mountp->fs->fs_op->stat(mountp, rel_path, buf);
     /* remember to decrement the open_files count */
     atomic_fetch_sub(&mountp->open_files, 1);
@@ -782,6 +785,7 @@ int vfs_statvfs(const char *restrict path, struct statvfs *restrict buf)
         atomic_fetch_sub(&mountp->open_files, 1);
         return -EPERM;
     }
+    memset(buf, 0, sizeof(*buf));
     res = mountp->fs->fs_op->statvfs(mountp, rel_path, buf);
     /* remember to decrement the open_files count */
     atomic_fetch_sub(&mountp->open_files, 1);
@@ -1042,6 +1046,7 @@ int vfs_sysop_stat_from_fstat(vfs_mount_t *mountp, const char *restrict path, st
     if (err < 0) {
         return err;
     }
+    memset(buf, 0, sizeof(*buf));
     err = f_op->fstat(&opened, buf);
     f_op->close(&opened);
     return err;

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -1046,7 +1046,6 @@ int vfs_sysop_stat_from_fstat(vfs_mount_t *mountp, const char *restrict path, st
     if (err < 0) {
         return err;
     }
-    memset(buf, 0, sizeof(*buf));
     err = f_op->fstat(&opened, buf);
     f_op->close(&opened);
     return err;


### PR DESCRIPTION
### Contribution description

File systems are sloppy around stat buffer initialization; this moves the zeroing over from the drivers to the VFS in general (before it even dispatches to the file system).

This was originally a problem of littlefs (fixed in the alternative PR https://github.com/RIOT-OS/RIOT/pull/17644) as found when reviewing the FatFS statvfs that would have had the same issue in https://github.com/RIOT-OS/RIOT/pull/17634#discussion_r805144779), and (when removing all the memsets that should have been there) also found in mtd-vfs and nvram-vfs (both around devfs, IIUC)

### Testing procedure

```
$ make -C examples/filesystem all term
main(): This is RIOT! (Version: 2022.04-devel-321-g02109f-littlefs-stat-buffers)
constfs mounted successfully
> format
format
/sda successfully formatted
> mount
mount
/sda successfully mounted
> vfs df
vfs df
Mountpoint              Total         Used    Available     Capacity
/sda                     2048            2         2046       0%
/const                     27           27            0     100%
> 
```

(Unmodified to status before -- we don't have any code that read the uninit'd fields, or it would have shown earlier)

### Issues/PRs references

This is a counterproposal to https://github.com/RIOT-OS/RIOT/pull/17644 as suggested by @benpicco; if it passes, also resolves the comment https://github.com/RIOT-OS/RIOT/pull/17634#discussion_r805144779 trivially.