### PR TITLE
nanocoap: define and use coap_request_ctx_t for request handlers

### DIFF
--- a/examples/cord_ep/main.c
+++ b/examples/cord_ep/main.c
@@ -50,7 +50,7 @@ static void _on_ep_event(cord_ep_standalone_event_t event)
 
 /* define some dummy CoAP resources */
 static ssize_t _handler_dummy(coap_pkt_t *pdu,
-                              uint8_t *buf, size_t len, void *ctx)
+                              uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
 
@@ -64,7 +64,7 @@ static ssize_t _handler_dummy(coap_pkt_t *pdu,
 }
 
 static ssize_t _handler_info(coap_pkt_t *pdu,
-                             uint8_t *buf, size_t len, void *ctx)
+                             uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
 

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -46,15 +46,15 @@ static ssize_t text_resp(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     return resp_len + slen;
 }
 
-static ssize_t handler_info(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t handler_info(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
     return text_resp(pdu, buf, len, riot_info, COAP_FORMAT_JSON);
 }
 
-static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
-    return text_resp(pdu, buf, len, (char *)ctx, COAP_FORMAT_TEXT);
+    return text_resp(pdu, buf, len, ctx->context, COAP_FORMAT_TEXT);
 }
 
 static const coap_resource_t resources[] = {

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -54,7 +54,7 @@ static ssize_t handler_info(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_requ
 
 static ssize_t handler_text(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
-    return text_resp(pdu, buf, len, ctx->context, COAP_FORMAT_TEXT);
+    return text_resp(pdu, buf, len, coap_request_ctx_get_context(ctx), COAP_FORMAT_TEXT);
 }
 
 static const coap_resource_t resources[] = {

--- a/examples/gcoap/server.c
+++ b/examples/gcoap/server.c
@@ -58,8 +58,8 @@ static const credman_credential_t credential = {
 
 static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context);
-static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
-static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
+static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
@@ -108,7 +108,7 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
  *      allows any two byte value for example purposes. Semantically, the only
  *      valid action is to set the value to 0.
  */
-static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
 
@@ -142,7 +142,7 @@ static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *c
     return 0;
 }
 
-static ssize_t _riot_board_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _riot_board_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);

--- a/examples/gcoap_block_server/gcoap_block.c
+++ b/examples/gcoap_block_server/gcoap_block.c
@@ -28,8 +28,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static ssize_t _sha256_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
-static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _sha256_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
+static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
 
 /* CoAP resources */
 static const coap_resource_t _resources[] = {
@@ -47,7 +47,7 @@ static const uint8_t block2_intro[] = "This is RIOT (Version: ";
 static const uint8_t block2_board[] = " running on a ";
 static const uint8_t block2_mcu[] = " board with a ";
 
-static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
     coap_block_slicer_t slicer;
@@ -80,7 +80,7 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, v
 
 /*
  * Uses block1 POSTs to generate an sha256 digest. */
-static ssize_t _sha256_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _sha256_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
 

--- a/examples/gcoap_fileserver/main.c
+++ b/examples/gcoap_fileserver/main.c
@@ -25,14 +25,9 @@
 #define MAIN_QUEUE_SIZE (4)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-static const gcoap_fileserver_entry_t _vfs_entry = {
-    .root = VFS_DEFAULT_DATA,
-    .resource = "/vfs",
-};
-
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/vfs", COAP_GET | COAP_MATCH_SUBTREE, gcoap_fileserver_handler, (void *)&_vfs_entry },
+    { "/vfs", COAP_GET | COAP_MATCH_SUBTREE, gcoap_fileserver_handler, VFS_DEFAULT_DATA },
 };
 
 static gcoap_listener_t _listener = {

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -22,7 +22,7 @@ static const uint8_t block2_intro[] = "This is RIOT (Version: ";
 static const uint8_t block2_board[] = " running on a ";
 static const uint8_t block2_mcu[] = " board with a ";
 
-static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void)context;
     char uri[CONFIG_NANOCOAP_URI_MAX];
@@ -37,14 +37,14 @@ static ssize_t _echo_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *co
                              (uint8_t *)sub_uri, sub_uri_len);
 }
 
-static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void)context;
     return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
             COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
 }
 
-static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void)context;
     coap_block_slicer_t slicer;
@@ -77,7 +77,7 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, v
                                    buf, len, payload_len, &slicer);
 }
 
-static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void) context;
 
@@ -112,7 +112,7 @@ static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, vo
             COAP_FORMAT_TEXT, (uint8_t*)rsp, p);
 }
 
-ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context)
+ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void)context;
 

--- a/examples/suit_update/coap_handler.c
+++ b/examples/suit_update/coap_handler.c
@@ -14,7 +14,8 @@
 #include "suit/transport/coap.h"
 #include "kernel_defines.h"
 
-static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                                   coap_request_ctx_t *context)
 {
     (void)context;
     return coap_reply_simple(pkt, COAP_CODE_205, buf, len,

--- a/sys/include/net/gcoap/fileserver.h
+++ b/sys/include/net/gcoap/fileserver.h
@@ -36,26 +36,24 @@
  *
  * * ``USEMODULE += gcoap_fileserver``
  *
- * * Have a @ref gcoap_fileserver_entry_t populated with the path you want to serve,
- *   and the number of path components to strip from incoming requests:
- *
- *   ```
- *   static const gcoap_fileserver_entry_t files_sd = {
- *       .root = "/sd0",
- *       .resource = "/files/sd"
- *   };
- *   ```
- *
  * * Enter a @ref gcoap_fileserver_handler handler into your CoAP server's
  *   resource list like this:
  *
  *   ```
  *   static const coap_resource_t _resources[] = {
  *       ...
- *       { "/files/sd", COAP_GET | COAP_MATCH_SUBTREE, gcoap_fileserver_handler, (void*)&files_sd },
+ *       {
+ *          .path = "/files/sd",
+ *          .methods = COAP_GET | COAP_MATCH_SUBTREE,
+ *          .handler = gcoap_fileserver_handler,
+ *          .context = "/sd0"
+ *       },
  *       ...
  *   }
  *   ```
+ *
+ *   The path argument specifies under which path the folder is served via CoAP while
+ *   the context argument contains the path on the local filesystem that will be served.
  *
  *   The allowed methods dictate whether it's read-only (``COAP_GET``) or (in the
  *   future<!-- WRITESUPPORT -->) read-write (``COAP_GET | COAP_PUT | COAP_DELETE``).
@@ -78,26 +76,6 @@ extern "C" {
 #include "net/nanocoap.h"
 
 /**
- * @brief File server starting point
- *
- * This struct needs to be present at the ctx of a gcoap_fileserver_handler entry
- * in a resource list.
- *
- */
-typedef struct {
-    /**
-     * @brief Path in the VFS that should be served.
-     *
-     * This does not need a trailing slash.
-     */
-    const char *root;
-    /**
-     * @brief The associated CoAP resource path
-     */
-    const char *resource;
-} gcoap_fileserver_entry_t;
-
-/**
  * @brief File server handler
  *
  * Serve a directory from the VFS as a CoAP resource tree.
@@ -106,12 +84,12 @@ typedef struct {
  * @param[in] pdu   CoAP request package
  * @param[out] buf  Buffer for the response
  * @param[in] len   Response buffer length
- * @param[in] ctx   pointer to a @ref gcoap_fileserver_entry_t
+ * @param[in] ctx   pointer to a @ref coap_request_ctx_t
  *
  * @return size of the response on success
  *         negative error
  */
-ssize_t gcoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+ssize_t gcoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -241,6 +241,11 @@ typedef struct {
 } coap_pkt_t;
 
 /**
+ * @brief   CoAP resource request handler context
+ */
+typedef struct _coap_request_ctx coap_request_ctx_t;
+
+/**
  * @brief   Resource handler type
  *
  * Functions that implement this must be prepared to be called multiple times
@@ -254,7 +259,8 @@ typedef struct {
  * For POST, PATCH and other non-idempotent methods, this is an additional
  * requirement introduced by the contract of this type.
  */
-typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context);
+typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                                  coap_request_ctx_t *context);
 
 /**
  * @brief   Coap blockwise request callback descriptor
@@ -306,6 +312,38 @@ typedef const struct {
     const coap_resource_t *resources;   /**< ptr to resource array  */
     const size_t resources_numof;       /**< number of entries in array */
 } coap_resource_subtree_t;
+
+/**
+ * @brief   CoAP resource request handler context
+ */
+struct _coap_request_ctx {
+    const coap_resource_t *resource;    /**< resource of the request        */
+    void *context;                      /**< request context                */
+};
+
+/**
+ * @brief   Get resource path associated with a CoAP request
+ *
+ * @param[in]   ctx The request context
+ *
+ * @return  Resource path of the request
+ */
+static inline const char *coap_request_get_path(const coap_request_ctx_t *ctx)
+{
+    return ctx->resource->path;
+}
+
+/**
+ * @brief   Get resource context associated with a CoAP request
+ *
+ * @param[in]   ctx The request context
+ *
+ * @return  Resource context of the request
+ */
+static inline void *coap_request_get_context(const coap_request_ctx_t *ctx)
+{
+    return ctx->context;
+}
 
 /**
  * @brief   Block1 helper struct
@@ -1953,7 +1991,7 @@ ssize_t coap_reply_simple(coap_pkt_t *pkt,
  */
 extern ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, \
                                                     uint8_t *buf, size_t len,
-                                                    void *context);
+                                                    coap_request_ctx_t *context);
 /**@}*/
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1849,13 +1849,14 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
  * @param[in]   pkt             pointer to (parsed) CoAP packet
  * @param[out]  resp_buf        buffer for response
  * @param[in]   resp_buf_len    size of response buffer
- * @param[in]   context         ptr to a @ref coap_resource_subtree_t instance
+ * @param[in]   context         pointer to request context, must contain context
+ *                              to @ref coap_resource_subtree_t instance
  *
  * @returns     size of the reply packet on success
  * @returns     <0 on error
  */
 ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
-                             size_t resp_buf_len, void *context);
+                             size_t resp_buf_len, coap_request_ctx_t *context);
 
 /**
  * @brief   Convert message code (request method) into a corresponding bit field

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -241,6 +241,11 @@ typedef struct {
 } coap_pkt_t;
 
 /**
+ * @brief   Forward declaration of internal CoAP resource request handler context
+ */
+struct _coap_request_ctx;
+
+/**
  * @brief   CoAP resource request handler context
  */
 typedef struct _coap_request_ctx coap_request_ctx_t;
@@ -322,24 +327,13 @@ typedef const struct {
 } coap_resource_subtree_t;
 
 /**
- * @brief   CoAP resource request handler context
- */
-struct _coap_request_ctx {
-    const coap_resource_t *resource;    /**< resource of the request        */
-    void *context;                      /**< request context                */
-};
-
-/**
  * @brief   Get resource path associated with a CoAP request
  *
  * @param[in]   ctx The request context
  *
  * @return  Resource path of the request
  */
-static inline const char *coap_request_get_path(const coap_request_ctx_t *ctx)
-{
-    return ctx->resource->path;
-}
+const char *coap_request_ctx_get_path(const coap_request_ctx_t *ctx);
 
 /**
  * @brief   Get resource context associated with a CoAP request
@@ -348,10 +342,7 @@ static inline const char *coap_request_get_path(const coap_request_ctx_t *ctx)
  *
  * @return  Resource context of the request
  */
-static inline void *coap_request_get_context(const coap_request_ctx_t *ctx)
-{
-    return ctx->context;
-}
+void *coap_request_ctx_get_context(const coap_request_ctx_t *ctx);
 
 /**
  * @brief   Block1 helper struct

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -258,6 +258,14 @@ typedef struct _coap_request_ctx coap_request_ctx_t;
  *
  * For POST, PATCH and other non-idempotent methods, this is an additional
  * requirement introduced by the contract of this type.
+ *
+ * @param[in]  pkt      The request packet
+ * @param[out] buf      Buffer for the response
+ * @param[in]  len      Size of the response buffer
+ * @param[in]  context  Request context
+ *
+ * @return     Number of response bytes written on success
+ *             Negative error on failure
  */
 typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                                   coap_request_ctx_t *context);

--- a/sys/net/application_layer/gcoap/Makefile
+++ b/sys/net/application_layer/gcoap/Makefile
@@ -2,4 +2,7 @@ SRC := gcoap.c
 
 SUBMODULES := 1
 
+# Since gcoap extends nanocoap, it shall be provided with nanocoap internals
+INCLUDES += -I$(RIOTBASE)/sys/net/application_layer/nanocoap
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -265,8 +265,8 @@ static ssize_t gcoap_fileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf,
 
 ssize_t gcoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                  coap_request_ctx_t *ctx) {
-    const char *root = ctx->context;
-    const char *resource = ctx->resource->path;
+    const char *root = coap_request_ctx_get_context(ctx);
+    const char *resource = coap_request_ctx_get_path(ctx);
     struct requestdata request = {
         .etag_sent = false,
         .blocknum2 = 0,

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -102,7 +102,7 @@ static ssize_t _forward_proxy_handler(coap_pkt_t *pdu, uint8_t *buf,
                                       size_t len, coap_request_ctx_t *ctx)
 {
     int pdu_len;
-    sock_udp_ep_t *remote = (sock_udp_ep_t *)ctx->context;
+    sock_udp_ep_t *remote = coap_request_ctx_get_context(ctx);
 
     pdu_len = gcoap_forward_proxy_request_process(pdu, remote);
 

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -41,7 +41,7 @@ static int _request_matcher_forward_proxy(gcoap_listener_t *listener,
                                           const coap_resource_t **resource,
                                           coap_pkt_t *pdu);
 static ssize_t _forward_proxy_handler(coap_pkt_t* pdu, uint8_t *buf,
-                                      size_t len, void *ctx);
+                                      size_t len, coap_request_ctx_t *ctx);
 
 const coap_resource_t forward_proxy_resources[] = {
     { "/", COAP_IGNORE, _forward_proxy_handler, NULL },
@@ -99,10 +99,10 @@ static int _request_matcher_forward_proxy(gcoap_listener_t *listener,
 }
 
 static ssize_t _forward_proxy_handler(coap_pkt_t *pdu, uint8_t *buf,
-                                      size_t len, void *ctx)
+                                      size_t len, coap_request_ctx_t *ctx)
 {
-    int pdu_len = 0;
-    sock_udp_ep_t *remote = (sock_udp_ep_t *)ctx;
+    int pdu_len;
+    sock_udp_ep_t *remote = (sock_udp_ep_t *)ctx->context;
 
     pdu_len = gcoap_forward_proxy_request_process(pdu, remote);
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -28,6 +28,8 @@
 #include "assert.h"
 #include "net/coap.h"
 #include "net/gcoap.h"
+#include "net/gcoap/forward_proxy.h"
+#include "nanocoap_internal.h"
 #include "net/nanocoap/cache.h"
 #include "net/sock/async/event.h"
 #include "net/sock/util.h"
@@ -41,8 +43,6 @@
 #include "net/credman.h"
 #include "net/dsm.h"
 #endif
-
-#include "net/gcoap/forward_proxy.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -426,10 +426,10 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
 }
 
 ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                             void *context)
+                             coap_request_ctx_t *context)
 {
     assert(context);
-    coap_resource_subtree_t *subtree = context;
+    coap_resource_subtree_t *subtree = context->context;
     return coap_tree_handler(pkt, buf, len, subtree->resources,
                              subtree->resources_numof);
 }
@@ -461,7 +461,11 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
             break;
         }
         else {
-            return resource->handler(pkt, resp_buf, resp_buf_len, resource->context);
+            coap_request_ctx_t ctx = {
+                .resource = resource,
+                .context  = resource->context,
+            };
+            return resource->handler(pkt, resp_buf, resp_buf_len, &ctx);
         }
     }
 
@@ -1196,7 +1200,7 @@ size_t coap_blockwise_put_bytes(coap_block_slicer_t *slicer, uint8_t *bufpos,
 }
 
 ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \
-                                             size_t len, void *context)
+                                             size_t len, coap_request_ctx_t *context)
 {
     (void)context;
     coap_block_slicer_t slicer;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #include "bitarithm.h"
-#include "net/nanocoap.h"
+#include "nanocoap_internal.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -429,7 +429,7 @@ ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                              coap_request_ctx_t *context)
 {
     assert(context);
-    coap_resource_subtree_t *subtree = context->context;
+    coap_resource_subtree_t *subtree = coap_request_ctx_get_context(context);
     return coap_tree_handler(pkt, buf, len, subtree->resources,
                              subtree->resources_numof);
 }
@@ -1235,4 +1235,14 @@ unsigned coap_get_len(coap_pkt_t *pkt)
         pktlen += pkt->payload_len + 1;
     }
     return pktlen;
+}
+
+const char *coap_request_ctx_get_path(const coap_request_ctx_t *ctx)
+{
+    return ctx->resource->path;
+}
+
+void *coap_request_ctx_get_context(const coap_request_ctx_t *ctx)
+{
+    return ctx->context;
 }

--- a/sys/net/application_layer/nanocoap/nanocoap_internal.h
+++ b/sys/net/application_layer/nanocoap/nanocoap_internal.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_nanocoap
+ * @{
+ *
+ * @file
+ * @brief       NanoCoAP internals
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef NANOCOAP_INTERNAL_H
+#define NANOCOAP_INTERNAL_H
+
+#include "net/nanocoap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Internal CoAP resource request handler context
+ */
+struct _coap_request_ctx {
+    const coap_resource_t *resource;    /**< resource of the request */
+    void *context;                      /**< request context, needed to supply
+                                             the remote for the forward proxy */
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* NANOCOAP_INTERNAL_H */
+/** @} */

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -33,7 +33,7 @@
 #endif
 
 static ssize_t _version_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                                void *context)
+                                coap_request_ctx_t *context)
 {
     (void)context;
     return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
@@ -41,7 +41,7 @@ static ssize_t _version_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
 }
 
 static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                                void *context)
+                                coap_request_ctx_t *context)
 {
     (void)context;
     unsigned code;
@@ -66,12 +66,12 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
 
 #ifdef MODULE_RIOTBOOT_SLOT
 static ssize_t _slot_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                             void *context)
+                             coap_request_ctx_t *context)
 {
     /* context is passed either as NULL or 0x1 for /active or /inactive */
     char c = '0';
 
-    if (context) {
+    if (coap_request_ctx_get_context(context)) {
         c += riotboot_slot_other();
     }
     else {

--- a/tests/gcoap_dns/main.c
+++ b/tests/gcoap_dns/main.c
@@ -239,7 +239,7 @@ static int _unittests(int argc, char **argv)
     return 0;
 }
 
-static ssize_t _mock_dns_server(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+static ssize_t _mock_dns_server(coap_pkt_t *pdu, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
     (void)ctx;
     if ((_resp_code >> 5) == COAP_CLASS_SUCCESS) {

--- a/tests/nanocoap_cli/request_handlers.c
+++ b/tests/nanocoap_cli/request_handlers.c
@@ -32,7 +32,7 @@
 /* internal value that can be read/written via CoAP */
 static uint8_t internal_value = 0;
 
-static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+static ssize_t _value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void) context;
 

--- a/tests/pkg_edhoc_c/responder.c
+++ b/tests/pkg_edhoc_c/responder.c
@@ -58,7 +58,7 @@ static wc_Sha256 _sha_r;
 struct tc_sha256_state_struct _sha_r;
 #endif
 
-ssize_t _edhoc_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context)
+ssize_t _edhoc_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, coap_request_ctx_t *context)
 {
     (void)context;
     ssize_t msg_len = 0;

--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -17,7 +17,7 @@ static riotboot_flashwrite_t _writer;
 
 ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
-    riotboot_flashwrite_t *writer = ctx->context;
+    riotboot_flashwrite_t *writer = coap_request_ctx_get_context(ctx);
 
     uint32_t result = COAP_CODE_204;
 

--- a/tests/riotboot_flashwrite/coap_handler.c
+++ b/tests/riotboot_flashwrite/coap_handler.c
@@ -15,9 +15,9 @@
 
 static riotboot_flashwrite_t _writer;
 
-ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context)
+ssize_t _flashwrite_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, coap_request_ctx_t *ctx)
 {
-    riotboot_flashwrite_t *writer = context;
+    riotboot_flashwrite_t *writer = ctx->context;
 
     uint32_t result = COAP_CODE_204;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently a resource handler has no information about the resource it handles.
This leads to awkward work-around such as specifying the resource path in the user context again.

To avoid this, introduce a `coap_resource_ctx_t` struct that contains the user context and the resource path, that can be easily extended if more context is needed in the future.

### Testing procedure

All CoAP applications should still work.
Since the user context was usually NULL, most will not even notice a change.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14397#issuecomment-1100191189
Can provide an alternative to #16827 (and also move `tl_type` out of `coap_pkt_t` into  `coap_resource_ctx_t`)

depends on [!11](https://gitlab.com/etonomy/riot-wrappers/-/merge_requests/11)