### PR TITLE
drivers/at86rf215: fix CONFIG_AT86RF215_RPC_EN macro name

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -82,7 +82,7 @@ void at86rf215_reset_and_cfg(at86rf215_t *dev)
 
     dev->flags |= AT86RF215_OPT_AUTOACK
                |  AT86RF215_OPT_CSMA
-#if CONFIG_AT86RF215_RPC
+#if CONFIG_AT86RF215_RPC_EN
                |  AT86RF215_OPT_RPC
 #endif
                ;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The macro name is `CONFIG_AT86RF215_RPC_EN`, not `CONFIG_AT86RF215_RPC` .

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
