### PR TITLE
nanocoap_vfs: add nanocoap_vfs_put()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -86,6 +86,7 @@
 #include <unistd.h>
 
 #ifdef RIOT_VERSION
+#include "bitarithm.h"
 #include "bitfield.h"
 #include "byteorder.h"
 #include "iolist.h"
@@ -987,6 +988,19 @@ bool coap_has_unprocessed_critical_options(const coap_pkt_t *pkt);
 static inline unsigned coap_szx2size(unsigned szx)
 {
     return (1 << (szx + 4));
+}
+
+/**
+ * @brief   Helper to encode byte size into next equal or smaller SZX value
+ *
+ * @param[in]   len     Size in bytes
+ *
+ * @returns     closest SZX value that fits into a buffer of @p len
+ */
+static inline unsigned coap_size2szx(unsigned len)
+{
+    assert(len >= 16);
+    return bitarithm_msb(len >> 4);
 }
 /**@}*/
 

--- a/sys/include/net/nanocoap_vfs.h
+++ b/sys/include/net/nanocoap_vfs.h
@@ -51,6 +51,37 @@ int nanocoap_vfs_get_url(const char *url, const char *dst);
  */
 int nanocoap_vfs_get(nanocoap_sock_t *sock, const char *path, const char *dst);
 
+/**
+ * @brief   Uploads the @p file to @p url via blockwise PUT.
+ *
+ * @param[in]   url          URL to the resource
+ * @param[in]   src          Path to the source file
+ * @param[in]   work_buf     Buffer to read file blocks into
+ * @param[in]   work_buf_len Size of the buffer. Should be 1 byte more
+ *                           than the desired CoAP blocksize.
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+int nanocoap_vfs_put_url(const char *url, const char *src,
+                         void *work_buf, size_t work_buf_len);
+
+/**
+ * @brief   Uploads the @p file to @p path via blockwise PUT.
+ *
+ * @param[in]   sock         Connection to the server
+ * @param[in]   path         Remote query path to the resource
+ * @param[in]   src          Path to the source file
+ * @param[in]   work_buf     Buffer to read file blocks into
+ * @param[in]   work_buf_len Size of the buffer. Should be 1 byte more
+ *                           than the desired CoAP blocksize.
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+int nanocoap_vfs_put(nanocoap_sock_t *sock, const char *path, const char *src,
+                     void *work_buf, size_t work_buf_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/application_layer/nanocoap/vfs.c
+++ b/sys/net/application_layer/nanocoap/vfs.c
@@ -19,7 +19,7 @@
  */
 
 #include <fcntl.h>
-#include "net/nanocoap_sock.h"
+#include "net/nanocoap_vfs.h"
 #include "net/sock/util.h"
 #include "vfs.h"
 
@@ -91,4 +91,69 @@ int nanocoap_vfs_get_url(const char *url, const char *dst)
     res = nanocoap_get_blockwise_url(url, CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT,
                                      _2file, &fd);
     return _finalize_file(fd, res, dst, dst_tmp);
+}
+
+static int _vfs_put(coap_block_request_t *ctx, const char *file, void *buffer)
+{
+    int res, fd = vfs_open(file, O_RDONLY, 0644);
+    if (fd < 0) {
+        return fd;
+    }
+
+    /* buffer is at least one larger than SZX value */
+    int buffer_len = coap_szx2size(ctx->blksize) + 1;
+
+    bool more = true;
+    while (more && (res = vfs_read(fd, buffer, buffer_len)) > 0) {
+        more = res == buffer_len;
+        res = nanocoap_sock_block_request(ctx, buffer,
+                                          res, more, NULL, NULL);
+        if (res < 0) {
+            break;
+        }
+        vfs_lseek(fd, -1, SEEK_CUR);
+    }
+
+    nanocoap_block_request_done(ctx);
+
+    vfs_close(fd);
+    return res;
+}
+
+int nanocoap_vfs_put(nanocoap_sock_t *sock, const char *path, const char *src,
+                     void *work_buf, size_t work_buf_len)
+{
+    DEBUG("nanocoap: uploading %s to %s\n", src, path);
+
+    if (work_buf_len < coap_szx2size(0) + 1) {
+        return -ENOBUFS;
+    }
+
+    coap_block_request_t ctx = {
+        .path = path,
+        .method = COAP_METHOD_PUT,
+        .blksize = coap_size2szx(work_buf_len - 1),
+        .sock = *sock,
+    };
+
+    return _vfs_put(&ctx, src, work_buf);
+}
+
+int nanocoap_vfs_put_url(const char *url, const char *src,
+                         void *work_buf, size_t work_buf_len)
+{
+    DEBUG("nanocoap: uploading %s to %s\n", src, url);
+
+    if (work_buf_len < coap_szx2size(0) + 1) {
+        return -ENOBUFS;
+    }
+
+    coap_block_request_t ctx;
+    int res = nanocoap_block_request_init_url(&ctx, url, COAP_METHOD_PUT,
+                                              coap_size2szx(work_buf_len - 1));
+    if (res) {
+        return res;
+    }
+
+    return _vfs_put(&ctx, src, work_buf);
 }

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -27,6 +27,9 @@ ifeq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   # USEMODULE += vfs_auto_format
   USEMODULE += shell_commands
 
+  # VFS operations require more stack on the main thread
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
+
   # always enable auto-format for native
   ifeq ($(BOARD),native)
     USEMODULE += vfs_auto_format


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a function to upload a file from VFS to a CoAP server via block-wise PUT request.

### Testing procedure

You can test this with `aiocoap-fileserver -w`:

#### download a file from the CoAP server

```
> ncget coap://[fe80::2454:cfff:fea7:4598]/LICENSE
Saved as /nvm0/LICENSE
```

#### upload the file again under a different name

```
> ncput /nvm0/LICENSE coap://[fe80::2454:cfff:fea7:4598]/LICENSE-2
Saved to coap://[fe80::2454:cfff:fea7:4598]/LICENSE-2
```

#### the files should be identical

```
$ md5sum LICENSE*
a4ce26a8dcc018faa99a6cd08cbcd1c3  LICENSE
a4ce26a8dcc018faa99a6cd08cbcd1c3  LICENSE-2
```

### Issues/PRs references

depends on ~~#17937~~, ~~#17960~~, ~~#17958~~
