### PR TITLE
STM32 UART: trigger on TX register empty, not TX complete

### DIFF
--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -430,7 +430,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 #endif
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     for (size_t i = 0; i < len; i++) {
-        dev(uart)->CR1 |= (USART_CR1_TCIE);
+        dev(uart)->CR1 |= (USART_CR1_TXEIE);
         if (irq_is_in() || __get_PRIMASK()) {
             /* if ring buffer is full free up a spot */
             if (tsrb_full(&uart_tx_rb[uart])) {
@@ -495,7 +495,7 @@ static inline void irq_handler_tx(uart_t uart)
 
     /* disable the interrupt if there are no more bytes to send */
     if (tsrb_empty(&uart_tx_rb[uart])) {
-        dev(uart)->CR1 &= ~(USART_CR1_TCIE);
+        dev(uart)->CR1 &= ~(USART_CR1_TXEIE);
     }
 }
 #endif
@@ -505,7 +505,7 @@ static inline void irq_handler(uart_t uart)
     uint32_t status = dev(uart)->ISR_REG;
 
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
-    if (status & ISR_TC) {
+    if (status & ISR_TXE) {
         irq_handler_tx(uart);
     }
 #endif


### PR DESCRIPTION
## Contribution description

The STM32 serial driver uses an interrupt-controlled transmitter which triggers on TCIE "TX complete", i.e. the transmitter has completed sending the stop bits and is idle.

This introduces unnecessary delay and slows down high-speed output. The correct interrupt to use is TXEIE "TX register is empty", i.e. the transmitter has read from the TX register and started sending a byte, thus the TX register is free to buffer the next byte.

### Testing procedure

I have built the Blink example for `BOARD=bluepill` and confirmed that it (a) does use the tx buffer, (b) still works, (c) has lower delay between bytes (if the baud rate is high enough for that to be noticeable on the 'scope).
