### PR TITLE
Revert "gnrc_ipv6_nib: consider all local interfaces when looking for…

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -915,7 +915,6 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                             const ndp_nbr_sol_t *nbr_sol, size_t icmpv6_len)
 {
     size_t tmp_len = icmpv6_len - sizeof(ndp_nbr_sol_t);
-    gnrc_netif_t *tgt_netif;
     int tgt_idx;
     ndp_opt_t *opt;
 
@@ -941,23 +940,13 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
               ipv6_addr_to_str(addr_str, &ipv6->dst, sizeof(addr_str)));
         return;
     }
-
-    /* check if the address belongs to this host */
-    tgt_netif = gnrc_netif_get_by_ipv6_addr(&nbr_sol->tgt);
-
-    if (tgt_netif != NULL) {
-        /* check if target is assigned only now in case the length was wrong */
-        tgt_idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_sol->tgt);
-    } else {
-        tgt_idx = -1;
-    }
-
+    /* check if target is assigned only now in case the length was wrong */
+    tgt_idx = gnrc_netif_ipv6_addr_idx(netif, &nbr_sol->tgt);
     if (tgt_idx < 0) {
         DEBUG("nib: Target address %s is not assigned to the local interface\n",
               ipv6_addr_to_str(addr_str, &nbr_sol->tgt, sizeof(addr_str)));
         return;
     }
-
     /* pre-check option length */
     FOREACH_OPT(nbr_sol, opt, tmp_len) {
         if (tmp_len > icmpv6_len) {
@@ -979,16 +968,19 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     DEBUG("     - Destination address: %s\n",
           ipv6_addr_to_str(addr_str, &ipv6->dst, sizeof(addr_str)));
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
+    gnrc_netif_t *tgt_netif = gnrc_netif_get_by_ipv6_addr(&nbr_sol->tgt);
 
     if (tgt_netif != NULL) {
+        int idx;
+
         gnrc_netif_acquire(tgt_netif);
-        tgt_idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_sol->tgt);
+        idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_sol->tgt);
         /* if idx < 0:
          * nbr_sol->tgt was removed between getting tgt_netif by nbr_sol->tgt
          * and gnrc_netif_acquire(tgt_netif). This is like `tgt_netif` would
          * have been NULL in the first place so just continue as if it would
          * have. */
-        if ((tgt_idx >= 0) && gnrc_netif_ipv6_addr_dad_trans(tgt_netif, tgt_idx)) {
+        if ((idx >= 0) && gnrc_netif_ipv6_addr_dad_trans(tgt_netif, idx)) {
             if (!ipv6_addr_is_unspecified(&ipv6->src)) {
                 /* (see https://tools.ietf.org/html/rfc4862#section-5.4.3) */
                 DEBUG("nib: Neighbor is performing AR, but target address is "
@@ -998,7 +990,7 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
             }
             /* cancel validation timer */
             evtimer_del(&_nib_evtimer,
-                        &tgt_netif->ipv6.addrs_timers[tgt_idx].event);
+                        &tgt_netif->ipv6.addrs_timers[idx].event);
             /* _remove_tentative_addr() context switches to `tgt_netif->pid` so
              * release `tgt_netif`. We are done here anyway. */
             gnrc_netif_release(tgt_netif);

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -355,16 +355,11 @@ void gnrc_ndp_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
     gnrc_netif_acquire(netif);
     do {    /* XXX: hidden goto */
         int tgt_idx;
-        gnrc_netif_t *tgt_netif = gnrc_netif_get_by_ipv6_addr(tgt);
 
-        if (tgt_netif == NULL) {
+        if ((tgt_idx = gnrc_netif_ipv6_addr_idx(netif, tgt)) < 0) {
             DEBUG("ndp: tgt not assigned to interface. Abort sending\n");
             break;
         }
-
-        tgt_idx = gnrc_netif_ipv6_addr_idx(tgt_netif, tgt);
-        assert(tgt_idx >= 0);
-
         if (gnrc_netif_is_rtr(netif) && gnrc_netif_is_rtr_adv(netif)) {
             adv_flags |= NDP_NBR_ADV_FLAGS_R;
         }
@@ -397,7 +392,7 @@ void gnrc_ndp_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
         }
         /* TODO: also check if the node provides proxy services for tgt */
         if ((pkt != NULL) &&
-            (tgt_netif->ipv6.addrs_flags[tgt_idx] &
+            (netif->ipv6.addrs_flags[tgt_idx] &
              GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST)) {
             /* TL2A is not supplied and tgt is not anycast */
             adv_flags |= NDP_NBR_ADV_FLAGS_O;


### PR DESCRIPTION
### Contribution description

#16569 was entirely unnecessary and the original behavior was correct. The response to a neighbor solicitation should only consider addresses on the interface on which the neighbor solicitation was received. 
#16557 turned out to be the proper fix for this issue.


### Testing procedure

Consider a node with the `gnrc_ipv6_auto_subnets_simple` module:

```
2022-02-17 19:28:23,963 # Iface  6  HWaddr: AE:A9:37:56:1E:EE 
2022-02-17 19:28:23,967 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2022-02-17 19:28:23,969 #           RTR_ADV  
2022-02-17 19:28:23,972 #           Source address length: 6
2022-02-17 19:28:23,975 #           Link type: wired
2022-02-17 19:28:23,981 #           inet6 addr: fe80::aca9:37ff:fe56:1eee  scope: link  VAL
2022-02-17 19:28:23,988 #           inet6 addr: 2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee  scope: global  VAL
2022-02-17 19:28:23,990 #           inet6 group: ff02::2
2022-02-17 19:28:23,993 #           inet6 group: ff02::1
2022-02-17 19:28:23,997 #           inet6 group: ff02::1:ff56:1eee
2022-02-17 19:28:23,998 #           
2022-02-17 19:28:24,001 #           Statistics for Layer 2
2022-02-17 19:28:24,003 #             RX packets 0  bytes 0
2022-02-17 19:28:24,008 #             TX packets 3 (Multicast: 3)  bytes 0
2022-02-17 19:28:24,011 #             TX succeeded 0 errors 3
2022-02-17 19:28:24,014 #           Statistics for IPv6
2022-02-17 19:28:24,017 #             RX packets 0  bytes 0
2022-02-17 19:28:24,021 #             TX packets 3 (Multicast: 3)  bytes 208
2022-02-17 19:28:24,024 #             TX succeeded 3 errors 0
2022-02-17 19:28:24,024 # 
2022-02-17 19:28:24,027 # Iface  5  HWaddr: AE:A9:37:56:1E:EF 
2022-02-17 19:28:24,032 #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2022-02-17 19:28:24,035 #           Source address length: 6
2022-02-17 19:28:24,037 #           Link type: wired
2022-02-17 19:28:24,043 #           inet6 addr: fe80::aca9:37ff:fe56:1eef  scope: link  VAL
2022-02-17 19:28:24,050 #           inet6 addr: 2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef  scope: global  VAL
2022-02-17 19:28:24,053 #           inet6 group: ff02::2
2022-02-17 19:28:24,056 #           inet6 group: ff02::1
2022-02-17 19:28:24,059 #           inet6 group: ff02::1:ff56:1eef
2022-02-17 19:28:24,060 #           
2022-02-17 19:28:24,063 #           Statistics for Layer 2
2022-02-17 19:28:24,066 #             RX packets 1  bytes 110
2022-02-17 19:28:24,071 #             TX packets 4 (Multicast: 4)  bytes 320
2022-02-17 19:28:24,074 #             TX succeeded 4 errors 0
2022-02-17 19:28:24,076 #           Statistics for IPv6
2022-02-17 19:28:24,079 #             RX packets 1  bytes 96
2022-02-17 19:28:24,084 #             TX packets 4 (Multicast: 4)  bytes 264
2022-02-17 19:28:24,087 #             TX succeeded 4 errors 0
```

We should be able to reach both the upstream and the downstream interface from an outside host:

```
PING 2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef(2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef) 56 data bytes
64 bytes from 2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef: icmp_seq=1 ttl=63 time=60.1 ms
64 bytes from 2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef: icmp_seq=2 ttl=63 time=34.5 ms
64 bytes from 2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef: icmp_seq=3 ttl=63 time=26.6 ms

--- 2001:16b8:459a:b9f8:aca9:37ff:fe56:1eef ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2002ms
rtt min/avg/max/mdev = 26.582/40.392/60.059/14.280 ms
```

```
PING 2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee(2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee) 56 data bytes
64 bytes from 2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee: icmp_seq=1 ttl=63 time=33.9 ms
64 bytes from 2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee: icmp_seq=2 ttl=63 time=28.7 ms
64 bytes from 2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee: icmp_seq=3 ttl=63 time=34.4 ms

--- 2001:16b8:459a:b9fa:aca9:37ff:fe56:1eee ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2003ms
rtt min/avg/max/mdev = 28.680/32.342/34.446/2.599 ms
```

### Issues/PRs references

reverts #16569
