### PR TITLE
sys/od/kconfig: add od_string module

### DIFF
--- a/sys/od/Kconfig
+++ b/sys/od/Kconfig
@@ -4,7 +4,11 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-config MODULE_OD
+menuconfig MODULE_OD
     bool "OD Hex Dump"
     select MODULE_FMT
     depends on TEST_KCONFIG
+
+config MODULE_OD_STRING
+    bool "Print ASCII representation of the dumped data"
+    depends on MODULE_OD


### PR DESCRIPTION
### Contribution description
This adds the `od_string` module which was missing during modelling of `od`.

### Testing procedure
- Check that it shows up properly in menuconfig
- Green CI

### Issues/PRs references
Split from #17789 
