### PR TITLE
nanocoap: follow-up fixes

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -658,6 +658,7 @@ endif
 ifneq (,$(filter nanocoap_sock,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += sock_util
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter nanocoap_%,$(USEMODULE)))

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -357,7 +357,7 @@ int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
 
         if (res) {
             DEBUG("error fetching block %u: %d\n", num, res);
-            return -1;
+            return res;
         }
 
         num += 1;

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -301,11 +301,10 @@ static int _block_cb(void *arg, coap_pkt_t *pkt)
     /* response was not block-wise */
     if (!coap_get_block2(pkt, &block2)) {
         block2.offset = 0;
-        ctx->more = false;
-    } else {
-        ctx->more = block2.more;
+        block2.more = false;
     }
 
+    ctx->more = block2.more;
     return ctx->callback(ctx->arg, block2.offset, pkt->payload, pkt->payload_len, block2.more);
 }
 

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -220,7 +220,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
                 if (cb) {
                     res = cb(arg, pkt);
                 } else {
-                    res = 0;
+                    res = _get_error(pkt);
                 }
                 break;
             }
@@ -298,16 +298,7 @@ ssize_t nanocoap_sock_get(nanocoap_sock_t *sock, const char *path, void *buf, si
     pkt.payload = pktpos;
     pkt.payload_len = 0;
 
-    int res = nanocoap_sock_request_cb(sock, &pkt, _get_cb, &ctx);
-    if (res < 0) {
-        return res;
-    }
-
-    if (coap_get_code(&pkt) != 205) {
-        return -ENOENT;
-    }
-
-    return res;
+    return nanocoap_sock_request_cb(sock, &pkt, _get_cb, &ctx);
 }
 
 ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
@@ -382,14 +373,7 @@ static int _fetch_block(nanocoap_sock_t *sock, uint8_t *buf, size_t len,
     pkt.payload = buf;
     pkt.payload_len = 0;
 
-    int res = nanocoap_sock_request_cb(sock, &pkt, _block_cb, ctx);
-    if (res < 0) {
-        return res;
-    }
-
-    DEBUG("code=%i\n", coap_get_code(&pkt));
-
-    return _get_error(&pkt);
+    return nanocoap_sock_request_cb(sock, &pkt, _block_cb, ctx);
 }
 
 int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -6,7 +6,12 @@ USEMODULE += netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
 USEMODULE += gnrc_ipv6_default
-USEMODULE += sock_udp
+
+# Optionally include DNS support. This includes resolution of names at an
+# upstream DNS server and the handling of RDNSS options in Router Advertisements
+# to auto-configure that upstream DNS server.
+# USEMODULE += sock_dns              # include DNS client
+# USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 USEMODULE += nanocoap_sock
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

NanoCoAP should use random message IDs and randomize the retransmit timeout.
This PR takes care of this.

### Testing procedure

Block-wise does still work:

```
main(): This is RIOT! (Version: 2022.07-devel-63-g12dbc-nanocoap-fixes)
nanocoap test app
All up, running the shell now
> url get coap://[fe80::581a:98ff:fe23:2d6c%5]/riot/ver
offset 000: This is RIOT (Version: 2022.07-d
offset 032: evel-64-g414f73-nanocoap_vfs) ru
offset 064: nning on a native board with a n
offset 096: ative MCU.
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
