### PR TITLE
cpu/saml21: derive low power SRAM length from model number

### DIFF
--- a/cpu/sam0_common/sam0_info.mk
+++ b/cpu/sam0_common/sam0_info.mk
@@ -1,0 +1,14 @@
+# Extract SAM0 infos from CPU_MODEL
+# Example for saml21e15b
+# - SAM0_FAMILY:  l
+# - SAM0_SERIES:  21
+# - SAM0_PINCNT:  e  (32 Pins)
+# - SAM0_DENSITY: 15 (32k Flash)
+# - SAM0_VARIANT: b  (release stepping)
+
+SAM0_INFO    := $(shell echo $(CPU_MODEL) | sed -E -e 's/^sam(d|e|l|r)([0-9][0-9])([a-z])([0-9][0-9])(.)?/\1 \2 \3 \4 \5/')
+SAM0_FAMILY  := $(word 1, $(SAM0_INFO))
+SAM0_SERIES  := $(word 2, $(SAM0_INFO))
+SAM0_PINCNT  := $(word 3, $(SAM0_INFO))
+SAM0_DENSITY := $(word 4, $(SAM0_INFO))
+SAM0_VARIANT := $(word 5, $(SAM0_INFO))

--- a/cpu/saml21/Makefile.include
+++ b/cpu/saml21/Makefile.include
@@ -1,3 +1,5 @@
+include $(RIOTCPU)/sam0_common/sam0_info.mk
+
 ifneq (,$(filter saml21%a,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAML21A
 endif
@@ -13,9 +15,15 @@ endif
 
 CFLAGS += -DCPU_COMMON_SAML21
 
-ifneq (,$(filter saml21j18b saml21j18a samr30g18a samr34j18b,$(CPU_MODEL)))
-  BACKUP_RAM_ADDR = 0x30000000
-  BACKUP_RAM_LEN  = 0x2000
+BACKUP_RAM_ADDR = 0x30000000
+ifeq (18, $(SAM0_DENSITY))
+  BACKUP_RAM_LEN  = 0x2000  # 8k
+else ifeq (17, $(SAM0_DENSITY))
+  BACKUP_RAM_LEN  = 0x2000  # 8k
+else ifeq (16, $(SAM0_DENSITY))
+  BACKUP_RAM_LEN  = 0x1000  # 4k
+else ifeq (15, $(SAM0_DENSITY))
+  BACKUP_RAM_LEN  =  0x800  # 2k
 endif
 
 include $(RIOTCPU)/sam0_common/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The size of the low power SRAM on SAM L21 family chips varies between members.
Decode the model number just like it's done for STM32 so we don't need to maintain an ever expanding list.

![image](https://user-images.githubusercontent.com/1301112/154972541-ed22ab0a-21fa-498b-8e97-5236bc30bd4e.png)


### Testing procedure

`tests/periph_backup_ram` should still compile.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
