### PR TITLE
build system: Fix compilation for RISC-V with newer GCC

### DIFF
--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -15,11 +15,14 @@
 _TRIPLES_TO_TEST := \
     riscv-none-embed \
     riscv32-none-elf \
-    riscv-none-elf \
     riscv32-unknown-elf \
+    riscv32-elf \
+    riscv-none-elf \
     riscv-unknown-elf \
+    riscv-elf \
     riscv64-none-elf \
-    riscv64-unknown-elf
+    riscv64-unknown-elf \
+    riscv64-elf
 
 TARGET_ARCH_RISCV ?= \
   $(strip \

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -33,6 +33,10 @@ TARGET_ARCH_RISCV ?= \
 
 TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
 
+ifeq (,$(TARGET_ARCH))
+  $(error No RISC-V toolchain detected. Make sure a RISC-V toolchain is installed.)
+endif
+
 ifeq ($(TOOLCHAIN),gnu)
   NEW_RISCV_ISA := $(shell echo "" | $(TARGET_ARCH)-as -march=rv32imac_zicsr -mabi=ilp32 - > /dev/null 2>&1 && echo 1 || echo 0)
 endif


### PR DESCRIPTION
### Contribution description

A backward incompatible change in the RISC-V resulting in instructions previously included by rv32imac to only be available with rv32imac_zicsr. All RISC-V CPUs supported by RIOT are hence either considered as rv32imac (from the old ISA spec point of view) or as rv32imac_zicsr (from the new ISA spec point of view). This adds a simple test if GCC understands rv32imac_zicsr and uses it then as march, but uses rv32imac as march if not.

### Testing procedure

When running `make BOARD=hifive1b -C examples/default` with newer GCC versions, one will see an error message similar to:

```
/home/foobar/RIOT/cpu/riscv_common/start.S: Assembler messages:
/home/foobar/RIOT/cpu/riscv_common/start.S:20: Error: unrecognized opcode `csrc 0x300,0x00000008'
```

With this PR, the compilation should work again, but also remain working with older GCC versions.

### Issues/PRs references

None