### PR TITLE
sys/syscalls: make gettimeofday() implementation optional

### DIFF
--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -25,7 +25,6 @@ config CPU_ARCH_NATIVE
 
     # needed modules
     select MODULE_PERIPH if TEST_KCONFIG
-    select MODULE_ZTIMER64_XTIMER_COMPAT if MODULE_ZTIMER_XTIMER_COMPAT
 
 config CPU_CORE_NATIVE
     bool

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -40,9 +40,12 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-  # requires 64bit for syscalls
-  USEMODULE += ztimer64_xtimer_compat
+ifneq (,$(filter libc_gettimeofday,$(USEMODULE)))
+  USEMODULE += xtimer
+  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    # requires 64bit timestamps
+    USEMODULE += ztimer64_xtimer_compat
+  endif
 endif
 
 USEMODULE += periph

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -42,6 +42,7 @@
 #include "xtimer.h"
 #include "stdio_base.h"
 
+#include "kernel_defines.h"
 #include "native_internal.h"
 
 #define ENABLE_DEBUG 0
@@ -474,10 +475,10 @@ int getpid(void)
     return -1;
 }
 
-#ifdef MODULE_XTIMER
+#if (IS_USED(MODULE_LIBC_GETTIMEOFDAY))
 int _gettimeofday(struct timeval *tp, void *restrict tzp)
 {
-    (void) tzp;
+    (void)tzp;
     uint64_t now = xtimer_now_usec64();
     tp->tv_sec  = now / US_PER_SEC;
     tp->tv_usec = now - tp->tv_sec;

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -121,6 +121,10 @@ PSEUDOMODULES += log
 PSEUDOMODULES += log_printfnoformat
 PSEUDOMODULES += log_color
 PSEUDOMODULES += lora
+## @defgroup pseudomodule_libc_gettimeofday libc_gettimeofday
+## @brief Includes implementation of gettimeofday()
+##
+PSEUDOMODULES += libc_gettimeofday
 
 ## @defgroup pseudomodule_mpu_stack_guard mpu_stack_guard
 ## @brief MPU based stack guard

--- a/pkg/lua/Makefile.dep
+++ b/pkg/lua/Makefile.dep
@@ -17,3 +17,11 @@ FEATURES_BLACKLIST += arch_riscv
 # - lua/liolib.c:671:38: error: '_IOFBF' undeclared (first use in this function)
 # - lua/liolib.c:671:46: error: '_IOLBF' undeclared (first use in this function)
 FEATURES_BLACKLIST += picolibc
+
+ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
+  USEMODULE += libc_gettimeofday
+endif
+
+ifneq (,$(filter native,$(CPU)))
+  USEMODULE += libc_gettimeofday
+endif

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -14,3 +14,11 @@ ifneq (,$(filter sock_dtls,$(USEMODULE)))
   USEMODULE += tinydtls_sock_dtls
   USEMODULE += ztimer_usec
 endif
+
+ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
+  USEMODULE += libc_gettimeofday
+endif
+
+ifneq (,$(filter native,$(CPU)))
+  USEMODULE += libc_gettimeofday
+endif

--- a/pkg/wolfssl/Makefile.dep
+++ b/pkg/wolfssl/Makefile.dep
@@ -82,5 +82,13 @@ ifneq (,$(filter wolfcrypt_random,$(USEMODULE)))
   USEMODULE += random
 endif
 
+ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
+  USEMODULE += libc_gettimeofday
+endif
+
+ifneq (,$(filter native,$(CPU)))
+  USEMODULE += libc_gettimeofday
+endif
+
 # wolfssl is only supported by 32 bit architectures
 FEATURES_REQUIRED += arch_32bit

--- a/sys/Kconfig
+++ b/sys/Kconfig
@@ -49,8 +49,14 @@ config MODULE_NEWLIB
 config MODULE_PICOLIBC
     bool "Picolibc"
     depends on HAS_PICOLIBC
-
 endchoice
+
+config MODULE_LIBC_GETTIMEOFDAY
+    bool
+    select MODULE_XTIMER
+    select MODULE_ZTIMER64_XTIMER_COMPAT if MODULE_ZTIMER_XTIMER_COMPAT
+    help
+        Support for gettimeofday()
 
 rsource "Kconfig.newlib"
 rsource "Kconfig.picolibc"

--- a/sys/Kconfig.newlib
+++ b/sys/Kconfig.newlib
@@ -18,9 +18,16 @@ config MODULE_NEWLIB_SYSCALLS_DEFAULT
     default y
     depends on !HAVE_CUSTOM_NEWLIB_SYSCALLS
     select MODULE_DIV
-    select MODULE_ZTIMER64_XTIMER_COMPAT if MODULE_ZTIMER_XTIMER_COMPAT
     help
         Default implementation of newlib system calls.
+
+config MODULE_LIBC_GETTIMEOFDAY
+    bool
+    select MODULE_NEWLIB_SYSCALLS_DEFAULT if MODULE_NEWLIB
+    select MODULE_XTIMER
+    select MODULE_ZTIMER64_XTIMER_COMPAT if MODULE_ZTIMER_XTIMER_COMPAT
+    help
+        Support for gettimeofday()
 
 endif # MODULE_NEWLIB
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -242,9 +242,12 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   endif
   ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
     USEMODULE += div
-    ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-      # requires 64bit timestamps when using xtimer
-      USEMODULE += ztimer64_xtimer_compat
+    ifneq (,$(filter libc_gettimeofday,$(USEMODULE)))
+      USEMODULE += xtimer
+      ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+        # requires 64bit timestamps
+        USEMODULE += ztimer64_xtimer_compat
+      endif
     endif
   endif
 endif

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -630,23 +630,15 @@ int _kill(pid_t pid, int sig)
     return -1;
 }
 
-#ifdef MODULE_XTIMER
+#if (IS_USED(MODULE_LIBC_GETTIMEOFDAY))
 int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restrict tzp)
 {
-    (void) r;
-    (void) tzp;
+    (void)tzp;
+    (void)r;
     uint64_t now = xtimer_now_usec64();
     tp->tv_sec = div_u64_by_1000000(now);
     tp->tv_usec = now - (tp->tv_sec * US_PER_SEC);
     return 0;
-}
-#else
-int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restrict tzp)
-{
-    (void) tp;
-    (void) tzp;
-    r->_errno = ENOSYS;
-    return -1;
 }
 #endif
 

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -2,5 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += cpp11-compat
 USEMODULE += xtimer
+USEMODULE += libc_gettimeofday
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

A follow-up to #17732  to not force 64bit on all syscalls users.

With this PR the users of ztimer64 should be limited to:

Revisited list of apps using `ztimer64`:

`for app in examples/* tests/*; do make -C ${app} info-modules | if grep -q ztimer64; then echo ${app};fi;done`
```
examples/ccn-lite-relay
examples/cord_ep
examples/cord_lc
examples/dtls-echo
examples/dtls-sock
examples/dtls-wolfssl
examples/gcoap_dtls
examples/gnrc_networking_mac
examples/lua_basic
examples/lua_REPL
examples/openthread
examples/posix_select
examples/wasm
tests/cpp11_condition_variable
tests/cpp11_mutex
tests/cpp11_thread
tests/driver_ltc4150
tests/driver_pir
tests/gnrc_gomach
tests/lua_loader
tests/nimble_autoconn_ccnl
tests/pkg_arduino_sdi_12
tests/pkg_flatbuffers
tests/pkg_tensorflow-lite
tests/pkg_tinydtls_sock_async
tests/pkg_wolfcrypt-ed25519-verify
tests/pkg_wolfssl
tests/posix_semaphore
tests/pthread
tests/pthread_barrier
tests/pthread_cleanup
tests/pthread_condition_variable
tests/pthread_cooperation
tests/pthread_flood
tests/pthread_rwlock
tests/pthread_tls
tests/saul_drivers
tests/sema
tests/sntp
tests/sys_fido2_ctap
tests/unittests
tests/ztimer64_msg
```

### Testing procedure

Green Murdock, although should probably wait for #17721 or cherry-pick f7f7a9310b17dad691710b02ef34d0d729b2a8ae to test for missing dependencies.

### Issues/PRs references

Follow up to #17732 
Related to #17721 and #17365
