### PR TITLE
sys/gnrc/sixlowpan/frag/fb: guard sfr_types.h header include

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag/fb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/fb.h
@@ -28,7 +28,9 @@
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG_HINT
 #include "net/gnrc/sixlowpan/frag/hint.h"
 #endif /* MODULE_GNRC_SIXLOWPAN_FRAG_HINT */
+#if IS_USED(MODULE_GNRC_SIXLOWPAN_FRAG_SFR)
 #include "net/gnrc/sixlowpan/frag/sfr_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

This guards the header.

### Testing procedure

- green murdock
- in master the following error showed up if using `ztimer_xtimer_compat` (no 64bit), which exposed the wrongful inclusion.


`USEMODULE=ztimer_xtimer_compat make -C tests/gnrc_sixlowpan_frag -j`
```
In file included from /home/francisco/workspace/RIOT/sys/include/evtimer_msg.h:24,
                 from /home/francisco/workspace/RIOT/sys/include/net/gnrc/sixlowpan/frag/sfr_types.h:25,
                 from /home/francisco/workspace/RIOT/sys/include/net/gnrc/sixlowpan/frag/fb.h:31,
                 from /home/francisco/workspace/RIOT/sys/net/gnrc/network_layer/sixlowpan/frag/fb/gnrc_sixlowpan_frag_fb.c:20:
/home/francisco/workspace/RIOT/sys/include/evtimer.h: In function ‘evtimer_now_msec’:
/home/francisco/workspace/RIOT/sys/include/evtimer.h:134:12: error: implicit declaration of function ‘xtimer_now_usec64’; did you mean ‘xtimer_now_usec’? [-Werror=implicit-function-declaration]
  134 |     return xtimer_now_usec64() / US_PER_MS;
      |            ^~~~~~~~~~~~~~~~~
      |            xtimer_now_usec
```

Note: the above command still yields an error, but will be fixed in another PR.

### Issues/PRs references

Found in [#17365](https://github.com/RIOT-OS/RIOT/pull/17365)