### PR TITLE
pkg/edhoc-c: bump version

### DIFF
--- a/pkg/edhoc-c/Makefile
+++ b/pkg/edhoc-c/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME = EDHOC-C
 PKG_URL = https://github.com/future-proof-iot/EDHOC-C.git
-PKG_VERSION = 13660352d1c1551b292ba53ece1365f34f60aa2e
+PKG_VERSION = 27be50625bed86f7b2d3cbedc373e0c26f276e93
 PKG_LICENSE = BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

This rebases to latest master, it also includes a patch to allow
generating credentials when using tinycrypt as the crypto backend
as well as patch conn_id generaiton.

```
    src/crypto/tinycrypt: add crypto_gen_keypair
    src/process: use random for conn_id generation
```

### Testing procedure

Follow the README

```
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

NETOPT_RX_END_IRQ not implemented by driver
main(): This is RIOT! (Version: 2022.04-devel-670-gc5860-pr_edhoc_c_bump)
[initiator]: load ephemeral key: ONLY FOR TESTING
[initiator]: preset cid: ONLY FOR TESTING
[responder]: load ephemeral key: ONLY FOR TESTING
[responder]: preset cid: ONLY FOR TESTING
Starting the shell
>
>
> ifconfig
ifconfig
Iface  5  HWaddr: 0E:0D:B4:B7:C5:92
          L2-PDU:1500  MTU:1500  HL:64  RTR
          RTR_ADV
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::c0d:b4ff:feb7:c592  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffb7:c592

> init handshake fe80::c0d:b4ff:feb7:c592%5 5683
init handshake fe80::c0d:b4ff:feb7:c592%5 5683
[initiator]: sending msg1 (37 bytes):
0x0d 0x00 0x58 0x20 0x8d 0x3e 0xf5 0x6d
0x1b 0x75 0x0a 0x43 0x51 0xd6 0x8a 0xc2
0x50 0xa0 0xe8 0x83 0x79 0x0e 0xfc 0x80
0xa5 0x38 0xa4 0x44 0xee 0x9e 0x2b 0x57
0xe2 0x44 0x1a 0x7c 0x21
[responder]: received an EDHOC message (len 37):
0x0d 0x00 0x58 0x20 0x8d 0x3e 0xf5 0x6d
0x1b 0x75 0x0a 0x43 0x51 0xd6 0x8a 0xc2
0x50 0xa0 0xe8 0x83 0x79 0x0e 0xfc 0x80
0xa5 0x38 0xa4 0x44 0xee 0x9e 0x2b 0x57
0xe2 0x44 0x1a 0x7c 0x21
[responder]: sending msg2 (46 bytes):
0x58 0x20 0x52 0xfb 0xa0 0xbd 0xc8 0xd9
0x53 0xdd 0x86 0xce 0x1a 0xb2 0xfd 0x7c
0x05 0xa4 0x65 0x8c 0x7c 0x30 0xaf 0xdb
0xfc 0x33 0x01 0x04 0x70 0x69 0x45 0x1b
0xaf 0x35 0x37 0x4a 0xa3 0xf1 0xbd 0x5d
0x02 0x8d 0x19 0xcf 0x3c 0x99
[initiator]: received a message (46 bytes):
0x58 0x20 0x52 0xfb 0xa0 0xbd 0xc8 0xd9
0x53 0xdd 0x86 0xce 0x1a 0xb2 0xfd 0x7c
0x05 0xa4 0x65 0x8c 0x7c 0x30 0xaf 0xdb
0xfc 0x33 0x01 0x04 0x70 0x69 0x45 0x1b
0xaf 0x35 0x37 0x4a 0xa3 0xf1 0xbd 0x5d
0x02 0x8d 0x19 0xcf 0x3c 0x99
[initiator]: sending msg3 (20 bytes):
0x37 0x52 0xd5 0x53 0x5f 0x31 0x47 0xe8
0x5f 0x1c 0xfa 0xcd 0x9e 0x78 0xab 0xf9
0xe0 0xa8 0x1b 0xbf
[responder]: received an EDHOC message (len 20):
0x37 0x52 0xd5 0x53 0x5f 0x31 0x47 0xe8
0x5f 0x1c 0xfa 0xcd 0x9e 0x78 0xab 0xf9
0xe0 0xa8 0x1b 0xbf
[responder]: finalize exchange
[responder]: handshake successfully completed
[initiator]: handshake successfully completed
[initiator]: Transcript hash 4 (32 bytes):
0x7c 0xcf 0xde 0xdc 0x2c 0x10 0xca 0x03
0x56 0xe9 0x57 0xb9 0xf6 0xa5 0x92 0xe0
0xfa 0x74 0xdb 0x2a 0xb5 0x4f 0x59 0x24
0x40 0x96 0xf9 0xa2 0xac 0x56 0xd2 0x07

> init oscore
init oscore
OSCORE secret:
0x5b 0xb2 0xae 0xe2 0x5b 0x16 0x0e 0x7c
0x6d 0x26 0x12 0xb0 0xa6 0x01 0x09 0x16

OSCORE salt:
0x8e 0x44 0x92 0x10 0xe0 0x3b 0xc2 0x9d

> resp oscore
resp oscore
OSCORE secret:
0x5b 0xb2 0xae 0xe2 0x5b 0x16 0x0e 0x7c
0x6d 0x26 0x12 0xb0 0xa6 0x01 0x09 0x16

OSCORE salt:
0x8e 0x44 0x92 0x10 0xe0 0x3b 0xc2 0x9d

>
```