### PR TITLE
tests: rework eth drivers

### DIFF
--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -443,8 +443,6 @@ static int stm32_eth_init(netdev_t *netdev)
                 | ETH_DMABMR_RDP_32Beat | ETH_DMABMR_PBL_32Beat
                 | ETH_DMABMR_EDE;
 
-    netdev_register(netdev, NETDEV_STM32_ETH, 0);
-
     eui48_t hwaddr;
     netdev_eui48_get(netdev, &hwaddr);
     stm32_eth_set_addr(hwaddr.uint8);
@@ -719,4 +717,5 @@ void stm32_eth_netdev_setup(netdev_t *netdev)
 {
     stm32_eth_netdev = netdev;
     netdev->driver = &netdev_driver_stm32f4eth;
+    netdev_register(netdev, NETDEV_STM32_ETH, 0);
 }

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -81,13 +81,15 @@ static inline void unlock(encx24j600_t *dev) {
     spi_release(dev->spi);
 }
 
-void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params)
+void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params, uint8_t index)
 {
     dev->netdev.driver = &netdev_driver_encx24j600;
     dev->spi = params->spi;
     dev->cs = params->cs_pin;
     dev->int_pin = params->int_pin;
     dev->rx_next_ptr = RX_BUFFER_START;
+
+    netdev_register(&dev->netdev, NETDEV_ENCX24J600, index);
 }
 
 static void encx24j600_isr(void *arg)

--- a/drivers/include/encx24j600.h
+++ b/drivers/include/encx24j600.h
@@ -59,8 +59,10 @@ typedef struct {
  *
  * @param[out] dev     the handle of the device to initialize
  * @param[in]  params  parameters for device initialization
+ * @param[in]  index   Index of @p params in a global parameter struct array.
+ *                     If initialized manually, pass a unique identifier instead.
  */
-void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params);
+void encx24j600_setup(encx24j600_t *dev, const encx24j600_params_t *params, uint8_t index);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -324,6 +324,7 @@ typedef enum {
     NETDEV_ETHOS,
     NETDEV_SLIPDEV,
     NETDEV_TAP,
+    NETDEV_W5100,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -325,6 +325,7 @@ typedef enum {
     NETDEV_SLIPDEV,
     NETDEV_TAP,
     NETDEV_W5100,
+    NETDEV_ENCX24J600,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/drivers/include/w5100.h
+++ b/drivers/include/w5100.h
@@ -74,8 +74,13 @@ typedef struct {
  *
  * This function pre-initializes the netdev structure, saves the configuration
  * parameters and finally initializes the SPI bus and the used GPIO pins.
+ *
+ * @param [out] dev     the handle of the device to initialize
+ * @param [in]  params  parameters for device initialization
+ * @param [in]  index   Index of @p params in a global parameter struct array.
+ *                      If initialized manually, pass a unique identifier instead.
  */
-void w5100_setup(w5100_t *dev, const w5100_params_t *params);
+void w5100_setup(w5100_t *dev, const w5100_params_t *params, uint8_t index);
 
 #ifdef __cplusplus
 }

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -110,8 +110,11 @@ static void extint(void *arg)
     netdev_trigger_event_isr(&dev->nd);
 }
 
-void w5100_setup(w5100_t *dev, const w5100_params_t *params)
+void w5100_setup(w5100_t *dev, const w5100_params_t *params, uint8_t index)
 {
+    assert(dev);
+    assert(params);
+
     /* initialize netdev structure */
     dev->nd.driver = &netdev_driver_w5100;
     dev->nd.event_callback = NULL;
@@ -123,6 +126,8 @@ void w5100_setup(w5100_t *dev, const w5100_params_t *params)
     /* initialize the chip select pin and the external interrupt pin */
     spi_init_cs(dev->p.spi, dev->p.cs);
     gpio_init_int(dev->p.evt, GPIO_IN, GPIO_FALLING, extint, dev);
+
+    netdev_register(&dev->nd, NETDEV_W5100, index);
 }
 
 static int init(netdev_t *netdev)

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -188,6 +188,9 @@ endif
 ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
   DIRS += test_utils/interactive_sync
 endif
+ifneq (,$(filter test_utils_netdev_eth_minimal,$(USEMODULE)))
+  DIRS += test_utils/netdev_eth_minimal
+endif
 ifneq (,$(filter test_utils_result_output,$(USEMODULE)))
   DIRS += test_utils/result_output
 endif

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -151,3 +151,7 @@ ifneq (,$(filter usbus_dfu riotboot_reset,$(USEMODULE)))
   CFLAGS += -DCPU_RAM_BASE=$(RAM_START_ADDR)
   CFLAGS += -DCPU_RAM_SIZE=$(RAM_LEN)
 endif
+
+ifneq (,$(filter test_utils_netdev_eth_minimal,$(USEMODULE)))
+  CFLAGS += -DCONFIG_NETDEV_REGISTER_SIGNAL
+endif

--- a/sys/include/test_utils/netdev_eth_minimal.h
+++ b/sys/include/test_utils/netdev_eth_minimal.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    test_utils_netdev_eth_minimal Minimal netdev Ethernet device processing
+ * @ingroup     sys
+ *
+ * @{
+ * @file
+ * @brief       Provides basic functionalities to interact with an Ethernet networking
+ *              device which implements the @ref drivers_netdev_api.
+ *
+ * To use the functionalities, include the module `USEMODULE += test_utils_netdev_eth_minimal`.
+ * The test application should provide:
+ *  - device initialization, via the implementation of @ref netdev_eth_minimal_init_devs
+ *  - number of devices to test, via the definition of @ref NETDEV_ETH_MINIMAL_NUMOF in `init_dev.h`
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef TEST_UTILS_NETDEV_ETH_MINIMAL_H
+#define TEST_UTILS_NETDEV_ETH_MINIMAL_H
+
+#include "net/netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef DOXYGEN
+/**
+ * @brief Maximum number of devices to handle.
+ * @note Should be provided by the application via `init_dev.h`.
+ */
+#define NETDEV_ETH_MINIMAL_NUMOF
+#endif
+
+/**
+ * @brief   Device-under-test initialization function.
+ * @note    Should be implemented by the test application
+ *
+ * @param[in] cb    Callback to be set to @ref netdev::event_callback
+ *
+ * @retval 0 on success
+ * @retval != 0 on error
+ */
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb);
+
+/**
+ * @brief   Initialize the module.
+ *
+ * @retval 0 on success
+ * @retval != 0 on error
+ */
+int netdev_eth_minimal_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEST_UTILS_NETDEV_ETH_MINIMAL_H */
+/** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_encx24j600.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_encx24j600.c
@@ -58,7 +58,7 @@ void auto_init_encx24j600(void)
         LOG_DEBUG("[auto_init_netif] initializing encx24j600 #%u\n", i);
 
         /* setup netdev device */
-        encx24j600_setup(&encx24j600[i], &encx24j600_params[i]);
+        encx24j600_setup(&encx24j600[i], &encx24j600_params[i], i);
 
         /* initialize netdev<->gnrc adapter state */
         gnrc_netif_ethernet_create(&_netif[i], _netdev_eth_stack[i], ENCX24J600_MAC_STACKSIZE,

--- a/sys/net/gnrc/netif/init_devs/auto_init_w5100.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_w5100.c
@@ -55,7 +55,7 @@ void auto_init_w5100(void)
         LOG_DEBUG("[auto_init_netif] initializing w5100 #%u\n", i);
 
         /* setup netdev device */
-        w5100_setup(&dev[i], &w5100_params[i]);
+        w5100_setup(&dev[i], &w5100_params[i], i);
         /* initialize netdev <-> gnrc adapter state */
         gnrc_netif_ethernet_create(&_netif[i], stack[i], MAC_STACKSIZE, MAC_PRIO, "w5100",
                                    &dev[i].nd);

--- a/sys/test_utils/Makefile.dep
+++ b/sys/test_utils/Makefile.dep
@@ -10,3 +10,6 @@ ifneq (,$(filter benchmark_udp,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += xtimer
 endif
+ifneq (,$(filter test_utils_netdev_eth_minimal,$(USEMODULE)))
+  include $(RIOTBASE)/sys/test_utils/netdev_eth_minimal/Makefile.dep
+endif

--- a/sys/test_utils/netdev_eth_minimal/Makefile
+++ b/sys/test_utils/netdev_eth_minimal/Makefile
@@ -1,0 +1,3 @@
+MODULE = test_utils_netdev_eth_minimal
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/test_utils/netdev_eth_minimal/Makefile.dep
+++ b/sys/test_utils/netdev_eth_minimal/Makefile.dep
@@ -1,0 +1,6 @@
+USEMODULE += event
+USEMODULE += event_thread
+USEMODULE += l2util
+USEMODULE += od
+USEMODULE += od_string
+USEMODULE += shell

--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     test_utils_netdev_eth_minimal
+ * @{
+ *
+ * @file
+ * @brief       Implementation of netdev Eth minimal test utility module
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#include <stdio.h>
+
+#include "event.h"
+#include "event/thread.h"
+#include "od.h"
+#include "net/ethernet.h"
+#include "net/ethernet/hdr.h"
+#include "net/l2util.h"
+#include "net/netdev.h"
+#include "net/netdev/eth.h"
+#include "test_utils/netdev_eth_minimal.h"
+#include "netdev_eth_minimal_internal.h"
+
+/* provided by the test application */
+#include "init_dev.h"
+
+device_reg_entry_t _devices[NETDEV_ETH_MINIMAL_NUMOF];
+static uint8_t _buffer[ETHERNET_MAX_LEN];
+static char _addr_str[ETHERNET_ADDR_LEN * 3];
+
+void _recv(netdev_t *dev)
+{
+    ssize_t data_len;
+    netdev_eth_rx_info_t rx_info = { 0 };
+    ethernet_hdr_t *header = (ethernet_hdr_t *)_buffer;
+    uint8_t *payload = _buffer + sizeof(ethernet_hdr_t);
+
+    putchar('\n');
+    data_len = dev->driver->recv(dev, _buffer, sizeof(_buffer), &rx_info);
+    if (data_len < 0) {
+        return;
+    }
+
+    l2util_addr_to_str(header->dst, ETHERNET_ADDR_LEN, _addr_str);
+    printf("Dest. addr.: %s\n", _addr_str);
+
+    l2util_addr_to_str(header->src, ETHERNET_ADDR_LEN, _addr_str);
+    printf("Src. addr.: %s\n", _addr_str);
+
+    data_len -= sizeof(ethernet_hdr_t);
+    printf("Payload (%u bytes): \n", (unsigned)data_len);
+    od_hex_dump(payload, data_len, 0);
+}
+
+static void _isr_event_handler(event_t *event)
+{
+    /* recover the netdev from the event */
+    device_reg_entry_t *netdev_event = container_of(event, device_reg_entry_t, event);
+    netdev_t *netdev = netdev_event->dev;
+    netdev->driver->isr(netdev);
+}
+
+static void _event_cb(netdev_t *dev, netdev_event_t event)
+{
+    device_reg_entry_t *device = dev->context;
+
+    switch (event) {
+    case NETDEV_EVENT_ISR:
+        event_post(EVENT_PRIO_HIGHEST, &device->event);
+        break;
+
+    case NETDEV_EVENT_RX_COMPLETE:
+        _recv(dev);
+        break;
+
+    default:
+        break;
+    }
+}
+
+/* Implement netdev_register_signal hook to associate registered devices to specific event
+ * structures.
+ */
+void netdev_register_signal(struct netdev *dev, netdev_type_t type, uint8_t index)
+{
+    (void) type;
+
+    if (index > NETDEV_ETH_MINIMAL_NUMOF) {
+        return;
+    }
+    printf("Device %d registered (type: %d)\n", index, type);
+    dev->context = &_devices[index];
+    _devices[index].dev = dev;
+    _devices[index].event.handler = _isr_event_handler;
+}
+
+int netdev_eth_minimal_init(void)
+{
+    return netdev_eth_minimal_init_devs(_event_cb);
+}
+
+/** @} */

--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal_internal.h
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal_internal.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test_utils_netdev_eth_minimal
+ *
+ * @{
+ * @file
+ * @brief       Internal definitions for the netdev_eth_minimal module
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef NETDEV_ETH_MINIMAL_INTERNAL_H
+#define NETDEV_ETH_MINIMAL_INTERNAL_H
+
+#include "net/netdev.h"
+#include "event.h"
+#include "init_dev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Registry entry to keep track of registered Ethernet network devices
+ *
+ * Each registered device has an associated event to serve its ISRs.
+ */
+typedef struct {
+    event_t event;      /**< event to serve ISR */
+    netdev_t *dev;      /**< pointer to the device */
+} device_reg_entry_t;
+
+/**
+ * @brief   Registry of Ethernet devices to serve ISRs.
+ */
+extern device_reg_entry_t _devices[NETDEV_ETH_MINIMAL_NUMOF];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETDEV_ETH_MINIMAL_INTERNAL_H */
+/** @} */

--- a/sys/test_utils/netdev_eth_minimal/shell_commands.c
+++ b/sys/test_utils/netdev_eth_minimal/shell_commands.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     test_utils_netdev_eth_minimal
+ * @{
+ *
+ * @file
+ * @brief       Shell commands for netdev Eth minimal test utility module
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "net/ethernet/hdr.h"
+#include "net/ethertype.h"
+#include "net/l2util.h"
+#include "byteorder.h"
+#include "shell.h"
+#include "iolist.h"
+#include "assert.h"
+#include "netdev_eth_minimal_internal.h"
+#include "init_dev.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+int ifconfig_list(int idx)
+{
+    int res;
+    netdev_t *dev = _devices[idx].dev;
+    uint8_t addr[ETHERNET_ADDR_LEN];
+    char addr_str[ETHERNET_ADDR_LEN * 3];
+
+    printf("Iface %3d  HWaddr: ", idx);
+    res = dev->driver->get(dev, NETOPT_ADDRESS, addr, sizeof(addr));
+    assert(res > 0);
+    l2util_addr_to_str(addr, ETHERNET_ADDR_LEN, addr_str);
+    printf("%s\n", addr_str);
+
+    return 0;
+}
+
+int cmd_ifconfig(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    for (unsigned int i = 0; i < NETDEV_ETH_MINIMAL_NUMOF; i++) {
+        ifconfig_list(i);
+    }
+    return 0;
+}
+
+static int _print_txtsnd_usage(char *cmd) {
+    printf("usage: %s <iface> <addr> <text>\n", cmd);
+    return 1;
+}
+
+static int cmd_txtsnd(int argc, char **argv)
+{
+    ethernet_hdr_t header;
+    int res;
+
+    if (4 != argc) {
+        return _print_txtsnd_usage(argv[0]);
+    }
+
+    int iface = atoi(argv[1]);
+    if (iface < 0 || (unsigned)iface >= NETDEV_ETH_MINIMAL_NUMOF) {
+        printf("unknown interface %d\n", iface);
+        return _print_txtsnd_usage(argv[0]);
+    }
+
+    /* build Ethernet header */
+    res = l2util_addr_from_str(argv[2], header.dst);
+    if (!res) {
+        puts("Could not parse address");
+        return _print_txtsnd_usage(argv[0]);
+    }
+
+    netdev_t *dev = _devices[iface].dev;
+    if (!dev) {
+        return _print_txtsnd_usage(argv[0]);
+    }
+
+    dev->driver->get(dev, NETOPT_ADDRESS, header.src, ETHERNET_ADDR_LEN);
+    header.type = byteorder_htons(ETHERTYPE_UNKNOWN);
+
+    /* prepare iolists to send */
+    iolist_t io_data = { 0 };
+    io_data.iol_base = argv[3];
+    io_data.iol_len = strlen(argv[3]);
+
+    iolist_t io_header = { 0 };
+    io_header.iol_base = &header;
+    io_header.iol_len = sizeof(ethernet_hdr_t);
+    io_header.iol_next = &io_data;
+
+    /* send */
+    res = dev->driver->send(dev, &io_header);
+    if (res < 0) {
+        puts("txtsnd: Could not send");
+        return 1;
+    }
+
+    puts("Successfully sent");
+    return 0;
+}
+
+SHELL_COMMAND(txtsnd, "Send an Ethernet frame", cmd_txtsnd);
+SHELL_COMMAND(ifconfig, "List interfaces", cmd_ifconfig);

--- a/tests/driver_dose/Makefile
+++ b/tests/driver_dose/Makefile
@@ -1,3 +1,7 @@
+include ../Makefile.tests_common
+
+USEMODULE += test_utils_netdev_eth_minimal
+
 # the driver to test
 USEMODULE += dose
 
@@ -13,4 +17,6 @@ ifneq (,$(filter same54-xpro, $(BOARD)))
   USEMODULE += dose_watchdog
 endif
 
-include ../driver_netdev_common/Makefile.netdev.mk
+INCLUDES += -I$(APPDIR)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_dose/Makefile.ci
+++ b/tests/driver_dose/Makefile.ci
@@ -1,30 +1,13 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
-    arduino-mega2560 \
     arduino-nano \
     arduino-uno \
-    atxmega-a3bu-xplained \
     atmega328p \
     atmega328p-xplained-mini \
-    bluepill-stm32f030c8 \
-    i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
-    nucleo-f303k8 \
-    nucleo-f334r8 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
-    nucleo-l053r8 \
     samd10-xmini \
-    slstk3400a \
-    stk3200 \
     stm32f030f4-demo \
-    stm32f0discovery \
-    stm32g0316-disco \
-    stm32l0538-disco \
-    waspmote-pro \
     #

--- a/tests/driver_dose/init_dev.h
+++ b/tests/driver_dose/init_dev.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file DOSE driver
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "net/netdev.h"
+
+#include "dose.h"
+#include "dose_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DOSE_NUM   ARRAY_SIZE(dose_params)
+#define NETDEV_ETH_MINIMAL_NUMOF      DOSE_NUM
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_dose/main.c
+++ b/tests/driver_dose/main.c
@@ -1,1 +1,68 @@
-../driver_netdev_common/main.c
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for DOSE driver
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "test_utils/netdev_eth_minimal.h"
+#include "init_dev.h"
+#include "assert.h"
+#include "dose.h"
+#include "dose_params.h"
+
+static dose_t dose[DOSE_NUM];
+
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb) {
+    for (unsigned i = 0; i < DOSE_NUM; i ++) {
+        netdev_t *device = &dose[i].netdev;
+
+        /* setup the specific driver */
+        dose_setup(&dose[i], &dose_params[i], i);
+
+        /* set the application-provided callback */
+        device->event_callback = cb;
+
+        /* initialize the device driver */
+        int res = device->driver->init(device);
+        assert(!res);
+    }
+
+    return 0;
+}
+
+
+int main(void)
+{
+    puts("Test application for DOSE driver");
+
+    int res = netdev_eth_minimal_init();
+    if (res) {
+        puts("Error initializing devices");
+        return 1;
+    }
+
+    /* start the shell */
+    puts("Initialization successful - starting the shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -1,12 +1,9 @@
+INCLUDES += -I$(APPDIR)
+
 include ../Makefile.tests_common
 
-USEMODULE += auto_init_gnrc_netif
+USEMODULE += test_utils_netdev_eth_minimal
 USEMODULE += enc28j60
-USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += shell
-USEMODULE += shell_commands
-USEMODULE += ps
 
 # set board specific peripheral configurations
 ifneq (,$(filter stm32f4discovery,$(BOARD)))
@@ -14,20 +11,11 @@ ifneq (,$(filter stm32f4discovery,$(BOARD)))
   ENC_CS  ?= GPIO_PIN\(PORT_B,12\)
   ENC_INT ?= GPIO_PIN\(PORT_B,11\)
   ENC_RST ?= GPIO_PIN\(PORT_B,10\)
+  # export SPI and pins
+  CFLAGS += -DENC28J60_PARAM_SPI=$(ENC_SPI)
+  CFLAGS += -DENC28J60_PARAM_CS=$(ENC_CS)
+  CFLAGS += -DENC28J60_PARAM_INT=$(ENC_INT)
+  CFLAGS += -DENC28J60_PARAM_RESET=$(ENC_RST)
 endif
-
-# fallback: set SPI bus and pins to default values
-ENC_SPI ?= SPI_DEV\(0\)
-ENC_CS  ?= GPIO_PIN\(0,0\)
-ENC_INT ?= GPIO_PIN\(0,1\)
-ENC_RST ?= GPIO_PIN\(0,2\)
-# export SPI and pins
-CFLAGS += -DENC28J60_PARAM_SPI=$(ENC_SPI)
-CFLAGS += -DENC28J60_PARAM_CS=$(ENC_CS)
-CFLAGS += -DENC28J60_PARAM_INT=$(ENC_INT)
-CFLAGS += -DENC28J60_PARAM_RESET=$(ENC_RST)
-
-# make sure we read the local enc28j60 params file
-CFLAGS += -I$(CURDIR)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_enc28j60/Makefile.ci
+++ b/tests/driver_enc28j60/Makefile.ci
@@ -1,35 +1,16 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
-    arduino-mega2560 \
     arduino-nano \
     arduino-uno \
-    atmega1284p \
     atmega328p \
     atmega328p-xplained-mini \
-    atxmega-a3bu-xplained \
-    bluepill-stm32f030c8 \
-    derfmega128 \
-    i-nucleo-lrwan1 \
-    mega-xplained \
-    microduino-corerf \
-    msb-430 \
-    msb-430h \
+    esp8266-esp-12x \
+    esp8266-olimex-mod \
+    esp8266-sparkfun-thing \
     nucleo-f031k6 \
-    nucleo-f042k6 \
-    nucleo-f303k8 \
-    nucleo-f334r8 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
-    nucleo-l053r8 \
     samd10-xmini \
-    slstk3400a \
     stk3200 \
     stm32f030f4-demo \
-    stm32f0discovery \
-    stm32l0538-disco \
-    telosb \
-    waspmote-pro \
-    z1 \
-    zigduino \
     #

--- a/tests/driver_enc28j60/init_dev.h
+++ b/tests/driver_enc28j60/init_dev.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file ENC28J60 ethernet device driver
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "net/netdev.h"
+
+#include "enc28j60.h"
+#include "enc28j60_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ENC28J60_NUM   ARRAY_SIZE(enc28j60_params)
+#define NETDEV_ETH_MINIMAL_NUMOF      ENC28J60_NUM
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -1,12 +1,9 @@
+INCLUDES += -I$(APPDIR)
+
 include ../Makefile.tests_common
 
-USEMODULE += auto_init_gnrc_netif
+USEMODULE += test_utils_netdev_eth_minimal
 USEMODULE += encx24j600
-USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_icmpv6_echo
-USEMODULE += shell
-USEMODULE += shell_commands
-USEMODULE += ps
 
 # set board specific peripheral configurations
 ifneq (,$(filter nucleo-f334r8,$(BOARD)))
@@ -23,9 +20,3 @@ ifneq (,$(filter nucleo-f334r8,$(BOARD)))
 endif
 
 include $(RIOTBASE)/Makefile.include
-
-# lower pktbuf size
-# Set GNRC_PKTBUF_SIZE via CFLAGS if not being set via Kconfig.
-ifndef CONFIG_GNRC_PKTBUF_SIZE
-  CFLAGS += -DCONFIG_GNRC_PKTBUF_SIZE=2048
-endif

--- a/tests/driver_encx24j600/Makefile.ci
+++ b/tests/driver_encx24j600/Makefile.ci
@@ -1,27 +1,13 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
-    arduino-mega2560 \
     arduino-nano \
     arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
-    bluepill-stm32f030c8 \
-    i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
     nucleo-f031k6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
-    nucleo-l053r8 \
     samd10-xmini \
-    slstk3400a \
     stk3200 \
     stm32f030f4-demo \
-    stm32f0discovery \
-    stm32l0538-disco \
-    telosb \
-    waspmote-pro \
-    z1 \
     #

--- a/tests/driver_encx24j600/init_dev.h
+++ b/tests/driver_encx24j600/init_dev.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file ENCX24J600 ethernet device driver
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "net/netdev.h"
+
+#include "encx24j600.h"
+#include "encx24j600_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ENCX24J600_NUM   ARRAY_SIZE(encx24j600_params)
+#define NETDEV_ETH_MINIMAL_NUMOF      ENCX24J600_NUM
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_esp_eth/Makefile
+++ b/tests/driver_esp_eth/Makefile
@@ -1,0 +1,14 @@
+BOARD ?= esp32-ethernet-kit-v1_0
+
+include ../Makefile.tests_common
+
+USEMODULE += test_utils_netdev_eth_minimal
+
+# the driver to test
+USEMODULE += esp_eth
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += periph_eth
+
+INCLUDES += -I$(APPDIR)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_esp_eth/init_dev.h
+++ b/tests/driver_esp_eth/init_dev.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file ESP ethernet peripheral
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NETDEV_ETH_MINIMAL_NUMOF      1
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_esp_eth/main.c
+++ b/tests/driver_esp_eth/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for ESP ethernet peripheral
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "test_utils/netdev_eth_minimal.h"
+#include "init_dev.h"
+#include "assert.h"
+#include "net/netdev.h"
+#include "esp_eth_netdev.h"
+#include "esp_eth_params.h"
+
+extern void esp_eth_setup(esp_eth_netdev_t* dev);
+extern esp_eth_netdev_t _esp_eth_dev;
+
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb) {
+    netdev_t *device = &_esp_eth_dev.netdev;
+
+    /* setup the specific driver */
+    esp_eth_setup(&_esp_eth_dev);
+
+    /* set the application-provided callback */
+    device->event_callback = cb;
+
+    /* initialize the device driver */
+    int res = device->driver->init(device);
+    assert(!res);
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("Test application for ESP ethernet peripheral");
+
+    int res = netdev_eth_minimal_init();
+    if (res) {
+        puts("Error initializing devices");
+        return 1;
+    }
+
+    /* start the shell */
+    puts("Initialization successful - starting the shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_ethos/Makefile
+++ b/tests/driver_ethos/Makefile
@@ -1,4 +1,10 @@
-# the network driver to test
-USEMODULE = ethos
+include ../Makefile.tests_common
 
-include ../driver_netdev_common/Makefile.netdev.mk
+USEMODULE += test_utils_netdev_eth_minimal
+
+# the driver to test
+USEMODULE += ethos
+
+INCLUDES += -I$(APPDIR)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ethos/Makefile.ci
+++ b/tests/driver_ethos/Makefile.ci
@@ -1,30 +1,14 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
-    arduino-mega2560 \
     arduino-nano \
     arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
-    atxmega-a3bu-xplained \
-    bluepill-stm32f030c8 \
-    i-nucleo-lrwan1 \
-    msb-430 \
-    msb-430h \
-    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
-    nucleo-f303k8 \
-    nucleo-f334r8 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
-    nucleo-l053r8 \
     samd10-xmini \
-    slstk3400a \
     stk3200 \
     stm32f030f4-demo \
-    stm32f0discovery \
-    stm32g0316-disco \
-    stm32l0538-disco \
-    waspmote-pro \
     #

--- a/tests/driver_ethos/init_dev.h
+++ b/tests/driver_ethos/init_dev.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file ETHOS driver
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "net/netdev.h"
+
+#include "ethos.h"
+#include "ethos_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ETHOS_NUM   ARRAY_SIZE(ethos_params)
+#define NETDEV_ETH_MINIMAL_NUMOF      ETHOS_NUM
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_ethos/main.c
+++ b/tests/driver_ethos/main.c
@@ -1,1 +1,68 @@
-../driver_netdev_common/main.c
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for ethernet-over-serial driver
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "test_utils/netdev_eth_minimal.h"
+#include "init_dev.h"
+#include "assert.h"
+#include "ethos.h"
+#include "ethos_params.h"
+
+static ethos_t ethos[ETHOS_NUM];
+static uint8_t inbuf[ETHOS_NUM][2048];
+
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb) {
+    for (unsigned i = 0; i < ETHOS_NUM; i++) {
+        netdev_t *device = &ethos[i].netdev;
+
+        /* setup the specific driver */
+        ethos_setup(&ethos[i], &ethos_params[i], i, inbuf[i], sizeof(inbuf[i]));
+
+        /* set the application-provided callback */
+        device->event_callback = cb;
+
+        /* initialize the device driver */
+        int res = device->driver->init(device);
+        assert(!res);
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("Test application for ETHOS driver");
+
+    int res = netdev_eth_minimal_init();
+    if (res) {
+        puts("Error initializing devices");
+        return 1;
+    }
+
+    /* start the shell */
+    puts("Initialization successful - starting the shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_netdev_common/Makefile
+++ b/tests/driver_netdev_common/Makefile
@@ -1,4 +1,6 @@
 # use the default network interface for the board
 USEMODULE += netdev_default
 
+EXTERNAL_BOARD_DIRS += $(CURDIR)/../external_board_dirs/netdev-ci-boards
+
 include Makefile.netdev.mk

--- a/tests/driver_sam0_eth/Makefile
+++ b/tests/driver_sam0_eth/Makefile
@@ -1,0 +1,14 @@
+BOARD ?= same54-xpro
+
+include ../Makefile.tests_common
+
+USEMODULE += test_utils_netdev_eth_minimal
+
+# the driver to test
+USEMODULE += sam0_eth
+FEATURES_REQUIRED += periph_eth
+FEATURES_REQUIRED += cpu_samd5x # TODO: complete with other SAM0 CPUs that have ethernet
+
+INCLUDES += -I$(APPDIR)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sam0_eth/init_dev.h
+++ b/tests/driver_sam0_eth/init_dev.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file SAM0 ethernet peripheral
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NETDEV_ETH_MINIMAL_NUMOF      1
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_sam0_eth/main.c
+++ b/tests/driver_sam0_eth/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for SAM0 ethernet peripheral
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "test_utils/netdev_eth_minimal.h"
+#include "init_dev.h"
+#include "assert.h"
+#include "net/netdev.h"
+#include "sam0_eth_netdev.h"
+
+static netdev_t sam0_eth;
+
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb) {
+
+    /* setup the specific driver */
+    sam0_eth_setup(&sam0_eth);
+
+    /* set the application-provided callback */
+    sam0_eth.event_callback = cb;
+
+    /* initialize the device driver */
+    int res = sam0_eth.driver->init(&sam0_eth);
+    assert(!res);
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("Test application for SAM0 ethernet peripheral");
+
+    int res = netdev_eth_minimal_init();
+    if (res) {
+        puts("Error initializing devices");
+        return 1;
+    }
+
+    /* start the shell */
+    puts("Initialization successful - starting the shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_stm32_eth/Makefile
+++ b/tests/driver_stm32_eth/Makefile
@@ -1,0 +1,15 @@
+BOARD ?= nucleo-f207zg
+
+INCLUDES += -I$(APPDIR)
+
+include ../Makefile.tests_common
+
+USEMODULE += test_utils_netdev_eth_minimal
+
+# the driver to test
+USEMODULE += stm32_eth
+
+FEATURES_REQUIRED += periph_eth
+FEATURES_REQUIRED += cpu_stm32
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_stm32_eth/init_dev.h
+++ b/tests/driver_stm32_eth/init_dev.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file STM32 ethernet peripheral driver
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NETDEV_ETH_MINIMAL_NUMOF      1
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_stm32_eth/main.c
+++ b/tests/driver_stm32_eth/main.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for STM32 ethernet peripheral driver
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "assert.h"
+#include "stm32_eth.h"
+#include "test_utils/netdev_eth_minimal.h"
+
+static netdev_t stm32_eth;
+
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb) {
+
+    /* setup the specific driver */
+    stm32_eth_netdev_setup(&stm32_eth);
+
+    /* set the application-provided callback */
+    stm32_eth.event_callback = cb;
+
+    /* initialize the device driver */
+    int res = stm32_eth.driver->init(&stm32_eth);
+    assert(!res);
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("Test application for STM32 ethernet peripheral driver");
+
+    int res = netdev_eth_minimal_init();
+    if (res) {
+        puts("Error initializing devices");
+        return 1;
+    }
+
+    /* start the shell */
+    puts("Initialization successful - starting the shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_w5100/Makefile
+++ b/tests/driver_w5100/Makefile
@@ -1,4 +1,10 @@
-# the driver to test
-USEMODULE = w5100
+include ../Makefile.tests_common
 
-include ../driver_netdev_common/Makefile.netdev.mk
+USEMODULE += test_utils_netdev_eth_minimal
+
+# the driver to test
+USEMODULE += w5100
+
+INCLUDES += -I$(APPDIR)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_w5100/init_dev.h
+++ b/tests/driver_w5100/init_dev.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief   Device-specific test header file W5100 ethernet device driver
+ *
+ * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+#ifndef INIT_DEV_H
+#define INIT_DEV_H
+
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "net/netdev.h"
+
+#include "w5100.h"
+#include "w5100_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define W5100_NUM   ARRAY_SIZE(w5100_params)
+#define NETDEV_ETH_MINIMAL_NUMOF      W5100_NUM
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INIT_DEV_H */
+/** @} */

--- a/tests/driver_w5100/main.c
+++ b/tests/driver_w5100/main.c
@@ -1,1 +1,67 @@
-../driver_netdev_common/main.c
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for W5100 ethernet device driver
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "test_utils/netdev_eth_minimal.h"
+#include "init_dev.h"
+#include "assert.h"
+#include "w5100.h"
+#include "w5100_params.h"
+
+static w5100_t w5100[W5100_NUM];
+
+int netdev_eth_minimal_init_devs(netdev_event_cb_t cb) {
+    for (unsigned i = 0; i < W5100_NUM; i++) {
+        netdev_t *device = &w5100[i].nd;
+
+        /* setup the specific driver */
+        w5100_setup(&w5100[i], &w5100_params[i], i);
+
+        /* set the application-provided callback */
+        device->event_callback = cb;
+
+        /* initialize the device driver */
+        int res = device->driver->init(device);
+        assert(!res);
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("Test application for W5100 ethernet device driver");
+
+    int res = netdev_eth_minimal_init();
+    if (res) {
+        puts("Error initializing devices");
+        return 1;
+    }
+
+    /* start the shell */
+    puts("Initialization successful - starting the shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Kconfig
+++ b/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2022 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840-ci-eth" if BOARD_NRF52840DK_CI_ETH
+
+config BOARD_NRF52840DK_CI_ETH
+    bool
+    default y
+    select BOARDS_COMMON_NRF52XXXDK
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_USBDEV
+    select HAS_VDD_LC_FILTER_REG0
+    select HAVE_MTD_SPI_NOR
+
+    # bring ethernet drivers
+    select HAVE_W5100
+    select HAVE_ETHOS
+    select HAVE_DOSE
+    select HAVE_ENCX24J600
+    select HAVE_ENC28J60
+
+    select MODULE_BOARDS_COMMON_NRF52XXXDK if TEST_KCONFIG
+
+source "$(RIOTBOARD)/common/nrf52xxxdk/Kconfig"

--- a/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile
+++ b/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile
@@ -1,0 +1,6 @@
+# This must be a different name than 'board' as it is implemented by 'nrf52840dk'
+MODULE = board_nrf52840_ci_eth
+
+DIRS += $(RIOTBOARD)/nrf52840dk
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile.dep
+++ b/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile.dep
@@ -1,0 +1,11 @@
+USEMODULE += board_nrf52840_ci_eth
+
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += w5100
+  USEMODULE += ethos
+  USEMODULE += dose
+  USEMODULE += encx24j600
+  USEMODULE += enc28j60
+endif
+
+include $(RIOTBOARD)/nrf52840dk/Makefile.dep

--- a/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile.features
+++ b/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nrf52840dk/Makefile.features

--- a/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile.include
+++ b/tests/external_board_dirs/netdev-ci-boards/nrf52840-ci-eth/Makefile.include
@@ -1,0 +1,5 @@
+# We must duplicate the include done by $(RIOTBASE)/Makefile.include
+# to also include the main board header
+INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/nrf52840dk/include))
+
+include $(RIOTBOARD)/nrf52840dk/Makefile.include


### PR DESCRIPTION
### Contribution description
Split from #17739, but with a difference: instead of using symlinks the common functionality to interact with Ethernet netdev drivers is implemented in its own test_utils module.

### Testing procedure
- Run the tests, you should be able to send an receive Ethernet frames
- Green CI

### Issues/PRs references
#17739
