### PR TITLE
gnrc_sock: warn about non-zero receive timeouts with sock_async

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -132,6 +132,14 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     }
 #endif
     if (timeout != 0) {
+#if defined(DEVELHELP) && IS_ACTIVE(SOCK_HAS_ASYNC)
+        if (reg->async_cb.generic) {
+            /* this warning is a false positive when sock_*_recv() was not called from
+             * the asynchronous handler */
+            LOG_WARNING("gnrc_sock: timeout != 0 within the asynchronous callback lead "
+                        "to unexpected delays within the asynchronous handler.\n");
+        }
+#endif
         mbox_get(&reg->mbox, &msg);
     }
     else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
It took me nearly a day of debugging to find out that my event queue was broken due to the handler thread being stuck in a `sock_udp_recv()`. To prevent that in the future, issue a warning about non-zero-timeouts when the asynchronous callback is set.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Apply the following patch:

```patch
diff --git a/tests/gnrc_sock_async_event/main.c b/tests/gnrc_sock_async_event/main.c
index d77e84c084..93bdc9a485 100644
--- a/tests/gnrc_sock_async_event/main.c
+++ b/tests/gnrc_sock_async_event/main.c
@@ -78,7 +78,7 @@ static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
         sock_udp_ep_t remote;
         ssize_t res;
 
-        if ((res = sock_udp_recv(sock, _buffer, sizeof(_buffer), 0,
+        if ((res = sock_udp_recv(sock, _buffer, sizeof(_buffer), 20,
                                  &remote)) >= 0) {
             printf("Received UDP packet from [%s]:%u:\n",
                    ipv6_addr_to_str(_addr_str, (ipv6_addr_t *)remote.addr.ipv6,
```

Running `make -C tests/gnrc_sock_async_event/ -j flash test` for any platform should include the warning in the output

```
gnrc_sock: timeout != 0 with async callback set may lead to unexpected behavior.
```

It should not show up without the change.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
