### PR TITLE
sys/net/ipv4: ipv4_addr_t pointer should be const

### DIFF
--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -52,7 +52,7 @@ typedef union {
  * @return  true, if @p a and @p b are equal
  * @return  false, otherwise.
  */
-static inline bool ipv4_addr_equal(ipv4_addr_t *a, ipv4_addr_t *b)
+static inline bool ipv4_addr_equal(const ipv4_addr_t *a, const ipv4_addr_t *b)
 {
     return (a->u32.u32 == b->u32.u32);
 }


### PR DESCRIPTION
### Contribution description

The pointers are not written to, so it should be const.


### Testing procedure

Can be tested with #17763
