### PR TITLE
vfs: Introduce reliable disk enumeration

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -660,23 +660,6 @@ struct vfs_file_system_ops {
      * @return <0 on error
      */
     int (*statvfs) (vfs_mount_t *mountp, const char *restrict path, struct statvfs *restrict buf);
-
-    /**
-     * @brief Get file system status of an open file
-     *
-     * @p path is only passed for consistency against the POSIX statvfs function.
-     * @c vfs_statvfs calls this function only when it has determined that
-     * @p path belongs to this file system. @p path is a file system relative
-     * path and does not necessarily name an existing file.
-     *
-     * @param[in]  mountp  file system mount to operate on
-     * @param[in]  filp    pointer to an open file on the file system being queried
-     * @param[out] buf     pointer to statvfs struct to fill
-     *
-     * @return 0 on success
-     * @return <0 on error
-     */
-    int (*fstatvfs) (vfs_mount_t *mountp, vfs_file_t *filp, struct statvfs *buf);
 };
 
 /**

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -304,7 +304,7 @@ struct vfs_mount_struct {
     const vfs_file_system_t *fs; /**< The file system driver for the mount point */
     const char *mount_point;     /**< Mount point, e.g. "/mnt/cdrom" */
     size_t mount_point_len;      /**< Length of mount_point string (set by vfs_mount) */
-    atomic_int open_files;       /**< Number of currently open files */
+    atomic_int open_files;       /**< Number of currently open files and directories */
     void *private_data;          /**< File system driver private data, implementation defined */
 };
 
@@ -889,7 +889,7 @@ int vfs_rename(const char *from_path, const char *to_path);
 /**
  * @brief Unmount a mounted file system
  *
- * This will fail if there are any open files on the mounted file system
+ * This will fail if there are any open files or directories on the mounted file system
  *
  * @param[in]  mountp    pointer to the mount structure of the file system to unmount
  *

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -1014,8 +1014,8 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur);
  * access to the mount point's stats through @ref vfs_dstatvfs. If mounts or
  * unmounts happen while iterating, this is guaranteed to report all file
  * systems that stayed mounted, and may report any that are transiently
- * mounted. Note that the volume being reported can not be unmounted as @p dir
- * is an open directory.
+ * mounted for up to as often as they are (re)mounted. Note that the volume
+ * being reported can not be unmounted as @p dir is an open directory.
  *
  * Zero-initialize @p dir to start. As long as @c true is returned, @p dir is a
  * valid directory on which the user can call @ref vfs_readdir or @ref

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -998,8 +998,6 @@ int vfs_normalize_path(char *buf, const char *path, size_t buflen);
  *
  * Set @p cur to @c NULL to start from the beginning
  *
- * @see @c sc_vfs.c (@c df command) for a usage example
- *
  * @param[in]  cur  current iterator value
  *
  * @return     Pointer to next mounted file system in list after @p cur
@@ -1028,6 +1026,8 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur);
  * Note that this requires all enumerated file systems to support the `opendir`
  * @ref vfs_dir_ops; any file system that does not support that will
  * prematurely terminate the mount point enumeration.
+ *
+ * @see @c sc_vfs.c (@c df command) for a usage example
  *
  * @param[inout]  dir     The root directory of the discovered mount point
  *

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -716,6 +716,17 @@ int vfs_fstat(int fd, struct stat *buf);
 int vfs_fstatvfs(int fd, struct statvfs *buf);
 
 /**
+ * @brief Get file system status of the file system containing an open directory
+ *
+ * @param[in]  dirp     pointer to open directory
+ * @param[out] buf      pointer to statvfs struct to fill
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int vfs_dstatvfs(vfs_DIR *dirp, struct statvfs *buf);
+
+/**
  * @brief Seek to position in file
  *
  * @p whence determines the function of the seek and should be set to one of

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -1008,6 +1008,35 @@ int vfs_normalize_path(char *buf, const char *path, size_t buflen);
 const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur);
 
 /**
+ * @brief Iterate through all mounted file systems by their root directories
+ *
+ * Unlike @ref vfs_iterate_mounts, this is thread safe, and allows thread safe
+ * access to the mount point's stats through @ref vfs_dstatvfs. If mounts or
+ * unmounts happen while iterating, this is guaranteed to report all file
+ * systems that stayed mounted, and may report any that are transiently
+ * mounted. Note that the volume being reported can not be unmounted as @p dir
+ * is an open directory.
+ *
+ * Zero-initialize @p dir to start. As long as @c true is returned, @p dir is a
+ * valid directory on which the user can call @ref vfs_readdir or @ref
+ * vfs_dstatvfs (or even peek at its `.mp` if they dare ignore the warning in
+ * @ref vfs_DIR).
+ *
+ * Users MUST NOT call @ref vfs_closedir if they intend to keep iterating, but
+ * MUST call it when aborting iteration.
+ *
+ * Note that this requires all enumerated file systems to support the `opendir`
+ * @ref vfs_dir_ops; any file system that does not support that will
+ * prematurely terminate the mount point enumeration.
+ *
+ * @param[inout]  dir     The root directory of the discovered mount point
+ *
+ * @return     @c true if another file system is mounted; @p dir then contains an open directory.
+ * @return     @c false if the file system list is exhausted; @p dir is uninitialized then.
+ */
+bool vfs_iterate_mount_dirs(vfs_DIR *dir);
+
+/**
  * @brief   Get information about the file for internal purposes
  *
  * @attention   Not thread safe! Do not modify any of the fields in the returned

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -998,6 +998,9 @@ int vfs_normalize_path(char *buf, const char *path, size_t buflen);
  *
  * Set @p cur to @c NULL to start from the beginning
  *
+ * @deprecated This will become an internal-only function after the 2022.04
+ *   release, use @ref vfs_iterate_mount_dirs instead.
+ *
  * @param[in]  cur  current iterator value
  *
  * @return     Pointer to next mounted file system in list after @p cur

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -896,10 +896,11 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur)
             /* empty list */
             return NULL;
         }
+        node = node->next;
     }
     else {
         node = cur->list_entry.next;
-        if (node == _vfs_mounts_list.next) {
+        if (node == _vfs_mounts_list.next->next) {
             return NULL;
         }
     }

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -216,15 +216,11 @@ int vfs_fstatvfs(int fd, struct statvfs *buf)
     }
     vfs_file_t *filp = &_vfs_open_files[fd];
     memset(buf, 0, sizeof(*buf));
-    if (filp->mp->fs->fs_op->fstatvfs == NULL) {
-        /* file system driver does not implement fstatvfs() */
-        if (filp->mp->fs->fs_op->statvfs != NULL) {
-            /* Fall back to statvfs */
-            return filp->mp->fs->fs_op->statvfs(filp->mp, "/", buf);
-        }
+    if (filp->mp->fs->fs_op->statvfs == NULL) {
+        /* file system driver does not implement statvfs() */
         return -EINVAL;
     }
-    return filp->mp->fs->fs_op->fstatvfs(filp->mp, filp, buf);
+    return filp->mp->fs->fs_op->statvfs(filp->mp, "/", buf);
 }
 
 off_t vfs_lseek(int fd, off_t off, int whence)

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -223,6 +223,20 @@ int vfs_fstatvfs(int fd, struct statvfs *buf)
     return filp->mp->fs->fs_op->statvfs(filp->mp, "/", buf);
 }
 
+int vfs_dstatvfs(vfs_DIR *dirp, struct statvfs *buf)
+{
+    DEBUG("vfs_dstatvfs: %p, %p\n", (void*)dirp, (void *)buf);
+    if (buf == NULL) {
+        return -EFAULT;
+    }
+    memset(buf, 0, sizeof(*buf));
+    if (dirp->mp->fs->fs_op->statvfs == NULL) {
+        /* file system driver does not implement statvfs() */
+        return -EINVAL;
+    }
+    return dirp->mp->fs->fs_op->statvfs(dirp->mp, "/", buf);
+}
+
 off_t vfs_lseek(int fd, off_t off, int whence)
 {
     DEBUG("vfs_lseek: %d, %ld, %d\n", fd, (long)off, whence);

--- a/tests/vfs_iterate_mount/Makefile
+++ b/tests/vfs_iterate_mount/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += vfs
+USEMODULE += constfs
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/vfs_iterate_mount/Makefile.ci
+++ b/tests/vfs_iterate_mount/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #

--- a/tests/vfs_iterate_mount/main.c
+++ b/tests/vfs_iterate_mount/main.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) Christian Amsüss <chrysn@fsfe.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * Mount and unmount a few file systems, demonstrating that
+ * vfs_iterate_mount_dirs performs as advertised.
+ *
+ * @author      Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+#include <vfs.h>
+#include <fs/constfs.h>
+
+static constfs_file_t constfs_files[1] = {
+    /* Not completely empty -- that'd be a hassle around empty arrays and
+     * their size */
+    {
+        .path = "some-file",
+        .size = 0,
+        .data = (void*)"",
+    },
+};
+
+static constfs_t constfs_desc = {
+    .nfiles = ARRAY_SIZE(constfs_files),
+    .files = constfs_files,
+};
+
+static vfs_mount_t mount1 = {
+    .fs = &constfs_file_system,
+    .mount_point = "/const1",
+    .private_data = &constfs_desc,
+};
+
+static vfs_mount_t mount2 = {
+    .fs = &constfs_file_system,
+    .mount_point = "/const2",
+    .private_data = &constfs_desc,
+};
+
+static vfs_mount_t mount3 = {
+    .fs = &constfs_file_system,
+    .mount_point = "/const3",
+    .private_data = &constfs_desc,
+};
+
+static vfs_mount_t mount4 = {
+    .fs = &constfs_file_system,
+    .mount_point = "/const4",
+    .private_data = &constfs_desc,
+};
+
+/* Crank the iterator, reporting "N%s" for the next entry, or "O\n" for the end
+ * of the iterator (avoiding the letter "E" which may be misread for an error
+ * in a casual look at the error output) */
+static void iter_and_report(vfs_DIR *iter) {
+    bool result = vfs_iterate_mount_dirs(iter);
+    if (result) {
+        printf("N(%s)", iter->mp->mount_point);
+    } else {
+        printf("O\n");
+        /* Zero out so we're ready for next round immediately */
+        memset(iter, 0, sizeof(*iter));
+    }
+}
+
+int main(void) {
+    int res = 0;
+
+    vfs_DIR iter;
+    memset(&iter, 0, sizeof(iter));
+
+    res |= vfs_mount(&mount1);
+    res |= vfs_mount(&mount2);
+    res |= vfs_mount(&mount3);
+    res |= vfs_mount(&mount4);
+    assert(res == 0);
+    printf("Mounted 1234\n");
+
+    /* N1N2N3N4E */
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+
+    /* N1N2, unmount 3, N4E */
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+    res |= vfs_umount(&mount3);
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+
+    /* N1, unmount 2, (3 is already unmounted), N4, mount 3 N3, unmount 1 and remount it at the end N1, O */
+    /* It is OK that 1 is reported twice, because its first occurrence is its
+     * old mounting, and later it reappears */
+    iter_and_report(&iter);
+    res |= vfs_umount(&mount2);
+    iter_and_report(&iter);
+    res |= vfs_mount(&mount3);
+    iter_and_report(&iter);
+    res |= vfs_umount(&mount1);
+    res |= vfs_mount(&mount1);
+    iter_and_report(&iter);
+    iter_and_report(&iter);
+
+    /* This ensures we're not leaking locks */
+    res |= vfs_umount(&mount1);
+    res |= vfs_umount(&mount3);
+    res |= vfs_umount(&mount4);
+    printf("All unmounted\n");
+
+    /* Only O */
+    iter_and_report(&iter);
+}

--- a/tests/vfs_iterate_mount/tests/01-run.py
+++ b/tests/vfs_iterate_mount/tests/01-run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 Christian Amsüss <chrysn@fsfe.org>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("Mounted 1234")
+    child.expect_exact("N(/const1)N(/const2)N(/const3)N(/const4)O")
+    child.expect_exact("N(/const1)N(/const2)N(/const4)O")
+    child.expect_exact("N(/const1)N(/const4)N(/const3)N(/const1)O")
+    child.expect_exact("All unmounted")
+    child.expect_exact("O")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

Listing mount points was previously documented as racy, and generic modules using it could barely ensure that nothing else in the system would mount/unmount at impractical times (#17658 was an attempt to fix that by making the mutex public, but that had other downsides).

This introduces an iteration mechanism that is thread-safe because it keeps a directory handle open for the currently viewed FS, and that (just like an open file) keeps the FS from being unmounted.

In bycatch and related changes, it
* removes per-filesystem `fstatvfs` calls (for lack of reason to have that as a separate driver method, when all users go through the generic `statvfs` method that has the same properties anyways)
* alters `vfs_iterate_mounts` to produce the actual mount sequence (and not some 2-instructions-shorter-but-confusing reordering that is an artifact of clists), thus making it practical to get a view on the mount points that at least captures those mount points that are not altered during iteration
* introduces `dstatvfs` (in analogy to `fstatvfs`, and it's really the slimmest of all the `*statvfs` calls because the directory readily contains a valid pointer to the FS)
* fixes details in the docs (gobbling up  #17659)

### Testing procedure

A new test covers this:

```
$ make -C tests/vfs_iterate_mount all test
[...]
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.04-devel-379-g882ea6-vfs-drop-per-fs-fstatvfs)
Mounted 1234
N(/const1)N(/const2)N(/const3)N(/const4)O
N(/const1)N(/const2)N(/const4)O
N(/const1)N(/const4)N(/const3)N(/const1)O
All unmounted
O

make: Leaving directory '/home/chrysn/git/RIOT/tests/vfs_iterate_mount'
$
```

(I tested this with the riot-wrappers, but without actually interspersing mounting with iteration -- and anyhow that's not a practical thing to describe in a PR).

### Issues/PRs references

#17658 was an earlier attempt.

The documentation fix was originally in #17659.

[edit: Added reference to #17659; tests described]