### PR TITLE
dist/tools/kconfiglib: avoid rewriting /dev/null

### DIFF
--- a/dist/tools/kconfiglib/genconfig.py
+++ b/dist/tools/kconfiglib/genconfig.py
@@ -395,7 +395,7 @@ with error.""")
 
     # HACK: Force all symbols to be evaluated, to catch warnings generated
     # during evaluation (such as out-of-range integers)
-    kconf.write_config(os.devnull)
+    kconf.write_config(os.devnull, save_old=False)
 
     if not check_configs(kconf) and not args.ignore_config_errors:
         sys.exit(1)


### PR DESCRIPTION
### Contribution description
By default kconfiglib's `write_config` saves the old version of the configuration file. This was causing to rewrite `/dev/null` when run with `sudo`, as described in #17862. This PR fixes it by setting the `save_old` parameter to `False`.

### Testing procedure
- Follow the steps from #17862 and verify `/dev/null` is not overwritten.

### Issues/PRs references
Fixes #17862
