### PR TITLE
examples/lorawan: disable loramac state persistence on EEPROM

### DIFF
--- a/examples/lorawan/Makefile
+++ b/examples/lorawan/Makefile
@@ -44,7 +44,13 @@ USEPKG += semtech-loramac
 USEMODULE += $(DRIVER)
 USEMODULE += fmt
 FEATURES_OPTIONAL += periph_rtc
-FEATURES_OPTIONAL += periph_eeprom
+
+# Uncomment the following line to enable Loramac stack state persistence on EEPROM.
+# Make sure the EEPROM is erased before enabling this and when flashing a board
+# with an EEPROM the first time. If the board already contains a previous Loramac state
+# in its EEPROM that is not corresponding to your LoRaWAN application settings,
+# joining a network will fail.
+# FEATURES_OPTIONAL += periph_eeprom
 
 CFLAGS += -DSEND_PERIOD_S=$(SEND_PERIOD_S)
 ifeq (otaa,$(ACTIVATION_MODE))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is an attempt to fix the problem with `examples/loramac` raised in the 2022.04 release tests when the EEPROM of a board under test already contains a loramac stack state from a previous user.

The proposed fix is to simply disable the use of `periph_eeprom` by default. This way no previously stored stack state is reloaded and the test should succeed in any case.

A comment is added to explain how to reenable that feature and how to avoid the same issues as in the release tests.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green CI
- `make test-with-config` should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This is an attempt to fix the LoRaWAN failing release tests: https://github.com/RIOT-OS/Release-Specs/issues/244
Might also fix #17907

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
