### PR TITLE
drivers/mcp2515: fixes and cleanups

### DIFF
--- a/drivers/include/candev_mcp2515.h
+++ b/drivers/include/candev_mcp2515.h
@@ -42,7 +42,7 @@ extern "C" {
  * Default CAN bitrate
  */
 #ifndef CANDEV_MCP2515_DEFAULT_BITRATE
-#define CANDEV_MCP2515_DEFAULT_BITRATE 125000
+#define CANDEV_MCP2515_DEFAULT_BITRATE 500000
 #endif
 
 /**

--- a/drivers/include/candev_mcp2515.h
+++ b/drivers/include/candev_mcp2515.h
@@ -32,7 +32,6 @@
 #include "periph/gpio.h"
 #include "periph/spi.h"
 #include "mutex.h"
-#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/mcp2515/Kconfig
+++ b/drivers/mcp2515/Kconfig
@@ -14,7 +14,7 @@ config MODULE_MCP2515
     select MODULE_PERIPH_GPIO
     select MODULE_PERIPH_GPIO_IRQ
     select MODULE_PERIPH_SPI
-    select MODULE_XTIMER
+    select ZTIMER_USEC
 
 config HAVE_MCP2515
     bool

--- a/drivers/mcp2515/Makefile.dep
+++ b/drivers/mcp2515/Makefile.dep
@@ -1,2 +1,2 @@
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 FEATURES_REQUIRED += periph_gpio periph_spi periph_gpio_irq

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -428,10 +428,6 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
 
     candev_mcp2515_t *dev_mcp = container_of(dev, candev_mcp2515_t, candev);
 
-    if (f.can_mask == 0) {
-        return -EINVAL; /* invalid mask */
-    }
-
     if (mutex_trylock(&_mcp_mutex)) {
         mode = mcp2515_get_mode(dev_mcp);
         res = mcp2515_set_mode(dev_mcp, MODE_CONFIG);
@@ -529,10 +525,6 @@ static int _remove_filter(candev_t *dev, const struct can_filter *filter)
     enum mcp2515_mode mode;
 
     candev_mcp2515_t *dev_mcp = container_of(dev, candev_mcp2515_t, candev);
-
-    if (f.can_mask == 0) {
-        return -1; /* invalid mask */
-    }
 
     if (mutex_trylock(&_mcp_mutex)) {
         mode = mcp2515_get_mode(dev_mcp);

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -156,11 +156,6 @@ static int _send(candev_t *candev, const struct can_frame *frame)
     int ret = 0;
     enum mcp2515_mode mode;
 
-    if (frame->can_id > 0x1FFFFFFF) {
-        DEBUG("Illegal CAN-ID!\n");
-        return -EINVAL;
-    }
-
     if (mutex_trylock(&_mcp_mutex)) {
         mode = mcp2515_get_mode(dev);
         mutex_unlock(&_mcp_mutex);

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -32,7 +32,7 @@
 #include "periph_conf.h"
 #include "thread.h"
 #include "sched.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -245,6 +245,7 @@ static void _isr(candev_t *candev)
 
     if (mutex_trylock(&_mcp_mutex)) {
         flag = mcp2515_get_irq(dev);
+        mcp2515_clear_irq(dev, flag & ~(INT_RX0 | INT_RX1));
         mutex_unlock(&_mcp_mutex);
     }
     else {
@@ -283,24 +284,13 @@ static void _isr(candev_t *candev)
         if (flag & INT_MESSAGE_ERROR) {
             _irq_message_error(dev);
         }
-
         if (mutex_trylock(&_mcp_mutex)) {
             flag = mcp2515_get_irq(dev);
-            mutex_unlock(&_mcp_mutex);
-        }
-        else {
-            DEBUG("isr2: Failed to lock mutex\n");
-            _neednewisr = 1;
-            return;
-        }
-
-        /* clear all flags except for RX flags, which are cleared by receiving */
-        if (mutex_trylock(&_mcp_mutex)) {
             mcp2515_clear_irq(dev, flag & ~(INT_RX0 | INT_RX1));
             mutex_unlock(&_mcp_mutex);
         }
         else {
-            DEBUG("isr3: failed to lock mutex\n");
+            DEBUG("isr2: Failed to lock mutex\n");
             _neednewisr = 1;
             return;
         }

--- a/drivers/mcp2515/mcp2515.c
+++ b/drivers/mcp2515/mcp2515.c
@@ -20,7 +20,7 @@
 
 #include <string.h>
 
-#include "xtimer.h"
+#include "ztimer.h"
 #include "mcp2515.h"
 #include "mcp2515_spi.h"
 #include "mcp2515_defines.h"
@@ -122,13 +122,13 @@ void mcp2515_reset(candev_mcp2515_t *dev)
 {
     if (gpio_is_valid(dev->conf->rst_pin)) {
         gpio_clear(dev->conf->rst_pin);
-        xtimer_usleep(RESET_DELAY_US);
+        ztimer_sleep(ZTIMER_USEC, RESET_DELAY_US);
         gpio_set(dev->conf->rst_pin);
     }
     else {
         mcp2515_spi_reset(dev);
     }
-    xtimer_usleep(_osc_startup(dev));
+    ztimer_sleep(ZTIMER_USEC, _osc_startup(dev));
 }
 
 static void _fill_standard_id(uint32_t id, uint8_t *bytebuf)
@@ -280,7 +280,7 @@ void mcp2515_wake_up(candev_mcp2515_t *dev)
     dev->wakeup_src = MCP2515_WKUP_SRC_INTERNAL;
     mcp2515_spi_bitmod(dev, MCP2515_CANINTF, MCP2515_CANINTF_WAKIF,
                        MCP2515_CANINTF_WAKIF);
-    xtimer_usleep(_osc_startup(dev));
+    ztimer_sleep(ZTIMER_USEC, _osc_startup(dev));
 
     uint8_t flag = mcp2515_get_irq(dev);
 

--- a/drivers/mcp2515/mcp2515.c
+++ b/drivers/mcp2515/mcp2515.c
@@ -99,7 +99,9 @@ int mcp2515_init(candev_mcp2515_t *dev, void (*irq_handler_cb)(void *))
         DEBUG("Error setting interrupt pin!\n");
         return -1;
     }
-    gpio_init(dev->conf->rst_pin, GPIO_OUT);
+    if (gpio_is_valid(dev->conf->rst_pin)) {
+        gpio_init(dev->conf->rst_pin, GPIO_OUT);
+    }
 
     res = mcp2515_spi_init(dev);
     if (res < 0) {
@@ -118,9 +120,14 @@ int mcp2515_init(candev_mcp2515_t *dev, void (*irq_handler_cb)(void *))
 
 void mcp2515_reset(candev_mcp2515_t *dev)
 {
-    gpio_clear(dev->conf->rst_pin);
-    xtimer_usleep(RESET_DELAY_US);
-    gpio_set(dev->conf->rst_pin);
+    if (gpio_is_valid(dev->conf->rst_pin)) {
+        gpio_clear(dev->conf->rst_pin);
+        xtimer_usleep(RESET_DELAY_US);
+        gpio_set(dev->conf->rst_pin);
+    }
+    else {
+        mcp2515_spi_reset(dev);
+    }
     xtimer_usleep(_osc_startup(dev));
 }
 

--- a/drivers/mcp2515/mcp2515_spi.c
+++ b/drivers/mcp2515/mcp2515_spi.c
@@ -25,7 +25,6 @@
 #include "periph/gpio.h"
 #include "periph/spi.h"
 
-#include "xtimer.h"
 #include "irq.h"
 
 #define ENABLE_DEBUG 0

--- a/sys/auto_init/can/auto_init_mcp2515.c
+++ b/sys/auto_init/can/auto_init_mcp2515.c
@@ -16,11 +16,10 @@
  * @}
  */
 
-#ifdef MODULE_MCP2515
 #include "can/device.h"
 #include "mcp2515_params.h"
 
-#define CANDEV_MCP2515_NUMOF ((ARRAY_SIZE(candev_mcp2515_params) / ARRAY_SIZE(candev_params_t)))
+#define CANDEV_MCP2515_NUMOF (ARRAY_SIZE(candev_mcp2515_params))
 
 #ifndef CANDEV_MCP2515_STACKSIZE
 #define CANDEV_MCP2515_STACKSIZE (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)
@@ -55,6 +54,3 @@ void auto_init_can_mcp2515(void) {
                             &candev_dev_mcp2515[i]);
     }
 }
-#else
-typedef int dont_be_pedantic;
-#endif


### PR DESCRIPTION
### Contribution description

This PR addresses some issues with the `mcp2515` driver:

- ef3d8349b9e6010eef0c769de2da261b9be59b70: not all breakouts have a reset pin, this allow it to be set to GPIO_UNDEF
- 16921869da5fa99adeb88b999539df81bdf82acd: currently after the first read `irq_flags` are not cleared, and the flags are re-read before clearing, this results in the same flags triggering twice. This fixes it by clearing it after reading.
- 2f31ab4a33db208820bf70f3d89665489110ca03 and 2e4840e79e2d863a4282cf07272ccc3d4858220a: address value checks that should be allowed
- dc206bce5b7bd984225b5d53f3175b5b07b2ff57: increases the default bitrate
- fa147b7c3af58d9542fe468c553428e8d5ac8221: uses ztimer

### Testing procedure

- `tests/conn_can`

- `tests/candev`:

first mcp2515
```
2022-04-19 09:02:49,687 # receive
2022-04-19 09:02:49,689 # Reading from Rxbuf...
2022-04-19 09:02:56,091 # id: 1 dlc: hx Data:
2022-04-19 09:02:56,093 # 0xC 0x20 0x56
> receive
2022-04-19 09:03:18,805 # receive
2022-04-19 09:03:18,806 # Reading from Rxbuf...
2022-04-19 09:03:18,808 # id: 1 dlc: hx Data:
2022-04-19 09:03:18,810 # 0xC 0x20 0x56
```

second mcp2515
```
> send 12 32 342
2022-04-19 09:02:56,090 # send 12 32 342
> send 12 32 342
2022-04-19 09:03:16,989 # send 12 32 342
```


