### PR TITLE
sys/net/application_layer/gcoap: use COAP_PORT

### DIFF
--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -175,7 +175,7 @@ static bool _parse_endpoint(sock_udp_ep_t *remote,
         }
     }
     else {
-        remote->port = 5683;
+        remote->port = COAP_PORT;
     }
 
     return true;


### PR DESCRIPTION
### Contribution description

Just a cleanup, make it use the `COAP_PORT` define instead of inlining the value.

### Testing procedure

- Green murdock
