### PR TITLE
sys/ztimer64: fix `ztimer64_remove()` not properly clearing timer struct

### DIFF
--- a/sys/ztimer64/ztimer64.c
+++ b/sys/ztimer64/ztimer64.c
@@ -127,6 +127,12 @@ static int _add_entry_to_list(ztimer64_clock_t *clock, ztimer64_base_t *entry)
     }
 }
 
+static void _clear(ztimer64_base_t *entry)
+{
+    entry->next = NULL;
+    entry->target = 0;
+}
+
 static int _del_entry_from_list(ztimer64_clock_t *clock, ztimer64_base_t *entry)
 {
     DEBUG("_del_entry_from_list()\n");
@@ -137,7 +143,7 @@ static int _del_entry_from_list(ztimer64_clock_t *clock, ztimer64_base_t *entry)
     if (clock->first == entry) {
         /* special case: removing first entry */
         clock->first = entry->next;
-        entry->next = 0;
+        _clear(entry);
         return 1;
     }
     else {
@@ -151,7 +157,7 @@ static int _del_entry_from_list(ztimer64_clock_t *clock, ztimer64_base_t *entry)
             pos = pos->next;
         }
 
-        entry->next = 0;
+        _clear(entry);
 
         return 0;
     }
@@ -238,9 +244,9 @@ void ztimer64_handler(void *arg)
             ztimer64_t *timer = (ztimer64_t *)clock->first;
             /* remove timer from list */
             clock->first = clock->first->next;
+
             /* clear timer struct so it can be re-set */
-            timer->base.next = NULL;
-            timer->base.target = 0;
+            _clear(&timer->base);
 
             /* shoot callback */
             timer->callback(timer->arg);

--- a/tests/unittests/tests-ztimer64/tests-ztimer64-core.c
+++ b/tests/unittests/tests-ztimer64/tests-ztimer64-core.c
@@ -216,6 +216,28 @@ static void test_ztimer64_set_uninitialized(void)
     ztimer64_set(z64, &timer, 0);
 }
 
+static void test_ztimer64_remove_clear(void)
+{
+    /* regression test, testing if a removed timer passes `!(is_set(t)` */
+    ztimer_mock_t zmock;
+    ztimer_clock_t *z = &zmock.super;
+    ztimer64_clock_t z64mock;
+    ztimer64_clock_t *z64 = &z64mock;
+
+    memset(&zmock, '\0', sizeof(ztimer_mock_t));
+    memset(&z64mock, '\0', sizeof(ztimer64_clock_t));
+    /* ztimer base clock is already extended to 32bit */
+    ztimer_mock_init(&zmock, 32);
+    ztimer64_clock_init(z64, z);
+
+    ztimer64_t timer = { .base.target = 1 };
+
+    ztimer64_set(z64, &timer, 100000000LLU);
+    TEST_ASSERT(ztimer64_is_set(&timer));
+    ztimer64_remove(z64, &timer);
+    TEST_ASSERT(!ztimer64_is_set(&timer));
+}
+
 Test *tests_ztimer64_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -225,6 +247,7 @@ Test *tests_ztimer64_tests(void)
         new_TestFixture(test_ztimer64_set_at),
         new_TestFixture(test_ztimer64_checkpoint),
         new_TestFixture(test_ztimer64_set_uninitialized),
+        new_TestFixture(test_ztimer64_remove_clear),
     };
 
     EMB_UNIT_TESTCALLER(ztimer64_tests, setup, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

ztimer64 wasn't properly clearing a removed timer struct, but depended on that for it's `ztimer64_is_set()`.

This PR adds a fix, and a regression test.

regression test output with the fix reverted:

```
main(): This is RIOT! (Version: 2022.04-devel-568-g33dae8-fix_ztimer64_remove)
Help: Press s to start test, r to print it is ready
rs
READY
START
.......
ztimer64_tests.test_ztimer64_remove_clear (tests/unittests/tests-ztimer64/tests-ztimer64-core.c 238) !ztimer64_is_set(&timer)

run 7 failures 1
```
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI tests this now. :)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found with #17365.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
