### PR TITLE
mtd doc: Add overview defining terms; link modules

### DIFF
--- a/drivers/include/mtd_flashpage.h
+++ b/drivers/include/mtd_flashpage.h
@@ -11,6 +11,10 @@
  * @ingroup     drivers_storage
  * @brief       Driver for internal flash devices implementing flashpage interface
  *
+ * The MTD device created by @ref MTD_FLASHPAGE_INIT_VAL spans the complete
+ * accessible flash page memory. To expose merely an area of that as a single
+ * MTD partition, the @ref drivers_mtd_mapper can be used.
+ *
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

MTD doesn't explicitly say what it is about, picking the term from a Linux subsystem but using different terms internally (sector and page vs. Linux's eraseblock). This adds clarifying text and links relevant modules.

### Testing procedure

* Look at built docs, confirm they match your expectations of MTD.

### Issues/PRs references

Contributes-To: https://github.com/RIOT-OS/RIOT/issues/17663