### PR TITLE
cpu/stm32/include/periph/f7: add missing ADC_DEVS

### DIFF
--- a/cpu/stm32/include/periph/f7/periph_cpu.h
+++ b/cpu/stm32/include/periph/f7/periph_cpu.h
@@ -39,6 +39,11 @@ extern "C" {
 #define GET_RDP(x) ((x & 0xFF00) >> 8)
 
 /**
+ * @brief   Available number of ADC devices
+ */
+#define ADC_DEVS            (3U)
+
+/**
  * @brief   Override the ADC resolution configuration
  * @{
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

`#define ADC_DEVS` was missing for `stm32f7xxxx`. All have 3 ADC units. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=nucleo-f767zi  make -C tests/pkg_mbedtls flash term` crashes on `master` branch.

ADC3 is used in `periph_conf.h`.
```C
static const adc_conf_t adc_config[] = {
    {GPIO_PIN(PORT_A, 3), 2, 3},
    {GPIO_PIN(PORT_C, 0), 2, 10},
    {GPIO_PIN(PORT_C, 3), 2, 13},
    {GPIO_PIN(PORT_F, 3), 2, 9},
    {GPIO_PIN(PORT_F, 5), 2, 15},
    {GPIO_PIN(PORT_F, 10), 2, 8},
    {GPIO_UNDEF, 0, 18}, /* VBAT */
};
```
Locks for every ADCx are defined in `adc_f4_f7.c`.
```C
static mutex_t locks[] = {
#if ADC_DEVS > 1
    MUTEX_INIT,
#endif
#if ADC_DEVS > 2
    MUTEX_INIT,
#endif
    MUTEX_INIT
};
```

When `prep()` in `adc_f4_f7.c` tries to lock the mutex at `locks[2]`, illegal memory is accessed.



Using this PR, it runs successful. (`tests/pkg_mbedtls` uses ADC noise as entropy source.)

```
Welcome to pyterm!
Type '/exit' to exit.
s
2022-04-12 22:36:42,424 # START
2022-04-12 22:36:42,429 # main(): This is RIOT! (Version: 2022.07-devel-3-gc89f6b)
2022-04-12 22:36:42,430 # mbedtls test
2022-04-12 22:36:42,430 # 
2022-04-12 22:36:42,433 #   SHA-224 test #1: passed
2022-04-12 22:36:42,435 #   SHA-224 test #2: passed
2022-04-12 22:36:43,137 #   SHA-224 test #3: passed
2022-04-12 22:36:43,139 #   SHA-256 test #1: passed
2022-04-12 22:36:43,142 #   SHA-256 test #2: passed
2022-04-12 22:36:43,844 #   SHA-256 test #3: passed
2022-04-12 22:36:43,845 # 
2022-04-12 22:36:43,847 # adc_noise_single_entropy: 0
2022-04-12 22:36:43,855 #   ENTROPY test: passed
2022-04-12 22:36:43,856 # 
2022-04-12 22:36:43,943 # { "threads": [{ "name": "main", "stack_size": 2048, "stack_used": 1536 }]}
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
