### PR TITLE
cpu/arm7, arch/cortexm: Remove -fno-builtin flag

### DIFF
--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -9,7 +9,7 @@ INCLUDES += -I$(RIOTBASE)/cpu/arm7_common/include/
 MCPU ?= arm7tdmi-s
 
 CFLAGS_CPU  = -mcpu=$(MCPU)
-CFLAGS_LINK = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+CFLAGS_LINK = -ffunction-sections -fdata-sections -fshort-enums
 CFLAGS_DBG  ?= -ggdb -g3
 CFLAGS_OPT  ?= -Os
 

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -20,7 +20,7 @@ ifneq (llvm,$(TOOLCHAIN))
   endif
 endif
 
-CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+CFLAGS_LINK  = -ffunction-sections -fdata-sections -fshort-enums
 CFLAGS_DBG  ?= -ggdb -g3
 CFLAGS_OPT  ?= -Os
 


### PR DESCRIPTION
### Contribution description

Re-enable compiler builtins for arm processors by removing the -fno-builtin flag from the arm7_common and cortexm makefile fragments.

The -fno-builtin flag disables all builtin functions provided by the compiler as well as disabling all optimizations and error checking related to standard C library functions. If you're using a C library which conforms to the ANSI C standard, you want to leave these compiler features enabled.

### Testing procedure

Pre-patch, note that printf calls are not optimized to puts calls (yeah, not a terribly helpful optimization, but it's how I discovered the issue):
```
$ sed -i '1a \
FEATURES_OPTIONAL += picolibc\
' examples/hello-world/Makefile
$ make -C examples/hello-world BOARD=microbit
$ nm -u examples/hello-world/bin/microbit/core_lib/init.o 
         U auto_init
         U cpu_switch_context_exit
         U main
         U printf
         U thread_create
```

Now apply the patch and check again:

```
$ make -C examples/hello-world BOARD=microbit
$ nm -u examples/hello-world/bin/microbit/core_lib/init.o 
         U auto_init
         U cpu_switch_context_exit
         U main
         U puts
         U thread_create
```

With the compiler able to use its knowledge about standard C library functions, it can convert the printf call in init.c which passes a constant string into a call to puts.

### Issues/PRs references

This PR references no outstanding issues.

