### PR TITLE
sys/bitfield: add support for bit-wise bitfield operations

### DIFF
--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -21,11 +21,11 @@
 #include "bitfield.h"
 #include "irq.h"
 
-int bf_get_unset(uint8_t field[], int size)
+int bf_get_unset(uint8_t field[], size_t size)
 {
     int result = -1;
     int nbytes = (size + 7) / 8;
-    int i = 0;
+    size_t i = 0;
 
     unsigned state = irq_disable();
 
@@ -43,5 +43,5 @@ int bf_get_unset(uint8_t field[], int size)
     }
 
     irq_restore(state);
-    return(result);
+    return result;
 }

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -182,12 +182,12 @@ static inline void bf_inv(uint8_t out[], const uint8_t a[], size_t len)
  * This function can be used to record e.g., empty entries in an array.
  *
  * @param[in,out] field The bitfield
- * @param[in]     size  The size of the bitfield
+ * @param[in]     len   The number of bits in the bitfield to consider
  *
  * @return      number of bit that was set
  * @return      -1 if no bit was unset
  */
-int bf_get_unset(uint8_t field[], int size);
+int bf_get_unset(uint8_t field[], size_t len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -90,6 +90,93 @@ static inline bool bf_isset(uint8_t field[], size_t idx)
 }
 
 /**
+ * @brief  Perform a bitwise OR operation on two bitfields
+ *         `out = a | b`
+ *
+ * @pre   The size of @p a, @p b and @p out must be at least @p len bits
+ *
+ * @note  This operation will also affect unused bits of the bytes that make up
+ *        the bitfield.
+ *
+ * @param[out]    out   The resulting bitfield
+ * @param[in]     a     The first bitfield
+ * @param[in]     b     The second bitfield
+ * @param[in]     len   The number of bits in the bitfields
+ */
+static inline void bf_or(uint8_t out[], const uint8_t a[], const uint8_t b[], size_t len)
+{
+    len = (len + 7) / 8;
+    while (len--) {
+        out[len] = a[len] | b[len];
+    }
+}
+
+/**
+ * @brief  Perform a bitwise AND operation on two bitfields
+ *         `out = a & b`
+ *
+ * @pre   The size of @p a, @p b and @p out must be at least @p len bits
+ *
+ * @note  This operation will also affect unused bits of the bytes that make up
+ *        the bitfield.
+ *
+ * @param[out]    out   The resulting bitfield
+ * @param[in]     a     The first bitfield
+ * @param[in]     b     The second bitfield
+ * @param[in]     len   The number of bits in the bitfields
+ */
+static inline void bf_and(uint8_t out[], const uint8_t a[], const uint8_t b[], size_t len)
+{
+    len = (len + 7) / 8;
+    while (len--) {
+        out[len] = a[len] & b[len];
+    }
+}
+
+/**
+ * @brief  Perform a bitwise XOR operation on two bitfields
+ *         `out = a ^ b`
+ *
+ * @pre   The size of @p a, @p b and @p out must be at least @p len bits
+ *
+ * @note  This operation will also affect unused bits of the bytes that make up
+ *        the bitfield.
+ *
+ * @param[out]    out   The resulting bitfield
+ * @param[in]     a     The first bitfield
+ * @param[in]     b     The second bitfield
+ * @param[in]     len   The number of bits in the bitfields
+ */
+static inline void bf_xor(uint8_t out[], const uint8_t a[], const uint8_t b[], size_t len)
+{
+    len = (len + 7) / 8;
+    while (len--) {
+        out[len] = a[len] ^ b[len];
+    }
+}
+
+/**
+ * @brief  Perform a bitwise NOT operation on a bitfield
+ *         `out = ~a`
+ *
+ * @pre   The size of @p a and @p out must be at least @p len bits
+ *
+ * @note  This operation will also affect unused bits of the bytes that make up
+ *        the bitfield.
+ *
+ * @param[out]    out   The resulting bitfield
+ * @param[in]     a     The bitfield to invert
+ * @param[in]     len   The number of bits in the bitfield
+ */
+static inline void bf_inv(uint8_t out[], const uint8_t a[], size_t len)
+{
+    len = (len + 7) / 8;
+    while (len--) {
+        out[len] = ~a[len];
+    }
+}
+
+/**
  * @brief  Atomically get the number of an unset bit and set it
  *
  * This function can be used to record e.g., empty entries in an array.

--- a/tests/unittests/tests-bitfield/tests-bitfield.c
+++ b/tests/unittests/tests-bitfield/tests-bitfield.c
@@ -197,6 +197,31 @@ static void test_bf_get_unset_lastbyte(void)
     TEST_ASSERT_EQUAL_INT(39, res);
 }
 
+static void test_bf_ops(void)
+{
+    const uint8_t zero[3] = {0};
+    const uint8_t set[3] = { 0xFF, 0xFF, 0xFF };
+
+    uint8_t a[3] = { 0xAA, 0x55, 0xF0 };
+    uint8_t b[3] = { 0x55, 0xAA, 0x0F };
+    uint8_t c[3];
+
+    bf_or(c, a, b, 24);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(c, set, sizeof(c)));
+
+    bf_inv(c, c, 24);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(c, zero, sizeof(c)));
+
+    bf_and(c, a, b, 24);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(c, zero, sizeof(c)));
+
+    bf_inv(c, c, 24);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(c, set, sizeof(c)));
+
+    bf_xor(c, c, a, 24);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(c, b, sizeof(c)));
+}
+
 Test *tests_bitfield_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -208,6 +233,7 @@ Test *tests_bitfield_tests(void)
         new_TestFixture(test_bf_get_unset_firstbyte),
         new_TestFixture(test_bf_get_unset_middle),
         new_TestFixture(test_bf_get_unset_lastbyte),
+        new_TestFixture(test_bf_ops),
     };
 
     EMB_UNIT_TESTCALLER(bitfield_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds support for bit-wise (AND, OR, XOR, NOT) operations to bitfields.


### Testing procedure

The `tests-bitfield` unit test has been extended with the new operations. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
