### PR TITLE
sys/event: Add documentation and enforce waiter on wait

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -80,6 +80,7 @@ event_t *event_wait_multi(event_queue_t *queues, size_t n_queues)
     do {
         unsigned state = irq_disable();
         for (size_t i = 0; i < n_queues; i++) {
+            assert(queues[i].waiter);
             result = container_of(clist_lpop(&queues[i].event_list),
                                   event_t, list_node);
             if (result) {
@@ -100,6 +101,7 @@ event_t *event_wait_multi(event_queue_t *queues, size_t n_queues)
 static event_t *_wait_timeout(event_queue_t *queue)
 {
     assert(queue);
+    assert(queue->waiter);
     event_t *result;
     thread_flags_t flags = 0;
 

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -312,6 +312,8 @@ event_t *event_get(event_queue_t *queue);
  *          the strictest requirements.
  *
  * @pre     0 < @p n_queues (expect blowing `assert()` otherwise)
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
  *
  * @param[in]   queues      Array of event queues to get event from
  * @param[in]   n_queues    Number of event queues passed in @p queues
@@ -330,6 +332,9 @@ event_t *event_wait_multi(event_queue_t *queues, size_t n_queues);
  *
  * @warning     There can only be a single waiter on a queue!
  *
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
+ *
  * @param[in]   queue   event queue to get event from
  *
  * @returns     pointer to next event
@@ -343,6 +348,9 @@ static inline event_t *event_wait(event_queue_t *queue)
 /**
  * @brief   Get next event from event queue, blocking until timeout expires
  *
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
+ *
  * @param[in]   queue    queue to query for an event
  * @param[in]   timeout  maximum time to wait for an event to be posted in us
  *
@@ -353,6 +361,9 @@ event_t *event_wait_timeout(event_queue_t *queue, uint32_t timeout);
 
 /**
  * @brief   Get next event from event queue, blocking until timeout expires
+ *
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
  *
  * @param[in]   queue    queue to query for an event
  * @param[in]   timeout  maximum time to wait for an event to be posted in us
@@ -369,6 +380,9 @@ event_t *event_wait_timeout64(event_queue_t *queue, uint64_t timeout);
  *
  * This function is the same as event_wait_timeout() with the difference that it
  * uses ztimer instead of xtimer as timer backend.
+ *
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
  *
  * @param[in]   queue    queue to query for an event
  * @param[in]   clock    ztimer clock to use
@@ -400,6 +414,9 @@ event_t *event_wait_timeout_ztimer(event_queue_t *queue,
  *
  * @see event_wait_multi
  *
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
+ *
  * @param[in]   queues      Event queues to process
  * @param[in]   n_queues    Number of queues passed with @p queues
  */
@@ -425,6 +442,9 @@ static inline void event_loop_multi(event_queue_t *queues, size_t n_queues)
  *         event->handler(event);
  *     }
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * @pre     The queue must have a waiter (i.e. it should have been claimed, or
+ *          initialized using @ref event_queue_init, @ref event_queues_init)
  *
  * @param[in]   queue   event queue to process
  */

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -257,6 +257,8 @@ static inline void event_queue_claim(event_queue_t *queue)
  * in the previous position on the queue. So reposting an event while it is
  * already on the queue will have no effect.
  *
+ * @pre     queue should be initialized
+ *
  * @param[in]   queue   event queue to queue event in
  * @param[in]   event   event to queue in event queue
  */


### PR DESCRIPTION
### Contribution description
- d3ee32fe97aceeea3b5fa26b91084f561f31225b explicitly documents that a queue needs to be initialized (either attached or detached) before posting events to it.
- b3b76bf6f35c1a940fe36c3777ccfb319e477053 documents and enforces that a queue has a `waiter` assigned before waiting for thread flags.

### Testing procedure
- `tests/events` should work as usual

### Issues/PRs references
None