### PR TITLE
treewide: use sock_tl_name2ep() class of functions where applicable

### DIFF
--- a/examples/asymcute_mqttsn/main.c
+++ b/examples/asymcute_mqttsn/main.c
@@ -246,7 +246,7 @@ static int _cmd_connect(int argc, char **argv)
 
     /* get sock ep */
     sock_udp_ep_t ep;
-    if (sock_udp_str2ep(&ep, argv[2]) != 0) {
+    if (sock_udp_name2ep(&ep, argv[2]) != 0) {
         puts("error: unable to parse gateway address");
         return 1;
     }

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -83,7 +83,7 @@ int main(void)
     /* parse RD address information */
     sock_udp_ep_t rd_ep;
 
-    if (sock_udp_str2ep(&rd_ep, RD_ADDR) < 0) {
+    if (sock_udp_name2ep(&rd_ep, RD_ADDR) < 0) {
         puts("error: unable to parse RD address from RD_ADDR variable");
         return 1;
     }

--- a/examples/cord_lc/cord_lc_cli.c
+++ b/examples/cord_lc/cord_lc_cli.c
@@ -35,7 +35,7 @@ static unsigned rd_initialized = 0;
 static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
 {
     ep->port = 0;
-    if (sock_udp_str2ep(ep, addr) < 0) {
+    if (sock_udp_name2ep(ep, addr) < 0) {
         return -1;
     }
     /* if netif not specified in addr */

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -263,7 +263,7 @@ int nanocoap_get_blockwise_url(const char *url,
         return -EINVAL;
     }
 
-    if (sock_udp_str2ep(&remote, hostport) < 0) {
+    if (sock_udp_name2ep(&remote, hostport) < 0) {
         DEBUG("nanocoap: invalid URL\n");
         return -EINVAL;
     }

--- a/sys/shell/commands/sc_cord_ep.c
+++ b/sys/shell/commands/sc_cord_ep.c
@@ -30,7 +30,7 @@
 static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
 {
     ep->port = 0;
-    if (sock_udp_str2ep(ep, addr) < 0) {
+    if (sock_udp_name2ep(ep, addr) < 0) {
         return -1;
     }
     /* if netif not specified in addr */

--- a/tests/emcute/main.c
+++ b/tests/emcute/main.c
@@ -105,7 +105,7 @@ static int _con(int argc, char **argv)
         return 1;
     }
 
-    if (sock_udp_str2ep(&_gw, argv[1]) != 0) {
+    if (sock_udp_name2ep(&_gw, argv[1]) != 0) {
         puts("error: unable to parse gateway address");
         _gw.port = 0;
         return 1;

--- a/tests/lwip/tcp.c
+++ b/tests/lwip/tcp.c
@@ -131,7 +131,7 @@ static int tcp_connect(char *addr_str, char *local_port_str)
     }
 
     /* parse destination address */
-    if (sock_tcp_str2ep(&dst, addr_str) < 0) {
+    if (sock_tcp_name2ep(&dst, addr_str) < 0) {
         puts("Error: unable to parse destination address");
         return 1;
     }

--- a/tests/lwip/udp.c
+++ b/tests/lwip/udp.c
@@ -99,7 +99,7 @@ static int udp_send(char *addr_str, char *data, unsigned int num,
     size_t data_len;
 
     /* parse destination address */
-    if (sock_udp_str2ep(&dst, addr_str) < 0) {
+    if (sock_udp_name2ep(&dst, addr_str) < 0) {
         puts("Error: unable to parse destination address");
         return 1;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `sock_tl_name2ep()` class of functions behave exactly as `sock_tl_str2ep()` except for when the `sock_dns` module is enabled.
In this case they will also be able to resolve a name via DNS in addition to parsing raw IP addresses.

This enables e.g. to fetch SUIT updates using a domain name instead of a hard coded IP address or supplying domain names in interactive tests.


### Testing procedure

No functional changes unless `sock_dns` is used. 


### Issues/PRs references

follow-up to #17510
