### PR TITLE
tests/thread_float: use ztimer_usec

### DIFF
--- a/tests/thread_float/Makefile
+++ b/tests/thread_float/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += printf_float
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 
 # native has known issues: the context switch via glibc's setcontext()
 # apparently doesn't properly save and restore the FPU state. This results in

--- a/tests/thread_float/main.c
+++ b/tests/thread_float/main.c
@@ -25,7 +25,7 @@
 
 #include "thread.h"
 #include "msg.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "timex.h"
 
 static char t1_stack[THREAD_STACKSIZE_MAIN];
@@ -34,17 +34,17 @@ static char t3_stack[THREAD_STACKSIZE_MAIN];
 
 static kernel_pid_t p1, p2, p3;
 
-static xtimer_t timer;
-#define OFFSET (10 * XTIMER_BACKOFF)
+static ztimer_t timer;
+
+#define OFFSET (100)
 
 static mutex_t lock = MUTEX_INIT;
 
 static void timer_cb(void *arg)
 {
     (void) arg;
-
     thread_yield();
-    xtimer_set(&timer, OFFSET);
+    ztimer_set(ZTIMER_USEC, &timer, OFFSET);
 }
 
 static void *thread_1_2_3(void *_arg)
@@ -92,7 +92,7 @@ int main(void)
     puts("THREADS CREATED\n");
 
     timer.callback = timer_cb;
-    xtimer_set(&timer, OFFSET);
+    ztimer_set(ZTIMER_USEC, &timer, OFFSET);
 
     return 0;
 }

--- a/tests/thread_float/main.c
+++ b/tests/thread_float/main.c
@@ -42,7 +42,7 @@ static mutex_t lock = MUTEX_INIT;
 
 static void timer_cb(void *arg)
 {
-    (void) arg;
+    (void)arg;
     thread_yield();
     ztimer_set(ZTIMER_USEC, &timer, OFFSET);
 }
@@ -80,6 +80,7 @@ int main(void)
     const char *t1_name = "t1";
     const char *t2_name = "t2";
     const char *t3_name = "t3";
+
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN + 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
                        thread_1_2_3, (void *)t1_name, t1_name);


### PR DESCRIPTION
### Contribution description

If using `ztimer_xtimer_compat` then `XTIMER_BACKOFF` is meaningless, the small offset leads to an offset that is
shorter than the time taken to set the timer, and therefore it gets stuck in a timer firing loop. Instead, directly use `ztimer_usec` with a 100usec base offset.

### Testing procedure

```
BOARD=samr21-xpro RYOT_CI=1 make -C tests/thread_float/ flash test -j7
main(): This is RIOT! (Version: 2022.04-devel-904-g0e462-pr_tests_thread_float_ztimer)
THREADS CREATED

THREAD t1 start
THREAD t2 start
THREAD t3 start
t1: 141.443787
t3: 141.466812
t1: 141.443787
t3: 141.466812
t1: 141.443787
t3: 141.466812
t1: 141.443787
t3: 141.466812
t1: 141.443787
t3: 141.466812
t1: 141.443787
t3: 141.466812
```

### Issues/PRs references

Found in #17721
