### PR TITLE
drivers/rtt_rtc: add option to not attempt to retain time across reboots

### DIFF
--- a/drivers/rtt_rtc/Kconfig
+++ b/drivers/rtt_rtc/Kconfig
@@ -13,3 +13,9 @@ config MODULE_RTT_RTC
     select MODULE_RTC_UTILS
     help
         Basic RTC implementation based on a RTT.
+
+config RTT_RTC_NO_RETAIN
+    bool "Don't try to retain time across reboots"
+    depends on MODULE_RTT_RTC
+    help
+        Don't try to keep the time across reboots but start from 0 again.

--- a/drivers/rtt_rtc/rtt_rtc.c
+++ b/drivers/rtt_rtc/rtt_rtc.c
@@ -52,6 +52,12 @@
 #define BACKUP_RAM      __attribute__((section(".noinit")))
 #endif
 
+/* don't attempt to retain time across reboots */
+#if CONFIG_RTT_RTC_NO_RETAIN
+#undef BACKUP_RAM
+#define BACKUP_RAM
+#endif
+
 static uint32_t rtc_now BACKUP_RAM;         /**< The RTC timestamp when the last RTT alarm triggered */
 static uint32_t last_alarm BACKUP_RAM;      /**< The RTT timestamp of the last alarm */
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This can be error prone if no backup RAM is available.
When keeping multiple sensors in sync, it can be more desirable to let them all start at 0 (when powered on at the same time) than some random time when using the `.noinit` section.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
