### PR TITLE
cpu/samd5x: allow to block IDLE mode

### DIFF
--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -53,7 +53,11 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (3)
+#define PM_NUM_MODES       4            /**< Backup, Hibernate, Standby, Idle */
+
+#ifndef PM_BLOCKER_INITIAL
+#define PM_BLOCKER_INITIAL 0x00010101   /**< Block all modes but Idle */
+#endif
 /** @} */
 
 /**

--- a/cpu/samd5x/periph/pm.c
+++ b/cpu/samd5x/periph/pm.c
@@ -45,11 +45,13 @@ void pm_set(unsigned mode)
             _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
             deep = 1;
             break;
-        default: /* Falls through */
         case 3:
             DEBUG_PUTS("pm_set(): setting IDLE2 mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
             break;
+        default:
+            /* no sleep */
+            return;
     }
 
     /* write sleep configuration */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If SDHC runs off the CPU clock and we wait for the transfer to complete, we can *not* enter IDLE mode as that will stop the CPU clock.
Add a new mode that acts as a no-op where we just spin the CPU.

### Testing procedure

No change in behavior or power consumption as IDLE is unblocked by default.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
