### PR TITLE
sys,examples,tests,fuzzing: add missing includes 

### DIFF
--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -24,6 +24,7 @@
 #include "net/gcoap.h"
 #include "net/cord/epsim.h"
 #include "net/cord/common.h"
+#include "net/gnrc/netif.h"
 #include "net/sock/util.h"
 #include "net/ipv6/addr.h"
 #include "xtimer.h"

--- a/examples/cord_lc/cord_lc_cli.c
+++ b/examples/cord_lc/cord_lc_cli.c
@@ -23,6 +23,7 @@
 
 #include "net/cord/config.h"
 #include "net/cord/lc.h"
+#include "net/gnrc/netif.h"
 #include "net/gcoap.h"
 #include "net/sock/util.h"
 

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -26,6 +26,7 @@
 #include <inttypes.h>
 
 #include "timex.h"
+#include "net/gnrc/netif.h"
 #include "net/sock/udp.h"
 #include "tinydtls_keys.h"
 

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -20,6 +20,7 @@
 
 #include "kernel_defines.h"
 
+#include "net/gnrc/netif.h"
 #include "net/sock/udp.h"
 #include "net/sock/dtls.h"
 #include "net/sock/dtls/creds.h"

--- a/examples/dtls-wolfssl/dtls-client.c
+++ b/examples/dtls-wolfssl/dtls-client.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "net/gnrc/netif.h"
 #include "log.h"
 
 #define SERVER_PORT 11111

--- a/examples/emcute_mqttsn/main.c
+++ b/examples/emcute_mqttsn/main.c
@@ -27,6 +27,7 @@
 #include "msg.h"
 #include "net/emcute.h"
 #include "net/ipv6/addr.h"
+#include "thread.h"
 
 #ifndef EMCUTE_ID
 #define EMCUTE_ID           ("gertrud")

--- a/fuzzing/gnrc_tcp/main.c
+++ b/fuzzing/gnrc_tcp/main.c
@@ -14,6 +14,7 @@
 
 #include "net/af.h"
 #include "net/gnrc/tcp.h"
+#include "net/gnrc/netreg.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/pkt.h"
 

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -99,7 +99,6 @@
 #define NET_GNRC_IPV6_H
 
 #include "sched.h"
-#include "net/gnrc.h"
 #include "thread.h"
 
 #include "net/ipv6.h"

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -523,6 +523,7 @@
 #define NET_SOCK_DTLS_H
 
 #include <assert.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -268,6 +268,7 @@
 #ifndef NET_SOCK_IP_H
 #define NET_SOCK_IP_H
 
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -299,6 +299,7 @@
 #ifndef NET_SOCK_TCP_H
 #define NET_SOCK_TCP_H
 
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -268,6 +268,7 @@
 #ifndef NET_SOCK_UDP_H
 #define NET_SOCK_UDP_H
 
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -22,6 +22,7 @@
 #include "kernel_defines.h"
 #include "net/dhcpv6/client.h"
 #include "net/dhcpv6.h"
+#include "net/netif.h"
 #include "net/sock/udp.h"
 #include "random.h"
 #include "timex.h"

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 
 #include "net/ipv6.h"
+#include "net/gnrc/netreg.h"
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/pktbuf.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -20,6 +20,7 @@
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/netif/internal.h"
+#include "net/gnrc/netreg.h"
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
 #include "net/gnrc/sixlowpan/nd.h"
 #endif  /* MODULE_GNRC_SIXLOWPAN_ND */

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -25,6 +25,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/ndp.h"
+#include "net/gnrc/netreg.h"
 #include "net/gnrc/pktqueue.h"
 #include "net/gnrc/sixlowpan/nd.h"
 #include "net/ndp.h"

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "net/gnrc/netreg.h"
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/sock/include/sock_types.h
+++ b/sys/net/gnrc/sock/include/sock_types.h
@@ -27,8 +27,6 @@
 
 #include "mbox.h"
 #include "net/af.h"
-#include "net/gnrc.h"
-#include "net/gnrc/tcp.h"
 #include "net/gnrc/netreg.h"
 #ifdef SOCK_HAS_ASYNC
 #include "net/sock/async/types.h"

--- a/sys/shell/commands/sc_cord_ep.c
+++ b/sys/shell/commands/sc_cord_ep.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 #include "net/cord/ep.h"
+#include "net/gnrc/netif.h"
 #include "net/nanocoap.h"
 #include "net/sock/util.h"
 #include "net/cord/config.h"

--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -24,6 +24,7 @@
 #include "net/sntp.h"
 #include "net/ntp_packet.h"
 #include "net/af.h"
+#include "net/gnrc/netif.h"
 #include "net/ipv6/addr.h"
 #include "timex.h"
 

--- a/tests/gnrc_sock_neterr/main.c
+++ b/tests/gnrc_sock_neterr/main.c
@@ -19,6 +19,8 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
+
 #include "msg.h"
 #include "net/sock/udp.h"
 

--- a/tests/gnrc_sock_tcp/main.c
+++ b/tests/gnrc_sock_tcp/main.c
@@ -12,6 +12,7 @@
 #include "shell.h"
 #include "msg.h"
 #include "net/sock/tcp.h"
+#include "net/gnrc/tcp.h"
 
 #define MAIN_QUEUE_SIZE (8)
 #define SOCK_TCP_QUEUE_SIZE (1)

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -24,9 +24,12 @@
 #include <string.h>
 
 #include "net/coap.h"
+#include "net/gnrc/netif.h"
+#include "net/ipv6.h"
 #include "net/nanocoap.h"
 #include "net/nanocoap_sock.h"
 #include "net/sock/udp.h"
+
 #include "od.h"
 
 static ssize_t _send(coap_pkt_t *pkt, size_t len, char *addr_str, char *port_str)

--- a/tests/pkg_edhoc_c/initiator.c
+++ b/tests/pkg_edhoc_c/initiator.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 
+#include "net/gnrc/netif.h"
 #include "net/ipv6.h"
 #include "net/nanocoap_sock.h"
 #include "shell.h"

--- a/tests/pkg_tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg_tinydtls_sock_async/dtls-client.c
@@ -21,6 +21,7 @@
 
 #include "event/thread.h"
 #include "event/timeout.h"
+#include "net/gnrc/netif.h"
 #include "net/sock/async/event.h"
 #include "net/sock/udp.h"
 #include "net/sock/dtls.h"

--- a/tests/sock_udp_aux/main.c
+++ b/tests/sock_udp_aux/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "thread.h"
 #include "fmt.h"
 #include "net/sock/udp.h"
 #include "shell.h"


### PR DESCRIPTION
### Contribution description

a huge examples and tests, some sys-modules and fuzzing/gnrc use functions of xtimer, gnrc(/nteif), without including the header, this PR adds these includes.

### Testing procedure

- reading

- Murdock 

- build them

### Issues/PRs references

was found while working on #17693