### PR TITLE
tests: add default BOARDS

### DIFF
--- a/examples/arduino_hello-world/Makefile
+++ b/examples/arduino_hello-world/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= arduino-zero
+
 # name of your application
 APPLICATION = arduino_hello-world
 

--- a/tests/candev/Makefile
+++ b/tests/candev/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEMODULE += shell

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEMODULE += shell

--- a/tests/dbgpin/Makefile
+++ b/tests/dbgpin/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEMODULE += dbgpin

--- a/tests/mpu_noexec_ram/Makefile
+++ b/tests/mpu_noexec_ram/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEMODULE += mpu_noexec_ram

--- a/tests/mpu_stack_guard/Makefile
+++ b/tests/mpu_stack_guard/Makefile
@@ -1,4 +1,5 @@
-BOARD ?= samr21-xpro
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEMODULE += mpu_stack_guard

--- a/tests/mtd_at24cxxx/Makefile
+++ b/tests/mtd_at24cxxx/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEMODULE += mtd_at24cxxx

--- a/tests/periph_backup_ram/Makefile
+++ b/tests/periph_backup_ram/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr34-xpro
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += backup_ram

--- a/tests/periph_dma/Makefile
+++ b/tests/periph_dma/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr34-xpro
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_dma

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr34-xpro
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_gpio

--- a/tests/periph_gpio_arduino/Makefile
+++ b/tests/periph_gpio_arduino/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio

--- a/tests/periph_uart_mode/Makefile
+++ b/tests/periph_uart_mode/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr34-xpro
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_uart

--- a/tests/periph_uart_nonblocking/Makefile
+++ b/tests/periph_uart_nonblocking/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr34-xpro
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_uart_nonblocking

--- a/tests/periph_vbat/Makefile
+++ b/tests/periph_vbat/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_vbat

--- a/tests/pkg_arduino_sdi_12/Makefile
+++ b/tests/pkg_arduino_sdi_12/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 USEPKG += arduino_sdi_12

--- a/tests/pkg_cryptoauthlib_compare_sha256/Makefile
+++ b/tests/pkg_cryptoauthlib_compare_sha256/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 # Test fails to build for these boards fails due to

--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= nucleo-f767zi
+
 include ../Makefile.tests_common
 
 # Test fails to build for these boards fails due to

--- a/tests/sys_arduino/Makefile
+++ b/tests/sys_arduino/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= arduino-zero
+
 include ../Makefile.tests_common
 
 USEMODULE += arduino

--- a/tests/sys_arduino_lib/Makefile
+++ b/tests/sys_arduino_lib/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= arduino-zero
+
 include ../Makefile.tests_common
 
 USEPKG += talking_leds


### PR DESCRIPTION
### Contribution description

This adds a building default Board to many tests that are currently missing one

#### Why?
when working on  #17693 ( the part that has become #17714) I wanted to build ~all Tests (for any BOARD) - prior to uploading that for murdock to do the same for all boards, and some of them did just fail because they where build for native, because there was no Board set

<details>
Makefile i used (copied to examples or tests)

https://gist.github.com/kfessel/9af890ddf7e7088cec9acbddbda4ebdb
</details>


### Testing procedure

```
$ make -C <some test>
```
#### Example:

before PR
```
$ make -C tests/periph_dma
make: Entering directory ' ... /tests/periph_dma'
There are unsatisfied feature requirements: periph_dma
```
after PR
```
$ make -C tests/periph_dma
make: Entering directory '... /tests/periph_dma'
Building application "tests_periph_dma" for "samr34-xpro" with MCU "saml21".
```

### Issues/PRs references

was in #17693

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
