### PR TITLE
boards/adafruit-pybadge: add support

### DIFF
--- a/boards/adafruit-pybadge/Kconfig
+++ b/boards/adafruit-pybadge/Kconfig
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "adafruit-pybadge" if BOARD_ADAFRUIT_PYBADGE
+
+config BOARD_ADAFRUIT_PYBADGE
+    bool
+    default y
+    select CPU_MODEL_SAMD51J19A
+    select HAS_HIGHLEVEL_STDIO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # select HAVE_ST7735  # not supported yet
+    select HAVE_SAUL_GPIO
+    select HAVE_MTD_SPI_NOR
+    # This specific board requires SPI_ON_QSPI for the MTD_SPI_NOR
+    select MODULE_PERIPH_SPI_ON_QSPI if MODULE_MTD_SPI_NOR
+
+source "$(RIOTBOARD)/common/samdx1-arduino-bootloader/Kconfig"

--- a/boards/adafruit-pybadge/Makefile
+++ b/boards/adafruit-pybadge/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/samdx1-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/adafruit-pybadge/Makefile.dep
+++ b/boards/adafruit-pybadge/Makefile.dep
@@ -1,0 +1,16 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  # Driver not supported yet
+  # USEMODULE += st7735
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi_on_qspi
+  USEMODULE += mtd_spi_nor
+endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.dep

--- a/boards/adafruit-pybadge/Makefile.features
+++ b/boards/adafruit-pybadge/Makefile.features
@@ -1,0 +1,21 @@
+CPU = samd5x
+CPU_MODEL = samd51j19a
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# This configuration enables modules that are only available when using Kconfig
+# module modelling
+ifeq (1, $(TEST_KCONFIG))
+  KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/samdx1-arduino-bootloader/samdx1-arduino-bootloader.config
+endif

--- a/boards/adafruit-pybadge/Makefile.include
+++ b/boards/adafruit-pybadge/Makefile.include
@@ -1,0 +1,9 @@
+CFLAGS += -DBOOTLOADER_UF2
+
+# stdio over usb takes several seconds to be up after flashing
+TERM_DELAY ?= 4
+
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
+# Include handling of serial and non-bossa programmers (if selected by user)
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/adafruit-pybadge/board.c
+++ b/boards/adafruit-pybadge/board.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-pybadge
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the Adafruit PyBadge
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "mtd_spi_nor.h"
+#include "timex.h"
+
+#include "periph/gpio.h"
+
+#if IS_USED(MODULE_MTD)
+/* GD25Q16C */
+static const mtd_spi_nor_params_t _samd51_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 15 * US_PER_SEC,
+    .wait_32k_erase = 150 * US_PER_MS,
+    .wait_64k_erase = 250 * US_PER_MS,
+    .wait_sector_erase = 50 * US_PER_MS,
+    .wait_chip_wake_up = 1 * US_PER_MS,
+    .clk  = MHZ(54),
+    .flag = SPI_NOR_F_SECT_4K
+          | SPI_NOR_F_SECT_32K
+          | SPI_NOR_F_SECT_64K,
+    .spi  = SPI_DEV(3),
+    .mode = SPI_MODE_0,
+    .cs   = SAM0_QSPI_PIN_CS,
+    .wp   = SAM0_QSPI_PIN_DATA_2,
+    .hold = SAM0_QSPI_PIN_DATA_3,
+};
+
+static mtd_spi_nor_t samd51_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = 256,
+        .pages_per_sector = 16,
+    },
+    .params = &_samd51_nor_params,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&samd51_nor_dev;
+#endif /* MODULE_MTD */
+
+void board_init(void)
+{
+    if (IS_USED(MODULE_DAC_DDS)) {
+        gpio_init(SPEAKER_ENABLE_PIN, GPIO_OUT);
+        gpio_set(SPEAKER_ENABLE_PIN);
+    }
+
+    /* ST7735 driver is not supported yet uncomment the following code once it is */
+    /* if (IS_USED(MODULE_ST7735)) {
+        gpio_init(BACKLIGHT_PIN, GPIO_OUT);
+    }*/
+}

--- a/boards/adafruit-pybadge/doc.txt
+++ b/boards/adafruit-pybadge/doc.txt
@@ -1,0 +1,40 @@
+/**
+@defgroup    boards_adafruit-pybadge Adafruit PyBadge
+@ingroup     boards
+@brief       Support for the Adafruit PyBadge board.
+
+### General information
+
+The [Adafruit PyBadge](https://www.adafruit.com/product/4200) is a
+learning and development board that provides 5 Neopixel LEDs, an accelerometer,
+a light sensor, a speaker, several buttons and an LCD screen.
+It is powered by an Atmel SAMD51 microcontroller.
+
+The display, RGB LEDs, buttons and accelerometer of this board are currently not supported.
+
+The [Adafruit PyBadge LC](https://www.adafruit.com/product/3939) and
+[Adafruit EdgeBadge](https://www.adafruit.com/product/4400)) are
+variants of the Pybadge with small differences:
+- EdgeBadge provides an extra microphone (not supported)
+- PyBadgeLC only have one Neopixel LED (instead of 5)
+Both are compatible with the PyBadge RIOT port and the current port can easily
+be adapted/extended with their respective differences.
+
+### Flash the board
+
+Connect the board via USB and use `BOARD=adafruit-pybadge` with the `make` command;
+this uses the Arduino style bootloader preprogrammed on the board.<br/>
+Example with `hello-world` application:
+```
+     make BOARD=adafruit-pybadge -C examples/hello-world flash
+```
+
+In case of a crash of the firmware, one has to manually reset the board in
+bootloader mode to be able to re-flash it again: simply double tap the reset
+button before running the flash command provided above.
+
+### Accessing STDIO via UART
+
+STDIO of RIOT is directly available over the USB port.
+
+ */

--- a/boards/adafruit-pybadge/include/board.h
+++ b/boards/adafruit-pybadge/include/board.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-pybadge
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Adafruit PyBadge
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "mtd.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 23)                    /**< LED0 pin */
+
+#define LED_PORT            PORT->Group[PA]                     /**< LED0 port */
+#define LED0_MASK           (1 << 23)                           /**< LED0 mask */
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)   /**< LED0 on macro */
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)   /**< LED0 off macro */
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)   /**< LED0 toggle macro */
+
+#define LED0_NAME           "LED(Red)"                          /**< LED0 name */
+/** @} */
+
+/**
+ * @name    Buttons control (TI SN74HC165 shift register)
+ * @{
+ */
+#define BUTTON_LATCH        GPIO_PIN(PB, 0)                     /**< Latch pin */
+#define BUTTON_CLK          GPIO_PIN(PB, 31)                    /**< Clock pin */
+#define BUTTON_OUT          GPIO_PIN(PB, 30)                    /**< Serial output pin */
+/** @} */
+
+/**
+ * @name    Backlight control
+ * @{
+ */
+#define BACKLIGHT_PIN          GPIO_PIN(PA, 1)                  /**< Backlight pin */
+#define BACKLIGHT_PORT         PORT->Group[PA]                  /**< Backlight pin port */
+#define BACKLIGHT_MASK         (1 << 1)                         /**< Backlight pin mask */
+#define BACKLIGHT_ON           (BACKLIGHT_PORT.OUTSET.reg = BACKLIGHT_MASK) /**< Turn backlight on */
+#define BACKLIGHT_OFF          (BACKLIGHT_PORT.OUTCLR.reg = BACKLIGHT_MASK) /**< Turn backlight off */
+/** @} */
+
+/**
+ * @name    Display configuration (not supported yet)
+ * @{
+ */
+#define ST7735_PARAM_SPI       SPI_DEV(1)                      /**< SPI device */
+#define ST7735_PARAM_CS        GPIO_PIN(PB, 7)                 /**< Chip select pin */
+#define ST7735_PARAM_DCX       GPIO_PIN(PB, 5)                 /**< DCX pin */
+#define ST7735_PARAM_RST       GPIO_PIN(PA, 0)                 /**< Reset pin */
+#define ST7735_PARAM_NUM_LINES (128U)                          /**< Number of screen lines */
+#define ST7735_PARAM_RGB       (1)                             /**< RGB configuration */
+#define ST7735_PARAM_INVERTED  (1)                             /**< Inversion configuration */
+/** @} */
+
+/**
+ * @name    Neopixel LEDs (not supported yet)
+ * @{
+ */
+#define WS281X_PARAM_PIN        (GPIO_PIN(PA, 15))              /**< GPIO pin connected to the data pin of the first LED */
+#define WS281X_PARAM_NUMOF      (5U)                            /**< Number of LEDs chained */
+/** @} */
+
+/**
+ * @name    Speaker (supported via DAC DDS module)
+ * @{
+ */
+#define SPEAKER_ENABLE_PIN      GPIO_PIN(PA, 27)                /**< Speaker enable pin */
+#define SPEAKER_PIN             GPIO_PIN(PA, 2)                 /**< Speaker pin (A0) */
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+extern mtd_dev_t *mtd0;                                         /**< pointer to mtd0 */
+#define MTD_0 mtd0                                              /**< mtd0 constant */
+/** @} */
+
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (32)                        /**< Default timer is 32bit width */
+#define XTIMER_HZ                   (1000000ul)                 /**< Default timer runs at 1MHz */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/adafruit-pybadge/include/gpio_params.h
+++ b/boards/adafruit-pybadge/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-pybadge
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = LED0_NAME,
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/adafruit-pybadge/include/periph_conf.h
+++ b/boards/adafruit-pybadge/include/periph_conf.h
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C)  2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-pybadge
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Adafruit PyBadge
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    desired core clock frequency
+ * @{
+ */
+#ifndef CLOCK_CORECLOCK
+#define CLOCK_CORECLOCK     MHZ(120)
+#endif
+/** @} */
+
+/**
+ * @name    32kHz Oscillator configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                    0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      1
+/** @} */
+
+/**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC0,
+        .irq            = TC0_IRQn,
+        .mclk           = &MCLK->APBAMASK.reg,
+        .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
+        .gclk_id        = TC0_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {   /* Timer 1 */
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
+        .mclk           = &MCLK->APBBMASK.reg,
+        .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
+        .gclk_id        = TC2_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_ISR         isr_tc0
+
+/* Timer 1 configuration */
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_ISR         isr_tc2
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {    /* Virtual COM Port */
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB, 16),
+        .tx_pin   = GPIO_PIN(PB, 17),
+#ifdef MODULE_SAM0_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_PERIPH,
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5_2
+#define UART_0_ISR_TX       isr_sercom5_0
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 22), GPIO_MUX_G, 2 },
+};
+#endif
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    { .tim  = TCC_CONFIG(TCC0),
+      .chan = pwm_chan0_config,
+      .chan_numof = ARRAY_SIZE(pwm_chan0_config),
+      .gclk_src = SAM0_GCLK_PERIPH,
+    },
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &(SERCOM1->SPI),
+        .miso_pin = GPIO_PIN(PB, 22),
+        .mosi_pin = GPIO_PIN(PB, 23),
+        .clk_pin  = GPIO_PIN(PA, 17),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_2,
+        .mosi_pad = SPI_PAD_MOSI_3_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM1_DMAC_ID_TX,
+        .rx_trigger = SERCOM1_DMAC_ID_RX,
+#endif
+    },
+    {   /* Connected to TFT display */
+        .dev      = &(SERCOM4->SPI),
+        .miso_pin = GPIO_PIN(PB, 12),
+        .mosi_pin = GPIO_PIN(PB, 15),
+        .clk_pin  = GPIO_PIN(PB, 13),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_3_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
+    },
+    {   /* Connected to PDM Mic */
+        .dev      = &(SERCOM3->SPI),
+        .miso_pin = GPIO_PIN(PA, 18),
+        .mosi_pin = GPIO_PIN(PA, 19),
+        .clk_pin  = GPIO_PIN(PA, 16),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_2,
+        .mosi_pad = SPI_PAD_MOSI_3_SCK_1,
+        .gclk_src = SAM0_GCLK_PERIPH,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
+    },
+#ifdef MODULE_PERIPH_SPI_ON_QSPI
+    {    /* QSPI in SPI mode */
+        .dev      = QSPI,
+        .miso_pin = SAM0_QSPI_PIN_DATA_1,
+        .mosi_pin = SAM0_QSPI_PIN_DATA_0,
+        .clk_pin  = SAM0_QSPI_PIN_CLK,
+        .miso_mux = SAM0_QSPI_MUX,
+        .mosi_mux = SAM0_QSPI_MUX,
+        .clk_mux  = SAM0_QSPI_MUX,
+        .miso_pad = SPI_PAD_MISO_0,         /* unused */
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1,   /* unused */
+        .gclk_src = SAM0_GCLK_MAIN,         /* unused */
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = QSPI_DMAC_ID_TX,
+        .rx_trigger = QSPI_DMAC_ID_RX,
+#endif
+    },
+#endif
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 13),
+        .sda_pin  = GPIO_PIN(PA, 12),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = SAM0_GCLK_PERIPH,
+        .flags    = I2C_FLAG_NONE
+    },
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**,
+ * @name RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_H,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    }
+};
+/** @} */
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLA_PRESCALER_DIV128
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
+#define ADC_DEV                             ADC1
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN2)}, /* A2 */
+    {GPIO_PIN(PB, 9), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN3)}, /* A3 */
+    {GPIO_PIN(PB, 4), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6)}, /* A7 - Light sensor */
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+#define DAC_CLOCK           SAM0_GCLK_TIMER         /**< Must not exceed 12 MHz */
+/** Use external reference voltage on PA03
+ *
+ * PA03 has to be manually connected to Vcc.
+ * Internal reference only gives 1V */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VREFPU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14891,3 +14891,32 @@ drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J6
 drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAM_CS \(macro definition\) of file encx24j600_params\.h is not documented\.
 drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAM_INT \(macro definition\) of file encx24j600_params\.h is not documented\.
 drivers/encx24j600/include/encx24j600_params\.h:[0-9]+: warning: Member ENCX24J600_PARAMS \(macro definition\) of file encx24j600_params\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member CLOCK_CORECLOCK \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member EXTERNAL_OSC32_SOURCE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member TIMER_1_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member TIMER_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member timer_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR_TX \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member PWM_0_EN \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member PWM_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member pwm_chan0_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member I2C_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member RTT_FREQUENCY \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_PRESCALER \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_NEG_INPUT \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_REF_DEFAULT \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_DEV \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member adc_channels\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member sam_usbdev_config\[\] \(variable\) of file periph_conf\.h is not documented\.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds support for the [Adafruit PyBadge](https://www.adafruit.com/product/4200) board(s). The board support should also work for PyBadge LC (this one has only one NeoPixel instead of 5) and EdgeBadge (this one provides a microphone) variants.
They are very similar to the Itsybitsy (SAMD51, same QSPI nor flash, etc) but don't use the same MCU variant (samd51j19a instead of samd51**g**19a) and have some small configuration difference.

The current port provides definitions for the Neopixel LEDs, the TFT backlight and TFT screen although they are not really supported:
- the Neopixel requires WS281X driver but no compatible backend is available
- the TFT display is a ST7735 so requires #16176 (and I tried with it but didn't succeed)

Other things that are missing:
- there's an LIS3DH IMU, there's a driver on RIOT but uses SPI while on this board it's available via I2C
- All 8 control buttons are behind a shift register (similar to the one in DSP0401), probably a TI SN74HC165 (according to the [board schematics](https://cdn-learn.adafruit.com/assets/assets/000/075/064/original/adafruit_products_PyBadge_Sch.png)), so a dedicated driver is missing to be able to use them (that's easy to do but it's more work).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I wasn't able to fully run `compile_and_test_for_board.py` because after sometime my USB controller crashes and all tests start to fail.
I tested the I2C config by scanning 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
