### PR TITLE
boards/blxxxpill: configure usbdev_fs

### DIFF
--- a/boards/common/blxxxpill/Kconfig
+++ b/boards/common/blxxxpill/Kconfig
@@ -17,6 +17,7 @@ config BOARD_COMMON_BLXXXPILL
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_QDEC
+    select HAS_PERIPH_USBDEV
 
     # Clock configuration
     select BOARD_HAS_HSE

--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -11,3 +11,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_qdec
+FEATURES_PROVIDED += periph_usbdev

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -310,6 +310,32 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @brief USB device FS configuration
+ */
+static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
+    {
+        .base_addr  = (uintptr_t)USB,
+        .rcc_mask   = RCC_APB1ENR_USBEN,
+        .irqn       = USB_LP_CAN1_RX0_IRQn,
+        .apb        = APB1,
+        .dm         = GPIO_PIN(PORT_A, 11),
+        .dp         = GPIO_PIN(PORT_A, 12),
+        .af         = GPIO_AF_UNDEF,
+        .disconn    = GPIO_UNDEF,
+    },
+};
+
+/**
+ * @brief Interrupt function name mapping
+ */
+#define USBDEV_ISR             isr_usb_lp_can1_rx0
+
+/**
+ * @brief Number of available USB device FS peripherals
+ */
+#define USBDEV_NUMOF           ARRAY_SIZE(stm32_usbdev_fs_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -4,7 +4,8 @@
 USEMODULE += periph stm32_clk stm32_vectors
 
 ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
-  ifeq (,$(filter f3 wb,$(CPU_FAM)))
+  # TODO: STM32F105xx and STM32F107xx also use synopsys_dwc2
+  ifeq (,$(filter f1 f3 wb,$(CPU_FAM)))
     USEMODULE += usbdev_synopsys_dwc2
   endif
   USEMODULE += ztimer

--- a/cpu/stm32/include/periph/cpu_gpio.h
+++ b/cpu/stm32/include/periph/cpu_gpio.h
@@ -117,9 +117,9 @@ typedef enum {
     GPIO_AF14,              /**< use alternate function 14 */
     GPIO_AF15,              /**< use alternate function 15 */
 #endif
+#endif
     GPIO_AF_UNDEF           /** an UNDEF value definition, e.g. for register
                                 based spi */
-#endif
 } gpio_af_t;
 
 #ifdef CPU_FAM_STM32F1

--- a/cpu/stm32/periph/Makefile
+++ b/cpu/stm32/periph/Makefile
@@ -51,7 +51,7 @@ endif
 
 # Select the correct implementation for `periph_usbdev`
 ifneq (,$(filter periph_usbdev,$(USEMODULE)))
-  ifneq (,$(filter f3 wb,$(CPU_FAM)))
+  ifneq (,$(filter f1 f3 wb,$(CPU_FAM)))
     SRC += usbdev_fs.c
   endif
 endif

--- a/tests/sys_fido2_ctap/Makefile.ci
+++ b/tests/sys_fido2_ctap/Makefile.ci
@@ -1,0 +1,6 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    blackpill \
+    blackpill-128kib \
+    bluepill \
+    bluepill-128kib \
+    #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This attempts to enable the `usbdev_fs` module on STM32F1.
Unfortunately this does not work yet - It builds, but it looks like something else needs to be enabled on this platform.
Nothing shows up in `dmesg` when the USB test code is run (also no errors).

I don't know where to start looking for what it could be, but looking for some pointers to get USB support for this popular board.


### Testing procedure

Flash e.g. `tests/usbus_hid` or `tests/usbus_cdc_acm_stdio` on a bluepill or blackpill board.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
