### PR TITLE
sys/posix/pthread: newlib compatibility

### DIFF
--- a/sys/posix/pthread/include/pthread_once.h
+++ b/sys/posix/pthread/include/pthread_once.h
@@ -23,15 +23,21 @@ extern "C" {
 
 /**
  * @brief           Datatype to supply to pthread_once().
+ * @details         This data type must be compatible with the one defined
+ *                  in newlib's `include/sys/_pthreadtypes.h`.
  */
-typedef volatile int pthread_once_t;
+typedef struct {
+  int   is_initialized;  /**< initialized */
+  int   init_executed;   /**< init function executed */
+} pthread_once_t;
 
 /**
  * @def             PTHREAD_ONCE_INIT
  * @brief           Initialization for pthread_once_t.
- * @details         A zeroed out pthread_once_t is initialized.
+ * @details         pthread_once_t variables are declared as initialized, but
+ *                  the init function is not yet executed.
  */
-#define PTHREAD_ONCE_INIT 0
+#define PTHREAD_ONCE_INIT  { 1, 0 }
 
 /**
  * @brief           Helper function that ensures that `init_routine` is called at once.

--- a/sys/posix/pthread/pthread_once.c
+++ b/sys/posix/pthread/pthread_once.c
@@ -22,11 +22,11 @@
 
 int pthread_once(pthread_once_t *once_control, void (*init_routine)(void))
 {
-    if (*once_control == PTHREAD_ONCE_INIT) {
+    if (!once_control->init_executed) {
         init_routine();
     }
 
-    *once_control = PTHREAD_ONCE_INIT + 1;
+    once_control->init_executed = 1;
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

This PR provides a `pthread_once_t` type that is compatible with newlib's `pthread_once_t`.

When using a toolchain with built-in POSIX thread support, static C++ constructors use a static (fake) mutex variable which is initialized with `pthread_once` when first used. However, since RIOT's `pthread_once_t` type is different from that in newlib's `pthread`, which is assumed by GCC, RIOT crashes as soon as static constructors are used.

Changing the `pthread_once_t` type to be compatible with newlib's `pthread_once_t` type solves the problem and allows the RIOT `pthread` modules to be used even with toolchains with built-in POSIX thread support. The costs for this change is one additional `int` variable.

With this change, the precompiled ESP32 toolchains including OpenOCD from Espressif can be used and is no longer necessary to compile them especially for RIOT.

Found out while migrating the ESP32 port to ESP-IDF 4.4, which is the prerequisite for the RIOT port on all different ESP32 SoC variants.

### Testing procedure

Compilation in CI should succeed and the `tests/pthread*` and `tests/cpp_ctors` should still work. A succeeding  test run in CI should be sufficient.

### Issues/PRs references

Prerequisite for PR #17601