### PR TITLE
doc/rust: Remove duplicate (and wrong) line

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -122,7 +122,6 @@ and needs some patches applied:
 ```shell
 $ rustup install nightly-2019-12-05
 $ rustup component add --toolchain nightly-2019-12-05 rustfmt rustc-dev
-$ cargo +nightly-2019-12-05 install c2rust
 $ git clone https://github.com/chrysn-pull-requests/c2rust -b for-riot
 $ cd c2rust
 $ cargo +nightly-2019-12-05 install --locked --path c2rust


### PR DESCRIPTION
Doc fix: Some line duplication happened already in the initial version, and when [17504] had the `--locked` added, the opportunity to remove the duplication was missed.

[17504]: https://github.com/RIOT-OS/RIOT/pull/17504

### Issues/PRs references

This obsoletes https://github.com/RIOT-OS/RIOT/pull/17694 which would solve half of that line's problem (the missing `--locked`; the other is that it's not installing from the checked-out source)

Later https://github.com/RIOT-OS/RIOT/pull/17536 will touch this all again, but that's still waiting for a CI update and for a full test run.