### PR TITLE
{examples,tests}/rust: Rust updates (-sys/-wrappers version, stable)

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -84,9 +84,19 @@ Toolchain {#toolchain}
 
 To install the necessary Rust components, it is easiest use [**rustup**, installed as described on its website].
 
-Using Rust on RIOT requires a nightly version of Rust,
+Using most of Rust on RIOT requires a nightly version of Rust,
 because some transpiled expressions for RIOT make use of unstable features,
 and because the RIOT wrappers use some unstable idioms.
+
+@note
+Building on stable is supported for some examples and platforms starting with Rust 1.59
+(e.g., the rust-hello-world on any ARM Cortex, but not yet on native).
+Try it out by adding `CARGO_CHANNEL=stable` to the project's Makefile;
+where it doesn't work, rustc will complain that "`#![feature]` may not be used on the stable release channel".
+
+@note
+A stable version of Rust is not currently provided with the Docker images;
+consequently, builds on stable are not tested as regularly as builds on nightly.
 
 Make sure you have both the nightly **toolchain**
 and the core library for the CPU (**target**) of your choice available:

--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -534,7 +534,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#3a4487b3bf678e454aa8b3d6c8003600707d6583"
+source = "git+https://gitlab.com/etonomy/riot-module-examples/#2fc38cbc4a14529cad9162f4dc3ed0f56c01448c"
 dependencies = [
  "coap-handler",
  "coap-handler-implementations",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0945e5819b4bf59e0af38998faab1846dc8e9f530b968ace030a66029acdfc69"
+checksum = "b2041eeef3e226f836d27cace1e6131f88a53b53df0ae62eb1cae060d9eb2a6e"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.17"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62946759a8042f516e6b395cc1183da6435e84fcd7a1cd4d9138c8e6a8820ec"
+checksum = "1fc2844134d2599d7a010382c659aa0713d9ddc845a3791bf48e2801e9f4c59f"
 dependencies = [
  "bare-metal 1.0.0",
  "coap-handler",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/examples/rust-gcoap/Cargo.toml
+++ b/examples/rust-gcoap/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 crate-type = ["staticlib"]
 
 [dependencies]
-riot-wrappers = { version = "^0.7", features = [ "with_coap_message", "with_coap_handler" ] }
+riot-wrappers = { version = "^0.7.18", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler" ] }
 
 coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
 coap-handler-implementations = "0.3"

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -30,6 +30,11 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+# Add 3k extra stack: The Rust examples take more of it than gcoap expects,
+# presumably because the example use the standard library's sting formatting
+# instead of one of the more optimized formatters.
+CFLAGS += -DGCOAP_STACK_SIZE='(THREAD_STACKSIZE_DEFAULT+DEBUG_EXTRA_STACKSIZE+sizeof(coap_pkt_t)+1024)'
+
 # The name of crate (as per Cargo.toml package name, but with '-' replaced with '_')
 APPLICATION_RUST_MODULE = rust_gcoap
 BASELIBS += $(APPLICATION_RUST_MODULE).module

--- a/examples/rust-gcoap/Makefile.ci
+++ b/examples/rust-gcoap/Makefile.ci
@@ -1,11 +1,19 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    airfy-beacon \
     blackpill \
     bluepill \
     bluepill-stm32f030c8 \
+    calliope-mini \
+    im880b \
     i-nucleo-lrwan1 \
+    microbit \
+    nrf51dongle \
+    nrf6310 \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f070rb \
+    nucleo-f072rb \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
@@ -22,4 +30,5 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32g0316-disco \
     stm32l0538-disco \
     stm32mp157c-dk2 \
+    yunjia-nrf51822 \
     #

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -456,9 +456,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0945e5819b4bf59e0af38998faab1846dc8e9f530b968ace030a66029acdfc69"
+checksum = "b2041eeef3e226f836d27cace1e6131f88a53b53df0ae62eb1cae060d9eb2a6e"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.17"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62946759a8042f516e6b395cc1183da6435e84fcd7a1cd4d9138c8e6a8820ec"
+checksum = "1fc2844134d2599d7a010382c659aa0713d9ddc845a3791bf48e2801e9f4c59f"
 dependencies = [
  "bare-metal 1.0.0",
  "cstr_core",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/examples/rust-hello-world/Cargo.toml
+++ b/examples/rust-hello-world/Cargo.toml
@@ -9,4 +9,5 @@ resolver = "2"
 crate-type = ["staticlib"]
 
 [dependencies]
-riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ] }
+# `default-features = false` can be removed with 0.8, and enables building on stable during the 0.7 series
+riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ], default-features = false }

--- a/examples/rust-hello-world/Cargo.toml
+++ b/examples/rust-hello-world/Cargo.toml
@@ -9,4 +9,4 @@ resolver = "2"
 crate-type = ["staticlib"]
 
 [dependencies]
-riot-wrappers = "0.7"
+riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ] }

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -456,9 +456,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0945e5819b4bf59e0af38998faab1846dc8e9f530b968ace030a66029acdfc69"
+checksum = "b2041eeef3e226f836d27cace1e6131f88a53b53df0ae62eb1cae060d9eb2a6e"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.17"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62946759a8042f516e6b395cc1183da6435e84fcd7a1cd4d9138c8e6a8820ec"
+checksum = "1fc2844134d2599d7a010382c659aa0713d9ddc845a3791bf48e2801e9f4c59f"
 dependencies = [
  "bare-metal 1.0.0",
  "cstr_core",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/tests/rust_minimal/Cargo.toml
+++ b/tests/rust_minimal/Cargo.toml
@@ -9,4 +9,5 @@ resolver = "2"
 crate-type = ["staticlib"]
 
 [dependencies]
-riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ] }
+# `default-features = false` can be removed with 0.8, and enables building on stable during the 0.7 series
+riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ], default-features = false }

--- a/tests/rust_minimal/Cargo.toml
+++ b/tests/rust_minimal/Cargo.toml
@@ -9,4 +9,4 @@ resolver = "2"
 crate-type = ["staticlib"]
 
 [dependencies]
-riot-wrappers = "0.7"
+riot-wrappers = { version = "0.7", features = [ "set_panic_handler" ] }


### PR DESCRIPTION
### Contribution description

Another round of updates to the Rust examples, with the usual steps of

* updating versions and
* following all the latest riot-wrappers deprecations (so that going through a breaking version will be painless),

with extas of

* increasing the stack size (cherry-picked from #17554 -- turned out some resources' rendering overflew the stack), and
* documenting it's now usable in some cases with stable Rust.

Disabling default-features on two examples sits somewhere between them -- the deprecation note says only that we have to pull in those that were default so far, but it is necessary to make things work on stable unmodified.

### Testing procedure

* Green CI (which includes tests)
* Optionally, `make all term CARGO_CHANNEL=stable BOARD=microbit-v2 all flash term -C examples/rust-hello-world` (if you have Rust 1.59 at hand and all the relevant targets installed)

### Issues/PRs references

Closes https://github.com/RIOT-OS/RIOT/issues/17526

Includes a cherry-pick from #17554

Once this is through, I can open one at https://arewertosyet.com/ to make our "compiles on stable" checkbox go green.