### PR TITLE
tests/sys_crypto: fix potentially unitialized error

### DIFF
--- a/tests/sys_crypto/tests-crypto-modes-ocb.c
+++ b/tests/sys_crypto/tests-crypto-modes-ocb.c
@@ -401,7 +401,11 @@ static void test_crypto_modes_ocb_decrypt(void)
 
 static void test_crypto_modes_ocb_bad_parameter_values(void)
 {
-    uint8_t key[16], auth_data[1], nonce[16], input[16], output[32];
+    uint8_t key[16] = {0};
+    uint8_t auth_data[1] = {0};
+    uint8_t nonce[16] = {0};
+    uint8_t input[16] = {0};
+    uint8_t output[32] = {0};
     cipher_t cipher;
 
     cipher_init(&cipher, CIPHER_AES, key, 16);


### PR DESCRIPTION
### Contribution description

On resent gcc I get a warning on the test:

```
/home/francisco/workspace/RIOT/tests/sys_crypto/tests-crypto-modes-ocb.c:407:5: error: ‘key’ may be used uninitialized [-Werror=maybe-uninitialized]
  407 |     cipher_init(&cipher, CIPHER_AES, key, 16);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/francisco/workspace/RIOT/tests/sys_crypto/tests-crypto-modes-ocb.c:9:
/home/francisco/workspace/RIOT/sys/include/crypto/ciphers.h:141:5: note: by argument 3 of type ‘const uint8_t *’ {aka ‘const unsigned char *’} to ‘cipher_init’ declared here
  141 | int cipher_init(cipher_t *cipher, cipher_id_t cipher_id, const uint8_t *key,
      |     ^~~~~~~~~~~
/home/francisco/workspace/RIOT/tests/sys_crypto/tests-crypto-modes-ocb.c:404:13: note: ‘key’ declared here
  404 |     uint8_t key[16], auth_data[1], nonce[16], input[16], output[32] = {0};
```

### Testing procedure

- Green murdock
