### PR TITLE
examples/suit_update/test: use 'suit seq_no' to get version

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/sys.py
+++ b/dist/pythonlibs/riotctrl_shell/sys.py
@@ -43,13 +43,13 @@ class Version(ShellInteraction):
 
 class SUITSequenceNoParser(ShellInteractionParser):
     def __init__(self):
-        self.c_seq_no = re.compile(r"seq_no: (?P<seq_no>\d+)$")
+        self.c_seq_no = re.compile(r"seq_no: (?P<seq_no>0x[0-9a-fA-F:]+)$")
 
     def parse(self, cmd_output):
         for line in cmd_output.splitlines():
             m = self.c_seq_no.search(line)
             if m is not None:
-                return int(m.group("seq_no"))
+                return int(m.group("seq_no"), 16)
         return None
 
 

--- a/dist/pythonlibs/riotctrl_shell/tests/test_sys.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_sys.py
@@ -44,11 +44,11 @@ def test_suit_fetch():
 def test_suit_sequence_no():
     rc = init_ctrl(
         output="""
-seq_no: 123456789
+seq_no: 0x12345678
     """
     )
     si = riotctrl_shell.sys.SUIT(rc)
     res = si.suit_sequence_no()
     parser = riotctrl_shell.sys.SUITSequenceNoParser()
     # mock just returns last input
-    assert parser.parse(res) == 123456789
+    assert parser.parse(res) == 0x12345678

--- a/examples/suit_update/tests-with-config/01-run.py
+++ b/examples/suit_update/tests-with-config/01-run.py
@@ -123,20 +123,19 @@ def get_reachable_addr(child):
     return "[{}]".format(client_addr)
 
 
-def app_version(child):
+def seq_no(child):
     utils.test_utils_interactive_sync_shell(child, 5, 1)
     # get version of currently running image
-    # "Image Version: 0x00000000"
-    child.sendline('riotboot-hdr')
-    child.expect(r"Image Version: (?P<app_ver>0x[0-9a-fA-F:]+)\r\n")
-    app_ver = int(child.match.group("app_ver"), 16)
+    # "seq_no: 0x00000000"
+    child.sendline('suit seq_no')
+    child.expect(r"seq_no: (?P<seq_no>0x[0-9a-fA-F:]+)\r\n")
+    app_ver = int(child.match.group("seq_no"), 16)
     return app_ver
 
 
 def running_slot(child):
     utils.test_utils_interactive_sync_shell(child, 5, 1)
-    # get version of currently running image
-    # "Image Version: 0x00000000"
+
     child.sendline('current-slot')
     child.expect(r"Running from slot (\d+)\r\n")
     slot = int(child.match.group(1))
@@ -191,7 +190,7 @@ def _test_suit_command_is_there(child):
 
 def testfunc(child):
     # Get current app_ver
-    current_app_ver = app_version(child)
+    current_app_ver = seq_no(child)
     # Verify client is reachable and get address
     client = get_reachable_addr(child)
 

--- a/examples/suit_update/tests-with-config/01-run.py
+++ b/examples/suit_update/tests-with-config/01-run.py
@@ -143,8 +143,8 @@ def running_slot(child):
 
 
 def _test_invalid_version(child, client, app_ver):
-    publish(TMPDIR.name, COAP_HOST, app_ver - 1)
-    notify(COAP_HOST, client, app_ver - 1)
+    publish(TMPDIR.name, COAP_HOST, app_ver)
+    notify(COAP_HOST, client, app_ver)
     child.expect_exact("suit_coap: trigger received")
     child.expect_exact("suit: verifying manifest signature")
     child.expect_exact("seq_nr <= running image")

--- a/sys/shell/commands/sc_suit.c
+++ b/sys/shell/commands/sc_suit.c
@@ -44,7 +44,7 @@ int _suit_handler(int argc, char **argv)
     else if (strcmp(argv[1], "seq_no") == 0) {
         uint32_t seq_no = 0;
         suit_storage_get_highest_seq_no(&seq_no);
-        printf("seq_no: %" PRIu32 "\n", seq_no);
+        printf("seq_no: 0x%08" PRIx32 "\n", seq_no);
     }
     else {
         _print_usage(argv);


### PR DESCRIPTION
### Contribution description

Follow-up to #17941, it changes the `examples/suit_update` teste to use the `suit seq_no` command and adapts that command formatting to be as `riotboot` hdr dump.

### Testing procedure

- murdock should test the `shell` changes
- `exmples/suit_update` rebase on #17950

### Issues/PRs references

Depends on #17950 since the current SUIT CoAP is broken.
