### PR TITLE
tools/dhcpv6-pd_ia: create /run/kea on startup

### DIFF
--- a/dist/tools/dhcpv6-pd_ia/kea.py
+++ b/dist/tools/dhcpv6-pd_ia/kea.py
@@ -113,4 +113,6 @@ class KeaServer(base.DHCPv6Server):
                 # workaround: Arch does not create that directory on first
                 # install
                 os.makedirs("/var/run/kea/")
+        # workaround: Ubuntu does not create that directory automatically
+        os.makedirs("/run/kea/", exist_ok=True)
         super().run()


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I was wondering why the border router would not work on `native` witth `USE_DHCPV6=1`, then I remembered that I manually have to create `/run/kea` each time.

So let's add this to the `dhcpv6-pd_ia.py` script so it will 'just work' in the future. 

It looks like on Arch something simimar was needed, but on Ubuntu `/run` is a tmpfs, so we have to create the directory after each reboot.

### Testing procedure

    make -C examples/gnrc_border_router USE_DHCPV6=1 all term

should get a global address on the ZEP interface.  

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
