### PR TITLE
sys/ztimer: Name callback types

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -289,6 +289,11 @@ typedef struct ztimer_base ztimer_base_t;
 typedef struct ztimer_clock ztimer_clock_t;
 
 /**
+ * @brief Type of callbacks in @ref ztimer_t "timers"
+ */
+typedef void (*ztimer_callback_t)(void *arg);
+
+/**
  * @brief   Minimum information for each timer
  */
 struct ztimer_base {
@@ -310,7 +315,7 @@ typedef uint32_t ztimer_now_t;  /**< type for ztimer_now() result */
  */
 typedef struct {
     ztimer_base_t base;             /**< clock list entry */
-    void (*callback)(void *arg);    /**< timer callback function pointer */
+    ztimer_callback_t callback;     /**< timer callback function pointer */
     void *arg;                      /**< timer callback argument */
 } ztimer_t;
 

--- a/sys/include/ztimer/periodic.h
+++ b/sys/include/ztimer/periodic.h
@@ -81,6 +81,11 @@ extern "C" {
 #define ZTIMER_PERIODIC_KEEP_GOING true
 
 /**
+ * @brief Type of callbacks in @ref ztimer_periodic_t "periodic timers"
+ */
+typedef bool (*ztimer_periodic_callback_t)(void *);
+
+/**
  * @brief   ztimer periodic structure
  */
 typedef struct {
@@ -88,7 +93,7 @@ typedef struct {
     ztimer_clock_t *clock;      /**< clock for this timer               */
     uint32_t interval;          /**< interval of this timer             */
     ztimer_now_t last;          /**< last trigger time                  */
-    bool (*callback)(void *);   /**< called on each trigger             */
+    ztimer_periodic_callback_t callback;   /**< called on each trigger             */
     void *arg;                  /**< argument for callback              */
 } ztimer_periodic_t;
 


### PR DESCRIPTION
### Contribution description

This introduces a name to the callback types of ztimer_t and ztimer_periodic_t.

This is has no effect in C directly, where the weak typing of macros in ZTIMER_PERIODIC_KEEP_GOING and the unchecked casting of function pointers makes this invisible, but when wrapping things for Rust I have to use matching types (or assert for all perpetuity that the casts are OK, which might make future changes not ring any bells).

This is one of the rare times a change is requested only for the benefit of Rust and with no tangible upsides on C, so please review carefully with that in mind.

### Testing procedure

A build test should cover all effects of this.

### Issues/PRs references

The change of periodic callback return values from int to bool in https://github.com/RIOT-OS/RIOT/pull/17351 triggered this.

More on the topic of types for callbacks in [in the forum under "Please name callback types"](https://forum.riot-os.org/t/please-name-callback-types/3546).

Asking for reviews from @kaspar030 (who originally decided to not name these when creating the structs) and @benpicco (whose PR triggered it).