### PR TITLE
cpu/esp32/esp-eth: move GNRC auto_init to init_devs

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -29,6 +29,7 @@ INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/tcpip_adapter
 INCLUDES += -I$(RIOTCPU)/$(CPU)
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))
+  INCLUDES += -I$(RIOTCPU)/$(CPU)/esp-eth
   INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/ethernet
 endif
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_esp_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_esp_eth.c
@@ -16,8 +16,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#if defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET)
-
 #include "esp_eth_params.h"
 #include "esp_eth_netdev.h"
 #include "net/gnrc/netif/ethernet.h"
@@ -39,10 +37,4 @@ void auto_init_esp_eth(void)
     gnrc_netif_ethernet_create(&_netif, _esp_eth_stack, ESP_ETH_STACKSIZE, ESP_ETH_PRIO,
                                "netif-esp-eth", &_esp_eth_dev.netdev);
 }
-
-#else /* defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET) */
-
-typedef int dont_be_pedantic;
-
-#endif /* defined(MODULE_ESP_ETH) && defined(MODULE_GNRC_NETIF_ETHERNET) */
 /**@}*/


### PR DESCRIPTION
### Contribution description
This moves the GNRC auto_init of ESP32 ethernet peripheral driver to `init_devs`, where all the other drivers are initialized.

### Testing procedure
- Test some GNRC-based example while using `esp_eth` module

### Issues/PRs references
Split from #17739 