### PR TITLE
sys/ztimer/xtimer_compat: fix bug introduced in #17690

### DIFF
--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -54,9 +54,28 @@ extern "C" {
 #define XTIMER_WIDTH    (32)
 #define XTIMER_MASK     (0)
 
+/**
+ * a default XTIMER_BACKOFF value, this is not used by ztimer, but other code
+ * uses this value to set timers
+ */
+
+#ifndef XTIMER_BACKOFF
+#define XTIMER_BACKOFF  1
+#endif
+
 typedef ztimer_t xtimer_t;
 typedef uint32_t xtimer_ticks32_t;
 typedef uint64_t xtimer_ticks64_t;
+
+static inline void xtimer_init(void)
+{
+    ztimer_init();
+}
+
+static inline bool xtimer_is_set(const xtimer_t *timer)
+{
+    return ztimer_is_set(ZTIMER_USEC, timer);
+}
 
 static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks)
 {
@@ -191,6 +210,16 @@ static inline int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us)
 {
     assert(us <= UINT32_MAX);
     if (ztimer_mutex_lock_timeout(ZTIMER_USEC, mutex, (uint32_t)us)) {
+        /* Impedance matching required: Convert -ECANCELED error code to -1: */
+        return -1;
+    }
+    return 0;
+}
+
+static inline int xtimer_rmutex_lock_timeout(rmutex_t *rmutex, uint64_t us)
+{
+    assert(us <= UINT32_MAX);
+    if (ztimer_rmutex_lock_timeout(ZTIMER_USEC, rmutex, us)) {
         /* Impedance matching required: Convert -ECANCELED error code to -1: */
         return -1;
     }

--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -142,16 +142,16 @@ static inline void xtimer_tsleep32(xtimer_ticks32_t ticks)
     xtimer_usleep(xtimer_usec_from_ticks(ticks));
 }
 
-static inline uint64_t xtimer_tsleep64(xtimer_ticks64_t ticks)
+static inline void xtimer_tsleep64(xtimer_ticks64_t ticks)
 {
     const uint32_t max_sleep = UINT32_MAX;
     uint64_t time = xtimer_usec_from_ticks64(ticks);
 
     while (time > max_sleep) {
-        xtimer_usleep(clock, max_sleep);
+        xtimer_usleep(max_sleep);
         time -= max_sleep;
     }
-    xtimer_usleep(clock, time);
+    xtimer_usleep(time);
 }
 
 static inline void xtimer_set(xtimer_t *timer, uint32_t offset)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

while working on #17693 a bug in #17690 was detected

`xtimer_usleep(x)` -which redirects to `ztimer_sleep(ZTIMER_USEC,x)` needs no `clock` in `xtimer_tsleep64()`

also adds  missing
```
    dummy XTIMER_BACKOFF
    xtimer_init
    xtimer_is_set
    xtimer_rmutex_lock_timeout
```
### Testing procedure

build xtimer_test using ztimer/xtimer_compat

either by include of ztimer/xtimer_compat.h and adding ztimer_usec to USEMODULE

or adding 

ztimer_xtimer_compat to USEMODULE

### Issues/PRs references

while working on #17693 a bug in #17690 was detected