### PR TITLE
Fix argument type of lora_time_on_air to avoid errors in C++

### DIFF
--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -987,7 +987,7 @@ typedef enum {
  * @param[in] cr                        Coding rate used to send the packet
  * @return                              time on air in us
  */
-static inline uint32_t lora_time_on_air(size_t pkt_len, uint8_t dr, uint8_t cr)
+static inline uint32_t lora_time_on_air(size_t pkt_len, loramac_dr_idx_t dr, uint8_t cr)
 {
     assert(dr <= LORAMAC_DR_6);
     const uint8_t _K[6][4] = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
When using the LoRa driver from C++, the following error is emitted:
```
/[...]/RIOT/sys/include/net/loramac.h: In function 'uint32_t lora_time_on_air(size_t, uint8_t, uint8_t)':
/[...]/RIOT/sys/include/net/loramac.h:1005:41: error: enumeral and non-enumeral type in conditional expression [-Werror=extra]
 1005 |     uint8_t index = (dr < LORAMAC_DR_6) ? dr : LORAMAC_DR_5;
```
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

g++ complains about the differing types in the ternary statement. This patch changes `dr`'s type to `loramac_dr_idx_t` to reflect its real type and avoid the error.

