### PR TITLE
cpu/samx21: allow to override PM_BLOCKER_INITIAL

### DIFF
--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -39,7 +39,9 @@ extern "C" {
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */
+#ifndef PM_BLOCKER_INITIAL
 #define PM_BLOCKER_INITIAL      0x00000001
+#endif
 
 /**
  * @name   SAMD21 sleep modes for PM

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -37,7 +37,9 @@ extern "C" {
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */
+#ifndef PM_BLOCKER_INITIAL
 #define PM_BLOCKER_INITIAL  0x00000001
+#endif
 
 /**
  * @name   SAML1x GCLK definitions


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

PM_BLOCKER_INITIAL cannot overridden on samd21 and saml21 boards. This PR changes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Needed by #11237 where the PM_BLOCKER_INITIAL value is already set at application level (with no effect on samd21/saml21).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
