### PR TITLE
drivers/atwinc15x0: join multicast groups

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -466,6 +466,18 @@ static int _atwinc15x0_set(netdev_t *netdev, netopt_t opt, const void *val,
         case NETOPT_STATE:
             assert(max_len <= sizeof(netopt_state_t));
             return _set_state(dev, *((const netopt_state_t *)val));
+        case NETOPT_L2_GROUP:
+            if (m2m_wifi_enable_mac_mcast((void *)val, 1)) {
+                return -EINVAL;
+            } else {
+                return max_len;
+            }
+        case NETOPT_L2_GROUP_LEAVE:
+            if (m2m_wifi_enable_mac_mcast((void *)val, 0)) {
+                return -EINVAL;
+            } else {
+                return max_len;
+            }
         default:
             return netdev_eth_set(netdev, opt, val, max_len);
     }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I noticed the wifi module would not receive any router advertisements while an esp8266 did just fine.

Turns out joining the multicast groups was not enabled.
With this it works as expected.


### Testing procedure

Just connect to a IPv6 enabled WiFi network:

```
nib: Handle timer event (ctx = 0x20001778, type = 0x4fc3, now = 4335ms)
nib: Handle packet (icmpv6->type = 134)
nib: Received valid router advertisement:
     - Source address: fe80::3e37:12ff:fe9a:7d18
     - Destination address: ff02::1
     - Cur Hop Limit: 255
     - Flags: -O
     - Router Lifetime: 1800s
     - Reachable Time: 0ms
     - Retrans Timer: 0ms
nib: received valid Prefix Information option:
     - Prefix: 2a00:20:6006:a846::/64
     - Flags: LA
     - Valid lifetime: 7200
     - Preferred lifetime: 3600
nib: Handle timer event (ctx = 0x200017ba, type = 0x4fd1, now = 4414ms)
nib: Handle timer event (ctx = 0x200017ba, type = 0x4fd2, now = 5422ms)
ifconfig
Iface  5  HWaddr: F8:F0:05:A9:EC:19  Channel: 6  RSSI: -37  Link: up
           State: IDLE
          L2-PDU:1500  MTU:1500  HL:255  Source address length: 6
          Link type: wireless
          inet6 addr: fe80::faf0:5ff:fea9:ec19  scope: link  VAL
          inet6 addr: 2a00:20:6006:a846:faf0:5ff:fea9:ec19  scope: global  VAL
          inet6 group: ff02::1
          inet6 group: ff02::1:ffa9:ec19

          Statistics for Layer 2
            RX packets 7  bytes 526
            TX packets 4 (Multicast: 4)  bytes 148
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 1  bytes 152
            TX packets 4 (Multicast: 4)  bytes 232
            TX succeeded 4 errors 0
```

Without this patch I would never receive a global address/router advertisement. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
