### PR TITLE
drivers/sht3x: ztimer_msec port

### DIFF
--- a/drivers/sht3x/Kconfig
+++ b/drivers/sht3x/Kconfig
@@ -11,7 +11,7 @@ config MODULE_SHT3X
     depends on TEST_KCONFIG
     select MODULE_PERIPH_I2C
     select MODULE_CHECKSUM
-    select MODULE_XTIMER
+    select MODULE_ZTIMER_MSEC
 
 config HAVE_SHT3X
     bool

--- a/drivers/sht3x/Makefile.dep
+++ b/drivers/sht3x/Makefile.dep
@@ -1,3 +1,3 @@
-USEMODULE += xtimer
+USEMODULE += ztimer_msec
 USEMODULE += checksum
 FEATURES_REQUIRED += periph_i2c

--- a/drivers/sht3x/sht3x.c
+++ b/drivers/sht3x/sht3x.c
@@ -23,7 +23,7 @@
 
 #include "checksum/crc8.h"
 #include "sht3x.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define ASSERT_PARAM(cond) \
     do { \
@@ -60,12 +60,12 @@
 
 /* SHT3x measurement period times in us */
 static const uint32_t SHT3X_MEASURE_PERIOD[] = {
-          0,   /* [SINGLE_SHOT ] */
-    2000000,   /* [PERIODIC_0_5] */
-    1000000,   /* [PERIODIC_1  ] */
-     500000,   /* [PERIODIC_2  ] */
-     250000,   /* [PERIODIC_4  ] */
-     100000    /* [PERIODIC_10 ] */
+       0,   /* [SINGLE_SHOT ] */
+    2000,   /* [PERIODIC_0_5] */
+    1000,   /* [PERIODIC_1  ] */
+     500,   /* [PERIODIC_2  ] */
+     250,   /* [PERIODIC_4  ] */
+     100    /* [PERIODIC_10 ] */
 };
 
 /* SHT3x measurement command sequences */
@@ -84,9 +84,9 @@ static const uint16_t SHT3X_CMD_MEASURE[6][3] = {
 #define SHT3X_MEAS_DURATION_REP_LOW    5
 
 /* measurement durations in us */
-const uint16_t SHT3X_MEAS_DURATION_US[3] = { SHT3X_MEAS_DURATION_REP_HIGH   * 1000,
-                                             SHT3X_MEAS_DURATION_REP_MEDIUM * 1000,
-                                             SHT3X_MEAS_DURATION_REP_LOW    * 1000 };
+const uint16_t SHT3X_MEAS_DURATION_MS[3] = { SHT3X_MEAS_DURATION_REP_HIGH,
+                                             SHT3X_MEAS_DURATION_REP_MEDIUM,
+                                             SHT3X_MEAS_DURATION_REP_LOW };
 
 /* functions for internal use */
 static int _get_raw_data(sht3x_dev_t* dev, uint8_t* raw_data);
@@ -180,7 +180,7 @@ static int _start_measurement (sht3x_dev_t* dev)
      */
     if (dev->mode != SHT3X_SINGLE_SHOT) {
         /* sensor needs up to 250 us to process the measurement command */
-        xtimer_usleep (1000);
+        ztimer_sleep(ZTIMER_MSEC, 1);
 
         uint16_t status;
         int res;
@@ -197,8 +197,8 @@ static int _start_measurement (sht3x_dev_t* dev)
         }
     }
 
-    dev->meas_start_time = xtimer_now_usec();
-    dev->meas_duration = SHT3X_MEAS_DURATION_US[dev->repeat];
+    dev->meas_start_time = ztimer_now(ZTIMER_MSEC);
+    dev->meas_duration = SHT3X_MEAS_DURATION_MS[dev->repeat];
     dev->meas_started = true;
 
     return SHT3X_OK;
@@ -215,10 +215,10 @@ static int _get_raw_data(sht3x_dev_t* dev, uint8_t* raw_data)
     }
 
     /* determine the time elapsed since the start of current measurement cycle */
-    uint32_t elapsed = xtimer_now_usec() - dev->meas_start_time;
+    uint32_t elapsed = ztimer_now(ZTIMER_MSEC) - dev->meas_start_time;
     if (elapsed < dev->meas_duration) {
         /* if necessary, wait until the measurement results become available */
-        xtimer_usleep(dev->meas_duration - elapsed);
+        ztimer_sleep(ZTIMER_MSEC, dev->meas_duration - elapsed);
     }
 
     /* send fetch command in any periodic mode (mode > 0) before read raw data */
@@ -240,7 +240,7 @@ static int _get_raw_data(sht3x_dev_t* dev, uint8_t* raw_data)
     }
     /* start next measurement cycle in periodic modes */
     else {
-        dev->meas_start_time = xtimer_now_usec();
+        dev->meas_start_time = ztimer_now(ZTIMER_MSEC);
         dev->meas_duration = SHT3X_MEASURE_PERIOD[dev->mode];
     }
 
@@ -340,7 +340,7 @@ static int _reset (sht3x_dev_t* dev)
      * in idle mode. We don't check I2C errors at this moment.
      */
     _send_command(dev, SHT3X_CMD_BREAK);
-    xtimer_usleep (1000);
+    ztimer_sleep(ZTIMER_MSEC, 1);
 
     /* send the soft-reset command */
     if (_send_command(dev, SHT3X_CMD_RESET) != SHT3X_OK) {
@@ -349,7 +349,7 @@ static int _reset (sht3x_dev_t* dev)
     }
 
     /* wait for 2 ms, the time needed to restart (according to datasheet 0.5 ms) */
-    xtimer_usleep (2000);
+    ztimer_sleep(ZTIMER_MSEC, 2);
 
     /* send reset command */
     if (_send_command(dev, SHT3X_CMD_CLEAR_STATUS) != SHT3X_OK) {
@@ -358,7 +358,7 @@ static int _reset (sht3x_dev_t* dev)
     }
 
     /* sensor needs some time to process the command */
-    xtimer_usleep (500);
+    ztimer_sleep(ZTIMER_MSEC, 1);
 
     uint16_t status;
     int res = SHT3X_OK;

--- a/tests/driver_sht3x/main.c
+++ b/tests/driver_sht3x/main.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "sht3x.h"
 #include "sht3x_params.h"
 
@@ -55,7 +55,7 @@ int main(void)
         else {
             printf("Could not read data from sensor, error %d\n", res);
         }
-        xtimer_usleep(1000000);
+        ztimer_sleep(ZTIMER_MSEC, 1000);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

The PR contains the changes to use `ztimer_msec` instead of `xtimer`.

### Testing procedure

`tests/driver_sht3x` should still work.

### Issues/PRs references
