### PR TITLE
sys/net/dsm: add missing dependencies

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -571,6 +571,11 @@ ifneq (,$(filter gcoap_dtls,$(USEMODULE)))
   USEMODULE += event_timeout_ztimer
 endif
 
+ifneq (,$(filter dsm,$(USEMODULE)))
+  USEMODULE += sock_dtls
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
   USEMODULE += sock_async_event

--- a/sys/net/dsm/Makefile.dep
+++ b/sys/net/dsm/Makefile.dep
@@ -1,1 +1,0 @@
-FEATURES_REQUIRED += sock_dtls


### PR DESCRIPTION
### Contribution description

Caught by CI when running on #17670. `sock_dtls` is a module and not a feature, the Makefile.dep was never included, move it to the generic `sys/Makefile.dep`

### Testing procedure

Green Murdock should be enough

### Issues/PRs references

Split from #17670.