### PR TITLE
driver/mtd_spi_nor: cleanup sleep timing

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -342,7 +342,7 @@ static uint32_t mtd_spi_nor_get_size(const mtd_jedec_id_t *id)
 static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us)
 {
     unsigned i = 0, j = 0;
-    uint32_t div = 2;
+    uint32_t div = 1; /* first wait one full interval */
 #if IS_ACTIVE(ENABLE_DEBUG)
     uint32_t diff = 0;
 #endif
@@ -362,13 +362,15 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
         i++;
 #if IS_USED(MODULE_ZTIMER_USEC)
         if (us) {
-            ztimer_sleep(ZTIMER_USEC, us);
+            uint32_t wait_us = us / div;
+            uint32_t wait_min = 2;
+
+            wait_us = wait_us > wait_min ? wait_us : wait_min;
+
+            ztimer_sleep(ZTIMER_USEC, wait_us);
             /* reduce the waiting time quickly if the estimate was too short,
              * but still avoid busy (yield) waiting */
-            if (us > 2) {
-                us -= (us / div);
-                div++;
-            }
+            div++;
         }
         else {
             j++;
@@ -376,16 +378,15 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
         }
 #elif IS_USED(MODULE_XTIMER)
         if (us) {
-            xtimer_usleep(us);
+            uint32_t wait_us = us / div;
+            uint32_t wait_min = 2 * XTIMER_BACKOFF;
+
+            wait_us = wait_us > wait_min ? wait_us : wait_min;
+
+            xtimer_usleep(wait_us);
             /* reduce the waiting time quickly if the estimate was too short,
              * but still avoid busy (yield) waiting */
-            if (us > 2 * XTIMER_BACKOFF) {
-                us -= (us / div);
-                div++;
-            }
-            else {
-                us = 2 * XTIMER_BACKOFF;
-            }
+            div++;
         }
         else {
             j++;


### PR DESCRIPTION
### Contribution description

while reviewing #17836 i found the wait function timing calculation quiet strange with this i try to write that clearer

the wait timing is `us / (the numbers of loops)`

### Testing procedure

i did not test this patch,
do not know how to,
don't have hardware with a mtd_spi_nor

### Issues/PRs references

#9349 introduced that calculation 
