### PR TITLE
sys/net/link_layer/csma_sender: use public xtimer_now()

### DIFF
--- a/sys/net/link_layer/csma_sender/csma_sender.c
+++ b/sys/net/link_layer/csma_sender/csma_sender.c
@@ -152,7 +152,7 @@ int csma_sender_csma_ca_send(netdev_t *dev, iolist_t *iolist,
 
     /* if we arrive here, then we must perform the CSMA/CA procedure
        ourselves by software */
-    random_init(_xtimer_now());
+    random_init(xtimer_now_usec());
     DEBUG("csma: Starting software CSMA/CA....\n");
 
     int nb = 0, be = conf->min_be;


### PR DESCRIPTION
### Contribution description

The private API should not be used.

### Testing procedure

- green murdock

### Issues/PRs references

Found in [#17365](https://github.com/RIOT-OS/RIOT/pull/17365)
