### PR TITLE
drivers/atwinc15x0: enable sleep state

### DIFF
--- a/drivers/include/atwinc15x0.h
+++ b/drivers/include/atwinc15x0.h
@@ -32,6 +32,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Enable reception of broadcast frames
+ *
+ *          If your application does not rely on receiving broadcast messages
+ *          you can disable this to save power.
+ */
+#ifndef CONFIG_ATWINC15X0_RECV_BCAST
+#define CONFIG_ATWINC15X0_RECV_BCAST (1)
+#endif
+
+/**
  * @brief   ATWINC15x0 hardware and global parameters
  */
 typedef struct {
@@ -52,6 +62,7 @@ typedef struct atwinc15x0 {
     atwinc15x0_params_t params; /**< Device initialization parameters */
 
     bool connected;             /**< Indicates whether connected to an AP */
+    netopt_state_t state;       /**< Current interface state, only sleep or idle */
     char ap[ETHERNET_ADDR_LEN]; /**< BSSID of current AP */
     uint8_t channel;            /**< Channel used for current AP */
     int8_t rssi;                /**< RSSI last measured by the WiFi module */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This allows the interface to enter SLEEP state in which it only consumes 4µA.
As with some other drivers the STANDBY state was used to model automatic wake on send. 

### Testing procedure

Tested with `tests/driver_atwinc15x0`:

```
main(): This is RIOT! (Version: 2022.04-devel-934-g6be6c-drivers/atwinc15x0-sleep)
> [atwinc15x0] WiFi connected
PKTDUMP: data received:
~~ SNIP  0 - size:  42 byte, type: NETTYPE_UNDEF (0)
00000000  00  00  F5  81  80  00  00  06  00  00  00  00  00  00  00  00
00000010  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00
00000020  00  00  00  00  00  00  00  00  00  00
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 3  rssi: -32768  lqi: 0
flags: 0x0
src_l2addr: 98:D8:63:7B:D3:70
dst_l2addr: F8:F0:05:A9:EB:F0
~~ PKT    -  2 snips, total size:  62 byte

> ifconfig 3 set state sleep
success: set state of interface 3 to SLEEP
> ifconfig
Iface  3  HWaddr: F8:F0:05:A9:EB:F0  Channel: 1  Link: down
           State: SLEEP
          L2-PDU:1500  Source address length: 6

> ifconfig 3 set state idle
success: set state of interface 3 to IDLE

> PKTDUMP: data received:
~~ SNIP  0 - size:  42 byte, type: NETTYPE_UNDEF (0)
00000000  00  00  F5  81  80  00  00  06  00  00  00  00  00  00  00  00
00000010  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00
00000020  00  00  00  00  00  00  00  00  00  00
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 3  rssi: -32768  lqi: 0
flags: 0x0
src_l2addr: 98:D8:63:7B:D3:70
dst_l2addr: F8:F0:05:A9:EB:F0
~~ PKT    -  2 snips, total size:  62 byte
ifconfig 3
Iface  3  HWaddr: F8:F0:05:A9:EB:F0  Channel: 1  RSSI: -46  Link: up
           State: IDLE
          L2-PDU:1500  Source address length: 6

> PKTDUMP: data received:
~~ SNIP  0 - size:  42 byte, type: NETTYPE_UNDEF (0)
00000000  00  00  F5  81  80  00  00  06  00  00  00  00  00  00  00  00
00000010  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00  00
00000020  00  00  00  00  00  00  00  00  00  00
~~ SNIP  1 - size:  20 byte, type: NETTYPE_NETIF (-1)
if_pid: 3  rssi: -32768  lqi: 0
flags: 0x0
src_l2addr: 98:D8:63:7B:D3:70
dst_l2addr: F8:F0:05:A9:EB:F0
~~ PKT    -  2 snips, total size:  62 byte
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
