### PR TITLE
boards/nucleo-f334r8 f429zi and f446ze: enable cpy2remed programmer

### DIFF
--- a/boards/nucleo-f334r8/Makefile.include
+++ b/boards/nucleo-f334r8/Makefile.include
@@ -1,2 +1,8 @@
+#variable needed by cpy2remed PROGRAMMER
+#it contains name of ST-Link removable media
+DIR_NAME_AT_REMED = "NODE_F334R8"
+
+PROGRAMMERS_SUPPORTED += cpy2remed
+
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f334r8/doc.txt
+++ b/boards/nucleo-f334r8/doc.txt
@@ -52,6 +52,9 @@ STM32F334R8 microcontroller with 12Kb of RAM and 64Kb or ROM.
 
 
 ## Flashing the device
+
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-F334R8 board includes an on-board ST-LINK V2 programmer.
 The easiest way to program the board is to use OpenOCD. Once you have
 installed
@@ -66,6 +69,18 @@ and debug via GDB by simply typing
 BOARD=nucleo-f334r8 make debug
 ```
 
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f429zi PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
 ## Supported Toolchains
 For using the ST Nucleo-F334R8 board we strongly recommend the usage of the

--- a/boards/nucleo-f429zi/Makefile.include
+++ b/boards/nucleo-f429zi/Makefile.include
@@ -1,2 +1,9 @@
+#variable needed by cpy2remed PROGRAMMER
+#it contains name of ST-Link removable media
+DIR_NAME_AT_REMED = "NODE_F429ZI"
+
+PROGRAMMERS_SUPPORTED += cpy2remed
+
+
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f429zi/doc.txt
+++ b/boards/nucleo-f429zi/doc.txt
@@ -2,4 +2,21 @@
 @defgroup    boards_nucleo-f429zi STM32 Nucleo-F429ZI
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F429ZI
+
+
+## Flashing the device
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f429zi PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-f446ze/Makefile.include
+++ b/boards/nucleo-f446ze/Makefile.include
@@ -1,2 +1,8 @@
+#variable needed by cpy2remed PROGRAMMER
+#it contains name of ST-Link removable media
+DIR_NAME_AT_REMED = "NODE_F446ZE"
+
+PROGRAMMERS_SUPPORTED += cpy2remed
+
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f446ze/doc.txt
+++ b/boards/nucleo-f446ze/doc.txt
@@ -51,6 +51,8 @@ STM32F446ZE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
 
 ## Flashing the device
 
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-F446ZE board includes an on-board ST-LINK V2 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
@@ -63,6 +65,19 @@ and debug via GDB by simply typing
 ```
 make BOARD=nucleo-f446ze debug
 ```
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f446ze PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
 ## Supported Toolchains
 


### PR DESCRIPTION
### Contribution description

This PR enables **_cpy2remed_** programmer (see #17550) to three STM Nucleo boards: F334r8, F429ZI and F446ZE.
All boards have initially older ST-LINK firmware - the oldest was:
```
Version: 0221
Build:   Nov  4 2015 15:25:25  
``` 
During firmware update I checked few, and the minimal version of the ST-LINK firmware which works with **_cpy2remed_** programmer is 2.37.36 (V2.J37.M26 - shown in the  ST-LinkUpgrade program).  

### Testing procedure

Go to RIOT/examples/blinky and run command
```
make BOARD=nucleo-f334r8 PROGRAMMER=cpy2remed flash
make BOARD=nucleo-f429zi PROGRAMMER=cpy2remed flash
make BOARD=nucleo-f446ze PROGRAMMER=cpy2remed flash
```
After a while, green LED (LED0) should start blinking.

Changes in documentaion can be observed using commands:
```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f334r8.html
xdg-open doc/doxygen/html/group__boards__nucleo-f429zi.html
xdg-open doc/doxygen/html/group__boards__nucleo-f426ze.html
```


### Issues/PRs references

#17550 