### PR TITLE
drivers/lcd: slightly rework params to expose offset values to ili9341 driver

### DIFF
--- a/boards/adafruit-clue/include/board.h
+++ b/boards/adafruit-clue/include/board.h
@@ -107,7 +107,8 @@ extern "C" {
 #define ILI9341_PARAM_NUM_LINES (240U)                          /**< Number of screen lines */
 #define ILI9341_PARAM_RGB       (1)                             /**< RGB configuration */
 #define ILI9341_PARAM_INVERTED  (1)                             /**< Inversion configuration */
-#define ILI9341_PARAM_ROTATION  (LCD_ROTATION_HORZ_FLIP)        /**< Rotation mode */
+#define ILI9341_PARAM_ROTATION  (LCD_ROTATION_VERT)             /**< Rotation mode */
+#define ILI9341_PARAM_OFFSET_X  (80)                            /**< Vertical rotation requires a 80 pixel offset */
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -168,6 +168,11 @@ static void _set_area(const lcd_t *dev, uint16_t x1, uint16_t x2,
 {
     be_uint16_t params[2];
 
+    x1 += dev->params->offset_x;
+    x2 += dev->params->offset_x;
+    y1 += dev->params->offset_y;
+    y2 += dev->params->offset_y;
+
     params[0] = byteorder_htons(x1);
     params[1] = byteorder_htons(x2);
 

--- a/drivers/ili9341/include/ili9341_params.h
+++ b/drivers/ili9341/include/ili9341_params.h
@@ -20,6 +20,7 @@
 #define ILI9341_PARAMS_H
 
 #include "board.h"
+#include "lcd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,9 +61,14 @@ extern "C" {
 #ifndef ILI9341_PARAM_RGB_CHANNELS
 #define ILI9341_PARAM_RGB_CHANNELS      240U    /**< Number of RGB channels (e.g. columns) */
 #endif
-
 #ifndef ILI9341_PARAM_ROTATION
-#define ILI9341_PARAM_ROTATION     LCD_ROTATION_HORZ_FLIP
+#define ILI9341_PARAM_ROTATION          LCD_ROTATION_HORZ_FLIP
+#endif
+#ifndef ILI9341_PARAM_OFFSET_X
+#define ILI9341_PARAM_OFFSET_X          0               /**< Horizontal offset */
+#endif
+#ifndef ILI9341_PARAM_OFFSET_Y
+#define ILI9341_PARAM_OFFSET_Y          0               /**< Vertival offset */
 #endif
 
 /**
@@ -78,8 +84,10 @@ extern "C" {
                                       .rgb = ILI9341_PARAM_RGB, \
                                       .inverted = ILI9341_PARAM_INVERTED, \
                                       .lines = ILI9341_PARAM_NUM_LINES, \
-                                      .rotation = ILI9341_PARAM_ROTATION, \
                                       .rgb_channels = ILI9341_PARAM_RGB_CHANNELS, \
+                                      .rotation = ILI9341_PARAM_ROTATION, \
+                                      .offset_x = ILI9341_PARAM_OFFSET_X, \
+                                      .offset_y = ILI9341_PARAM_OFFSET_Y, \
 }
 #endif
 /** @} */

--- a/drivers/include/lcd.h
+++ b/drivers/include/lcd.h
@@ -107,6 +107,8 @@ typedef  struct {
     uint16_t lines;             /**< Number of lines, from 16 to 320 in 8 line steps */
     uint16_t rgb_channels;      /**< Display rgb channels */
     lcd_rotation_t rotation;    /**< Display rotation mode */
+    uint8_t offset_x;           /**< LCD offset to apply on x axis. */
+    uint8_t offset_y;           /**< LCD offset to apply on y axis. */
 } lcd_params_t;
 
 /**

--- a/drivers/include/st7735.h
+++ b/drivers/include/st7735.h
@@ -87,15 +87,6 @@ typedef struct {
 } st7735_t;
 
 /**
- * @brief   Device initialization parameters
- */
-typedef struct {
-    lcd_params_t params;            /**< LCD struct params */
-    uint8_t offset_x;             /**< LCD offset to apply on x axis. */
-    uint8_t offset_y;             /**< LCD offset to apply on y axis. */
-} st7735_params_t;
-
-/**
  * @brief   LCD device operations table
  */
 extern const lcd_driver_t lcd_st7735_driver;

--- a/drivers/lcd/include/lcd_internal.h
+++ b/drivers/lcd/include/lcd_internal.h
@@ -68,30 +68,6 @@ extern "C" {
 #define LCD_CMD_IFCTL           0xf6    /**< Interface control */
 /** @} */
 
-/**
- * @name Memory access control bits
- * @{
- */
-#define LCD_MADCTL_MY           0x80    /**< Row address order */
-#define LCD_MADCTL_MX           0x40    /**< Column access order */
-#define LCD_MADCTL_MV           0x20    /**< Row column exchange */
-#define LCD_MADCTL_ML           0x10    /**< Vertical refresh order */
-#define LCD_MADCTL_BGR          0x08    /**< Color selector switch control */
-#define LCD_MADCTL_MH           0x04    /**< Horizontal refresh direction */
-/** @} */
-
-/**
- * @name Display rotation modes
- * @{
- */
-#define LCD_MADCTL_VERT         LCD_MADCTL_MX       /**< Vertical mode */
-#define LCD_MADCTL_VERT_FLIP    LCD_MADCTL_MY       /**< Flipped vertical */
-#define LCD_MADCTL_HORZ         LCD_MADCTL_MV       /**< Horizontal mode */
-#define LCD_MADCTL_HORZ_FLIP    LCD_MADCTL_MV | \
-                                LCD_MADCTL_MY | \
-                                LCD_MADCTL_MX       /**< Horizontal flipped */
-/** @} */
-
 #define LCD_PIXSET_16BIT        0x55    /**< MCU and RGB 16 bit interface */
 #define LCD_PIXSET_18BIT        0x66    /**< MCU and RGB 18 bit interface (not implemented) */
 

--- a/drivers/st7735/include/st7735_params.h
+++ b/drivers/st7735/include/st7735_params.h
@@ -22,6 +22,7 @@
 #define ST7735_PARAMS_H
 
 #include "board.h"
+#include "lcd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,29 +63,33 @@ extern "C" {
 #ifndef ST7735_PARAM_RGB_CHANNELS
 #define ST7735_PARAM_RGB_CHANNELS   128U            /**< Number of RGB channels (e.g. columns) */
 #endif
-#ifndef ST7735_OFFSET_X
-#define ST7735_OFFSET_X             0               /**< Horizontal offset */
+#ifndef ST7735_PARAM_ROTATION
+#define ST7735_PARAM_ROTATION       LCD_ROTATION_HORZ   /**< Rotation mode (unused) */
 #endif
-#ifndef ST7735_OFFSET_Y
-#define ST7735_OFFSET_Y             0               /**< Vertival offset */
+#ifndef ST7735_PARAM_OFFSET_X
+#define ST7735_PARAM_OFFSET_X       0               /**< Horizontal offset */
+#endif
+#ifndef ST7735_PARAM_OFFSET_Y
+#define ST7735_PARAM_OFFSET_Y       0               /**< Vertival offset */
 #endif
 
 /**
  * @brief   Default params
  */
 #ifndef ST7735_PARAMS
-#define ST7735_PARAMS              {  .params.spi = ST7735_PARAM_SPI, \
-                                      .params.spi_clk = ST7735_PARAM_SPI_CLK, \
-                                      .params.spi_mode = ST7735_PARAM_SPI_MODE, \
-                                      .params.cs_pin = ST7735_PARAM_CS, \
-                                      .params.dcx_pin = ST7735_PARAM_DCX, \
-                                      .params.rst_pin = ST7735_PARAM_RST, \
-                                      .params.rgb = ST7735_PARAM_RGB, \
-                                      .params.inverted = ST7735_PARAM_INVERTED, \
-                                      .params.lines = ST7735_PARAM_NUM_LINES, \
-                                      .params.rgb_channels = ST7735_PARAM_RGB_CHANNELS, \
-                                      .offset_x = ST7735_OFFSET_X, \
-                                      .offset_y = ST7735_OFFSET_Y, \
+#define ST7735_PARAMS              {  .spi = ST7735_PARAM_SPI, \
+                                      .spi_clk = ST7735_PARAM_SPI_CLK, \
+                                      .spi_mode = ST7735_PARAM_SPI_MODE, \
+                                      .cs_pin = ST7735_PARAM_CS, \
+                                      .dcx_pin = ST7735_PARAM_DCX, \
+                                      .rst_pin = ST7735_PARAM_RST, \
+                                      .rgb = ST7735_PARAM_RGB, \
+                                      .inverted = ST7735_PARAM_INVERTED, \
+                                      .lines = ST7735_PARAM_NUM_LINES, \
+                                      .rgb_channels = ST7735_PARAM_RGB_CHANNELS, \
+                                      .rotation = LCD_ROTATION_HORZ, \
+                                      .offset_x = ST7735_PARAM_OFFSET_X, \
+                                      .offset_y = ST7735_PARAM_OFFSET_Y, \
                                     }
 #endif
 /** @} */
@@ -99,7 +104,7 @@ extern "C" {
 /**
  * @brief   Configure LCD
  */
-static const st7735_params_t st7735_params[] =
+static const lcd_params_t st7735_params[] =
 {
     ST7735_PARAMS,
 };

--- a/drivers/st7735/st7735.c
+++ b/drivers/st7735/st7735.c
@@ -192,14 +192,12 @@ static int _init(lcd_t *dev, const lcd_params_t *params)
 static void _set_area(const lcd_t *dev, uint16_t x1, uint16_t x2,
                       uint16_t y1, uint16_t y2)
 {
-    st7735_params_t *st7735_params = (st7735_params_t *)dev->params;
-
     be_uint16_t params[2];
 
-    x1 += st7735_params->offset_x;
-    x2 += st7735_params->offset_x;
-    y1 += st7735_params->offset_y;
-    y2 += st7735_params->offset_y;
+    x1 += dev->params->offset_x;
+    x2 += dev->params->offset_x;
+    y1 += dev->params->offset_y;
+    y2 += dev->params->offset_y;
 
     params[0] = byteorder_htons(x1);
     params[1] = byteorder_htons(x2);

--- a/sys/auto_init/screen/auto_init_st7735.c
+++ b/sys/auto_init/screen/auto_init_st7735.c
@@ -47,7 +47,7 @@ void auto_init_st7735(void)
     for (size_t i = 0; i < ST7735_NUMOF; i++) {
         st7735_devs[i].dev.driver = &lcd_st7735_driver;
         LOG_DEBUG("[auto_init_screen] initializing st7735 #%u\n", i);
-        if (lcd_init(&st7735_devs[i].dev, &st7735_params[i].params) < 0) {
+        if (lcd_init(&st7735_devs[i].dev, &st7735_params[i]) < 0) {
             LOG_ERROR("[auto_init_screen] error initializing st7735 #%u\n", i);
             continue;
         }

--- a/tests/driver_st7735/main.c
+++ b/tests/driver_st7735/main.c
@@ -46,7 +46,7 @@ int main(void)
     BACKLIGHT_ON;
 #endif
 
-    if (lcd_init(&dev, &st7735_params[0].params) == 0) {
+    if (lcd_init(&dev, &st7735_params[0]) == 0) {
         puts("[OK]");
     }
     else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is a follow-up of #16176 that reworks the ili9341 parameters to also expose X/Y offset values. The idea behind this PR is about the adafruit-clue display that was not oriented correctly.
Setting the orientation parameter to the right value (`LCD_ROTATION_VERT`) raised an offset issue with the ili9341.

It seems that the offset values can be handled in a similar way as for the st7735 driver. So this PR unifies all this.

What is not done by this PR is to add the possibility to play with the ST7735 orientation parameters (they are actually still hard coded) but I couldn't find a combination that works for all possible values.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `tests/driver_ili9341` display is correctly oriented on adafruit-clue (tested and it works)
- Green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #16176 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
