### PR TITLE
cpu/sam0_common/eth: expose correct setup function

### DIFF
--- a/cpu/sam0_common/sam0_eth/sam0_eth_netdev.h
+++ b/cpu/sam0_common/sam0_eth/sam0_eth_netdev.h
@@ -44,11 +44,10 @@ typedef struct {
 /**
  * @brief Setup SAM0 Ethernet peripheral
  *
- * @param[in] dev   Pointer to the SAM0 Ethernet netdev struct
+ * @param[in] dev   Pointer to the netdev struct
  *
  */
-
-void sam0_eth_netdev_setup(sam0_eth_netdev_t* dev);
+void sam0_eth_setup(netdev_t* dev);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/netif/init_devs/auto_init_sam0_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sam0_eth.c
@@ -24,8 +24,6 @@ static netdev_t sam0eth;
 static char stack[THREAD_STACKSIZE_DEFAULT];
 static gnrc_netif_t _netif;
 
-extern void sam0_eth_setup(netdev_t *netdev);
-
 void auto_init_sam0_eth(void)
 {
     /* setup netdev device */


### PR DESCRIPTION
### Contribution description
Currently `sam0_eth_netdev.h` exposes `sam0_eth_netdev_setup`, which is not defined. Instead `sam0_eth_setup` is used, but not exposed. This fixes the issue by changing the exposed setup function.

### Testing procedure
- Green CI
- Alternatively run a networking example on a board sam0-based board with Ethernet (e.g., `same54-xpro`).

### Issues/PRs references
Split from #17739 