### PR TITLE
cpu/stm32: Add STM32_LINE cases for STM32L1xxx6

### DIFF
--- a/cpu/stm32/stm32_line.mk
+++ b/cpu/stm32/stm32_line.mk
@@ -113,7 +113,13 @@ ifeq (L,$(STM32_TYPE))
   endif
   ifeq (1,$(STM32_FAMILY))  # STM32L1
     ifneq (,$(filter $(STM32_MODEL), 100 151 152 162))
-      ifneq (,$(filter $(STM32_ROMSIZE), C))
+      ifneq (,$(filter $(STM32_ROMSIZE), 6))
+        ifneq (,$(filter $(STM32_RAMMOD), _A))
+          CPU_LINE = STM32L$(STM32_MODEL)xBA
+        else
+          CPU_LINE = STM32L$(STM32_MODEL)xB
+        endif
+      else ifneq (,$(filter $(STM32_ROMSIZE), C))
         CPU_LINE = STM32L$(STM32_MODEL)xC
       else ifneq (,$(filter $(STM32_ROMSIZE), B))
         ifneq (,$(filter $(STM32_RAMMOD), _A))


### PR DESCRIPTION
### Contribution description

Adds specific case to `stm32_line.mk` file to support the `STM32L1xxx6 /6_A` lines of MCUs.

### Testing procedure

Tested with a custom board and works correctly (UART, SPI, clock setup, etc.). There's no board present on RIOT to test this (yet).

### Issues/PRs references
