### PR TITLE
pkg/mynewt-core: fix semaphore

### DIFF
--- a/pkg/uwb-core/include/dpl/dpl_sem.h
+++ b/pkg/uwb-core/include/dpl/dpl_sem.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include "dpl_types.h"
+#include "dpl_error.h"
 #include "os/os_sem.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

The current implementation could not block forever, this did not really show since it would result in waiting for `UINT32_MAX`, bode makes for a more complete implementation.

### Testing procedure

Green murdock should be enough.

