### PR TITLE
boards/samr34: cleanup, add 2nd uart & timer

### DIFF
--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -21,6 +21,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,7 +30,7 @@ extern "C" {
 /**
  * @brief   GCLK reference speed
  */
-#define CLOCK_CORECLOCK     (48000000U)
+#define CLOCK_CORECLOCK     MHZ(48)
 
 /**
  * @brief Enable the internal DC/DC converter
@@ -57,6 +58,7 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_0_CHANNELS    2
 #define TIMER_0_ISR         isr_tc0
 #define TIMER_NUMOF         (sizeof(timer_config)/sizeof(timer_config[0]))
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
 /**
@@ -83,7 +85,7 @@ static const uart_conf_t uart_config[] = {
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom0
 
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 /**
@@ -109,7 +111,7 @@ static const spi_conf_t spi_config[] = {
     }
 };
 
-#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**
@@ -127,7 +129,7 @@ static const i2c_conf_t i2c_config[] = {
         .flags    = I2C_FLAG_NONE
      }
 };
-#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */
 
 /**

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -51,13 +51,23 @@ static const tc32_conf_t timer_config[] = {
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
+        .mclk           = &MCLK->APBCMASK.reg,
+        .mclk_mask      = MCLK_APBCMASK_TC2 | MCLK_APBCMASK_TC3,
+        .gclk_id        = TC2_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };
 
 /* Timer 0 configuration */
 #define TIMER_0_CHANNELS    2
 #define TIMER_0_ISR         isr_tc0
-#define TIMER_NUMOF         (sizeof(timer_config)/sizeof(timer_config[0]))
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_ISR         isr_tc2
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
@@ -79,11 +89,26 @@ static const uart_conf_t uart_config[] = {
         .tx_pad   = UART_PAD_TX_0,
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {    /* EXT1 */
+        .dev      = &SERCOM3->USART,
+        .rx_pin   = GPIO_PIN(PA, 17),
+        .tx_pin   = GPIO_PIN(PA, 16),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom0
+#define UART_1_ISR          isr_sercom3
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -5137,8 +5137,11 @@ boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member RTT_FREQUENCY
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member SPI_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_1_CHANNELS \(macro definition\) of file periph_conf\.h is not documented\.
+boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samr34\-xpro/include/periph_conf\.h:[0-9]+: warning: Member adc_channels\[\] \(variable\) of file periph_conf\.h is not documented\.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Make use of the helper macros to clean up the board definition, add a second timer and uart instance.


### Testing procedure

<details><summary>tests/periph_uart</summary>

``` 
2022-04-11 17:58:47,592 # UART INFO:
2022-04-11 17:58:47,593 # Available devices:               2
2022-04-11 17:58:47,594 # UART used for STDIO (the shell): UART_DEV(0)
2022-04-11 17:58:47,594 # 
2022-04-11 17:58:52,271 # > test 1
2022-04-11 17:58:52,271 # [START]
2022-04-11 17:58:52,390 # [SUCCESS]
```
</details>

<details><summary>tests/periph_timer</summary>

```
2022-04-11 18:02:03,178 # main(): This is RIOT! (Version: 2022.07-devel-8-g760b7-boards/samr34-xpro-enhance)
2022-04-11 18:02:03,178 # 
2022-04-11 18:02:03,180 # Test for peripheral TIMERs
2022-04-11 18:02:03,180 # 
2022-04-11 18:02:03,182 # Available timers: 2
2022-04-11 18:02:03,182 # 
2022-04-11 18:02:03,184 # Testing TIMER_0:
2022-04-11 18:02:03,187 # TIMER_0: initialization successful
2022-04-11 18:02:03,188 # TIMER_0: stopped
2022-04-11 18:02:03,191 # TIMER_0: set channel 0 to 5000
2022-04-11 18:02:03,194 # TIMER_0: set channel 1 to 10000
2022-04-11 18:02:03,196 # TIMER_0: starting
2022-04-11 18:02:03,211 # TIMER_0: channel 0 fired at SW count    24001 - init:    24001
2022-04-11 18:02:03,217 # TIMER_0: channel 1 fired at SW count    47979 - diff:    23978
2022-04-11 18:02:03,217 # 
2022-04-11 18:02:03,219 # Testing TIMER_1:
2022-04-11 18:02:03,222 # TIMER_1: initialization successful
2022-04-11 18:02:03,223 # TIMER_1: stopped
2022-04-11 18:02:03,226 # TIMER_1: set channel 0 to 5000
2022-04-11 18:02:03,229 # TIMER_1: set channel 1 to 10000
2022-04-11 18:02:03,231 # TIMER_1: starting
2022-04-11 18:02:03,246 # TIMER_1: channel 0 fired at SW count    24001 - init:    24001
2022-04-11 18:02:03,252 # TIMER_1: channel 1 fired at SW count    47978 - diff:    23977
2022-04-11 18:02:03,252 # 
2022-04-11 18:02:03,254 # TEST SUCCEEDED
2022-04-11 18:02:03,260 # { "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 432 }]}
```
</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
