### PR TITLE
tests/cpu_avr8_xmega_driver: fix BOARD name

### DIFF
--- a/tests/cpu_avr8_xmega_drivers/Makefile
+++ b/tests/cpu_avr8_xmega_drivers/Makefile
@@ -1,4 +1,4 @@
-BOARD ?= atxmega_a1u_xpro
+BOARD ?= atxmega-a1u-xpro
 
 include ../Makefile.tests_common
 


### PR DESCRIPTION
### Contribution description

Wrong BOARD name is used

### Testing procedure

- Green murdock


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
