### PR TITLE
Don't busy-wait when sending on UART

### DIFF
--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -28,6 +28,7 @@
 
 #include "cpu.h"
 #include "sched.h"
+#include "mutex.h"
 #include "thread.h"
 #include "assert.h"
 #include "periph/uart.h"
@@ -90,6 +91,9 @@ static struct {
     uart_rx_cb_t rx_cb;   /**< data received interrupt callback */
     void *arg;            /**< argument to both callback routines */
     uint8_t data_mask;    /**< mask applied to the data register */
+#if defined(MODULE_PERIPH_UART_NONBLOCKING) || defined(DOXYGEN)
+    mutex_t tx_empty;     /**< lock for waiting for an empty tx buffer */
+#endif
 } isr_ctx[UART_NUMOF];
 
 static inline USART_TypeDef *dev(uart_t uart)
@@ -183,6 +187,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     /* set up the TX buffer */
+    mutex_init(&isr_ctx[uart].tx_empty);
     tsrb_init(&uart_tx_rb[uart], uart_tx_rb_buf[uart], UART_TXBUF_SIZE);
 #endif
 
@@ -439,7 +444,11 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             tsrb_add_one(&uart_tx_rb[uart], data[i]);
         }
         else {
-            while (tsrb_add_one(&uart_tx_rb[uart], data[i]) < 0) {}
+            while (tsrb_add_one(&uart_tx_rb[uart], data[i]) < 0) {
+                /* Wait until the buffer is empty */
+                mutex_trylock(&isr_ctx[uart].tx_empty);
+                mutex_lock(&isr_ctx[uart].tx_empty);
+            }
         }
     }
 #else
@@ -496,6 +505,7 @@ static inline void irq_handler_tx(uart_t uart)
     /* disable the interrupt if there are no more bytes to send */
     if (tsrb_empty(&uart_tx_rb[uart])) {
         dev(uart)->CR1 &= ~(USART_CR1_TCIE);
+        mutex_unlock(&isr_ctx[uart].tx_empty);
     }
 }
 #endif

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -65,6 +65,9 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#ifdef MODULE_PERIPH_UART_NONBLOCKING
+#include "mutex.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -116,6 +119,9 @@ typedef struct {
 #ifdef MODULE_PERIPH_UART_RXSTART_IRQ
     uart_rxstart_cb_t rxs_cb;   /**< start condition received interrupt callback */
     void *rxs_arg;          /**< argument to start condition received callback */
+#endif
+#ifdef MODULE_PERIPH_UART_NONBLOCKING
+    mutex_t *tx_empty;      /**< lock for waiting for an empty TX buffer */
 #endif
 } uart_isr_ctx_t;
 #endif

--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -12,6 +12,8 @@ RIOTBASE ?= $(CURDIR)/../..
 # development process:
 DEVELHELP ?= 1
 
+CFLAGS += -DUART_TXBUF_SIZE=4
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 


### PR DESCRIPTION
### Contribution description

Busy-waiting on UART transmission is not a good idea (unless called from interrupt …).

This commit modifies those UART drivers which already use a transmit interrupt+buffer to wait on a mutex when the buffer is full, instead of busy-looping until there's space.

### Testing procedure

I verified that this scheme works on a bluepill board.

The others are untested.
