### PR TITLE
boards/common/qn908x: perform elf checksum on shadow copy

### DIFF
--- a/boards/common/qn908x/Makefile.include
+++ b/boards/common/qn908x/Makefile.include
@@ -22,8 +22,12 @@ OPENOCD_PRE_FLASH_CMDS += "-c qn908x disable_wdog"
 # in another ELF file and we set it as the FLASHFILE.
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 ELFFILE_CHECKSUM ?= $(ELFFILE:.elf=-checksum.elf)
+ELFFILE_SHADOW ?= $(ELFFILE:.elf=-shadow.elf)
 
-$(ELFFILE_CHECKSUM): $(ELFFILE)
+$(ELFFILE_SHADOW): $(ELFFILE)
+	$(Q)cp $(ELFFILE) $(ELFFILE_SHADOW)
+
+$(ELFFILE_CHECKSUM): $(ELFFILE_SHADOW)
 	$(Q)$(OBJCOPY) --dump-section .vectors=$<.vectors $<
 	$(Q)$(RIOTBOARD)/common/qn908x/dist/nxp_checksum.py $(if $(Q),--quiet) \
 	  $<.vectors


### PR DESCRIPTION
### Contribution description
**WIP**
Some sort of race condition seems to be triggering random errors on the `qn9080dk` board: `arm-none-eabi-size: /tmp/dwq.0.09674638050766471/103682e29d7607ed5a01e49cd01d1398/build/tests_driver_dcf77.elf: file format not recognized`.

I could reproduce this locally when running murdock script:
```
/bin/bash -c "source .murdock; JOBS=4 compile tests/driver_mag3110 qn9080dk:gnu"
```

~~This seems to fix the problem locally for me, but I'm not 100% sure this is the cause.~~
For what we observed, the operations of objcopy on the `.elf` file are affecting the file itself, so other operations (e.g.: calculating hash for Kconfig test, printing size) seem to fail depending on when the file is accessed. As there is no strong dependency for the `$(ELFFILE_CHECKSUM)` target on the other targets accessing the file, it turns into a race condition. This PR attempts to fix this by creating a copy of the `$(ELFFILE)` on which to perform all the operations, so it does not affect other targets.

### Testing procedure
- Green CI

### Issues/PRs references
None
