### PR TITLE
sys/net/gnrc: ztimer_no_periph_rtt if gomach

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -21,6 +21,7 @@ ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer
   USEMODULE += gnrc_mac
+  USEMODULE += ztimer_no_periph_rtt
   FEATURES_REQUIRED += periph_rtt
 endif
 


### PR DESCRIPTION
### Contribution description

gomach uses periph_rtt therefore should not have rtt used by ztimer.

### Testing procedure

- green murdock
- in gomach example rtt is used but not by ztimer:
```
BOARD=iotlab-m3 make -C examples/gnrc_networking_mac/ info-modules | grep rtt
periph_init_rtt
periph_rtt
ztimer_no_periph_rtt
```

### Issues/PRs references

Split from #17365
