### PR TITLE
sys/net/gnrc_sixlowpan_frag_sfr: use xtimer_set

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
@@ -84,7 +84,7 @@ static char addr_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
 #endif  /* MODULE_GNRC_IPV6_NIB */
 
 static evtimer_msg_t _arq_timer;
-static xtimer_t _if_gap_timer = { .offset = 0, .long_offset = 0 };
+static xtimer_t _if_gap_timer = { 0 };
 static msg_t _if_gap_msg = { .type = GNRC_SIXLOWPAN_FRAG_SFR_INTER_FRAG_GAP_MSG };
 static uint32_t _last_frame_sent = 0U;
 
@@ -1481,8 +1481,7 @@ static void _sched_next_frame(void)
 {
     if (CONFIG_GNRC_SIXLOWPAN_SFR_INTER_FRAME_GAP_US > 0) {
         int state = irq_disable();  /* make timer check atomic */
-        bool already_set = (_if_gap_timer.offset ||
-                            _if_gap_timer.long_offset);
+        bool already_set = xtimer_is_set(&_if_gap_timer);
 
         irq_restore(state);
         if (!already_set) {


### PR DESCRIPTION
### Contribution description

The change should be trivial, use `xtimer_is_set` which does the same thing, and avoid touching `.long_offset` for ztimer compatibility. Since those are static variables they are initialized as 0 anyway.

### Testing procedure

- green murdock should do

```
make -C tests/gnrc_sixlowpan_frag flash test -j

LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2022.04-devel-389-g13bb0-pr_sixlowpanfrag_xtimer_is_set)
..............
OK (14 tests)
```

### Issues/PRs references

Split and adapted from  #17365