### PR TITLE
test/pbkdf2: enlarge stdio rx buffer

### DIFF
--- a/tests/pbkdf2/Makefile
+++ b/tests/pbkdf2/Makefile
@@ -8,6 +8,9 @@ USEMODULE += base64
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
 
+#ensure the rx buffer has some room even with large test patterns
+CFLAGS += -DSTDIO_UART_RX_BUFSIZE=128
+
 include $(RIOTBASE)/Makefile.include
 
 # Increase Stack size for AVR


### PR DESCRIPTION
### Contribution description

The pbkdf2-test contains transfers of upto 67 byte (65+2) only limited by the speed of the serial connection.
The default rx buffer is 64 bytes -> if uart irqs are tight enough the bytes are not taken fast enough from the buffer and some are lost -> test fails 

the failing test can be seen by sometimes failing on the emulated microbit in murdock.

The large writes are defined by [pbkdf2/tests/02-random.py](https://github.com/RIOT-OS/RIOT/blob/32ac29bd9838f871f8022594de8d7bba55e50615/tests/pbkdf2/tests/02-random.py#L72:L73)

This enlarges the buffer to 2^7 (128) bytes 

### Testing procedure

read and exec that test; sadly one might have to do multiple execs of that test to see it fail without this PR

### Issues/PRs references

split out from #17918 as it is not that related to murdock