### PR TITLE
sys/mountfs: add static mount file system

### DIFF
--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -40,5 +40,6 @@ USEMODULE += littlefs2
 # USEMODULE += fatfs_vfs
 USEMODULE += constfs
 # USEMODULE += devfs
+USEMODULE += mountfs
 
 include $(RIOTBASE)/Makefile.include

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -14,6 +14,9 @@ endif
 ifneq (,$(filter constfs,$(USEMODULE)))
   DIRS += fs/constfs
 endif
+ifneq (,$(filter mountfs,$(USEMODULE)))
+  DIRS += fs/mountfs
+endif
 ifneq (,$(filter cord_common,$(USEMODULE)))
   DIRS += net/application_layer/cord/common
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -494,6 +494,10 @@ ifneq (,$(filter constfs,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter mountfs,$(USEMODULE)))
+  USEMODULE += vfs
+endif
+
 ifneq (,$(filter devfs,$(USEMODULE)))
   USEMODULE += vfs
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -154,6 +154,11 @@ void auto_init(void)
         extern void auto_init_devfs(void);
         auto_init_devfs();
     }
+    if (IS_USED(MODULE_MOUNTFS)) {
+        LOG_DEBUG("Mounting /.\n");
+        extern void auto_init_mountfs(void);
+        auto_init_mountfs();
+    }
     if (IS_USED(MODULE_VFS_AUTO_MOUNT)) {
         LOG_DEBUG("Mounting filesystems.\n");
         extern void auto_init_vfs(void);

--- a/sys/fs/mountfs/Kconfig
+++ b/sys/fs/mountfs/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2022 ML!PA Consulting GmbH
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_MOUNTFS
+    bool "MountFS support"
+    help
+      MountFS static file system.

--- a/sys/fs/mountfs/Makefile
+++ b/sys/fs/mountfs/Makefile
@@ -1,0 +1,2 @@
+MODULE=mountfs
+include $(RIOTBASE)/Makefile.base

--- a/sys/fs/mountfs/mountfs.c
+++ b/sys/fs/mountfs/mountfs.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_fs_mountfs MountFS static file system
+ * @ingroup     sys_fs
+ * @{
+ *
+ * @file
+ * @brief       mountfs implementation
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include "clist.h"
+#include "vfs.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+clist_node_t *vfs_get_mounts(void);
+
+static vfs_mount_t const_mount;
+
+typedef struct {
+    clist_node_t *node;
+    clist_node_t *start;
+} mountfs_ctx_t;
+
+static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
+{
+    (void)abs_path;
+    if (strncmp(dirname, "/", 2) != 0) {
+        return -ENOENT;
+    }
+
+    mountfs_ctx_t *ctx = (void *)dirp->private_data.buffer;
+    ctx->node = vfs_get_mounts();
+    ctx->start = ctx->node;
+    return 0;
+}
+
+static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
+{
+    while (1) {
+        mountfs_ctx_t *ctx = (void *)dirp->private_data.buffer;
+        if (ctx->node == NULL) {
+            return 0;
+        }
+        vfs_mount_t *it = container_of(ctx->node, vfs_mount_t, list_entry);
+
+        ctx->node = ctx->node->next;
+        if (ctx->node == ctx->start) {
+            ctx->node = NULL;
+        }
+
+        if (it->mount_point == NULL) {
+            continue;
+        }
+
+        if (it == &const_mount) {
+            continue;
+        }
+
+        strncpy(entry->d_name, it->mount_point + 1, VFS_NAME_MAX);
+        break;
+    };
+
+    return 1;
+}
+
+static int _closedir(vfs_DIR *dirp)
+{
+    mountfs_ctx_t *ctx = (void *)dirp->private_data.buffer;
+    ctx->node = NULL;
+
+    return 0;
+}
+
+static const vfs_file_system_ops_t mountfs_fs_ops;
+static const vfs_file_ops_t mountfs_file_ops;
+static const vfs_dir_ops_t mountfs_dir_ops = {
+    .opendir = _opendir,
+    .readdir = _readdir,
+    .closedir = _closedir,
+};
+
+static const vfs_file_system_t mountfs_file_system = {
+    .f_op = &mountfs_file_ops,
+    .fs_op = &mountfs_fs_ops,
+    .d_op = &mountfs_dir_ops,
+};
+
+static vfs_mount_t const_mount = {
+    .fs = &mountfs_file_system,
+    .mount_point = "/",
+};
+
+void auto_init_mountfs(void)
+{
+    vfs_mount(&const_mount);
+}

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -127,7 +127,7 @@ static inline int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *moun
  * @return mount index on success
  * @return <0 on error
  */
-static inline int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path);
+static int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path);
 
 /**
  * @internal
@@ -964,7 +964,7 @@ static inline int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *moun
     return fd;
 }
 
-static inline int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path)
+static int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path)
 {
     size_t longest_match = 0;
     size_t name_len = strlen(name);
@@ -1074,4 +1074,8 @@ void auto_init_vfs(void)
     }
 }
 
+clist_node_t *vfs_get_mounts(void)
+{
+    return _vfs_mounts_list.next;
+}
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a virtual file system than lists all available mount points.


### Testing procedure

#### examples/filesystem 

```
> ls /
const
total 0 files
> mount
/sda successfully mounted
> ls /
sda
const
total 0 files
> ls /sda
./
../
total 0 files
> ls /const
hello-world	14 B
hello-riot	13 B
total 2 files
```


### Issues/PRs references

#15291
