### PR TITLE
examples/gcoap: add IPv4 support

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -14,17 +14,33 @@ RIOTBASE ?= $(CURDIR)/../..
 USEMODULE += netdev_default
 
 # use GNRC by default
-LWIP ?= 0
+LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 0
 
-ifeq (0,$(LWIP))
+ifeq (,$(filter 1, $(LWIP_IPV4) $(LWIP_IPV6)))
   USEMODULE += auto_init_gnrc_netif
   # Specify the mandatory networking modules
   USEMODULE += gnrc_ipv6_default
   # Additional networking modules that can be dropped if not needed
   USEMODULE += gnrc_icmpv6_echo
 else
-  USEMODULE += lwip_ipv6
   USEMODULE += lwip_netdev
+
+  ifeq (1,$(LWIP_IPV4))
+    USEMODULE += ipv4_addr
+
+    USEMODULE += lwip_arp
+    USEMODULE += lwip_ipv4
+    USEMODULE += lwip_dhcp_auto
+    CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
+  endif
+
+  ifeq (1,$(LWIP_IPV6))
+    USEMODULE += ipv6_addr
+
+    USEMODULE += lwip_ipv6
+    USEMODULE += lwip_ipv6_autoconfig
+  endif
 endif
 
 USEMODULE += gcoap
@@ -33,6 +49,7 @@ USEMODULE += gcoap
 USEMODULE += od
 USEMODULE += fmt
 USEMODULE += netutils
+USEMODULE += random
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_cmds_default

--- a/examples/gcoap_dtls/Makefile
+++ b/examples/gcoap_dtls/Makefile
@@ -14,17 +14,33 @@ RIOTBASE ?= $(CURDIR)/../..
 USEMODULE += netdev_default
 
 # use GNRC by default
-LWIP ?= 0
+LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 0
 
-ifeq (0,$(LWIP))
+ifeq (,$(filter 1, $(LWIP_IPV4) $(LWIP_IPV6)))
   USEMODULE += auto_init_gnrc_netif
   # Specify the mandatory networking modules
   USEMODULE += gnrc_ipv6_default
   # Additional networking modules that can be dropped if not needed
   USEMODULE += gnrc_icmpv6_echo
 else
-  USEMODULE += lwip_ipv6
   USEMODULE += lwip_netdev
+
+  ifeq (1,$(LWIP_IPV4))
+    USEMODULE += ipv4_addr
+
+    USEMODULE += lwip_arp
+    USEMODULE += lwip_ipv4
+    USEMODULE += lwip_dhcp_auto
+    CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
+  endif
+
+  ifeq (1,$(LWIP_IPV6))
+    USEMODULE += ipv6_addr
+
+    USEMODULE += lwip_ipv6
+    USEMODULE += lwip_ipv6_autoconfig
+  endif
 endif
 
 USEMODULE += gcoap
@@ -33,6 +49,7 @@ USEMODULE += gcoap
 USEMODULE += od
 USEMODULE += fmt
 USEMODULE += netutils
+USEMODULE += random
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_cmds_default

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -189,3 +189,7 @@ endif
 ifneq (,$(filter preprocessor_%,$(USEMODULE)))
   include $(RIOTBASE)/sys/preprocessor/Makefile.include
 endif
+
+ifneq (,$(filter gcoap,$(USEMODULE)))
+  include $(RIOTBASE)/sys/net/application_layer/gcoap/Makefile.include
+endif

--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -58,6 +58,23 @@ static inline bool ipv4_addr_equal(const ipv4_addr_t *a, const ipv4_addr_t *b)
 }
 
 /**
+ * @brief   Check if @p addr is a multicast address.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc1112.html#section-4">
+ *          RFC 1112, section 4
+ *      </a>
+ *
+ * @param[in] addr  An IPv4 address.
+ *
+ * @return  true, if @p addr is multicast address,
+ * @return  false, otherwise.
+ */
+static inline bool ipv4_addr_is_multicast(const ipv4_addr_t *addr)
+{
+    return (addr->u8[0] >= 0xE0 && addr->u8[0] <= 0xEF);
+}
+
+/**
  * @brief   Converts an IPv4 address to its string representation
  *
  * @param[out] result       The resulting string representation of at least

--- a/sys/net/application_layer/gcoap/Makefile.include
+++ b/sys/net/application_layer/gcoap/Makefile.include
@@ -1,0 +1,4 @@
+ifeq (2, $(words $(filter ipv4 ipv6, $(USEMODULE))))
+  $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Due to limitations in the gcoap API it is currently not \
+                         possible to use a dual stack setup$(COLOR_RESET)" 1>&2)
+endif


### PR DESCRIPTION
### Contribution description

Add IPv4 support to `examples/gcoap`and `examples/gcoap_dtls`.

Dual stack mode using IPv4 and IPv6 would require some changes on the gcoap API, therefore compilation stops with an error right now.


### Testing procedure

Use the example applications to connect by IPv4 instead of IPv6 by compiling with `LWIP_IPV4=1`


### Issues/PRs references

Dependencies:
- #17765
- #17766
- #17764
