### PR TITLE
drivers/encx24j600: define default parameters

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14887,3 +14887,7 @@ pkg/lvgl7/include/lvgl_riot_conf\.h:[0-9]+: warning: Member LV_TICK_CUSTOM \(mac
 pkg/lvgl7/include/lvgl_riot_conf\.h:[0-9]+: warning: Member LV_TICK_CUSTOM_INCLUDE \(macro definition\) of file lvgl_riot_conf\.h is not documented\.
 pkg/lvgl7/include/lvgl_riot_conf\.h:[0-9]+: warning: Member LV_TICK_CUSTOM_SYS_TIME_EXPR \(macro definition\) of file lvgl_riot_conf\.h is not documented\.
 pkg/lvgl7/include/lvgl_riot_conf\.h:[0-9]+: warning: Member lv_coord_t \(typedef\) of file lvgl_riot_conf\.h is not documented\.
+drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAM_SPI \(macro definition\) of file encx24j600_params\.h is not documented\.
+drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAM_CS \(macro definition\) of file encx24j600_params\.h is not documented\.
+drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAM_INT \(macro definition\) of file encx24j600_params\.h is not documented\.
+drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAMS \(macro definition\) of file encx24j600_params\.h is not documented\.

--- a/drivers/encx24j600/include/encx24j600_params.h
+++ b/drivers/encx24j600/include/encx24j600_params.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_encx24j600
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for the ENCX24J600 Ethernet driver
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef ENCX24J600_PARAMS_H
+#define ENCX24J600_PARAMS_H
+
+#include "encx24j600.h"
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the ENCX24J600 driver
+ * @{
+ */
+#ifndef ENCX24J600_PARAM_SPI
+#define ENCX24J600_PARAM_SPI      (SPI_DEV(0))
+#endif
+#ifndef ENCX24J600_PARAM_CS
+#define ENCX24J600_PARAM_CS       (GPIO_PIN(0, 0))
+#endif
+#ifndef ENCX24J600_PARAM_INT
+#define ENCX24J600_PARAM_INT      (GPIO_PIN(0, 1))
+#endif
+
+#ifndef ENCX24J600_PARAMS
+#define ENCX24J600_PARAMS         { .spi = ENCX24J600_PARAM_SPI,     \
+                                    .cs_pin = ENCX24J600_PARAM_CS,   \
+                                    .int_pin = ENCX24J600_PARAM_INT }
+#endif
+/** @} */
+
+/**
+ * @brief   ENCX24J600 configuration
+ */
+static const  encx24j600_params_t encx24j600_params[] = {
+    ENCX24J600_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ENCX24J600_PARAMS_H */
+/** @} */

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -15,19 +15,12 @@ ifneq (,$(filter nucleo-f334r8,$(BOARD)))
   ENC_SPI ?= SPI_DEV\(0\)
   ENC_CS  ?= GPIO_PIN\(PORT_C,10\)
   ENC_INT ?= GPIO_PIN\(PORT_D,2\)
+
+  # export SPI and pins
+  CFLAGS += -DENCX24J600_SPI=$(ENC_SPI)
+  CFLAGS += -DENCX24J600_CS=$(ENC_CS)
+  CFLAGS += -DENCX24J600_INT=$(ENC_INT)
 endif
-
-# fallback: set SPI bus and pins to default values
-ENC_SPI ?= SPI_DEV\(0\)
-ENC_CS  ?= GPIO_PIN\(0,0\)
-ENC_INT ?= GPIO_PIN\(0,1\)
-# export SPI and pins
-CFLAGS += -DENCX24J600_SPI=$(ENC_SPI)
-CFLAGS += -DENCX24J600_CS=$(ENC_CS)
-CFLAGS += -DENCX24J600_INT=$(ENC_INT)
-
-# make sure we read the local encx24j600 params file
-CFLAGS += -I$(CURDIR)
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
### Contribution description
This adds default params to the `encx24j600` (the values are taken from the test application), and modifies the `auto_init` code to support multiple driver instances.

### Testing procedure
- Green CI
- Optionally run the test application (I could not do this as I don't have the device)

### Issues/PRs references
Split from #17739 
