### PR TITLE
periph/timer: fix Kconfig menu title

### DIFF
--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -149,6 +149,7 @@ config MODULE_PERIPH_INIT_TEMPERATURE
     default y if MODULE_PERIPH_INIT
     depends on MODULE_PERIPH_TEMPERATURE
 
+rsource "Kconfig.timer"
 rsource "Kconfig.uart"
 
 config MODULE_PERIPH_USBDEV
@@ -169,6 +170,5 @@ config HAVE_SHARED_PERIPH_RTT_PERIPH_RTC
         The periph_rtc module or the periph_rtt module share hardware, thus,
         only one can be selected.
 
-rsource "Kconfig.timer"
 rsource "Kconfig.vbat"
 rsource "Kconfig.wdt"

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -84,16 +84,6 @@ config MODULE_PERIPH_INIT_HWRNG
 
 rsource "Kconfig.i2c"
 
-config MODULE_PERIPH_PWM
-    bool "PWM peripheral driver"
-    depends on HAS_PERIPH_PWM
-    select MODULE_PERIPH_COMMON
-
-config MODULE_PERIPH_INIT_PWM
-    bool "Auto initialize PWM peripheral"
-    default y if MODULE_PERIPH_INIT
-    depends on MODULE_PERIPH_PWM
-
 config MODULE_PERIPH_PM
     bool "Power Management (PM) peripheral driver"
     default y
@@ -104,6 +94,16 @@ config MODULE_PERIPH_INIT_PM
     bool "Auto initialize Power Management (PM) peripheral"
     default y if MODULE_PERIPH_INIT
     depends on MODULE_PERIPH_PM
+
+config MODULE_PERIPH_PWM
+    bool "PWM peripheral driver"
+    depends on HAS_PERIPH_PWM
+    select MODULE_PERIPH_COMMON
+
+config MODULE_PERIPH_INIT_PWM
+    bool "Auto initialize PWM peripheral"
+    default y if MODULE_PERIPH_INIT
+    depends on MODULE_PERIPH_PWM
 
 config MODULE_PERIPH_QDEC
     bool "Quadrature Decoder (QDEC) peripheral driver"

--- a/drivers/periph_common/Kconfig.timer
+++ b/drivers/periph_common/Kconfig.timer
@@ -7,7 +7,7 @@
 if TEST_KCONFIG
 
 menuconfig MODULE_PERIPH_TIMER
-    bool "Configure timer peripheral driver"
+    bool "Timer peripheral driver"
     depends on HAS_PERIPH_TIMER
     select MODULE_PERIPH_COMMON
 


### PR DESCRIPTION
### Contribution description

This PR is a very small fix of inconsistent peripheral driver entry in `Kconfig` for `periph/timer`.

In Kconfig menu `(Top) → Drivers → Peripherals drivers` all entries start with the peripheral name in alphabetical order with only one exception, the timer entry. This entry is called `Configure timer peripheral driver`:
```
[ ] CPU unique ID
[ ] EEPROM peripheral driver
[ ] Flashpage peripheral driver  ----
[*] GPIO peripheral driver  --->
[ ] HWRNG peripheral driver
[ ] PWM peripheral driver
[*] Power Management (PM) peripheral driver
[*]     Auto initialize Power Management (PM) peripheral
[ ] Quadrature Decoder (QDEC) peripheral driver
[ ] RTC peripheral driver  ----
[ ] SPI peripheral driver  ----
[*] UART peripheral driver  --->
[*] Configure timer peripheral driver  --->
```
This is confusing and doesn't help to find the right entry. This PR
1. changes the entry to `Timer peripheral driver` and
2. corrects the alphabetical order.

### Testing procedure

Use command
```
TEST_KCONFIG=1 make -C tests/periph_timer menuconfig
```
and check the output. in menu `(Top) → Drivers → Peripherals drivers`. It should be with this PR:
```
[ ] CPU unique ID
[ ] EEPROM peripheral driver
[ ] Flashpage peripheral driver  ----
[*] GPIO peripheral driver  --->
[ ] HWRNG peripheral driver
[ ] PWM peripheral driver
[*] Power Management (PM) peripheral driver
[*]     Auto initialize Power Management (PM) peripheral
[ ] Quadrature Decoder (QDEC) peripheral driver
[ ] RTC peripheral driver  ----
[ ] SPI peripheral driver  ----
[*] Timer peripheral driver  --->
[*] UART peripheral driver  --->
```
### Issues/PRs references
