### PR TITLE
periph/flashpage: deprecate *_free functions

### DIFF
--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -151,7 +151,7 @@ enum {
 #error "periph/flashpage: FLASHPAGE_NUMOF not defined"
 #endif
 
-#ifdef MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE
+#if defined(MODULE_PERIPH_FLASHPAGE_IN_ADDRESS_SPACE) || defined(DOXYGEN)
 /**
  * @def   FLASH_WRITABLE_INIT(name, size)
  * @brief Define an array in flash memory

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -238,6 +238,9 @@ void flashpage_erase(unsigned page);
 
 /**
  * @brief Get number of first free flashpage
+ * @deprecated Use @ref FLASH_WRITABLE_INIT instead, which is usable in modules
+ *             as well as applications. The function will be removed after
+ *             the 2022.04 release.
  *
  * If riotboot is used in two slot mode, this number will change across
  * firmware updates as the firmware slots alternate.
@@ -246,6 +249,9 @@ unsigned flashpage_first_free(void);
 
 /**
  * @brief Get number of last free flashpage
+ * @deprecated Use @ref FLASH_WRITABLE_INIT instead, which is usable in modules
+ *             as well as applications. The function will be removed after
+ *             the 2022.04 release.
  *
  * If riotboot is used in two slot mode, this number will change across
  * firmware updates as the firmware slots alternate.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The functions `flashpage_first_free` and `flashpage_last_free` added with #16972 were introduced to avoid overwriting and therefore corrupting firmware / bootloaders when writing to flash memory. These functions have the flaw that if multiple modules simultaneously use them they will not be aware of each other. E.g. `flashpage_first_free` will return the same value for all modules and can therefore lead to the modules corrupting each others data by writing to the same flashpage.

With #17436 being merged a new and better mechanism has been introduced that achieves the same goal as #16972 but without the flaws. It enables the reservation of flash memory at compile time and ensures that no data is corrupted. Furthermore multiple modules can use this mechanism simultaneously. Based on this the `flashpage_*_free` functions are no longer needed and can be deprecated.

I have never deprecated anything, therefore I need some help of what I need to to. Thanks !

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
