### PR TITLE
ipv6/nib: bugfix of 6CO length checking

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -280,14 +280,10 @@ uint32_t _handle_6co(const icmpv6_hdr_t *icmpv6,
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
     uint8_t cid;
 #endif  /* MODULE_GNRC_SIXLOWPAN_CTX */
-
-    if ((sixco->len != SIXLOWPAN_ND_OPT_6CTX_LEN_MIN) ||
-        ((sixco->len != SIXLOWPAN_ND_OPT_6CTX_LEN_MAX) &&
-         (sixco->ctx_len > 64U)) ||
-        (icmpv6->type != ICMPV6_RTR_ADV)) {
-        DEBUG("nib: received 6CO of invalid length (%u), must be %u "
-              "or wasn't delivered by RA."
-              "\n",
+    (void)icmpv6;
+    if (sixco->len != (sixco->ctx_len > 64U
+        ? SIXLOWPAN_ND_OPT_6CTX_LEN_MAX : SIXLOWPAN_ND_OPT_6CTX_LEN_MIN)) {
+        DEBUG("nib: received 6CO of invalid length (%u), must be %u\n",
               sixco->len,
               (sixco->ctx_len > 64U) ? SIXLOWPAN_ND_OPT_6CTX_LEN_MAX :
                                        SIXLOWPAN_ND_OPT_6CTX_LEN_MIN);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The condition to check the length of an 6LoWPAN-ND Context Option was wrong.
If the prefix length > 64 it must be 3 (MAX), if it is less or equal 64 it must be 2 (MIN).
RFC6775 section 4.2
### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

See https://github.com/RIOT-OS/RIOT/pull/17803#issuecomment-1074031270.
At least `nib: received 6CO of invalid length (3), must be 3 or wasn't delivered by RA.` does not show up anymore.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
