### PR TITLE
sys/sema: add sema_ztimer64 to implement old api, deprecate sema

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -2,3 +2,4 @@
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
 DEPRECATED_MODULES += event_thread_lowest
 DEPRECATED_MODULES += gnrc_netdev_default
+DEPRECATED_MODULES += sema_deprecated

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -186,6 +186,7 @@ PSEUDOMODULES += saul_pwm
 PSEUDOMODULES += scanf_float
 PSEUDOMODULES += sched_cb
 PSEUDOMODULES += sched_runq_callback
+PSEUDOMODULES += sema_deprecated
 PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += senml_cbor
 PSEUDOMODULES += senml_phydat

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -246,7 +246,7 @@ ifneq (,$(filter posix_select,$(USEMODULE)))
   endif
   USEMODULE += core_thread_flags
   USEMODULE += posix_headers
-  USEMODULE += xtimer
+  USEMODULE += ztimer64_usec
 endif
 
 ifneq (,$(filter picolibc,$(USEMODULE)))
@@ -390,7 +390,7 @@ ifneq (,$(filter netstats_neighbor_%, $(USEMODULE)))
 endif
 
 ifneq (,$(filter pthread,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer64_usec
   USEMODULE += timex
   ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
     # requires 64bit ftimestamps

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -339,6 +339,16 @@ ifneq (,$(filter sema_inv,$(USEMODULE)))
   USEMODULE += atomic_utils
 endif
 
+ifneq (,$(filter sema,$(USEMODULE)))
+  USEMODULE += ztimer
+endif
+
+ifneq (,$(filter sema_deprecated,$(USEMODULE)))
+  USEMODULE += sema
+  USEMODULE += ztimer64
+  USEMODULE += ztimer64_usec
+endif
+
 ifneq (,$(filter telnet,$(USEMODULE)))
   USEMODULE += pipe
   USEMODULE += sock_tcp

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -316,12 +316,8 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))
-  USEMODULE += sema
-  USEMODULE += xtimer
-  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-    # requires sema_timed that requires 64bit
-    USEMODULE += ztimer64_xtimer_compat
-  endif
+  USEMODULE += sema_deprecated
+  USEMODULE += ztimer64_usec
   USEMODULE += posix_headers
 endif
 

--- a/sys/posix/semaphore/posix_semaphore.c
+++ b/sys/posix/semaphore/posix_semaphore.c
@@ -26,7 +26,7 @@
 #include "sema.h"
 #include "timex.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer64.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -37,7 +37,7 @@ int sem_timedwait(sem_t *sem, const struct timespec *abstime)
 {
     uint64_t timeout = (((uint64_t)abstime->tv_sec) * US_PER_SEC) +
                        (abstime->tv_nsec / NS_PER_US);
-    uint64_t now = xtimer_now_usec64();
+    uint64_t now = ztimer64_now(ZTIMER64_USEC);
 
     if (now > timeout) {
         errno = ETIMEDOUT;

--- a/sys/sema/Kconfig
+++ b/sys/sema/Kconfig
@@ -8,4 +8,9 @@
 config MODULE_SEMA
     bool "Semaphore"
     depends on TEST_KCONFIG
-    depends on MODULE_XTIMER || MODULE_ZTIMER
+    select MODULE_ZTIMER
+
+config MODULE_SEMA_DEPRECATED
+    bool "Semaphore compatible with 64bit timeouts, deprecated"
+    select MODULE_SEMA
+    select ZTIMER64_USEC

--- a/sys/sema/sema.c
+++ b/sys/sema/sema.c
@@ -22,10 +22,6 @@
 #include "assert.h"
 #include "sema.h"
 
-#if IS_USED(MODULE_XTIMER)
-#include "xtimer.h"
-#endif
-
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -49,8 +45,8 @@ void sema_destroy(sema_t *sema)
     mutex_unlock(&sema->mutex);
 }
 
-#if IS_USED(MODULE_XTIMER)
-int _sema_wait_xtimer(sema_t *sema, int block, uint64_t us)
+#if IS_USED(MODULE_SEMA_DEPRECATED)
+int _sema_wait_ztimer64(sema_t *sema, int block, ztimer64_clock_t *clock, uint64_t us)
 {
     assert(sema != NULL);
 
@@ -66,9 +62,9 @@ int _sema_wait_xtimer(sema_t *sema, int block, uint64_t us)
             mutex_lock(&sema->mutex);
         }
         else {
-            uint64_t start = xtimer_now_usec64();
-            block = !xtimer_mutex_lock_timeout(&sema->mutex, us);
-            uint64_t elapsed = xtimer_now_usec64() - start;
+            uint64_t start = ztimer64_now(clock);
+            block = !ztimer64_mutex_lock_timeout(clock, &sema->mutex, us);
+            uint64_t elapsed = ztimer64_now(clock) - start;
 
             if (elapsed < us) {
                 us -= elapsed;
@@ -103,7 +99,6 @@ int _sema_wait_xtimer(sema_t *sema, int block, uint64_t us)
 }
 #endif
 
-#if IS_USED(MODULE_ZTIMER)
 int _sema_wait_ztimer(sema_t *sema, int block,
                       ztimer_clock_t *clock, uint32_t timeout)
 {
@@ -156,7 +151,6 @@ int _sema_wait_ztimer(sema_t *sema, int block,
 
     return 0;
 }
-#endif
 
 int sema_post(sema_t *sema)
 {

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -2,5 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += fmt
 USEMODULE += posix_semaphore
+USEMODULE += ztimer64_usec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -30,7 +30,7 @@
 #include "msg.h"
 #include "timex.h"
 #include "thread.h"
-#include "xtimer.h"
+#include "ztimer64.h"
 
 #define SEMAPHORE_MSG_QUEUE_SIZE        (8)
 #define SEMAPHORE_TEST_THREADS          (5)
@@ -263,12 +263,12 @@ void test4(void)
 
     puts("first: wait 1 sec for s1");
 
-    start = xtimer_now_usec64();
+    start = ztimer64_now(ZTIMER64_USEC);
     abs.tv_sec = (time_t)((start / US_PER_SEC) + 1);
     abs.tv_nsec = (long)((start % US_PER_SEC) * 1000);
 
     int ret = sem_timedwait(&s1, &abs);
-    elapsed = xtimer_now_usec64() - start;
+    elapsed = ztimer64_now(ZTIMER64_USEC) - start;
 
     if (ret != 0) {
         if (errno != ETIMEDOUT) {

--- a/tests/sema/Makefile
+++ b/tests/sema/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
 USEMODULE += sema
-USEMODULE += xtimer
-USEMODULE += ztimer_usec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sema/Makefile
+++ b/tests/sema/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += sema
+USEMODULE += sema_deprecated
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This PR takes for `sema` a similar approach to `event_timeout`. The module is switched to `ztimer` removing the `xtimer` based implementation.

To keep compatibility the old api (using 64bit timeouts) is kept if selecting `sema` module, which uses `ztimer64`, but this module is marked now as deprecated.

This PR also migrates posix to use `ztimer64` and in therefore gives a user for `sema_ztimer64` by using it to implement `posix_sempahore`

### Testing procedure

- green murdock