### PR TITLE
gnrc_netif: handle NETDEV_EVENT_LINK_UP/DOWN events

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -487,6 +487,9 @@ static int _init(netdev_t *netdev)
 {
     DEBUG("%s: %p\n", __func__, netdev);
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -404,5 +404,9 @@ static int _init(netdev_t *netdev)
     native_async_read_add_handler(dev->tap_fd, netdev, _tap_isr);
 
     DEBUG("gnrc_tapnet: initialized.\n");
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }

--- a/cpu/nrf5x_common/radio/nrfble/nrfble.c
+++ b/cpu/nrf5x_common/radio/nrfble/nrfble.c
@@ -279,6 +279,10 @@ static int _nrfble_init(netdev_t *dev)
     NVIC_EnableIRQ(RADIO_IRQn);
 
     DEBUG("[nrfble] initialization successful\n");
+
+    /* signal link UP */
+    dev->event_callback(dev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -448,6 +448,9 @@ static int nrfmin_init(netdev_t *dev)
 
     DEBUG("[nrfmin] initialization successful\n");
 
+    /* signal link UP */
+    dev->event_callback(dev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -55,6 +55,10 @@ static int _sam0_eth_init(netdev_t *netdev)
     eui48_t hwaddr;
     netdev_eui48_get(netdev, &hwaddr);
     sam0_eth_set_mac(&hwaddr);
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -460,6 +460,11 @@ static int stm32_eth_init(netdev_t *netdev)
 
     _setup_phy();
 
+    /* signal link UP if no proper link detection is enabled */
+    if (!IS_USED(MODULE_STM32_ETH_LINK_UP)) {
+        netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+    }
+
     return 0;
 }
 

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -137,6 +137,9 @@ static int _init(netdev_t *netdev)
     /* reset device to default values and put it into RX state */
     at86rf215_reset_and_cfg(dev);
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -108,6 +108,9 @@ static int _init(netdev_t *netdev)
     /* reset device to default values and put it into RX state */
     at86rf2xx_reset(dev);
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -343,6 +343,10 @@ static int cc110x_init(netdev_t *netdev)
     }
 
     DEBUG("[cc110x] netdev_driver_t::init(): Success\n");
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -136,7 +136,13 @@ static int _init(netdev_t *netdev)
         return -1;
     }
 
-    return cc2420_init(dev);
+    int res = cc2420_init(dev);
+    if (res == 0) {
+        /* signal link UP */
+        netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+    }
+
+    return res;
 }
 
 static void _isr(netdev_t *netdev)

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -761,6 +761,8 @@ static int _init(netdev_t *dev)
 
     state(ctx, DOSE_SIGNAL_INIT);
 
+    dev->event_callback(dev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -211,9 +211,11 @@ static void _isr(netdev_t *netdev)
     netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
 }
 
-static int _init(netdev_t *encdev)
+static int _init(netdev_t *netdev)
 {
-    (void)encdev;
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -100,6 +100,9 @@ static int kw41zrf_netdev_init(netdev_t *netdev)
         return -1;
     }
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -64,6 +64,9 @@ static int _init(netdev_t *netdev)
         return -ENODEV;
     }
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -365,6 +365,10 @@ static int _init(netdev_t *netdev)
                           &enable, sizeof(enable));
 
     netdev_submac->dev.txpower = tx_power;
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -255,6 +255,10 @@ static int _init(netdev_t *netdev)
         DEBUG_PUTS("[nrf24l01p_ng] _init(): gpio_init_int() failed");
         return -EIO;
     }
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -88,6 +88,10 @@ static int _init(netdev_t *netdev)
                   dev->config.uart, dev->config.baudrate);
         return -ENODEV;
     }
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -141,6 +141,10 @@ static int _init(netdev_t *netdev)
     }
 
     DEBUG("[sx126x] netdev: initialization successful\n");
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -229,6 +229,9 @@ static int _init(netdev_t *netdev)
 
     DEBUG("[sx127x] netdev: initialization done\n");
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/sx1280/sx1280_netdev.c
+++ b/drivers/sx1280/sx1280_netdev.c
@@ -149,6 +149,10 @@ static int _init(netdev_t *netdev)
     }
 
     DEBUG("[sx1280] netdev: initialization successful\n");
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -180,6 +180,9 @@ static int init(netdev_t *netdev)
     /* release the SPI bus again */
     spi_release(dev->p.spi);
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -639,6 +639,10 @@ int xbee_init(netdev_t *dev)
     }
 
     DEBUG("[xbee] init: Initialization successful\n");
+
+    /* signal link UP */
+    dev->event_callback(dev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -304,6 +304,26 @@ void gnrc_ipv6_nib_init(void);
 void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif);
 
 /**
+ * @brief   Call bring-up functions when the interface comes online
+ *
+ * @pre `netif != NULL`
+ *
+ * @param[in,out] netif The interface that just got online
+ */
+void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif);
+
+/**
+ * @brief   Clean up when the interface goes offline
+ *
+ * @pre `netif != NULL`
+ *
+ * @param[in,out] netif         The interface that has just got offline
+ * @param[in]     send_final_ra Whether to advertise router disappearance
+ *                              in a final router advertisement
+ */
+void gnrc_ipv6_nib_iface_down(gnrc_netif_t *netif, bool send_final_ra);
+
+/**
  * @brief   Gets link-layer address of next hop to a destination address
  *
  * @pre `(dst != NULL) && (nce != NULL)`

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1974,6 +1974,14 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
         DEBUG("gnrc_netif: event triggered -> %i\n", event);
         gnrc_pktsnip_t *pkt = NULL;
         switch (event) {
+#if IS_USED(MODULE_GNRC_IPV6_NIB)
+            case NETDEV_EVENT_LINK_UP:
+                gnrc_ipv6_nib_iface_up(netif);
+                break;
+            case NETDEV_EVENT_LINK_DOWN:
+                gnrc_ipv6_nib_iface_down(netif, false);
+                break;
+#endif
             case NETDEV_EVENT_RX_COMPLETE:
                 pkt = netif->ops->recv(netif);
                 /* send packet previously queued within netif due to the lower

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
@@ -194,6 +194,16 @@ static inline void _init_iface_arsm(gnrc_netif_t *netif)
 }
 
 /**
+ * @brief   Deinitializes interface from address registration state machine
+ *
+ * @param[in] netif An interface
+ */
+static inline void _deinit_iface_arsm(gnrc_netif_t *netif)
+{
+    _evtimer_del(&netif->ipv6.recalc_reach_time);
+}
+
+/**
  * @brief   Gets neighbor unreachability state of a neighbor
  *
  * @param[in] nbr   Neighbor cache entry representing the neighbor.
@@ -232,11 +242,11 @@ bool _is_reachable(_nib_onl_entry_t *entry);
 #define _handle_state_timeout(ctx)                  (void)ctx
 #define _probe_nbr(nbr, reset)                      (void)nbr; (void)reset
 #define _init_iface_arsm(netif)                     (void)netif
+#define _deinit_iface_arsm(netif)                   (void)netif
 #define _handle_adv_l2(netif, nce, icmpv6, tl2ao)   (void)netif; (void)nce; \
                                                     (void)icmpv6; (void)tl2ao
 #define _recalc_reach_time(netif)                   (void)netif
 #define _set_reachable(netif, nce)                  (void)netif; (void)nce
-#define _init_iface_arsm(netif)                     (void)netif
 
 #define _get_nud_state(nbr)                 (GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNMANAGED)
 #define _set_nud_state(netif, nce, state)   (void)netif; (void)nbr; (void)state

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -23,13 +23,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-#include <kernel_defines.h>
 
 #include "bitfield.h"
 #include "evtimer_msg.h"
 #include "sched.h"
 #include "mutex.h"
 #include "net/eui64.h"
+#include "kernel_defines.h"
 #include "net/ipv6/addr.h"
 #ifdef MODULE_GNRC_IPV6
 #include "net/gnrc/ipv6.h"
@@ -836,6 +836,16 @@ int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *ctx,
 uint32_t _evtimer_lookup(const void *ctx, uint16_t type);
 
 /**
+ * @brief   Removes an event from the event timer
+ *
+ * @param[in] event Representation of the event.
+ */
+static inline void _evtimer_del(evtimer_msg_event_t *event)
+{
+    evtimer_del(&_nib_evtimer, &event->event);
+}
+
+/**
  * @brief   Adds an event to the event timer
  *
  * @param[in] ctx       The context of the event
@@ -851,7 +861,7 @@ static inline void _evtimer_add(void *ctx, int16_t type,
 #else
     kernel_pid_t target_pid = KERNEL_PID_LAST;  /* just for testing */
 #endif
-    evtimer_del((evtimer_t *)(&_nib_evtimer), (evtimer_event_t *)event);
+    _evtimer_del(event);
     event->event.next = NULL;
     event->event.offset = offset;
     event->msg.type = type;

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -155,6 +155,9 @@ static int _init(netdev_t *netdev)
 
     netdev_eui48_get(netdev, (eui48_t*)&cdcecm->mac_netdev);
 
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
     return 0;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If an interface goes offline we can to stop sending router solicitations on it.
But more importantly, if the interface gets online again, we need to send out a router solicitation immediately to get a fresh address.


### Testing procedure

This was tested with a `atwinc15x0` WiFi module. When it connects to a WiFi network it generates a `NETDEV_EVENT_LINK_UP` event, when the WiFi is no longer connected a `NETDEV_EVENT_LINK_DOWN` event is generated.

I used two custom functions to manage the netif state, but `ifconfig` should work too:

```C
static void _netup(gnrc_netif_t *netif)
{
    netopt_state_t state = NETOPT_STATE_IDLE;
    while (gnrc_netapi_set(netif->pid, NETOPT_STATE, 0, &state, sizeof(state)) == -EBUSY) {}
}
```

```C
static void _drop_global_addr(gnrc_netif_t *netif)
{
    ipv6_addr_t addr[CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF];
    int num = gnrc_netif_ipv6_addrs_get(netif, addr, sizeof(addr));
    for (int i = 0; i < num; ++i) {
        if (ipv6_addr_is_global(&addr[i])) {
            gnrc_netif_ipv6_addr_remove(netif, &addr[i]);
        }
    }
}

static void _netdown(gnrc_netif_t *netif)
{
    netopt_state_t state = NETOPT_STATE_SLEEP;
    while (gnrc_netapi_set(netif->pid, NETOPT_STATE, 0, &state, sizeof(state)) == -EBUSY) {}

    _drop_global_addr(netif);
}
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
