### PR TITLE
pkg/tinydtls: crypto: remove unnecessary usage of malloc()

### DIFF
--- a/pkg/tinydtls/patches/0005-crypto-remove-unnecessary-usage-of-malloc-dtls_hmac_.patch
+++ b/pkg/tinydtls/patches/0005-crypto-remove-unnecessary-usage-of-malloc-dtls_hmac_.patch
@@ -1,0 +1,105 @@
+From a98c493857d27f25e6ab142fe893ffcc9e6a6474 Mon Sep 17 00:00:00 2001
+From: "Martine S. Lenders" <m.lenders@fu-berlin.de>
+Date: Mon, 28 Mar 2022 15:00:02 +0200
+Subject: [PATCH] crypto: remove unnecessary usage of malloc()/dtls_hmac_new()
+
+---
+ crypto.c | 57 ++++++++++++++++++++++++++------------------------------
+ 1 file changed, 26 insertions(+), 31 deletions(-)
+
+diff --git a/crypto.c b/crypto.c
+index 43d3079198..6475eb81d0 100644
+--- a/crypto.c
++++ b/crypto.c
+@@ -207,7 +207,7 @@ dtls_p_hash(dtls_hashfunc_t h,
+ 	    const unsigned char *random1, size_t random1len,
+ 	    const unsigned char *random2, size_t random2len,
+ 	    unsigned char *buf, size_t buflen) {
+-  dtls_hmac_context_t *hmac_a, *hmac_p;
++  dtls_hmac_context_t hmac_a, hmac_p;
+ 
+   unsigned char A[DTLS_HMAC_DIGEST_SIZE];
+   unsigned char tmp[DTLS_HMAC_DIGEST_SIZE];
+@@ -215,54 +215,49 @@ dtls_p_hash(dtls_hashfunc_t h,
+   size_t len = 0;			/* result length */
+   (void)h;
+ 
+-  hmac_a = dtls_hmac_new(key, keylen);
+-  if (!hmac_a)
+-    return 0;
++  dtls_hmac_init(&hmac_a, key, keylen);
+ 
+   /* calculate A(1) from A(0) == seed */
+-  HMAC_UPDATE_SEED(hmac_a, label, labellen);
+-  HMAC_UPDATE_SEED(hmac_a, random1, random1len);
+-  HMAC_UPDATE_SEED(hmac_a, random2, random2len);
++  HMAC_UPDATE_SEED(&hmac_a, label, labellen);
++  HMAC_UPDATE_SEED(&hmac_a, random1, random1len);
++  HMAC_UPDATE_SEED(&hmac_a, random2, random2len);
+ 
+-  dlen = dtls_hmac_finalize(hmac_a, A);
+-
+-  hmac_p = dtls_hmac_new(key, keylen);
+-  if (!hmac_p)
+-    goto error;
++  dlen = dtls_hmac_finalize(&hmac_a, A);
+ 
+   while (len + dlen < buflen) {
+ 
+-    /* FIXME: rewrite loop to avoid superflous call to dtls_hmac_init() */
+-    dtls_hmac_init(hmac_p, key, keylen);
+-    dtls_hmac_update(hmac_p, A, dlen);
++    dtls_hmac_init(&hmac_p, key, keylen);
++    dtls_hmac_update(&hmac_p, A, dlen);
+ 
+-    HMAC_UPDATE_SEED(hmac_p, label, labellen);
+-    HMAC_UPDATE_SEED(hmac_p, random1, random1len);
+-    HMAC_UPDATE_SEED(hmac_p, random2, random2len);
++    HMAC_UPDATE_SEED(&hmac_p, label, labellen);
++    HMAC_UPDATE_SEED(&hmac_p, random1, random1len);
++    HMAC_UPDATE_SEED(&hmac_p, random2, random2len);
+ 
+-    len += dtls_hmac_finalize(hmac_p, tmp);
++    len += dtls_hmac_finalize(&hmac_p, tmp);
+     memcpy(buf, tmp, dlen);
+     buf += dlen;
+ 
+     /* calculate A(i+1) */
+-    dtls_hmac_init(hmac_a, key, keylen);
+-    dtls_hmac_update(hmac_a, A, dlen);
+-    dtls_hmac_finalize(hmac_a, A);
++    dtls_hmac_init(&hmac_a, key, keylen);
++    dtls_hmac_update(&hmac_a, A, dlen);
++    dtls_hmac_finalize(&hmac_a, A);
+   }
+ 
+-  dtls_hmac_init(hmac_p, key, keylen);
+-  dtls_hmac_update(hmac_p, A, dlen);
++  dtls_hmac_init(&hmac_p, key, keylen);
++  dtls_hmac_update(&hmac_p, A, dlen);
+   
+-  HMAC_UPDATE_SEED(hmac_p, label, labellen);
+-  HMAC_UPDATE_SEED(hmac_p, random1, random1len);
+-  HMAC_UPDATE_SEED(hmac_p, random2, random2len);
++  HMAC_UPDATE_SEED(&hmac_p, label, labellen);
++  HMAC_UPDATE_SEED(&hmac_p, random1, random1len);
++  HMAC_UPDATE_SEED(&hmac_p, random2, random2len);
+   
+-  dtls_hmac_finalize(hmac_p, tmp);
++  dtls_hmac_finalize(&hmac_p, tmp);
+   memcpy(buf, tmp, buflen - len);
+ 
+- error:
+-  dtls_hmac_free(hmac_a);
+-  dtls_hmac_free(hmac_p);
++  /* prevent exposure of sensible data */
++  memset(&hmac_a, 0, sizeof(hmac_a));
++  memset(&hmac_p, 0, sizeof(hmac_p));
++  memset(tmp, 0, sizeof(tmp));
++  memset(A, 0, sizeof(A));
+ 
+   return buflen;
+ }
+-- 
+2.25.1
+

--- a/pkg/tinydtls/patches/0006-crypto-only-one-HMAC-context-is-required.patch
+++ b/pkg/tinydtls/patches/0006-crypto-only-one-HMAC-context-is-required.patch
@@ -1,0 +1,95 @@
+From 49de0a5763e5ced05f62b2539a63e90b9a439c18 Mon Sep 17 00:00:00 2001
+From: "Martine S. Lenders" <m.lenders@fu-berlin.de>
+Date: Tue, 29 Mar 2022 12:06:00 +0200
+Subject: [PATCH] crypto: only one HMAC context is required
+
+Signed-off-by: Martine Lenders <m.lenders@fu-berlin.de>
+---
+ crypto.c | 45 ++++++++++++++++++++++-----------------------
+ 1 file changed, 22 insertions(+), 23 deletions(-)
+
+diff --git a/crypto.c b/crypto.c
+index 6475eb8..b3845ae 100644
+--- a/crypto.c
++++ b/crypto.c
+@@ -207,7 +207,7 @@ dtls_p_hash(dtls_hashfunc_t h,
+ 	    const unsigned char *random1, size_t random1len,
+ 	    const unsigned char *random2, size_t random2len,
+ 	    unsigned char *buf, size_t buflen) {
+-  dtls_hmac_context_t hmac_a, hmac_p;
++  dtls_hmac_context_t hmac;
+ 
+   unsigned char A[DTLS_HMAC_DIGEST_SIZE];
+   unsigned char tmp[DTLS_HMAC_DIGEST_SIZE];
+@@ -215,47 +215,46 @@ dtls_p_hash(dtls_hashfunc_t h,
+   size_t len = 0;			/* result length */
+   (void)h;
+ 
+-  dtls_hmac_init(&hmac_a, key, keylen);
++  dtls_hmac_init(&hmac, key, keylen);
+ 
+   /* calculate A(1) from A(0) == seed */
+-  HMAC_UPDATE_SEED(&hmac_a, label, labellen);
+-  HMAC_UPDATE_SEED(&hmac_a, random1, random1len);
+-  HMAC_UPDATE_SEED(&hmac_a, random2, random2len);
++  HMAC_UPDATE_SEED(&hmac, label, labellen);
++  HMAC_UPDATE_SEED(&hmac, random1, random1len);
++  HMAC_UPDATE_SEED(&hmac, random2, random2len);
+ 
+-  dlen = dtls_hmac_finalize(&hmac_a, A);
++  dlen = dtls_hmac_finalize(&hmac, A);
+ 
+   while (len + dlen < buflen) {
+ 
+-    dtls_hmac_init(&hmac_p, key, keylen);
+-    dtls_hmac_update(&hmac_p, A, dlen);
++    dtls_hmac_init(&hmac, key, keylen);
++    dtls_hmac_update(&hmac, A, dlen);
+ 
+-    HMAC_UPDATE_SEED(&hmac_p, label, labellen);
+-    HMAC_UPDATE_SEED(&hmac_p, random1, random1len);
+-    HMAC_UPDATE_SEED(&hmac_p, random2, random2len);
++    HMAC_UPDATE_SEED(&hmac, label, labellen);
++    HMAC_UPDATE_SEED(&hmac, random1, random1len);
++    HMAC_UPDATE_SEED(&hmac, random2, random2len);
+ 
+-    len += dtls_hmac_finalize(&hmac_p, tmp);
++    len += dtls_hmac_finalize(&hmac, tmp);
+     memcpy(buf, tmp, dlen);
+     buf += dlen;
+ 
+     /* calculate A(i+1) */
+-    dtls_hmac_init(&hmac_a, key, keylen);
+-    dtls_hmac_update(&hmac_a, A, dlen);
+-    dtls_hmac_finalize(&hmac_a, A);
++    dtls_hmac_init(&hmac, key, keylen);
++    dtls_hmac_update(&hmac, A, dlen);
++    dtls_hmac_finalize(&hmac, A);
+   }
+ 
+-  dtls_hmac_init(&hmac_p, key, keylen);
+-  dtls_hmac_update(&hmac_p, A, dlen);
++  dtls_hmac_init(&hmac, key, keylen);
++  dtls_hmac_update(&hmac, A, dlen);
+   
+-  HMAC_UPDATE_SEED(&hmac_p, label, labellen);
+-  HMAC_UPDATE_SEED(&hmac_p, random1, random1len);
+-  HMAC_UPDATE_SEED(&hmac_p, random2, random2len);
++  HMAC_UPDATE_SEED(&hmac, label, labellen);
++  HMAC_UPDATE_SEED(&hmac, random1, random1len);
++  HMAC_UPDATE_SEED(&hmac, random2, random2len);
+   
+-  dtls_hmac_finalize(&hmac_p, tmp);
++  dtls_hmac_finalize(&hmac, tmp);
+   memcpy(buf, tmp, buflen - len);
+ 
+   /* prevent exposure of sensible data */
+-  memset(&hmac_a, 0, sizeof(hmac_a));
+-  memset(&hmac_p, 0, sizeof(hmac_p));
++  memset(&hmac, 0, sizeof(hmac));
+   memset(tmp, 0, sizeof(tmp));
+   memset(A, 0, sizeof(A));
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Removes an unnecessary usage of malloc() within TinyDTLS. In certain cases (actually depending on a binaries layout and RAM usage) this malloc() usage can lead to a silent failure of a handshake, as the failing HMAC calculation leads to the server declining a client trying to establish a session without a configured secret (as that calculation failed).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
TinyDTLS should (still) work (e.g. when using `examples/gcoap_dtls`). If you had problems before establishing a session, this might solve it.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Patch provided upstream in https://github.com/eclipse/tinydtls/pull/130
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
