### PR TITLE
doc: fix broken link/footnote in using-rust.md/maintenance

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -153,4 +153,4 @@ Dealing with this,
 and other aspects of maintenance of the crates,
 is described in [the `rust_minimal` test's README].
 
-[the `rust_minimal` test's README]: (https://github.com/RIOT-OS/RIOT/blob/master/tests/rust_minimal/README.md).
+[the `rust_minimal` test's README]: https://github.com/RIOT-OS/RIOT/blob/master/tests/rust_minimal/README.md


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fixed a footnote in the ["Using Rust in RIOT"](https://doc.riot-os.org/using-rust.html) section of the documentation, that pointed to the [rust_minimal test's README](https://github.com/RIOT-OS/RIOT/blob/master/tests/rust_minimal/README.md).


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

The (current) live version of the [Using Rust](https://doc.riot-os.org/using-rust.html) page's link tag is

```html
<a href="(https://github.com/RIOT-OS/RIOT/blob/master/tests/rust_minimal/README.md).">
```

After this change, using `make doc` regenerates it to
```html
<a href="https://github.com/RIOT-OS/RIOT/blob/master/tests/rust_minimal/README.md">
```

### Issues/PRs references

I have not found any existing Issue/PR for this.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
