### PR TITLE
boards: fix ztimer adjust values for arduino-mega2560 and z1

### DIFF
--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -19,11 +19,20 @@
 #ifndef BOARD_H
 #define BOARD_H
 
-#include "board_common.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @name    ztimer configuration values
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET     (132)
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (120)
+/** @} */
+
+#include "board_common.h"
 
 #ifdef __cplusplus
 }

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -54,8 +54,8 @@ extern "C" {
  * @name    ztimer configuration values
  * @{
  */
-#define CONFIG_ZTIMER_USEC_ADJUST_SET     (96)
-#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (97)
+#define CONFIG_ZTIMER_USEC_ADJUST_SET     (99)
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (100)
 /** @} */
 
 /**

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14940,3 +14940,5 @@ boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \
 boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member spi_config\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member ETH_DMA_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/nucleo\-f439zi/include/periph_conf\.h:[0-9]+: warning: Member eth_config \(variable\) of file periph_conf\.h is not documented\.
+boards/arduino\-mega2560/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SET \(macro definition\) of file board\.h is not documented\.
+boards/arduino\-mega2560/include/board\.h:[0-9]+: warning: Member CONFIG_ZTIMER_USEC_ADJUST_SLEEP \(macro definition\) of file board\.h is not documented\.


### PR DESCRIPTION
### Contribution description

This fixes the values.

### Testing procedure

Simply run `tests/ztimer_overhead`

```
BUILD_IN_DOCKER=1  BOARD=z1 make -C tests/ztimer_overhead/ flash test -j
main(): This is RIOT! (Version: 2022.04-devel-905-g6ce15-pr_ztimer_adjust_correcitons)
ZTIMER_USEC auto_adjust params:
    ZTIMER_USEC->adjust_set = 99
    ZTIMER_USEC->adjust_sleep = 100
ZTIMER_USEC auto_adjust params cleared
zitmer_overhead_set...
min=99 max=100 avg_diff=99
zitmer_overhead_sleep...
min=100 max=101 avg_diff=100
ZTIMER_USEC adjust params for z1:
    CONFIG_ZTIMER_USEC_ADJUST_SET    99
    CONFIG_ZTIMER_USEC_ADJUST_SLEEP  100
```

```
BUILD_IN_DOCKER=1  BOARD=arduino-mega2560 make -C tests/ztimer_overhead/ flash test -j
main(): This is RIOT! (Version: 2022.04-devel-905-g6ce15-pr_ztimer_adjust_correcitons)
ZTIMER_USEC auto_adjust params:
    ZTIMER_USEC->adjust_set = 132
    ZTIMER_USEC->adjust_sleep = 120
ZTIMER_USEC auto_adjust params cleared
zitmer_overhead_set...
min=132 max=136 avg_diff=133
zitmer_overhead_sleep...
min=120 max=124 avg_diff=123
ZTIMER_USEC adjust params for arduino-mega2560:
    CONFIG_ZTIMER_USEC_ADJUST_SET    132
    CONFIG_ZTIMER_USEC_ADJUST_SLEEP  120
```


