### PR TITLE
gnrc_netif: fix potential null pointer dereference

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -139,8 +139,8 @@ unsigned gnrc_netif_numof(void)
 
 gnrc_netif_t *gnrc_netif_iter(const gnrc_netif_t *prev)
 {
-    netif_t *result = netif_iter(&prev->netif);
-    return container_of(result, gnrc_netif_t, netif);
+    netif_t *result = netif_iter((prev) ? &prev->netif : NULL);
+    return (result) ? container_of(result, gnrc_netif_t, netif) : NULL;
 }
 
 gnrc_netif_t *gnrc_netif_get_by_type(netdev_type_t type, uint8_t index)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
While it appears to be okay, UBSAN actually catches this as a potential NULL pointer dereference.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and run `gnrc_networking` with `all-ubsan`:

```sh
UBSAN_MODE=msg_recover make -C examples/gnrc_networking all-ubsan -j
make -C examples/gnrc_networking term
```

In current `master`, UBSAN will complain: `sys/net/gnrc/netif/gnrc_netif.c:142:23: runtime error: member access within null pointer of type 'const struct gnrc_netif_t'`, with this fix it will not.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
