### PR TITLE
drivers/mtd_spi_nor: fix Atmel size calculation

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -304,7 +304,8 @@ static uint32_t mtd_spi_nor_get_size(const mtd_jedec_id_t *id)
     if (mtd_spi_manuf_match(id, SPI_NOR_JEDEC_ATMEL) &&
         /* ID 2 is used to encode the product version, usually 1 or 2 */
         (id->device[1] & ~0x3) == 0) {
-        return (0x1F & id->device[0]) * MBIT_AS_BYTES;
+        /* capacity encoded as power of 32k sectors */
+        return (32 * 1024) << (0x1F & id->device[0]);
     }
     if (mtd_spi_manuf_match(id, SPI_NOR_JEDEC_MICROCHIP)) {
         switch (id->device[1]) {


### PR DESCRIPTION
 

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Lower bits of the device ID are not the capacity in bytes but in sectors:

    4 - 4 Mb -> 32k << 4
    5 - 8 Mb -> 32k << 5
    …


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

split off #17692