### PR TITLE
sys: sort out ztimer_xtimer_compat and ztimer64_xtimer_compat depes

### DIFF
--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -25,6 +25,7 @@ config CPU_ARCH_NATIVE
 
     # needed modules
     select MODULE_PERIPH if TEST_KCONFIG
+    select MODULE_ZTIMER64_XTIMER_COMPAT if MODULE_ZTIMER_XTIMER_COMPAT
 
 config CPU_CORE_NATIVE
     bool

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -40,6 +40,11 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  # requires 64bit for syscalls
+  USEMODULE += ztimer64_xtimer_compat
+endif
+
 USEMODULE += periph
 
 # UART is needed by startup.c

--- a/sys/Kconfig.newlib
+++ b/sys/Kconfig.newlib
@@ -18,6 +18,7 @@ config MODULE_NEWLIB_SYSCALLS_DEFAULT
     default y
     depends on !HAVE_CUSTOM_NEWLIB_SYSCALLS
     select MODULE_DIV
+    select MODULE_ZTIMER64_XTIMER_COMPAT if MODULE_ZTIMER_XTIMER_COMPAT
     help
         Default implementation of newlib system calls.
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -135,6 +135,10 @@ endif
 ifneq (,$(filter sntp,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += xtimer
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit ftimestamps
+    USEMODULE += ztimer64_xtimer_compat
+  endif
 endif
 
 ifneq (,$(filter sock_%,$(USEMODULE)))
@@ -229,6 +233,10 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   endif
   ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
     USEMODULE += div
+    ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+      # requires 64bit timestamps when using xtimer
+      USEMODULE += ztimer64_xtimer_compat
+    endif
   endif
 endif
 
@@ -310,6 +318,10 @@ endif
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   USEMODULE += sema
   USEMODULE += xtimer
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires sema_timed that requires 64bit
+    USEMODULE += ztimer64_xtimer_compat
+  endif
   USEMODULE += posix_headers
 endif
 
@@ -339,6 +351,9 @@ endif
 ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE += universal_address
   USEMODULE += xtimer
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    USEMODULE += ztimer64_xtimer_compat
+  endif
   USEMODULE += posix_headers
 endif
 
@@ -353,6 +368,10 @@ ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   USEMODULE += timex
   FEATURES_REQUIRED += cpp
   FEATURES_REQUIRED += libstdcpp
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit for syscalls
+    USEMODULE += ztimer64_xtimer_compat
+  endif
 endif
 
 ifneq (,$(filter netstats_%, $(USEMODULE)))
@@ -367,6 +386,10 @@ endif
 ifneq (,$(filter pthread,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += timex
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit ftimestamps
+    USEMODULE += ztimer64_xtimer_compat
+  endif
 endif
 
 ifneq (,$(filter schedstatistics,$(USEMODULE)))
@@ -580,6 +603,10 @@ endif
 ifneq (,$(filter dsm,$(USEMODULE)))
   USEMODULE += sock_dtls
   USEMODULE += xtimer
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit timestamps when using xtimer
+    USEMODULE += ztimer64_xtimer_compat
+  endif
 endif
 
 ifneq (,$(filter gcoap,$(USEMODULE)))
@@ -640,6 +667,10 @@ ifneq (,$(filter cord_lc cord_ep,$(USEMODULE)))
   USEMODULE += cord_common
   ifneq (,$(filter shell_commands,$(USEMODULE)))
     USEMODULE += sock_util
+  endif
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit timestamps when using xtimer
+    USEMODULE += ztimer64_xtimer_compat
   endif
 endif
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -167,6 +167,9 @@ ifneq (,$(filter trickle,$(USEMODULE)))
   USEMODULE += random
   ifeq (,$(filter ztimer_msec,$(USEMODULE)))
     USEMODULE += xtimer
+    ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+      USEMODULE += ztimer_msec
+    endif
   endif
 endif
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -798,6 +798,9 @@ ifneq (,$(filter evtimer,$(USEMODULE)))
     USEMODULE += ztimer_msec
   else
     USEMODULE += xtimer
+    ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+      USEMODULE += evtimer_on_ztimer
+    endif
   endif
 endif
 

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -20,6 +20,10 @@ ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
   USEMODULE += gnrc_nettype_gomach
   USEMODULE += random
   USEMODULE += xtimer
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit timestamps
+    USEMODULE += ztimer64_xtimer_compat
+  endif
   USEMODULE += gnrc_mac
   FEATURES_REQUIRED += periph_rtt
 endif

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -166,7 +166,6 @@ config MODULE_ZTIMER64_XTIMER_COMPAT
     select MODULE_DIV
     select MODULE_ZTIMER64
     select MODULE_ZTIMER64_USEC
-    depends on MODULE_ZTIMER_XTIMER_COMPAT
     help
         This is a wrapper of xtimer API on ztimer64_usec.
 


### PR DESCRIPTION
### Contribution description

This PR splits from [#17365](https://github.com/RIOT-OS/RIOT/pull/17365) all modules depending on 64bit features of xtimer. It allows not using `64bit` if not needed, note that because of `newlib` this is actually used most of the time (a nice case to optimize @kfessel)

In cases where there was already a ztimer based alternative for xtimer, those get used instead.

Note that some might still be missed as covered in the build but some of these modules.

### Testing procedure

- Green murdock

### Issues/PRs references

Split from [#17365](https://github.com/RIOT-OS/RIOT/pull/17365)
