### PR TITLE
driver/lpsxxx: adding lps22ch support

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -88,7 +88,7 @@ ifneq (,$(filter tmp1075 lm75%,$(USEMODULE)))
   USEMODULE += lm75
 endif
 
-ifneq (,$(filter lps331ap lps2%hb lps22hh,$(USEMODULE)))
+ifneq (,$(filter lps331ap lps2%,$(USEMODULE)))
   USEMODULE += lpsxxx
 endif
 

--- a/drivers/include/lpsxxx.h
+++ b/drivers/include/lpsxxx.h
@@ -37,7 +37,7 @@ extern "C" {
 #include "periph/i2c.h"
 
 /**
- * @defgroup drivers_lpsxxx_config     LPS331AP/LPS25HB/LPS22HB driver compile configuration
+ * @defgroup drivers_lpsxxx_config     LPS331AP/LPS25HB/LPS22HB/LPS22HH/LPS22CH driver compile configuration
  * @ingroup config_drivers_sensors
  * @{
  */
@@ -81,7 +81,7 @@ typedef enum {
     LPSXXX_RATE_25HZ = 3,       /**< sample with 25Hz, default */
     LPSXXX_RATE_50HZ = 4,       /**< sample with 50Hz */
     LPSXXX_RATE_75HZ = 5        /**< sample with 75Hz */
-#elif MODULE_LPS22HH
+#elif MODULE_LPS22HH || MODULE_LPS22CH
     LPSXXX_RATE_10HZ = 2,       /**< sample with 10Hz */
     LPSXXX_RATE_25HZ = 3,       /**< sample with 25Hz, default */
     LPSXXX_RATE_50HZ = 4,       /**< sample with 50Hz */
@@ -96,7 +96,7 @@ typedef enum {
  */
 #if MODULE_LPS331AP || MODULE_LPS25HB
 #define LPSXXX_DEFAULT_RATE     (LPSXXX_RATE_7HZ)
-#else /* MODULE_LPS22HB || MODULE_LPS22HH */
+#else /* MODULE_LPS22HB || MODULE_LPS22HH  || MODULE_LPS22CH */
 #define LPSXXX_DEFAULT_RATE     (LPSXXX_RATE_25HZ)
 #endif
 

--- a/drivers/lpsxxx/Kconfig
+++ b/drivers/lpsxxx/Kconfig
@@ -15,7 +15,7 @@ menuconfig MODULE_LPSXXX
     select MODULE_PERIPH_I2C
     help
         Device driver for the LPSXXX pressure sensor family
-        (LPS331AP/LPS25HB/LPS22HB/LPS22HH). Select a model.
+        (LPS331AP/LPS25HB/LPS22HB/LPS22HH/LPS22CH). Select a model.
 
 if MODULE_LPSXXX
 
@@ -25,9 +25,10 @@ choice
     default MODULE_LPS22HB if HAVE_LPS22HB
     default MODULE_LPS22HH if HAVE_LPS22HH
     default MODULE_LPS25HB if HAVE_LPS25HB
+    default MODULE_LPS22CH if HAVE_LPS22CH
     help
         Device driver for the LPSXXX pressure sensor family
-        (LPS331AP/LPS25HB/LPS22HB/LPS22HH). Select a model.
+        (LPS331AP/LPS25HB/LPS22HB/LPS22HH/LPS22CH). Select a model.
 
 config MODULE_LPS331AP
     bool "LPS331AP"
@@ -40,6 +41,9 @@ config MODULE_LPS22HH
 
 config MODULE_LPS25HB
     bool "LPS25HB"
+
+config MODULE_LPS22CH
+    bool "LPS22CH"
 
 endchoice
 
@@ -91,3 +95,9 @@ config HAVE_LPS25HB
     select HAVE_LPSXXX
     help
         Indicates that a LPS25HB sensor is present.
+
+config HAVE_LPS22CH
+    bool
+    select HAVE_LPSXXX
+    help
+        Indicates that a LPS22CH sensor is present.

--- a/drivers/lpsxxx/Makefile.include
+++ b/drivers/lpsxxx/Makefile.include
@@ -1,5 +1,6 @@
 # include variants of lpsxxx drivers as pseudo modules
 PSEUDOMODULES += lps331ap
+PSEUDOMODULES += lps22ch
 PSEUDOMODULES += lps22hb
 PSEUDOMODULES += lps22hh
 PSEUDOMODULES += lps25hb

--- a/drivers/lpsxxx/include/lpsxxx_internal.h
+++ b/drivers/lpsxxx/include/lpsxxx_internal.h
@@ -168,10 +168,10 @@ extern "C" {
  */
 #define LPSXXX_WHO_AM_I                 (0xb1)
 
-#elif MODULE_LPS22HH
+#elif MODULE_LPS22HH || MODULE_LPS22CH
 
 /**
- * @name    LPS22HH registers
+ * @name    LPS22HH/LPS22CH registers
  * @{
  */
 #define LPSXXX_REG_INT_CFG              (0x0b)
@@ -198,7 +198,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name    LPS22HH CTRL_REG1 bitfields
+ * @name    LPS22HH/LPS22CH CTRL_REG1 bitfields
  * @{
  */
 #define LPSXXX_CTRL_REG1_EN_LPFP        (0x08)
@@ -207,18 +207,18 @@ extern "C" {
 /** @} */
 
 /**
- * @name    LPS22HH CTRL_REG2 bitfields
+ * @name    LPS22HH/LPS22CH CTRL_REG2 bitfields
  * @{
  */
 #define LPSXXX_CTRL_REG2_ID_ADD_INC     (0x10)
 /** @} */
 
 /**
- * @brief   LPS22HH WHO_AM_I register value
+ * @brief   LPS22HH/LPS22CH WHO_AM_I register value
  */
 #define LPSXXX_WHO_AM_I                 (0xb3)
 
-#endif /* MODULE_LPS22HH */
+#endif /* MODULE_LPS22HH/LPS22CH */
 
 #ifdef __cplusplus
 }

--- a/drivers/lpsxxx/include/lpsxxx_params.h
+++ b/drivers/lpsxxx/include/lpsxxx_params.h
@@ -57,6 +57,8 @@ extern "C" {
 #define LPSXXX_SAUL_NAME    "lps22hb"
 #elif MODULE_LPS22HH
 #define LPSXXX_SAUL_NAME    "lps22hh"
+#elif MODULE_LPS22CH
+#define LPSXXX_SAUL_NAME    "lps22ch"
 #endif
 #ifndef LPSXXX_SAUL_INFO
 #define LPSXXX_SAUL_INFO                { .name = LPSXXX_SAUL_NAME }

--- a/drivers/lpsxxx/lpsxxx.c
+++ b/drivers/lpsxxx/lpsxxx.c
@@ -106,7 +106,7 @@ int lpsxxx_init(lpsxxx_t *dev, const lpsxxx_params_t * params)
 #elif MODULE_LPS22HB
     tmp = LPSXXX_CTRL_REG1_EN_LPFP | /* Low-pass filter configuration: ODR/9 */
             LPSXXX_CTRL_REG1_BDU | (DEV_RATE << LPSXXX_CTRL_REG1_ODR_POS);
-#elif MODULE_LPS22HH
+#elif MODULE_LPS22HH || MODULE_LPS22CH
     tmp = LPSXXX_CTRL_REG1_EN_LPFP | /* Low-pass filter configuration: ODR/9 */
             LPSXXX_CTRL_REG1_BDU | (DEV_RATE << LPSXXX_CTRL_REG1_ODR_POS);
 #endif

--- a/drivers/lpsxxx/lpsxxx_saul.c
+++ b/drivers/lpsxxx/lpsxxx_saul.c
@@ -12,7 +12,7 @@
  * @{
  *
  * @file
- * @brief       LPSXXX (LPS331ap/LPS25HB/LPS22HB/LPS22HH) adaption to SAUL
+ * @brief       LPSXXX (LPS331ap/LPS25HB/LPS22HB/LPS22HH/LPS22CH) adaption to SAUL
  *              interface
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/tests/driver_lpsxxx/README.md
+++ b/tests/driver_lpsxxx/README.md
@@ -1,7 +1,7 @@
 # About
 
 This is a manual test application for the LPSXXX family of pressure sensors
-driver. This driver can be used with LPS331AP, LPS25HB, LPS22HB and LPS22HH.
+driver. This driver can be used with LPS331AP, LPS22CH, LPS25HB, LPS22HB and LPS22HH.
 
 Default driver is `lps331ap`. To use the LPS25HB driver, set the `DRIVER` when
 building the application:


### PR DESCRIPTION
### Contribution description

Integrates the LPS22CH as a pseudomodule into the lpsxxx driver.
Integration is seamless as the sensor is nigh identical to the LPS22HH save for the a few details, but from a driver point of view both sensors are identical. 

### Testing procedure

Flashing a board with the software and then getting console output. A finger was place on the sensor to see if the temperature was increasing(as it should) and air was blown onto the sensor to see if the pressure was increasing. Both worked fine and the results are present below:
![image](https://user-images.githubusercontent.com/87858569/157455012-d4286aee-8ddd-49e2-b45e-c753be5fa054.png)


### Issues/PRs references

-