### PR TITLE
drivers/at86rf215: make at86rf215_blocking_send a DEFAULT_MODULE

### DIFF
--- a/drivers/at86rf215/Makefile.dep
+++ b/drivers/at86rf215/Makefile.dep
@@ -26,7 +26,7 @@ FEATURES_REQUIRED += periph_spi
 
 ifneq (,$(filter gnrc,$(USEMODULE)))
   ifeq (,$(filter gnrc_netif_pktq,$(USEMODULE)))
-    USEMODULE += at86rf215_blocking_send
+    DEFAULT_MODULE += at86rf215_blocking_send
   endif
 endif
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

So it can be disabled.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
    DISABLE_MODULE += at86rf215_blocking_send


should work now.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
