### PR TITLE
sys/net/sock_util: don't require interface for link-local addr if there is only a single interface

### DIFF
--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -200,6 +200,17 @@ int netif_set_opt(netif_t *netif, netopt_t opt, uint16_t context,
  */
 int netif_register(netif_t *netif);
 
+/**
+ * @brief   Removes a network interface in the global interface list.
+ *
+ * @param[in] netif     Interface to be removed
+ *
+ * @return  0 on success
+ * @return  -EINVAL if @p netif is NULL
+ *                  or not part of the global interface list
+ */
+int netif_unregister(netif_t *netif);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -36,6 +36,21 @@ int netif_register(netif_t *netif)
     return 0;
 }
 
+int netif_unregister(netif_t *netif)
+{
+    void *found;
+
+    if (netif == NULL) {
+        return -EINVAL;
+    }
+
+    unsigned state = irq_disable();
+    found = list_remove(&netif_list, &netif->node);
+    irq_restore(state);
+
+    return found ? 0 : -EINVAL;
+}
+
 netif_t *netif_iter(const netif_t *last)
 {
     if (last == NULL) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When the `sock_tl_str2ep()` function is supplied with a link-local address but no interface, if there is only a single interface use that instead of not setting the interface.

This is to match the behavior of the `ping` command.

### Testing procedure

`tests/nanocoap_cli` is a user of this API.

```
> url get coap://[fe80::90a7:a6ff:fe4b:2e32%5]/hello.txt     
url get coap://[fe80::90a7:a6ff:fe4b:2e32%5]/hello.txt
optpos: 0x8072da1
offset 000: Hello RIOT!
```
still works but now you can also do

```
> url get coap://[fe80::90a7:a6ff:fe4b:2e32]/hello.txt
url get coap://[fe80::90a7:a6ff:fe4b:2e32]/hello.txt
optpos: 0x8072da1
offset 000: Hello RIOT!
```

If there is only a single interface.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
