### PR TITLE
tools/pr_check: add "Update" keywork to "needs squashing" check

### DIFF
--- a/dist/tools/pr_check/check.sh
+++ b/dist/tools/pr_check/check.sh
@@ -36,7 +36,8 @@ keyword_filter() {
     grep -i \
         -e "^    [0-9a-f]\+ .\{0,2\}SQUASH" \
         -e "^    [0-9a-f]\+ .\{0,2\}FIX" \
-        -e "^    [0-9a-f]\+ .\{0,2\}REMOVE *ME"
+        -e "^    [0-9a-f]\+ .\{0,2\}REMOVE *ME" \
+        -e "^    [0-9a-f]\+ .\{0,2\}Update"
 }
 
 SQUASH_COMMITS="$(git log $(git merge-base HEAD "${RIOT_MASTER}")...HEAD --pretty=format:"    %h %s" | \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When one accepts a suggestion in a review, Github by default creates commits with a message that starts with `Update`. This PR adds a rule to make the needs squashing check to fail in this case.

With auto-merge enabled, some already ACKed PR could go in if a contributor accepts a suggestion afterwards and Murdock hasn't completed yet for example.  This PR should mitigate this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

There an empty commit that should make the check to fail. I'll remove it before merging.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that issue in #10082 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
