### PR TITLE
drivers/atwinc15x0: register with netdev

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -575,13 +575,15 @@ const netdev_driver_t atwinc15x0_netdev_driver = {
     .set = _atwinc15x0_set,
 };
 
-void atwinc15x0_setup(atwinc15x0_t *dev, const atwinc15x0_params_t *params)
+void atwinc15x0_setup(atwinc15x0_t *dev, const atwinc15x0_params_t *params, uint8_t idx)
 {
     assert(dev);
 
     atwinc15x0 = dev;
     atwinc15x0->netdev.driver = &atwinc15x0_netdev_driver;
     atwinc15x0->params = *params;
+
+    netdev_register(&dev->netdev, NETDEV_ATWINC15X0, idx);
 }
 
 void atwinc15x0_irq(void)

--- a/drivers/include/atwinc15x0.h
+++ b/drivers/include/atwinc15x0.h
@@ -80,8 +80,9 @@ typedef struct atwinc15x0 {
  *
  * @param[in] dev     Device descriptor
  * @param[in] params  Parameters for device initialization
+ * @param[in] idx     Index in the params struct
  */
-void atwinc15x0_setup(atwinc15x0_t *dev, const atwinc15x0_params_t *params);
+void atwinc15x0_setup(atwinc15x0_t *dev, const atwinc15x0_params_t *params, uint8_t idx);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -326,6 +326,7 @@ typedef enum {
     NETDEV_TAP,
     NETDEV_W5100,
     NETDEV_ENCX24J600,
+    NETDEV_ATWINC15X0,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/pkg/lwip/init_devs/auto_init_atwinc15x0.c
+++ b/pkg/lwip/init_devs/auto_init_atwinc15x0.c
@@ -33,7 +33,7 @@ static atwinc15x0_t atwinc15x0_devs[NETIF_ATWINC_NUMOF];
 static void auto_init_atwinc15x0(void)
 {
     for (unsigned i = 0; i < NETIF_ATWINC_NUMOF; i++) {
-        atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
+        atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i], i);
         if (lwip_add_ethernet(&netif[i], &atwinc15x0_devs[i].netdev) == NULL) {
             DEBUG("Could not add atwinc15x0 device\n");
             return;

--- a/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
@@ -59,7 +59,7 @@ void auto_init_atwinc15x0(void)
         LOG_DEBUG("[auto_init_netif] initializing atwinc15x0 #%u\n", i);
 
         /* setup netdev device */
-        atwinc15x0_setup(&dev[i], &atwinc15x0_params[i]);
+        atwinc15x0_setup(&dev[i], &atwinc15x0_params[i], i);
         gnrc_netif_ethernet_create(&_netif[i], stack[i],
                                    ATWINC15X0_MAC_STACKSIZE,
                                    ATWINC15X0_MAC_PRIO, "atwinc15x0",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Just register the driver so it can be queried with `gnrc_netif_get_by_type()`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
