### PR TITLE
gcoap_forward_proxy: provide cache validation mechanism

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14273,6 +14273,7 @@ sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_ACCEPT \(macro definiti
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_BLOCK1 \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_BLOCK2 \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_CONTENT_FORMAT \(macro definition\) of group net_coap is not documented\.
+sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_ETAG \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_MAX_AGE \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_LOCATION_PATH \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_LOCATION_QUERY \(macro definition\) of group net_coap is not documented\.

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -36,6 +36,7 @@ extern "C" {
  * @{
  */
 #define COAP_OPT_URI_HOST       (3)
+#define COAP_OPT_ETAG           (4)
 #define COAP_OPT_OBSERVE        (6)
 #define COAP_OPT_LOCATION_PATH  (8)
 #define COAP_OPT_URI_PATH       (11)
@@ -168,6 +169,13 @@ extern "C" {
  * @{
  */
 #define COAP_TOKEN_LENGTH_MAX    (8)
+/** @} */
+
+/**
+ * @name    CoAP option constants
+ * @{
+ */
+#define COAP_ETAG_LENGTH_MAX     (8U)   /**< maximum length of the ETag option */
 /** @} */
 
 /**

--- a/sys/net/application_layer/nanocoap/cache.c
+++ b/sys/net/application_layer/nanocoap/cache.c
@@ -94,6 +94,11 @@ void nanocoap_cache_key_generate(const coap_pkt_t *req, uint8_t *cache_key)
     for (unsigned i = 0; i < req->options_len; i++) {
         ssize_t optlen = coap_opt_get_next(req, &opt, &value, !i);
         if (optlen >= 0) {
+            /* gCoAP forward proxy is ETag-aware, so skip ETag option,
+             * see https://datatracker.ietf.org/doc/html/rfc7252#section-5.4.2 */
+            if (IS_USED(MODULE_GCOAP_FORWARD_PROXY) && (opt.opt_num == COAP_OPT_ETAG)) {
+                continue;
+            }
             /* skip NoCacheKey,
                see https://tools.ietf.org/html/rfc7252#section-5.4.6 */
             if ((opt.opt_num & 0x1E) == 0x1C) {
@@ -218,7 +223,6 @@ int nanocoap_cache_process(const uint8_t *cache_key, unsigned request_method,
             /* no space left in the cache? */
             return -1;
         }
-        /* TODO: ETAG handling */
     }
 
     return 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This provides support for the [cache validation mechanism of CoAP](https://datatracker.ietf.org/doc/html/rfc7252#section-5.6.2) for the `gcoap_forward_proxy` module if `nanocoap_cache` is also provided.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
TBD procedurally, but could be easily done with an `aiocoap` server with ETag support, a RIOT client and a RIOT forward proxy inbetween the two. The client requests a resource via the proxy (the server delivers the data with an ETag), waits until the Max-Age (default 60 seconds) of the resource passed, then requests the (assumed to be unchanging) resource again. This should trigger the proxy to send a request with the resource's ETag to the server which in turn answers with a 2.03 Valid response. The proxy should then send the original cached response back (and update the cache entries Max-Age).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Requires #13889 and its dependencies.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
