### PR TITLE
tests/periph_flashpage: fix conditional compilation

### DIFF
--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -67,7 +67,7 @@ static int getpage(const char *str)
     return page;
 }
 
-#ifdef FLASHPAGE_SIZE
+#ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 static void dumpchar(uint8_t mem)
 {
     if (mem >= ' ' && mem <= '~') {
@@ -131,7 +131,7 @@ static int cmd_info(int argc, char **argv)
     return 0;
 }
 
-#ifdef FLASHPAGE_SIZE
+#ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 static int cmd_dump(int argc, char **argv)
 {
     int page;
@@ -271,7 +271,7 @@ static int cmd_erase(int argc, char **argv)
     return 0;
 }
 
-#ifdef FLASHPAGE_SIZE
+#ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 static int cmd_edit(int argc, char **argv)
 {
     int offset;
@@ -297,9 +297,7 @@ static int cmd_edit(int argc, char **argv)
 
     return 0;
 }
-#endif
 
-#ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 static int cmd_test(int argc, char **argv)
 {
     int page;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There were some issues in the tests conditional compilation:

1. `page_mem` was hard ifdef'd to MODULE_FLASHPAGE_PAGEWISE, but used under other conditions below
2. some shell commands where also hard ifdef'ed using the same module define, but their `cmd_...` functions had different conditionals.

<details>

```
Building application "tests_periph_flashpage" for "iotlab-m3" with MCU "stm32".                                           [231/307]
                                                                                                                                   
/home/kaspar/src/riot/tests/periph_flashpage/main.c: In function 'dump_local':
/home/kaspar/src/riot/tests/periph_flashpage/main.c:101:13: error: 'page_mem' undeclared (first use in this function)              
  101 |     memdump(page_mem, FLASHPAGE_SIZE);                                                                                     
      |             ^~~~~~~~                                     
/home/kaspar/src/riot/tests/periph_flashpage/main.c:101:13: note: each undeclared identifier is reported only once for each functio
n it appears in                                                                                                                    
/home/kaspar/src/riot/tests/periph_flashpage/main.c: In function 'cmd_read':                                                       
/home/kaspar/src/riot/tests/periph_flashpage/main.c:181:26: error: 'page_mem' undeclared (first use in this function)              
  181 |     flashpage_read(page, page_mem);                                                                                        
      |                          ^~~~~~~~                                                                                          
/home/kaspar/src/riot/tests/periph_flashpage/main.c: In function 'cmd_edit':                                                       
/home/kaspar/src/riot/tests/periph_flashpage/main.c:295:13: error: 'page_mem' undeclared (first use in this function)              
  295 |     memcpy(&page_mem[offset], argv[2], data_len);                                                                          
      |             ^~~~~~~~                                                                                                       
At top level:                                                    
/home/kaspar/src/riot/tests/periph_flashpage/main.c:275:12: error: 'cmd_edit' defined but not used [-Werror=unused-function]       
  275 | static int cmd_edit(int argc, char **argv)                                                                                 
      |            ^~~~~~~~                                                                                                        
/home/kaspar/src/riot/tests/periph_flashpage/main.c:167:12: error: 'cmd_read' defined but not used [-Werror=unused-function]       
  167 | static int cmd_read(int argc, char **argv)                                                                                 
      |            ^~~~~~~~                                      
/home/kaspar/src/riot/tests/periph_flashpage/main.c:157:12: error: 'cmd_dump_local' defined but not used [-Werror=unused-function]
  157 | static int cmd_dump_local(int argc, char **argv)
      |            ^~~~~~~~~~~~~~
/home/kaspar/src/riot/tests/periph_flashpage/main.c:135:12: error: 'cmd_dump' defined but not used [-Werror=unused-function]
  135 | static int cmd_dump(int argc, char **argv)
      |            ^~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [/home/kaspar/src/riot/Makefile.base:146: /home/kaspar/src/riot/tests/periph_flashpage/bin/iotlab-m3/application_tests
_periph_flashpage/main.o] Error 1
```

</details>
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
