### PR TITLE
core/macros: add math helper macros

### DIFF
--- a/core/include/macros/math.h
+++ b/core/include/macros/math.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_macros
+ * @{
+ *
+ * @file
+ * @brief       Math helper macros
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef MACROS_MATH_H
+#define MACROS_MATH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Returns the sign of @p a, either -1 or 1
+ */
+#define SIGNOF(a) _Generic(a, unsigned char: 1,          \
+                              unsigned short: 1,         \
+                              unsigned int: 1,           \
+                              unsigned long: 1,          \
+                              unsigned long long: 1,     \
+                              default: (long long)(a) < 0 ? -1 : 1)
+/**
+ * @brief Calculates @p a/ @p b with arithmetic rounding
+ */
+#define DIV_ROUND(a, b) (((a) + SIGNOF(a) * (b) / 2) / (b))
+
+/**
+ * @brief Calculates @p a/ @p b, always rounding up to the
+ *        next whole number
+ */
+#define DIV_ROUND_UP(a, b) (((a) + SIGNOF(a) * ((b) - SIGNOF(b))) / (b))
+
+/**
+ * @brief Align @p num with the next multiple of @p chunk
+ */
+#define MATH_ALIGN(num, chunk) ((chunk) * DIV_ROUND_UP(num, chunk))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MACROS_MATH_H */
+/** @} */

--- a/tests/unittests/tests-core/tests-core-macros.c
+++ b/tests/unittests/tests-core/tests-core-macros.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+#include <limits.h>
+#include "embUnit.h"
+#include "tests-core.h"
+#include "macros/math.h"
+
+static void test_math_signof(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, SIGNOF(3));
+    TEST_ASSERT_EQUAL_INT(-1, SIGNOF(-3));
+    TEST_ASSERT_EQUAL_INT(-1, SIGNOF(INT32_MIN));
+    TEST_ASSERT_EQUAL_INT(1, SIGNOF(UINT32_MAX));
+}
+
+static void test_math_div_round(void)
+{
+    TEST_ASSERT_EQUAL_INT(3, DIV_ROUND(20, 7));
+    TEST_ASSERT_EQUAL_INT(3, DIV_ROUND(21, 7));
+    TEST_ASSERT_EQUAL_INT(3, DIV_ROUND(22, 7));
+    TEST_ASSERT_EQUAL_INT(0, DIV_ROUND(1, UINT32_MAX));
+}
+
+static void test_math_div_round_up(void)
+{
+    TEST_ASSERT_EQUAL_INT(3, DIV_ROUND_UP(20, 7));
+    TEST_ASSERT_EQUAL_INT(3, DIV_ROUND_UP(21, 7));
+    TEST_ASSERT_EQUAL_INT(4, DIV_ROUND_UP(22, 7));
+    TEST_ASSERT_EQUAL_INT(1, DIV_ROUND_UP(1, UINT32_MAX));
+
+    TEST_ASSERT_EQUAL_INT(1536, MATH_ALIGN(1514, 64));
+}
+
+Test *tests_core_macros_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_math_signof),
+        new_TestFixture(test_math_div_round),
+        new_TestFixture(test_math_div_round_up),
+   };
+
+    EMB_UNIT_TESTCALLER(core_macros_tests, NULL, NULL, fixtures);
+
+    return (Test *)&core_macros_tests;
+}

--- a/tests/unittests/tests-core/tests-core.c
+++ b/tests/unittests/tests-core/tests-core.c
@@ -19,4 +19,5 @@ void tests_core(void)
     TESTS_RUN(tests_core_byteorder_tests());
     TESTS_RUN(tests_core_ringbuffer_tests());
     TESTS_RUN(tests_core_xfa_tests());
+    TESTS_RUN(tests_core_macros_tests());
 }

--- a/tests/unittests/tests-core/tests-core.h
+++ b/tests/unittests/tests-core/tests-core.h
@@ -92,6 +92,13 @@ Test *tests_core_ringbuffer_tests(void);
  */
 Test *tests_core_xfa_tests(void);
 
+/**
+ * @brief   Generates tests for macros
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_core_macros_tests(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a few commonly useful math helper macros to `core/macros`:

 - `SIGNOF()` returns the sign of an integer
 - `DIV_ROUND()` performs arithmetic integer division
 - `DIV_ROUND_UP()` performs arithmetic integer division, always rounding to the next integer larger in magnitude. 


### Testing procedure

`unittests/tests-core` was extended with test cases for the new macros


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
