### PR TITLE
gcoap: small dependencies fixes

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -648,9 +648,7 @@ ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += ztimer_usec
   USEMODULE += event_callback
   USEMODULE += event_timeout_ztimer
-  ifneq (,$(filter openwsn%,$(USEMODULE)))
-    USEMODULE += openwsn_sock_udp
-  endif
+  USEMODULE += random
 endif
 
 ifneq (,$(filter luid,$(USEMODULE)))

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -1,5 +1,5 @@
 ifneq (,$(filter gcoap,$(USEMODULE)))
-   USEMODULE += gnrc_sock_async
+  USEMODULE += gnrc_sock_async
 endif
 
 ifneq (,$(filter sock_async,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

`gcoap` uses `random` but does not pull it indirectly, this fixes it. It's currently not shown because all possible network stacks pull in `random` for it.


