### PR TITLE
sys/test_utils/print_stack_usage: work with small stacks

### DIFF
--- a/tests/pthread_flood/Makefile
+++ b/tests/pthread_flood/Makefile
@@ -4,4 +4,7 @@ USEMODULE += posix_headers
 USEMODULE += pthread
 CFLAGS += -DMAXTHREADS=8
 
+# include "fmt" so print_stack_usage needs less stack
+USEMODULE += fmt
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

#17706 introduced printing of stack metrics. But, it printed them in the exiting thread, causing stack overflows due to `printf()`, for very small stacks.

This PR fixes the issue two-fold:

1. `print_str()` is used, if `fmt` is linked in.
2. the actual stack size is checked, and nothing is printed if the stack is too small

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
