### PR TITLE
gnrc_netif: make auto-config of compression context optional

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -194,6 +194,16 @@ extern "C" {
 #define CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU 0
 #endif
 
+/**
+ * @brief   Automatically add 6LoWPAN compression at border router
+ *
+ * When set, 6LoWPAN compression context 0 will be automatically set for the prefix configured by
+ * prefix deligation at the border router.
+ */
+#ifndef CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX
+#define CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX   1
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/netif/Kconfig
+++ b/sys/net/gnrc/netif/Kconfig
@@ -74,5 +74,12 @@ config GNRC_NETIF_LORAWAN_NETIF_HDR
         GNRC LoRaWAN packets will include the GNRC Netif
         header. Therefore this parameter will be removed
 
+config GNRC_NETIF_IPV6_BR_AUTO_6CTX
+    bool "Automatically add 6LoWPAN compression at border router"
+    default y
+    depends on USEMODULE_GNRC_IPV6_NIB_6LBR && USEMODULE_GNRC_SIXLOWPAN_IPHC && USEMODULE_GNRC_SIXLOWPAN_CTX
+    help
+        When set, 6LoWPAN compression context 0 will be automatically set for the prefix configured
+        by prefix deligation at the border router.
 
 endif # KCONFIG_USEMODULE_GNRC_NETIF

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1287,10 +1287,12 @@ int gnrc_netif_ipv6_add_prefix(gnrc_netif_t *netif,
         IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C) &&
         gnrc_netif_is_6ln(netif)) {
 
-        /* configure compression context */
-        if (gnrc_sixlowpan_ctx_update_6ctx(pfx, pfx_len, valid)) {
-            DEBUG("gnrc_netif: add compression context for prefix %s/%u\n",
-                   ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)), pfx_len);
+        if (IS_ACTIVE(CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX)) {
+            /* configure compression context */
+            if (gnrc_sixlowpan_ctx_update_6ctx(pfx, pfx_len, valid)) {
+                DEBUG("gnrc_netif: add compression context for prefix %s/%u\n",
+                       ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)), pfx_len);
+            }
         }
 
         (void)gnrc_ipv6_nib_abr_add(&addr);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
For a set of my currently ongoing experiments it is important that the 6LoWPAN header stays roughly the same over all hops. With global addresses this can easily be achieved by not configuring a compression context. However, when using a border router with UHCP or DHCPv6, the compression context will be configured automatically and when you try to delete it, it is most often to late, as the prefix and the compression contexts are already disseminated throughout the network (and any further auto config message for the prefix might re-add it).

This change makes the auto-configuration of the compression context by setting the Kconfig variable `CONFIG_GNRC_NETIF_IPV6_DO_NOT_COMP_PREFIX` to false.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Flash and run the `examples/gnrc_border_router` twice: Once as is, and once with the new option set (e.g. by using `make menuconfig`. Once a global prefix is configured (use `ifconfig` to check) use `6ctx` to check: for the untouched binary, `6ctx` should show the prefix as compression context 0, for when `CONFIG_GNRC_NETIF_IPV6_DO_NOT_COMP_PREFIX=y` the table should be empty.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
