### PR TITLE
boards/adafruit-pybadge: enable ST7735 display

### DIFF
--- a/boards/adafruit-pybadge/Kconfig
+++ b/boards/adafruit-pybadge/Kconfig
@@ -23,7 +23,7 @@ config BOARD_ADAFRUIT_PYBADGE
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
 
-    # select HAVE_ST7735  # not supported yet
+    select HAVE_ST7735
     select HAVE_SAUL_GPIO
     select HAVE_MTD_SPI_NOR
     # This specific board requires SPI_ON_QSPI for the MTD_SPI_NOR

--- a/boards/adafruit-pybadge/Makefile.dep
+++ b/boards/adafruit-pybadge/Makefile.dep
@@ -3,8 +3,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter disp_dev,$(USEMODULE)))
-  # Driver not supported yet
-  # USEMODULE += st7735
+  USEMODULE += st7735
 endif
 
 ifneq (,$(filter mtd,$(USEMODULE)))

--- a/boards/adafruit-pybadge/board.c
+++ b/boards/adafruit-pybadge/board.c
@@ -64,8 +64,7 @@ void board_init(void)
         gpio_set(SPEAKER_ENABLE_PIN);
     }
 
-    /* ST7735 driver is not supported yet uncomment the following code once it is */
-    /* if (IS_USED(MODULE_ST7735)) {
+    if (IS_USED(MODULE_ST7735)) {
         gpio_init(BACKLIGHT_PIN, GPIO_OUT);
-    }*/
+    }
 }

--- a/boards/adafruit-pybadge/include/board.h
+++ b/boards/adafruit-pybadge/include/board.h
@@ -67,13 +67,16 @@ extern "C" {
  * @name    Display configuration (not supported yet)
  * @{
  */
-#define ST7735_PARAM_SPI       SPI_DEV(1)                      /**< SPI device */
-#define ST7735_PARAM_CS        GPIO_PIN(PB, 7)                 /**< Chip select pin */
-#define ST7735_PARAM_DCX       GPIO_PIN(PB, 5)                 /**< DCX pin */
-#define ST7735_PARAM_RST       GPIO_PIN(PA, 0)                 /**< Reset pin */
-#define ST7735_PARAM_NUM_LINES (128U)                          /**< Number of screen lines */
-#define ST7735_PARAM_RGB       (1)                             /**< RGB configuration */
-#define ST7735_PARAM_INVERTED  (1)                             /**< Inversion configuration */
+#define ST7735_PARAM_SPI        SPI_DEV(1)                      /**< SPI device */
+#define ST7735_PARAM_CS         GPIO_PIN(PB, 7)                 /**< Chip select pin */
+#define ST7735_PARAM_DCX        GPIO_PIN(PB, 5)                 /**< DCX pin */
+#define ST7735_PARAM_RST        GPIO_PIN(PA, 0)                 /**< Reset pin */
+#define ST7735_PARAM_NUM_LINES  (160U)                          /**< Number of screen lines */
+#define ST7735_PARAM_RGB_CHANNELS   (128U)                      /**< Number of screen rgb channel (height) */
+#define ST7735_PARAM_RGB        (1)                             /**< RGB configuration */
+#define ST7735_PARAM_INVERTED   (0)                             /**< Inversion configuration */
+#define LCD_SCREEN_WIDTH        (ST7735_PARAM_NUM_LINES)        /**< LCD screen width */
+#define LCD_SCREEN_HEIGHT       (ST7735_PARAM_RGB_CHANNELS)     /**< LCD screen height */
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR enables the st7735 driver and update the board configuration on the pybadge.

The board display can now be used with disp_dev and lvgl after #16176 is merged.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`tests/driver_st7735`, `tests/disp_dev` and `tests/pkg_lvgl*` are working on the pybadge.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Requires #16176 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
