### PR TITLE
sys/*timer: rework dependecies to ease backend switch, prefer ztimer_xtimer_compat over xtimer_on_ztimer

### DIFF
--- a/cpu/efm32/periph/Kconfig
+++ b/cpu/efm32/periph/Kconfig
@@ -39,14 +39,14 @@ config MODULE_PERIPH_RTC_SERIES1
         help
         RTC driver implementation for EFM32 series 1.
 
-config MODULE_PERIPH_RTT_SERIES0
+config PERIPH_RTT_SERIES0
     bool
     depends on CPU_EFM32_SERIES0
     default MODULE_PERIPH_RTT
     help
         RTT driver implementation for EFM32 series 0.
 
-config MODULE_PERIPH_RTT_SERIES1
+config PERIPH_RTT_SERIES1
     bool
     depends on CPU_EFM32_SERIES1
     default MODULE_PERIPH_RTT

--- a/cpu/qn908x/periph/Kconfig
+++ b/cpu/qn908x/periph/Kconfig
@@ -21,6 +21,4 @@ config MODULE_PERIPH_GPIO_MUX
 config MODULE_PERIPH_ADC
     bool "ADC peripheral driver"
     depends on HAS_PERIPH_ADC
-    select MODULE_ZTIMER
-    select MODULE_ZTIMER_USEC
-    select MODULE_ZTIMER_PERIPH_TIMER
+    select ZTIMER_USEC

--- a/drivers/ccs811/Kconfig
+++ b/drivers/ccs811/Kconfig
@@ -14,9 +14,7 @@ menuconfig MODULE_CCS811
     depends on TEST_KCONFIG
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_I2C
-    select MODULE_ZTIMER
-    select MODULE_ZTIMER_USEC
-    select MODULE_ZTIMER_PERIPH_TIMER
+    select ZTIMER_USEC
 
 config MODULE_CCS811_FULL
     bool "Full functionalities"

--- a/makefiles/boards/ztimer_only.dep.mk
+++ b/makefiles/boards/ztimer_only.dep.mk
@@ -1,11 +1,11 @@
 # Include this for boards whose timer periph cannot generate a clock frequency
 # suitable for xtimer with the available clock sources and dividers.
 # This will use ztimer to perform the required frequency conversion.
-# By default, xtimer is still used with ztimer as backed, unless
-# ztimer_xtimer_compat is used.
+# By default, ztimer_xtimer_compat is used unless xtimer_on_ztimer is
+# selected.
 
 ifneq (,$(filter xtimer,$(USEMODULE)))
-  ifeq (,$(filter ztimer_xtimer_compat ztimer64_xtimer_compat,$(USEMODULE)))
-    USEMODULE += xtimer_on_ztimer
+  ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+    USEMODULE += ztimer_xtimer_compat
   endif
 endif

--- a/makefiles/default_modules.deps.mk
+++ b/makefiles/default_modules.deps.mk
@@ -13,3 +13,9 @@ endif
 ifneq (,$(filter auto_init_saul,$(USEMODULE)))
   USEMODULE += saul_init_devs
 endif
+
+ifneq (,$(filter xtimer,$(USEMODULE)))
+  ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    USEMODULE += div
+  endif
+endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -257,6 +257,7 @@ PSEUDOMODULES += vfs_default
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer
+PSEUDOMODULES += xtimer_no_ztimer_default
 PSEUDOMODULES += zptr
 PSEUDOMODULES += ztimer
 PSEUDOMODULES += ztimer_%

--- a/pkg/u8g2/Kconfig
+++ b/pkg/u8g2/Kconfig
@@ -10,8 +10,7 @@ config PACKAGE_U8G2
     depends on TEST_KCONFIG
     depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_GPIO
-    select MODULE_ZTIMER
-    select MODULE_ZTIMER_USEC
+    select ZTIMER_USEC
     select MODULE_U8G2_RIOT
     select MODULE_U8G2_CSRC
 

--- a/pkg/ucglib/Kconfig
+++ b/pkg/ucglib/Kconfig
@@ -10,8 +10,7 @@ config PACKAGE_UCGLIB
     depends on TEST_KCONFIG
     depends on HAS_PERIPH_GPIO
     select MODULE_PERIPH_GPIO
-    select MODULE_ZTIMER
-    select MODULE_ZTIMER_USEC
+    select ZTIMER_USEC
     select MODULE_UCGLIB_RIOT
     select MODULE_UCGLIB_CSRC
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -857,20 +857,7 @@ endif
 
 # handle xtimer's deps. Needs to be done *after* ztimer
 ifneq (,$(filter xtimer,$(USEMODULE)))
-  ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-    # xtimer is used, ztimer xtimer wrapper is not
-    DEFAULT_MODULE += auto_init_xtimer
-    USEMODULE += div
-    ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
-      # ztimer is not used, so use *periph_timer as low-level timer*.
-      FEATURES_REQUIRED += periph_timer
-    else
-      # will use *ztimer_usec as low-level timer*
-    endif
-  else
-    # ztimer_xtimer_compat is used, all of *xtimer's API will be mapped on ztimer
-    # or ztimer64 *
-  endif
+  include $(RIOTBASE)/sys/xtimer/Makefile.dep
 endif
 
 ifneq (,$(filter devfs_hwrng,$(USEMODULE)))

--- a/sys/shell/commands/sc_gnrc_udp.c
+++ b/sys/shell/commands/sc_gnrc_udp.c
@@ -31,9 +31,10 @@
 #include "net/utils.h"
 #include "timex.h"
 #include "utlist.h"
-#if IS_USED(MODULE_ZTIMER)
+#if IS_USED(MODULE_ZTIMER_USEC) || IS_USED(MODULE_ZTIMER_MSEC)
 #include "ztimer.h"
-#else
+#endif
+#if IS_USED(MODULE_XTIMER)
 #include "xtimer.h"
 #endif
 

--- a/sys/trace/Kconfig
+++ b/sys/trace/Kconfig
@@ -8,6 +8,4 @@
 config MODULE_TRACE
     bool "Trace program flows"
     depends on TEST_KCONFIG
-    select MODULE_ZTIMER
-    select MODULE_ZTIMER_USEC
-    select MODULE_ZTIMER_PERIPH_TIMER
+    select ZTIMER_USEC

--- a/sys/xtimer/Kconfig
+++ b/sys/xtimer/Kconfig
@@ -8,17 +8,22 @@
 menuconfig MODULE_XTIMER
     bool "xtimer"
     depends on HAS_PERIPH_TIMER
-    depends on TEST_KCONFIG
-    # use timer peripheral unless ztimer compatibility module is used
-    select MODULE_PERIPH_TIMER if HAS_PERIPH_TIMER && !MODULE_XTIMER_ON_ZTIMER && !MODULE_ZTIMER_XTIMER_COMPAT && !MODULE_ZTIMER64_XTIMER_COMPAT
-
+    select MODULE_PERIPH_TIMER
     select MODULE_DIV if !MODULE_ZTIMER_XTIMER_COMPAT
+    select ZTIMER_USEC if !MODULE_XTIMER_NO_ZTIMER_DEFAULT
     help
         Include xtimer module. xtimer requires a low-level timer implementation
         that can be provided either by a peripheral timer or the ztimer module
         when MODULE_XTIMER_ON_ZTIMER is enabled.
 
+if MODULE_XTIMER
+
+config MODULE_XTIMER_NO_ZTIMER_DEFAULT
+    bool "xtimer does not select ztimer"
+    default y
+
 config MODULE_AUTO_INIT_XTIMER
     bool "Auto-init xtimer"
     default y if MODULE_AUTO_INIT && !MODULE_ZTIMER_XTIMER_COMPAT
-    depends on MODULE_XTIMER
+
+endif # MODULE_XTIMER

--- a/sys/xtimer/Makefile.dep
+++ b/sys/xtimer/Makefile.dep
@@ -1,14 +1,31 @@
-ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-  # xtimer is used, ztimer xtimer wrapper is not
-  DEFAULT_MODULE += auto_init_xtimer
-  USEMODULE += div
-  ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
-    # ztimer is not used, so use *periph_timer as low-level timer*.
-    FEATURES_REQUIRED += periph_timer
-  else
-    # will use *ztimer_usec as low-level timer*
+DEFAULT_MODULE += auto_init_xtimer
+# In whatever combination of backends periph_timer will be required
+# - xtimer (only) -> periph_timer
+# - xtimer_on_ztimer -> ztimer_usec -> ztimer_periph_timer -> periph_timer
+# - ztimer_xtimer_compat -> ztimer_usec -> ztimer_periph_timer -> periph_timer
+# But requesting it here avoid an ifeq dependency that would be subject to
+# dependency inclusion order issues
+FEATURES_REQUIRED += periph_timer
+
+USEMODULE += xtimer_no_ztimer_default
+ifeq (,$(filter xtimer_no_ztimer_default,$(USEMODULE)))
+  ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    USEMODULE += xtimer_on_ztimer
   endif
 else
-  # ztimer_xtimer_compat is used, all of *xtimer's API will be mapped on ztimer
-  # or ztimer64 *
+  ifneq (,$(filter ztimer,$(USEMODULE)))
+    ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+      USEMODULE += xtimer_on_ztimer
+    endif
+  endif
+endif
+
+ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  DISABLE_MODULE += auto_init_xtimer
+  USEMODULE += div
+endif
+
+# make xtimer use ztimer_usec as low level timer
+ifneq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+  USEMODULE += ztimer_usec
 endif

--- a/sys/xtimer/Makefile.dep
+++ b/sys/xtimer/Makefile.dep
@@ -9,13 +9,13 @@ FEATURES_REQUIRED += periph_timer
 
 USEMODULE += xtimer_no_ztimer_default
 ifeq (,$(filter xtimer_no_ztimer_default,$(USEMODULE)))
-  ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-    USEMODULE += xtimer_on_ztimer
+  ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+    USEMODULE += ztimer_xtimer_compat
   endif
 else
   ifneq (,$(filter ztimer,$(USEMODULE)))
-    ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-      USEMODULE += xtimer_on_ztimer
+    ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+      USEMODULE += ztimer_xtimer_compat
     endif
   endif
 endif

--- a/sys/xtimer/Makefile.dep
+++ b/sys/xtimer/Makefile.dep
@@ -1,0 +1,14 @@
+ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  # xtimer is used, ztimer xtimer wrapper is not
+  DEFAULT_MODULE += auto_init_xtimer
+  USEMODULE += div
+  ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+    # ztimer is not used, so use *periph_timer as low-level timer*.
+    FEATURES_REQUIRED += periph_timer
+  else
+    # will use *ztimer_usec as low-level timer*
+  endif
+else
+  # ztimer_xtimer_compat is used, all of *xtimer's API will be mapped on ztimer
+  # or ztimer64 *
+endif

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -143,23 +143,18 @@ choice
     bool "xtimer compatibility"
     depends on MODULE_XTIMER && MODULE_ZTIMER
 
-config MODULE_XTIMER_ON_ZTIMER
-    bool "ztimer_usec as timer backend for xtimer"
-    select MODULE_ZTIMER_USEC
-    select MODULE_ZTIMER_PERIPH_TIMER
-
 config MODULE_ZTIMER_XTIMER_COMPAT
     bool "map xtimer calls to ztimer"
     select MODULE_DIV
     select MODULE_ZTIMER_USEC
     select MODULE_ZTIMER_PERIPH_TIMER
     help
-        This is a wrapper of xtimer API on ztimer_usec and is currently
-        incomplete. Unless doing testing, use xtimer on ztimer.
+        This is a wrapper of xtimer API on ztimer_usec.
 
-comment "The ztimer xtimer compatibility module is incomplete, consider using MODULE_ZTIMER64_XTIMER_COMPAT instead."
-    depends on MODULE_ZTIMER_XTIMER_COMPAT
-
+config MODULE_XTIMER_ON_ZTIMER
+    bool "ztimer_usec as timer backend for xtimer"
+    select MODULE_ZTIMER_USEC
+    select MODULE_ZTIMER_PERIPH_TIMER
 endchoice
 
 config MODULE_ZTIMER64_XTIMER_COMPAT

--- a/sys/ztimer/Kconfig
+++ b/sys/ztimer/Kconfig
@@ -152,6 +152,7 @@ config MODULE_ZTIMER_XTIMER_COMPAT
     bool "map xtimer calls to ztimer"
     select MODULE_DIV
     select MODULE_ZTIMER_USEC
+    select MODULE_ZTIMER_PERIPH_TIMER
     help
         This is a wrapper of xtimer API on ztimer_usec and is currently
         incomplete. Unless doing testing, use xtimer on ztimer.

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -13,13 +13,6 @@ endif
 
 # unless ztimer_xtimer_compat is used, make xtimer use ztimer_usec as backend.
 ifneq (,$(filter ztimer,$(USEMODULE)))
-  ifneq (,$(filter xtimer,$(USEMODULE)))
-    ifeq (,$(filter ztimer_xtimer_compat ztimer64_xtimer_compat,$(USEMODULE)))
-      USEMODULE += xtimer_on_ztimer
-    else
-      USEMODULE += div
-    endif
-  endif
   ifneq (,$(filter evtimer,$(USEMODULE)))
     USEMODULE += evtimer_on_ztimer
   endif
@@ -32,11 +25,6 @@ endif
 ifneq (,$(filter ztimer64_xtimer_compat,$(USEMODULE)))
   USEMODULE += ztimer64_usec
   USEMODULE += ztimer_xtimer_compat
-endif
-
-# make xtimer use ztimer_usec as low level timer
-ifneq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
-  USEMODULE += ztimer_usec
 endif
 
 # make evtimer use ztimer_msec as low level timer

--- a/tests/xtimer_now32_overflow/Makefile
+++ b/tests/xtimer_now32_overflow/Makefile
@@ -1,7 +1,23 @@
 include ../Makefile.tests_common
 
 USEMODULE += xtimer
+USEMODULE += xtimer_no_ztimer_default
 
 DISABLE_MODULE += auto_init_xtimer
+
+# Boards that can't run only on xtimer or that always select ztimer
+BOARD_BLACKLIST += \
+                   feather-nrf52840 \
+                   hamilton \
+                   mulle \
+                   pinetime \
+                   ruuvitag \
+                   stm32f429i-disco \
+                   thingy52 \
+                   waspmote-pro  \
+                   weact-f401cc \
+                   weact-f401ce \
+                   weact-f411ce \
+                   #
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_now32_overflow/app.config.test
+++ b/tests/xtimer_now32_overflow/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_XTIMER_NO_ZTIMER_DEFAULT=y
 CONFIG_MODULE_AUTO_INIT_XTIMER=n

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -2,8 +2,23 @@ include ../Makefile.tests_common
 
 USEMODULE += fmt
 USEMODULE += xtimer
+USEMODULE += xtimer_no_ztimer_default
 
 # This test randomly fails on `native` so disable it from CI
 TEST_ON_CI_BLACKLIST += native
+# Boards that can't run only on xtimer or that always select ztimer
+BOARD_BLACKLIST += \
+                   feather-nrf52840 \
+                   hamilton \
+                   mulle \
+                   pinetime \
+                   ruuvitag \
+                   stm32f429i-disco \
+                   thingy52 \
+                   waspmote-pro  \
+                   weact-f401cc \
+                   weact-f401ce \
+                   weact-f411ce \
+                   #
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_now64_continuity/app.config.test
+++ b/tests/xtimer_now64_continuity/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_XTIMER=y
+CONFIG_MODULE_XTIMER_NO_ZTIMER_DEFAULT=y
 CONFIG_MODULE_FMT=y


### PR DESCRIPTION
### Contribution description

Although I prefer how it's done in #17809, I realize I'm changing a lot of things when the initial objective was only to have an easy-to-switch backend default for `xtimer`, so let's do it simple, even if it keeps all the indirections...

Note this PR also changes the default prefered `xtimer` backend to `ztimer_on_xtimer`, that can also be an individual PR.

~~Marking as WIP will I let Murdock check I didn't make a fundamentally wrong change.~~

### Testing procedure

- Green Murdock

### Issues/PRs references

#17721
