### PR TITLE
nanocoap: add nanocoap_get_blockwise_url_to_buf() function

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -241,6 +241,29 @@ int nanocoap_get_blockwise_url(const char *url,
                                coap_blockwise_cb_t callback, void *arg);
 
 /**
+ * @brief    Performs a blockwise coap get request to the specified url, store
+ *           the response in a buffer.
+ *
+ * This function will fetch the content of the specified resource path via
+ * block-wise-transfer.
+ * The blocks will be re-assembled into @p buf
+ *
+ * @param[in]   url        Absolute URL pointer to source path (i.e. not containing
+ *                         a fragment identifier)
+ * @param[in]   blksize    sender suggested SZX for the COAP block request
+ * @param[in]   work_buf   Work buffer, must be `NANOCOAP_BLOCKWISE_BUF(blksize)` bytes
+ * @param[in]   buf        Target buffer
+ * @param[in]   len        Target buffer length
+ *
+ * @returns     -EINVAL    if an invalid url is provided
+ * @returns     -1         if failed to fetch the url content
+ * @returns     size of the response payload on success
+ */
+ssize_t nanocoap_get_blockwise_url_to_buf(const char *url,
+                                          coap_blksize_t blksize, void *work_buf,
+                                          void *buf, size_t len);
+
+/**
  * @brief   Simple synchronous CoAP request
  *
  * @param[in]       sock    socket to use for the request


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This moves the internal convenience function `suit_coap_get_blockwise_url_buf()` into nanocoap to make it globally available.

### Testing procedure

`examples/suit_update` still works

<details><summary>firmware update on same54-xpro via ethos</summary>

```
> ifconfig
Iface  4  HWaddr: 66:9B:87:4C:41:52 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::649b:87ff:fe4c:4152  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4c:4152
          inet6 group: ff02::1:ff00:2
          
suit: received URL: "coap://[2001:db8::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[2001:db8::1]/fw/same54-xpro/suit_update-riot.suit_signed.latest.bin"
suit_coap: got manifest with size 495
suit: verifying manifest signature
suit: validated manifest version
)riotboot_hdr_validate: riotboot_hdr magic number invalid
Manifest seq_no: 1647893258, highest available: 1647893156
suit: validated sequence number
)Formatted component name: 
Comparing manifest offset 4000 with other slot offset
Comparing manifest offset 82000 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 50244518-6a7c-5ce7-932b-88b318336c82 to 50244518-6a7c-5ce7-932b-88b318336c82 from manifest
validating class id: OK
Comparing manifest offset 4000 with other slot offset
Comparing manifest offset 82000 with other slot offset
SUIT policy check OK.
Formatted component name: 
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x6238db0a
Image start address: 0x00082400
Header chksum: 0x3857feec

suit_coap: rebooting...
----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.04-devel-904-gd96220-nanocoap_get_blockwise_url_to_buf)
RIOT SUIT update example application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x6238db0a
Image start address: 0x00082400
Header chksum: 0x3857feec

suit_coap: started.
Starting the shell
> 

```
</details>


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
