### PR TITLE
shell/sc_gnrc_udp: always use delay in µs

### DIFF
--- a/sys/shell/commands/sc_gnrc_udp.c
+++ b/sys/shell/commands/sc_gnrc_udp.c
@@ -31,7 +31,7 @@
 #include "net/utils.h"
 #include "timex.h"
 #include "utlist.h"
-#if IS_USED(MODULE_ZTIMER_MSEC)
+#if IS_USED(MODULE_ZTIMER)
 #include "ztimer.h"
 #else
 #include "xtimer.h"
@@ -106,10 +106,12 @@ static void _send(const char *addr_str, const char *port_str,
         printf("Success: sent %u byte(s) to [%s]:%u\n", payload_size, addr_str,
                port);
         if (num) {
-#if IS_USED(MODULE_ZTIMER_MSEC)
-            ztimer_sleep(ZTIMER_MSEC, delay);
-#else
+#if IS_USED(MODULE_ZTIMER_USEC)
+            ztimer_sleep(ZTIMER_USEC, delay);
+#elif IS_USED(MODULE_XTIMER)
             xtimer_usleep(delay);
+#elif IS_USED(MODULE_ZTIMER_MSEC)
+            ztimer_sleep(ZTIMER_MSEC, (delay + US_PER_MS - 1) / US_PER_MS);
 #endif
         }
     }
@@ -162,13 +164,8 @@ int _gnrc_udp_cmd(int argc, char **argv)
         uint32_t num = 1;
         uint32_t delay;
         if (argc < 5) {
-#if IS_USED(MODULE_ZTIMER_MSEC)
-            printf("usage: %s send "
-                   "<addr> <port> <data> [<num> [<delay in ms>]]\n", argv[0]);
-#else
             printf("usage: %s send "
                    "<addr> <port> <data> [<num> [<delay in us>]]\n", argv[0]);
-#endif
             return 1;
         }
         if (argc > 5) {
@@ -177,7 +174,7 @@ int _gnrc_udp_cmd(int argc, char **argv)
         if (argc > 6) {
             delay = atoi(argv[6]);
         } else {
-            delay = IS_USED(MODULE_ZTIMER_MSEC) ? 1000 : 1000000;
+            delay = US_PER_SEC;
         }
         _send(argv[2], argv[3], argv[4], num, delay);
     }

--- a/sys/shell/commands/sc_gnrc_udp.c
+++ b/sys/shell/commands/sc_gnrc_udp.c
@@ -158,7 +158,7 @@ int _gnrc_udp_cmd(int argc, char **argv)
 
     if (strcmp(argv[1], "send") == 0) {
         uint32_t num = 1;
-        uint32_t delay = 1000000;
+        uint32_t delay;
         if (argc < 5) {
 #if IS_USED(MODULE_ZTIMER_MSEC)
             printf("usage: %s send "
@@ -174,6 +174,8 @@ int _gnrc_udp_cmd(int argc, char **argv)
         }
         if (argc > 6) {
             delay = atoi(argv[6]);
+        } else {
+            delay = IS_USED(MODULE_ZTIMER_MSEC) ? 1000 : 1000000;
         }
         _send(argv[2], argv[3], argv[4], num, delay);
     }

--- a/sys/shell/commands/sc_gnrc_udp.c
+++ b/sys/shell/commands/sc_gnrc_udp.c
@@ -60,7 +60,7 @@ static void _send(const char *addr_str, const char *port_str,
         return;
     }
 
-    for (unsigned int i = 0; i < num; i++) {
+    while (num--) {
         gnrc_pktsnip_t *payload, *udp, *ip;
         unsigned payload_size;
         /* allocate payload */
@@ -105,11 +105,13 @@ static void _send(const char *addr_str, const char *port_str,
          * => use temporary variable for output */
         printf("Success: sent %u byte(s) to [%s]:%u\n", payload_size, addr_str,
                port);
+        if (num) {
 #if IS_USED(MODULE_ZTIMER_MSEC)
-        ztimer_sleep(ZTIMER_MSEC, delay);
+            ztimer_sleep(ZTIMER_MSEC, delay);
 #else
-        xtimer_usleep(delay);
+            xtimer_usleep(delay);
 #endif
+        }
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

i noticed that lately `udp send ff02::1 1234 test` would not return back to the shell and appear blocked.
Some investigation into the code revealed that with xtimer the command would add a 1000000 µs delay after each packet, but with ztimer it would add a 1000000 **ms** delay (~16 minutes).

Fix this by setting the proper default delay depending on the timer used.

There is also no need for a delay after the last packet to begin with, this is only an artifact of sending multiple packets - so add a check to only delay if the packet was not the last one.

### Testing procedure

`udp send` should work again.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
