### PR TITLE
drivers/atwinc15x0: disconnect when sleeping

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -443,8 +443,14 @@ static int _set_state(atwinc15x0_t *dev, netopt_state_t state)
         m2m_wifi_disconnect();
         m2m_wifi_set_sleep_mode(M2M_PS_MANUAL, CONFIG_ATWINC15X0_RECV_BCAST);
         m2m_wifi_request_sleep(UINT32_MAX);
+        if (gpio_is_valid(atwinc15x0->params.wake_pin)) {
+            gpio_clear(atwinc15x0->params.wake_pin);
+        }
        return sizeof(netopt_state_t);
     case NETOPT_STATE_IDLE:
+        if (gpio_is_valid(atwinc15x0->params.wake_pin)) {
+            gpio_set(atwinc15x0->params.wake_pin);
+        }
         m2m_wifi_set_sleep_mode(M2M_PS_DEEP_AUTOMATIC, CONFIG_ATWINC15X0_RECV_BCAST);
         dev->state = state;
         _atwinc15x0_connect();

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -252,13 +252,13 @@ static int _atwinc15x0_send(netdev_t *netdev, const iolist_t *iolist)
     assert(iolist);
 
     if (!dev->connected) {
-        DEBUG("%s WiFi is still not connected to AP, cannot send", __func__);
+        DEBUG("%s WiFi is still not connected to AP, cannot send\n", __func__);
         return -ENODEV;
     }
 
     /* send wakes from standby but not from sleep */
     if (dev->state == NETOPT_STATE_SLEEP) {
-        DEBUG("%s WiFi is in SLEEP state, cannot send", __func__);
+        DEBUG("%s WiFi is in SLEEP state, cannot send\n", __func__);
         return -ENODEV;
     }
     if (dev->state == NETOPT_STATE_STANDBY) {

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -193,6 +193,11 @@ static void _atwinc15x0_wifi_cb(uint8_t type, void *msg)
                     atwinc15x0->connected = false;
                     atwinc15x0->netdev.event_callback(&atwinc15x0->netdev,
                                                       NETDEV_EVENT_LINK_DOWN);
+                    /* do not reconnect on standby or sleep */
+                    if (atwinc15x0->state == NETOPT_STATE_STANDBY ||
+                        atwinc15x0->state == NETOPT_STATE_SLEEP) {
+                        break;
+                    }
                     /* wait and try to reconnect */
                     ztimer_sleep(ZTIMER_MSEC, ATWINC15X0_WAIT_RECONNECT_MS);
                     _atwinc15x0_connect();
@@ -434,13 +439,15 @@ static int _set_state(atwinc15x0_t *dev, netopt_state_t state)
     switch (state) {
     case NETOPT_STATE_SLEEP:
     case NETOPT_STATE_STANDBY:
+        dev->state = state;
+        m2m_wifi_disconnect();
         m2m_wifi_set_sleep_mode(M2M_PS_MANUAL, CONFIG_ATWINC15X0_RECV_BCAST);
         m2m_wifi_request_sleep(UINT32_MAX);
-        dev->state = state;
        return sizeof(netopt_state_t);
     case NETOPT_STATE_IDLE:
         m2m_wifi_set_sleep_mode(M2M_PS_DEEP_AUTOMATIC, CONFIG_ATWINC15X0_RECV_BCAST);
         dev->state = state;
+        _atwinc15x0_connect();
         return sizeof(netopt_state_t);
     default:
         break;


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Don't try to re-connect when the interface is in SLEEP state.
Also disconnect before entering sleep.


### Testing procedure

This prevents an issue where the devices sleep state would get out of sync with the requested sleep state. The device would try to re-connect even though it should be asleep. 

### Issues/PRs references

follow-up to #17854