### PR TITLE
boards/native: select MTD defaults for FAT

### DIFF
--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -60,10 +60,18 @@ void _native_LED_RED_TOGGLE(void);
  * @{
  */
 #ifndef MTD_PAGE_SIZE
+#ifdef MODULE_FATFS
+#define MTD_PAGE_SIZE           (512)
+#else
 #define MTD_PAGE_SIZE           (256)
 #endif
+#endif
 #ifndef MTD_SECTOR_SIZE
+#ifdef MODULE_FATFS
+#define MTD_SECTOR_SIZE         (512)
+#else
 #define MTD_SECTOR_SIZE         (4096)
+#endif
 #endif
 #ifndef MTD_SECTOR_NUM
 #define MTD_SECTOR_NUM          (2048)

--- a/examples/filesystem/README.md
+++ b/examples/filesystem/README.md
@@ -91,8 +91,6 @@ riot_fatfs_disk.img
 
 ```
 CFLAGS += -DMTD_NATIVE_FILENAME=\"riot_fatfs_disk.img\"
-CFLAGS += -DMTD_PAGE_SIZE=512
-CFLAGS += -DMTD_SECTOR_SIZE=512
 CFLAGS += -DMTD_SECTOR_NUM=262144
 ```
 

--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -15,8 +15,6 @@ FATFS_IMAGE_FILE_SIZE_MIB ?= 128
 ifeq ($(BOARD),native)
 #overwrite default mtd_native-config to use fat image as flash device
 CFLAGS += -DMTD_NATIVE_FILENAME=\"./bin/riot_fatfs_disk.img\"
-CFLAGS += -DMTD_PAGE_SIZE=512
-CFLAGS += -DMTD_SECTOR_SIZE=512
 CFLAGS += -DFATFS_IMAGE_FILE_SIZE_MIB=$(FATFS_IMAGE_FILE_SIZE_MIB)
 CFLAGS += -DMTD_SECTOR_NUM=\(\(\(FATFS_IMAGE_FILE_SIZE_MIB\)*1024*1024\)/MTD_SECTOR_SIZE\)
 else

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -11,12 +11,8 @@ ifeq ($(BOARD),native)
 
   #overwrite default mtd_native-config to use fat image as flash device
   MTD_NATIVE_FILENAME    ?= \"./bin/riot_fatfs_disk.img\"
-  MTD_PAGE_SIZE   ?= 512
-  MTD_SECTOR_SIZE ?= 512
   MTD_SECTOR_NUM  ?= \(\(\(FATFS_IMAGE_FILE_SIZE_MIB\)*1024*1024\)/MTD_SECTOR_SIZE\)
   CFLAGS += -DMTD_NATIVE_FILENAME=$(MTD_NATIVE_FILENAME)
-  CFLAGS += -DMTD_PAGE_SIZE=$(MTD_PAGE_SIZE)
-  CFLAGS += -DMTD_SECTOR_SIZE=$(MTD_SECTOR_SIZE)
   CFLAGS += -DFATFS_IMAGE_FILE_SIZE_MIB=$(FATFS_IMAGE_FILE_SIZE_MIB)
   CFLAGS += -DMTD_SECTOR_NUM=$(MTD_SECTOR_NUM)
 else


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The FAT file system makes some strong assumptions about sector and block size that are not met by the default native MTD emulation.

To avoid this trip hazard, change the native MTD defaults when FAT is used.


### Testing procedure

The tests still work without overwriting the default values. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
