### PR TITLE
sys/suit: save seq_number when parsing manifest

### DIFF
--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -245,6 +245,7 @@ typedef struct {
     uint8_t validation_buf[SUIT_COSE_BUF_SIZE];
     char *urlbuf;                   /**< Buffer containing the manifest url */
     size_t urlbuf_len;              /**< Length of the manifest url */
+    uint32_t seq_number;            /**< Set sequence number */
 } suit_manifest_t;
 
 /**

--- a/sys/suit/handlers_global.c
+++ b/sys/suit/handlers_global.c
@@ -76,6 +76,7 @@ static int _seq_no_handler(suit_manifest_t *manifest, int key,
     }
 
     LOG_INFO("suit: validated sequence number\n)");
+    manifest->seq_number = seq_nr;
     manifest->validated |= SUIT_VALIDATED_SEQ_NR;
     return SUIT_OK;
 

--- a/sys/suit/storage/ram.c
+++ b/sys/suit/storage/ram.c
@@ -120,11 +120,9 @@ static int _ram_finish(suit_storage_t *storage, const suit_manifest_t *manifest)
     return SUIT_OK;
 }
 
-static int _ram_install(suit_storage_t *storage,
-                        const suit_manifest_t *manifest)
+static int _ram_install(suit_storage_t *storage, const suit_manifest_t *manifest)
 {
-    (void)manifest;
-    (void)storage;
+    suit_storage_set_seq_no(storage, manifest->seq_number);
     return SUIT_OK;
 }
 

--- a/tests/suit_manifest/create_test_data.sh
+++ b/tests/suit_manifest/create_test_data.sh
@@ -47,5 +47,5 @@ gen_manifest "${MANIFEST_DIR}/manifest3.bin".unsigned 2 "${MANIFEST_DIR}/file1.b
 sign_manifest "${MANIFEST_DIR}/manifest3.bin".unsigned "${MANIFEST_DIR}/manifest3.bin"
 
 # valid manifest, valid seqnr, signed, 2 components
-gen_manifest "${MANIFEST_DIR}/manifest4.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin:0:ram:0" "${MANIFEST_DIR}/file2.bin:0:ram:1"
+gen_manifest "${MANIFEST_DIR}/manifest4.bin".unsigned 3 "${MANIFEST_DIR}/file1.bin:0:ram:0" "${MANIFEST_DIR}/file2.bin:0:ram:1"
 sign_manifest "${MANIFEST_DIR}/manifest4.bin".unsigned "${MANIFEST_DIR}/manifest4.bin"


### PR DESCRIPTION
### Contribution description

At the end of an update the manifest `seq_no` should set "somewhere". For firmware update, this is done implicitly since the `seq_no` is contained in the firmware update. But for other storage units, it needs to be obtained from the manifest.

Therefore when parsing the manifest save the sequence number, and for `ram` storage set it during `install`.

### Testing procedure

In master, the `sequence_no` is never checked when using RAM storage, with this PR it is (although only ephemerally). Follow the [README.native.md](https://github.com/RIOT-OS/RIOT/blob/master/examples/suit_update/README.native.md)

Or alternatively, leverage https://github.com/RIOT-OS/RIOT/pull/16771.