### PR TITLE
sys/net/dhcpv6: miscellaneous tweaks 

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -1016,6 +1016,10 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
             default:
                 break;
         }
+        /* 0 option is used as an end marker, len can include bogus bytes */
+        if (!byteorder_ntohs(opt->type)) {
+            break;
+        }
     }
     if ((cid == NULL) || (sid == NULL)) {
         DEBUG("DHCPv6 client: ADVERTISE does not contain either server ID "

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -613,8 +613,6 @@ static int _preparse_advertise(uint8_t *adv, size_t len, uint8_t **buf)
     dhcpv6_opt_duid_t *cid = NULL, *sid = NULL;
     dhcpv6_opt_pref_t *pref = NULL;
     dhcpv6_opt_status_t *status = NULL;
-    dhcpv6_opt_ia_pd_t *ia_pd = NULL;
-    dhcpv6_opt_ia_na_t *ia_na = NULL;
     size_t orig_len = len;
     uint8_t pref_val = 0;
 
@@ -640,16 +638,6 @@ static int _preparse_advertise(uint8_t *adv, size_t len, uint8_t **buf)
             case DHCPV6_OPT_STATUS:
                 status = (dhcpv6_opt_status_t *)opt;
                 break;
-            case DHCPV6_OPT_IA_PD:
-                if (IS_USED(MODULE_DHCPV6_CLIENT_IA_PD)) {
-                    ia_pd = (dhcpv6_opt_ia_pd_t *)opt;
-                }
-                break;
-            case DHCPV6_OPT_IA_NA:
-                if (IS_USED(MODULE_DHCPV6_CLIENT_IA_NA)) {
-                    ia_na = (dhcpv6_opt_ia_na_t *)opt;
-                }
-                break;
             case DHCPV6_OPT_PREF:
                 pref = (dhcpv6_opt_pref_t *)opt;
                 break;
@@ -657,11 +645,9 @@ static int _preparse_advertise(uint8_t *adv, size_t len, uint8_t **buf)
                 break;
         }
     }
-    if ((cid == NULL) || (sid == NULL) ||
-        (IS_USED(MODULE_DHCPV6_CLIENT_IA_PD) && (ia_pd == NULL)) ||
-        (IS_USED(MODULE_DHCPV6_CLIENT_IA_NA) && (ia_na == NULL))) {
-        DEBUG("DHCPv6 client: ADVERTISE does not contain either server ID, "
-              "client ID, IA_PD or IA_NA option\n");
+    if ((cid == NULL) || (sid == NULL)) {
+        DEBUG("DHCPv6 client: ADVERTISE does not contain either server ID "
+              "or client ID\n");
         return -1;
     }
     if (!_check_status_opt(status) || !_check_cid_opt(cid)) {
@@ -991,8 +977,6 @@ static bool _parse_ia_na_option(dhcpv6_opt_ia_na_t *ia_na)
 static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
 {
     dhcpv6_opt_duid_t *cid = NULL, *sid = NULL;
-    dhcpv6_opt_ia_pd_t *ia_pd = NULL;
-    dhcpv6_opt_ia_na_t *ia_na = NULL;
     dhcpv6_opt_status_t *status = NULL;
     dhcpv6_opt_smr_t *smr = NULL;
     dhcpv6_opt_imr_t *imr = NULL;
@@ -1020,16 +1004,6 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
             case DHCPV6_OPT_STATUS:
                 status = (dhcpv6_opt_status_t *)opt;
                 break;
-            case DHCPV6_OPT_IA_PD:
-                if (IS_USED(MODULE_DHCPV6_CLIENT_IA_PD)) {
-                    ia_pd = (dhcpv6_opt_ia_pd_t *)opt;
-                }
-                break;
-            case DHCPV6_OPT_IA_NA:
-                if (IS_USED(MODULE_DHCPV6_CLIENT_IA_NA)) {
-                    ia_na = (dhcpv6_opt_ia_na_t *)opt;
-                }
-                break;
             case DHCPV6_OPT_SMR:
                 smr = (dhcpv6_opt_smr_t *)opt;
                 break;
@@ -1043,11 +1017,9 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
                 break;
         }
     }
-    if ((cid == NULL) || (sid == NULL) ||
-        (IS_USED(MODULE_DHCPV6_CLIENT_IA_PD) && (ia_pd == NULL)) ||
-        (IS_USED(MODULE_DHCPV6_CLIENT_IA_NA) && (ia_na == NULL))) {
-        DEBUG("DHCPv6 client: ADVERTISE does not contain either server ID, "
-              "client ID, IA_PD or IA_NA option\n");
+    if ((cid == NULL) || (sid == NULL)) {
+        DEBUG("DHCPv6 client: ADVERTISE does not contain either server ID "
+              "or client ID\n");
         return false;
     }
     if (!_check_cid_opt(cid) || !_check_sid_opt(sid)) {

--- a/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_simple_pd.c
@@ -93,6 +93,9 @@ static void _configure_dhcpv6_client(void)
 {
     gnrc_netif_t *netif = NULL;
     gnrc_netif_t *upstream = _find_upstream_netif();
+    if (IS_ACTIVE(MODULE_DHCPV6_CLIENT_IA_NA)) {
+        upstream->ipv6.aac_mode |= GNRC_NETIF_AAC_DHCP;
+    }
     while ((netif = gnrc_netif_iter(netif))) {
         if (IS_USED(MODULE_GNRC_DHCPV6_CLIENT_6LBR)
             && !gnrc_netif_is_6lo(netif)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If `dhcpv6_client_ia_na` is enabled, `gnrc_dhcpv6_client_simple_pd ` should also attempt to get an address for the upstream interface via DHCPv6. The module only makes sense when router advertisements/SLAAC is disabled in the router.

The DHCP client should also not reject a response if no downstream interfaces are configured for IA_PD but the module is enabled - they might simple not be initialized yet.

The DHCP server in the TP-Link WR400 sends a response that ends with option 0 (Reserved), which has a bogus length of 4 when the remaining length is 3, which would cause an underflow.
To fix getting a DHCP configuration from that router, consider option 0 end and marker.


### Testing procedure

I used the following modules: `gnrc_dhcpv6_client_simple_pd dhcpv6_client_ia_na sock_dns atwinc15x0`

```
main(): This is RIOT! (Version: 2022.04-devel-590-gb1d7a-dhcpv6-tweaks)
RIOT network stack example application
All up, running the shell now
> [atwinc15x0] WiFi connected
ifconfig
Iface  5  HWaddr: F8:F0:05:A9:EB:F0  Channel: 4  RSSI: -33  Link: up
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wireless
          inet6 addr: fe80::faf0:5ff:fea9:ebf0  scope: link  VAL
          inet6 addr: 2a00:20:6051:168c::1  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffa9:ebf0
          inet6 group: ff02::1a
          inet6 group: ff02::1:ff00:1

          Statistics for Layer 2
            RX packets 16  bytes 2088
            TX packets 14 (Multicast: 12)  bytes 1074
            TX succeeded 12 errors 0
          Statistics for IPv6
            RX packets 15  bytes 1548
            TX packets 14 (Multicast: 12)  bytes 1018
            TX succeeded 14 errors 0

> ping riot-os.org
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=0 ttl=51 time=36.845 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=1 ttl=51 time=33.817 ms
12 bytes from 2001:67c:254:b0b0::1: icmp_seq=2 ttl=51 time=35.163 ms

--- riot-os.org PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 33.817/35.275/36.845 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
