### PR TITLE
core/xfa: implement accessor functions

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -27,6 +27,13 @@
 
 #include <inttypes.h>
 
+#if !defined(__clang__) && __GNUC__ < 8
+/* yes, avr and xtensa are stuck to gcc 5.2. In 2022. :/ */
+# define NO_SANITIZE
+#else
+# define NO_SANITIZE __attribute__((no_sanitize("undefined")))
+#endif
+
 /*
  * Unfortunately, current gcc trips over accessing XFA's because of their
  * zero-size start/end array that are used of symbol markers, with an "array
@@ -208,10 +215,10 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
     static inline unsigned name ## _len(void) { \
         return (unsigned)((uintptr_t)&name ## _end - (uintptr_t)&name) / sizeof(type); \
     } \
-    static inline __attribute__((no_sanitize("undefined"))) type name ## _get_copy(unsigned n) { \
+    static inline NO_SANITIZE type name ## _get_copy(unsigned n) { \
         return (type)name[n]; \
     } \
-    static inline __attribute__((no_sanitize("undefined"))) __VA_ARGS__ type * name ## _get_ptr(unsigned n) { \
+    static inline NO_SANITIZE __VA_ARGS__ type * name ## _get_ptr(unsigned n) { \
         return (__VA_ARGS__ type *) &name[n]; \
     }
 

--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -216,7 +216,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
         return (unsigned)((uintptr_t)&name ## _end - (uintptr_t)&name) / sizeof(type); \
     } \
     static inline NO_SANITIZE type name ## _get_copy(unsigned n) { \
-        return (type)name[n]; \
+        return *(type*)&name[n]; \
     } \
     static inline NO_SANITIZE __VA_ARGS__ type * name ## _get_ptr(unsigned n) { \
         return (__VA_ARGS__ type *) &name[n]; \

--- a/tests/unittests/tests-core/tests-core-xfa.c
+++ b/tests/unittests/tests-core/tests-core-xfa.c
@@ -23,21 +23,63 @@ XFA_USE_CONST(xfatest_t, xfatest_use_const);
 /* Verifying that cross file array linking is correct by iterating over an external array */
 static void test_xfa_data(void)
 {
-    unsigned n = XFA_LEN(xfatest_t, xfatest);
+    unsigned n = xfatest_len();
     TEST_ASSERT_EQUAL_INT(2, n);
     unsigned found = 0;
     for (unsigned k = 0; k < n; ++k) {
         /* we do not want to enforce the order of the data elements */
-        switch (xfatest[k].val) {
+        switch (xfatest_get_copy(k).val) {
             case 12345:
                 /* tests-core-xfa-data1.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest1", xfatest[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest1", xfatest_get_copy(k).text);
                 TEST_ASSERT(!(found & BIT0));
                 found |= BIT0;
                 break;
             case 0xbeef:
                 /* tests-core-xfa-data2.c */
-                TEST_ASSERT_EQUAL_STRING("another test string", xfatest[k].text);
+                TEST_ASSERT_EQUAL_STRING("another test string", xfatest_get_copy(k).text);
+                TEST_ASSERT(!(found & BIT1));
+                found |= BIT1;
+                break;
+            default:
+                break;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT((1U << n) - 1, found);
+}
+
+/* Verifying that rw cross file arrays can be changed */
+static void test_xfa_data_change(void)
+{
+    unsigned n = xfatest_len();
+    TEST_ASSERT_EQUAL_INT(2, n);
+    for (unsigned k = 0; k < n; ++k) {
+        /* we do not want to enforce the order of the data elements */
+        xfatest_t *entry = xfatest_get_ptr(k);
+        switch (entry->val) {
+            case 12345:
+                entry->val = 54321;
+                break;
+            case 0xbeef:
+                entry->val = 0xfeeb;
+                break;
+            default:
+                break;
+        }
+    }
+    unsigned found = 0;
+    for (unsigned k = 0; k < n; ++k) {
+        /* we do not want to enforce the order of the data elements */
+        switch (xfatest_get_copy(k).val) {
+            case 54321:
+                /* tests-core-xfa-data1.c */
+                TEST_ASSERT_EQUAL_STRING("xfatest1", xfatest_get_copy(k).text);
+                TEST_ASSERT(!(found & BIT0));
+                found |= BIT0;
+                break;
+            case 0xfeeb:
+                /* tests-core-xfa-data2.c */
+                TEST_ASSERT_EQUAL_STRING("another test string", xfatest_get_copy(k).text);
                 TEST_ASSERT(!(found & BIT1));
                 found |= BIT1;
                 break;
@@ -55,15 +97,15 @@ static void test_xfa_const_data(void)
     unsigned found = 0;
     for (unsigned k = 0; k < n; ++k) {
         /* we do not want to enforce the order of the data elements */
-        switch (xfatest_const[k].val) {
+        switch (xfatest_const_get_copy(k).val) {
             case 0xcafe:
                 /* tests-core-xfa-data1.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest_const1", xfatest_const[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest_const1", xfatest_const_get_copy(k).text);
                 ++found;
                 break;
             case 32444:
                 /* tests-core-xfa-data2.c */
-                TEST_ASSERT_EQUAL_STRING("const string xfa 2", xfatest_const[k].text);
+                TEST_ASSERT_EQUAL_STRING("const string xfa 2", xfatest_const_get_copy(k).text);
                 ++found;
                 break;
             default:
@@ -80,20 +122,20 @@ static void test_xfa_use_data(void)
     unsigned found = 0;
     for (unsigned k = 0; k < n; ++k) {
         /* we do not want to enforce the order of the data elements */
-        switch (xfatest_use[k].val) {
+        switch (xfatest_use_get_copy(k).val) {
             case 3333:
                 /* tests-core-xfa-data1.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest_use1", xfatest_use[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest_use1", xfatest_use_get_copy(k).text);
                 ++found;
                 break;
             case 555:
                 /* tests-core-xfa-data1.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest use again", xfatest_use[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest use again", xfatest_use_get_copy(k).text);
                 ++found;
                 break;
             case 11111:
                 /* tests-core-xfa-data2.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest_use2", xfatest_use[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest_use2", xfatest_use_get_copy(k).text);
                 ++found;
                 break;
             default:
@@ -110,15 +152,15 @@ static void test_xfa_use_const_data(void)
     unsigned found = 0;
     for (unsigned k = 0; k < n; ++k) {
         /* we do not want to enforce the order of the data elements */
-        switch (xfatest_use_const[k].val) {
+        switch (xfatest_use_const_get_copy(k).val) {
             case 4444:
                 /* tests-core-xfa-data1.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest_use_const1", xfatest_use_const[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest_use_const1", xfatest_use_const_get_copy(k).text);
                 ++found;
                 break;
             case 22222:
                 /* tests-core-xfa-data2.c */
-                TEST_ASSERT_EQUAL_STRING("xfatest_use_const2", xfatest_use_const[k].text);
+                TEST_ASSERT_EQUAL_STRING("xfatest_use_const2", xfatest_use_const_get_copy(k).text);
                 ++found;
                 break;
             default:
@@ -132,6 +174,7 @@ Test *tests_core_xfa_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_xfa_data),
+        new_TestFixture(test_xfa_data_change),
         new_TestFixture(test_xfa_const_data),
         new_TestFixture(test_xfa_use_data),
         new_TestFixture(test_xfa_use_const_data),

--- a/tests/xfa/main.c
+++ b/tests/xfa/main.c
@@ -35,12 +35,12 @@ int main(void)
     unsigned n = XFA_LEN(xfatest_t, xfatest);
     printf("xfatest[%u]:\n", n);
     for (unsigned i = 0; i < n; i++) {
-        printf("[%u] = %u, \"%s\"\n", i, xfatest[i].val, xfatest[i].text);
+        printf("[%u] = %u, \"%s\"\n", i, xfatest_get_ptr(i)->val, xfatest_get_ptr(i)->text);
     }
     n = XFA_LEN(xfatest_t, xfatest_const);
     printf("xfatest_const[%u]:\n", n);
     for (unsigned i = 0; i < n; i++) {
-        printf("[%u] = %u, \"%s\"\n", i, xfatest_const[i].val, xfatest_const[i].text);
+        printf("[%u] = %u, \"%s\"\n", i, xfatest_const_get_ptr(i)->val, xfatest_const_get_ptr(i)->text);
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
    ubsan (the Undefined Behavior sanitizer) trips on the previous access
    method for XFAs:
    
    ```
    /home/kaspar/src/riot/tests/unittests/tests-core/
    tests-core-xfa.c:18:1: runtime error: load of address 0x080559dc with insufficient space for an object of type 'struct xfatest_t'
    0x080559dc: note: pointer points here
      dd 87 05 08 39 30 00 00  d4 87 05 08 ef be 00 00  10 88 05 08 2b 02 00 00  a6 87 05 08 05 0d 00 00
    ```
    
    In order to avoid this false positive, a function can be annotated with
    ```__attribute__((no_sanitize("undefined")))``.
    So, this PR creates an accessor function that has this attribute,
    named `<xfaname>_get(n)`.
    
    To reduce macro use in regular code, a `<xfa name>_len()` function
    equivalent to `XFA_LEN()` is also added.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

CI should be fine.
To reproduce the issue, either on master or after reverting the unittests commit,
build&run `BOARD=native make -C tests/unittests all-ubsan tests-core`.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
