### PR TITLE
nanocoap_sock: add nanocoap_sock_url_connect()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -173,6 +173,17 @@ int nanocoap_sock_connect(nanocoap_sock_t *sock, sock_udp_ep_t *local,
                           sock_udp_ep_t *remote);
 
 /**
+ * @brief   Create a CoAP client socket by URL
+ *
+ * @param[in]   url     URL with server information to connect to
+ * @param[out]  sock    CoAP UDP socket
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+int nanocoap_sock_url_connect(const char *url, nanocoap_sock_t *sock);
+
+/**
  * @brief   Close a CoAP client socket
  *
  * @param[in]  sock     CoAP UDP socket

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -103,6 +103,16 @@ static inline int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint,
 int sock_urlsplit(const char *url, char *hostport, char *urlpath);
 
 /**
+ * @brief   Returns a pointer to the path component in @p url
+ *
+ * @param[in]   url         URL to examine. Must not be NULL.
+ *
+ * @returns     pointer to the start of the path component in @p url
+ * @returns     NULL if @p url is invalid
+ */
+const char *sock_urlpath(const char *url);
+
+/**
  * @brief    Convert string to common IP-based transport layer endpoint
  *
  * Takes eg., "[2001:db8::1]:1234" and converts it into the corresponding UDP

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -149,6 +149,17 @@ int sock_urlsplit(const char *url, char *hostport, char *urlpath)
     return 0;
 }
 
+const char *sock_urlpath(const char *url)
+{
+    assert(url);
+    char *hoststart = _find_hoststart(url);
+    if (!hoststart) {
+        return NULL;
+    }
+
+    return _find_pathstart(hoststart);
+}
+
 int _parse_port(sock_udp_ep_t *ep_out, const char *portstart)
 {
     int port_len = strlen(portstart);

--- a/tests/unittests/tests-sock_util/tests-sock_util.c
+++ b/tests/unittests/tests-sock_util/tests-sock_util.c
@@ -114,6 +114,7 @@ static void test_sock_util_urlsplit__host_path(void)
             sock_urlsplit(TEST_URL, addr, urlpath));
     TEST_ASSERT_EQUAL_STRING(TEST_URL_HOSTPART, (char*)addr);
     TEST_ASSERT_EQUAL_STRING(TEST_URL_LOCALPART, (char*)urlpath);
+    TEST_ASSERT_EQUAL_STRING(TEST_URL_LOCALPART, sock_urlpath(TEST_URL));
 }
 
 static void test_sock_util_urlsplit__no_path(void)
@@ -130,18 +131,21 @@ static void test_sock_util_urlsplit__dnsname(void)
             sock_urlsplit(TEST_URL_DNS, addr, urlpath));
     TEST_ASSERT_EQUAL_STRING(TEST_URL_DNS_HOSTPART, (char*)addr);
     TEST_ASSERT_EQUAL_STRING(TEST_URL_LOCALPART, (char*)urlpath);
+    TEST_ASSERT_EQUAL_STRING(TEST_URL_LOCALPART, sock_urlpath(TEST_URL));
 }
 
 static void test_sock_util_urlsplit__invalid_sep(void)
 {
     TEST_ASSERT_EQUAL_INT(-EINVAL,
             sock_urlsplit(TEST_URL_INVALID, addr, urlpath));
+    TEST_ASSERT_NULL(sock_urlpath(TEST_URL_INVALID));
 }
 
 static void test_sock_util_urlsplit__no_schema(void)
 {
     TEST_ASSERT_EQUAL_INT(-EINVAL,
             sock_urlsplit(TEST_URL_INVALID2, addr, urlpath));
+    TEST_ASSERT_NULL(sock_urlpath(TEST_URL_INVALID2));
 }
 
 static void test_sock_util_urlsplit__hostport_too_long(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This introduces a `sock_urlpath()` function that just returns a pointer to the path component of a URL without having to copy it.

This moves the URL parsing code out of `nanocoap_get_blockwise_url()` into `nanocoap_sock_url_connect()` and save some stack by not having to allocate a `CONFIG_SOCK_URLPATH_MAXLEN` sized buffer there.

### Testing procedure

The `url` command in `tests/nanocoap_cli` still works


```
main(): This is RIOT! (Version: 2022.07-devel-91-g135d3-sock_urlpath)
nanocoap test app
All up, running the shell now
> url get coap://[fe80::90a7:a6ff:fe4b:2e32%5]/.well-known/core
url get coap://[fe80::90a7:a6ff:fe4b:2e32%5]/.well-known/core
offset 000: </>;ct=40;rt="tag:chrysn@fsfe.or
offset 032: g,2022:fileserver"
```

### Issues/PRs references

useful for #17962, #17937
