### PR TITLE
board/microbit: increase testtimeout for emulated testing

### DIFF
--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -14,5 +14,9 @@ ifneq (,$(filter microbit,$(USEMODULE)))
   INCLUDES += -I$(RIOTBOARD)/common/microbit/include
 endif
 
+ifeq (1,$(EMULATE))
+   RIOT_TEST_TIMEOUT ?= 20
+endif
+
 # include nrf51 boards common configuration
 include $(RIOTBOARD)/common/nrf51/Makefile.include


### PR DESCRIPTION
### Contribution description

this increases the timeout for tests run by murdock on emulated microbit (accounting for startup of qemu)

### Testing procedure

murdock

### Issues/PRs references

#17894 