### PR TITLE
ipv6/nib: bugfix handle SLLAO on 6LR if ARO is not present

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
@@ -136,28 +136,26 @@ gnrc_pktsnip_t *_copy_and_handle_aro(gnrc_netif_t *netif,
                                      const ndp_opt_t *sl2ao)
 {
     gnrc_pktsnip_t *reply_aro = NULL;
+    assert(aro);
+    uint8_t status = _handle_aro(netif, ipv6, (icmpv6_hdr_t *)nbr_sol, aro,
+                                 sl2ao, NULL);
 
-    if (aro != NULL) {
-        uint8_t status = _handle_aro(netif, ipv6, (icmpv6_hdr_t *)nbr_sol, aro,
-                                     sl2ao, NULL);
-
-        if ((status != _ADDR_REG_STATUS_TENTATIVE) &&
-            (status != _ADDR_REG_STATUS_IGNORE)) {
-            reply_aro = gnrc_sixlowpan_nd_opt_ar_build(status,
-                                                       byteorder_ntohs(aro->ltime),
-                                                       (eui64_t *)&aro->eui64,
-                                                       NULL);
-            if (reply_aro == NULL) {
-                DEBUG("nib: No space left in packet buffer. Not replying NS");
-            }
+    if ((status != _ADDR_REG_STATUS_TENTATIVE) &&
+        (status != _ADDR_REG_STATUS_IGNORE)) {
+        reply_aro = gnrc_sixlowpan_nd_opt_ar_build(status,
+                                                   byteorder_ntohs(aro->ltime),
+                                                   (eui64_t *)&aro->eui64,
+                                                   NULL);
+        if (reply_aro == NULL) {
+            DEBUG("nib: No space left in packet buffer. Not replying NS");
         }
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_DAD)
-        else if (status != _ADDR_REG_STATUS_IGNORE) {
-            DEBUG("nib: Address was marked TENTATIVE => not replying NS, "
-                  "waiting for DAC\n");
-        }
-#endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_DAD */
     }
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_DAD)
+    else if (status != _ADDR_REG_STATUS_IGNORE) {
+        DEBUG("nib: Address was marked TENTATIVE => not replying NS, "
+              "waiting for DAC\n");
+    }
+#endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_DAD */
     return reply_aro;
 }
 #else  /* CONFIG_GNRC_IPV6_NIB_6LR */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
@@ -106,7 +106,7 @@ uint8_t _reg_addr_upstream(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
  * @param[in] nbr_sol   The neighbor solicitation carrying the original ARO
  *                      (handed over as @ref icmpv6_hdr_t, since it is just
  *                      handed to @ref _handle_aro()).
- * @param[in] aro       The original ARO
+ * @param[in] aro       The original ARO, must not be NULL
  * @param[in] sl2ao     SL2AO associated with the ARO.
  *
  * @return  registration status of the address (including

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1005,7 +1005,6 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
         gnrc_ndp_nbr_adv_send(&nbr_sol->tgt, netif, &ipv6->src, false, NULL);
     }
     else {
-        gnrc_pktsnip_t *reply_aro = NULL;
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LR)
         ndp_opt_t *sl2ao = NULL;
         sixlowpan_nd_opt_ar_t *aro = NULL;
@@ -1027,7 +1026,7 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                     if (gnrc_netif_is_6lr(netif)) {
                         DEBUG("nib: Storing SL2AO for later handling\n");
                         sl2ao = opt;
-                        break;
+                        break; /* SL2AO is handled below together with an ARO */
                     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LR */
                     _handle_sl2ao(netif, ipv6, (const icmpv6_hdr_t *)nbr_sol,
@@ -1045,7 +1044,18 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                     break;
             }
         }
-        reply_aro = _copy_and_handle_aro(netif, ipv6, nbr_sol, aro, sl2ao);
+        gnrc_pktsnip_t *reply_aro = NULL;
+        if (aro && sl2ao) {
+        /* If no SLLAO is included, then any included ARO is ignored. */
+            if (!(reply_aro = _copy_and_handle_aro(netif, ipv6, nbr_sol, aro, sl2ao))) {
+            /* If the Length field is not two, or if the Status field is not zero,
+               then the NS is silently ignored.*/
+                return;
+            }
+        }
+        else if (sl2ao) {
+            _handle_sl2ao(netif, ipv6, (const icmpv6_hdr_t *)nbr_sol, sl2ao);
+        }
         /* check if target address is anycast */
         if (netif->ipv6.addrs_flags[tgt_idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST) {
             _send_delayed_nbr_adv(netif, &nbr_sol->tgt, ipv6, reply_aro);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When I was Iooking through the code and was following debug messages, I discovered that the SLLA option in a Neighbor Solicitation is "stored for later handling" but it is never touched again if not also an AR option is present on 6LR.
This can be fixed by removing a `break`.
 
### Testing procedure

Two `nrf52840dk` `node A` and `node B` running `gnrc_networing.`
Assign both nodes an ipv6 address.

`$A ifconfig 6 add fd00:b:b::1`
`$B ifconfig 6 add fd00:b:b::2`

When `B` tries to ping `A`, it sends a multicast NS to ask for the L2 address of the target `fd00:b:b::1`.
`B` includes an SLLA option, so `A` knows the L2 address of `B` and can reply with a Neighbor Advertisement.
If `A` does not handle the SLLA option, it does not create a Neighbor Cache Entry for `B`, so it fails to deliver the NA.
Hence, the ping request of `B` fails because `B` did not receive the L2 address of `A`.

<details>
<summary>This is node A</summary>

```
2022-03-16 17:37:26,793 # All up, running the shell now
> 2022-03-16 17:37:26,795 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 319ms)
2022-03-16 17:37:26,797 # nib: lookup ctx = 0x20001388, type = 4fc3
i2022-03-16 17:37:30,932 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:30,936 # nib: Received valid router solicitation:
2022-03-16 17:37:30,940 #      - Source address: fe80::a4d7:37db:ab10:e97c
2022-03-16 17:37:30,943 #      - Destination address: ff02::2
2022-03-16 17:37:30,950 # nib: Getting on-link node entry (addr = fe80::a4d7:37db:ab10:e97c, iface = 6)
2022-03-16 17:37:30,953 #   No suitable entry found
fconfig
2022-03-16 17:37:32,113 # ifconfig
2022-03-16 17:37:32,119 # Iface  6  HWaddr: 28:38  Channel: 26  NID: 0x23  PHY: O-QPSK 
2022-03-16 17:37:32,123 #           Long HWaddr: 6E:F6:D8:01:53:E3:28:38 
2022-03-16 17:37:32,125 #            State: IDLE 
2022-03-16 17:37:32,130 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2022-03-16 17:37:32,132 #           6LO  IPHC  
2022-03-16 17:37:32,135 #           Source address length: 8
2022-03-16 17:37:32,138 #           Link type: wireless
2022-03-16 17:37:32,144 #           inet6 addr: fe80::6cf6:d801:53e3:2838  scope: link  VAL
2022-03-16 17:37:32,146 #           inet6 group: ff02::2
2022-03-16 17:37:32,149 #           inet6 group: ff02::1
2022-03-16 17:37:32,153 #           inet6 group: ff02::1:ffe3:2838
2022-03-16 17:37:32,156 #           inet6 group: ff02::1a
2022-03-16 17:37:32,157 #           
2022-03-16 17:37:32,159 #           Statistics for Layer 2
2022-03-16 17:37:32,163 #             RX packets 1  bytes 43
2022-03-16 17:37:32,167 #             TX packets 4 (Multicast: 4)  bytes 0
2022-03-16 17:37:32,170 #             TX succeeded 3 errors 0
2022-03-16 17:37:32,173 #           Statistics for IPv6
2022-03-16 17:37:32,176 #             RX packets 1  bytes 64
2022-03-16 17:37:32,180 #             TX packets 3 (Multicast: 3)  bytes 178
2022-03-16 17:37:32,183 #             TX succeeded 3 errors 0
2022-03-16 17:37:32,183 # 
> 2022-03-16 17:37:36,100 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 10329ms)
2022-03-16 17:37:36,104 # nib: lookup ctx = 0x20001388, type = 4fc3
2022-03-16 17:37:40,944 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:40,947 # nib: Received valid router solicitation:
2022-03-16 17:37:40,951 #      - Source address: fe80::a4d7:37db:ab10:e97c
2022-03-16 17:37:40,955 #      - Destination address: ff02::2
2022-03-16 17:37:40,961 # nib: Getting on-link node entry (addr = fe80::a4d7:37db:ab10:e97c, iface = 6)
2022-03-16 17:37:40,964 #   No suitable entry found
ifconfig 6 add fd00:b:b::1/64
2022-03-16 17:37:45,250 # ifconfig 6 add fd00:b:b::1/64
2022-03-16 17:37:45,258 # nib: Allocating off-link-entry entry (next_hop = NULL, iface = 6, pfx = fd00:b:b::1/64)
2022-03-16 17:37:45,259 #   using 0x20000f08
2022-03-16 17:37:45,264 # nib: Allocating on-link node entry (addr = NULL, iface = 6)
2022-03-16 17:37:45,265 #   using 0
2022-03-16 17:37:45,269 # success: added fd00:b:b::1/64 to interface 6
> 2022-03-16 17:37:46,111 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 20339ms)
2022-03-16 17:37:46,114 # nib: lookup ctx = 0x20001388, type = 4fc3
2022-03-16 17:37:54,953 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:54,956 # nib: Received valid router solicitation:
2022-03-16 17:37:54,960 #      - Source address: fe80::a4d7:37db:ab10:e97c
2022-03-16 17:37:54,964 #      - Destination address: ff02::2
2022-03-16 17:37:54,970 # nib: Getting on-link node entry (addr = fe80::a4d7:37db:ab10:e97c, iface = 6)
2022-03-16 17:37:54,973 #   No suitable entry found
ifco2022-03-16 17:38:00,121 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 34349ms)
2022-03-16 17:38:00,125 # nib: lookup ctx = 0x20001388, type = 4fc3
nfig
2022-03-16 17:38:00,742 # ifconfig
2022-03-16 17:38:00,748 # Iface  6  HWaddr: 28:38  Channel: 26  NID: 0x23  PHY: O-QPSK 
2022-03-16 17:38:00,752 #           Long HWaddr: 6E:F6:D8:01:53:E3:28:38 
2022-03-16 17:38:00,754 #            State: IDLE 
2022-03-16 17:38:00,759 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2022-03-16 17:38:00,761 #           6LO  IPHC  
2022-03-16 17:38:00,764 #           Source address length: 8
2022-03-16 17:38:00,767 #           Link type: wireless
2022-03-16 17:38:00,773 #           inet6 addr: fe80::6cf6:d801:53e3:2838  scope: link  VAL
2022-03-16 17:38:00,778 #           inet6 addr: fd00:b:b::1  scope: global  VAL
2022-03-16 17:38:00,780 #           inet6 group: ff02::2
2022-03-16 17:38:00,783 #           inet6 group: ff02::1
2022-03-16 17:38:00,786 #           inet6 group: ff02::1:ffe3:2838
2022-03-16 17:38:00,789 #           inet6 group: ff02::1a
2022-03-16 17:38:00,792 #           inet6 group: ff02::1:ff00:1
2022-03-16 17:38:00,793 #           
2022-03-16 17:38:00,796 #           Statistics for Layer 2
2022-03-16 17:38:00,800 #             RX packets 3  bytes 129
2022-03-16 17:38:00,804 #             TX packets 7 (Multicast: 7)  bytes 0
2022-03-16 17:38:00,807 #             TX succeeded 6 errors 0
2022-03-16 17:38:00,810 #           Statistics for IPv6
2022-03-16 17:38:00,813 #             RX packets 3  bytes 192
2022-03-16 17:38:00,818 #             TX packets 6 (Multicast: 6)  bytes 370
2022-03-16 17:38:00,820 #             TX succeeded 6 errors 0
2022-03-16 17:38:00,821 # 
> 2022-03-16 17:38:08,882 # nib: Handle packet (icmpv6->type = 135)
2022-03-16 17:38:08,886 # nib: Received valid neighbor solicitation:
2022-03-16 17:38:08,889 #      - Target address: fd00:b:b::1
2022-03-16 17:38:08,892 #      - Source address: fd00:b:b::2
2022-03-16 17:38:08,896 #      - Destination address: ff02::1:ff00:1
2022-03-16 17:38:08,899 # nib: Storing SL2AO for later handling
2022-03-16 17:38:08,904 # nib: get next hop link-layer address of fd00:b:b::2%6
2022-03-16 17:38:08,910 # nib: Getting on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:08,912 #   No suitable entry found
2022-03-16 17:38:08,916 # nib: fd00:b:b::2 is off-link, resolve route
2022-03-16 17:38:08,920 # nib: get route fd00:b:b::2 for packet 0x20001ad4
2022-03-16 17:38:08,924 # nib: get match for destination fd00:b:b::2 from NIB
2022-03-16 17:38:08,929 # nib: fd00:b:b::/64 => (nil)%6 matches with 126 bits
2022-03-16 17:38:08,931 # nib: best match (126 bits)
2022-03-16 17:38:08,938 # nib: no route to fd00:b:b::2 found or is prefix list entry, search neighbor cache
2022-03-16 17:38:08,943 # nib: prefix list entry => taking dst as next hop
2022-03-16 17:38:08,948 # nib: Getting on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:08,951 #   No suitable entry found
2022-03-16 17:38:08,955 # nib: resolve address fd00:b:b::2 by probing neighbors
2022-03-16 17:38:08,961 # nib: Allocating on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:08,964 #   0x20001130 is an exact match
2022-03-16 17:38:08,969 # nib: Adding to neighbor cache (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:08,975 # nib: queueing (addr = fd00:b:b::2, iface = 6) for potential removal
2022-03-16 17:38:08,980 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:08,986 # multicast to fd00:b:b::2's solicited nodes (retrans. timer = 1000ms)
2022-03-16 17:38:09,901 # nib: Handle packet (icmpv6->type = 135)
2022-03-16 17:38:09,905 # nib: Received valid neighbor solicitation:
2022-03-16 17:38:09,908 #      - Target address: fd00:b:b::1
2022-03-16 17:38:09,910 #      - Source address: fd00:b:b::2
2022-03-16 17:38:09,914 #      - Destination address: ff02::1:ff00:1
2022-03-16 17:38:09,918 # nib: Storing SL2AO for later handling
2022-03-16 17:38:09,923 # nib: get next hop link-layer address of fd00:b:b::2%6
2022-03-16 17:38:09,928 # nib: Getting on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:09,930 #   Found 0x20001130
2022-03-16 17:38:09,935 # nib: fd00:b:b::2 is in NC, start address resolution
2022-03-16 17:38:09,940 # nib: Getting on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:09,942 #   Found 0x20001130
2022-03-16 17:38:09,946 # nib: resolve address fd00:b:b::2 by probing neighbors
2022-03-16 17:38:09,951 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:09,960 # multicast to fd00:b:b::2's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:09,963 # nib: host unreachable
2022-03-16 17:38:09,993 # nib: Handle timer event (ctx = 0x20001130, type = 0x4fc1, now = 44221ms)
2022-03-16 17:38:09,996 # nib: Retransmit neighbor solicitation
2022-03-16 17:38:10,001 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:10,007 # multicast to fd00:b:b::2's solicited nodes (retrans. timer = 1000ms)
2022-03-16 17:38:10,924 # nib: Handle packet (icmpv6->type = 135)
2022-03-16 17:38:10,927 # nib: Received valid neighbor solicitation:
2022-03-16 17:38:10,930 #      - Target address: fd00:b:b::1
2022-03-16 17:38:10,933 #      - Source address: fd00:b:b::2
2022-03-16 17:38:10,937 #      - Destination address: ff02::1:ff00:1
2022-03-16 17:38:10,940 # nib: Storing SL2AO for later handling
2022-03-16 17:38:10,945 # nib: get next hop link-layer address of fd00:b:b::2%6
2022-03-16 17:38:10,951 # nib: Getting on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:10,952 #   Found 0x20001130
2022-03-16 17:38:10,957 # nib: fd00:b:b::2 is in NC, start address resolution
2022-03-16 17:38:10,963 # nib: Getting on-link node entry (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:10,964 #   Found 0x20001130
2022-03-16 17:38:10,969 # nib: resolve address fd00:b:b::2 by probing neighbors
2022-03-16 17:38:10,974 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:10,983 # multicast to fd00:b:b::2's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:10,985 # nib: host unreachable
2022-03-16 17:38:11,013 # nib: Handle timer event (ctx = 0x20001130, type = 0x4fc1, now = 45242ms)
2022-03-16 17:38:11,017 # nib: Retransmit neighbor solicitation
2022-03-16 17:38:11,021 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:11,028 # multicast to fd00:b:b::2's solicited nodes (retrans. timer = 1000ms)
2022-03-16 17:38:12,034 # nib: Handle timer event (ctx = 0x20001130, type = 0x4fc1, now = 46262ms)
2022-03-16 17:38:12,037 # nib: Retransmit neighbor solicitation
2022-03-16 17:38:12,043 # nib: remove from neighbor cache (addr = fd00:b:b::2, iface = 6)
2022-03-16 17:38:12,965 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:38:12,969 # nib: Received valid router solicitation:
2022-03-16 17:38:12,972 #      - Source address: fe80::a4d7:37db:ab10:e97c
2022-03-16 17:38:12,975 #      - Destination address: ff02::2
2022-03-16 17:38:12,983 # nib: Getting on-link node entry (addr = fe80::a4d7:37db:ab10:e97c, iface = 6)
2022-03-16 17:38:12,985 #   No suitable entry found
2022-03-16 17:38:18,131 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 52359ms)
2022-03-16 17:38:18,135 # nib: lookup ctx = 0x20001388, type = 4fc3
```

</details>

<details>
<summary>This is node B</summary>

```
2022-03-16 17:37:21,513 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 539ms)
2022-03-16 17:37:21,514 # nib: lookup ctx = 0x20001388, type = 4fc3
2022-03-16 17:37:25,803 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:25,807 # nib: Received valid router solicitation:
2022-03-16 17:37:25,812 #      - Source address: fe80::6cf6:d801:53e3:2838
2022-03-16 17:37:25,815 #      - Destination address: ff02::2
2022-03-16 17:37:25,821 # nib: Getting on-link node entry (addr = fe80::6cf6:d801:53e3:2838, iface = 6)
2022-03-16 17:37:25,824 #   No suitable entry found
2022-03-16 17:37:26,100 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:26,104 # nib: Received valid router solicitation:
2022-03-16 17:37:26,108 #      - Source address: fe80::6cf6:d801:53e3:2838
2022-03-16 17:37:26,111 #      - Destination address: ff02::2
2022-03-16 17:37:26,118 # nib: Getting on-link node entry (addr = fe80::6cf6:d801:53e3:2838, iface = 6)
2022-03-16 17:37:26,120 #   No suitable entry found
2022-03-16 17:37:30,923 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 10549ms)
2022-03-16 17:37:30,926 # nib: lookup ctx = 0x20001388, type = 4fc3
ifconfig
2022-03-16 17:37:34,851 # ifconfig
2022-03-16 17:37:34,856 # Iface  6  HWaddr: 69:7C  Channel: 26  NID: 0x23  PHY: O-QPSK 
2022-03-16 17:37:34,860 #           Long HWaddr: A6:D7:37:DB:AB:10:E9:7C 
2022-03-16 17:37:34,863 #            State: IDLE 
2022-03-16 17:37:34,868 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2022-03-16 17:37:34,870 #           6LO  IPHC  
2022-03-16 17:37:34,873 #           Source address length: 8
2022-03-16 17:37:34,875 #           Link type: wireless
2022-03-16 17:37:34,881 #           inet6 addr: fe80::a4d7:37db:ab10:e97c  scope: link  VAL
2022-03-16 17:37:34,884 #           inet6 group: ff02::2
2022-03-16 17:37:34,887 #           inet6 group: ff02::1
2022-03-16 17:37:34,890 #           inet6 group: ff02::1:ff10:e97c
2022-03-16 17:37:34,893 #           inet6 group: ff02::1a
2022-03-16 17:37:34,894 #           
2022-03-16 17:37:34,897 #           Statistics for Layer 2
2022-03-16 17:37:34,900 #             RX packets 3  bytes 115
2022-03-16 17:37:34,905 #             TX packets 5 (Multicast: 5)  bytes 0
2022-03-16 17:37:34,908 #             TX succeeded 4 errors 0
2022-03-16 17:37:34,910 #           Statistics for IPv6
2022-03-16 17:37:34,913 #             RX packets 3  bytes 178
2022-03-16 17:37:34,918 #             TX packets 4 (Multicast: 4)  bytes 242
2022-03-16 17:37:34,921 #             TX succeeded 4 errors 0
2022-03-16 17:37:34,921 # 
> 2022-03-16 17:37:36,110 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:36,114 # nib: Received valid router solicitation:
2022-03-16 17:37:36,118 #      - Source address: fe80::6cf6:d801:53e3:2838
2022-03-16 17:37:36,121 #      - Destination address: ff02::2
2022-03-16 17:37:36,128 # nib: Getting on-link node entry (addr = fe80::6cf6:d801:53e3:2838, iface = 6)
2022-03-16 17:37:36,130 #   No suitable entry found
2022-03-16 17:37:40,933 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 20559ms)
2022-03-16 17:37:40,937 # nib: lookup ctx = 0x20001388, type = 4fc3
2022-03-16 17:37:46,121 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:37:46,125 # nib: Received valid router solicitation:
2022-03-16 17:37:46,129 #      - Source address: fe80::6cf6:d801:53e3:2838
2022-03-16 17:37:46,132 #      - Destination address: ff02::2
2022-03-16 17:37:46,139 # nib: Getting on-link node entry (addr = fe80::6cf6:d801:53e3:2838, iface = 6)
2022-03-16 17:37:46,141 #   No suitable entry found
ifconfig 6 add fd00:b:b::2/64
2022-03-16 17:37:54,394 # ifconfig 6 add fd00:b:b::2/64
2022-03-16 17:37:54,402 # nib: Allocating off-link-entry entry (next_hop = NULL, iface = 6, pfx = fd00:b:b::2/64)
2022-03-16 17:37:54,404 #   using 0x20000f08
2022-03-16 17:37:54,409 # nib: Allocating on-link node entry (addr = NULL, iface = 6)
2022-03-16 17:37:54,410 #   using 0
2022-03-16 17:37:54,414 # success: added fd00:b:b::2/64 to interface 6
> 2022-03-16 17:37:54,943 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 34569ms)
2022-03-16 17:37:54,947 # nib: lookup ctx = 0x20001388, type = 4fc3
ifconfig
2022-03-16 17:37:57,249 # ifconfig
2022-03-16 17:37:57,255 # Iface  6  HWaddr: 69:7C  Channel: 26  NID: 0x23  PHY: O-QPSK 
2022-03-16 17:37:57,259 #           Long HWaddr: A6:D7:37:DB:AB:10:E9:7C 
2022-03-16 17:37:57,261 #            State: IDLE 
2022-03-16 17:37:57,266 #           ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
2022-03-16 17:37:57,268 #           6LO  IPHC  
2022-03-16 17:37:57,271 #           Source address length: 8
2022-03-16 17:37:57,274 #           Link type: wireless
2022-03-16 17:37:57,280 #           inet6 addr: fe80::a4d7:37db:ab10:e97c  scope: link  VAL
2022-03-16 17:37:57,284 #           inet6 addr: fd00:b:b::2  scope: global  VAL
2022-03-16 17:37:57,287 #           inet6 group: ff02::2
2022-03-16 17:37:57,290 #           inet6 group: ff02::1
2022-03-16 17:37:57,294 #           inet6 group: ff02::1:ff10:e97c
2022-03-16 17:37:57,296 #           inet6 group: ff02::1a
2022-03-16 17:37:57,300 #           inet6 group: ff02::1:ff00:2
2022-03-16 17:37:57,301 #           
2022-03-16 17:37:57,304 #           Statistics for Layer 2
2022-03-16 17:37:57,307 #             RX packets 5  bytes 201
2022-03-16 17:37:57,311 #             TX packets 7 (Multicast: 7)  bytes 0
2022-03-16 17:37:57,314 #             TX succeeded 6 errors 0
2022-03-16 17:37:57,317 #           Statistics for IPv6
2022-03-16 17:37:57,320 #             RX packets 5  bytes 306
2022-03-16 17:37:57,324 #             TX packets 6 (Multicast: 6)  bytes 370
2022-03-16 17:37:57,328 #             TX succeeded 6 errors 0
2022-03-16 17:37:57,328 # 
> 2022-03-16 17:38:00,132 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:38:00,135 # nib: Received valid router solicitation:
2022-03-16 17:38:00,140 #      - Source address: fe80::6cf6:d801:53e3:2838
2022-03-16 17:38:00,143 #      - Destination address: ff02::2
2022-03-16 17:38:00,150 # nib: Getting on-link node entry (addr = fe80::6cf6:d801:53e3:2838, iface = 6)
2022-03-16 17:38:00,152 #   No suitable entry found
ping fd00:b:b::1
2022-03-16 17:38:08,786 # ping fd00:b:b::1
2022-03-16 17:38:08,791 # nib: get next hop link-layer address of fd00:b:b::1%6
2022-03-16 17:38:08,796 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:08,799 #   No suitable entry found
2022-03-16 17:38:08,803 # nib: fd00:b:b::1 is off-link, resolve route
2022-03-16 17:38:08,807 # nib: get route fd00:b:b::1 for packet 0x20001a34
2022-03-16 17:38:08,811 # nib: get match for destination fd00:b:b::1 from NIB
2022-03-16 17:38:08,816 # nib: fd00:b:b::/64 => (nil)%6 matches with 127 bits
2022-03-16 17:38:08,818 # nib: best match (127 bits)
2022-03-16 17:38:08,826 # nib: no route to fd00:b:b::1 found or is prefix list entry, search neighbor cache
2022-03-16 17:38:08,830 # nib: prefix list entry => taking dst as next hop
2022-03-16 17:38:08,835 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:08,838 #   No suitable entry found
2022-03-16 17:38:08,842 # nib: resolve address fd00:b:b::1 by probing neighbors
2022-03-16 17:38:08,848 # nib: Allocating on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:08,851 #   0x20001130 is an exact match
2022-03-16 17:38:08,856 # nib: Adding to neighbor cache (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:08,862 # nib: queueing (addr = fd00:b:b::1, iface = 6) for potential removal
2022-03-16 17:38:08,867 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:08,873 # multicast to fd00:b:b::1's solicited nodes (retrans. timer = 1000ms)
2022-03-16 17:38:08,994 # nib: Handle packet (icmpv6->type = 135)
2022-03-16 17:38:08,998 # nib: Received valid neighbor solicitation:                                !!!!! Other node wants to know L2 address !!!!!
2022-03-16 17:38:09,001 #      - Target address: fd00:b:b::2
2022-03-16 17:38:09,004 #      - Source address: fd00:b:b::1
2022-03-16 17:38:09,008 #      - Destination address: ff02::1:ff00:2
2022-03-16 17:38:09,011 # nib: Storing SL2AO for later handling                                     !!!!! This SLLAO is never being handled --> NCE is not created !!!!!
2022-03-16 17:38:09,016 # nib: get next hop link-layer address of fd00:b:b::1%6
2022-03-16 17:38:09,021 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:09,023 #   Found 0x20001130
2022-03-16 17:38:09,028 # nib: fd00:b:b::1 is in NC, start address resolution
2022-03-16 17:38:09,033 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:09,035 #   Found 0x20001130
2022-03-16 17:38:09,040 # nib: resolve address fd00:b:b::1 by probing neighbors
2022-03-16 17:38:09,044 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:09,054 # multicast to fd00:b:b::1's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:09,056 # nib: host unreachable
2022-03-16 17:38:09,791 # nib: get next hop link-layer address of fd00:b:b::1%6
2022-03-16 17:38:09,797 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:09,798 #   Found 0x20001130
2022-03-16 17:38:09,803 # nib: fd00:b:b::1 is in NC, start address resolution
2022-03-16 17:38:09,808 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:09,810 #   Found 0x20001130
2022-03-16 17:38:09,815 # nib: resolve address fd00:b:b::1 by probing neighbors
2022-03-16 17:38:09,820 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:09,829 # multicast to fd00:b:b::1's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:09,831 # nib: host unreachable
2022-03-16 17:38:09,880 # nib: Handle timer event (ctx = 0x20001130, type = 0x4fc1, now = 49506ms)
2022-03-16 17:38:09,883 # nib: Retransmit neighbor solicitation
2022-03-16 17:38:09,888 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:09,894 # multicast to fd00:b:b::1's solicited nodes (retrans. timer = 1000ms)
2022-03-16 17:38:10,016 # nib: Handle packet (icmpv6->type = 135)
2022-03-16 17:38:10,020 # nib: Received valid neighbor solicitation:
2022-03-16 17:38:10,023 #      - Target address: fd00:b:b::2
2022-03-16 17:38:10,026 #      - Source address: fd00:b:b::1
2022-03-16 17:38:10,030 #      - Destination address: ff02::1:ff00:2
2022-03-16 17:38:10,033 # nib: Storing SL2AO for later handling
2022-03-16 17:38:10,038 # nib: get next hop link-layer address of fd00:b:b::1%6
2022-03-16 17:38:10,043 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:10,045 #   Found 0x20001130
2022-03-16 17:38:10,050 # nib: fd00:b:b::1 is in NC, start address resolution
2022-03-16 17:38:10,055 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:10,057 #   Found 0x20001130
2022-03-16 17:38:10,062 # nib: resolve address fd00:b:b::1 by probing neighbors
2022-03-16 17:38:10,066 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:10,076 # multicast to fd00:b:b::1's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:10,078 # nib: host unreachable
2022-03-16 17:38:10,791 # nib: get next hop link-layer address of fd00:b:b::1%6
2022-03-16 17:38:10,797 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:10,798 #   Found 0x20001130
2022-03-16 17:38:10,803 # nib: fd00:b:b::1 is in NC, start address resolution
2022-03-16 17:38:10,808 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:10,810 #   Found 0x20001130
2022-03-16 17:38:10,815 # nib: resolve address fd00:b:b::1 by probing neighbors
2022-03-16 17:38:10,820 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:10,829 # multicast to fd00:b:b::1's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:10,831 # nib: host unreachable
2022-03-16 17:38:10,901 # nib: Handle timer event (ctx = 0x20001130, type = 0x4fc1, now = 50526ms)
2022-03-16 17:38:10,904 # nib: Retransmit neighbor solicitation
2022-03-16 17:38:10,909 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:10,915 # multicast to fd00:b:b::1's solicited nodes (retrans. timer = 1000ms)
2022-03-16 17:38:11,036 # nib: Handle packet (icmpv6->type = 135)
2022-03-16 17:38:11,040 # nib: Received valid neighbor solicitation:
2022-03-16 17:38:11,043 #      - Target address: fd00:b:b::2
2022-03-16 17:38:11,046 #      - Source address: fd00:b:b::1
2022-03-16 17:38:11,050 #      - Destination address: ff02::1:ff00:2
2022-03-16 17:38:11,053 # nib: Storing SL2AO for later handling
2022-03-16 17:38:11,058 # nib: get next hop link-layer address of fd00:b:b::1%6
2022-03-16 17:38:11,064 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:11,065 #   Found 0x20001130
2022-03-16 17:38:11,070 # nib: fd00:b:b::1 is in NC, start address resolution
2022-03-16 17:38:11,076 # nib: Getting on-link node entry (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:11,077 #   Found 0x20001130
2022-03-16 17:38:11,082 # nib: resolve address fd00:b:b::1 by probing neighbors
2022-03-16 17:38:11,087 # nib: Probing nib: lookup ctx = 0x20001130, type = 4fc1
2022-03-16 17:38:11,096 # multicast to fd00:b:b::1's solicited nodes (skipping since there is already a multicast NS within 1000ms)
2022-03-16 17:38:11,098 # nib: host unreachable
2022-03-16 17:38:11,786 # 
2022-03-16 17:38:11,789 # --- fd00:b:b::1 PING statistics ---
2022-03-16 17:38:11,795 # 3 packets transmitted, 0 packets received, 100% packet loss
> 2022-03-16 17:38:11,921 # nib: Handle timer event (ctx = 0x20001130, type = 0x4fc1, now = 51547ms)
2022-03-16 17:38:11,925 # nib: Retransmit neighbor solicitation
2022-03-16 17:38:11,930 # nib: remove from neighbor cache (addr = fd00:b:b::1, iface = 6)
2022-03-16 17:38:12,954 # nib: Handle timer event (ctx = 0x20001388, type = 0x4fc3, now = 52580ms)
2022-03-16 17:38:12,957 # nib: lookup ctx = 0x20001388, type = 4fc3
2022-03-16 17:38:18,142 # nib: Handle packet (icmpv6->type = 133)
2022-03-16 17:38:18,145 # nib: Received valid router solicitation:
2022-03-16 17:38:18,150 #      - Source address: fe80::6cf6:d801:53e3:2838
2022-03-16 17:38:18,153 #      - Destination address: ff02::2
2022-03-16 17:38:18,159 # nib: Getting on-link node entry (addr = fe80::6cf6:d801:53e3:2838, iface = 6)
2022-03-16 17:38:18,162 #   No suitable entry found
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
