### PR TITLE
vfs_default: add compile test and add default mount for more boards

### DIFF
--- a/boards/common/weact-f4x1cx/Makefile.dep
+++ b/boards/common/weact-f4x1cx/Makefile.dep
@@ -13,3 +13,9 @@ endif
 ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_spi_nor
 endif
+
+# default to using littlefs2 on the external flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif

--- a/boards/common/weact-f4x1cx/board.c
+++ b/boards/common/weact-f4x1cx/board.c
@@ -52,4 +52,9 @@ static mtd_spi_nor_t weact_nor_dev = {
 };
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&weact_nor_dev;
+
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(weact_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
 #endif /* MODULE_MTD */

--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -9,4 +9,10 @@ ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_spi_nor
 endif
 
+# default to using littlefs2 on the external flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif
+
 USEMODULE += boards_common_iotlab

--- a/boards/iotlab-m3/mtd.c
+++ b/boards/iotlab-m3/mtd.c
@@ -52,4 +52,9 @@ static mtd_spi_nor_t mtd_nor_dev = {
 };
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd_nor_dev;
+
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(mtd_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
 #endif /* MODULE_MTD */

--- a/boards/mcb2388/Makefile.dep
+++ b/boards/mcb2388/Makefile.dep
@@ -7,3 +7,9 @@ endif
 ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_mci
 endif
+
+# default to using FAT on the SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif

--- a/boards/mcb2388/board_init.c
+++ b/boards/mcb2388/board_init.c
@@ -31,6 +31,11 @@ static mtd_dev_t _mtd_mci = { .driver = &mtd_mci_driver };
 mtd_dev_t *mtd0 = &_mtd_mci;
 #endif
 
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(fatfs, { .dev = &_mtd_mci }, VFS_DEFAULT_SD(0), 0);
+#endif
+
 void led_init(void)
 {
     /* LEDs */

--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -12,3 +12,9 @@ endif
 ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_mci
 endif
+
+# default to using FAT on the SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -27,11 +27,14 @@
 #include "board.h"
 #include "cpu.h"
 #include "mtd.h"
-#include "periph/init.h"
-#include "stdio_base.h"
 
 #ifdef MODULE_MTD_MCI
 extern const mtd_desc_t mtd_mci_driver;
 static mtd_dev_t _mtd_mci = { .driver = &mtd_mci_driver };
 mtd_dev_t *mtd0 = &_mtd_mci;
+#endif
+
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(fatfs, { .dev = &_mtd_mci }, VFS_DEFAULT_SD(0), 0);
 #endif

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -35,7 +35,7 @@ mtd_dev_t *mtd0 = &mtd0_dev.base;
 #endif
 
 #ifdef MODULE_VFS
-#include "vfs.h"
+#include "vfs_default.h"
 
 /*
  * On `native` we define auto-mounts for every file system.
@@ -47,27 +47,19 @@ mtd_dev_t *mtd0 = &mtd0_dev.base;
 
 /* littlefs support */
 #if defined(MODULE_LITTLEFS)
-
-#include "fs/littlefs_fs.h"
-VFS_AUTO_MOUNT(littlefs, VFS_MTD(mtd0_dev), "/nvm", 0);
+VFS_AUTO_MOUNT(littlefs, VFS_MTD(mtd0_dev), VFS_DEFAULT_NVM(0), 0);
 
 /* littlefs2 support */
 #elif defined(MODULE_LITTLEFS2)
-
-#include "fs/littlefs2_fs.h"
-VFS_AUTO_MOUNT(littlefs2, VFS_MTD(mtd0_dev), "/nvm", 0);
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(mtd0_dev), VFS_DEFAULT_NVM(0), 0);
 
 /* spiffs support */
 #elif defined(MODULE_SPIFFS)
-
-#include "fs/spiffs_fs.h"
-VFS_AUTO_MOUNT(spiffs, VFS_MTD(mtd0_dev), "/nvm", 0);
+VFS_AUTO_MOUNT(spiffs, VFS_MTD(mtd0_dev), VFS_DEFAULT_NVM(0), 0);
 
 /* FAT support */
 #elif defined(MODULE_FATFS_VFS)
-
-#include "fs/fatfs.h"
-VFS_AUTO_MOUNT(fatfs, VFS_MTD(mtd0_dev), "/nvm", 0);
+VFS_AUTO_MOUNT(fatfs, VFS_MTD(mtd0_dev), VFS_DEFAULT_NVM(0), 0);
 
 #endif
 #endif /* MODULE_VFS */

--- a/boards/nrf52840dk/Makefile.dep
+++ b/boards/nrf52840dk/Makefile.dep
@@ -4,4 +4,10 @@ ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_spi_nor
 endif
 
+# default to using littlefs2 on the external flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += mtd
+endif
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep

--- a/boards/nrf52840dk/mtd.c
+++ b/boards/nrf52840dk/mtd.c
@@ -54,4 +54,8 @@ static mtd_spi_nor_t nrf52840dk_nor_dev = {
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&nrf52840dk_nor_dev;
 
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(nrf52840dk_nor_dev), VFS_DEFAULT_NVM(0), 0);
+#endif
 #endif

--- a/boards/same54-xpro/board.c
+++ b/boards/same54-xpro/board.c
@@ -63,8 +63,8 @@ static mtd_at24cxxx_t at24mac_dev = {
 mtd_dev_t *mtd1 = (mtd_dev_t *)&at24mac_dev;
 
 #ifdef MODULE_VFS_DEFAULT
-#include "fs/littlefs2_fs.h"
-VFS_AUTO_MOUNT(littlefs2, VFS_MTD(same54_nor_dev), "/nvm", 0);
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, VFS_MTD(same54_nor_dev), VFS_DEFAULT_NVM(0), 0);
 #endif
 #endif /* MODULE_MTD */
 

--- a/sys/include/vfs_default.h
+++ b/sys/include/vfs_default.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_vfs
+ * @brief     VFS default mount points
+ *
+ * @{
+ * @file
+ * @brief   VFS layer default definitions & mount points
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef VFS_DEFAULT_H
+#define VFS_DEFAULT_H
+
+#include "board.h"
+#include "vfs.h"
+
+#if IS_USED(MODULE_FATFS_VFS)
+#include "fs/fatfs.h"
+#endif
+#if IS_USED(MODULE_LITTLEFS)
+#include "fs/littlefs_fs.h"
+#endif
+#if IS_USED(MODULE_LITTLEFS2)
+#include "fs/littlefs2_fs.h"
+#endif
+#if IS_USED(MODULE_SPIFFS)
+#include "fs/spiffs_fs.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default mount point for removable storage
+ */
+#ifndef VFS_DEFAULT_SD
+#define VFS_DEFAULT_SD(n)   "/sd" # n
+#endif
+
+/**
+ * @brief   Default mount point for non-removable storage
+ */
+#ifndef VFS_DEFAULT_NVM
+#define VFS_DEFAULT_NVM(n)  "/nvm" # n
+#endif
+
+/**
+ * @brief   Default data directory
+ *          This can be written to by applications
+ */
+#ifndef VFS_DEFAULT_DATA
+#if IS_USED(MODULE_MTD_MCI) || IS_USED(MODULE_MTD_SDCARD)
+#define VFS_DEFAULT_DATA    VFS_DEFAULT_SD(0)
+#else
+#define VFS_DEFAULT_DATA    VFS_DEFAULT_NVM(0)
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VFS_DEFAULT_H */
+
+/** @} */

--- a/tests/vfs_default/Makefile
+++ b/tests/vfs_default/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+USEMODULE += vfs_default
+USEMODULE += vfs_auto_format
+
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/vfs_default/Makefile.ci
+++ b/tests/vfs_default/Makefile.ci
@@ -1,0 +1,11 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-leonardo \
+    arduino-nano \
+    atmega328p-xplained-mini \
+    arduino-duemilanove \
+    arduino-uno \
+    atmega328p \
+    stm32f030f4-demo \
+    samd10-xmini \
+    nucleo-l011k4 \
+    #

--- a/tests/vfs_default/main.c
+++ b/tests/vfs_default/main.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for vfs_default
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "shell_commands.h"
+#include "vfs_default.h"
+
+int main(void)
+{
+    vfs_DIR mount = {0};
+
+    /* list mounted file systems */
+    puts("mount points:");
+    while (vfs_iterate_mount_dirs(&mount)) {
+        printf("\t%s\n", mount.mp->mount_point);
+    }
+    printf("\ndata dir: %s\n", VFS_DEFAULT_DATA);
+
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a compile-test application `tests/vfs_default` as well as more default mount configurations for existing boards.


### Testing procedure

Run the new `tests/vfs_default` application. 

```
main(): This is RIOT! (Version: 2022.04-devel-500-g74115-vfs_default-test)
mount points:
	/nvm0

data dir: /nvm0
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
