### PR TITLE
sys/sc_suit: add seq_no command

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/sys.py
+++ b/dist/pythonlibs/riotctrl_shell/sys.py
@@ -10,7 +10,8 @@ sys-related shell interactions
 Defines sys-related shell command interactions
 """
 
-from riotctrl.shell import ShellInteraction
+import re
+from riotctrl.shell import ShellInteraction, ShellInteractionParser
 
 
 class Help(ShellInteraction):
@@ -38,3 +39,32 @@ class Version(ShellInteraction):
     def version(self, timeout=-1, async_=False):
         """Sends the reboot command via the terminal"""
         return self.cmd("version", timeout, async_)
+
+
+class SUITSequenceNoParser(ShellInteractionParser):
+    def __init__(self):
+        self.c_seq_no = re.compile(r"seq_no: (?P<seq_no>\d+)$")
+
+    def parse(self, cmd_output):
+        for line in cmd_output.splitlines():
+            m = self.c_seq_no.search(line)
+            if m is not None:
+                return int(m.group("seq_no"))
+        return None
+
+
+class SUIT(ShellInteraction):
+    @ShellInteraction.check_term
+    def suit_cmd(self, args=None, timeout=-1, async_=False):
+        cmd = "suit"
+        if args is not None:
+            cmd += " {args}".format(args=" ".join(str(a) for a in args))
+        return self.cmd(cmd, timeout=timeout, async_=False)
+
+    def suit_sequence_no(self, timeout=-1, async_=False):
+        return self.suit_cmd(args=("seq_no",), timeout=timeout, async_=async_)
+
+    def suit_fetch(self, manifest, timeout=-1, async_=False):
+        return self.suit_cmd(
+            args=("fetch", f'"{manifest}"'), timeout=timeout, async_=async_
+        )

--- a/dist/pythonlibs/riotctrl_shell/tests/test_sys.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_sys.py
@@ -31,3 +31,24 @@ def test_version():
     res = si.version()
     # mock just returns last input
     assert res == "version"
+
+
+def test_suit_fetch():
+    rc = init_ctrl()
+    si = riotctrl_shell.sys.SUIT(rc)
+    res = si.suit_fetch("coap://[2001:db8::2:1]/manifest")
+    # mock just returns last input
+    assert res == 'suit fetch "coap://[2001:db8::2:1]/manifest"'
+
+
+def test_suit_sequence_no():
+    rc = init_ctrl(
+        output="""
+seq_no: 123456789
+    """
+    )
+    si = riotctrl_shell.sys.SUIT(rc)
+    res = si.suit_sequence_no()
+    parser = riotctrl_shell.sys.SUITSequenceNoParser()
+    # mock just returns last input
+    assert parser.parse(res) == 123456789

--- a/sys/shell/commands/sc_suit.c
+++ b/sys/shell/commands/sc_suit.c
@@ -23,15 +23,33 @@
 #include <inttypes.h>
 
 #include "suit/transport/coap.h"
+#include "suit/storage.h"
+
+static void _print_usage(char **argv)
+{
+    printf("Usage: %s fetch <manifest url>\n", argv[0]);
+    printf("       %s seq_no\n", argv[0]);
+}
 
 int _suit_handler(int argc, char **argv)
 {
-    if (argc != 2) {
-        printf("Usage: %s <manifest url>\n", argv[0]);
+    if (argc < 2) {
+        _print_usage(argv);
         return 1;
     }
 
-    suit_coap_trigger((uint8_t *)argv[1], strlen(argv[1]));
+    if (strcmp(argv[1], "fetch") == 0) {
+        suit_coap_trigger((uint8_t *)argv[2], strlen(argv[2]));
+    }
+    else if (strcmp(argv[1], "seq_no") == 0) {
+        uint32_t seq_no = 0;
+        suit_storage_get_highest_seq_no(&seq_no);
+        printf("seq_no: %" PRIu32 "\n", seq_no);
+    }
+    else {
+        _print_usage(argv);
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

Adds a command to retrieve the highest `seq_no` of all storage units.

Shell interactions are also added.

### Testing procedure

```
2022-04-14 08:45:25,013 # suit
2022-04-14 08:45:25,015 # Usage: suit fetch <manifest url>
2022-04-14 08:45:25,017 #        suit seq_no
2022-04-14 08:45:30,173 # suit seq_no
2022-04-14 08:45:30,180 # seq_no: 1649918660

```