### PR TITLE
gnrc_netif: don't allocate message queue on the stack

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -184,6 +184,10 @@ typedef struct {
      */
     gnrc_netif_pktq_t send_queue;
 #endif
+    /**
+     * @brief   Message queue for the netif thread
+     */
+    msg_t msg_queue[GNRC_NETIF_MSG_QUEUE_SIZE];
     uint8_t cur_hl;                         /**< Current hop-limit for out-going packets */
     uint8_t device_type;                    /**< Device type */
     kernel_pid_t pid;                       /**< PID of the network interface's thread */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1834,7 +1834,6 @@ static void *_gnrc_netif_thread(void *args)
     netdev_t *dev;
     int res;
     msg_t reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-    msg_t msg_queue[GNRC_NETIF_MSG_QUEUE_SIZE];
 
     DEBUG("gnrc_netif: starting thread %i\n", thread_getpid());
     netif = ctx->netif;
@@ -1848,7 +1847,7 @@ static void *_gnrc_netif_thread(void *args)
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 
     /* setup the link-layer's message queue */
-    msg_init_queue(msg_queue, GNRC_NETIF_MSG_QUEUE_SIZE);
+    msg_init_queue(netif->msg_queue, ARRAY_SIZE(netif->msg_queue));
     /* initialize low-level driver */
     ctx->result = netif->ops->init(netif);
     /* signal that driver init is done */

--- a/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
@@ -23,12 +23,13 @@
 #include "atwinc15x0.h"
 #include "atwinc15x0_params.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define ATWINC15X0_MAC_STACKSIZE    (THREAD_STACKSIZE_DEFAULT)
+#define ATWINC15X0_MAC_STACKSIZE    (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef ATWINC15X0_MAC_PRIO
 #define ATWINC15X0_MAC_PRIO         (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
@@ -23,28 +23,15 @@
 #include "cc1xxx_common.h"
 #include "cc110x_params.h"
 #include "log.h"
-#include "msg.h"
-#include "net/gnrc/netif/conf.h"    /* <- GNRC_NETIF_MSG_QUEUE_SIZE */
+#include "include/init_devs.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifndef CC110X_EXTRA_STACKSIZE
-/**
- * @brief   Additional stack size required by the driver
- *
- * With increasing of GNRC_NETIF_MSG_QUEUE_SIZE the required stack size
- * increases as well. A queue size of 8 messages works with default stack size,
- * so we increase the stack by `sizeof(msg_t)` for each additional element
- */
-#define CC110X_EXTRA_STACKSIZE          ((GNRC_NETIF_MSG_QUEUE_SIZE - 8) * sizeof(msg_t))
-#endif
-
 /**
  * @brief   Calculate the stack size for the MAC layer thread(s)
  */
-#define CC110X_MAC_STACKSIZE            (THREAD_STACKSIZE_DEFAULT + \
-                                        CC110X_EXTRA_STACKSIZE + \
+#define CC110X_MAC_STACKSIZE            (GNRC_NETIF_STACKSIZE_DEFAULT + \
                                         DEBUG_EXTRA_STACKSIZE)
 #ifndef CC110X_MAC_PRIO
 /**

--- a/sys/net/gnrc/netif/init_devs/auto_init_dose.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_dose.c
@@ -22,12 +22,13 @@
 #include "dose.h"
 #include "dose_params.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define DOSE_MAC_STACKSIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define DOSE_MAC_STACKSIZE (GNRC_NETIF_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #ifndef DOSE_MAC_PRIO
 #define DOSE_MAC_PRIO      (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_enc28j60.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_enc28j60.c
@@ -23,12 +23,13 @@
 #include "enc28j60.h"
 #include "enc28j60_params.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define ENC28J60_MAC_STACKSIZE   (THREAD_STACKSIZE_DEFAULT)
+#define ENC28J60_MAC_STACKSIZE   (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef ENC28J60_MAC_PRIO
 #define ENC28J60_MAC_PRIO        (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_encx24j600.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_encx24j600.c
@@ -22,12 +22,13 @@
 #include "encx24j600.h"
 #include "encx24j600_params.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define ENCX24J600_MAC_STACKSIZE    (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define ENCX24J600_MAC_STACKSIZE    (GNRC_NETIF_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #ifndef ENCX24J600_MAC_PRIO
 #define ENCX24J600_MAC_PRIO         (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_esp_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_esp_eth.c
@@ -19,6 +19,7 @@
 #include "esp_eth_params.h"
 #include "esp_eth_netdev.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 static gnrc_netif_t _netif;
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_ethos.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_ethos.c
@@ -23,6 +23,7 @@
 #include "ethos_params.h"
 #include "periph/uart.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 #define ETHOS_NUM ARRAY_SIZE(ethos_params)
 
@@ -37,7 +38,7 @@ static gnrc_netif_t _netif[ETHOS_NUM];
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define ETHOS_MAC_STACKSIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define ETHOS_MAC_STACKSIZE (GNRC_NETIF_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #ifndef ETHOS_MAC_PRIO
 #define ETHOS_MAC_PRIO      (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_netdev_tap.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_netdev_tap.c
@@ -21,8 +21,9 @@
 #include "debug.h"
 #include "netdev_tap_params.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
-#define TAP_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define TAP_MAC_STACKSIZE           (GNRC_NETIF_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #define TAP_MAC_PRIO                (GNRC_NETIF_PRIO)
 
 static netdev_tap_t netdev_tap[NETDEV_TAP_MAX];

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
@@ -24,6 +24,8 @@
 #include "log.h"
 #include "msg.h"
 #include "net/gnrc/netif/conf.h"
+#include "include/init_devs.h"
+
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -42,7 +44,7 @@
 /**
  * @brief   Calculate the stack size for the MAC layer thread(s)
  */
-#define NRF24L01P_NG_MAC_STACKSIZE          (THREAD_STACKSIZE_DEFAULT + \
+#define NRF24L01P_NG_MAC_STACKSIZE          (GNRC_NETIF_STACKSIZE_DEFAULT + \
                                             NRF24L01P_NG_EXTRA_STACKSIZE + \
                                             DEBUG_EXTRA_STACKSIZE)
 #ifndef NRF24L01P_NG_MAC_PRIO

--- a/sys/net/gnrc/netif/init_devs/auto_init_sam0_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sam0_eth.c
@@ -19,9 +19,10 @@
 
 #include "net/gnrc/netif/ethernet.h"
 #include "sam0_eth_netdev.h"
+#include "include/init_devs.h"
 
 static netdev_t sam0eth;
-static char stack[THREAD_STACKSIZE_DEFAULT];
+static char stack[GNRC_NETIF_STACKSIZE_DEFAULT];
 static gnrc_netif_t _netif;
 
 void auto_init_sam0_eth(void)
@@ -29,7 +30,7 @@ void auto_init_sam0_eth(void)
     /* setup netdev device */
     sam0_eth_setup(&sam0eth);
     /* initialize netdev <-> gnrc adapter state */
-    gnrc_netif_ethernet_create(&_netif, stack, THREAD_STACKSIZE_DEFAULT,
+    gnrc_netif_ethernet_create(&_netif, stack, GNRC_NETIF_STACKSIZE_DEFAULT,
                                GNRC_NETIF_PRIO, "sam0_eth", &sam0eth);
 }
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_slipdev.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_slipdev.c
@@ -21,6 +21,7 @@
 #include "board.h"
 #include "net/gnrc/netif/raw.h"
 #include "net/gnrc.h"
+#include "include/init_devs.h"
 
 #include "slipdev.h"
 #include "slipdev_params.h"
@@ -31,7 +32,7 @@
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define SLIPDEV_STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
+#define SLIPDEV_STACKSIZE       (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef SLIPDEV_PRIO
 #define SLIPDEV_PRIO            (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_stm32_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_stm32_eth.c
@@ -9,9 +9,10 @@
 
 #include "stm32_eth.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 static netdev_t stm32eth;
-static char stack[THREAD_STACKSIZE_DEFAULT];
+static char stack[GNRC_NETIF_STACKSIZE_DEFAULT];
 static gnrc_netif_t _netif;
 
 void auto_init_stm32_eth(void)
@@ -19,7 +20,7 @@ void auto_init_stm32_eth(void)
   /* setup netdev device */
   stm32_eth_netdev_setup(&stm32eth);
         /* initialize netdev <-> gnrc adapter state */
-  gnrc_netif_ethernet_create(&_netif, stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO, "stm32_eth",
+  gnrc_netif_ethernet_create(&_netif, stack, GNRC_NETIF_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO, "stm32_eth",
                              &stm32eth);
 }
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx126x.c
@@ -24,6 +24,7 @@
 #include "net/gnrc/netif/lorawan_base.h"
 #include "net/gnrc/netif/raw.h"
 #include "net/gnrc.h"
+#include "include/init_devs.h"
 
 #include "sx126x.h"
 #include "sx126x_params.h"
@@ -36,7 +37,7 @@
 /**
  * @brief   Define stack parameters for the MAC layer thread
  */
-#define SX126X_STACKSIZE            (THREAD_STACKSIZE_DEFAULT)
+#define SX126X_STACKSIZE            (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef SX126X_PRIO
 #define SX126X_PRIO                 (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
@@ -24,6 +24,7 @@
 #include "net/gnrc/netif/lorawan_base.h"
 #include "net/gnrc/netif/raw.h"
 #include "net/gnrc.h"
+#include "include/init_devs.h"
 
 #include "sx127x.h"
 #include "sx127x_params.h"
@@ -36,7 +37,7 @@
 /**
  * @brief   Define stack parameters for the MAC layer thread
  */
-#define SX127X_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
+#define SX127X_STACKSIZE           (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef SX127X_PRIO
 #define SX127X_PRIO                (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_usbus_cdc_ecm.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_usbus_cdc_ecm.c
@@ -22,6 +22,7 @@
 #include "log.h"
 #include "usb/usbus/cdc/ecm.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 /**
  * @brief global cdc ecm object, declared in the usb auto init file
@@ -32,7 +33,7 @@ extern usbus_cdcecm_device_t cdcecm;
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define CDCECM_MAC_STACKSIZE (THREAD_STACKSIZE_DEFAULT)
+#define CDCECM_MAC_STACKSIZE (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef CDCECM_MAC_PRIO
 #define CDCECM_MAC_PRIO      (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/auto_init_w5100.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_w5100.c
@@ -21,12 +21,13 @@
 #include "w5100.h"
 #include "w5100_params.h"
 #include "net/gnrc/netif/ethernet.h"
+#include "include/init_devs.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define MAC_STACKSIZE   (THREAD_STACKSIZE_DEFAULT)
+#define MAC_STACKSIZE   (GNRC_NETIF_STACKSIZE_DEFAULT)
 #define MAC_PRIO        (GNRC_NETIF_PRIO)
 /*** @} */
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_xbee.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_xbee.c
@@ -24,6 +24,7 @@
 #include "gnrc_netif_xbee.h"
 #include "xbee.h"
 #include "xbee_params.h"
+#include "include/init_devs.h"
 
 /**
  * @brief   Calculate the number of configured XBee devices
@@ -33,7 +34,7 @@
 /**
  * @brief   Define stack parameters for the MAC layer thread
  */
-#define XBEE_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
+#define XBEE_MAC_STACKSIZE           (GNRC_NETIF_STACKSIZE_DEFAULT)
 #ifndef XBEE_MAC_PRIO
 #define XBEE_MAC_PRIO                (GNRC_NETIF_PRIO)
 #endif

--- a/sys/net/gnrc/netif/init_devs/include/init_devs.h
+++ b/sys/net/gnrc/netif/init_devs/include/init_devs.h
@@ -20,9 +20,21 @@
 #define INIT_DEVS_H
 
 #include "thread.h"
+#include "msg.h"
+#include "net/gnrc/netif/conf.h"    /* <- GNRC_NETIF_MSG_QUEUE_SIZE */
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @brief   stack size of a netif thread
+ *
+ *          Message queue was previously allocated on the stack, reduce
+ *          stack size by default msg queue size to keep the RAM use the same
+ */
+#ifndef GNRC_NETIF_STACKSIZE_DEFAULT
+#define GNRC_NETIF_STACKSIZE_DEFAULT    (THREAD_STACKSIZE_DEFAULT - 128)
 #endif
 
 /**
@@ -31,18 +43,18 @@ extern "C" {
  * You may increase this value if you experience a stack overflow
  * with IEEE 802.15.4 security enabled.
  */
+#ifdef MODULE_IEEE802154_SECURITY
 #define IEEE802154_SECURITY_EXTRA_STACKSIZE (128)
+#else
+#define IEEE802154_SECURITY_EXTRA_STACKSIZE (0)
+#endif
 
 #ifndef IEEE802154_STACKSIZE_DEFAULT
-#ifdef MODULE_IEEE802154_SECURITY
-#define IEEE802154_STACKSIZE_DEFAULT    (THREAD_STACKSIZE_DEFAULT + \
-                                        IEEE802154_SECURITY_EXTRA_STACKSIZE)
-#else
 /**
  * @brief   stack size of an ieee802154 device
  */
-#define IEEE802154_STACKSIZE_DEFAULT    (THREAD_STACKSIZE_DEFAULT)
-#endif
+#define IEEE802154_STACKSIZE_DEFAULT    (GNRC_NETIF_STACKSIZE_DEFAULT + \
+                                         IEEE802154_SECURITY_EXTRA_STACKSIZE)
 #endif
 
 #ifdef __cplusplus

--- a/tests/netutils/Makefile
+++ b/tests/netutils/Makefile
@@ -15,4 +15,7 @@ USEMODULE += ipv6_addr
 # pretend to include sock_dns
 CFLAGS += -DMODULE_SOCK_DNS=1
 
+# We don't actually run the mock netifs
+CFLAGS += -DGNRC_NETIF_MSG_QUEUE_SIZE=1
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The message queue of the netif was allocated on the netif stack, so we had to increase the netif stack size if we increase the message queue size.
    
CC110x was the only driver to get this right - add a new `GNRC_NETIF_STACKSIZE_DEFAULT` define so all drivers will get this right by default.



### Testing procedure

This should not change the stack size except for one case: `cc110x` had `CC110X_EXTRA_STACKSIZE` set to `(GNRC_NETIF_MSG_QUEUE_SIZE - 8) * sizeof(msg_t))` but the default message queue size is 16, adding `(16 - 8) * 8` = 64 bytes to the stack.

Leaving this at 8 for all drivers would effectively bump their stack by 8 messages.
Maybe this was a mistake or maybe `cc110x` really needs the extra 64 bytes of stack. 

@maribu might be able to give this a try and say if stack size is still sufficient.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
