### PR TITLE
cpu/cortexm_common: remove breakpoint from hard_fault_handler

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -449,7 +449,6 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
             : "r0", "r1", "r2", "r3", "r12"
             );
     }
-    __BKPT(1);
 
     core_panic(PANIC_HARD_FAULT, "HARD FAULT HANDLER");
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The hard fault handler would normally call `core_panic()` which in turn calls `ps()` - this already helps debugging a lot of crashes caused by a thread stack overflow.

With the breakpoint in place, the code will not advance to this, leaving users unknown of this feature in the dark.

On top, the breakpoint is not very helpful if thread stacks are already corrupted.

Let's just drop it for simplicity's sake - it's not there for any other architectures.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
