### PR TITLE
boards/nucleo-f429zi: add support for ethernet

### DIFF
--- a/boards/nucleo-f429zi/Kconfig
+++ b/boards/nucleo-f429zi/Kconfig
@@ -17,6 +17,7 @@ config BOARD_NUCLEO_F429ZI
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
+    select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC

--- a/boards/nucleo-f429zi/Makefile.dep
+++ b/boards/nucleo-f429zi/Makefile.dep
@@ -1,1 +1,5 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += stm32_eth
+endif
+
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32f429zi
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -34,6 +34,7 @@
 #include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_timer_tim5.h"
 #include "cfg_usb_otg_fs.h"
+#include "mii.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,10 +47,12 @@ extern "C" {
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+    { .stream = 8 },    /* DMA2 Stream 0 - ETH_TX  */
 };
 
 #define DMA_0_ISR           isr_dma2_stream3
 #define DMA_1_ISR           isr_dma2_stream2
+#define DMA_2_ISR           isr_dma2_stream0
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
 /** @} */
@@ -191,6 +194,32 @@ static const adc_conf_t adc_config[] = {
 
 #define VBAT_ADC            ADC_LINE(6) /**< VBAT ADC line */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+/**
+ * @name ETH configuration
+ * @{
+ */
+static const eth_conf_t eth_config = {
+    .mode = RMII,
+    .speed = MII_BMCR_SPEED_100 | MII_BMCR_FULL_DPLX,
+    .dma = 2,
+    .dma_chan = 8,
+    .phy_addr = 0x00,
+    .pins = {
+        GPIO_PIN(PORT_G, 13),
+        GPIO_PIN(PORT_B, 13),
+        GPIO_PIN(PORT_G, 11),
+        GPIO_PIN(PORT_C, 4),
+        GPIO_PIN(PORT_C, 5),
+        GPIO_PIN(PORT_A, 7),
+        GPIO_PIN(PORT_C, 1),
+        GPIO_PIN(PORT_A, 2),
+        GPIO_PIN(PORT_A, 1),
+    }
+};
+
+#define ETH_DMA_ISR        isr_dma2_stream0
 /** @} */
 
 #ifdef __cplusplus

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14919,3 +14919,6 @@ boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_DEV 
 boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member ADC_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member adc_channels\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/adafruit\-pybadge/include/periph_conf\.h:[0-9]+: warning: Member sam_usbdev_config\[\] \(variable\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f429zi/include/periph_conf\.h:[0-9]+: warning: Member DMA_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f429zi/include/periph_conf\.h:[0-9]+: warning: Member ETH_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/nucleo\-f429zi/include/periph_conf\.h:[0-9]+: warning: Member eth_config \(variable\) of file periph_conf\.h is not documented\.

--- a/tests/Makefile.boards.netif
+++ b/tests/Makefile.boards.netif
@@ -32,6 +32,7 @@ BOARD_PROVIDES_NETIF := \
     nrf52dk \
     nrf6310 \
     nucleo-f207zg \
+    nucleo-f429zi \
     nucleo-f767zi \
     openlabs-kw41z-mini \
     openlabs-kw41z-mini-256kib \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As the title says. With #17827 which is very similar, I saw that the Ethernet configuration was missing for this board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The Ethernet interface pops up in ifconfig when flashing `examples/default`:

<details>

```
2022-03-18 16:10:12,993 # NETOPT_RX_END_IRQ not implemented by driver
2022-03-18 16:10:12,996 # main(): This is RIOT! (Version: 2022.04-devel-893-g1de68-pr/boards/nucleo-f429zi-eth)
2022-03-18 16:10:12,996 # Welcome to RIOT!
> 2022-03-18 16:10:13,911 # PKTDUMP: data received:
2022-03-18 16:10:13,912 # ~~ SNIP  0 - size:  96 byte, type: NETTYPE_UNDEF (0)
2022-03-18 16:10:13,923 # 00000000  60  00  00  00  00  38  00  01  FE  80  00  00  00  00  00  00
2022-03-18 16:10:13,929 # 00000010  DE  82  33  B9  9A  73  C6  90  FF  02  00  00  00  00  00  00
2022-03-18 16:10:13,935 # 00000020  00  00  00  00  00  00  00  16  3A  00  05  02  00  00  01  00
2022-03-18 16:10:13,947 # 00000030  8F  00  32  B2  00  00  00  02  04  00  00  00  FF  02  00  00
2022-03-18 16:10:13,948 # 00000040  00  00  00  00  00  00  00  00  00  00  00  FB  04  00  00  00
2022-03-18 16:10:13,953 # 00000050  FF  02  00  00  00  00  00  00  00  00  00  01  FF  73  C6  90
2022-03-18 16:10:13,959 # ~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
2022-03-18 16:10:13,960 # if_pid: 3  rssi: -32768  lqi: 0
2022-03-18 16:10:13,960 # flags: 0x0
2022-03-18 16:10:13,965 # src_l2addr: D8:EB:97:BF:2F:A7
2022-03-18 16:10:13,965 # dst_l2addr: 33:33:00:00:00:16
2022-03-18 16:10:13,971 # ~~ PKT    -  2 snips, total size: 116 byte
2022-03-18 16:10:14,146 # PKTDUMP: data received:
2022-03-18 16:10:14,151 # ~~ SNIP  0 - size:  96 byte, type: NETTYPE_UNDEF (0)
2022-03-18 16:10:14,157 # 00000000  60  00  00  00  00  38  00  01  FE  80  00  00  00  00  00  00
2022-03-18 16:10:14,165 # 00000010  DE  82  33  B9  9A  73  C6  90  FF  02  00  00  00  00  00  00
2022-03-18 16:10:14,170 # 00000020  00  00  00  00  00  00  00  16  3A  00  05  02  00  00  01  00
2022-03-18 16:10:14,176 # 00000030  8F  00  32  B2  00  00  00  02  04  00  00  00  FF  02  00  00
2022-03-18 16:10:14,188 # 00000040  00  00  00  00  00  00  00  00  00  00  00  FB  04  00  00  00
2022-03-18 16:10:14,190 # 00000050  FF  02  00  00  00  00  00  00  00  00  00  01  FF  73  C6  90
2022-03-18 16:10:14,194 # ~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
2022-03-18 16:10:14,199 # if_pid: 3  rssi: -32768  lqi: 0
2022-03-18 16:10:14,200 # flags: 0x0
2022-03-18 16:10:14,200 # src_l2addr: D8:EB:97:BF:2F:A7
2022-03-18 16:10:14,205 # dst_l2addr: 33:33:00:00:00:16
2022-03-18 16:10:14,212 # ~~ PKT    -  2 snips, total size: 116 byte
ifconfig
2022-03-18 16:10:18,111 # ifconfig
2022-03-18 16:10:18,117 # Iface  3  HWaddr: A6:D7:5E:88:84:3E  Link: up 
2022-03-18 16:10:18,123 #           L2-PDU:1500  Source address length: 6
2022-03-18 16:10:18,123 #           
> 2022-03-18 16:10:19,637 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that when working on #17827 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
