### PR TITLE
pkg/fatfs, shell: enable RTC support if rtt_rtc is used

### DIFF
--- a/pkg/fatfs/Makefile.dep
+++ b/pkg/fatfs/Makefile.dep
@@ -6,4 +6,6 @@ ifneq (,$(filter vfs_auto_format,$(USEMODULE)))
 endif
 
 # Use RTC for timestamps if available
-FEATURES_OPTIONAL += periph_rtc
+ifeq (,$(filter rtt_rtc,$(USEMODULE)))
+  FEATURES_OPTIONAL += periph_rtc
+endif

--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -11,10 +11,10 @@ ifneq (,$(filter fatfs_vfs,$(USEMODULE)))
 endif
 
 #if periph_rtc is available use it. Otherwise use static timestamps
-ifneq (,$(filter periph_rtc,$(USEMODULE)))
-  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=0
-else
+ifeq (,$(filter rtt_rtc periph_rtc,$(USEMODULE)))
   CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=1
+else
+  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=0
 endif
 
 ifeq ($(OS),Darwin)

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -106,7 +106,7 @@ ifneq (,$(filter lwip_netif,$(USEMODULE)))
   SRC += sc_lwip_netif.c
 endif
 
-ifneq (,$(filter periph_rtc,$(USEMODULE)))
+ifneq (,$(filter rtt_rtc periph_rtc,$(USEMODULE)))
   SRC += sc_rtc.c
 endif
 

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -64,7 +64,7 @@ extern int _at30tse75x_handler(int argc, char **argv);
 extern int _saul(int argc, char **argv);
 #endif
 
-#ifdef MODULE_PERIPH_RTC
+#if defined(MODULE_PERIPH_RTC) || defined(MODULE_RTT_RTC)
 extern int _rtc_handler(int argc, char **argv);
 #endif
 
@@ -262,7 +262,7 @@ const shell_command_t _shell_command_list[] = {
     { "random_init", "initializes the PRNG", _random_init },
     { "random_get", "returns 32 bit of pseudo randomness", _random_get },
 #endif
-#ifdef MODULE_PERIPH_RTC
+#if defined(MODULE_PERIPH_RTC) || defined(MODULE_RTT_RTC)
     {"rtc", "control RTC peripheral interface",  _rtc_handler},
 #endif
 #ifdef MODULE_RTT_CMD


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`rtt_rtc` implements the same interface as `periph_rtc`, so enable the `rtc` shell command and RTC support in fatfs if it's used.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
