### PR TITLE
examples/suit_udpate: update check suit command

### DIFF
--- a/examples/suit_update/tests-with-config/01-run.py
+++ b/examples/suit_update/tests-with-config/01-run.py
@@ -186,7 +186,7 @@ def _test_successful_update(child, client, app_ver):
 
 def _test_suit_command_is_there(child):
     child.sendline('suit')
-    child.expect_exact("Usage: suit <manifest url>")
+    child.expect_exact("Usage: suit fetch <manifest url>")
 
 
 def testfunc(child):


### PR DESCRIPTION
### Contribution description

Cleanup from #17941 where I didn't realize the test-checked for the cmd being there.

### Testing procedure

`examples/suit_update` is still failing but the issue is another, as it fails to verify the signature after the first slot update...

```
riotboot-hdr

>
>
>
> riotboot-hdr
Image magic_number: 0x544f4952
Image Version: 0x625e98d3
Image start address: 0x00001100
Header chksum: 0x09e4a9d3

> ifconfig
ifconfig
Iface  4  HWaddr: AA:04:26:28:76:39
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::a804:26ff:fe28:7639  scope: link  VAL
pinging node...
PING fe80::a804:26ff:fe28:7639%riot0(fe80::a804:26ff:fe28:7639%riot0) 56 data bytes

--- fe80::a804:26ff:fe28:7639%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 40.695/40.695/40.695/0.000 ms
pinging node succeeded.
suit
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff28:7639
          inet6 group: ff02::1:ff00:2

> suit
Usage: suit fetch <manifest url>
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366676.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366676.riot.bin...
suit: generating key in /home/francisco/workspace/RIOT/keys
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1650366676.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.1650366676.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366676.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot0.1650366676.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366676.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot1.1650366676.riot.bin"
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
aiocoap-client -m POST "coap://[fe80::a804:26ff:fe28:7639%riot0]/suit/trigger" \
        --payload "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin" && \
        echo "Triggered [fe80::a804:26ff:fe28:7639%riot0] to update."
Triggered [fe80::a804:26ff:fe28:7639%riot0] to update.
       suit seq_no
> suit: received URL: "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
Unable to validate signature: -2
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366674.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366674.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1650366674.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.1650366674.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1650366674.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366674.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366674.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot0.1650366674.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366674.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot1.1650366674.riot.bin"
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
aiocoap-client -m POST "coap://[fe80::a804:26ff:fe28:7639%riot0]/suit/trigger" \
        --payload "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366674.bin" && \
        echo "Triggered [fe80::a804:26ff:fe28:7639%riot0] to update."
Triggered [fe80::a804:26ff:fe28:7639%riot0] to update.
suit_parse() failed. res=-6
suit: received URL: "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366674.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366674.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1650366674, highest available: 1650366675
seq_nr <= running image
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366676.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366676.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1650366676.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.1650366676.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366676.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot0.1650366676.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366676.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot1.1650366676.riot.bin"
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
aiocoap-client -m POST "coap://[fe80::a804:26ff:fe28:7639%riot0]/suit/trigger" \
        --payload "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin" && \
        echo "Triggered [fe80::a804:26ff:fe28:7639%riot0] to update."
Triggered [fe80::a804:26ff:fe28:7639%riot0] to update.
)suit_parse() failed. res=-5
suit: received URL: "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366676.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
suit: validated manifest version
)Manifest seq_no: 1650366676, highest available: 1650366675
suit: validated sequence number
)Formatted component name:
Comparing manifest offset 1000 with other slot offset
Comparing manifest offset 20800 with other slot offset
validating vendor ID
Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
validating vendor ID: OK
validating class id
Comparing 8818989e-a257-5994-ac9a-554b77898083 to 8818989e-a257-5994-ac9a-554b77898083 from manifest
validating class id: OK
Comparing manifest offset 1000 with other slot offset
Comparing manifest offset 20800 with other slot offset
SUIT policy check OK.
Formatted component name:
riotboot_flashwrite: initializing update to target slot 1
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
Image magic_number: 0x544f4952
Image Version: 0x625e98d4
Image start address: 0x00020900
Header chksum: 0xf9e9a1d6

suit_coap: rebooting...


----> ethos: hello received
Failed to send flush request: Operation not permitted
gnrc_uhcpc: Using 4 as border interface and 0 as wireless interface.
current-slot
gnrc_uhcpc: only one interface found, skipping setup.
main(): This is RIOT! (Version: 2022.07-devel-108-g0d984e-pr_update_check_sui)
RIOT SUIT update example application
Running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x625e98d4
Image start address: 0x00020900
Header chksum: 0xf9e9a1d6

suit_coap: started.
Starting the shell
>
>
> ifconfig
current-slot
Running from slot 1
> ifconfig
Iface  4  HWaddr: AA:04:26:28:76:39
          L2-PDU:1500  MTU:1500  HL:64  RTR
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::a804:26ff:fe28:7639  scope: link  VAL
pinging node...
PING fe80::a804:26ff:fe28:7639%riot0(fe80::a804:26ff:fe28:7639%riot0) 56 data bytes

--- fe80::a804:26ff:fe28:7639%riot0 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 42.016/42.016/42.016/0.000 ms
pinging node succeeded.
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
compiling /home/francisco/workspace/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366677.riot.bin...
creating /home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366677.riot.bin...
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.1650366677.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.1650366677.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.1650366677.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366677.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.latest.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot0.1650366677.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot0.1650366677.riot.bin"
published "/home/francisco/workspace/RIOT/examples/suit_update/bin/samr21-xpro/suit_update-slot1.1650366677.riot.bin"
       as "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-slot1.1650366677.riot.bin"
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
aiocoap-client -m POST "coap://[fe80::a804:26ff:fe28:7639%riot0]/suit/trigger" \
        --payload "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366677.bin" && \
        echo "Triggered [fe80::a804:26ff:fe28:7639%riot0] to update."
Triggered [fe80::a804:26ff:fe28:7639%riot0] to update.
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff28:7639
          inet6 group: ff02::1:ff00:2

> suit: received URL: "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366677.bin"
suit_coap: trigger received
suit_coap: downloading "coap://[fd00:dead:beef::1]/fw/samr21-xpro/suit_update-riot.suit_signed.1650366677.bin"
suit_coap: got manifest with size 507
suit: verifying manifest signature
Unable to validate signature: -2
suit_parse() failed. res=-6
```

Skipping build test as the test is currently not run on ci...