### PR TITLE
sys/net/ipv6: add ipv6_addr_init() helper function

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -532,6 +532,19 @@ uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b);
 void ipv6_addr_init_prefix(ipv6_addr_t *out, const ipv6_addr_t *prefix, uint8_t bits);
 
 /**
+ * @brief   Sets IPv6 address @p out with a given prefix and interface ID
+ *
+ * @param[out]  out     Address to initialize
+ * @param[in]   prefix  Prefix in host byte order
+ * @param[in]   iid     Interface ID in host byte order
+ */
+static inline void ipv6_addr_init(ipv6_addr_t *out, uint64_t prefix, uint64_t iid)
+{
+    out->u64[0] = byteorder_htonll(prefix);
+    out->u64[1] = byteorder_htonll(iid);
+}
+
+/**
  * @brief   Sets the last @p bits of IPv6 address @p out to @p iid.
  *          Leading bits of @p out stay untouched.
  *

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -552,6 +552,19 @@ static void test_ipv6_addr_match_prefix_same_pointer(void)
     TEST_ASSERT_EQUAL_INT(128, ipv6_addr_match_prefix(&a, &a));
 }
 
+static void test_ipv6_addr_init(void)
+{
+    ipv6_addr_t a = { {
+            0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        },
+    };
+    ipv6_addr_t b;
+    ipv6_addr_init(&b, 0xff02000000000000ULL, 0x1);
+
+    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
+}
+
 static void test_ipv6_addr_init_prefix(void)
 {
     ipv6_addr_t a = { {
@@ -1129,6 +1142,7 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_match_prefix_match_127),
         new_TestFixture(test_ipv6_addr_match_prefix_match_128),
         new_TestFixture(test_ipv6_addr_match_prefix_same_pointer),
+        new_TestFixture(test_ipv6_addr_init),
         new_TestFixture(test_ipv6_addr_init_prefix),
         new_TestFixture(test_ipv6_addr_init_iid),
         new_TestFixture(test_ipv6_addr_set_unspecified),


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Setting a compile-time const IP address can be a bit cumbersome.
Add a helper function to easy the process.


### Testing procedure

`unittests/tests-ipv6_addr` was extended with the new function. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
