### PR TITLE
sys/pm_layered: use array representation, get rid of implicit IDLE mode

### DIFF
--- a/cpu/atxmega/include/periph_cpu.h
+++ b/cpu/atxmega/include/periph_cpu.h
@@ -95,7 +95,7 @@ enum {
  * @name    Power management configuration
  * @{
  */
-#define PM_NUM_MODES            (4)
+#define PM_NUM_MODES            (5)
 /** @} */
 
 /**

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -56,7 +56,7 @@ typedef uint32_t gpio_t;
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (4)
+#define PM_NUM_MODES        (5)
 /** @} */
 
 /**

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -452,7 +452,7 @@ typedef struct {
 /**
  * @brief   Number of usable power modes.
  */
-#define PM_NUM_MODES    (2U)
+#define PM_NUM_MODES    (3U)
 
 /**
  * @name    Watchdog timer (WDT) configuration

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -38,7 +38,7 @@ extern "C" {
 /**
  * @brief   Number of usable low power modes
  */
-#define PM_NUM_MODES            (2U)
+#define PM_NUM_MODES            (3U)
 
 /**
  * @name    Power modes

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -148,7 +148,7 @@ typedef uint32_t spi_cs_t;
  * @name    Kinetis power mode configuration
  * @{
  */
-#define PM_NUM_MODES    (3U)
+#define PM_NUM_MODES    (4U)
 enum {
     KINETIS_PM_LLS  = 0,
     KINETIS_PM_VLPS = 1,

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -73,7 +73,7 @@ typedef enum {
 /**
  * @brief   Power management configuration
  */
-#define PM_NUM_MODES    (2U)
+#define PM_NUM_MODES    (3U)
 
 /**
  * @brief   UART device configuration

--- a/cpu/lpc23xx/include/periph_cpu.h
+++ b/cpu/lpc23xx/include/periph_cpu.h
@@ -36,7 +36,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (3)
+#define PM_NUM_MODES        (4)
 /** @} */
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -32,7 +32,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (3)
+#define PM_NUM_MODES        (4)
 /** @} */
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -37,10 +37,10 @@ extern "C" {
 
 /**
  * @brief   Override the default initial PM blocker
- * @todo   Idle modes are enabled by default, deep sleep mode blocked
+ *          Idle modes are enabled by default, deep sleep mode blocked
  */
 #ifndef PM_BLOCKER_INITIAL
-#define PM_BLOCKER_INITIAL      0x00000001
+#define PM_BLOCKER_INITIAL      { 1, 0, 0, 0 }
 #endif
 
 /**

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -53,11 +53,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES       4            /**< Backup, Hibernate, Standby, Idle */
-
-#ifndef PM_BLOCKER_INITIAL
-#define PM_BLOCKER_INITIAL 0x00010101   /**< Block all modes but Idle */
-#endif
+#define PM_NUM_MODES            (4)     /**< Backup, Hibernate, Standby, Idle */
 /** @} */
 
 /**

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -34,14 +34,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Override the default initial PM blocker
- * @todo   Idle modes are enabled by default, deep sleep mode blocked
- */
-#ifndef PM_BLOCKER_INITIAL
-#define PM_BLOCKER_INITIAL  0x00000001
-#endif
-
-/**
  * @name   SAML1x GCLK definitions
  * @{
  */

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -30,7 +30,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (1)
+#define PM_NUM_MODES        (2)
 /** @} */
 
 /**

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -35,7 +35,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (2)
+#define PM_NUM_MODES        (3)
 /** @} */
 
 /**

--- a/cpu/stm32/include/periph/cpu_pm.h
+++ b/cpu/stm32/include/periph/cpu_pm.h
@@ -32,14 +32,15 @@ extern "C" {
 /**
  * @brief   Number of usable low power modes
  */
-#define PM_NUM_MODES    (2U)
+#define PM_NUM_MODES            (3U)
 
 /**
  * @name    Power modes
  * @{
  */
-#define STM32_PM_STOP         (1U)  /**< Index of STOP mode */
-#define STM32_PM_STANDBY      (0U)  /**< Index of STANDBY mode */
+#define STM32_PM_IDLE           (2U)  /**< Index of IDLE mode */
+#define STM32_PM_STOP           (1U)  /**< Index of STOP mode */
+#define STM32_PM_STANDBY        (0U)  /**< Index of STANDBY mode */
 /** @} */
 
 #ifndef PM_EWUP_CONFIG

--- a/examples/lorawan/Makefile
+++ b/examples/lorawan/Makefile
@@ -53,10 +53,6 @@ else ifeq (abp,$(ACTIVATION_MODE))
   CFLAGS += -DUSE_ABP
 endif
 
-# Enable deep sleep power mode (e.g. STOP mode on STM32) which
-# in general provides RAM retention after wake-up.
-CFLAGS += -DPM_BLOCKER_INITIAL=0x00000001
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -27,6 +27,7 @@
 #include "thread.h"
 #include "fmt.h"
 
+#include "periph/pm.h"
 #if IS_USED(MODULE_PERIPH_RTC)
 #include "periph/rtc.h"
 #else
@@ -147,6 +148,16 @@ int main(void)
 {
     puts("LoRaWAN Class A low-power application");
     puts("=====================================");
+
+    /*
+     * Enable deep sleep power mode (e.g. STOP mode on STM32) which
+     * in general provides RAM retention after wake-up.
+     */
+#if IS_USED(MODULE_PM_LAYERED)
+    for (unsigned i = 1; i < PM_NUM_MODES; ++i) {
+        pm_unblock(i);
+    }
+#endif
 
     /* Initialize the radio driver */
 #if IS_USED(MODULE_SX127X)

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -54,7 +54,7 @@ extern "C" {
  * @brief Power Management mode blocker typedef
  */
 typedef struct {
-    uint8_t val_u8[PM_NUM_MODES];       /**< power mode blockers u8 */
+    uint8_t blockers[PM_NUM_MODES];     /**< number of blockers for the mode */
 } pm_blocker_t;
 
 /**

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -16,9 +16,10 @@
  *
  * This simple power management interface is based on the following assumptions:
  *
- * - CPUs define up to 4 power modes (from zero, the lowest power mode, to
- *   PM_NUM_MODES-1, the highest)
- * - there is an implicit extra idle mode (which has the number PM_NUM_MODES)
+ * - CPUs define a number of power modes (from zero, the lowest power mode, to
+ *   PM_NUM_MODES, the highest)
+ * - there is an implicit extra busy-wait mode (which has the number PM_NUM_MODES)
+ *   where the CPU is kept spinning if all modes are blocked.
  * - individual power modes can be blocked/unblocked, e.g., by peripherals
  * - if a mode is blocked, so are implicitly all lower modes
  * - the idle thread automatically selects and sets the lowest unblocked mode
@@ -52,8 +53,7 @@ extern "C" {
 /**
  * @brief Power Management mode blocker typedef
  */
-typedef union {
-    uint32_t val_u32;                   /**< power mode blockers u32 */
+typedef struct {
     uint8_t val_u8[PM_NUM_MODES];       /**< power mode blockers u8 */
 } pm_blocker_t;
 

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -54,7 +54,7 @@
 /**
  * @brief Global variable for keeping track of blocked modes
  */
-static pm_blocker_t pm_blocker = { .val_u8 = PM_BLOCKER_INITIAL };
+static pm_blocker_t pm_blocker = { .blockers = PM_BLOCKER_INITIAL };
 
 void pm_set_lowest(void)
 {
@@ -63,7 +63,7 @@ void pm_set_lowest(void)
     /* set lowest mode if blocker is still the same */
     unsigned state = irq_disable();
     while (mode) {
-        if (pm_blocker.val_u8[mode-1]) {
+        if (pm_blocker.blockers[mode - 1]) {
             break;
         }
         mode--;
@@ -77,19 +77,19 @@ void pm_set_lowest(void)
 
 void pm_block(unsigned mode)
 {
-    assert(pm_blocker.val_u8[mode] != 255);
+    assert(pm_blocker.blockers[mode] != 255);
 
     unsigned state = irq_disable();
-    pm_blocker.val_u8[mode]++;
+    pm_blocker.blockers[mode]++;
     irq_restore(state);
 }
 
 void pm_unblock(unsigned mode)
 {
-    assert(pm_blocker.val_u8[mode] > 0);
+    assert(pm_blocker.blockers[mode] > 0);
 
     unsigned state = irq_disable();
-    pm_blocker.val_u8[mode]--;
+    pm_blocker.blockers[mode]--;
     irq_restore(state);
 }
 

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -107,7 +107,7 @@ static int cmd_unblock(char *arg)
     }
 
     pm_blocker_t pm_blocker = pm_get_blocker();
-    if (pm_blocker.val_u8[mode] == 0) {
+    if (pm_blocker.blockers[mode] == 0) {
         printf("Mode %d is already unblocked.\n", mode);
         return 1;
     }
@@ -127,8 +127,8 @@ static int cmd_show(char *arg)
 
     pm_blocker_t pm_blocker = pm_get_blocker();
     for (unsigned i = 0; i < PM_NUM_MODES; i++) {
-        printf("mode %u blockers: %u \n", i, pm_blocker.val_u8[i]);
-        if (pm_blocker.val_u8[i]) {
+        printf("mode %u blockers: %u \n", i, pm_blocker.blockers[i]);
+        if (pm_blocker.blockers[i]) {
             lowest_allowed_mode = i + 1;
         }
     }

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -105,7 +105,7 @@ static int cmd_unblock_rtc(int argc, char **argv)
     }
 
     pm_blocker_t pm_blocker = pm_get_blocker();
-    if (pm_blocker.val_u8[mode] == 0) {
+    if (pm_blocker.blockers[mode] == 0) {
         printf("Mode %d is already unblocked.\n", mode);
         return 1;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`PM_NUM_MODES` is confusing as it must *not* include the default IDLE mode.
In #17883 I added the IDLE mode to `PM_NUM_MODES` of `samd5x` so it *can* be blocked too (falling back to polling the CPU), which introduced an introducing.

I think this was done to fit all blockers for the modes into an `uint32_t`, but is is entirely unnecessary as the blockers are typically accessed as an array anyway.

So always make `pm_blocker_t` an array to remove the limitation to 4 modes.

### Testing procedure

This should retain the current behavior. `samd5x` was not changed as it already implements the new convention.
`native` was accidentally already using the new convention, causing it not to enter sleep at all with the current implementation. As a side effect, this is now fixed by this PR.


### Issues/PRs references

#13475