### PR TITLE
cpu/riscv_common: fix undeclared memory region linker error

### DIFF
--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -231,7 +231,7 @@ SECTIONS
 
   .flash_writable (NOLOAD) : {
     KEEP(*(SORT(.flash_writable.*)))
-  } > rom
+  } > flash
 
   .end_fw (NOLOAD) : ALIGN(4) {
     _end_fw = . ;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
By mistake my PR #17436 reintroduced a linker warning on riscv that was fixed with #17581.
This PR reapplies this fix by placing the `flash_writable` region into the `flash` memory region.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
