### PR TITLE
pba-d-01-kw2x: fix clock init by preceding cpu_init with modem clock init

### DIFF
--- a/boards/pba-d-01-kw2x/board.c
+++ b/boards/pba-d-01-kw2x/board.c
@@ -54,7 +54,7 @@ static inline void modem_clock_init(void)
     while (KW2XDRF_GPIO->PDIR & (1 << KW2XDRF_IRQ_PIN));
 }
 
-void board_init(void)
+void post_startup(void)
 {
     modem_clock_init();
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fixes the execution order of clock init steps.
#16055 moved all cpu_init() calls from board_init() to startup code which changed the execution order of clock init code for this board. The cpu_init() implementation and config of this board assumes that CLK_OUT of the radio drives the MCU PTA18/EXTAL0 pin at 4 MHz, which are setup by modem_clock_init(). However, on master the modem clock init happens after cpu_init(), wich potentially locks up the MCU.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Confirm that the order was swapped before [diff](https://github.com/RIOT-OS/RIOT/pull/16055/commits/fc88c4c4e5b9c03403b9284534babbc965974deb#diff-5bcd5d3402646b3c5072df4840062c20ed5e6f5cfdd14926a560a3eabc092132) + [diff](https://github.com/RIOT-OS/RIOT/pull/16055/commits/bcb0df8e18837d2ce71b106cbbc2415b533a2ad5)

`BOARD=pba-d-01-kw2x make -C examples/hello-world all flash term`
Any application locks up with no shell output on master but works fine again with this PR.
Since the wrong clock configuration is temporary (only during init) you may find boards that even work on master.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
 #16055
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
