### PR TITLE
drivers/periph_common/cpuid: disable false positive warnings

### DIFF
--- a/drivers/periph_common/cpuid.c
+++ b/drivers/periph_common/cpuid.c
@@ -31,6 +31,12 @@
 #ifdef CPUID_ADDR
 void cpuid_get(void *id)
 {
+/* gcc 11.2.0 builtin bounds checking raises the following false positive warnings */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas" /* silence the CI due to unknown -Wstringop-overread */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
     memcpy(id, (void *)CPUID_ADDR, CPUID_LEN);
+#pragma GCC diagnostic pop
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


I have encountered the following on current master:
`BOARD=nrf52840dk make -C tests/periph_cpuid/`
```
/home/fabian/forks/RIOT/drivers/periph_common/cpuid.c: In function 'cpuid_get':
/home/fabian/forks/RIOT/drivers/periph_common/cpuid.c:38:5: error: 'memcpy' offset [0, 7] is out of the bounds [0, 0] [-Werror=array-bounds]
   38 |     memcpy(id, (void *)CPUID_ADDR, CPUID_LEN);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
This PR suppresses the warnings because they seem to be false positive and we should rather keep builtin bounds checking enabled. Also I would be interested if someone else can reproduce the compilation error.
If someone sees why the warnings could be justified, then of course the actual cause must be fixed. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

```
cd tests/periph_cpuid/
BOARD=nrf52840dk make flash term
```
```
Welcome to pyterm!
Type '/exit' to exit.
s
2022-04-10 11:44:01,661 # START
2022-04-10 11:44:01,666 # main(): This is RIOT! (Version: 2022.04-devel-1128-g6efbb)
2022-04-10 11:44:01,668 # Test for the CPUID driver
2022-04-10 11:44:01,673 # This test is reading out the CPUID of the platforms CPU
2022-04-10 11:44:01,674 # 
2022-04-10 11:44:01,675 # CPUID_LEN: 8
2022-04-10 11:44:01,678 # CPUID: 0x4c 0xb2 0x50 0x7a 0xab 0xf4 0x7a 0x38
2022-04-10 11:44:01,685 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 400 }]}
2022-04-10 11:55:32,409 # Exiting Pyterm
```
Screenshot from the [reference manual](https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.1.pdf)
![Screenshot_20220410_115422](https://user-images.githubusercontent.com/15147337/162613682-0eabcf81-fcdc-4874-bcf7-33da4012f7b9.png)

Read the `DEVICEID` with `nrfjprog`:
```
$ nrfjprog --memrd 0x10000060 --w 8 --n 8
0x10000060: 4C B2 50 7A AB F4 7A 38                           |L.Pz..z8|
```
They match.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

A `git bisect` led me to #17898.