### PR TITLE
sys: some simple xtimer->ztimer conversions

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -274,7 +274,6 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += vfs
   USEMODULE += posix_headers
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter shell,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -817,7 +817,7 @@ endif
 
 ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
   USEMODULE += nanocoap_sock
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
   USEMODULE += sock_util
 endif
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -167,7 +167,7 @@ endif
 
 ifneq (,$(filter uhcpc,$(USEMODULE)))
   USEMODULE += posix_inet
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter netdev_tap,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -99,7 +99,7 @@ endif
 
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
-  USEMODULE += xtimer
+  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter dhcpv6_%,$(USEMODULE)))

--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -12,7 +12,7 @@
 #include "net/af.h"
 #include "net/sock/udp.h"
 #include "net/uhcp.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 /**
  * @brief Request prefix from uhcp server
@@ -51,7 +51,7 @@ void uhcp_client(uhcp_iface_t iface)
         res = sock_udp_recv(&sock, buf, sizeof(buf), 10U*US_PER_SEC, &remote);
         if (res > 0) {
             uhcp_handle_udp(buf, res, remote.addr.ipv6, remote.port, iface);
-            xtimer_sleep(60);
+            ztimer_sleep(ZTIMER_MSEC, 60 * MS_PER_SEC);
         }
         else {
             LOG_ERROR("uhcp_client(): no reply received\n");

--- a/sys/net/link_layer/csma_sender/csma_sender.c
+++ b/sys/net/link_layer/csma_sender/csma_sender.c
@@ -22,8 +22,9 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <kernel_defines.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "random.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
@@ -152,7 +153,7 @@ int csma_sender_csma_ca_send(netdev_t *dev, iolist_t *iolist,
 
     /* if we arrive here, then we must perform the CSMA/CA procedure
        ourselves by software */
-    random_init(xtimer_now_usec());
+    random_init(ztimer_now(ZTIMER_USEC));
     DEBUG("csma: Starting software CSMA/CA....\n");
 
     int nb = 0, be = conf->min_be;
@@ -160,7 +161,7 @@ int csma_sender_csma_ca_send(netdev_t *dev, iolist_t *iolist,
     while (nb <= conf->max_be) {
         /* delay for an adequate random backoff period */
         uint32_t bp = choose_backoff_period(be, conf);
-        xtimer_usleep(bp);
+        ztimer_sleep(ZTIMER_USEC, bp);
 
         /* try to send after a CCA */
         res = send_if_cca(dev, iolist);

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -32,7 +32,7 @@
 #include "net/nanocoap_sock.h"
 #include "thread.h"
 #include "periph/pm.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #include "suit/transport/coap.h"
 #include "net/sock/util.h"
@@ -112,27 +112,6 @@ ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                              subtree->resources_numof);
 }
 
-static inline uint32_t _now(void)
-{
-    return xtimer_now_usec();
-}
-
-static inline uint32_t deadline_from_interval(int32_t interval)
-{
-    assert(interval >= 0);
-    return _now() + (uint32_t)interval;
-}
-
-static inline uint32_t deadline_left(uint32_t deadline)
-{
-    int32_t left = (int32_t)(deadline - _now());
-
-    if (left < 0) {
-        left = 0;
-    }
-    return left;
-}
-
 static void _suit_handle_url(const char *url, coap_blksize_t blksize, void *work_buf)
 {
     LOG_INFO("suit_coap: downloading \"%s\"\n", url);
@@ -161,7 +140,7 @@ static void _suit_handle_url(const char *url, coap_blksize_t blksize, void *work
             const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(
                 riotboot_slot_other());
             riotboot_hdr_print(hdr);
-            xtimer_sleep(1);
+            ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
             if (riotboot_hdr_validate(hdr) == 0) {
                 LOG_INFO("suit_coap: rebooting...\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

do some simple xtimer->ztimer conversions avoid using any xtimer_compat 

These modules only use 32Bit of xtimer and and therefor are easy conversions to use ztimer(32)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Somehow there is another PR with the same Title doing something different 

#17693
