### PR TITLE
ipv6/nib: fix memcpy() bug in _handle_rtr_timeout()

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1376,9 +1376,8 @@ static void _handle_rtr_timeout(_nib_dr_entry_t *router)
     if ((router->next_hop != NULL) && (router->next_hop->mode & _DRL)) {
         _nib_offl_entry_t *route = NULL;
         unsigned iface = _nib_onl_get_if(router->next_hop);
-        ipv6_addr_t addr;
+        ipv6_addr_t addr = router->next_hop->ipv6;
 
-        memcpy(&addr, &router->next_hop, sizeof(addr));
         _nib_drl_remove(router);
         /* also remove all routes to that router */
         while ((route = _nib_offl_iter(route))) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

As the title says. I guess that is what it was supposed to be.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
