### PR TITLE
net/gnrc_sock: depend on iolist

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -81,6 +81,7 @@ ifneq (,$(filter gnrc_%,$(filter-out gnrc_lorawan gnrc_netapi gnrc_netreg gnrc_n
 endif
 
 ifneq (,$(filter gnrc_sock_%,$(USEMODULE)))
+  USEMODULE += iolist
   USEMODULE += gnrc_sock
   ifneq (,$(filter sock_aux_timestamp,$(USEMODULE)))
     USEMODULE += gnrc_netif_timestamp


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`gnrc_sock` requires `iolist` since #17485.
Looks like that got pulled in by other modules for GNRC so far.


### Testing procedure

Discovered when doing

    make -C examples/gnrc_border_router BOARD=esp32-wroom-32 UPLINK=wifi

```
/home/benpicco/dev/RIOT/examples/gnrc_border_router/bin/esp32-wroom-32/gnrc_sock_udp/gnrc_sock_udp.o: In function `sock_udp_recv_aux':
/home/benpicco/dev/RIOT/sys/net/gnrc/sock/udp/gnrc_sock_udp.c:187: undefined reference to `iolist_size'
/home/benpicco/dev/RIOT/examples/gnrc_border_router/bin/esp32-wroom-32/gnrc_sock_udp/gnrc_sock_udp.o: In function `sock_udp_sendv_aux':
/home/benpicco/dev/RIOT/sys/net/gnrc/sock/udp/gnrc_sock_udp.c:346: undefined reference to `iolist_size'
collect2: error: ld returned 1 exit status
make: *** [/home/benpicco/dev/RIOT/examples/gnrc_border_router/../../Makefile.include:725: /home/benpicco/dev/RIOT/examples/gnrc_border_router/bin/esp32-wroom-32/gnrc_border_router.elf] Error 1
make: Leaving directory '/home/benpicco/dev/RIOT/examples/gnrc_border_router'
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
