### PR TITLE
sys: some simple xtimer->ztimer conversions 

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -99,7 +99,7 @@ endif
 
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
-  USEMODULE += xtimer
+  USEMODULE += xztimer_fallback
 endif
 
 ifneq (,$(filter dhcpv6_%,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -858,6 +858,13 @@ ifneq (,$(filter evtimer,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter xztimer_fallback,$(USEMODULE)))
+  USEMODULE := $(filter-out xztimer_fallback,$(USEMODULE))
+  ifeq (,$(filter ztimer_usec,$(USEMODULE)))
+    USEMODULE += xtimer
+  endif
+endif
+
 # handle xtimer's deps. Needs to be done *after* ztimer
 ifneq (,$(filter xtimer,$(USEMODULE)))
   include $(RIOTBASE)/sys/xtimer/Makefile.dep

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -274,7 +274,6 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += vfs
   USEMODULE += posix_headers
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter shell,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -167,7 +167,7 @@ endif
 
 ifneq (,$(filter uhcpc,$(USEMODULE)))
   USEMODULE += posix_inet
-  USEMODULE += xtimer
+  USEMODULE += xztimer_fallback
 endif
 
 ifneq (,$(filter netdev_tap,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -817,7 +817,7 @@ endif
 
 ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
   USEMODULE += nanocoap_sock
-  USEMODULE += xtimer
+  USEMODULE += xztimer_fallback
   USEMODULE += sock_util
 endif
 

--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -12,7 +12,11 @@
 #include "net/af.h"
 #include "net/sock/udp.h"
 #include "net/uhcp.h"
+#if IS_USED(MODULE_ZTIMER_USEC)
+#include "ztimer/xtimer_compat.h"
+#else
 #include "xtimer.h"
+#endif
 
 /**
  * @brief Request prefix from uhcp server

--- a/sys/net/link_layer/csma_sender/csma_sender.c
+++ b/sys/net/link_layer/csma_sender/csma_sender.c
@@ -22,8 +22,13 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <kernel_defines.h>
 
+#if IS_USED(MODULE_ZTIMER_USEC)
+#include "ztimer/xtimer_compat.h"
+#else
 #include "xtimer.h"
+#endif
 #include "random.h"
 #include "net/netdev.h"
 #include "net/netopt.h"

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -32,7 +32,11 @@
 #include "net/nanocoap_sock.h"
 #include "thread.h"
 #include "periph/pm.h"
+#if IS_USED(MODULE_ZTIMER_USEC)
+#include "ztimer/xtimer_compat.h"
+#else
 #include "xtimer.h"
+#endif
 
 #include "suit/transport/coap.h"
 #include "net/sock/util.h"


### PR DESCRIPTION
### Contribution description

do some simple xtimer->ztimer conversions  using 'ztimer/xtimer_compat.h'

These modules only use 32Bit of xtimer and and therefor are able to use ztimer (32) through xtimer_compat.h

### Testing procedure



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
