### PR TITLE
pkg/tinydtls/sock_dtls: use ztimer_usec

### DIFF
--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -12,4 +12,5 @@ FEATURES_REQUIRED += arch_32bit
 
 ifneq (,$(filter sock_dtls,$(USEMODULE)))
   USEMODULE += tinydtls_sock_dtls
+  USEMODULE += ztimer_usec
 endif

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -22,7 +22,7 @@
 #include "log.h"
 #include "net/sock/dtls.h"
 #include "net/credman.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #if SOCK_HAS_ASYNC
 #include "net/sock/async.h"
@@ -624,8 +624,8 @@ ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
             msg_t msg;
             bool is_timed_out = false;
             do {
-                uint32_t start = xtimer_now_usec();
-                res = xtimer_msg_receive_timeout(&msg, timeout);
+                uint32_t start = ztimer_now(ZTIMER_USEC);
+                res = ztimer_msg_receive_timeout(ZTIMER_USEC, &msg, timeout);
 
                 if (timeout != SOCK_NO_TIMEOUT) {
                     timeout = _update_timeout(start, timeout);
@@ -768,7 +768,7 @@ ssize_t sock_dtls_recv_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
     /* loop breaks when timeout or application data read */
     while (1) {
         ssize_t res;
-        uint32_t start_recv = xtimer_now_usec();
+        uint32_t start_recv = ztimer_now(ZTIMER_USEC);
         msg_t msg;
 
         if (sock->buffer.data != NULL) {
@@ -840,7 +840,7 @@ static void _session_to_ep(const session_t *session, sock_udp_ep_t *ep)
 
 static inline uint32_t _update_timeout(uint32_t start, uint32_t timeout)
 {
-    uint32_t diff = (xtimer_now_usec() - start);
+    uint32_t diff = (ztimer_now(ZTIMER_USEC) - start);
 
     return (diff > timeout) ? 0: timeout - diff;
 }

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -119,6 +119,7 @@ static int _write(struct dtls_context_t *ctx, session_t *session, uint8_t *buf,
     remote.family = AF_INET6;
 
     ssize_t res = sock_udp_send(sock->udp_sock, buf, len, &remote);
+
     if (res < 0) {
         DEBUG("sock_dtls: failed to send DTLS record: %d\n", (int)res);
     }
@@ -133,17 +134,18 @@ static int _event(struct dtls_context_t *ctx, session_t *session,
 
     sock_dtls_t *sock = dtls_get_app_data(ctx);
     msg_t msg = { .type = code, .content.ptr = session };
+
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         switch (code) {
-            case DTLS_EVENT_CONNECT:
-                DEBUG("sock_dtls: event connect\n");
-                break;
-            case DTLS_EVENT_CONNECTED:
-                DEBUG("sock_dtls: event connected\n");
-                break;
-            case DTLS_EVENT_RENEGOTIATE:
-                DEBUG("sock_dtls: event renegotiate\n");
-                break;
+        case DTLS_EVENT_CONNECT:
+            DEBUG("sock_dtls: event connect\n");
+            break;
+        case DTLS_EVENT_CONNECTED:
+            DEBUG("sock_dtls: event connected\n");
+            break;
+        case DTLS_EVENT_RENEGOTIATE:
+            DEBUG("sock_dtls: event renegotiate\n");
+            break;
         }
     }
     if (!level && (code != DTLS_EVENT_CONNECT)) {
@@ -164,18 +166,18 @@ static int _event(struct dtls_context_t *ctx, session_t *session,
 #ifdef SOCK_HAS_ASYNC
     if (sock->async_cb != NULL) {
         switch (code) {
-            case DTLS_ALERT_CLOSE_NOTIFY:
-                /* peer closed their session */
-                memcpy(&sock->async_cb_session, session, sizeof(session_t));
-                sock->async_cb(sock, SOCK_ASYNC_CONN_FIN, sock->async_cb_arg);
-                break;
-            case DTLS_EVENT_CONNECTED:
-                /* we received a session handshake initialization */
-                sock->async_cb(sock, SOCK_ASYNC_CONN_RECV,
-                               sock->async_cb_arg);
-                break;
-            default:
-                break;
+        case DTLS_ALERT_CLOSE_NOTIFY:
+            /* peer closed their session */
+            memcpy(&sock->async_cb_session, session, sizeof(session_t));
+            sock->async_cb(sock, SOCK_ASYNC_CONN_FIN, sock->async_cb_arg);
+            break;
+        case DTLS_EVENT_CONNECTED:
+            /* we received a session handshake initialization */
+            sock->async_cb(sock, SOCK_ASYNC_CONN_RECV,
+                           sock->async_cb_arg);
+            break;
+        default:
+            break;
         }
     }
 #endif
@@ -216,7 +218,7 @@ static int _get_psk_info(struct dtls_context_t *ctx, const session_t *session,
         if (sock->client_psk_cb) {
             DEBUG("sock_dtls: requesting the application\n");
             credential.tag = sock->client_psk_cb(sock, &ep, sock->tags, sock->tags_len,
-                                                 (const char*)desc, desc_len);
+                                                 (const char *)desc, desc_len);
             if (credential.tag != CREDMAN_TAG_EMPTY) {
                 int ret = credman_get(&credential, credential.tag, CREDMAN_TYPE_PSK);
                 if (ret == CREDMAN_OK) {
@@ -316,6 +318,7 @@ static int _get_ecdsa_key(struct dtls_context_t *ctx, const session_t *session,
     _session_to_ep(session, &ep);
 
     credman_credential_t credential;
+
     credential.tag = CREDMAN_TAG_EMPTY;
     DEBUG("sock_dtls: get ECDSA key\n");
 
@@ -349,6 +352,7 @@ static int _get_ecdsa_key(struct dtls_context_t *ctx, const session_t *session,
     /* try to find a free ECDSA key assignment structure for the handshake. When unused, the session
      * is not set. */
     ecdsa_key_assignment_t *key = NULL;
+
     for (unsigned i = 0; i < CONFIG_DTLS_CREDENTIALS_MAX; i++) {
         if (!_ecdsa_keys[i].session) {
             key = &_ecdsa_keys[i];
@@ -374,11 +378,11 @@ static int _verify_ecdsa_key(struct dtls_context_t *ctx,
                              const unsigned char *other_pub_x,
                              const unsigned char *other_pub_y, size_t key_size)
 {
-    (void) ctx;
-    (void) session;
-    (void) other_pub_y;
-    (void) other_pub_x;
-    (void) key_size;
+    (void)ctx;
+    (void)session;
+    (void)other_pub_y;
+    (void)other_pub_x;
+    (void)key_size;
 
     return 0;
 }
@@ -401,7 +405,7 @@ int sock_dtls_create(sock_dtls_t *sock, sock_udp_t *udp_sock,
         return -1;
     }
     else if ((version == SOCK_DTLS_1_2) &&
-        (DTLS_VERSION != 0xfefd)) {
+             (DTLS_VERSION != 0xfefd)) {
         DEBUG("sock_dtls: tinydtls not compiled with support for DTLS 1.2\n");
         return -1;
     }
@@ -470,6 +474,7 @@ int sock_dtls_remove_credential(sock_dtls_t *sock, credman_tag_t tag)
 {
     assert(sock);
     int pos = -1;
+
     for (unsigned i = 0; i < sock->tags_len; i++) {
         if (sock->tags[i] == tag) {
             pos = i;
@@ -526,6 +531,7 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
     assert(remote);
 
     sock_udp_ep_t local;
+
     if (!sock->udp_sock || (sock_udp_get_local(sock->udp_sock, &local) < 0)) {
         return -EADDRNOTAVAIL;
     }
@@ -533,13 +539,13 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
         return -EINVAL;
     }
     switch (ep->family) {
-        case AF_INET:
+    case AF_INET:
  #if IS_ACTIVE(SOCK_HAS_IPV6)
-        case AF_INET6:
+    case AF_INET6:
  #endif
-            break;
-        default:
-            return -EINVAL;
+        break;
+    default:
+        return -EINVAL;
     }
 
     /* prepare the remote party to connect to */
@@ -563,6 +569,7 @@ int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
 void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote)
 {
     dtls_peer_t *peer = dtls_get_peer(sock->dtls_ctx, &remote->dtls_session);
+
     if (peer) {
         /* dtls_reset_peer() also sends close_notify if not already sent */
         dtls_reset_peer(sock->dtls_ctx, peer);
@@ -624,8 +631,7 @@ ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
                     timeout = _update_timeout(start, timeout);
                     is_timed_out = (res < 0) || (timeout == 0);
                 }
-            }
-            while (!is_timed_out && (msg.type != DTLS_EVENT_CONNECTED));
+            }while (!is_timed_out && (msg.type != DTLS_EVENT_CONNECTED));
             if (is_timed_out &&  (msg.type != DTLS_EVENT_CONNECTED)) {
                 DEBUG("sock_dtls: handshake process timed out\n");
 
@@ -835,6 +841,7 @@ static void _session_to_ep(const session_t *session, sock_udp_ep_t *ep)
 static inline uint32_t _update_timeout(uint32_t start, uint32_t timeout)
 {
     uint32_t diff = (xtimer_now_usec() - start);
+
     return (diff > timeout) ? 0: timeout - diff;
 }
 


### PR DESCRIPTION
### Contribution description

In  #17564 `tinydtls` code was migrated to `ztimer`, but for some reason, `sock_dtls` was looked over, and not caught by the CI, it's now resurfaced with #17670, so this PR cleans this up.

Since `sock` timeous are in `us` this PR us using `ztimer_usec, only 32bits are required here.

I also uncrustified in a separate commit.

### Testing procedure

I ran `examples/dtls-sock` between two native nodes, also change the timeouts from `SOCK_NO_TIMEOUT` to `5 * US_PER_SEC` and saw it timeout after 5 second when only one native node was up:

- timeout
```
main(): This is RIOT! (Version: 2022.04-devel-416-g092ca-pr_tinydtls_ztimer_cleanup)
DTLS sock example application
All up, running the shell now
> dtlsc fe80::4cb2:45ff:fe3a:8461 "secure data"
dtlsc fe80::4cb2:45ff:fe3a:8461 "secure data"
Error creating session: -110
>
```

- success
```
main(): This is RIOT! (Version: 2022.04-devel-416-g092ca-pr_tinydtls_ztimer_cleanup)
DTLS sock example application
All up, running the shell now
> dtlss start
dtlss start
> ifconfig
ifconfig
Iface  5  HWaddr: 4E:B2:45:3A:84:61
          L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
          Link type: wired
          inet6 addr: fe80::4cb2:45ff:fe3a:8461  scope: link  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ff3a:8461

> New client connected
Received 11 bytes -- (echo)

```

```
main(): This is RIOT! (Version: 2022.04-devel-416-g092ca-pr_tinydtls_ztimer_cleanup)
DTLS sock example application
All up, running the shell now
> dtlsc fe80::4cb2:45ff:fe3a:8461 "secure data"
dtlsc fe80::4cb2:45ff:fe3a:8461 "secure data"
From [fe80::4cb2:45ff:fe3a:8461%5]:20220
Client got hint: hint
Connection to server successful
Sent DTLS message
Received 11 bytes: "secure data"
Terminating
```

### Issues/PRs references

Cleanup from  #17564
Needed for  #17670 
