### PR TITLE
drivers/periph_cpuid: Minor cleanup [backport 2022.04]

### DIFF
--- a/drivers/periph_common/cpuid.c
+++ b/drivers/periph_common/cpuid.c
@@ -28,15 +28,15 @@
 
 #include "periph/cpuid.h"
 
+typedef struct {
+    uint8_t id[CPUID_LEN];
+} cpuid_t;
+
 #ifdef CPUID_ADDR
 void cpuid_get(void *id)
 {
-/* gcc 11.2.0 builtin bounds checking raises the following false positive warnings */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpragmas" /* silence the CI due to unknown -Wstringop-overread */
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#pragma GCC diagnostic ignored "-Wstringop-overread"
-    memcpy(id, (void *)CPUID_ADDR, CPUID_LEN);
-#pragma GCC diagnostic pop
+    cpuid_t *dest = id;
+    const volatile cpuid_t *src = (const void *)CPUID_ADDR;
+    *dest = *src;
 }
 #endif


### PR DESCRIPTION
# Backport of #17911

### Contribution description

Avoid use of `memcpy` altogether to work around false positive of `-Warray-bounds` in newer GCC versions.

### Testing procedure

Ideally, binaries should change. But more importantly, `tests/periph_cpuid` should yield the same output (which it at least does for my Nucleo-F767ZI).

### Issues/PRs references

Alternative to https://github.com/RIOT-OS/RIOT/pull/17909#event-6403618777