### PR TITLE
pkg/fatfs: fix missing mutex header

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -29,6 +29,7 @@
 #include "fs/fatfs.h"
 
 #include "time.h"
+#include "mutex.h"
 
 #define ENABLE_DEBUG 0
 #include <debug.h>

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -6,6 +6,7 @@ FEATURES_REQUIRED += periph_spi
 
 # remove this if you don't want to format your SD card
 USEMODULE += fatfs_vfs_format
+CFLAGS += -DCONFIG_FATFS_FORMAT_ALLOC_STATIC=1
 
 FATFS_IMAGE_FILE_SIZE_MIB ?= 128
 


### PR DESCRIPTION
### Contribution description

If `fatfs_vfs_format` is built with `CONFIG_FATFS_FORMAT_ALLOC_STATIC=1`, mutex headers are missing.


### Testing procedure

Compile `tests/pkg_fatfs_vfs`.

### Issues/PRs references
