### PR TITLE
drivers/mtd_flashpage: fix address mapping

### DIFF
--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -49,26 +49,26 @@ static int _init(mtd_dev_t *dev)
 
 static int _read(mtd_dev_t *dev, void *buf, uint32_t addr, uint32_t size)
 {
-    addr = _mtd_to_flashpage_addr(addr);
+    const uword_t flash_addr = _mtd_to_flashpage_addr(addr);
 
-    assert(addr < MTD_FLASHPAGE_END_ADDR);
+    assert(flash_addr < MTD_FLASHPAGE_END_ADDR);
 
     (void)dev;
 
 #ifndef CPU_HAS_UNALIGNED_ACCESS
-    if (addr % sizeof(uword_t)) {
+    if (flash_addr % sizeof(uword_t)) {
         return -EINVAL;
     }
 #endif
 
-    memcpy(buf, (void *)addr, size);
+    memcpy(buf, (void *)flash_addr, size);
 
     return 0;
 }
 
 static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
 {
-    addr = _mtd_to_flashpage_addr(addr);
+    const uword_t flash_addr = _mtd_to_flashpage_addr(addr);
 
     (void)dev;
 
@@ -77,30 +77,30 @@ static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
         return -EINVAL;
     }
 #endif
-    if (addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) {
+    if (flash_addr % FLASHPAGE_WRITE_BLOCK_ALIGNMENT) {
         return -EINVAL;
     }
     if (size % FLASHPAGE_WRITE_BLOCK_SIZE) {
         return -EOVERFLOW;
     }
-    if (addr + size > MTD_FLASHPAGE_END_ADDR) {
+    if (flash_addr + size > MTD_FLASHPAGE_END_ADDR) {
         return -EOVERFLOW;
     }
 
-    flashpage_write((void *)addr, buf, size);
+    flashpage_write((void *)flash_addr, buf, size);
 
     return 0;
 }
 
 int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 {
-    addr = _mtd_to_flashpage_addr(addr);
+    const uword_t flash_addr = _mtd_to_flashpage_addr(addr);
     size_t sector_size = dev->page_size * dev->pages_per_sector;
 
     if (size % sector_size) {
         return -EOVERFLOW;
     }
-    if (addr + size > MTD_FLASHPAGE_END_ADDR) {
+    if (flash_addr + size > MTD_FLASHPAGE_END_ADDR) {
         return -EOVERFLOW;
     }
     if (addr % sector_size) {
@@ -108,7 +108,7 @@ int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
     }
 
     for (size_t i = 0; i < size; i += sector_size) {
-        flashpage_erase(flashpage_page((void *)(addr + i)));
+        flashpage_erase(flashpage_page((void *)(flash_addr + i)));
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

The MTD driver assumes an address space 0-N. The flashpage driver operates on CPU's address space. The `mtd_flashpage` driver does not account for this. It passes addresses strait through. The entire CPU's address space is mapped as an MTD, flash, RAM, registers, and all. After looking at `tests/mtd_flashpage/main.c` I believe the intent was to have `mtd_flashpage` do this mapping.

This PR is a DRAFT meant to trigger a discussion of if it is the right fix. One could argue that breaking the current behavior is too disruptive of existing applications, and that the right fix would be to adopt the current behavior of the driver and change the tests to match it. There is also value in the current behavior. Many applications using `mtd_flashpage` will also use `mtd_mapper`. Since `mtd_mapper` needs a starting sector, it is convenient to set this in terms of the CPU's address space


### Testing procedure

TBD

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

none known

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
