### PR TITLE
core/Kconfig: move MODULE_CORE_LIB symbol to fix menuconfig display

### DIFF
--- a/core/Kconfig
+++ b/core/Kconfig
@@ -14,12 +14,6 @@ menuconfig MODULE_CORE
         RIOT's core module. Only change this if you know what you are doing. If
         unsure, say Y.
 
-config MODULE_CORE_LIB
-    bool
-    default y
-    help
-        Select y to to include core libs
-
 if MODULE_CORE
 
 config MODULE_CORE_IDLE_THREAD
@@ -56,6 +50,12 @@ config MODULE_SCHED_CB
     bool "Callback support on the scheduler"
 
 endif # MODULE_CORE
+
+config MODULE_CORE_LIB
+    bool
+    default y
+    help
+        Select y to to include core libs
 
 menuconfig KCONFIG_USEMODULE_CORE
     bool "Configure RIOT Core"


### PR DESCRIPTION
### Contribution description
#17652 split the library code in core, adding the new symbol `MODULE_CORE_LIB`. As it was placed directly after `MODULE_CORE` the rest of modules, although still depending on `MODULE_CORE`, are not displayed as a submenu. This moves the symbol down (which has no effects on the dependencies), but groups all core options again.

### Testing procedure
- In any application run `env TEST_KCONFIG=1 make menuconfig`, you should see all core modules inside the `RIOT Core` menu, in master they are in a flatten layout.


### Issues/PRs references
#17652
