### PR TITLE
makefiles: socat set tty mode 8N1 

### DIFF
--- a/dist/tools/goodfet/goodfet.bsl
+++ b/dist/tools/goodfet/goodfet.bsl
@@ -329,6 +329,8 @@ class LowLevel:
         if DEBUG > 1: sys.stderr.write("* comDone()")
         self.SetRSTpin(1)                       #disable power
         self.SetTESTpin(0)                      #disable power
+        self.serialport.parity = serial.PARITY_NONE    #set non parity mode
+        self.serialport.timeout = 0             #set no timeout
         self.serialport.close()
 
     def comRxHeader(self):

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -25,7 +25,7 @@ ifeq ($(RIOT_TERMINAL),pyterm)
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
   TERMPROG ?= $(RIOT_TERMINAL)
-  TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw
+  TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw,cs8,parenb=0,cstopb=0
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -6,11 +6,6 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# for z1, socat doesn't work (unknown reason)
-ifeq (z1, $(BOARD))
-  RIOT_TERMINAL ?= pyterm
-endif
-
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 

--- a/tests/shell_ble/Makefile
+++ b/tests/shell_ble/Makefile
@@ -15,11 +15,6 @@ TESTRUNNER_SHELL_SKIP_REBOOT = 1
 TESTRUNNER_RESET_BOARD_ON_STARTUP = 0
 
 ifneq (,$(filter term,$(MAKECMDGOALS)))
-  # for z1, socat doesn't work (unknown reason)
-  ifeq (z1, $(BOARD))
-    RIOT_TERMINAL ?= pyterm
-  endif
-
   # Use a terminal that does not introduce extra characters into the stream.
   RIOT_TERMINAL ?= socat
 else ifneq (,$(filter test,$(MAKECMDGOALS)))


### PR DESCRIPTION
### Contribution description

For some reason `z1` does not work with socat, all tests forcing socat ar bound to fail on `z1`.

### Testing procedure

A run of tests in master: https://ci.inria.fr/ci-riot-tribe/job/build-pipeline.jk/lastSuccessfulBuild/artifact/ all fail without event starting the terminal, a run of tests with this commi https://ci.inria.fr/ci-riot-tribe/job/build-pipeline.jk/327/artifact/z1/tests/, `congure` still is failing a couple of tests as well as `pkdf2` but not for the same reasons.

### Issues/PRs references

First time this issue was reported https://github.com/RIOT-OS/RIOT/pull/14658
