### PR TITLE
net/gcoap: introduce and use gcoap_resource_t

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -75,14 +75,14 @@ static ssize_t _handler_info(coap_pkt_t *pdu,
     return resp_len + slen;
 }
 
-static const coap_resource_t _resources[] = {
+static const gcoap_resource_t _resources[] = {
     { "/node/info",  COAP_GET, _handler_info, NULL },
     { "/sense/hum",  COAP_GET, _handler_dummy, NULL },
     { "/sense/temp", COAP_GET, _handler_dummy, NULL }
 };
 
 static gcoap_listener_t _listener = {
-    .resources     = (coap_resource_t *)&_resources[0],
+    .resources     = _resources,
     .resources_len = ARRAY_SIZE(_resources),
     .next          = NULL
 };

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -57,14 +57,14 @@ static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx
     return text_resp(pdu, buf, len, (char *)ctx, COAP_FORMAT_TEXT);
 }
 
-static const coap_resource_t resources[] = {
+static const gcoap_resource_t resources[] = {
     { "/riot/bar",  COAP_GET, handler_text, "foo" },
     { "/riot/foo",  COAP_GET, handler_text, "bar" },
     { "/riot/info", COAP_GET, handler_info, NULL }
 };
 
 static gcoap_listener_t listener = {
-    .resources     = &resources[0],
+    .resources     = resources,
     .resources_len = ARRAY_SIZE(resources),
     .next          = NULL
 };

--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -56,13 +56,13 @@ static const credman_credential_t credential = {
 };
 #endif
 
-static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
+static ssize_t _encode_link(const gcoap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
-static const coap_resource_t _resources[] = {
+static const gcoap_resource_t _resources[] = {
     { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },
 };
@@ -83,7 +83,7 @@ static gcoap_listener_t _listener = {
 
 
 /* Adds link format params to resource list */
-static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
+static ssize_t _encode_link(const gcoap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context) {
     ssize_t res = gcoap_encode_link(resource, buf, maxlen, context);
     if (res > 0) {

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -29,12 +29,12 @@ static uint8_t proxy_req_buf[CONFIG_GCOAP_PDU_BUF_SIZE];
 static client_ep_t _client_eps[CONFIG_GCOAP_REQ_WAITING_MAX];
 
 static int _request_matcher_forward_proxy(gcoap_listener_t *listener,
-                                          const coap_resource_t **resource,
+                                          const gcoap_resource_t **resource,
                                           coap_pkt_t *pdu);
 static ssize_t _forward_proxy_handler(coap_pkt_t* pdu, uint8_t *buf,
                                       size_t len, void *ctx);
 
-const coap_resource_t forward_proxy_resources[] = {
+const gcoap_resource_t forward_proxy_resources[] = {
     { "/", COAP_IGNORE, _forward_proxy_handler, NULL },
 };
 
@@ -73,7 +73,7 @@ static void _free_client_ep(client_ep_t *cep)
 }
 
 static int _request_matcher_forward_proxy(gcoap_listener_t *listener,
-                                          const coap_resource_t **resource,
+                                          const gcoap_resource_t **resource,
                                           coap_pkt_t *pdu)
 {
     (void) listener;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -70,16 +70,16 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu,
                            const sock_udp_ep_t *remote, bool by_mid);
 static int _find_resource(gcoap_socket_type_t tl_type,
                           coap_pkt_t *pdu,
-                          const coap_resource_t **resource_ptr,
+                          const gcoap_resource_t **resource_ptr,
                           gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
 static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
                                                        coap_pkt_t *pdu);
 static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
-                                   const coap_resource_t *resource);
+                                   const gcoap_resource_t *resource);
 
 static int _request_matcher_default(gcoap_listener_t *listener,
-                                    const coap_resource_t **resource,
+                                    const gcoap_resource_t **resource,
                                     coap_pkt_t *pdu);
 
 #if IS_USED(MODULE_GCOAP_DTLS)
@@ -88,7 +88,7 @@ static void _dtls_free_up_session(void *arg);
 #endif
 
 /* Internal variables */
-const coap_resource_t _default_resources[] = {
+const gcoap_resource_t _default_resources[] = {
     { "/.well-known/core", COAP_GET, _well_known_core_handler, NULL },
 };
 
@@ -536,7 +536,7 @@ static void _cease_retransmission(gcoap_request_memo_t *memo) {
 static size_t _handle_req(gcoap_socket_t *sock, coap_pkt_t *pdu, uint8_t *buf,
                           size_t len, sock_udp_ep_t *remote)
 {
-    const coap_resource_t *resource     = NULL;
+    const gcoap_resource_t *resource    = NULL;
     gcoap_listener_t *listener          = NULL;
     sock_udp_ep_t *observer             = NULL;
     gcoap_observe_memo_t *memo          = NULL;
@@ -656,7 +656,7 @@ static size_t _handle_req(gcoap_socket_t *sock, coap_pkt_t *pdu, uint8_t *buf,
 }
 
 static int _request_matcher_default(gcoap_listener_t *listener,
-                                    const coap_resource_t **resource,
+                                    const gcoap_resource_t **resource,
                                     coap_pkt_t *pdu)
 {
     uint8_t uri[CONFIG_NANOCOAP_URI_MAX];
@@ -675,7 +675,7 @@ static int _request_matcher_default(gcoap_listener_t *listener,
     for (size_t i = 0; i < listener->resources_len; i++) {
         *resource = &listener->resources[i];
 
-        int res = coap_match_path(*resource, uri);
+        int res = coap_match_path((coap_resource_t *)*resource, uri);
 
         /* URI mismatch */
         if (res > 0) {
@@ -716,7 +716,7 @@ static int _request_matcher_default(gcoap_listener_t *listener,
  */
 static int _find_resource(gcoap_socket_type_t tl_type,
                           coap_pkt_t *pdu,
-                          const coap_resource_t **resource_ptr,
+                          const gcoap_resource_t **resource_ptr,
                           gcoap_listener_t **listener_ptr)
 {
     int ret = GCOAP_RESOURCE_NO_PATH;
@@ -725,7 +725,7 @@ static int _find_resource(gcoap_socket_type_t tl_type,
     gcoap_listener_t *listener = _coap_state.listeners;
 
     while (listener) {
-        const coap_resource_t *resource;
+        const gcoap_resource_t *resource;
         int res;
 
         /* only makes sense to check if non-UDP transports are supported,
@@ -937,7 +937,7 @@ static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
  * resource[in] -- Resource to match
  */
 static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
-                                   const coap_resource_t *resource)
+                                   const gcoap_resource_t *resource)
 {
     *memo = NULL;
     for (int i = 0; i < CONFIG_GCOAP_OBS_REGISTRATIONS_MAX; i++) {
@@ -1309,7 +1309,7 @@ int gcoap_resp_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code)
 }
 
 int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
-                                                  const coap_resource_t *resource)
+                                                  const gcoap_resource_t *resource)
 {
     gcoap_observe_memo_t *memo = NULL;
 
@@ -1340,7 +1340,7 @@ int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 }
 
 size_t gcoap_obs_send(const uint8_t *buf, size_t len,
-                      const coap_resource_t *resource)
+                      const gcoap_resource_t *resource)
 {
     gcoap_observe_memo_t *memo = NULL;
     _find_obs_memo_resource(&memo, resource);
@@ -1420,7 +1420,7 @@ int gcoap_get_resource_list_tl(void *buf, size_t maxlen, uint8_t cf,
     return (int)pos;
 }
 
-ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
+ssize_t gcoap_encode_link(const gcoap_resource_t *resource, char *buf,
                           size_t maxlen, coap_link_encoder_ctx_t *context)
 {
     size_t path_len = strlen(resource->path);

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -25,13 +25,13 @@
 /*
  * A test set of dummy resources. The resource handlers are set to NULL.
  */
-static const coap_resource_t resources[] = {
+static const gcoap_resource_t resources[] = {
     { .path = "/act/switch", .methods = (COAP_GET | COAP_POST) },
     { .path = "/sensor/temp", .methods = (COAP_GET) },
     { .path = "/test/info/all", .methods = (COAP_GET) },
 };
 
-static const coap_resource_t resources_second[] = {
+static const gcoap_resource_t resources_second[] = {
     { .path = "/second/part", .methods = (COAP_GET)},
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Use a separate type for gcoap resources so we can change callback types for nanocoap.


### Testing procedure

This does not include any functional changes yet.


### Issues/PRs references

split from #17544
