### PR TITLE
tests/*: add BOARDs to Makefile.ci

### DIFF
--- a/tests/driver_scd30/Makefile.ci
+++ b/tests/driver_scd30/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    stk3200 \
+    #

--- a/tests/pkg_libfixmath_unittests/Makefile.ci
+++ b/tests/pkg_libfixmath_unittests/Makefile.ci
@@ -6,6 +6,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f302r8 \
+    nucleo-f303k8 \
+    nucleo-f334r8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \
@@ -18,4 +21,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f0discovery \
     stm32g0316-disco \
     stm32l0538-disco \
+    stm32mp157c-dk2 \
     #

--- a/tests/pkg_wolfssl/Makefile.ci
+++ b/tests/pkg_wolfssl/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml10-xpro \
     saml11-xpro \
     slstk3400a \
+    spark-core \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \


### PR DESCRIPTION

### Contribution description

These BOARDs overflowed in ROM after arm-none-eabi-gcc version
in riot/riotbuild changed to 10.3.2

### Testing procedure

Green murdock.

