### PR TITLE
nanocoap: add coap_get_token()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -396,6 +396,18 @@ static inline unsigned coap_get_token_len(const coap_pkt_t *pkt)
 }
 
 /**
+ * @brief   Get pointer to a message's token
+ *
+ * @param[in]   pkt   CoAP packet
+ *
+ * @returns     pointer to the token position
+ */
+static inline void *coap_get_token(const coap_pkt_t *pkt)
+{
+    return (uint8_t*)pkt->hdr + sizeof(coap_hdr_t);
+}
+
+/**
  * @brief   Get the total header length (4-byte header + token length)
  *
  * @param[in]   pkt   CoAP packet

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -292,7 +292,7 @@ static int _gcoap_forward_proxy_via_coap(coap_pkt_t *client_pkt,
     pkt.hdr->id = client_pkt->hdr->id;
 
     if (token_len) {
-        memcpy(pkt.token, client_pkt->token, token_len);
+        memcpy(coap_get_token(&pkt), coap_get_token(client_pkt), token_len);
     }
 
     /* copy all options from client_pkt to pkt */

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -608,7 +608,7 @@ static size_t _handle_req(gcoap_socket_t *sock, coap_pkt_t *pdu, uint8_t *buf,
             memo->token_len = coap_get_token_len(pdu);
             memo->socket = *sock;
             if (memo->token_len) {
-                memcpy(&memo->token[0], pdu->token, memo->token_len);
+                memcpy(&memo->token[0], coap_get_token(pdu), memo->token_len);
             }
             DEBUG("gcoap: Registered observer for: %s\n", memo->resource->path);
         }
@@ -803,7 +803,7 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
             }
         } else if (coap_get_token_len(memo_pdu) == cmplen) {
             memo_pdu->token = coap_hdr_data_ptr(memo_pdu->hdr);
-            if ((memcmp(src_pdu->token, memo_pdu->token, cmplen) == 0)
+            if ((memcmp(coap_get_token(src_pdu), memo_pdu->token, cmplen) == 0)
                     && sock_udp_ep_equal(&memo->remote_ep, remote)) {
                 *memo_ptr = memo;
                 break;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -504,7 +504,7 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
         }
     }
 
-    coap_build_hdr((coap_hdr_t *)rbuf, type, pkt->token, tkl, code,
+    coap_build_hdr((coap_hdr_t *)rbuf, type, coap_get_token(pkt), tkl, code,
                    ntohs(pkt->hdr->id));
     coap_hdr_set_type((coap_hdr_t *)rbuf, type);
     coap_hdr_set_code((coap_hdr_t *)rbuf, code);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a `coap_get_token()` function so we can eventually get rid of the token pointer in `coap_pkt_t`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
