### PR TITLE
drivers/mrf24j40: move CFLAG to Makefile.include

### DIFF
--- a/drivers/mrf24j40/Makefile.dep
+++ b/drivers/mrf24j40/Makefile.dep
@@ -7,11 +7,4 @@ FEATURES_REQUIRED += periph_spi
 
 ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
   DEFAULT_MODULE += netdev_ieee802154_oqpsk
-
-  ifndef CONFIG_KCONFIG_MODULE_MRF24J40
-    # all modules but mrf24j40ma have an external PA
-    ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
-      CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
-    endif
-  endif
 endif

--- a/drivers/mrf24j40/Makefile.include
+++ b/drivers/mrf24j40/Makefile.include
@@ -1,5 +1,14 @@
 # include variants of mrf24j40 drivers as pseudo modules
 PSEUDOMODULES += mrf24j40m%
 
+ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
+  ifndef CONFIG_KCONFIG_MODULE_MRF24J40
+    # all modules but mrf24j40ma have an external PA
+    ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
+      CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
+    endif
+  endif
+endif
+
 USEMODULE_INCLUDES_mrf24j40 := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_mrf24j40)


### PR DESCRIPTION
### Contribution description
CFLAGS should be added in `Makefile.include`s. For mrf24j40 it was being done in `Makefile.dep`, so this corrects it.

### Testing procedure
- Green CI
- Check that the external PA CFLAG is set when not using `mrf24j40ma` but other variant


### Issues/PRs references
Split from #17789 