### PR TITLE
treewide: initialize several stack-allocated, but uninitialized timer structs

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -120,14 +120,14 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
         return -EINVAL;
     }
 #if IS_USED(MODULE_ZTIMER_USEC)
-    ztimer_t timeout_timer;
+    ztimer_t timeout_timer = { .base = { .next = NULL } };
     if ((timeout != SOCK_NO_TIMEOUT) && (timeout != 0)) {
         timeout_timer.callback = _callback_put;
         timeout_timer.arg = reg;
         ztimer_set(ZTIMER_USEC, &timeout_timer, timeout);
     }
 #elif IS_USED(MODULE_XTIMER)
-    xtimer_t timeout_timer;
+    xtimer_t timeout_timer = { .callback = NULL };
 
     /* xtimer_spin would make this never receive anything.
      * Avoid that by setting the minimal not spinning timeout. */

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -110,7 +110,7 @@ int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg,
         return 1;
     }
 
-    ztimer_t t;
+    ztimer_t t = { .base = { .next = NULL } };
     msg_t m = { .type = MSG_ZTIMER, .content.ptr = &m };
 
     ztimer_set_msg(clock, &t, timeout, &m, thread_getpid());


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
While digging around for my TinyDTLS issue reported in https://github.com/RIOT-OS/RIOT/pull/17849, I did some valgrind probes with `gcoap_dtls` and noticed some missing initializations of timers. This PR fixes those.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile `examples/gcoap_dtls` with valgrind support (for `native`) and start a shell with valgrind support:

```
sudo dist/tools/tapsetup/tapsetup
make -C examples/gcoap_dtls -j all-valgrind
make -C examples/gcoap_dtls term-valgrind
```

open another shell

```
PORT=tap1 make -C examples/gcoap_dtls term-valgrind
```

and send a coap request using the `coap` command. With this PR, valgrind will remain mostly silent, while in current master it will complain about several "`Conditional jump or move depends on uninitialised value(s)`"

e.g.:
```
==76316==    at 0x806F620: ztimer64_remove (sys/ztimer64/ztimer64.c:64)
==76316==    by 0x805C8D2: xtimer_remove (sys/include/ztimer64/xtimer_compat.h:150)
==76316==    by 0x805C8D2: gnrc_sock_recv (./gnrc_sock.c:143)
==76316==    by 0x805CFAE: sock_udp_recv_buf_aux (sys/net/gnrc/sock/udp/gnrc_sock_udp.c:237)
==76316==    by 0x806EDC0: sock_udp_recv_buf (/home/mlenders/Repositories/RIOT-OS/RIOT/sys/include/net/sock/udp.h:605)
==76316==    by 0x806EDC0: _udp_cb (./sock_dtls.c:872)
==76316==    by 0x806696B: _event_handler (sys/net/sock/async/event/sock_async_event.c:33)
==76316==    by 0x80501F8: event_loop_multi (sys/include/event.h:409)
==76316==    by 0x80501F8: event_loop (sys/include/event.h:431)
==76316==    by 0x80501F8: _event_loop (./gcoap.c:183)
==76316==    by 0x41BE788: makecontext (in /usr/lib32/libc.so.6)
==76316==  Uninitialised value was created by a stack allocation
==76316==    at 0x805C7E4: gnrc_sock_recv (sys/net/gnrc/sock/gnrc_sock.c:97)
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
