### PR TITLE
sys/net/telnet: automatically disconnect after period of inactivity

### DIFF
--- a/sys/include/net/telnet.h
+++ b/sys/include/net/telnet.h
@@ -38,6 +38,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Automatically terminate the connection after a
+ *          period of inactivity.
+ *
+ *          Set to 0 to disable auto-disconnect.
+ *
+ *          This is a workaround for issue #17896
+ */
+#ifndef CONFIG_TELNET_AUTO_DISCONNECT_SEC
+#define CONFIG_TELNET_AUTO_DISCONNECT_SEC       (10)
+#endif
+
+/**
  * @brief   Start the Telnet server thread
  *
  * @return  0 on success, error otherwise


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`gnrc_tcp` can't detect if a connection was lost (not closed), so terminate the connection after a period of inactivity to prevent losing the socket forever if we lose the connection.


### Testing procedure

I tested this with `examples/telnet_server` on `same54-xpro` where I can easily trigger a loss of network connection by disconnecting the ethernet cable.
Make sure to set `CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS` to something lower than the default, otherwise you'll have to wait an additional 2 minutes for `sock_tcp_disconnect()` to return.

 - connect to the board with e.g `telnet fe80::fec2:3dff:fe23:22df%eno1`
 - disconnect the Ethernet cable
 - close the telnet application
 - wait 10s (`CONFIG_TELNET_AUTO_DISCONNECT_SEC`) and an additional ~10s (or whatever you have set for `CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS`)
 - connect the ethernet cable again
 - try to connect again with e.g. `telnet fe80::fec2:3dff:fe23:22df%eno1`

On `master` the new connection can not be established as the server is still connected to the stale socket.
With this patch you can connect to the server again.


### Issues/PRs references

work-around for #17896
