### PR TITLE
boards: add support for nucleo-f439zi

### DIFF
--- a/boards/nucleo-f439zi/Kconfig
+++ b/boards/nucleo-f439zi/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2022 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f439zi" if BOARD_NUCLEO_F439ZI
+
+config BOARD_NUCLEO_F439ZI
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F439ZI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f439zi/Makefile
+++ b/boards/nucleo-f439zi/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-f439zi/Makefile.dep
+++ b/boards/nucleo-f439zi/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += stm32_eth
+endif
+
+include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-f439zi/Makefile.features
+++ b/boards/nucleo-f439zi/Makefile.features
@@ -1,0 +1,16 @@
+CPU = stm32
+CPU_MODEL = stm32f439zi
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_eth
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo144/Makefile.features

--- a/boards/nucleo-f439zi/Makefile.include
+++ b/boards/nucleo-f439zi/Makefile.include
@@ -1,0 +1,9 @@
+#variable needed by cpy2remed PROGRAMMER
+#it contains name of ST-Link removable media
+DIR_NAME_AT_REMED = "NODE_F439ZI"
+
+PROGRAMMERS_SUPPORTED += cpy2remed
+
+
+# load the common Makefile.include for Nucleo-144 boards
+include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f439zi/doc.txt
+++ b/boards/nucleo-f439zi/doc.txt
@@ -1,0 +1,22 @@
+/**
+@defgroup    boards_nucleo-f439zi STM32 Nucleo-F439ZI
+@ingroup     boards_common_nucleo144
+@brief       Support for the STM32 Nucleo-F439ZI
+
+
+## Flashing the device
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f439zi PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
+ */

--- a/boards/nucleo-f439zi/include/periph_conf.h
+++ b/boards/nucleo-f439zi/include/periph_conf.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2022 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-f439zi
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for the nucleo-f439zi board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* This board provides an LSE */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE    1
+#endif
+
+/* This board provides an HSE */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE    1
+#endif
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_timer_tim5.h"
+#include "cfg_usb_otg_fs.h"
+#include "mii.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    DMA streams configuration
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+    { .stream = 8 },    /* DMA2 Stream 0 - ETH_TX  */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+#define DMA_2_ISR           isr_dma2_stream0
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 9),
+        .tx_pin     = GPIO_PIN(PORT_D, 8),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = DMA_STREAM_UNDEF,
+        .dma_chan   = UINT8_MAX,
+#endif
+    },
+    {
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 9),
+        .tx_pin     = GPIO_PIN(PORT_G, 14),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = DMA_STREAM_UNDEF,
+        .dma_chan   = UINT8_MAX,
+#endif
+    },
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = DMA_STREAM_UNDEF,
+        .dma_chan   = UINT8_MAX,
+#endif
+    },
+};
+
+#define UART_0_ISR          (isr_usart3)
+#define UART_1_ISR          (isr_usart6)
+#define UART_2_ISR          (isr_usart2)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3 */, .cc_chan = 2},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15) /* D9 */, .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name ETH configuration
+ * @{
+ */
+static const eth_conf_t eth_config = {
+    .mode = RMII,
+    .speed = MII_BMCR_SPEED_100 | MII_BMCR_FULL_DPLX,
+    .dma = 2,
+    .dma_chan = 8,
+    .phy_addr = 0x00,
+    .pins = {
+        GPIO_PIN(PORT_G, 13),
+        GPIO_PIN(PORT_B, 13),
+        GPIO_PIN(PORT_G, 11),
+        GPIO_PIN(PORT_C, 4),
+        GPIO_PIN(PORT_C, 5),
+        GPIO_PIN(PORT_A, 7),
+        GPIO_PIN(PORT_C, 1),
+        GPIO_PIN(PORT_A, 2),
+        GPIO_PIN(PORT_A, 1),
+    }
+};
+
+#define ETH_DMA_ISR        isr_dma2_stream0
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32/kconfigs/f4/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f4/Kconfig.lines
@@ -124,6 +124,7 @@ config CPU_LINE_STM32F439XX
     bool
     select CPU_FAM_F4
     select HAS_BACKUP_RAM
+    select HAS_PERIPH_HWRNG
     select CLOCK_MAX_180MHZ
 
 config CPU_LINE_STM32F446XX

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14922,3 +14922,21 @@ boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member sam_usbd
 boards/nucleo\-f429zi/include/periph_conf\.h:[0-9]+: warning: Member DMA_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-f429zi/include/periph_conf\.h:[0-9]+: warning: Member ETH_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-f429zi/include/periph_conf\.h:[0-9]+: warning: Member eth_config \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_LSE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member CONFIG_BOARD_HAS_HSE \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member DMA_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member DMA_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member DMA_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member DMA_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member dma_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member UART_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member UART_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member uart_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member PWM_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member pwm_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member ETH_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member eth_config \(variable\) of file periph_conf\.h is not documented\.

--- a/tests/Makefile.boards.netif
+++ b/tests/Makefile.boards.netif
@@ -33,6 +33,7 @@ BOARD_PROVIDES_NETIF := \
     nrf6310 \
     nucleo-f207zg \
     nucleo-f429zi \
+    nucleo-f439zi \
     nucleo-f767zi \
     openlabs-kw41z-mini \
     openlabs-kw41z-mini-256kib \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds support for another STM32 nucleo board, the nucleo-f439zi which is very similar to the nucleo-f429zi. It's also interesting because it provides an Ethernet port.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- I tested all features provided except SPI, but according to the datasheet and board documentation the provided configuration is ok
- I ran compile_and_test_for_board.py and got the following result:

```
ERROR:nucleo-f439zi:Tests failed: 2
Failures during compilation:
- [tests/rust_minimal](tests/rust_minimal/compilation.failed)

Failures during test:
- [tests/malloc](tests/malloc/test.failed)
```

I don't understand the malloc failure but I get the same error on nucleo-f429zi. Maybe it's also related to #17439 because the error seems similar:

```
Allocated 128 Bytes at 0x0x2002fd70, total 170944
Allocated 128 Bytes at 0x0x2002fe08, total 171080
Allocated 128 Bytes at 0x0x2002fea0, total 171216
Allocated 128 Bytes at 0x0x2002ff38, total 171352
Allocated 128 Bytes at 0x0x2002ffd0, total 171488

Context before hardfault:
   r0: 0x2002ffd0
   r1: 0x00000040
   r2: 0x20030050
   r3: 0x20030001
  r12: 0x0000000a
   lr: 0x08000275
   pc: 0x080014de
  psr: 0x81000000

FSR/FAR:
 CFSR: 0x00000400
 HFSR: 0x40000000
 DFSR: 0x00000008
 AFSR: 0x00000000
Misc
EXC_RET: 0xfffffffd
Active thread: 1 "main"
Attempting to reconstruct state for debugging...
In GDB:
  set $pc=0x80014de
  frame 0
  bt

ISR stack overflowed by at least 16 bytes.
```

For the rust build failure, I think it's a toolchain issue locally (I didn't try with BUILD_IN_DOCKER=1)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
