### PR TITLE
drivers/mtd_spi_nor: fix off by one bug

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -482,7 +482,7 @@ static void _set_addr_width(mtd_dev_t *mtd)
     uint32_t flash_size = mtd->pages_per_sector * mtd->page_size
                         * mtd->sector_count;
 
-    if (flash_size > 0xFFFFFF) {
+    if (flash_size > (0x1UL << 24)) {
         dev->addr_width = 4;
     } else {
         dev->addr_width = 3;


### PR DESCRIPTION
### Contribution description

The boolean expression to detect when 32 bit address mode are needed was off by one, this fixes the issue.

### Testing procedure

`tests/unittests/tests-mtd` should pass again on the `iotlab-m3`.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17613