### PR TITLE
tests/driver_dfplayer: use event_thread instead of event_thread_lowest

### DIFF
--- a/tests/driver_dfplayer/Makefile
+++ b/tests/driver_dfplayer/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += dfplayer
-USEMODULE += event_thread_lowest
+USEMODULE += event_thread
 USEMODULE += shell
 USEMODULE += shell_commands
 


### PR DESCRIPTION
### Contribution description

Avoid deprecated module.

### Testing procedure

Green murdock
