### PR TITLE
cpu/efm32: bump Gecko SDK version

### DIFF
--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -1,15 +1,3 @@
-ifneq (,$(filter periph_rtc,$(USEMODULE)))
-  USEMODULE += periph_rtc_series$(EFM32_SERIES)
-endif
-
-ifneq (,$(filter periph_rtt,$(USEMODULE)))
-  USEMODULE += periph_rtt_series$(EFM32_SERIES)
-endif
-
-ifneq (,$(filter periph_wdt,$(USEMODULE)))
-  USEMODULE += periph_wdt_series$(EFM32_SERIES)
-endif
-
 # include Gecko SDK package
 USEPKG += gecko_sdk
 

--- a/cpu/efm32/periph/Makefile
+++ b/cpu/efm32/periph/Makefile
@@ -1,1 +1,30 @@
+include $(RIOTCPU)/efm32/efm32-info.mk
+
+# Select the correct implementation for `periph_rtc`
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
+  ifeq (0,$(EFM32_SERIES))
+    SRC += rtc_series0.c
+  else ifeq (1,$(EFM32_SERIES))
+    SRC += rtc_series1.c
+  endif
+endif
+
+# Select the correct implementation for `periph_rtt`
+ifneq (,$(filter periph_rtt,$(USEMODULE)))
+  ifeq (0,$(EFM32_SERIES))
+    SRC += rtt_series0.c
+  else ifeq (1,$(EFM32_SERIES))
+    SRC += rtt_series1.c
+  endif
+endif
+
+# Select the correct implementation for `periph_wdt`
+ifneq (,$(filter periph_wdt,$(USEMODULE)))
+  ifeq (0,$(EFM32_SERIES))
+    SRC += wdt_series0.c
+  else ifeq (1,$(EFM32_SERIES))
+    SRC += wdt_series1.c
+  endif
+endif
+
 include $(RIOTMAKE)/periph.mk

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=b47581a678a53c01dacea9a0a3956c67854b12f4
+PKG_VERSION=e291e7e0bb56d3f51f03ef7c0b8af138a8d1301a
 PKG_LICENSE=Zlib
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Currently, RIOT supports only Series 0 and 1 EFM32 CPUs. I'm about to bring the first Series 2 CPU into RIOT. This PR updates the SDK to version 4.0, which is required for Series 2 support.

Furthermore, I have done some housekeeping and changed the mechanics how series-specific periph drivers are selected. I've found this trick in the STM32 cpu family ;-)

### Testing procedure

All EFM32-based boards should still work.

### Issues/PRs references

https://github.com/basilfx/RIOT-gecko-sdk/pull/4#issuecomment-1008045570
