### PR TITLE
pm: don't (un)block IDLE mode

### DIFF
--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -154,7 +154,7 @@ int main(void)
      * in general provides RAM retention after wake-up.
      */
 #if IS_USED(MODULE_PM_LAYERED)
-    for (unsigned i = 1; i < PM_NUM_MODES; ++i) {
+    for (unsigned i = 1; i < PM_NUM_MODES - 1; ++i) {
         pm_unblock(i);
     }
 #endif

--- a/pkg/openwsn/contrib/board.c
+++ b/pkg/openwsn/contrib/board.c
@@ -49,8 +49,8 @@ void board_init_openwsn(void)
     LOG_DEBUG("[openwsn/board]: init\n");
 
 #ifdef MODULE_PM_LAYERED
-    /* sleeping is currently not supported, block all sleep modes */
-    for (uint8_t i = 0; i < PM_NUM_MODES; i++) {
+    /* sleeping is currently not supported, block all sleep modes except IDLE */
+    for (uint8_t i = 0; i < PM_NUM_MODES - 1; i++) {
         pm_block(i);
     }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is already unblocked and will trigger an assertion.
The code is still broken as other modes might be unblocked too, but at least it is just as broken as it was before #17895



### Testing procedure

`examples/lorawan` should no longer crash on most boards.
(should still crash on samd21 boards as it would since ed9f740edde87fb69ed2a214ed6348024088fa2f)

### Issues/PRs references

follow-up to #17895
