### PR TITLE
drivers/ethos: add missing vfs include

### DIFF
--- a/drivers/ethos/stdio.c
+++ b/drivers/ethos/stdio.c
@@ -24,6 +24,9 @@
 #include "ethos.h"
 #include "isrpipe.h"
 #include "stdio_uart.h"
+#if IS_USED(MODULE_VFS)
+#include "vfs.h"
+#endif
 
 extern ethos_t ethos;
 


### PR DESCRIPTION
### Contribution description

Fix compilation issue.

### Testing procedure

Fails on master:

`USEMODULE=vfs BOARD=samr21-xpro make -C examples/gnrc_border_router/`
