### PR TITLE
examples/lorawan/main: use auto_init_loramac

### DIFF
--- a/examples/lorawan/Makefile
+++ b/examples/lorawan/Makefile
@@ -40,6 +40,7 @@ LORA_REGION ?= EU868
 
 # Include the Semtech-loramac package
 USEPKG += semtech-loramac
+USEMODULE += auto_init_loramac
 
 USEMODULE += $(DRIVER)
 USEMODULE += fmt

--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -38,18 +38,6 @@
 #include "net/loramac.h"
 #include "semtech_loramac.h"
 
-#if IS_USED(MODULE_SX127X)
-#include "sx127x.h"
-#include "sx127x_netdev.h"
-#include "sx127x_params.h"
-#endif
-
-#if IS_USED(MODULE_SX126X)
-#include "sx126x.h"
-#include "sx126x_netdev.h"
-#include "sx126x_params.h"
-#endif
-
 /* By default, messages are sent every 20s to respect the duty cycle
    on each channel */
 #ifndef SEND_PERIOD_S
@@ -63,13 +51,7 @@
 static kernel_pid_t sender_pid;
 static char sender_stack[THREAD_STACKSIZE_MAIN / 2];
 
-static semtech_loramac_t loramac;
-#if IS_USED(MODULE_SX127X)
-static sx127x_t sx127x;
-#endif
-#if IS_USED(MODULE_SX126X)
-static sx126x_t sx126x;
-#endif
+extern semtech_loramac_t loramac;
 #if !IS_USED(MODULE_PERIPH_RTC)
 static ztimer_t timer;
 #endif
@@ -158,22 +140,6 @@ int main(void)
         pm_unblock(i);
     }
 #endif
-
-    /* Initialize the radio driver */
-#if IS_USED(MODULE_SX127X)
-    sx127x_setup(&sx127x, &sx127x_params[0], 0);
-    loramac.netdev = &sx127x.netdev;
-    loramac.netdev->driver = &sx127x_driver;
-#endif
-
-#if IS_USED(MODULE_SX126X)
-    sx126x_setup(&sx126x, &sx126x_params[0], 0);
-    loramac.netdev = &sx126x.netdev;
-    loramac.netdev->driver = &sx126x_driver;
-#endif
-
-    /* Initialize the loramac stack */
-    semtech_loramac_init(&loramac);
 
 #ifdef USE_OTAA /* OTAA activation mode */
     /* Convert identifiers and keys strings to byte arrays */


### PR DESCRIPTION
### Contribution description

Change to use `auto_init_loramac`

This PR is sparked from https://forum.riot-os.org/t/cant-get-lorawan-shell-working/3526. 

### Testing procedure

- green murdock