### PR TITLE
drivers/at86rf215: fix disabling individual modulations

### DIFF
--- a/drivers/at86rf215/Makefile
+++ b/drivers/at86rf215/Makefile
@@ -1,1 +1,13 @@
+SRC := at86rf215.c at86rf215_getset.c at86rf215_netdev.c at86rf215_internal.c
+
+ifneq (,$(filter netdev_ieee802154_mr_ofdm,$(USEMODULE)))
+  SRC += at86rf215_ofdm.c
+endif
+ifneq (,$(filter netdev_ieee802154_mr_fsk,$(USEMODULE)))
+  SRC += at86rf215_fsk.c
+endif
+ifneq (,$(filter netdev_ieee802154_oqpsk netdev_ieee802154_mr_oqpsk,$(USEMODULE)))
+  SRC += at86rf215_o-qpsk.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -69,6 +69,7 @@ static bool _is_busy(at86rf215_t *dev)
     return false;
 }
 
+__attribute__((unused))
 static uint8_t _get_best_match(const uint8_t *array, uint8_t len, uint8_t val)
 {
     uint8_t res = 0;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If only a single modulation is used by the application, we can save some ROM by disabling modes that are not used.
However, this is broken as the .c files were still compiled and then failed because now struct members were missing,

Only compile the relevant .c files if the modulation is used.


### Testing procedure

This should work now:

    DISABLE_MODULE += netdev_ieee802154_mr_oqpsk
    DISABLE_MODULE += netdev_ieee802154_mr_ofdm
    DISABLE_MODULE += netdev_ieee802154_mr_fsk


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
