### PR TITLE
examples/gcoap: replace _parse_endpoint by sock_udp_name2ep

### DIFF
--- a/examples/gcoap/README.md
+++ b/examples/gcoap/README.md
@@ -56,9 +56,21 @@ Start the libcoap example server with the command below.
 
     ./coap-server
 
-Enter the query below in the RIOT CLI.
+\
+Below are some example queries to enter into the RIOT CLI. Ports can be omitted.
+The port defaults to 5683 for the `gcoap` and to 5684 for the `gcoap_dtls` example.
 
-    > coap get fe80::d8b8:65ff:feee:121b%6 5683 /.well-known/core
+- For IPv6 setup (network interface can be omitted)
+
+    > coap get [fe80::d8b8:65ff:feee:121b%6]:5683 /.well-known/core
+
+- For IPv4 setup
+
+    > coap get 192.168.2.135:5683 /.well-known/core
+
+- When including the module `sock_dns` for domain resolution
+
+    > coap get example.com:5683 /.well-known/core
 
 CLI output:
 


### PR DESCRIPTION
### Contribution description

Replace custom endpoint parsing function with the use of `sock_udp_name2ep`.
This changes the way be input the address and the port. These are now not two arguments anymore but only a single one.


### Issues/PRs references

Dependencies:
- #17763
