### PR TITLE
cpu/riscv_common: enable puf_sram feature

### DIFF
--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -12,6 +12,7 @@ config CPU_ARCH_RISCV
     select HAS_NEWLIB
     select HAS_PERIPH_CORETIMER
     select HAS_PICOLIBC if '$(RIOT_CI_BUILD)' != '1'
+    select HAS_PUF_SRAM
     select HAS_RUST_TARGET
     select HAS_SSP
 

--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += libstdcpp
 FEATURES_PROVIDED += newlib
 FEATURES_PROVIDED += periph_coretimer
+FEATURES_PROVIDED += puf_sram
 FEATURES_PROVIDED += rust_target
 FEATURES_PROVIDED += ssp
 

--- a/cpu/riscv_common/include/cpu_conf_common.h
+++ b/cpu/riscv_common/include/cpu_conf_common.h
@@ -38,6 +38,11 @@
 /** @} */
 
 /**
+ * @brief   Attribute for memory sections required by SRAM PUF
+ */
+#define PUF_SRAM_ATTRIBUTES __attribute__((used, section(".noinit")))
+
+/**
  * @brief   Declare the heap_stats function as available
  */
 #define HAVE_HEAP_STATS

--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -206,6 +206,16 @@ SECTIONS
     . = ALIGN(4);
   } >ram AT>ram :ram
 
+  .noinit (NOLOAD) :
+  {
+      __noinit_begin__ = .;
+
+      *(.noinit .noinit.*)
+
+        . = ALIGN(4) ;
+      __noinit_end__ = .;
+  } >ram AT>ram :ram
+
   . = ALIGN(8);
   PROVIDE( _end = . );
   PROVIDE( end = . );

--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -205,6 +205,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN(4);
   } >ram AT>ram :ram
+  PROVIDE( __bss_end = . );
 
   .noinit (NOLOAD) :
   {

--- a/cpu/riscv_common/riscv_init.c
+++ b/cpu/riscv_common/riscv_init.c
@@ -21,6 +21,17 @@
 #include "cpu_conf_common.h"
 #include "periph_cpu_common.h"
 
+#ifdef MODULE_PUF_SRAM
+#include "puf_sram.h"
+
+extern unsigned _sheap;
+
+void riscv_puf_sram_init(void)
+{
+    puf_sram_init((uint8_t *)&_sheap, SEED_RAM_LEN);
+}
+#endif /* MODULE_PUF_SRAM */
+
 void riscv_fpu_init(void)
 {
     /* Enable FPU if present */

--- a/cpu/riscv_common/start.S
+++ b/cpu/riscv_common/start.S
@@ -27,6 +27,10 @@ _start_real:
 .option pop
     la sp, _sp
 
+#ifdef MODULE_PUF_SRAM
+    /* PUF */
+    call riscv_puf_sram_init
+#endif
 
     /* Load data section */
     la a0, _data_lma

--- a/cpu/riscv_common/start.S
+++ b/cpu/riscv_common/start.S
@@ -41,9 +41,10 @@ _start_real:
     bltu a1, a2, 1b
 2:
 
+
     /* Clear bss section */
     la a0, __bss_start
-    la a1, _end
+    la a1, __bss_end
     bgeu a0, a1, 2f
 1:
     sw zero, (a0)


### PR DESCRIPTION
### Contribution description

This pull request enables the `puf_sram` feature for RISC-V platforms. The changes include:
- Add a `.noinit` section to the RISC-V linker script.
- Clear `.bss` section only until actual end of that section, to prevent clearing `.noinit`.
- New helper function that calls `puf_sram_init` is executed from startup code.
- Enable the feature via `Makefile.features`.

### Testing procedure

Execute *tests/puf_sram* on a RISC-V board as explained in the test [README](https://github.com/RIOT-OS/RIOT/tree/master/tests/puf_sram#readme). I have used the `hifive1b` board. Note that this platform requires a power-off time of ~10 seconds to produce fresh memory pattern on startup.  

1. Run the example test script alike `python tests/example_test.py -t 10 -n 100`. This produces 100 SRAM based seeds with a power-off time of 10 seconds. It should produce outputs similar to:

```
Iteration 0/100
1439302621
Iteration 1/100
3158746474
Iteration 2/100
...
Iteration 99/100
1221232866
Number of seeds: 100       
Seed length    : 32 Bit   
Abs. Entropy   : 28.94 Bit   
Rel. Entropy   : 90.44 perc. 
```

2. (Requires at least one preceding power-off cycle) Press the reset button. The soft-reset detection should trigger which becomes visible by the print before `main`.

```
random: PUF SEED not fresh
main(): This is RIOT! (Version: 2022.01-devel-1951-g397c17)
Start: Test random number generator
Success: Data for puf_sram_seed: [0xEEE4DC19]
End: Test finished

```




