### PR TITLE
cpu/nrf52/radio: fix confirm_op info cast

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -253,7 +253,7 @@ static int _confirm_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
 {
     (void) dev;
     bool eagain;
-    ieee802154_tx_info_t *info = NULL;
+    ieee802154_tx_info_t *info = ctx;
     int state = _state;
     bool enable_shorts = false;
     int radio_state = NRF_RADIO->STATE;


### PR DESCRIPTION
### Contribution description
The ieee802.15.4 info structure was never modified by the `confirm_op` radio operation. This fixes it.

### Testing procedure
- Run some networking application on a board with the nrf52 radio.

### Issues/PRs references
None
