### PR TITLE
sys/ztimer: add LPTIMER auto init

### DIFF
--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -67,13 +67,7 @@
 
 /* Step 0: define available ztimer-periphery by activated modules */
 
-/* #if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
- * replaces #if MODULE_ZTIMER_PERIPH_TIMER
- * the ztimer_periph_timer is always available
- * having an (1) config defined in ztimer/config.h
- */
-
-#if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
+#if MODULE_ZTIMER_PERIPH_TIMER
 #  define ZTIMER_TIMER      _ztimer_periph_timer
 #  define ZTIMER_TIMER_CLK  _ztimer_periph_timer.super
 #  define ZTIMER_TIMER_FREQ CONFIG_ZTIMER_USEC_BASE_FREQ
@@ -99,8 +93,11 @@
 /* ZTIMER_USEC always uses the basic timer
  * basic timer is available on all boards */
 #if MODULE_ZTIMER_USEC
-#  ifndef INIT_ZTIMER_TIMER
-#    define INIT_ZTIMER_TIMER 1
+#  ifdef ZTIMER_TIMER
+#    define ZTIMER_USEC_TIMER 1
+#    ifndef INIT_ZTIMER_TIMER
+#      define INIT_ZTIMER_TIMER 1
+#    endif
 #  endif
 #endif
 
@@ -116,7 +113,7 @@
 #    if ZTIMER_RTT_FREQ != FREQ_1KHZ
 #      define ZTIMER_MSEC_CONVERT_LOWER_FREQ ZTIMER_RTT_FREQ
 #    endif
-#  else
+#  elif defined(ZTIMER_TIMER)
 #    define ZTIMER_MSEC_TIMER 1
 #    ifndef INIT_ZTIMER_TIMER
 #      define INIT_ZTIMER_TIMER 1
@@ -135,19 +132,17 @@
 #      define INIT_ZTIMER_RTT 1
 #    endif
 #    define ZTIMER_SEC_CONVERT_LOWER_FREQ ZTIMER_RTT_FREQ
-#  else
-#    ifdef ZTIMER_RTC
-#      define ZTIMER_SEC_RTC
-#      ifndef INIT_ZTIMER_RTC
-#        define INIT_ZTIMER_RTC 1
-#      endif
-#    else
-#      define ZTIMER_SEC_TIMER
-#      ifndef INIT_ZTIMER_TIMER
-#        define INIT_ZTIMER_TIMER 1
-#      endif
-#      define ZTIMER_SEC_CONVERT_LOWER_FREQ ZTIMER_TIMER_FREQ
+#  elif defined(ZTIMER_RTC)
+#    define ZTIMER_SEC_RTC
+#    ifndef INIT_ZTIMER_RTC
+#      define INIT_ZTIMER_RTC 1
 #    endif
+#  elif defined(ZTIMER_TIMER)
+#    define ZTIMER_SEC_TIMER
+#    ifndef INIT_ZTIMER_TIMER
+#      define INIT_ZTIMER_TIMER 1
+#    endif
+#    define ZTIMER_SEC_CONVERT_LOWER_FREQ ZTIMER_TIMER_FREQ
 #  endif
 #endif
 
@@ -170,7 +165,7 @@ static ztimer_periph_rtc_t ZTIMER_RTC;
 /* Step 3: setup constants for ztimers and memory for converters */
 
 #if MODULE_ZTIMER_USEC
-#  ifdef ZTIMER_TIMER
+#  ifdef ZTIMER_USEC_TIMER
 ztimer_clock_t *const ZTIMER_USEC_BASE = &ZTIMER_TIMER_CLK;
 #  else
 #    error No suitable ZTIMER_USEC config. Basic timer configuration missing?
@@ -249,7 +244,7 @@ void ztimer_init(void)
 #if INIT_ZTIMER_TIMER
     LOG_DEBUG(
         "ztimer_init(): ZTIMER_TIMER using periph timer %u, freq %lu, width %u\n",
-        CONFIG_ZTIMER_USEC_DEV, CONFIG_ZTIMER_USEC_BASE_FREQ,
+        CONFIG_ZTIMER_USEC_DEV, ZTIMER_TIMER_FREQ,
         CONFIG_ZTIMER_USEC_WIDTH);
     ztimer_periph_timer_init(&ZTIMER_TIMER, CONFIG_ZTIMER_USEC_DEV,
                              ZTIMER_TIMER_FREQ, WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));


### PR DESCRIPTION
### Contribution description

adds LPTIMER to ztimer auto init

### Testing procedure
```
CONFIG_ZTIMER_LPTIMER_DEV
CONFIG_ZTIMER_LPTIMER_FREQ
CONFIG_ZTIMER_LPTIMER_WIDTH
CONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE
```
have to be defined 
and 
`ztimer_periph_lptimer `
be used
msec and sec prefer lptimer over rtt


I the details a diff can be found adding a second timer for stm32 (may not work on all devices) and using that in the `ztimer_xsec` example since this PR is about adding the lowpower-timer (`lptimer`) support to `ztimer` this was removed from it.

<details>

```
diff --git a/boards/common/stm32/include/cfg_timer_tim2.h b/boards/common/stm32/include/cfg_timer_tim2.h
index d7f6008c6f..c9c7126b30 100644
--- a/boards/common/stm32/include/cfg_timer_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim2.h
@@ -47,10 +47,18 @@ static const timer_conf_t timer_config[] = {
 #endif
         .bus      = APB1,
         .irqn     = TIM2_IRQn
-    }
+    },
+    {
+        .dev      = TIM5,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM5EN,
+        .bus      = APB1,
+        .irqn     = TIM5_IRQn
+    },
 };
 
 #define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim5
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
diff --git a/dist/tools/doccheck/exclude_patterns b/dist/tools/doccheck/exclude_patterns
index 362c11d1c3..8c1457d007 100644
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -13119,3 +13119,4 @@ boards/esp32\-ttgo\-t\-beam/doc\.txt:[0-9]+: warning: unable to resolve referenc
 boards/esp32\-wemos\-lolin\-d32\-pro/doc\.txt:[0-9]+: warning: explicit link request to 'esp32_wemos_lolin_d32_pro_optional_hardware' could not be resolved
 drivers/include/xbee\.h:[0-9]+: warning: found documented return type for xbee_setup that does not return anything
 boards/nrf52840dongle/doc\.txt:[0-9]+: warning: unable to resolve reference to 'nrf52840dongle_flash' for \\ref command
+boards/common/stm32/include/cfg_timer_tim2\.h:[0-9]+: warning: Member TIMER_1_ISR \(macro definition\) of file cfg_timer_tim2\.h is not documented\.
diff --git a/tests/ztimer_xsec/Makefile b/tests/ztimer_xsec/Makefile
index 8709ee2154..f34aa56d08 100644
--- a/tests/ztimer_xsec/Makefile
+++ b/tests/ztimer_xsec/Makefile
@@ -4,6 +4,9 @@ USEMODULE += ztimer
 USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec
 USEMODULE += ztimer_sec
+USEMODULE += ztimer_periph_lptimer
+
+CFLAGS += "-DCONFIG_ZTIMER_LPTIMER_DEV=TIMER_DEV(1)" "-DCONFIG_ZTIMER_LPTIMER_FREQ=1000LU" "-DCONFIG_ZTIMER_LPTIMER_WIDTH=32" "-DCONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE=ZTIMER_CLOCK_NO_REQUIRED_PM_MODE"
 
 # microbit qemu lacks rtt
 TEST_ON_CI_BLACKLIST += microbit
diff --git a/tests/ztimer_xsec/main.c b/tests/ztimer_xsec/main.c
index 993edfa344..4dc0d69d7b 100644
--- a/tests/ztimer_xsec/main.c
+++ b/tests/ztimer_xsec/main.c
@@ -56,7 +56,7 @@ int main(void)
 {
     puts("starting ztimers");
     /* start a timer on each high level ztimer*/
-    ztimer_set(ZTIMER_SEC, &sec_tim, 1);
+    ztimer_set(ZTIMER_SEC, &sec_tim, 3);
     ztimer_set(ZTIMER_MSEC, &msec_tim, 200);
     ztimer_set(ZTIMER_USEC, &usec_tim, 100 * US_PER_MS);
```

</details>

### Issues/PRs references

includes #16342
fixes #17611
this may help with using rtt64 by PR #18120
