### PR TITLE
tests/*xtimer*: remove uneeded timex calls

### DIFF
--- a/tests/bench_xtimer_load/main.c
+++ b/tests/bench_xtimer_load/main.c
@@ -73,7 +73,6 @@ static struct timer_msg msg_d = { .interval = (TEST_INTERVAL * 2) };
 static void *slacker_thread(void *arg)
 {
     (void)arg;
-    timex_t now;
 
     LOG_DEBUG("run thread %" PRIkernel_pid "\n", thread_getpid());
 
@@ -85,7 +84,6 @@ static void *slacker_thread(void *arg)
         msg_t m;
         msg_receive(&m);
         struct timer_msg *tmsg = m.content.ptr;
-        xtimer_now_timex(&now);
         xtimer_usleep(TEST_MSG_RX_USLEEP);
 
         tmsg->msg.type = 12345;

--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -65,7 +65,6 @@ struct timer_msg msg_d = { .interval = (TEST_INTERVAL * 2) };
 void *slacker_thread(void *arg)
 {
     (void) arg;
-    timex_t now;
 
     LOG_DEBUG("run thread %" PRIkernel_pid "\n", thread_getpid());
 
@@ -77,7 +76,6 @@ void *slacker_thread(void *arg)
         msg_t m;
         msg_receive(&m);
         struct timer_msg *tmsg = m.content.ptr;
-        xtimer_now_timex(&now);
         xtimer_usleep(TEST_MSG_RX_USLEEP);
 
         tmsg->msg.type = 12345;


### PR DESCRIPTION
### Contribution description

This PR removes unneeded `xtimer_now_timex` calls, the value was never used.

### Testing procedure

- Green Murdock

### Issues/PRs references

Found in #17365 and split.
