### PR TITLE
cpu/stm32: Fix CLOCK_CORECLOCK on stm32l0/l1

### DIFF
--- a/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
@@ -71,7 +71,7 @@ extern "C" {
  * PLL_MUL:         multiplier, allowed values: 3, 4, 6, 8, 12, 16, 24, 32, 48. Default is 4.
  * CORECLOCK        -> 32MHz MAX!
  */
-#define CLOCK_CORECLOCK                 ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_DIV) * CONFIG_CLOCK_PLL_MUL)
+#define CLOCK_CORECLOCK                 ((CLOCK_PLL_SRC * CONFIG_CLOCK_PLL_MUL) / CONFIG_CLOCK_PLL_DIV)
 #if CLOCK_CORECLOCK > MHZ(32)
 #error "SYSCLK cannot exceed 32MHz"
 #endif


### PR DESCRIPTION
### Contribution description

Fixes the `CLOCK_CORECLOCK` value for STM32L0/L1 MCUs, previously the value would lose some precision when dividing the PLL source clock (e.g.: `(MHZ(8)/3)*12` would result in 31999992 Hz instead of 32 MHz).


### Testing procedure

Compilation on STM32L0/L1 MCUs should succeed

### Issues/PRs references
