### PR TITLE
sys/vfs: add vfs_mount_by_path()

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -872,6 +872,21 @@ int vfs_format(vfs_mount_t *mountp);
 int vfs_mount(vfs_mount_t *mountp);
 
 /**
+ * @brief Mount a file system with a pre-configured mount path
+ *
+ * @note This assumes mount points have been configured with @ref VFS_AUTO_MOUNT.
+ *
+ * @warning If the @ref pseudomodule_vfs_auto_format is used a format attempt will
+ * be made if the mount fails.
+ *
+ * @param[in]  path     Path of the pre-configured mount point
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int vfs_mount_by_path(const char *path);
+
+/**
  * @brief Rename a file
  *
  * The file @p from_path will be renamed to @p to_path

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -34,6 +34,16 @@
 #define SHELL_VFS_BUFSIZE 256
 static uint8_t _shell_vfs_data_buffer[SHELL_VFS_BUFSIZE];
 
+/**
+ * @brief Auto-Mount array
+ */
+XFA_USE_CONST(vfs_mount_t, vfs_mountpoints_xfa);
+
+/**
+ * @brief Number of automatic mountpoints
+ */
+#define MOUNTPOINTS_NUMOF XFA_LEN(vfs_mount_t, vfs_mountpoints_xfa)
+
 static void _ls_usage(char **argv)
 {
     printf("%s <path>\n", argv[0]);
@@ -49,6 +59,9 @@ static void _vfs_usage(char **argv)
     printf("%s mv <src> <dest>\n", argv[0]);
     printf("%s rm <file>\n", argv[0]);
     printf("%s df [path]\n", argv[0]);
+    if (MOUNTPOINTS_NUMOF > 0) {
+        printf("%s mount [path]\n", argv[0]);
+    }
     puts("r: Read [bytes] bytes at [offset] in file <path>");
     puts("w: Write (<a>: append, <o> overwrite) <ascii> or <hex> string <data> in file <path>");
     puts("ls: list files in <path>");
@@ -133,6 +146,19 @@ static int _df_handler(int argc, char **argv)
         }
     }
     return 0;
+}
+
+static int _mount_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s [path]\n", argv[0]);
+        puts("mount pre-configured mount point");
+        return -1;
+    }
+
+    int res = vfs_mount_by_path(argv[1]);
+    puts(strerror(res));
+    return res;
 }
 
 static int _read_handler(int argc, char **argv)
@@ -588,6 +614,9 @@ int _vfs_handler(int argc, char **argv)
     }
     else if (strcmp(argv[1], "df") == 0) {
         return _df_handler(argc - 1, &argv[1]);
+    }
+    else if (MOUNTPOINTS_NUMOF > 0 && strcmp(argv[1], "mount") == 0) {
+        return _mount_handler(argc - 1, &argv[1]);
     }
     else {
         printf("vfs: unsupported sub-command \"%s\"\n", argv[1]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If auto-init of a default mount fs failed (e.g. because an SD card was not inserted on boot) or `vfs_auto_mount` was disabled, there is no way to mount such an auto-mount fs later manually.

Fix this by introducing a `vfs_mount_by_path()` function that takes the mount point of a pre-configured mount to trigger the mount procedure at run-time (e.g. when an SD card was inserted).


### Testing procedure

I extended the `vfs` command with a `mount` sub-command.

    vfs mount /


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
