### PR TITLE
sys/net/gnrc/sock_types: guard tcp.h header inclusion

### DIFF
--- a/sys/net/gnrc/sock/include/sock_types.h
+++ b/sys/net/gnrc/sock/include/sock_types.h
@@ -28,7 +28,9 @@
 #include "mbox.h"
 #include "net/af.h"
 #include "net/gnrc.h"
+#if IS_USED(MODULE_GNRC_TCP)
 #include "net/gnrc/tcp.h"
+#endif
 #include "net/gnrc/netreg.h"
 #ifdef SOCK_HAS_ASYNC
 #include "net/sock/async/types.h"


### PR DESCRIPTION

### Contribution description

This guards the tcp header inclusion since it holds references to `evtimer` which may not be included in the build if `gnrc_tcp` is not

### Testing procedure
This fails in master
```
BOARD=arduino-mega2560 USEMODULE=ztimer_xtimer_compat make -C tests/gnrc_sock_async_event/ -j
```
```
"make" -C /data/riotbuild/riotbase/sys/ztimer
cc1: all warnings being treated as errors
make[1]: *** [/data/riotbuild/riotbase/Makefile.base:146: /data/riotbuild/riotbase/tests/gnrc_sock_async_event/bin/arduino-mega2560/application_tests_gnrc_sock_async_event/main.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from /data/riotbuild/riotbase/sys/include/evtimer_msg.h:24:0,
                 from /data/riotbuild/riotbase/sys/include/net/gnrc/tcp/tcb.h:26,
                 from /data/riotbuild/riotbase/sys/include/net/gnrc/tcp.h:27,
                 from /data/riotbuild/riotbase/sys/net/gnrc/sock/include/sock_types.h:31,
                 from /data/riotbuild/riotbase/sys/net/gnrc/sock/gnrc_sock.c:33:
/data/riotbuild/riotbase/sys/include/evtimer.h: In function ‘evtimer_now_msec’:
/data/riotbuild/riotbase/sys/include/evtimer.h:134:12: error: implicit declaration of function ‘xtimer_now_usec64’ [-Werror=implicit-function-declaration]
     return xtimer_now_usec64() / US_PER_MS;
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
