### PR TITLE
makefiles/docker.ink.mk: do not always pass CFLAGS to docker

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -79,7 +79,6 @@ export DOCKER_ENV_VARS += \
 # Their origin cannot be checked since they are often redefined or overriden
 # in Makefile/Makefile.include, etc. and their origin is changed to file
 export DOCKER_ENV_VARS_ALWAYS += \
-  CFLAGS \
   DISABLE_MODULE \
   DEFAULT_MODULE \
   FEATURES_REQUIRED \


### PR DESCRIPTION
### Contribution description

This PR reverts part of #17396 for issues mentioned in https://github.com/RIOT-OS/RIOT/issues/17770. `CFLAGS` will often hold characters that need escaping when passing to docker which makes it harder to generalize.

### Testing procedure

The following fails in master and passes now:

```
BUILD_IN_DOCKER=1 make -C tests/progress_bar/ clean all -j
```

### Issues/PRs references

#17396 
