### PR TITLE
pkg/semtech-loramac: enable setting channels mask

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -407,3 +407,14 @@ uint32_t semtech_loramac_get_uplink_counter(semtech_loramac_t *mac)
     mutex_unlock(&mac->lock);
     return counter;
 }
+
+void semtech_loramac_set_channels_mask(semtech_loramac_t *mac, uint16_t *mask)
+{
+    mutex_lock(&mac->lock);
+    DEBUG("[semtech-loramac] setting channels mask\n");
+    MibRequestConfirm_t mibReqChannel;
+    mibReqChannel.Type = MIB_CHANNELS_MASK;
+    mibReqChannel.Param.ChannelsMask = mask;
+    LoRaMacMibSetRequestConfirm(&mibReqChannel);
+    mutex_unlock(&mac->lock);
+}

--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -412,9 +412,20 @@ void semtech_loramac_set_channels_mask(semtech_loramac_t *mac, uint16_t *mask)
 {
     mutex_lock(&mac->lock);
     DEBUG("[semtech-loramac] setting channels mask\n");
-    MibRequestConfirm_t mibReqChannel;
-    mibReqChannel.Type = MIB_CHANNELS_MASK;
-    mibReqChannel.Param.ChannelsMask = mask;
-    LoRaMacMibSetRequestConfirm(&mibReqChannel);
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_CHANNELS_MASK;
+    mibReq.Param.ChannelsMask = mask;
+    LoRaMacMibSetRequestConfirm(&mibReq);
+    mutex_unlock(&mac->lock);
+}
+
+void semtech_loramac_get_channels_mask(semtech_loramac_t *mac, uint16_t *mask)
+{
+    mutex_lock(&mac->lock);
+    DEBUG("[semtech-loramac] getting channels mask\n");
+    MibRequestConfirm_t mibReq;
+    mibReq.Type = MIB_CHANNELS_MASK;
+    LoRaMacMibGetRequestConfirm(&mibReq);
+    memcpy(mask, mibReq.Param.ChannelsMask, LORAMAC_CHANNELS_MASK_LEN);
     mutex_unlock(&mac->lock);
 }

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -505,6 +505,14 @@ uint8_t semtech_loramac_get_rx2_dr(semtech_loramac_t *mac);
 void semtech_loramac_set_uplink_counter(semtech_loramac_t *mac, uint32_t counter);
 
 /**
+ * @brief   Sets the Channels Mask
+ *
+ * @param[in] mac          Pointer to the mac
+ * @param[in] mask         Mask array, e.g., {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x0000, 0x0000}
+ */
+void semtech_loramac_set_channels_mask(semtech_loramac_t *mac, uint16_t *mask);
+
+/**
  * @brief   Gets the Uplink Frame Counter
  *
  * @param[in] mac          Pointer to the mac

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -505,6 +505,14 @@ uint8_t semtech_loramac_get_rx2_dr(semtech_loramac_t *mac);
 void semtech_loramac_set_uplink_counter(semtech_loramac_t *mac, uint32_t counter);
 
 /**
+ * @brief   Gets the Uplink Frame Counter
+ *
+ * @param[in] mac          Pointer to the mac
+ * @return                 Uplink frame counter
+ */
+uint32_t semtech_loramac_get_uplink_counter(semtech_loramac_t *mac);
+
+/**
  * @brief   Sets the Channels Mask
  *
  * @param[in] mac          Pointer to the mac
@@ -513,12 +521,12 @@ void semtech_loramac_set_uplink_counter(semtech_loramac_t *mac, uint32_t counter
 void semtech_loramac_set_channels_mask(semtech_loramac_t *mac, uint16_t *mask);
 
 /**
- * @brief   Gets the Uplink Frame Counter
+ * @brief   Gets the Channels Mask
  *
  * @param[in] mac          Pointer to the mac
- * @return                 Uplink frame counter
+ * @param[in] mask         Mask array pointer
  */
-uint32_t semtech_loramac_get_uplink_counter(semtech_loramac_t *mac);
+void semtech_loramac_get_channels_mask(semtech_loramac_t *mac, uint16_t *mask);
 
 #ifdef MODULE_PERIPH_EEPROM
 /**

--- a/pkg/semtech-loramac/patches/0005-relax-channel-mask-rules-in-regi.patch
+++ b/pkg/semtech-loramac/patches/0005-relax-channel-mask-rules-in-regi.patch
@@ -1,0 +1,41 @@
+From ba0f363621429a2f6ac78d63f1d17ec322820814 Mon Sep 17 00:00:00 2001
+From: Geovane Fedrecheski <geonnave@gmail.com>
+Date: Thu, 17 Mar 2022 23:11:38 -0300
+Subject: [PATCH] relax channel mask rules in region AU915
+
+This reflects the latest state of the RegionAU915ChanMaskSet function
+(latest change in Mar 8 2021):
+https://github.com/Lora-net/LoRaMac-node/blob/691086af5524803d17fd22d3096cda62da4b0713/src/mac/region/RegionAU915.c#L475
+
+The removal of the rules was made in this commit:
+https://github.com/Lora-net/LoRaMac-node/commit/e60bd869
+
+---
+ src/mac/region/RegionAU915.c | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/src/mac/region/RegionAU915.c b/src/mac/region/RegionAU915.c
+index 067a15df..68b311fd 100644
+--- a/src/mac/region/RegionAU915.c
++++ b/src/mac/region/RegionAU915.c
+@@ -384,17 +384,6 @@ void RegionAU915ApplyCFList( ApplyCFListParams_t* applyCFList )
+ 
+ bool RegionAU915ChanMaskSet( ChanMaskSetParams_t* chanMaskSet )
+ {
+-    uint8_t nbChannels = RegionCommonCountChannels( chanMaskSet->ChannelsMaskIn, 0, 4 );
+-
+-    // Check the number of active channels
+-    // According to ACMA regulation, we require at least 20 125KHz channels, if
+-    // the node shall utilize 125KHz channels.
+-    if( ( nbChannels < 20 ) &&
+-        ( nbChannels > 0 ) )
+-    {
+-        return false;
+-    }
+-
+     switch( chanMaskSet->ChannelsMaskType )
+     {
+         case CHANNELS_MASK:
+-- 
+2.20.1
+

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -548,13 +548,15 @@ extern "C" {
 #define LORAMAC_NETWORK_ID_LEN                  (3U)
 
 /**
- * @brief   Maximum length for channel mask
+ * @brief   Channel mask length
  *
- *          The actual length is set by each region-specific LoRaMac
- *          implementation (see CHANNELS_MASK_SIZE), which
- *          automatically slices down the channel array mask.
+ *          Must match CHANNELS_MASK_SIZE in src/mac/region/RegionXXYYY.c
  */
-#define LORAMAC_CHANNELS_MASK_MAX_LEN                     (6U)
+#if defined(REGION_AU915) || defined(REGION_CN470) || defined(REGION_US915) || defined(REGION_US915_HYBRID) || defined(REGION_AS923)
+#define LORAMAC_CHANNELS_MASK_LEN                     (6U)
+#else
+#define LORAMAC_CHANNELS_MASK_LEN                     (1U)
+#endif
 
 /** @} */
 

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -547,6 +547,15 @@ extern "C" {
  */
 #define LORAMAC_NETWORK_ID_LEN                  (3U)
 
+/**
+ * @brief   Maximum length for channel mask
+ *
+ *          The actual length is set by each region-specific LoRaMac
+ *          implementation (see CHANNELS_MASK_SIZE), which
+ *          automatically slices down the channel array mask.
+ */
+#define LORAMAC_CHANNELS_MASK_MAX_LEN                     (6U)
+
 /** @} */
 
 /**

--- a/sys/shell/commands/sc_loramac.c
+++ b/sys/shell/commands/sc_loramac.c
@@ -58,7 +58,7 @@ static void _loramac_tx_usage(void)
 static void _loramac_set_usage(void)
 {
     puts("Usage: loramac set <deveui|appeui|appkey|appskey|nwkskey|devaddr|"
-         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt> <value>");
+         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt|ch_mask> <value>");
 }
 
 static void _loramac_get_usage(void)
@@ -346,6 +346,22 @@ int _loramac_handler(int argc, char **argv)
             }
             uint32_t counter = atoi(argv[3]);
             semtech_loramac_set_uplink_counter(&loramac, counter);
+        }
+        else if (strcmp("ch_mask", argv[2]) == 0) {
+            if (argc < 4) {
+                puts("Usage: loramac set ch_mask <value>");
+                puts("Example (sets channels 0-3): loramac set ch_mask 000F00000000000000000000");
+                return 1;
+            }
+            uint16_t mask[LORAMAC_CHANNELS_MASK_MAX_LEN] = { 0 };
+            uint8_t tmp[LORAMAC_CHANNELS_MASK_MAX_LEN*2];
+            fmt_hex_bytes(tmp, argv[3]);
+            for (size_t i = 0, j = 0; i < LORAMAC_CHANNELS_MASK_MAX_LEN; i++, j+=2) {
+                /* copy over to span a 16-bit -wide unsigned integer */
+                mask[i] |= tmp[j] << 8;
+                mask[i] |= tmp[j+1];
+            }
+            semtech_loramac_set_channels_mask(&loramac, mask);
         }
         else {
             _loramac_set_usage();

--- a/sys/shell/commands/sc_loramac.c
+++ b/sys/shell/commands/sc_loramac.c
@@ -64,7 +64,7 @@ static void _loramac_set_usage(void)
 static void _loramac_get_usage(void)
 {
     puts("Usage: loramac get <deveui|appeui|appkey|appskey|nwkskey|devaddr|"
-         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt>");
+         "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt|ch_mask>");
 }
 
 int _loramac_handler(int argc, char **argv)
@@ -165,6 +165,15 @@ int _loramac_handler(int argc, char **argv)
         }
         else if (strcmp("ul_cnt", argv[2]) == 0) {
             printf("Uplink Counter: %"PRIu32"\n", semtech_loramac_get_uplink_counter(&loramac));
+        }
+        else if (strcmp("ch_mask", argv[2]) == 0) {
+            uint16_t mask[LORAMAC_CHANNELS_MASK_LEN] = { 0 };
+            semtech_loramac_get_channels_mask(&loramac, mask);
+            printf("Channels mask: ");
+            for (size_t i = 0; i < LORAMAC_CHANNELS_MASK_LEN; i++) {
+                printf("%04x", mask[i]);
+            }
+            printf("\n");
         }
         else {
             _loramac_get_usage();
@@ -353,10 +362,10 @@ int _loramac_handler(int argc, char **argv)
                 puts("Example (sets channels 0-3): loramac set ch_mask 000F00000000000000000000");
                 return 1;
             }
-            uint16_t mask[LORAMAC_CHANNELS_MASK_MAX_LEN] = { 0 };
-            uint8_t tmp[LORAMAC_CHANNELS_MASK_MAX_LEN*2];
+            uint16_t mask[LORAMAC_CHANNELS_MASK_LEN] = { 0 };
+            uint8_t tmp[LORAMAC_CHANNELS_MASK_LEN*2];
             fmt_hex_bytes(tmp, argv[3]);
-            for (size_t i = 0, j = 0; i < LORAMAC_CHANNELS_MASK_MAX_LEN; i++, j+=2) {
+            for (size_t i = 0, j = 0; i < LORAMAC_CHANNELS_MASK_LEN; i++, j+=2) {
                 /* copy over to span a 16-bit -wide unsigned integer */
                 mask[i] |= tmp[j] << 8;
                 mask[i] |= tmp[j+1];


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This change contains an addition to pkg/semtech-loramac/contrib and a patch to be applied on the original semtech-loramac code. Specifically, it:
- enable users to set the channels mask
- includes a patch that enables arbitrary channels masks to be set on region AU915. The change was extracted from the original *Lora-net/LoRaMac-node* repository, see [this commit](https://github.com/Lora-net/LoRaMac-node/commit/e60bd869). It reflects restrictions that were relaxed in a newer LoRa spec (v1.0.3rA).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I could not find automated unit tests for `semtech_loramac_getset.c`.

Manual testing could be performed as follows:
- on `examples/lorawan/main.c`, just after `semtech_loramac_set_dr`, add the following:
```.c
/* Set a mask for using only the first 8 channels */
uint16_t channel_mask[6] = {0x00FF, 0, 0, 0, 0, 0};
semtech_loramac_set_channels_mask(&loramac, channel_mask);
```
- inspect that `SendFrameOnChannel` only uses channels in the 0-7 range. For example, modify it temporarily as follows:
```diff
+#include <stdio.h>
LoRaMacStatus_t SendFrameOnChannel( uint8_t channel )
{
+    printf("SendFrameOnChannel: %d\n", channel);
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

N/A.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
