### PR TITLE
gnrc/nib: don't advertise single address for auto-configuration

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -69,7 +69,9 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
         (ipv6_addr_match_prefix(&netif->ipv6.addrs[idx], pfx) >= pfx_len)) {
         dst->flags |= _PFX_ON_LINK;
     }
-    if (netif->ipv6.aac_mode & GNRC_NETIF_AAC_AUTO) {
+
+    /* Auto-configuration only works if the prefix is more than a single address */
+    if ((netif->ipv6.aac_mode & GNRC_NETIF_AAC_AUTO) && (pfx_len < 128)) {
         dst->flags |= _PFX_SLAAC;
     }
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LBR) && IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When manually adding a global address with `gnrc_netif_ipv6_addr_add()` or `ifconfig add` it would be advertised as a /128 prefix in router advertisements.

This causes the receiving node to take that address, only to discard it via DAD - the second, real prefix is ignored.


### Testing procedure

The interface on the upstream router has `fd11::/16` and `fdea:dbee:f::10` configured on it's interface:

```
2022-03-12 15:49:15,050 - INFO # Iface  7 
2022-03-12 15:49:15,053 - INFO #           Long HWaddr: EE:FA:C6:85:D7:AF:25:E2 
2022-03-12 15:49:15,057 - INFO #           MTU:65535  HL:64  RTR  
2022-03-12 15:49:15,058 - INFO #           RTR_ADV  
2022-03-12 15:49:15,061 - INFO #           Link type: wired
2022-03-12 15:49:15,066 - INFO #           inet6 addr: fe80::ecfa:c685:d7af:25e2  scope: link  VAL
2022-03-12 15:49:15,072 - INFO #           inet6 addr: fd11::ecfa:c685:d7af:25e2  scope: global  VAL
2022-03-12 15:49:15,078 - INFO #           inet6 addr: fdea:dbee:f::10  scope: global  VAL
2022-03-12 15:49:15,080 - INFO #           inet6 group: ff02::2
2022-03-12 15:49:15,083 - INFO #           inet6 group: ff02::1
2022-03-12 15:49:15,087 - INFO #           inet6 group: ff02::1:ffaf:25e2
2022-03-12 15:49:15,090 - INFO #           inet6 group: ff02::1:ff00:1
```

The downstream node receives the router advertisement:

#### master
```
2022-03-12 15:01:13,939 - INFO # nib: Handle packet (icmpv6->type = 134)
2022-03-12 15:01:13,943 - INFO # nib: Received valid router advertisement:
2022-03-12 15:01:13,947 - INFO #      - Source address: fe80::ecfa:c685:d7af:25e2
2022-03-12 15:01:13,950 - INFO #      - Destination address: ff02::1
2022-03-12 15:01:13,953 - INFO #      - Cur Hop Limit: 0
2022-03-12 15:01:13,954 - INFO #      - Flags: --
2022-03-12 15:01:13,957 - INFO #      - Router Lifetime: 1800s
2022-03-12 15:01:13,959 - INFO #      - Reachable Time: 0ms
2022-03-12 15:01:13,962 - INFO #      - Retrans Timer: 0ms
2022-03-12 15:01:13,966 - INFO # nib: received valid Prefix Information option:
2022-03-12 15:01:13,969 - INFO #      - Prefix: fdea:dbee:f::10/128
2022-03-12 15:01:13,970 - INFO #      - Flags: LA
2022-03-12 15:01:13,973 - INFO #      - Valid lifetime: 4294967295
2022-03-12 15:01:13,977 - INFO #      - Preferred lifetime: 4294967295
2022-03-12 15:01:13,981 - INFO # nib: received valid Prefix Information option:
2022-03-12 15:01:13,983 - INFO #      - Prefix: fd11::/16
2022-03-12 15:01:13,985 - INFO #      - Flags: LA
2022-03-12 15:01:13,988 - INFO #      - Valid lifetime: 4294967295
2022-03-12 15:01:13,991 - INFO #      - Preferred lifetime: 4294967295
2022-03-12 15:01:13,998 - INFO # nib: Handle timer event (ctx = 0x20002dc6, type = 0x4fd1, now = 3685ms)
2022-03-12 15:01:14,008 - INFO # nib: Handle packet (icmpv6->type = 136)
2022-03-12 15:01:14,012 - INFO # nib: Received valid neighbor advertisement:
2022-03-12 15:01:14,015 - INFO #      - Target address: fdea:dbee:f::10
2022-03-12 15:01:14,019 - INFO #      - Source address: fe80::ecfa:c685:d7af:25e2
2022-03-12 15:01:14,024 - INFO #      - Destination address: fe80::ac1a:52e4:324e:aa4b
2022-03-12 15:01:14,026 - INFO #      - Flags: RS-
2022-03-12 15:01:14,033 - INFO # nib: duplicate address detected, removing target address from this interface
```

##### this patch

```
2022-03-12 15:33:39,848 - INFO # nib: Handle packet (icmpv6->type = 134)
2022-03-12 15:33:39,852 - INFO # nib: Received valid router advertisement:
2022-03-12 15:33:39,856 - INFO #      - Source address: fe80::ecfa:c685:d7af:25e2
2022-03-12 15:33:39,859 - INFO #      - Destination address: ff02::1
2022-03-12 15:33:39,862 - INFO #      - Cur Hop Limit: 0
2022-03-12 15:33:39,863 - INFO #      - Flags: --
2022-03-12 15:33:39,866 - INFO #      - Router Lifetime: 1800s
2022-03-12 15:33:39,868 - INFO #      - Reachable Time: 0ms
2022-03-12 15:33:39,870 - INFO #      - Retrans Timer: 0ms
2022-03-12 15:33:39,875 - INFO # nib: received valid Prefix Information option:
2022-03-12 15:33:39,877 - INFO #      - Prefix: fd11::/16
2022-03-12 15:33:39,878 - INFO #      - Flags: LA
2022-03-12 15:33:39,881 - INFO #      - Valid lifetime: 4294967295
2022-03-12 15:33:39,885 - INFO #      - Preferred lifetime: 4294967295
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
