### PR TITLE
pkg/uwb-dw1000: add patch for rf_txctrl value

### DIFF
--- a/pkg/uwb-dw1000/patches/0001-uwb_dw1000-include-dw1000-dw1000_dev-add-linked-list.patch
+++ b/pkg/uwb-dw1000/patches/0001-uwb_dw1000-include-dw1000-dw1000_dev-add-linked-list.patch
@@ -1,7 +1,7 @@
 From fe110d931bfa6c2b02cb99293d59dc1daee4e00a Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Fri, 14 Aug 2020 13:38:05 +0200
-Subject: [PATCH 1/5] uwb_dw1000/include/dw1000/dw1000_dev: add linked list
+Subject: [PATCH 1/6] uwb_dw1000/include/dw1000/dw1000_dev: add linked list
  next ptr
 
 ---
@@ -18,8 +18,7 @@ index aec0bec..2dcd7f8 100644
  #endif
 +    struct _dw1000_dev_instance_t* next;
  } dw1000_dev_instance_t;
- 
- //! SPI and other init parameters
--- 
-2.28.0
 
+ //! SPI and other init parameters
+--
+2.32.0

--- a/pkg/uwb-dw1000/patches/0002-uwb_dw1000-dw1000_hal-send-spi-cmd-and-data-separetl.patch
+++ b/pkg/uwb-dw1000/patches/0002-uwb_dw1000-dw1000_hal-send-spi-cmd-and-data-separetl.patch
@@ -1,7 +1,7 @@
-From 3a3f9c49095768d2dc908f240ca02ee998c3d9b9 Mon Sep 17 00:00:00 2001
+From 4ab42b1e44052730b436ac57469be4983a9c3c02 Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Fri, 14 Aug 2020 13:55:11 +0200
-Subject: [PATCH 2/5] uwb_dw1000/dw1000_hal: send spi cmd and data separetly
+Subject: [PATCH 2/6] uwb_dw1000/dw1000_hal: send spi cmd and data separetly
  for RIOT
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 2/5] uwb_dw1000/dw1000_hal: send spi cmd and data separetly
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
-index 2390635..b195c23 100644
+index 2390635..a5e24af 100644
 --- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
 +++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
 @@ -310,7 +310,7 @@ hal_dw1000_read(struct _dw1000_dev_instance_t * inst,
@@ -53,5 +53,4 @@ index 2390635..b195c23 100644
  #endif
 
 --
-2.28.0
-
+2.32.0

--- a/pkg/uwb-dw1000/patches/0003-uwb_dw1000-dw1000_hal-define-even-if-DW1000_DEVICE_0.patch
+++ b/pkg/uwb-dw1000/patches/0003-uwb_dw1000-dw1000_hal-define-even-if-DW1000_DEVICE_0.patch
@@ -1,7 +1,7 @@
-From d6bc7b9e752f3d4418b1ef4e3468e8b2077a7ed1 Mon Sep 17 00:00:00 2001
+From 8bb0bafd2e0cca88e96fd678b83a0a1ed14bd1d3 Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Fri, 14 Aug 2020 13:56:25 +0200
-Subject: [PATCH 3/5] uwb_dw1000/dw1000_hal: define even if DW1000_DEVICE_0 is
+Subject: [PATCH 3/6] uwb_dw1000/dw1000_hal: define even if DW1000_DEVICE_0 is
  unset
 
 In RIOT multiple DW1000 devices will be speficied thorugh a link
@@ -13,13 +13,13 @@ The rest of the api should still be defined
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
-index b195c23..9268193 100644
+index a5e24af..bdc0656 100644
 --- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
 +++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
 @@ -262,6 +262,8 @@ hal_dw1000_inst(uint8_t idx)
      return 0;
  }
- 
+
 +#endif
 +
  /**
@@ -31,6 +31,5 @@ index b195c23..9268193 100644
  }
 -
 -#endif
--- 
-2.28.0
-
+--
+2.32.0

--- a/pkg/uwb-dw1000/patches/0004-uwb_dw1000-dw1000_hal-os_sr_t-by-dpl_sr_t.patch
+++ b/pkg/uwb-dw1000/patches/0004-uwb_dw1000-dw1000_hal-os_sr_t-by-dpl_sr_t.patch
@@ -1,14 +1,14 @@
-From 4e384bd9c5cb1b34c8371c43e82add678d717946 Mon Sep 17 00:00:00 2001
+From 0e0e919319eb7d228b020e84a9225b1430779d39 Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Thu, 17 Sep 2020 12:26:44 +0200
-Subject: [PATCH 4/5] uwb_dw1000/dw1000_hal: os_sr_t by dpl_sr_t
+Subject: [PATCH 4/6] uwb_dw1000/dw1000_hal: os_sr_t by dpl_sr_t
 
 ---
  hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
-index 9268193..3a93800 100644
+index bdc0656..58608f2 100644
 --- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
 +++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
 @@ -715,7 +715,7 @@ int
@@ -20,6 +20,5 @@ index 9268193..3a93800 100644
      assert(inst->spi_sem);
      rc = dpl_sem_pend(inst->spi_sem, DPL_TIMEOUT_NEVER);
      if (rc != DPL_OK) {
--- 
-2.28.0
-
+--
+2.32.0

--- a/pkg/uwb-dw1000/patches/0005-dw1000-dw1000_dev-use-gpio_t-types-for-dev_cfg.patch
+++ b/pkg/uwb-dw1000/patches/0005-dw1000-dw1000_dev-use-gpio_t-types-for-dev_cfg.patch
@@ -1,7 +1,7 @@
-From 888fecffc4faafef81a0ac6eafdc74f6f1c932b4 Mon Sep 17 00:00:00 2001
+From 45785e8bbacf0a38690ea8e77d51358b753a1a60 Mon Sep 17 00:00:00 2001
 From: Francisco Molina <femolina@uc.cl>
 Date: Wed, 7 Oct 2020 14:11:43 +0200
-Subject: [PATCH 5/5] dw1000/dw1000_dev: use gpio_t types for dev_cfg
+Subject: [PATCH 5/6] dw1000/dw1000_dev: use gpio_t types for dev_cfg
 
 ---
  hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h | 6 +++---
@@ -21,9 +21,8 @@ index 2dcd7f8..e149054 100644
 +    gpio_t rst_pin;               //!< Reset pin
 +    gpio_t irq_pin;               //!< Interrupt request pin
 +    gpio_t ss_pin;                //!< Slave select pin
- 
+
      uint16_t rx_antenna_delay;    //!< Receive antenna delay
      uint16_t tx_antenna_delay;    //!< Transmit antenna delay
--- 
-2.28.0
-
+--
+2.32.0

--- a/pkg/uwb-dw1000/patches/0006-hw-drivers-uwb_dw100-update-RF_TXCTRL-value-for-chan.patch
+++ b/pkg/uwb-dw1000/patches/0006-hw-drivers-uwb_dw100-update-RF_TXCTRL-value-for-chan.patch
@@ -1,0 +1,25 @@
+From 76861326a7762b45b7da1dc53e6169b5b158f067 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Tue, 1 Mar 2022 14:50:01 +0100
+Subject: [PATCH 6/6] hw/drivers/uwb_dw100: update RF_TXCTRL value for channel
+ 5
+
+---
+ hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h
+index c27c695..64808cc 100644
+--- a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h
++++ b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_regs.h
+@@ -1001,7 +1001,7 @@ extern "C" {
+ #define RF_TXCTRL_CH2           0x00045CA0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
+ #define RF_TXCTRL_CH3           0x00086CC0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
+ #define RF_TXCTRL_CH4           0x00045C80UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
+-#define RF_TXCTRL_CH5           0x001E3FE0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
++#define RF_TXCTRL_CH5           0x001E3FE3UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
+ #define RF_TXCTRL_CH7           0x001E7DE0UL    /* 32-bit value to program to Sub-Register 0x28:0C � RF_TXCTRL */
+
+ /* offset from TX_CAL_ID in bytes */
+--
+2.32.0


### PR DESCRIPTION
### Contribution description

This PR adds a patch for https://github.com/Decawave/uwb-dw1000/issues/2, if this is merged upstream I'll remove the patch.

### Testing procedure

Just checking the reference manual value is enough, see Table 38: Sub-Register 0x28:0C– RF_TXCTRL values in https://www.decawave.com/sites/default/files/resources/dw1000_user_manual_2.11.pdf

### Issues/PRs references

https://github.com/Decawave/uwb-dw1000/issues/2
PR fixing issue: https://github.com/Decawave/uwb-dw1000/pull/4