### PR TITLE
pkg/tinydtls: set DTLS_CONSTRAINED_STACK

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -11,6 +11,9 @@ INCLUDES += -I$(PKG_BUILDDIR)
 # Mandatory for tinyDTLS
 CFLAGS += -DDTLSv12 -DWITH_SHA256
 
+# Reduce stack requirements by using shared buffer
+CFLAGS += -DDTLS_CONSTRAINED_STACK
+
 # Check that the used PRNG implementation is cryptographically secure
 CRYPTO_SECURE_IMPLEMENTATIONS := prng_sha256prng prng_sha1prng prng_hwrng
 USED_PRNG_IMPLEMENTATIONS := $(filter prng_%,$(USEMODULE))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This uses shared buffers (protected with mutex) instead of placing buffers on the stack.



### Testing procedure

#### this patch

```
> coap get fe80::7837:fcff:fe7d:1aaf 5684 /riot/board
gcoap_cli: sending msg ID 32573, 17 bytes
gcoap: response Success, code 2.05, 6 bytes
native
> ps
	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) |  0x8094c40 |  0x8094c40
	  1 | idle                 | pending  Q |  15 |   8192 ( 1084) ( 7108) |  0x808d540 |  0x808f39c 
	  2 | main                 | running  Q |   7 |  12288 ( 3092) ( 9196) |  0x808f540 |  0x809239c 
	  3 | event                | bl anyfl _ |   6 |   8192 (  976) ( 7216) |  0x8099080 |  0x809aedc 
	  4 | ipv6                 | bl rx    _ |   4 |   8192 ( 1776) ( 6416) |  0x809f460 |  0x80a12bc 
	  5 | udp                  | bl rx    _ |   5 |   8192 ( 1296) ( 6896) |  0x80a50e0 |  0x80a6f3c 
	  6 | coap                 | bl anyfl _ |   6 |  16476 ( 2952) (13524) |  0x809b400 |  0x809f2b8 
	  7 | gnrc_netdev_tap      | bl rx    _ |   2 |   8192 ( 2492) ( 5700) |  0x80a1880 |  0x80a36dc 
	    | SUM                  |            |     |  77916 (13668) (64248)
```

#### master

```
> coap get fe80::7837:fcff:fe7d:1aaf 5684 /riot/board
gcoap_cli: sending msg ID 18945, 17 bytes
gcoap: response Success, code 2.05, 6 bytes
native
> ps
	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
	  - | isr_stack            | -        - |   - |   8192 (   -1) ( 8193) |  0x8094c40 |  0x8094c40
	  1 | idle                 | pending  Q |  15 |   8192 ( 1084) ( 7108) |  0x808d540 |  0x808f39c 
	  2 | main                 | running  Q |   7 |  12288 ( 3092) ( 9196) |  0x808f540 |  0x809239c 
	  3 | event                | bl anyfl _ |   6 |   8192 (  976) ( 7216) |  0x8099080 |  0x809aedc 
	  4 | ipv6                 | bl rx    _ |   4 |   8192 ( 1840) ( 6352) |  0x809f460 |  0x80a12bc 
	  5 | udp                  | bl rx    _ |   5 |   8192 ( 1296) ( 6896) |  0x80a50e0 |  0x80a6f3c 
	  6 | coap                 | bl anyfl _ |   6 |  16476 ( 2952) (13524) |  0x809b400 |  0x809f2b8 
	  7 | gnrc_netdev_tap      | bl rx    _ |   2 |   8192 ( 2492) ( 5700) |  0x80a1880 |  0x80a36dc 
	    | SUM                  |            |     |  77916 (13732) (64184)
```

### Issues/PRs references

possible alternative to #17735?
