### PR TITLE
pkg/nimble/autoadv: add support for ext_adv

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -172,6 +172,8 @@ CLEAN = $(filter clean, $(MAKECMDGOALS))
 include $(RIOTMAKE)/utils/variables.mk
 include $(RIOTMAKE)/utils/strings.mk
 
+# include nimble makefile tools
+include $(RIOTMAKE)/pkg/nimble.adv.mk
 
 # UNAME is always needed so use simple variable expansion so only evaluated once
 UNAME := $(shell uname -m -s)

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14948,3 +14948,12 @@ boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member ETH_DMA_ISR
 boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member eth_config \(variable\) of file periph_conf\.h is not documented\.
 boards/arduino\-mega2560/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SET \(macro definition\) of file board\.h is not documented\.
 boards/arduino\-mega2560/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SLEEP \(macro definition\) of file board\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_ADV_ITVL_MS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_ADV_DURATION_MS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_FLAGS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_PHY \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_TX_POWER \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_CHANNEL_MAP \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_OWN_ADDR_TYPE \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_FILTER_POLICY \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
+pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_PARAMS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.

--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -14,8 +14,8 @@ USEMODULE += nimble_svc_gatt
 
 # Use automated advertising
 USEMODULE += nimble_autoadv
-CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"NimBLE GATT Example"'
-CFLAGS += -DNIMBLE_AUTOADV_START_MANUALLY=1
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_DEVICE_NAME='"NimBLE GATT Example"'
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_START_MANUALLY=1
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -288,7 +288,7 @@ int main(void)
     ble_gatts_start();
 
     /* start to advertise this node */
-    nimble_autoadv_start();
+    nimble_autoadv_start(NULL);
 
     return 0;
 }

--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -283,7 +283,7 @@ int main(void)
     assert(rc == 0);
 
     /* set the device name */
-    ble_svc_gap_device_name_set(NIMBLE_AUTOADV_DEVICE_NAME);
+    ble_svc_gap_device_name_set(CONFIG_NIMBLE_AUTOADV_DEVICE_NAME);
     /* reload the GATT server to link our added services */
     ble_gatts_start();
 

--- a/examples/nimble_heart_rate_sensor/Makefile
+++ b/examples/nimble_heart_rate_sensor/Makefile
@@ -17,8 +17,8 @@ USEMODULE += nimble_svc_gatt
 
 # Use automated advertising
 USEMODULE += nimble_autoadv
-CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"RIOT Heart Rate Sensor"'
-CFLAGS += -DNIMBLE_AUTOADV_START_MANUALLY=1
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_DEVICE_NAME='"RIOT Heart Rate Sensor"'
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_START_MANUALLY=1
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/nimble_heart_rate_sensor/main.c
+++ b/examples/nimble_heart_rate_sensor/main.c
@@ -296,7 +296,7 @@ int main(void)
     assert(res == 0);
 
     /* set the device name */
-    ble_svc_gap_device_name_set(NIMBLE_AUTOADV_DEVICE_NAME);
+    ble_svc_gap_device_name_set(CONFIG_NIMBLE_AUTOADV_DEVICE_NAME);
     /* reload the GATT server to link our added services */
     ble_gatts_start();
 

--- a/examples/nimble_heart_rate_sensor/main.c
+++ b/examples/nimble_heart_rate_sensor/main.c
@@ -215,7 +215,7 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg)
         case BLE_GAP_EVENT_CONNECT:
             if (event->connect.status) {
                 _stop_updating();
-                nimble_autoadv_start();
+                nimble_autoadv_start(NULL);
                 return 0;
             }
             _conn_handle = event->connect.conn_handle;
@@ -223,7 +223,7 @@ static int gap_event_cb(struct ble_gap_event *event, void *arg)
 
         case BLE_GAP_EVENT_DISCONNECT:
             _stop_updating();
-            nimble_autoadv_start();
+            nimble_autoadv_start(NULL);
             break;
 
         case BLE_GAP_EVENT_SUBSCRIBE:
@@ -300,25 +300,28 @@ int main(void)
     /* reload the GATT server to link our added services */
     ble_gatts_start();
 
-    struct ble_gap_adv_params advp;
-    memset(&advp, 0, sizeof(advp));
-
-    advp.conn_mode = BLE_GAP_CONN_MODE_UND;
-    advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
-    advp.itvl_min  = BLE_GAP_ADV_FAST_INTERVAL1_MIN;
-    advp.itvl_max  = BLE_GAP_ADV_FAST_INTERVAL1_MAX;
-
+    nimble_autoadv_cfg_t cfg = {
+        .adv_duration_ms = BLE_HS_FOREVER,
+        .adv_itvl_ms = BLE_GAP_ADV_ITVL_MS(100),
+        .flags = NIMBLE_AUTOADV_FLAG_CONNECTABLE | NIMBLE_AUTOADV_FLAG_LEGACY | \
+                 NIMBLE_AUTOADV_FLAG_SCANNABLE,
+        .channel_map = 0,
+        .filter_policy = 0,
+        .own_addr_type = nimble_riot_own_addr_type,
+        .phy = NIMBLE_PHY_1M,
+        .tx_power = 0,
+    };
     /* set advertise params */
-    nimble_autoadv_set_ble_gap_adv_params(&advp);
+    nimble_autoadv_cfg_update(&cfg);
 
     /* configure and set the advertising data */
     uint16_t hrs_uuid = BLE_GATT_SVC_HRS;
     nimble_autoadv_add_field(BLE_GAP_AD_UUID16_INCOMP, &hrs_uuid, sizeof(hrs_uuid));
 
-    nimble_auto_adv_set_gap_cb(&gap_event_cb, NULL);
+    nimble_autoadv_set_gap_cb(&gap_event_cb, NULL);
 
     /* start to advertise this node */
-    nimble_autoadv_start();
+    nimble_autoadv_start(NULL);
 
     /* run an event loop for handling the heart rate update events */
     event_loop(&_eq);

--- a/makefiles/pkg/nimble.adv.mk
+++ b/makefiles/pkg/nimble.adv.mk
@@ -1,0 +1,15 @@
+# Adds an external Advertisement Instance
+# Parameter 1: The value for the advertisement instance without the CONFIG_ prefix
+# Result:
+#   - Increases BLE_MULTI_ADV_INSTANCES count by 1, note that the actual amount
+#     of advertisement instances is MYNEWT_VAL_BLE_MULTI_ADV_INSTANCES + 1, which
+#     is why BLE_MULTI_ADV_INSTANCES starts at -1
+#   - Sets the adv instance for CONFIG_$1 index to $(BLE_MULTI_ADV_INSTANCES)
+BLE_MULTI_ADV_INSTANCES ?= -1
+define _add_ext_adv_instance
+  # Increase the count in one
+  BLE_MULTI_ADV_INSTANCES := $$(shell echo $$$$(($(BLE_MULTI_ADV_INSTANCES) + 1)))
+  # Export the definition in CFLAGS
+  $(1) := $$(BLE_MULTI_ADV_INSTANCES)
+  CFLAGS += -DCONFIG_$(1)=$$($(1))
+endef

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -165,6 +165,7 @@ PSEUDOMODULES += nimble_phy_coded
 PSEUDOMODULES += nimble_phy_2mbit
 PSEUDOMODULES += nimble_rpble_ext
 PSEUDOMODULES += nimble_statconn_ext
+PSEUDOMODULES += nimble_autoadv_shell
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -23,7 +23,7 @@ else
   CFLAGS += -Wno-unused-but-set-variable
 endif
 
-IGNORE := nimble_autoconn_% nimble_phy_% nimble_%_ext
+IGNORE := nimble_autoconn_% nimble_phy_% nimble_%_ext nimble_autoadv%
 SUBMODS := $(filter-out $(IGNORE),$(filter nimble_%,$(USEMODULE)))
 
 .PHONY: all
@@ -73,9 +73,6 @@ nimble_drivers_nrf5x:
 # additional, RIOT specific nimble modules
 nimble_addr:
 	$(QQ)"$(MAKE)" -C $(TDIR)/addr/
-
-nimble_autoadv:
-	$(QQ)"$(MAKE)" -C $(TDIR)/autoadv
 
 nimble_autoconn:
 	$(QQ)"$(MAKE)" -C $(TDIR)/autoconn

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -123,6 +123,15 @@ ifneq (,$(filter nimble_netif_ext,$(USEMODULE)))
 endif
 
 ifneq (,$(filter nimble_netif,$(USEMODULE)))
+  # nimble_netif and nimble_autoadv will both setup gat advertisement, which will
+  # conflict with each other. Using the extended advertisement module allows
+  # setting this up on independent state machines allowing them to run concurently
+  ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
+    USEMODULE += nimble_adv_ext
+  endif
+endif
+
+ifneq (,$(filter nimble_netif,$(USEMODULE)))
   FEATURES_REQUIRED += ble_nimble_netif
   USEMODULE += random
   USEMODULE += l2util

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -63,6 +63,10 @@ endif
 
 ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
   USEMODULE += bluetil_ad
+  USEMODULE += bluetil_addr
+  ifneq (,$(filter shell_commands,$(USEMODULE)))
+    DEFAULT_MODULE += nimble_autoadv_shell
+  endif
 endif
 
 ifneq (,$(filter nimble_autoconn_ext,$(USEMODULE)))

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -94,12 +94,22 @@ ifneq (,$(filter nimble_autoconn,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/autoconn/include
 endif
 
+
 ifneq (,$(filter nimble_adv_ext,$(USEMODULE)))
   CFLAGS += -DMYNEWT_VAL_BLE_EXT_ADV=1
   CFLAGS += -DMYNEWT_VAL_BLE_LL_EXT_ADV_AUX_PTR_CNT=2
+  CFLAGS += -DMYNEWT_VAL_BLE_LL_SCAN_AUX_SEGMENT_CNT=1
   ifneq (,$(filter nimble_controller,$(USEMODULE)))
     CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_LL_EXT_ADV=1
   endif
+  NIMBLE_ADVERTISING_INSTANCES ?= 0
+  ifneq (,$(filter nimble_netif,$(USEMODULE)))
+    ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
+      NIMBLE_ADVERTISING_INSTANCES = 1
+      CFLAGS += -DCONFIG_NIMBLE_AUTO_ADV_INST=1
+    endif
+  endif
+  CFLAGS += -DMYNEWT_VAL_BLE_MULTI_ADV_INSTANCES=$(NIMBLE_ADVERTISING_INSTANCES)
 endif
 
 ifneq (,$(filter nimble_netif,$(USEMODULE)))

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -88,6 +88,7 @@ endif
 
 ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/autoadv/include
+  DIRS += $(RIOTPKG)/nimble/autoadv
 endif
 
 ifneq (,$(filter nimble_autoconn,$(USEMODULE)))

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -94,7 +94,6 @@ ifneq (,$(filter nimble_autoconn,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/autoconn/include
 endif
 
-
 ifneq (,$(filter nimble_adv_ext,$(USEMODULE)))
   CFLAGS += -DMYNEWT_VAL_BLE_EXT_ADV=1
   CFLAGS += -DMYNEWT_VAL_BLE_LL_EXT_ADV_AUX_PTR_CNT=2
@@ -102,14 +101,16 @@ ifneq (,$(filter nimble_adv_ext,$(USEMODULE)))
   ifneq (,$(filter nimble_controller,$(USEMODULE)))
     CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_LL_EXT_ADV=1
   endif
-  NIMBLE_ADVERTISING_INSTANCES ?= 0
   ifneq (,$(filter nimble_netif,$(USEMODULE)))
-    ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
-      NIMBLE_ADVERTISING_INSTANCES = 1
-      CFLAGS += -DCONFIG_NIMBLE_AUTO_ADV_INST=1
-    endif
+    $(eval $(call _add_ext_adv_instance,NIMBLE_NETIF_ADV_INSTANCE))
   endif
-  CFLAGS += -DMYNEWT_VAL_BLE_MULTI_ADV_INSTANCES=$(NIMBLE_ADVERTISING_INSTANCES)
+  ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
+    $(eval $(call _add_ext_adv_instance,NIMBLE_AUTOADV_INSTANCE))
+  endif
+  # check that an advertisement instances was configured
+  ifneq (-1,$(BLE_MULTI_ADV_INSTANCES))
+    CFLAGS += -DMYNEWT_VAL_BLE_MULTI_ADV_INSTANCES=$(BLE_MULTI_ADV_INSTANCES)
+  endif
 endif
 
 ifneq (,$(filter nimble_netif,$(USEMODULE)))

--- a/pkg/nimble/autoadv/Makefile
+++ b/pkg/nimble/autoadv/Makefile
@@ -1,3 +1,7 @@
 MODULE = nimble_autoadv
 
+SUBMODULES = 1
+
+SRC += nimble_autoadv.c
+
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/autoadv/README.md
+++ b/pkg/nimble/autoadv/README.md
@@ -14,17 +14,17 @@ USEMODULE += nimble_autoadv
 to your makefile.
 
 If your application is calling functions from nimble, e.g.
-ble_svc_gap_device_name_set(), NIMBLE_AUTOADV_START_MANUALLY should be set to 1
+ble_svc_gap_device_name_set(), CONFIG_NIMBLE_AUTOADV_START_MANUALLY should be set to 1
 with the following line in your Makefile:
 ```
-CFLAGS += -DNIMBLE_AUTOADV_START_MANUALLY=1
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_START_MANUALLY=1
 ```
 Then the application should call nimble_autoadv_adv_start() after all of its
 nimble calls to prevent errors like BLE_HS_EBUSY.
 
 To specify a device name add the following line to your Makefile:
 ```
-CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"Riot OS device"'
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_DEVICE_NAME='"Riot OS device"'
 ```
 
 By the default, in the advertised packet, the module includes the advertising
@@ -36,8 +36,8 @@ omitted.
 
 If your application is not connectable (eg. a temperature sensor advertising
 its current value), you might want omit this flag by clearing the
-`NIMBLE_AUTOADV_FLAG_FIELD` when including this module:
+`CONFIG_NIMBLE_AUTOADV_FLAG_FIELD` when including this module:
 ```
-CFLAGS += -DNIMBLE_AUTOADV_FLAG_FIELD=0
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_FLAG_FIELD=0
 ```
 This will grant three extra bytes in the advertisement packet.

--- a/pkg/nimble/autoadv/include/nimble_autoadv.h
+++ b/pkg/nimble/autoadv/include/nimble_autoadv.h
@@ -35,25 +35,25 @@ extern "C" {
 #endif
 
 /**
-* @brief    Name of the device for the advertising procedure. If this is not
+ * @brief   Name of the device for the advertising procedure. If this is not
  *          defined, it will be defined as NULL, resulting in not configuring
  *          a name at all.
 */
-#ifndef NIMBLE_AUTOADV_DEVICE_NAME
-    #define NIMBLE_AUTOADV_DEVICE_NAME NULL
+#ifndef CONFIG_NIMBLE_AUTOADV_DEVICE_NAME
+#define CONFIG_NIMBLE_AUTOADV_DEVICE_NAME       "NimBLE on RIOT"
 #endif
 
 /**
 * @brief    If an application is calling functions from nimble, e.g.
- *          ble_svc_gap_device_name_set(), NIMBLE_AUTOADV_START_MANUALLY should
+ *          ble_svc_gap_device_name_set(), CONFIG_NIMBLE_AUTOADV_START_MANUALLY should
  *          be set to 1 and then the application should call
- *          nimble_autoadv_start() after all of its nimble calls to prevent
+ *          nimble_autoadv_start(NULL) after all of its nimble calls to prevent
  *          errors like BLE_HS_EBUSY.
  *
  *          Defined as 0 by default.
 */
-#ifndef NIMBLE_AUTOADV_START_MANUALLY
-    #define NIMBLE_AUTOADV_START_MANUALLY 0
+#ifndef CONFIG_NIMBLE_AUTOADV_START_MANUALLY
+#define CONFIG_NIMBLE_AUTOADV_START_MANUALLY    0
 #endif
 
 /**
@@ -63,8 +63,8 @@ extern "C" {
  *          are non-zero and the advertising packet is connectable, otherwise
  *          the Flags data type may be omitted.
  */
-#ifndef NIMBLE_AUTOADV_FLAG_FIELD
-    #define NIMBLE_AUTOADV_FLAG_FIELD 1
+#ifndef CONFIG_NIMBLE_AUTOADV_FLAG_FIELD
+#define CONFIG_NIMBLE_AUTOADV_FLAG_FIELD        1
 #endif
 
 /**
@@ -124,7 +124,7 @@ void nimble_auto_adv_set_gap_cb(ble_gap_event_fn *cb, void *cb_arg);
 /**
  * @brief   Start the automated advertising procedure.
  *
- *          Needs to be called manually when NIMBLE_AUTOADV_START_MANUALLY was
+ *          Needs to be called manually when CONFIG_NIMBLE_AUTOADV_START_MANUALLY was
  *          set to true and after every call of nimble_autoadv_stop() to start
  *          advertising again.
  */

--- a/pkg/nimble/autoadv/include/nimble_autoadv_params.h
+++ b/pkg/nimble/autoadv/include/nimble_autoadv_params.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_nimble_autoadv
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for the nimble_autoadv module
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef NIMBLE_AUTOADV_PARAMS_H
+#define NIMBLE_AUTOADV_PARAMS_H
+
+#include "nimble_autoadv.h"
+#include "nimble_riot.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Default parameters used for the nimble_autoadv module
+ * @{
+ */
+#ifndef NIMBLE_AUTOADV_ADV_ITVL_MS
+#define NIMBLE_AUTOADV_ADV_ITVL_MS         (100U) /* 100ms */
+#endif
+#ifndef NIMBLE_AUTOADV_ADV_DURATION_MS
+#define NIMBLE_AUTOADV_ADV_DURATION_MS     (BLE_HS_FOREVER) /* forever */
+#endif
+#ifndef NIMBLE_AUTOADV_FLAGS
+#define NIMBLE_AUTOADV_FLAGS               (NIMBLE_AUTOADV_FLAG_LEGACY | \
+                                            NIMBLE_AUTOADV_FLAG_CONNECTABLE | \
+                                            NIMBLE_AUTOADV_FLAG_SCANNABLE)
+#endif
+#ifndef NIMBLE_AUTOADV_PHY
+#define NIMBLE_AUTOADV_PHY                 NIMBLE_PHY_1M
+#endif
+#ifndef NIMBLE_AUTOADV_TX_POWER
+#define NIMBLE_AUTOADV_TX_POWER            0 /* 0dBm */
+#endif
+#ifndef NIMBLE_AUTOADV_CHANNEL_MAP
+#define NIMBLE_AUTOADV_CHANNEL_MAP         0
+#endif
+#ifndef NIMBLE_AUTOADV_OWN_ADDR_TYPE
+#define NIMBLE_AUTOADV_OWN_ADDR_TYPE       0xFF /* sets to nimble_riot_own_addr */
+#endif
+#ifndef NIMBLE_AUTOADV_FILTER_POLICY
+#define NIMBLE_AUTOADV_FILTER_POLICY       0
+#endif
+
+#ifndef NIMBLE_AUTOADV_PARAMS
+#define NIMBLE_AUTOADV_PARAMS                               \
+    { .adv_itvl_ms     = NIMBLE_AUTOADV_ADV_ITVL_MS,        \
+      .adv_duration_ms = NIMBLE_AUTOADV_ADV_DURATION_MS,    \
+      .flags           = NIMBLE_AUTOADV_FLAGS,              \
+      .phy             = NIMBLE_AUTOADV_PHY,                \
+      .tx_power        = NIMBLE_AUTOADV_TX_POWER,           \
+      .channel_map     = NIMBLE_AUTOADV_CHANNEL_MAP,        \
+      .own_addr_type   = NIMBLE_AUTOADV_OWN_ADDR_TYPE,      \
+      .filter_policy   = NIMBLE_AUTOADV_FILTER_POLICY }
+#endif
+/**@}*/
+
+/**
+ * @brief   nimble_autoadv configuration
+ */
+static const nimble_autoadv_cfg_t nimble_autoadv_cfg =
+    NIMBLE_AUTOADV_PARAMS;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIMBLE_AUTOADV_PARAMS_H */
+/** @} */

--- a/pkg/nimble/autoadv/nimble_autoadv.c
+++ b/pkg/nimble/autoadv/nimble_autoadv.c
@@ -74,7 +74,7 @@ void nimble_autoadv_init(void)
 {
     nimble_autoadv_reset();
 
-    if (!NIMBLE_AUTOADV_START_MANUALLY) {
+    if (!CONFIG_NIMBLE_AUTOADV_START_MANUALLY) {
         nimble_autoadv_start();
     }
 }
@@ -160,7 +160,7 @@ void nimble_autoadv_reset(void)
     int rc = 0;
     (void) rc;
 
-    if (IS_ACTIVE(NIMBLE_AUTOADV_FLAG_FIELD) && BLUETIL_AD_FLAGS_DEFAULT != 0) {
+    if (IS_ACTIVE(CONFIG_NIMBLE_AUTOADV_FLAG_FIELD) && BLUETIL_AD_FLAGS_DEFAULT != 0) {
         rc = bluetil_ad_init_with_flags(&_ad, buf, sizeof(buf),
                                         BLUETIL_AD_FLAGS_DEFAULT);
         assert(rc == BLUETIL_AD_OK);
@@ -169,8 +169,8 @@ void nimble_autoadv_reset(void)
         bluetil_ad_init(&_ad, buf, 0, sizeof(buf));
     }
 
-    if (NIMBLE_AUTOADV_DEVICE_NAME != NULL) {
-        rc = bluetil_ad_add_name(&_ad, NIMBLE_AUTOADV_DEVICE_NAME);
+    if (CONFIG_NIMBLE_AUTOADV_DEVICE_NAME != NULL) {
+        rc = bluetil_ad_add_name(&_ad, CONFIG_NIMBLE_AUTOADV_DEVICE_NAME);
         assert(rc == BLUETIL_AD_OK);
     }
 

--- a/pkg/nimble/autoadv/nimble_autoadv.c
+++ b/pkg/nimble/autoadv/nimble_autoadv.c
@@ -236,7 +236,7 @@ void nimble_autoadv_start(ble_addr_t *addr)
 #endif
 }
 
-int static _ble_gap_stop(void)
+static int _ble_gap_stop(void)
 {
 #if MYNEWT_VAL_BLE_EXT_ADV
     if (ble_gap_ext_adv_active(CONFIG_NIMBLE_AUTOADV_INSTANCE)) {

--- a/pkg/nimble/autoadv/nimble_autoadv.c
+++ b/pkg/nimble/autoadv/nimble_autoadv.c
@@ -128,26 +128,6 @@ void nimble_autoadv_set_gap_cb(ble_gap_event_fn *cb, void *cb_arg)
     }
 }
 
-#if MYNEWT_VAL_BLE_EXT_ADV
-static int _get_phy_hci(uint8_t mode)
-{
-    switch (mode) {
-    case NIMBLE_PHY_1M:
-        return BLE_HCI_LE_PHY_1M;
-#if IS_USED(MODULE_NIMBLE_PHY_2MBIT)
-    case NIMBLE_PHY_2M:
-        return BLE_HCI_LE_PHY_2M;
-#endif
-#if IS_USED(MODULE_NIMBLE_PHY_CODED)
-    case NIMBLE_PHY_CODED:
-        return BLE_HCI_LE_PHY_CODED;
-#endif
-    default:
-        return -1;
-    }
-}
-#endif
-
 void nimble_autoadv_start(ble_addr_t *addr)
 {
     int rc;
@@ -172,8 +152,8 @@ void nimble_autoadv_start(ble_addr_t *addr)
         .own_addr_type = _cfg.own_addr_type,
         .peer = *addr,
         .filter_policy = _cfg.filter_policy,
-        .primary_phy = _get_phy_hci(_cfg.phy),
-        .secondary_phy = _get_phy_hci(_cfg.phy),
+        .primary_phy = nimble_riot_get_phy_hci(_cfg.phy),
+        .secondary_phy = nimble_riot_get_phy_hci(_cfg.phy),
         .tx_power = _cfg.tx_power,
         .sid = CONFIG_NIMBLE_AUTOADV_INSTANCE,
     };

--- a/pkg/nimble/autoadv/nimble_autoadv.c
+++ b/pkg/nimble/autoadv/nimble_autoadv.c
@@ -29,54 +29,60 @@
 
 #include "nimble_autoadv.h"
 
-/* settings for advertising procedure */
-static struct ble_gap_adv_params _advp;
+#ifndef CONFIG_NIMBLE_AUTOADV_INSTANCE
+#define CONFIG_NIMBLE_AUTOADV_INSTANCE            0
+#endif
 
-/* duration of the advertisement procedure */
-static int32_t _adv_duration;
+/* settings for advertising procedure */
+static nimble_autoadv_cfg_t _cfg;
 
 /* buffer for _ad */
 static uint8_t buf[BLE_HS_ADV_MAX_SZ];
-
 /* advertising data struct */
 static bluetil_ad_t _ad;
 
 /* GAP callback function */
 static ble_gap_event_fn *_gap_cb;
-
 /* arguments for GAP callback function */
 static void *_gap_cb_arg;
 
-void nimble_autoadv_start(void);
-
 static int _gap_event_cb(struct ble_gap_event *event, void *arg)
 {
-    (void) arg;
+    (void)arg;
 
     switch (event->type) {
 
-        case BLE_GAP_EVENT_CONNECT:
-            if (event->connect.status != 0) {
-                // failed, ensure advertising is restarted
-                nimble_autoadv_start();
-            }
-            break;
+    case BLE_GAP_EVENT_CONNECT:
+        if (event->connect.status != 0) {
+            /* failed, ensure advertising is restarted */
+            nimble_autoadv_start(NULL);
+        }
+        break;
 
-        case BLE_GAP_EVENT_DISCONNECT:
-            nimble_autoadv_start();
-            break;
+    case BLE_GAP_EVENT_DISCONNECT:
+        nimble_autoadv_start(NULL);
+        break;
     }
 
     return 0;
 }
 
-void nimble_autoadv_init(void)
+void nimble_autoadv_init(const nimble_autoadv_cfg_t *cfg)
 {
-    nimble_autoadv_reset();
+    nimble_autoadv_reset((nimble_autoadv_cfg_t *)cfg);
 
     if (!CONFIG_NIMBLE_AUTOADV_START_MANUALLY) {
-        nimble_autoadv_start();
+        nimble_autoadv_start(NULL);
     }
+}
+
+static int _ble_gap_adv_active(void)
+{
+#if MYNEWT_VAL_BLE_EXT_ADV
+    return ble_gap_ext_adv_active(CONFIG_NIMBLE_AUTOADV_INSTANCE);
+#else
+    return ble_gap_adv_active();
+#endif
 }
 
 int nimble_autoadv_add_field(uint8_t type, const void *data, size_t data_len)
@@ -87,82 +93,183 @@ int nimble_autoadv_add_field(uint8_t type, const void *data, size_t data_len)
         return rc;
     }
 
-    if (ble_gap_adv_active()) {
-        nimble_autoadv_start();
+    if (_ble_gap_adv_active()) {
+        nimble_autoadv_start(NULL);
     }
 
     return rc;
 }
 
-void nimble_autoadv_set_ble_gap_adv_params(struct ble_gap_adv_params *params)
+void nimble_autoadv_cfg_update(nimble_autoadv_cfg_t *cfg)
 {
-    memcpy(&_advp, params, sizeof(struct ble_gap_adv_params));
+    memcpy(&_cfg, cfg, sizeof(nimble_autoadv_cfg_t));
 
-    if (ble_gap_adv_active()) {
-        nimble_autoadv_start();
+    if (cfg->own_addr_type == 0xff) {
+        _cfg.own_addr_type = nimble_riot_own_addr_type;
+    }
+
+    if (_ble_gap_adv_active()) {
+        nimble_autoadv_start(NULL);
     }
 }
 
-void nimble_auto_adv_set_adv_duration(int32_t duration_ms)
+void nimble_autoadv_get_cfg(nimble_autoadv_cfg_t *cfg)
 {
-    _adv_duration = duration_ms;
-
-    if (ble_gap_adv_active()) {
-        nimble_autoadv_start();
-    }
+    memcpy(cfg, &_cfg, sizeof(nimble_autoadv_cfg_t));
 }
 
-void nimble_auto_adv_set_gap_cb(ble_gap_event_fn *cb, void *cb_arg)
+void nimble_autoadv_set_gap_cb(ble_gap_event_fn *cb, void *cb_arg)
 {
     _gap_cb = cb;
     _gap_cb_arg = cb_arg;
 
-    if (ble_gap_adv_active()) {
-        nimble_autoadv_start();
+    if (_ble_gap_adv_active()) {
+        nimble_autoadv_start(NULL);
     }
 }
 
-void nimble_autoadv_start(void)
+#if MYNEWT_VAL_BLE_EXT_ADV
+static int _get_phy_hci(uint8_t mode)
+{
+    switch (mode) {
+    case NIMBLE_PHY_1M:
+        return BLE_HCI_LE_PHY_1M;
+#if IS_USED(MODULE_NIMBLE_PHY_2MBIT)
+    case NIMBLE_PHY_2M:
+        return BLE_HCI_LE_PHY_2M;
+#endif
+#if IS_USED(MODULE_NIMBLE_PHY_CODED)
+    case NIMBLE_PHY_CODED:
+        return BLE_HCI_LE_PHY_CODED;
+#endif
+    default:
+        return -1;
+    }
+}
+#endif
+
+void nimble_autoadv_start(ble_addr_t *addr)
 {
     int rc;
-    (void) rc;
 
-    rc = ble_gap_adv_stop();
-    assert(rc == BLE_HS_EALREADY || rc == 0);
+    (void)rc;
+
+    nimble_autoadv_stop();
+
+#if MYNEWT_VAL_BLE_EXT_ADV
+    struct ble_gap_ext_adv_params advp = {
+        .connectable = (_cfg.flags & NIMBLE_AUTOADV_FLAG_CONNECTABLE) ? 1 : 0,
+        .scannable = (_cfg.flags & NIMBLE_AUTOADV_FLAG_SCANNABLE) ? 1 : 0,
+        .directed = addr ? 1 : 0,
+        .high_duty_directed = (_cfg.flags & NIMBLE_AUTOADV_FLAG_HD_MODE) ? 1 : 0,
+        .legacy_pdu = (_cfg.flags & NIMBLE_AUTOADV_FLAG_LEGACY) ? 1 : 0,
+        .anonymous = (_cfg.flags & NIMBLE_AUTOADV_FLAG_ANONYMOUS) ? 1 : 0,
+        .include_tx_power = 0,
+        .scan_req_notif = (_cfg.flags & NIMBLE_AUTOADV_FLAG_SCAN_REQ_NOTIF) ? 1 : 0,
+        .itvl_min = BLE_GAP_ADV_ITVL_MS(_cfg.adv_itvl_ms),
+        .itvl_max = BLE_GAP_ADV_ITVL_MS(_cfg.adv_itvl_ms),
+        .channel_map = _cfg.channel_map,
+        .own_addr_type = _cfg.own_addr_type,
+        .peer = *addr,
+        .filter_policy = _cfg.filter_policy,
+        .primary_phy = _get_phy_hci(_cfg.phy),
+        .secondary_phy = _get_phy_hci(_cfg.phy),
+        .tx_power = _cfg.tx_power,
+        .sid = CONFIG_NIMBLE_AUTOADV_INSTANCE,
+    };
+
+    /* remove before configure */
+    if (ble_gap_ext_adv_active(CONFIG_NIMBLE_AUTOADV_INSTANCE)) {
+        rc = ble_gap_ext_adv_remove(CONFIG_NIMBLE_AUTOADV_INSTANCE);
+        assert(rc == 0);
+    }
+    /* configure */
+    rc = ble_gap_ext_adv_configure(CONFIG_NIMBLE_AUTOADV_INSTANCE, &advp,
+                                   NULL, _gap_event_cb, _gap_cb_arg);
+    assert(rc == 0);
+
+    /* get mbuf for adv data, this is freed from the `ble_gap_ext_adv_set_data` */
+    struct os_mbuf *data;
+
+    data = os_msys_get_pkthdr(BLE_HS_ADV_MAX_SZ, 0);
+    assert(data);
+
+    /* fill mbuf with adv data */
+    rc = os_mbuf_append(data, _ad.buf, _ad.pos);
+    assert(rc == 0);
+
+    /* set adv data */
+    rc = ble_gap_ext_adv_set_data(CONFIG_NIMBLE_AUTOADV_INSTANCE, data);
+    assert(rc == 0);
+
+    /* set a single advertisement event, ble_gap_ext_adv units are in 10s of ms */
+    int32_t dur = (_cfg.adv_duration_ms == BLE_HS_FOREVER) ? 0
+                                                           : _cfg.adv_duration_ms / 10;
+    rc = ble_gap_ext_adv_start(CONFIG_NIMBLE_AUTOADV_INSTANCE, dur, 0);
+    assert(rc == 0);
+#else
+    uint8_t mode = BLE_GAP_CONN_MODE_NON;
+    if (addr != NULL) {
+        mode = BLE_GAP_CONN_MODE_DIR;
+    }
+    else if (_cfg.flags && NIMBLE_AUTOADV_FLAG_CONNECTABLE) {
+        mode = BLE_GAP_CONN_MODE_UND;
+    }
+    uint8_t disc = (_cfg.flags && NIMBLE_AUTOADV_FLAG_SCANNABLE) ? BLE_GAP_CONN_MODE_DIR
+                                                                 : BLE_GAP_CONN_MODE_UND;
+    struct ble_gap_adv_params advp = {
+        .conn_mode = mode,
+        .disc_mode = disc,
+        .itvl_min = BLE_GAP_ADV_ITVL_MS(_cfg.adv_itvl_ms),
+        .itvl_max = BLE_GAP_ADV_ITVL_MS(_cfg.adv_itvl_ms),
+        .channel_map = _cfg.channel_map,
+        .filter_policy = _cfg.filter_policy,
+        .high_duty_cycle = (_cfg.flags & NIMBLE_AUTOADV_FLAG_HD_MODE) ? 1 : 0,
+    };
 
     rc = ble_gap_adv_set_data(_ad.buf, _ad.pos);
     assert(rc == 0);
 
-    rc = ble_gap_adv_start(nimble_riot_own_addr_type, NULL, _adv_duration, &_advp, _gap_cb, _gap_cb_arg);
+    rc = ble_gap_adv_start(_cfg.own_addr_type, addr, _cfg.adv_duration_ms,
+                           &advp, _gap_cb, _gap_cb_arg);
     assert(rc == 0);
+#endif
+}
+
+int static _ble_gap_stop(void)
+{
+#if MYNEWT_VAL_BLE_EXT_ADV
+    if (ble_gap_ext_adv_active(CONFIG_NIMBLE_AUTOADV_INSTANCE)) {
+        return ble_gap_ext_adv_stop(CONFIG_NIMBLE_AUTOADV_INSTANCE);
+    }
+#else
+    if (ble_gap_adv_active()) {
+        return ble_gap_adv_stop();
+    }
+#endif
+    return 0;
 }
 
 void nimble_autoadv_stop(void)
 {
-    int rc;
-    (void) rc;
+    int rc = _ble_gap_stop();
 
-    rc = ble_gap_adv_stop();
+    (void)rc;
     assert(rc == BLE_HS_EALREADY || rc == 0);
 }
 
-void nimble_autoadv_reset(void)
+void nimble_autoadv_reset(nimble_autoadv_cfg_t *cfg)
 {
+    int rc = 0;
+
+    (void)rc;
     _gap_cb = &_gap_event_cb;
     _gap_cb_arg = NULL;
 
-    _adv_duration = BLE_HS_FOREVER;
-
-    memset(&_advp, 0, sizeof _advp);
-    _advp.conn_mode = BLE_GAP_CONN_MODE_UND;
-    _advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
-
-    int rc = 0;
-    (void) rc;
+    nimble_autoadv_cfg_update(cfg);
 
     if (IS_ACTIVE(CONFIG_NIMBLE_AUTOADV_FLAG_FIELD) && BLUETIL_AD_FLAGS_DEFAULT != 0) {
-        rc = bluetil_ad_init_with_flags(&_ad, buf, sizeof(buf),
-                                        BLUETIL_AD_FLAGS_DEFAULT);
+        rc = bluetil_ad_init_with_flags(&_ad, buf, sizeof(buf), BLUETIL_AD_FLAGS_DEFAULT);
         assert(rc == BLUETIL_AD_OK);
     }
     else {
@@ -174,7 +281,12 @@ void nimble_autoadv_reset(void)
         assert(rc == BLUETIL_AD_OK);
     }
 
-    if (ble_gap_adv_active()) {
-        nimble_autoadv_start();
+    if (_ble_gap_adv_active()) {
+        nimble_autoadv_start(NULL);
     }
+}
+
+int nimble_autoadv_get_adv_instance(void)
+{
+    return CONFIG_NIMBLE_AUTOADV_INSTANCE;
 }

--- a/pkg/nimble/autoadv/shell.c
+++ b/pkg/nimble/autoadv/shell.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_nimble_autoadv
+ * @{
+ *
+ * @file
+ * @brief       Auto advertisement module shell commands
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "shell.h"
+#include "shell_commands.h"
+#include "xfa.h"
+
+#include "nimble_riot.h"
+#include "host/ble_hs.h"
+#include "host/ble_gap.h"
+#include "net/bluetil/ad.h"
+#include "net/bluetil/addr.h"
+#include "nimble_autoadv.h"
+
+static int _ble_gap_adv_active(void)
+{
+#if MYNEWT_VAL_BLE_EXT_ADV
+    return ble_gap_ext_adv_active(nimble_autoadv_get_adv_instance());
+#else
+    return ble_gap_adv_active();
+#endif
+}
+
+static void _print_usage(void)
+{
+    puts("Usage:");
+    puts("\tautoadv start [addr]: start NimBLE auto advertisement");
+    puts("\tautoadv stop: stop NimBLE auto advertisement");
+    puts("\tautoadv status: print NimBLE auto advertisement status");
+}
+
+static int _autoadv_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        _print_usage();
+        return -1;
+    }
+
+    if (!strcmp(argv[1], "start")) {
+        ble_addr_t *addr_ptr = NULL;
+        ble_addr_t addr = { .type = nimble_riot_own_addr_type };
+        if (argc == 3) {
+            uint8_t addrn[BLE_ADDR_LEN];
+            if (bluetil_addr_from_str(addrn, argv[2]) != NULL) {
+                /* NimBLE expects address in little endian, so swap */
+                bluetil_addr_swapped_cp(addrn, addr.val);
+                addr_ptr = &addr;
+                puts("Found BLE address: sending directed advertisements");
+            }
+
+        }
+        nimble_autoadv_start(addr_ptr);
+        printf("[autoadv] shell: start advertising on inst=(%d)\n",
+               nimble_autoadv_get_adv_instance());
+        return 0;
+    }
+
+    if (!strcmp(argv[1], "stop")) {
+        nimble_autoadv_stop();
+        printf("[autoadv] shell: stop advertising on inst=(%d)\n",
+               nimble_autoadv_get_adv_instance());
+        return 0;
+    }
+
+    if (!strcmp(argv[1], "status")) {
+        if (_ble_gap_adv_active()) {
+            printf("[autoadv] shell: active, inst=(%d)\n",
+                   nimble_autoadv_get_adv_instance());
+        }
+        else {
+            puts("[autoadv] shell: inactive\n");
+        }
+        return 0;
+    }
+
+    _print_usage();
+    return -1;
+}
+
+SHELL_COMMAND(autoadv, "NimBLE autoadv", _autoadv_handler);

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -93,6 +93,15 @@ extern uint8_t nimble_riot_own_addr_type;
  */
 void nimble_riot_init(void);
 
+/**
+ * @brief   Converts BLE PHY mode to BLE HCI PHY
+ *
+ * @param[in]   mode    ble phy mode to convert
+ */
+#if MYNEWT_VAL_BLE_EXT_ADV
+int nimble_riot_get_phy_hci(uint8_t mode);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -41,6 +41,11 @@
 #include "nimble_statconn.h"
 #endif
 
+#ifdef MODULE_NIMBLE_AUTOADV
+#include "nimble_autoadv_params.h"
+#include "nimble_autoadv.h"
+#endif
+
 #if defined(MODULE_NIMBLE_AUTOCONN) && !defined(MODULE_NIMBLE_AUTOCONN_NOAUTOINIT)
 #include "nimble_autoconn.h"
 #include "nimble_autoconn_params.h"
@@ -184,8 +189,7 @@ void nimble_riot_init(void)
 #endif
 
 #ifdef MODULE_NIMBLE_AUTOADV
-    extern void nimble_autoadv_init(void);
-    nimble_autoadv_init();
+    nimble_autoadv_init(&nimble_autoadv_cfg);
 #endif
 
 #ifdef MODULE_NIMBLE_RPBLE

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -197,3 +197,23 @@ void nimble_riot_init(void)
     assert(res == 0);
 #endif
 }
+
+#if MYNEWT_VAL_BLE_EXT_ADV
+int nimble_riot_get_phy_hci(uint8_t mode)
+{
+    switch (mode) {
+    case NIMBLE_PHY_1M:
+        return BLE_HCI_LE_PHY_1M;
+#if IS_USED(MODULE_NIMBLE_PHY_2MBIT)
+    case NIMBLE_PHY_2M:
+        return BLE_HCI_LE_PHY_2M;
+#endif
+#if IS_USED(MODULE_NIMBLE_PHY_CODED)
+    case NIMBLE_PHY_CODED:
+        return BLE_HCI_LE_PHY_CODED;
+#endif
+    default:
+        return -1;
+    }
+}
+#endif

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -684,26 +684,6 @@ int nimble_netif_close(int handle)
     return 0;
 }
 
-#if MYNEWT_VAL_BLE_EXT_ADV
-static int _get_phy_hci(uint8_t mode)
-{
-    switch (mode) {
-        case NIMBLE_PHY_1M:
-            return BLE_HCI_LE_PHY_1M;
-#if IS_USED(MODULE_NIMBLE_PHY_2MBIT)
-        case NIMBLE_PHY_2M:
-            return BLE_HCI_LE_PHY_2M;
-#endif
-#if IS_USED(MODULE_NIMBLE_PHY_CODED)
-        case NIMBLE_PHY_CODED:
-            return BLE_HCI_LE_PHY_CODED;
-#endif
-        default:
-            return -1;
-    }
-}
-#endif
-
 static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
                    const nimble_netif_accept_cfg_t *params)
 {
@@ -730,8 +710,8 @@ static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
     memset(&p, 0, sizeof(p));
 
     /* figure out PHY modes */
-    int phy_pri = _get_phy_hci(params->primary_phy);
-    int phy_sec = _get_phy_hci(params->secondary_phy);
+    int phy_pri = nimble_riot_get_phy_hci(params->primary_phy);
+    int phy_sec = nimble_riot_get_phy_hci(params->secondary_phy);
     if ((phy_pri < 0) || (phy_sec < 0)) {
         nimble_netif_conn_free(handle, NULL);
         return -EINVAL;

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -55,7 +55,9 @@
 #define NIMBLE_NETIF_PRIO       GNRC_NETIF_PRIO
 #endif
 
-#define EXT_ADV_INST            0
+#ifndef CONFIG_NIMBLE_NETIF_ADV_INSTANCE
+#define CONFIG_NIMBLE_NETIF_ADV_INSTANCE            0
+#endif
 
 /* thread flag used for signaling transmit readiness */
 #define FLAG_TX_UNSTALLED       (1u << 13)
@@ -763,7 +765,7 @@ static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
     p.secondary_phy = (uint8_t)phy_sec;
     p.tx_power = params->tx_power;
 
-    res = ble_gap_ext_adv_configure(EXT_ADV_INST, &p, NULL,
+    res = ble_gap_ext_adv_configure(CONFIG_NIMBLE_NETIF_ADV_INSTANCE, &p, NULL,
                                     _on_gap_slave_evt, (void *)handle);
     if (res != 0) {
         nimble_netif_conn_free(handle, NULL);
@@ -782,10 +784,10 @@ static int _accept(const uint8_t *ad, size_t ad_len, const ble_addr_t *addr,
             nimble_netif_conn_free(handle, NULL);
             return -ENOMEM;
         }
-        res = ble_gap_ext_adv_set_data(EXT_ADV_INST, data);
+        res = ble_gap_ext_adv_set_data(CONFIG_NIMBLE_NETIF_ADV_INSTANCE, data);
         assert(res == 0);
     }
-    res = ble_gap_ext_adv_start(EXT_ADV_INST, params->timeout_ms / 10, 0);
+    res = ble_gap_ext_adv_start(CONFIG_NIMBLE_NETIF_ADV_INSTANCE, params->timeout_ms / 10, 0);
 #else
     uint8_t mode = (addr != NULL) ? BLE_GAP_CONN_MODE_DIR
                                   : BLE_GAP_CONN_MODE_UND;
@@ -847,7 +849,7 @@ int nimble_netif_accept_stop(void)
 
     int res;
 #if MYNEWT_VAL_BLE_EXT_ADV
-    res = ble_gap_ext_adv_stop(EXT_ADV_INST);
+    res = ble_gap_ext_adv_stop(CONFIG_NIMBLE_NETIF_ADV_INSTANCE);
 #else
     res = ble_gap_adv_stop();
 #endif

--- a/sys/stdio_nimble/README.md
+++ b/sys/stdio_nimble/README.md
@@ -35,7 +35,7 @@ to your makefile.
 
 The advertised device name can then optionally be configured with
 ```
-CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"Riot OS device"'
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_DEVICE_NAME='"Riot OS device"'
 ```
 Otherwise the device will appear as "*RIOT OS device*".
 

--- a/tests/shell_ble/Makefile
+++ b/tests/shell_ble/Makefile
@@ -9,7 +9,7 @@ USEMODULE += ps
 
 USEMODULE += stdio_nimble stdio_nimble_debug
 USEMODULE += nimble_autoadv
-CFLAGS += -DNIMBLE_AUTOADV_DEVICE_NAME='"tests/shell_ble"'
+CFLAGS += -DCONFIG_NIMBLE_AUTOADV_DEVICE_NAME='"tests/shell_ble"'
 
 TESTRUNNER_SHELL_SKIP_REBOOT = 1
 TESTRUNNER_RESET_BOARD_ON_STARTUP = 0


### PR DESCRIPTION
### Contribution description

With `ext_adv` we can now have multiple independent advertisement state machines in parallel. This is useful for example when wanting to use `stdio_nimble` as well as `nimble_netif`, this PR enables this.

This configuring the advertisement indexes needs to be based on the enabled instances, a convenience make function is added to keep track of this and increase the advertisement index.

### Testing procedure

On two  `nrf52` based board (e.g. dwm1001):

`USEMODULE="nimble_autoadv stdio_nimble" BOARD=dwm1001 make -C examples/gnrc_networking flash term -j7`

For each open  a serial terminal using `ble-serial` (`ble-scan` can be used if using https://github.com/Jakeler/ble-serial)

```
$ ble-serial -d DE:DC:34:12:9A:F0 -p /tmp/dwad55 --write-uuid ccdd113f-40d5-4d68-86ac-a728dd82f4aa --read-uuid 35f28386-3070-4f3b-ba38-27507e991762
12:16:53.601 | INFO | linux_pty.py: Slave created on /tmp/dwad55 -> /dev/pts/4
12:16:53.601 | INFO | ble_interface.py: Receiver set up
12:16:53.601 | INFO | ble_interface.py: Trying to connect with DE:DC:34:12:9A:F0
12:16:54.851 | INFO | ble_interface.py: Device DE:DC:34:12:9A:F0 connected
12:16:54.851 | INFO | ble_interface.py: Found write characteristic ccdd113f-40d5-4d68-86ac-a728dd82f4aa (H. 15)
12:16:54.851 | INFO | ble_interface.py: Found notify characteristic 35f28386-3070-4f3b-ba38-27507e991762 (H. 12)
12:16:55.025 | INFO | main.py: Running main loop!
```

Then on the shell for one of the node advertise the device and from the other connect to it, ith this PR there is no connection drop in `stdio`:

- node 1:
```
2022-03-08 12:15:54,419 # ble adv toto
2022-03-08 12:15:54,420 # success: advertising this node as 'toto'
> 2022-03-08 12:15:59,593 # event: handle 0 -> CONNECTED as SLAVE (D3:59:5D:10:4C:F8)
2022-03-08 12:17:05,200 # ble info
2022-03-08 12:17:05,201 # Own Address: DE:DC:34:12:9A:F0 -> [FE80::DEDC:34FF:FE12:9AF0]
2022-03-08 12:17:05,201 # Supported PHY modes: 1M
2022-03-08 12:17:05,201 #  Free slots: 2/3
2022-03-08 12:17:05,201 # Advertising: no
2022-03-08 12:17:05,201 # Connections: 1
2022-03-08 12:17:05,201 # [ 0] D3:59:5D:10:4C:F8 [FE80::D359:5DFF:FE10:4CF8] (S,75ms,1500ms,0,1M)
2022-03-08 12:17:05,333 #      (role, conn itvl, superv. timeout, slave latency, PHY)
2022-03-08 12:17:05,333 # Slots:
2022-03-08 12:17:05,333 # [ 0] state: 0x0022 - GAP-slave L2CAP-server
2022-03-08 12:17:05,333 # [ 1] state: 0x8000 - unused
2022-03-08 12:17:05,333 # [ 2] state: 0x8000 - unused
2022-03-08 12:17:05,333 #
> ifconfig
2022-03-08 12:17:06,731 # ifconfig
2022-03-08 12:17:06,732 # Iface  8  HWaddr: DE:DC:34:12:9A:F0
2022-03-08 12:17:06,733 #           L2-PDU:1280  MTU:1280  HL:64  RTR
2022-03-08 12:17:06,733 #           6LO  IPHC
2022-03-08 12:17:06,734 #           Source address length: 6
2022-03-08 12:17:06,734 #           Link type: wireless
2022-03-08 12:17:06,735 #           inet6 addr: fe80::dedc:34ff:fe12:9af0  scope: link  VAL
2022-03-08 12:17:06,821 #           inet6 group: ff02::2
2022-03-08 12:17:06,822 #           inet6 group: ff02::1
2022-03-08 12:17:06,822 #           inet6 group: ff02::1:ff12:9af0
2022-03-08 12:17:06,823 #           inet6 group: ff02::1a
2022-03-08 12:17:06,823 #
2022-03-08 12:17:06,823 #           Statistics for Layer 2
2022-03-08 12:17:06,824 #             RX packets 0  bytes 0
2022-03-08 12:17:06,910 #             TX packets 0 (Multicast: 0)  bytes 23360
2022-03-08 12:17:06,911 #             TX succeeded 0 errors 0
2022-03-08 12:17:06,911 #           Statistics for IPv6
2022-03-08 12:17:06,912 #             RX packets 3  bytes 168
2022-03-08 12:17:06,912 #             TX packets 8 (Multicast: 8)  bytes 442
2022-03-08 12:17:06,913 #             TX succeeded 8 errors 0
2022-03-08 12:17:06,913 #
> ping6 fe80::d359:5dff:fe10:4cf8
2022-03-08 12:17:13,251 # ping6 fe80::d359:5dff:fe10:4cf8
2022-03-08 12:17:13,341 # 12 bytes from fe80::d359:5dff:fe10:4cf8%8: icmp_seq=0 ttl=64 time=145.034 ms
2022-03-08 12:17:14,333 # 12 bytes from fe80::d359:5dff:fe10:4cf8%8: icmp_seq=1 ttl=64 time=121.540 ms
2022-03-08 12:17:15,323 # 12 bytes from fe80::d359:5dff:fe10:4cf8%8: icmp_seq=2 ttl=64 time=98.089 ms
2022-03-08 12:17:15,323 #
2022-03-08 12:17:15,413 # --- fe80::d359:5dff:fe10:4cf8 PING statistics ---
2022-03-08 12:17:15,413 # 3 packets transmitted, 3 packets received, 0% packet loss
2022-03-08 12:17:15,414 # round-trip min/avg/max = 98.089/121.554/145.034 ms

```