### PR TITLE
pkg/openwsn: add patch to use memmove() instead of memcpy()

### DIFF
--- a/pkg/openwsn/patches/0014-openstack-03a-IPHC-use-memmove-instead-of-memcpy.patch
+++ b/pkg/openwsn/patches/0014-openstack-03a-IPHC-use-memmove-instead-of-memcpy.patch
@@ -1,0 +1,26 @@
+From d7c8d2a0ee86b7a2e1a7915f4f789c27fde83cf9 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Sun, 3 Apr 2022 20:39:23 +0200
+Subject: [PATCH] openstack/03a-IPHC: use memmove() instead of memcpy()
+
+The memory segments do overlap, so we must use memmove() instead of memcpy().
+---
+ openstack/03a-IPHC/frag.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/openstack/03a-IPHC/frag.c b/openstack/03a-IPHC/frag.c
+index d2ca5f45..7ee0b3ba 100644
+--- a/openstack/03a-IPHC/frag.c
++++ b/openstack/03a-IPHC/frag.c
+@@ -708,7 +708,7 @@ opentimers_id_t frag_timerq_dequeue(void) {
+     opentimers_id_t expired;
+     expired = frag_vars.frag_timerq[0];
+ 
+-    memcpy((uint8_t *) frag_vars.frag_timerq, (uint8_t * ) & (frag_vars.frag_timerq[1]), NUM_OF_CONCURRENT_TIMERS - 1);
++    memmove((uint8_t *) frag_vars.frag_timerq, (uint8_t * ) & (frag_vars.frag_timerq[1]), NUM_OF_CONCURRENT_TIMERS - 1);
+     frag_vars.frag_timerq[NUM_OF_CONCURRENT_TIMERS - 1] = 0;
+ 
+     return expired;
+-- 
+2.32.0
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

OpenWSN in one place uses `memcpy()` where `memmove()` is required due to overlapping memory regions.
Patch it to fix this.

### Testing procedure

Should fix

```
[INFO] cloning openwsn
git-cache: cloning from cache. tag=commite2958a031ad50a6f3eeca3a98ad1ae85aa773a48-688996
[INFO] updating openwsn /tmp/dwq.0.44905491325747215/3c9f2b3f67a3e6785d234b81f525a663/build/pkg/openwsn/.pkg-state.git-downloaded
echo e2958a031ad50a6f3eeca3a98ad1ae85aa773a48 > /tmp/dwq.0.44905491325747215/3c9f2b3f67a3e6785d234b81f525a663/build/pkg/openwsn/.pkg-state.git-downloaded
[INFO] patch openwsn
frag.c: In function 'frag_timerq_dequeue':
frag.c:711:5: error: 'memcpy' accessing 3 bytes at offsets 500 and 501 overlaps 2 bytes at offset 501 [-Werror=restrict]
  711 |     memcpy((uint8_t *) frag_vars.frag_timerq, (uint8_t * ) & (frag_vars.frag_timerq[1]), NUM_OF_CONCURRENT_TIMERS - 1);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

with `-fno-builtin` disabled.


### Issues/PRs references

discovered in #17898
