### PR TITLE
netdev_tap: make 'wired' property configurable

### DIFF
--- a/cpu/native/include/netdev_tap.h
+++ b/cpu/native/include/netdev_tap.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "net/netdev.h"
 
 #include "net/ethernet/hdr.h"
@@ -43,7 +44,8 @@ typedef struct netdev_tap {
     char tap_name[IFNAMSIZ];            /**< host dev file name */
     int tap_fd;                         /**< host file descriptor for the TAP */
     uint8_t addr[ETHERNET_ADDR_LEN];    /**< The MAC address of the TAP */
-    uint8_t promiscuous;                 /**< Flag for promiscuous mode */
+    bool promiscuous;                   /**< Flag for promiscuous mode */
+    bool wired;                         /**< Flag for wired mode */
 } netdev_tap_t;
 
 /**
@@ -52,6 +54,8 @@ typedef struct netdev_tap {
 typedef struct {
     char **tap_name;                    /**< Name of the host system's tap
                                              interface to bind to. */
+    bool wired;                         /**< Interface should behave like a
+                                             wired interface. */
 } netdev_tap_params_t;
 
 /**

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -94,6 +94,12 @@ static inline int _set_promiscuous(netdev_t *netdev, int value)
     return value;
 }
 
+static inline int _get_wired(netdev_t *netdev)
+{
+    netdev_tap_t *dev = container_of(netdev, netdev_tap_t, netdev);
+    return dev->wired;
+}
+
 static inline void _isr(netdev_t *netdev)
 {
     if (netdev->event_callback) {
@@ -123,6 +129,16 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
         case NETOPT_PROMISCUOUSMODE:
             *((bool*)value) = (bool)_get_promiscuous(dev);
             res = sizeof(bool);
+            break;
+        case NETOPT_IS_WIRED:
+            if (!_get_wired(dev)) {
+                res = -ENOTSUP;
+            } else {
+                if (value) {
+                    *((bool*)value) = true;
+                }
+                res = sizeof(bool);
+            }
             break;
         default:
             res = netdev_eth_get(dev, opt, value, max_len);
@@ -294,6 +310,7 @@ void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params, int 
     dev->netdev.driver = &netdev_driver_tap;
     strncpy(dev->tap_name, *(params->tap_name), IFNAMSIZ - 1);
     dev->tap_name[IFNAMSIZ - 1] = '\0';
+    dev->wired = params->wired;
     netdev_register(&dev->netdev, NETDEV_TAP, index);
 }
 

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -116,6 +116,9 @@ static const char short_opts[] = ":hi:s:deEoc:"
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     "p:"
 #endif
+#ifdef MODULE_NETDEV_TAP
+    "w:"
+#endif
     "";
 
 static const struct option long_opts[] = {
@@ -368,6 +371,11 @@ void usage_exit(int status)
 "        Specify the file path where the EEPROM content is stored\n"
 "        Example: --eeprom=/tmp/riot_native.eeprom\n");
 #endif
+#ifdef MODULE_NETDEV_TAP
+    real_printf(
+"    -w <tap>\n"
+"        Add a tap interface as a wireless interface\n");
+#endif
     real_exit(status);
 }
 
@@ -468,6 +476,9 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     _native_id = _native_pid;
 
     int c, opt_idx = 0, uart = 0;
+#ifdef MODULE_NETDEV_TAP
+    unsigned taps = 0;
+#endif
 #ifdef MODULE_SOCKET_ZEP
     unsigned zeps = 0;
 #endif
@@ -576,13 +587,20 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
                 break;
             }
 #endif
+#ifdef MODULE_NETDEV_TAP
+            case 'w':
+                netdev_tap_params[taps].tap_name = &argv[optind - 1];
+                netdev_tap_params[taps].wired = false;
+                ++taps;
+                break;
+#endif
             default:
                 usage_exit(EXIT_FAILURE);
                 break;
         }
     }
 #ifdef MODULE_NETDEV_TAP
-    for (int i = 0; i < NETDEV_TAP_MAX; i++) {
+    for (unsigned i = 0; i < NETDEV_TAP_MAX - taps; i++) {
         if (argv[optind + i] == NULL) {
             /* no tap parameter left */
             usage_exit(EXIT_FAILURE);
@@ -653,9 +671,9 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     native_cpu_init();
     native_interrupt_init();
 #ifdef MODULE_NETDEV_TAP
-    for (int i = 0; i < NETDEV_TAP_MAX; i++) {
-        netdev_tap_params[i].tap_name = &argv[optind + i];
-        netdev_tap_params[i].wired = true;
+    for (unsigned i = 0; taps < NETDEV_TAP_MAX; ++taps, ++i) {
+        netdev_tap_params[taps].tap_name = &argv[optind + i];
+        netdev_tap_params[taps].wired = true;
     }
 #endif
 

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -478,6 +478,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     int c, opt_idx = 0, uart = 0;
 #ifdef MODULE_NETDEV_TAP
     unsigned taps = 0;
+    memset(netdev_tap_params, 0, sizeof(netdev_tap_params));
 #endif
 #ifdef MODULE_SOCKET_ZEP
     unsigned zeps = 0;
@@ -599,14 +600,6 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
                 break;
         }
     }
-#ifdef MODULE_NETDEV_TAP
-    for (unsigned i = 0; i < NETDEV_TAP_MAX - taps; i++) {
-        if (argv[optind + i] == NULL) {
-            /* no tap parameter left */
-            usage_exit(EXIT_FAILURE);
-        }
-    }
-#endif
 #ifdef MODULE_SOCKET_ZEP
     if (zeps != SOCKET_ZEP_MAX) {
         /* not enough ZEPs given */
@@ -672,6 +665,9 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     native_interrupt_init();
 #ifdef MODULE_NETDEV_TAP
     for (unsigned i = 0; taps < NETDEV_TAP_MAX; ++taps, ++i) {
+        if (argv[optind + i] == NULL) {
+            break;
+        }
         netdev_tap_params[taps].tap_name = &argv[optind + i];
         netdev_tap_params[taps].wired = true;
     }

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -655,6 +655,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
 #ifdef MODULE_NETDEV_TAP
     for (int i = 0; i < NETDEV_TAP_MAX; i++) {
         netdev_tap_params[i].tap_name = &argv[optind + i];
+        netdev_tap_params[i].wired = true;
     }
 #endif
 

--- a/pkg/lwip/init_devs/auto_init_netdev_tap.c
+++ b/pkg/lwip/init_devs/auto_init_netdev_tap.c
@@ -33,6 +33,9 @@ static netdev_tap_t netdev_taps[NETIF_TAP_NUMOF];
 static void auto_init_netdev_tap(void)
 {
     for (unsigned i = 0; i < NETIF_TAP_NUMOF; i++) {
+        if (netdev_tap_params[i].tap_name == NULL) {
+            continue;
+        }
         netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i], i);
         if (lwip_add_ethernet(&netif[i], &netdev_taps[i].netdev) == NULL) {
             DEBUG("Could not add netdev_tap device\n");

--- a/sys/net/gnrc/netif/init_devs/auto_init_netdev_tap.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_netdev_tap.c
@@ -35,6 +35,10 @@ void auto_init_netdev_tap(void)
     for (unsigned i = 0; i < NETDEV_TAP_MAX; i++) {
         const netdev_tap_params_t *p = &netdev_tap_params[i];
 
+        if (p->tap_name == NULL) {
+            continue;
+        }
+
         LOG_DEBUG("[auto_init_netif] initializing netdev_tap #%u on TAP %s\n",
                   i, *(p->tap_name));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`netdev_tap` is a virtual interface, make it possible to simulate both a wired and a wireless interface.



### Testing procedure
```
$ bin/native/gnrc_networking.elf tap0

Iface  6  HWaddr: 7A:37:FC:7D:1A:AF 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
--->      Link type: wired
          inet6 addr: fe80::7837:fcff:fe7d:1aaf  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff7d:1aaf
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 4  bytes 480
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 4  bytes 424
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0
```

```
$ bin/native/gnrc_networking.elf -w tap0

Iface  6  HWaddr: 7A:37:FC:7D:1A:AF 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
--->      Link type: wireless
          inet6 addr: fe80::7837:fcff:fe7d:1aaf  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff7d:1aaf
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 4  bytes 480
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 4  bytes 424
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0

```

```
$ bin/native/gnrc_networking.elf -w tap0 tap1

Iface  7  HWaddr: 5A:B0:08:67:AD:82 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::58b0:8ff:fe67:ad82  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff67:ad82
          
          Statistics for Layer 2
            RX packets 5  bytes 526
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 5  bytes 456
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0

Iface  6  HWaddr: 7A:37:FC:7D:1A:AF 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wireless
          inet6 addr: fe80::7837:fcff:fe7d:1aaf  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff7d:1aaf
          
          Statistics for Layer 2
            RX packets 4  bytes 480
            TX packets 1 (Multicast: 1)  bytes 78
            TX succeeded 1 errors 0
          Statistics for IPv6
            RX packets 4  bytes 424
            TX packets 1 (Multicast: 1)  bytes 64
            TX succeeded 1 errors 0
```

#### LWIP

```
$  bin/native/paho-mqtt-example.elf -w tap0 tap1

Iface ET0 HWaddr: 7a:37:fc:7d:1a:af Link: up State: up
        Link type: wireless
        inet6 addr: fe80:0:0:0:7837:fcff:fe7d:1aaf scope: link
Iface ET1 HWaddr: 5a:b0:08:67:ad:82 Link: up State: up
        Link type: wired
        inet6 addr: fe80:0:0:0:58b0:8ff:fe67:ad82 scope: link
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17350#discussion_r814892585
