### PR TITLE
drivers/sdcard_spi: allow board to overwrite SD_CARD_SPI_SPEED_POSTINIT

### DIFF
--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -33,6 +33,7 @@ extern "C" {
 #include "stdbool.h"
 #include "sdcard_spi.h"
 #include "timex.h"
+#include "board.h"
 
 /* number of clocks that should be applied to the card on init
    before taking further actions (see sd spec. 6.4.1.1 Power Up Time of Card) */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Include `board.h` so we can overwrite `SD_CARD_SPI_SPEED_POSTINIT` there.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
