### PR TITLE
sys/ztimer: cleanup xtimer_compat.h for 32Bit only

### DIFF
--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -26,7 +26,6 @@
 /* make sure to overwrite potentially conflicting XTIMER_WIDTH definition from
  * board.h by eagerly including it */
 #include "board.h"
-#include "div.h"
 #include "timex.h"
 #ifdef MODULE_CORE_MSG
 #include "msg.h"
@@ -177,14 +176,6 @@ static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup,
     ztimer_periodic_wakeup(ZTIMER_USEC, last_wakeup, period);
 }
 
-static inline void xtimer_now_timex(timex_t *out)
-{
-    uint32_t now = xtimer_now_usec();
-
-    out->seconds = div_u64_by_1000000(now);
-    out->microseconds = now - (out->seconds * US_PER_SEC);
-}
-
 static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout)
 {
     return ztimer_msg_receive_timeout(ZTIMER_USEC, msg, timeout);
@@ -260,6 +251,7 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b)
 
    xtimer_ticks64_t xtimer_now64(void);
    uint64_t xtimer_now_usec64(void):
+   void xtimer_now_timex(timex_t *out)
    void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
    void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
                                        kernel_pid_t pid);

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -64,25 +64,32 @@ static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks)
     return ticks;
 }
 
+static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks)
+{
+    return ticks;
+}
+
+static inline uint64_t xtimer_usec_from_ticks64(xtimer_ticks64_t ticks)
+{
+    return ticks;
+}
+
+static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec)
+{
+    return usec;
+}
+
+static inline xtimer_ticks64_t xtimer_ticks_from_usec64(uint64_t usec)
+{
+    return usec;
+}
+
 static inline xtimer_ticks32_t xtimer_now(void)
 {
     return ztimer_now(ZTIMER_USEC);
 }
 
-static inline xtimer_ticks64_t xtimer_now64(void)
-{
-    return ztimer_now(ZTIMER_USEC);
-}
-
-/*static void xtimer_now_timex(timex_t *out) {
-   }*/
-
 static inline uint32_t xtimer_now_usec(void)
-{
-    return ztimer_now(ZTIMER_USEC);
-}
-
-static inline uint64_t xtimer_now_usec64(void)
 {
     return ztimer_now(ZTIMER_USEC);
 }
@@ -104,10 +111,10 @@ static inline void xtimer_sleep(uint32_t seconds)
 {
     /* TODO: use ZTIMER_SEC */
     if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
-        _ztimer_sleep_scale(ZTIMER_MSEC, seconds, 1000);
+        _ztimer_sleep_scale(ZTIMER_MSEC, seconds, MS_PER_SEC);
     }
     else {
-        _ztimer_sleep_scale(ZTIMER_USEC, seconds, 1000000);
+        _ztimer_sleep_scale(ZTIMER_USEC, seconds, US_PER_SEC);
     }
 }
 
@@ -117,7 +124,7 @@ static inline void xtimer_msleep(uint32_t milliseconds)
         ztimer_sleep(ZTIMER_MSEC, milliseconds);
     }
     else {
-        _ztimer_sleep_scale(ZTIMER_USEC, milliseconds, 1000);
+        _ztimer_sleep_scale(ZTIMER_USEC, milliseconds, US_PER_MS);
     }
 }
 
@@ -129,6 +136,23 @@ static inline void xtimer_usleep(uint32_t microseconds)
 static inline void xtimer_nanosleep(uint32_t nanoseconds)
 {
     ztimer_sleep(ZTIMER_USEC, nanoseconds / NS_PER_US);
+}
+
+static inline void xtimer_tsleep32(xtimer_ticks32_t ticks)
+{
+    xtimer_usleep(xtimer_usec_from_ticks(ticks));
+}
+
+static inline uint64_t xtimer_tsleep64(xtimer_ticks64_t ticks)
+{
+    const uint32_t max_sleep = UINT32_MAX;
+    uint64_t time = xtimer_usec_from_ticks64(ticks);
+
+    while (time > max_sleep) {
+        xtimer_usleep(clock, max_sleep);
+        time -= max_sleep;
+    }
+    xtimer_usleep(clock, time);
 }
 
 static inline void xtimer_set(xtimer_t *timer, uint32_t offset)
@@ -153,19 +177,9 @@ static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup,
     ztimer_periodic_wakeup(ZTIMER_USEC, last_wakeup, period);
 }
 
-static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks)
-{
-    return ticks;
-}
-
-static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec)
-{
-    return usec;
-}
-
 static inline void xtimer_now_timex(timex_t *out)
 {
-    uint64_t now = xtimer_now_usec64();
+    uint32_t now = xtimer_now_usec();
 
     out->seconds = div_u64_by_1000000(now);
     out->microseconds = now - (out->seconds * US_PER_SEC);
@@ -205,12 +219,7 @@ static inline void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
 
 static inline void xtimer_spin(xtimer_ticks32_t ticks)
 {
-    assert(ticks < US_PER_MS);
-    ztimer_now_t start = ztimer_now(ZTIMER_USEC);
-
-    while (ztimer_now(ZTIMER_USEC) - start < ticks) {
-        /* busy waiting */
-    }
+    ztimer_spin(ZTIMER_USEC, xtimer_usec_from_ticks(ticks));
 }
 
 static inline xtimer_ticks32_t xtimer_diff(xtimer_ticks32_t a,
@@ -246,22 +255,17 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b)
     return a < b;
 }
 
-/*
-   static inline void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
-   static inline void xtimer_tsleep32(xtimer_ticks32_t ticks);
-   static inline void xtimer_tsleep64(xtimer_ticks64_t ticks);
-   static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
-                                       kernel_pid_t pid);
-   static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec);
-   static inline xtimer_ticks64_t xtimer_ticks_from_usec64(uint64_t usec);
-   static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks);
-   static inline uint64_t xtimer_usec_from_ticks64(xtimer_ticks64_t ticks);
+/* unsupported due to using ztimer (32Bit):
+ * please use ztimer64_xtimer_compat if need
 
- #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
-   static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,
+   xtimer_ticks64_t xtimer_now64(void);
+   uint64_t xtimer_now_usec64(void):
+   void xtimer_set64(xtimer_t *timer, uint64_t offset_us);
+   void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
+                                       kernel_pid_t pid);
+   void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,
                                     msg_t *msg, kernel_pid_t target_pid);
-   static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
- #endif
+   int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
  */
 
 #endif /* DOXYGEN */


### PR DESCRIPTION
### Contribution description

removes all functions from `ztimer/xtimer_compat.h` (32 Bit) that are not implementable by using ztimer (32 Bit)

if these functions are used `ztimer64/xtimer_compat.h` should be used

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#17670 
