### PR TITLE
sys/event/timeout: stop old timer before overwriting it

### DIFF
--- a/sys/event/timeout_ztimer.c
+++ b/sys/event/timeout_ztimer.c
@@ -29,6 +29,9 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, ev
 void event_timeout_ztimer_init(event_timeout_t *event_timeout, ztimer_clock_t *clock,
                                event_queue_t *queue, event_t *event)
 {
+    if (event_timeout->clock) {
+        ztimer_remove(event_timeout->clock, &event_timeout->timer);
+    }
     event_timeout->clock = clock;
     event_timeout->timer.callback = _event_timeout_callback;
     event_timeout->timer.arg = event_timeout;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

dhcpv6 client client does

```C
static void _set_event_timeout_ms(event_timeout_t *timeout, event_t *event,
                                  uint32_t delay_ms)
{
    event_timeout_ztimer_init(timeout, ZTIMER_MSEC, event_queue, event);
    event_timeout_set(timeout, delay_ms);

static void _set_event_timeout_sec(event_timeout_t *timeout, event_t *event,
                                   uint32_t delay_sec)
{
    event_timeout_ztimer_init(timeout, ZTIMER_SEC, event_queue, event);
    event_timeout_set(timeout, delay_sec);
}

```

If e.g. first an event timeout in seconds was used, the seconds timer is still running when later a msec event is configured.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
