### PR TITLE
drivers/mtd_mapper: fix read_page and write_page backend

### DIFF
--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -116,7 +116,14 @@ static int _write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
                                  page + _page_offset(region),
                                  offset, count);
     _unlock(region);
-    return res;
+
+    if (res < 0) {
+        return res;
+    }
+
+    /* mtd_write_page_raw() returns 0 on success
+     * but we are expected to return the written byte count */
+    return count;
 }
 
 static int _read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count)
@@ -143,7 +150,14 @@ static int _read_page(mtd_dev_t *mtd, void *dest, uint32_t page,
                             page + _page_offset(region),
                             offset, count);
     _unlock(region);
-    return res;
+
+    if (res < 0) {
+        return res;
+    }
+
+    /* mtd_read_page() returns 0 on success
+     * but we are expected to return the read byte count */
+    return count;
 }
 
 static int _erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count)

--- a/tests/mtd_mapper/Makefile
+++ b/tests/mtd_mapper/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += mtd_mapper
+USEMODULE += mtd_write_page
 USEMODULE += embunit
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/mtd_mapper/app.config.test
+++ b/tests/mtd_mapper/app.config.test
@@ -1,4 +1,5 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
 CONFIG_MODULE_MTD_MAPPER=y
+CONFIG_MODULE_MTD_WRITE_PAGE=y
 CONFIG_MODULE_EMBUNIT=y

--- a/tests/mtd_mapper/main.c
+++ b/tests/mtd_mapper/main.c
@@ -38,9 +38,13 @@
 #define PAGE_SIZE 64
 #endif
 
-#define MEMORY_SIZE         PAGE_SIZE * PAGE_PER_SECTOR * SECTOR_COUNT
+#define MEMORY_PAGE_COUNT    PAGE_PER_SECTOR * SECTOR_COUNT
+
+#define MEMORY_SIZE          PAGE_SIZE * MEMORY_PAGE_COUNT
 
 #define REGION_FLASH_SIZE    MEMORY_SIZE / 2
+
+#define REGION_PAGE_COUNT    MEMORY_PAGE_COUNT / 2
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
@@ -252,6 +256,26 @@ static void test_mtd_read(void)
     }
 }
 
+static void test_mtd_read_page(void)
+{
+    int ret;
+
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_read_page(_dev_a, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+        _test_mem(_buffer, PAGE_SIZE, 0xff);
+    }
+
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_read_page(_dev_b, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+        _test_mem(_buffer, PAGE_SIZE, 0xff);
+    }
+
+    ret = mtd_read_page(_dev_b, _buffer, REGION_PAGE_COUNT, 0, PAGE_SIZE);
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+}
+
 static void test_mtd_write(void)
 {
     static const uint8_t test_val_a = 0xAA;
@@ -290,6 +314,53 @@ static void test_mtd_write(void)
     }
 }
 
+static void test_mtd_write_page(void)
+{
+    static const uint8_t test_val_a = 0xAA;
+    int ret;
+
+    memset(_buffer, test_val_a, PAGE_SIZE);
+
+    /* Write first region */
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_write_page(_dev_a, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+    }
+
+    /* Check second region, should still be 0xFF */
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_read_page(_dev_b, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+        _test_mem(_buffer, PAGE_SIZE, 0xFF);
+    }
+
+    static const uint8_t test_val_b = 0xBB;
+    memset(_buffer, test_val_b, PAGE_SIZE);
+
+    /* Write second region */
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_write_page(_dev_b, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+    }
+
+    /* Check second region after write, should now be 0xBB */
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_read_page(_dev_b, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+        _test_mem(_buffer, PAGE_SIZE, 0xBB);
+    }
+
+    /* Check first region, should still be 0xAA */
+    for (uint32_t i = 0; i < REGION_PAGE_COUNT; i += 1) {
+        ret = mtd_read_page(_dev_a, _buffer, i, 0, PAGE_SIZE);
+        TEST_ASSERT_EQUAL_INT(0, ret);
+        _test_mem(_buffer, PAGE_SIZE, 0xAA);
+    }
+
+    ret = mtd_write_page(_dev_b, _buffer, REGION_PAGE_COUNT, 0, PAGE_SIZE);
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+}
+
 static void set_up(void)
 {
     memset(_dummy_memory, 0xff, sizeof(_dummy_memory));
@@ -301,7 +372,9 @@ Test *tests_mtd_mapper_tests(void)
         new_TestFixture(test_mtd_init),
         new_TestFixture(test_mtd_erase),
         new_TestFixture(test_mtd_read),
+        new_TestFixture(test_mtd_read_page),
         new_TestFixture(test_mtd_write),
+        new_TestFixture(test_mtd_write_page),
     };
 
     EMB_UNIT_TESTCALLER(mtd_flashpage_tests, set_up, NULL, fixtures);

--- a/tests/mtd_mapper/main.c
+++ b/tests/mtd_mapper/main.c
@@ -290,6 +290,11 @@ static void test_mtd_write(void)
     }
 }
 
+static void set_up(void)
+{
+    memset(_dummy_memory, 0xff, sizeof(_dummy_memory));
+}
+
 Test *tests_mtd_mapper_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -299,7 +304,7 @@ Test *tests_mtd_mapper_tests(void)
         new_TestFixture(test_mtd_write),
     };
 
-    EMB_UNIT_TESTCALLER(mtd_flashpage_tests, NULL, NULL, fixtures);
+    EMB_UNIT_TESTCALLER(mtd_flashpage_tests, set_up, NULL, fixtures);
 
     return (Test *)&mtd_flashpage_tests;
 }


### PR DESCRIPTION
### Contribution description

This PR fixes the `mtd_mapper` backend for `read_page` and `write_page`.

The implementation uses `mtd_read_page()` and `mtd_write_page_raw()` on the backing device. These methods return `0` on successful [read](https://github.com/RIOT-OS/RIOT/blob/753b435cb50543a68b43354773c4ff0603ab9f58/drivers/include/mtd.h#L305) resp. [write](https://github.com/RIOT-OS/RIOT/blob/753b435cb50543a68b43354773c4ff0603ab9f58/drivers/include/mtd.h#L353). But the backend is expected to return the amount of [read](https://github.com/RIOT-OS/RIOT/blob/753b435cb50543a68b43354773c4ff0603ab9f58/drivers/include/mtd.h#L166) resp. [written](https://github.com/RIOT-OS/RIOT/blob/753b435cb50543a68b43354773c4ff0603ab9f58/drivers/include/mtd.h#L206) bytes.


### Testing procedure

Run `tests/mtd_mapper`. I've added a test triggering this bug. Without this patch it'll be caught in an endless loop.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
