### PR TITLE
pkg/fatfs: enable exFAT support

### DIFF
--- a/pkg/fatfs/vendor/include/ffconf.h
+++ b/pkg/fatfs/vendor/include/ffconf.h
@@ -135,7 +135,7 @@
 
 
 #ifndef FATFS_FFCONF_OPT_USE_LFN
-#define FF_USE_LFN	 0
+#define FF_USE_LFN	 FF_FS_EXFAT
 #else
 #define FF_USE_LFN	 FATFS_FFCONF_OPT_USE_LFN
 #endif

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -107,13 +107,27 @@ extern "C" {
 #endif
 
 #if FF_USE_FASTSEEK
-#define _FATFS_FILE_SEEK_PTR             (4)
+#define _FATFS_FILE_SEEK_PTR            (4)
 #else
-#define _FATFS_FILE_SEEK_PTR             (0)
+#define _FATFS_FILE_SEEK_PTR            (0)
 #endif
 
-#define FATFS_VFS_DIR_BUFFER_SIZE       (44)
-#define FATFS_VFS_FILE_BUFFER_SIZE      (72 + _FATFS_FILE_CACHE + _FATFS_FILE_SEEK_PTR)
+#if FF_FS_EXFAT
+#define _FATFS_FILE_EXFAT               (44)
+#define _FATFS_DIR_EXFAT                (32)
+#else
+#define _FATFS_FILE_EXFAT               (0)
+#define _FATFS_DIR_EXFAT                (0)
+#endif
+
+#if FF_USE_LFN
+#define _FATFS_DIR_LFN                  (4)
+#else
+#define _FATFS_DIR_LFN                  (0)
+#endif
+
+#define FATFS_VFS_DIR_BUFFER_SIZE       (44 + _FATFS_DIR_LFN + _FATFS_DIR_EXFAT)
+#define FATFS_VFS_FILE_BUFFER_SIZE      (72 + _FATFS_FILE_CACHE + _FATFS_FILE_SEEK_PTR + _FATFS_FILE_EXFAT)
 #else
 #define FATFS_VFS_DIR_BUFFER_SIZE       (1)
 #define FATFS_VFS_FILE_BUFFER_SIZE      (1)


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Enabling exFAT requires enabling long file names, so enable LFN if exFAT is enabled.
exFAT (and LFN) also requires bumping the per-file/per-dir buffer.


### Testing procedure

Can be tested with

    CFLAGS += -DFATFS_FFCONF_OPT_FS_EXFAT=1

```
2022-03-11 13:25:24,438 - INFO # > ls /
2022-03-11 13:25:24,438 - INFO # 
2022-03-11 13:25:24,441 - INFO # System Volume Information
2022-03-11 13:25:24,441 - INFO # test
2022-03-11 13:25:24,443 - INFO # hello.txt	19 B
2022-03-11 13:25:24,444 - INFO # total 1 files
2022-03-11 13:25:28,907 - INFO # > vfs r /hello.txt 32
2022-03-11 13:25:28,908 - INFO # 
2022-03-11 13:25:28,915 - INFO # 00000000: 4865 6c6c 6f20 6672 6f6d 2057 696e 646f  Hello from Windo
2022-03-11 13:25:28,920 - INFO # 00000010: 7773 21                                  ws!
2022-03-11 13:25:28,921 - INFO # -- EOF --
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
