### PR TITLE
pkg/tinydtls/contrib/sock_dtls: fix ep_to_session

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -119,9 +119,8 @@ static int dtls_handle_read(dtls_context_t *ctx)
         return 0;
     }
 
-    /* session requires the remote socket (IPv6:UDP) address and netif  */
-    session.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
-    session.port = remote.port;
+    dtls_session_init(&session);
+    session.addr.port = remote.port;
     if (remote.netif == SOCK_ADDR_ANY_NETIF) {
         session.ifindex = SOCK_ADDR_ANY_NETIF;
     }
@@ -129,11 +128,11 @@ static int dtls_handle_read(dtls_context_t *ctx)
         session.ifindex = remote.netif;
     }
 
-    memcpy(&session.addr, &remote.addr.ipv6, sizeof(session.addr));
+    memcpy(&session.addr.addr, &remote.addr.ipv6, sizeof(session.addr.addr));
 
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         DEBUG("DBG-Client: Msg received from \n\t Addr Src: [");
-        ipv6_addr_print(&session.addr);
+        ipv6_addr_print(&session.addr.addr);
         DEBUG("]:%u\n", remote.port);
     }
 
@@ -325,6 +324,8 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
     dtls_set_log_level(TINYDTLS_LOG_LVL);
 #endif
 
+    dtls_session_init(dst);
+
     /* First, we prepare the UDP Sock */
     local->port = (unsigned short) CLIENT_PORT;
     remote->port = (unsigned short) DTLS_DEFAULT_PORT;
@@ -358,11 +359,10 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
     }
 
     /* Second: We prepare the DTLS Session by means of ctx->app */
-    dst->size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
-    dst->port = remote->port;
+    dst->addr.port = remote->port;
 
-    /* NOTE: remote.addr.ipv6 and dst->addr are different structures. */
-    if (ipv6_addr_from_str(&dst->addr, addr_str) == NULL) {
+    /* NOTE: remote.addr.ipv6 and dst->addr.addr are different structures. */
+    if (ipv6_addr_from_str(&dst->addr.addr, addr_str) == NULL) {
         puts("ERROR: init_dtls was unable to load the IPv6 addresses!");
         return new_context;
     }

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -114,8 +114,8 @@ static int dtls_handle_read(dtls_context_t *ctx)
     DEBUG("DBG-Server: Record Rcvd\n");
 
     /* (DTLS) session requires the remote peer address (IPv6:Port) and netif */
-    session.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
-    session.port = remote_peer->remote->port;
+    dtls_session_init(&session);
+    session.addr.port = remote_peer->remote->port;
     if (remote_peer->remote->netif ==  SOCK_ADDR_ANY_NETIF) {
         session.ifindex = SOCK_ADDR_ANY_NETIF;
     }
@@ -123,7 +123,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
         session.ifindex = remote_peer->remote->netif;
     }
 
-    memcpy(&session.addr, &remote_peer->remote->addr.ipv6, sizeof(session.addr));
+    memcpy(&session.addr.addr, &remote_peer->remote->addr.ipv6, sizeof(session.addr.addr));
     return dtls_handle_message(ctx, &session, packet_rcvd, res);
 }
 

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -817,9 +817,9 @@ void sock_dtls_init(void)
 
 static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
 {
-    session->port = ep->port;
-    session->size = sizeof(ipv6_addr_t) +       /* addr */
-                    sizeof(unsigned short);     /* port */
+    dtls_session_init(session);
+    session->addr.port = ep->port;
+
     if (ipv6_addr_is_link_local((ipv6_addr_t *)ep->addr.ipv6)) {
         /* set ifindex for link-local addresses */
         session->ifindex = ep->netif;
@@ -827,15 +827,15 @@ static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
     else {
         session->ifindex = SOCK_ADDR_ANY_NETIF;
     }
-    memcpy(&session->addr, &ep->addr.ipv6, sizeof(ipv6_addr_t));
+    memcpy(&session->addr.addr, &ep->addr.ipv6, sizeof(session->addr.addr));
 }
 
 static void _session_to_ep(const session_t *session, sock_udp_ep_t *ep)
 {
-    ep->port = session->port;
+    ep->port = session->addr.port;
     ep->netif = session->ifindex;
     ep->family = AF_INET6;
-    memcpy(&ep->addr.ipv6, &session->addr, sizeof(ipv6_addr_t));
+    memcpy(&ep->addr.ipv6, &session->addr.addr, sizeof(ep->addr.ipv6));
 }
 
 static inline uint32_t _update_timeout(uint32_t start, uint32_t timeout)

--- a/pkg/tinydtls/patches/0002-session.h-Modify-session_t-for-RIOT.patch
+++ b/pkg/tinydtls/patches/0002-session.h-Modify-session_t-for-RIOT.patch
@@ -1,0 +1,47 @@
+From 6fbe634900e15b006edf3d6c9a6b79f19d286840 Mon Sep 17 00:00:00 2001
+From: Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+Date: Thu, 24 Mar 2022 12:00:27 +0100
+Subject: [PATCH] session.h: Modify session_t for RIOT
+
+Now the addr member of session_t includes both the IPv6 address and the
+port.
+---
+ session.c | 4 ++--
+ session.h | 6 ++++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/session.c b/session.c
+index 300224e..020ab5b 100644
+--- a/session.c
++++ b/session.c
+@@ -34,8 +34,8 @@
+ #elif defined(WITH_RIOT_GNRC)
+ #define _dtls_address_equals_impl(A,B)                          \
+   ((A)->size == (B)->size                                       \
+-   && (A)->port == (B)->port                                    \
+-   && ipv6_addr_equal(&((A)->addr),&((B)->addr))                \
++   && (A)->addr.port == (B)->addr.port                                    \
++   && ipv6_addr_equal(&((A)->addr.addr),&((B)->addr.addr))                \
+    && (A)->ifindex == (B)->ifindex)
+ #else /* WITH_CONTIKI */
+ 
+diff --git a/session.h b/session.h
+index a8ac8f3..2ab600a 100644
+--- a/session.h
++++ b/session.h
+@@ -35,8 +35,10 @@ typedef struct {
+ #include "net/ipv6/addr.h"
+ typedef struct {
+   unsigned char size;
+-  ipv6_addr_t addr;
+-  unsigned short port;
++  struct {
++    ipv6_addr_t addr;
++    unsigned short port;
++  } addr;
+   int ifindex;
+ } session_t;
+ #else /* ! WITH_CONTIKI && ! WITH_RIOT_GNRC */
+-- 
+2.35.1
+


### PR DESCRIPTION
### Contribution description
The size field in the session_t structure should reflect the size of the addr field for the particular OS. This was producing random errors when calculating the client_hello cookie, because the address is part of the hash, and the length used to update the `sha256_update` function was set to 18.

### Testing procedure
- `dtls_sock` application should work reliably. 

### Issues/PRs references
None
