### PR TITLE
drivers/dose: work around timer_stop() not always stopping the timer

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -151,6 +151,11 @@ static void _dose_watchdog_cb(void *arg, int chan)
     (void) chan;
     (void) arg;
 
+    /* Workaround: timer_stop() after timer_set_periodic() is sometimes ignored */
+    if (!_watchdog_users) {
+        timer_stop(DOSE_TIMER_DEV);
+    }
+
     for (unsigned i = 0; i < _dose_numof; ++i) {
         dose_t *ctx = &_dose_base[i];
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When `timer_stop()` is called right after `timer_set_periodic()`, the timer is often not actually stopped.

To avoid keeping the watchdog running when no interface has it enabled, add a check to the watchdog callback to disable the watchdog if there are no watchdog users left.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

workaround for until #17723 is in place
