### PR TITLE
nanocoap_sock: add nanocoap_sock_block_request()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -88,6 +88,7 @@
 #ifdef RIOT_VERSION
 #include "bitfield.h"
 #include "byteorder.h"
+#include "iolist.h"
 #include "net/coap.h"
 #else
 #include "coap.h"
@@ -200,6 +201,7 @@ typedef struct {
                                                        * @deprecated Use coap_get_token(),
                                                        *     Will be removed after 2022.10. */
     uint8_t *payload;                                 /**< pointer to payload      */
+    iolist_t *snips;                                  /**< payload snips (optional)*/
     uint16_t payload_len;                             /**< length of payload       */
     uint16_t options_len;                             /**< length of options array */
     coap_optpos_t options[CONFIG_NANOCOAP_NOPTS_MAX]; /**< option offset array     */
@@ -430,7 +432,9 @@ static inline unsigned coap_get_total_hdr_len(const coap_pkt_t *pkt)
 }
 
 /**
- * @brief   Get the total length of a CoAP packet
+ * @brief   Get the total length of a CoAP packet in the packet buffer
+ *
+ * @note This does not include possible payload snips.
  *
  * @param[in]   pkt   CoAP packet
  *

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -194,13 +194,27 @@ typedef struct {
 
 /**
  * @brief   CoAP PDU parsing context structure
+ *
+ * When this struct is used to assemble the header, @p payload is used as the
+ * write pointer and @p payload_len contains the number of free bytes left in
+ * then packet buffer pointed to by @ref coap_pkt_t::hdr
+ *
+ * When the header was written, @p payload must not be changed, it must remain
+ * pointing to the end of the header.
+ * @p payload_len must then be set to the size of the payload that was further
+ * copied into the packet buffer, after the header.
+ *
+ * @ref coap_pkt_t::snips can be used to attach further payload buffers without copying them
+ * into the CoAP packet buffer.
+ * If there are any, they will be attached in order after the last payload byte
+ * (or header byte) in the original CoAP packet buffer.
  */
 typedef struct {
     coap_hdr_t *hdr;                                  /**< pointer to raw packet   */
     uint8_t *token;                                   /**< pointer to token
                                                        * @deprecated Use coap_get_token(),
                                                        *     Will be removed after 2022.10. */
-    uint8_t *payload;                                 /**< pointer to payload      */
+    uint8_t *payload;                                 /**< pointer to end of the header */
     iolist_t *snips;                                  /**< payload snips (optional)*/
     uint16_t payload_len;                             /**< length of payload       */
     uint16_t options_len;                             /**< length of options array */

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -134,6 +134,7 @@
 
 #include "net/nanocoap.h"
 #include "net/sock/udp.h"
+#include "net/sock/util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -144,6 +145,17 @@ extern "C" {
  *
  */
 typedef sock_udp_t nanocoap_sock_t;
+
+/**
+ * @brief Blockwise request helper struct
+ */
+typedef struct {
+    nanocoap_sock_t sock;           /**< socket used for the request        */
+    const char *path;               /**< path on the server                 */
+    uint32_t blknum;                /**< current block number               */
+    uint8_t method;                 /**< request method (GET, POST, PUT)    */
+    uint8_t blksize;                /**< CoAP blocksize exponent            */
+} coap_block_request_t;
 
 /**
  * @brief   Start a nanocoap server instance
@@ -332,6 +344,87 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local,
 ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, void *buf,
                      size_t len);
 
+/**
+ * @brief   Initialize block request context
+ *
+ * @param[out]  ctx     The block request context to initialize
+ * @param[in]   remote  Server endpoint
+ * @param[in]   path    Server path for request
+ * @param[in]   method  Request method (`COAP_METHOD_{GET|PUT|POST}`)
+ * @param[in]   blksize Request blocksize exponent
+ *
+ * @retval      0       Success
+ * @retval      <0      Error (see @ref nanocoap_sock_connect for details)
+ */
+static inline int nanocoap_block_request_init(coap_block_request_t *ctx,
+                                              sock_udp_ep_t *remote,
+                                              const char *path,
+                                              uint8_t method,
+                                              coap_blksize_t blksize)
+{
+    ctx->path = path;
+    ctx->blknum = 0;
+    ctx->method = method;
+    ctx->blksize = blksize;
+    return nanocoap_sock_connect(&ctx->sock, NULL, remote);
+}
+
+/**
+ * @brief   Initialize block request context by URL
+ *
+ * @param[out]  ctx     The block request context to initialize
+ * @param[in]   url     The request URL
+ * @param[in]   method  Request method (`COAP_METHOD_{GET|PUT|POST}`)
+ * @param[in]   blksize Request blocksize exponent
+ *
+ * @retval      0       Success
+ * @retval      <0      Error (see @ref nanocoap_sock_url_connect for details)
+ */
+static inline int nanocoap_block_request_init_url(coap_block_request_t *ctx,
+                                                  const char *url,
+                                                  uint8_t method,
+                                                  coap_blksize_t blksize)
+{
+    ctx->path = sock_urlpath(url);
+    ctx->blknum = 0;
+    ctx->method = method;
+    ctx->blksize = blksize;
+    return nanocoap_sock_url_connect(url, &ctx->sock);
+}
+
+/**
+ * @brief   Free block request context
+ *
+ * @param[out]  ctx     The block request context to finalize
+ */
+static inline void nanocoap_block_request_done(coap_block_request_t *ctx)
+{
+    nanocoap_sock_close(&ctx->sock);
+}
+
+/**
+ * @brief   Do a block-wise request, send a single block.
+ *
+ *          This method is expected to be called in a loop until all
+ *          payload blocks have been transferred.
+ *
+ * @pre     @p ctx was initialized with @ref nanocoap_block_request_init or
+ *          @ref nanocoap_block_request_init_url
+ *
+ * @param[in]   ctx     blockwise request context
+ * @param[in]   data    payload to send
+ * @param[in]   len     payload length
+ * @param[in]   more    more blocks after this one
+ *                      (will be set automatically if @p len > block size)
+ * @param[in]   cb      callback for response
+ * @param[in]   arg     callback context
+ *
+ * @return      Number of payload bytes written on success
+ *              Negative error on failure
+ */
+int nanocoap_sock_block_request(coap_block_request_t *ctx,
+                                const void *data, size_t len, bool more,
+                                coap_request_cb_t cb, void *arg);
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -69,6 +69,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     pkt->payload = NULL;
     pkt->payload_len = 0;
     memset(pkt->opt_crit, 0, sizeof(pkt->opt_crit));
+    pkt->snips = NULL;
 
     if (len < sizeof(coap_hdr_t)) {
         DEBUG("msg too short\n");

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -31,11 +31,13 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 extern int nanotest_client_cmd(int argc, char **argv);
 extern int nanotest_client_url_cmd(int argc, char **argv);
 extern int nanotest_server_cmd(int argc, char **argv);
+extern int nanotest_client_put_cmd(int argc, char **argv);
 static int _list_all_inet6(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
     { "client", "CoAP client", nanotest_client_cmd },
     { "url", "CoAP client URL request", nanotest_client_url_cmd },
+    { "put", "experimental put", nanotest_client_put_cmd },
     { "server", "CoAP server", nanotest_server_cmd },
     { "inet6", "IPv6 addresses", _list_all_inet6 },
     { NULL, NULL, NULL }

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -29,6 +29,7 @@
 #include "net/nanocoap.h"
 #include "net/nanocoap_sock.h"
 #include "net/sock/udp.h"
+#include "net/sock/util.h"
 
 #include "od.h"
 
@@ -209,4 +210,59 @@ int nanotest_client_url_cmd(int argc, char **argv)
 error:
     printf("usage: %s <get|post|put> <url> [data]\n", argv[0]);
     return -1;
+}
+
+static const char song[] =
+    "Join us now and share the software;\n"
+    "You'll be free, hackers, you'll be free.\n"
+    "Join us now and share the software;\n"
+    "You'll be free, hackers, you'll be free.\n"
+    "\n"
+    "Hoarders can get piles of money,\n"
+    "That is true, hackers, that is true.\n"
+    "But they cannot help their neighbors;\n"
+    "That's not good, hackers, that's not good.\n"
+    "\n"
+    "When we have enough free software\n"
+    "At our call, hackers, at our call,\n"
+    "We'll kick out those dirty licenses\n"
+    "Ever more, hackers, ever more.\n"
+    "\n"
+    "Join us now and share the software;\n"
+    "You'll be free, hackers, you'll be free.\n"
+    "Join us now and share the software;\n"
+    "You'll be free, hackers, you'll be free.\n";
+
+int nanotest_client_put_cmd(int argc, char **argv)
+{
+    int res;
+    coap_block_request_t ctx;
+
+    if (argc < 2) {
+        printf("usage: %s <url>\n", argv[0]);
+        return 1;
+    }
+
+    res = nanocoap_block_request_init_url(&ctx, argv[1],
+                                          COAP_METHOD_PUT, COAP_BLOCKSIZE_32);
+    if (res < 0) {
+        printf("error: %d\n", res);
+        return res;
+    }
+
+    const char *pos = song;
+    size_t len = sizeof(song);
+
+    while (len) {
+        res = nanocoap_sock_block_request(&ctx, pos, len, 0, NULL, NULL);
+        if (res <= 0) {
+            puts(strerror(-res));
+            break;
+        }
+        len -= res;
+        pos += res;
+    }
+
+    nanocoap_block_request_done(&ctx);
+    return res;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This implements a `nanocoap_sock_block_request()` function for block-wise (block1) requests.
The function is expected to be called in a loop and will transmit a block each time it's called.

As an alternative to #17544 I simple added a `iolist_t *snips` to `coap_pkt_t` so we don't have to copy the payload into a temporary buffer and can leverage `sock_udp_sendv()` instead.


### Testing procedure

The `tests/nanocoap_cli` has been extended with a (crude) `put` command.
It will simply upload the lyrics of the Free Software Song via blockwise PUT, it can be used with

    put coap://[fe80::90a7:a6ff:fe4b:2e32%5]/song.txt

with

    aiocoap-fileserver --write .

on the other end.
This will be changed to instead integrate with `nanocoap_vfs` to upload files and integrate with the `url put/post` command, but I wanted to get some feedback on the API first.

### Issues/PRs references

