### PR TITLE
drivers/disp_dev: use struct to store display area coordinates

### DIFF
--- a/cpu/stm32/periph/ltdc.c
+++ b/cpu/stm32/periph/ltdc.c
@@ -212,11 +212,10 @@ void ltdc_fill(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const uint16_
 }
 
 #if IS_USED(MODULE_DISP_DEV)
-static void _ltdc_map(const disp_dev_t *disp_dev, uint16_t x1, uint16_t x2,
-                  uint16_t y1, uint16_t y2, const uint16_t *color)
+static void _ltdc_map(const disp_dev_t *disp_dev, const disp_dev_area_t *area, const uint16_t *color)
 {
     (void)disp_dev;
-    ltdc_map(x1, x2, y1, y2, color);
+    ltdc_map(area->x1, area->x2, area->y1, area->y2, color);
 }
 
 static uint16_t _ltdc_height(const disp_dev_t *disp_dev)

--- a/drivers/disp_dev/disp_dev.c
+++ b/drivers/disp_dev/disp_dev.c
@@ -63,12 +63,12 @@ disp_dev_reg_t *disp_dev_reg_find_screen(uint8_t screen_id)
 }
 
 void disp_dev_map(const disp_dev_t *dev,
-                  uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+                  const disp_dev_area_t *area,
                   const uint16_t *color)
 {
     assert(dev);
 
-    dev->driver->map(dev, x1, x2, y1, y2, color);
+    dev->driver->map(dev, area, color);
 }
 
 uint16_t disp_dev_height(const disp_dev_t *dev)

--- a/drivers/include/disp_dev.h
+++ b/drivers/include/disp_dev.h
@@ -43,6 +43,16 @@ extern "C" {
 typedef struct disp_dev disp_dev_t;
 
 /**
+ * @brief   Display area coordinates
+ */
+typedef struct {
+    uint16_t x1;                    /**< Horizontal start position (included) */
+    uint16_t x2;                    /**< Horizontal end position (included) */
+    uint16_t y1;                    /**< Vertical start position (included) */
+    uint16_t y2;                    /**< Vertical end position (included) */
+} disp_dev_area_t;
+
+/**
  * @brief   Generic type for a display driver
  */
 typedef struct {
@@ -50,14 +60,11 @@ typedef struct {
      * @brief   Map an area to display on the device
      *
      * @param[in] dev   Pointer to the display device
-     * @param[in] x1    Left coordinate
-     * @param[in] x2    Right coordinate
-     * @param[in] y1    Top coordinate
-     * @param[in] y2    Bottom coordinate
+     * @param[in] area  Coordinates of display area
      * @param[in] color Array of color to map to the display
      */
     void (*map)(const disp_dev_t *dev,
-                uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+                const disp_dev_area_t *area,
                 const uint16_t *color);
 
     /**
@@ -139,14 +146,11 @@ disp_dev_reg_t *disp_dev_reg_find_screen(uint8_t screen_id);
  * @brief   Map an area to display on the device
  *
  * @param[in] dev   Pointer to the display device
- * @param[in] x1    Left coordinate
- * @param[in] x2    Right coordinate
- * @param[in] y1    Top coordinate
- * @param[in] y2    Bottom coordinate
+ * @param[in] area  Coordinates of display area
  * @param[in] color Array of color to map to the display
  */
 void disp_dev_map(const disp_dev_t *dev,
-                  uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+                  const disp_dev_area_t *area,
                   const uint16_t *color);
 
 /**

--- a/drivers/lcd/lcd_disp_dev.c
+++ b/drivers/lcd/lcd_disp_dev.c
@@ -27,11 +27,10 @@
 #define LCD_DISP_COLOR_DEPTH    (16U)
 #endif
 
-static void _lcd_map(const disp_dev_t *dev, uint16_t x1, uint16_t x2,
-                  uint16_t y1, uint16_t y2, const uint16_t *color)
+static void _lcd_map(const disp_dev_t *dev, const disp_dev_area_t *area, const uint16_t *color)
 {
     lcd_t *lcd = (lcd_t *)dev;
-    lcd_pixmap(lcd, x1, x2, y1, y2, color);
+    lcd_pixmap(lcd, area->x1, area->x2, area->y1, area->y2, color);
 }
 
 static uint16_t _lcd_height(const disp_dev_t *disp_dev)

--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -76,8 +76,10 @@ static void _disp_map(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *col
         return;
     }
 
-    disp_dev_map(_screen_dev->display, area->x1, area->x2, area->y1, area->y2,
-                 (const uint16_t *)color_p);
+    const disp_dev_area_t disp_area = {
+        area->x1, area->x2, area->y1, area->y2
+    };
+    disp_dev_map(_screen_dev->display, &disp_area, (const uint16_t *)color_p);
 
     LOG_DEBUG("[lvgl] flush display\n");
 

--- a/pkg/lvgl7/contrib/lvgl.c
+++ b/pkg/lvgl7/contrib/lvgl.c
@@ -60,8 +60,10 @@ static void _disp_map(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *col
         return;
     }
 
-    disp_dev_map(_screen_dev->display, area->x1, area->x2, area->y1, area->y2,
-                 (const uint16_t *)color_p);
+    const disp_dev_area_t disp_area = {
+        area->x1, area->x2, area->y1, area->y2
+    };
+    disp_dev_map(_screen_dev->display, &disp_area, (const uint16_t *)color_p);
 
     LOG_DEBUG("[lvgl] flush display\n");
 

--- a/tests/disp_dev/main.c
+++ b/tests/disp_dev/main.c
@@ -60,16 +60,20 @@ int main(void)
     expect(max_height == 240);
 #endif
 
+    disp_dev_area_t area;
     for (uint16_t y = 0; y < max_height; ++y) {
-        disp_dev_map(disp_dev->dev, 0, max_width - 1, y, y, display_buffer);
+        area.x1 = 0;
+        area.x2 = max_width - 1;
+        area.y1 = y;
+        area.y2 = y;
+        disp_dev_map(disp_dev->dev, &area, display_buffer);
     }
 
-    disp_dev_map(
-        disp_dev->dev,
-        ((max_width - RIOT_LOGO_WIDTH) >> 1), ((max_width + RIOT_LOGO_WIDTH) >> 1) - 1,
-        ((max_height - RIOT_LOGO_HEIGHT) >> 1), ((max_height + RIOT_LOGO_HEIGHT) >> 1) - 1,
-        (const uint16_t *)picture
-    );
+    area.x1 = ((max_width - RIOT_LOGO_WIDTH) >> 1);
+    area.x2 = ((max_width + RIOT_LOGO_WIDTH) >> 1);
+    area.y1 = ((max_height - RIOT_LOGO_HEIGHT) >> 1);
+    area.y2 = ((max_height + RIOT_LOGO_HEIGHT) >> 1);
+    disp_dev_map(disp_dev->dev, &area, (const uint16_t *)picture);
 
     puts("SUCCESS");
 

--- a/tests/pkg_qr-code-generator/main.c
+++ b/tests/pkg_qr-code-generator/main.c
@@ -79,8 +79,12 @@ int main(void)
     const uint8_t h_offset = (disp_dev_height(disp_dev->dev) - (size * scale)) / 2;
 
     /* Clear the screen */
+    disp_dev_area_t area;
     for (uint16_t y = 0; y < disp_dev_height(disp_dev->dev); y ++) {
-        disp_dev_map(disp_dev->dev, 0, disp_dev_width(disp_dev->dev) - 1, y, y, display_buffer);
+        area.x1 = 0;
+        area.x2 = disp_dev_width(disp_dev->dev) - 1;
+        area.y1 = area.y2 = y;
+        disp_dev_map(disp_dev->dev, &area, display_buffer);
     }
 
     /* Prepare a subset of the display buffer for white tiles */
@@ -95,10 +99,11 @@ int main(void)
         for (int x = 0; x < size; x++) {
 #ifdef MODULE_DISP_DEV
             if (qrcodegen_getModule(qr0, x, y)) {
-                disp_dev_map(disp_dev->dev,
-                             w_offset + (x * scale), w_offset + ((x + 1)* scale) - 1,
-                             h_offset + (y * scale), h_offset + ((y + 1)* scale) - 1,
-                             display_buffer);
+                area.x1 = w_offset + (x * scale);
+                area.x2 = w_offset + ((x + 1)* scale) - 1;
+                area.y1 = h_offset + (y * scale);
+                area.y2 = h_offset + ((y + 1)* scale) - 1;
+                disp_dev_map(disp_dev->dev, &area, display_buffer);
             }
 #endif
             printf("%s", qrcodegen_getModule(qr0, x, y) ? "██" : "  ");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR is a take over of #14051 to only update the `disp_dev` API. Since now there are new modules that implements an adapter to this API (STM32 LTDC periph, LCD common drivers) and several users (lvgl packages, tests/disp_dev and tests/pkg_qr-code-generator).

This PR also contains small improvements compared to #14051:
- make input the parameter const
- call it `disp_dev_area_t` to better reflects what it is about

Compared to master this PR increases the ROM size by 16B (checked by compiling `tests/disp_dev` for the adafruit-clue board).
I guess that this is acceptable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- `tests/disp_dev`, `tests/pkg_lvgl` and `tests/pkg_qr-code-generator` are still working

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Closes #14051, depends on #16176 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
