### PR TITLE
boards/nucleo-f401re: add riotboot

### DIFF
--- a/boards/nucleo-f401re/Kconfig
+++ b/boards/nucleo-f401re/Kconfig
@@ -25,4 +25,7 @@ config BOARD_NUCLEO_F401RE
     select HAS_PERIPH_UART
     select HAS_PERIPH_QDEC
 
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f401re/Makefile.features
+++ b/boards/nucleo-f401re/Makefile.features
@@ -12,5 +12,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_qdec
 
+FEATURES_PROVIDED += riotboot
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features


### PR DESCRIPTION
### Contribution description

Adds riotboot.

### Testing procedure

Runt `tests/riotboot`. I can put tests results on Tuesday, I don't have the BOARD ATM but I've tested `suit` and `riotboot` in this BOARD.
