### PR TITLE
core: provide dummy implementation of thread and mutex for riotboot

### DIFF
--- a/core/Kconfig
+++ b/core/Kconfig
@@ -43,6 +43,10 @@ config MODULE_CORE_PANIC
     bool "Kernel crash handling module"
     default y
 
+config MODULE_CORE_THREAD
+    bool "Support for Threads"
+    default y
+
 config MODULE_CORE_THREAD_FLAGS
     bool "Thread flags"
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,5 +1,5 @@
 # exclude submodule sources from *.c wildcard source selection
-SRC := $(filter-out mbox.c msg.c msg_bus.c thread_flags.c,$(wildcard *.c))
+SRC := $(filter-out mbox.c msg.c msg_bus.c thread.c thread_flags.c,$(wildcard *.c))
 
 # enable submodules
 SUBMODULES := 1

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -97,7 +97,11 @@ extern "C" {
  * @brief The maximum number of threads to be scheduled
  */
 #ifndef MAXTHREADS
+#if defined(MODULE_CORE_THREAD)
 #define MAXTHREADS 32
+#else
+#define MAXTHREADS 0
+#endif
 #endif
 
 /**

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -325,7 +325,14 @@ void thread_sleep(void);
  *
  * @see     thread_yield_higher()
  */
+#if defined(MODULE_CORE_THREAD) || DOXYGEN
 void thread_yield(void);
+#else
+static inline void thread_yield(void)
+{
+    /* NO-OP */
+}
+#endif
 
 /**
  * @brief   Lets current thread yield in favor of a higher prioritized thread.
@@ -436,7 +443,15 @@ void thread_add_to_list(list_node_t *list, thread_t *thread);
  * @return          the threads name
  * @return          `NULL` if pid is unknown
  */
+#if defined(MODULE_CORE_THREAD) || DOXYGEN
 const char *thread_getname(kernel_pid_t pid);
+#else
+static inline const char *thread_getname(kernel_pid_t pid)
+{
+    (void)pid;
+    return "(none)";
+}
+#endif
 
 /**
  * @brief Measures the stack usage of a stack

--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -89,10 +89,16 @@ void kernel_init(void)
                       idle_thread, NULL, "idle");
     }
 
-    thread_create(main_stack, sizeof(main_stack),
-                  THREAD_PRIORITY_MAIN,
-                  THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-                  main_trampoline, NULL, "main");
+    if (IS_USED(MODULE_CORE_THREAD)) {
+        thread_create(main_stack, sizeof(main_stack),
+                      THREAD_PRIORITY_MAIN,
+                      THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                      main_trampoline, NULL, "main");
+    }
+    else {
+        irq_enable();
+        main_trampoline(NULL);
+    }
 
     cpu_switch_context_exit();
 }

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -33,6 +33,8 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#if MAXTHREADS > 1
+
 /**
  * @brief   Block waiting for a locked mutex
  * @pre     IRQs are disabled
@@ -226,3 +228,7 @@ int mutex_trylock_ffi(mutex_t *mutex)
 {
     return mutex_trylock(mutex);
 }
+
+#else /* MAXTHREADS < 2 */
+typedef int dont_be_pedantic;
+#endif

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -1,6 +1,6 @@
 DEFAULT_MODULE += board board_common_init \
                   cpu \
-                  core core_init core_lib core_msg core_panic \
+                  core core_init core_lib core_msg core_panic core_thread \
                   sys
 
 # Include potentially added default modules by the board


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Riotboot does not enter thread mode.
It can still be desirable to use periph code in this environment, e.g. SPI drivers that make use of mutex.
Since there are no threads, the implementation can be very simple: Busy wait on lock with the expectation to be un-locked from e.g. the TX complete ISR.

`mtd_spi_nor` nakes use of `thread_yield()` so provide a dummy implementation of that which is simple a no-op.

### Testing procedure

Add 

    DISABLE_MODULE += core_thread

to some single-threaded tests. You might have to bump `ISR_STACKSIZE`.


### Issues/PRs references

split off #17379
