### PR TITLE
boards/b-l475e-iot01a: Add SPI2 and SPI3 buses

### DIFF
--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -40,14 +40,20 @@ extern "C" {
 static const dma_conf_t dma_config[] = {
     { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX */
     { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
-    { .stream = 3 },    /* DMA1 Channel 4 - USART1_TX */
+    { .stream = 3 },    /* DMA1 Channel 4 - USART1_TX / SPI2_RX */
+    { .stream = 4 },    /* DMA1 Channel 5 - SPI2_TX */
+    { .stream = 8 },    /* DMA2 Channel 1 - SPI3_RX */
+    { .stream = 9 },    /* DMA2 Channel 2 - SPI3_TX */
     { .stream = 10 },   /* DMA2 Channel 3 - UART4_TX */
 };
 
 #define DMA_0_ISR  isr_dma1_channel2
 #define DMA_1_ISR  isr_dma1_channel3
 #define DMA_2_ISR  isr_dma1_channel4
-#define DMA_3_ISR  isr_dma2_channel3
+#define DMA_3_ISR  isr_dma1_channel5
+#define DMA_4_ISR  isr_dma2_channel1
+#define DMA_5_ISR  isr_dma2_channel2
+#define DMA_6_ISR  isr_dma2_channel3
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
 /** @} */
@@ -104,7 +110,7 @@ static const uart_conf_t uart_config[] = {
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
 #ifdef MODULE_PERIPH_DMA
-        .dma        = 3,
+        .dma        = 6,
         .dma_chan   = 2
 #endif
     }
@@ -158,6 +164,44 @@ static const spi_conf_t spi_config[] = {
         .tx_dma_chan = 1,
         .rx_dma   = 0,
         .rx_dma_chan = 1,
+#endif
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_D, 4),
+        .miso_pin = GPIO_PIN(PORT_D, 3),
+        .sclk_pin = GPIO_PIN(PORT_D, 1),
+        .cs_pin   = SPI_CS_UNDEF,
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB1ENR1_SPI2EN,
+        .apbbus   = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 3,
+        .tx_dma_chan = 1,
+        .rx_dma   = 2,
+        .rx_dma_chan = 1,
+#endif
+    },
+    {
+        .dev      = SPI3,
+        .mosi_pin = GPIO_PIN(PORT_C, 12),
+        .miso_pin = GPIO_PIN(PORT_C, 11),
+        .sclk_pin = GPIO_PIN(PORT_C, 10),
+        .cs_pin   = SPI_CS_UNDEF,
+        .mosi_af  = GPIO_AF6,
+        .miso_af  = GPIO_AF6,
+        .sclk_af  = GPIO_AF6,
+        .cs_af    = GPIO_AF6,
+        .rccmask  = RCC_APB1ENR1_SPI3EN,
+        .apbbus   = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 5,
+        .tx_dma_chan = 3,
+        .rx_dma   = 4,
+        .rx_dma_chan = 3,
 #endif
     }
 };

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -552,6 +552,9 @@ boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_0_ISR
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_3_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_4_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_5_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_6_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member DMA_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member I2C_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/b\-l475e\-iot01a/include/periph_conf\.h:[0-9]+: warning: Member I2C_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds support for the missing SPI2 and SPI3 buses on the b-l4753-iot0a1 board.
SPI2 is exposed on the PMOD connector, SPI3 is used internally to communicate with the radio modules onboard


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

SPI3 was tested by interfacing with the bluetooth module with the following code:
```c
#include <stdio.h>

#include "clk.h"
#include "board.h"
#include "periph_conf.h"
#include "timex.h"
#include "xtimer.h"
#include "periph/gpio.h"
#include "periph/spi.h"
#include "fmt.h"

spi_t spi = SPI_DEV(2);
gpio_t cs = GPIO_PIN(PORT_D, 13);
gpio_t rst = GPIO_PIN(PORT_A, 8);
gpio_t ble_int = GPIO_PIN(PORT_E, 6);


uint8_t txbuf[256];
uint8_t rxbuf[256];
char hexbuf[256];

void ble_int_cb(void *arg) {
    (void)arg;

    puts("Interrupt called");
}

bool ble_data_present(void) {
    return gpio_read(ble_int) != 0;
}

void ble_init(void) {
    // Keep BLE in reset
    gpio_init(rst, GPIO_OUT);
    gpio_write(rst, 0);
    xtimer_usleep(5000);

    spi_init(spi);
    spi_init_cs(spi, cs);

    gpio_init_int(ble_int, GPIO_IN_PD, GPIO_RISING, ble_int_cb, NULL);
    gpio_irq_enable(ble_int);

    // Take BLE out of reset
    gpio_set(rst);
    xtimer_usleep(5000);
}

int main(void) {

    ble_init();

    txbuf[0] = 0x0A;
    txbuf[1] = 0;
    txbuf[2] = 0;
    txbuf[3] = 0;
    txbuf[4] = 0;

    while(1) {
        spi_acquire(spi, cs, SPI_MODE_0, SPI_CLK_5MHZ);
        spi_transfer_bytes(spi, cs, false, txbuf, rxbuf, 5);
        spi_release(spi);

        printf("data present: %d\n", ble_data_present());
        fmt_bytes_hex(hexbuf, txbuf, 5);
        printf("TX: %s\n", hexbuf);
        fmt_bytes_hex(hexbuf, rxbuf, 5);
        printf("RX: %s\n", hexbuf);
        puts("");

        xtimer_sleep(1);
    }
}
```
