### PR TITLE
drivers/dose: only disable watchdog when transiting from RECV state

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -201,11 +201,11 @@ static dose_signal_t state_transit_idle(dose_t *ctx, dose_signal_t signal)
     (void) ctx;
     (void) signal;
 
-    _watchdog_stop();
-
     if (ctx->state == DOSE_STATE_RECV) {
         bool dirty = ctx->flags & DOSE_FLAG_RECV_BUF_DIRTY;
         bool done  = ctx->flags & DOSE_FLAG_END_RECEIVED;
+
+        _watchdog_stop();
 
         /* We got here from RECV state. The driver's thread has to look
          * if this frame should be processed. By queuing NETDEV_EVENT_ISR,


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The DOSE watchdog should only run if at least one interface is in RECV state.

That means it must be enabled when entering RECV state and disabled when leaving RECV state.

The watchdog was *always* disabled on a transition to IDLE.
This is wrong: If there are two interfaces and one is in RECV state but the other did just SEND something and transitions to IDLE state from SEND state, it would still disable the watchdog.

Fix this by only disabling the watchdog if the current state is RECV.


### Testing procedure

This can be hard to reproduce, but when it occurs it can forever lock an interface in `RECV` state:

A board with two DOSE interfaces is required. You need to enable the `dose_watchdog` module.
Lines are disconnected / no regular traffic *but* spurious UART interrupts caused by noise.

When such an interrupt happens one interface will enter `RECV` state, but as it does not receive any further bytes the watchdog should bring it back to `IDLE` after a short while.

However, if the second interface then sends something (or does some other action that causes an idle transition) it would disable the watchdog prematurely, forever leaving the other interface in RECV state (or until a full frame is received, which might be never).

If now the first interface attempts to send something, the send will block on the state mutex until it's state transitions from `RECV` - but without the watchdog this transition never happens and the interface is blocked.

This manifests itself in `ifconfig` hanging as the netdev thread can no longer respond to IPC messages. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
