### PR TITLE
net/nanocoap: remove coap_pkt token ptr

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -225,9 +225,6 @@ typedef struct {
  */
 typedef struct {
     coap_hdr_t *hdr;                                  /**< pointer to raw packet   */
-    uint8_t *token;                                   /**< pointer to token
-                                                       * @deprecated Use coap_get_token(),
-                                                       *     Will be removed after 2022.10. */
     uint8_t *payload;                                 /**< pointer to end of the header */
     iolist_t *snips;                                  /**< payload snips (optional)*/
     uint16_t payload_len;                             /**< length of payload       */

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -865,8 +865,7 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
                 break;
             }
         } else if (coap_get_token_len(memo_pdu) == cmplen) {
-            memo_pdu->token = coap_hdr_data_ptr(memo_pdu->hdr);
-            if ((memcmp(coap_get_token(src_pdu), memo_pdu->token, cmplen) == 0)
+            if ((memcmp(coap_get_token(src_pdu), coap_get_token(memo_pdu), cmplen) == 0)
                     && (sock_udp_ep_equal(&memo->remote_ep, remote)
                       /* Multicast addresses are not considered in matching responses */
                       || _memo_ep_is_multicast(memo)
@@ -977,15 +976,14 @@ static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
                 *memo = &_coap_state.observe_memos[i];
                 break;
             }
-
-            if (_coap_state.observe_memos[i].token_len == coap_get_token_len(pdu)) {
-                unsigned cmplen = _coap_state.observe_memos[i].token_len;
-                if (cmplen &&
-                        memcmp(&_coap_state.observe_memos[i].token[0], &pdu->token[0],
-                                                                       cmplen) == 0) {
-                    *memo = &_coap_state.observe_memos[i];
-                    break;
-                }
+            unsigned memo_token_len = _coap_state.observe_memos[i].token_len;
+            if (memo_token_len == coap_get_token_len(pdu)
+                && memo_token_len
+                && memcmp(&_coap_state.observe_memos[i].token[0],
+                          coap_get_token(pdu),
+                          memo_token_len) == 0) {
+                *memo = &_coap_state.observe_memos[i];
+                break;
             }
         }
     }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -80,19 +80,12 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
         return -EBADMSG;
     }
 
-    /* token value (tkl bytes) */
-    if (coap_get_token_len(pkt) == 0) {
-        pkt->token = NULL;
-    }
-    else if (coap_get_token_len(pkt) <= COAP_TOKEN_LENGTH_MAX) {
-        pkt->token = pkt_pos;
-        /* pkt_pos range is validated after options parsing loop below */
-        pkt_pos += coap_get_token_len(pkt);
-    }
-    else {
+    if (coap_get_token_len(pkt) > COAP_TOKEN_LENGTH_MAX) {
         DEBUG("nanocoap: token length invalid\n");
         return -EBADMSG;
     }
+    /* pkt_pos range is validated after options parsing loop below */
+    pkt_pos += coap_get_token_len(pkt);
 
     coap_optpos_t *optpos = pkt->options;
     unsigned option_count = 0;
@@ -360,7 +353,7 @@ ssize_t coap_opt_get_string(coap_pkt_t *pkt, uint16_t optnum,
             target += opt_len;
             left -= (opt_len + 1);
         }
-    } while(opt_pos);
+    } while (opt_pos);
 
     *target = '\0';
 
@@ -544,7 +537,6 @@ void coap_pkt_init(coap_pkt_t *pkt, uint8_t *buf, size_t len, size_t header_len)
 {
     memset(pkt, 0, sizeof(coap_pkt_t));
     pkt->hdr = (coap_hdr_t *)buf;
-    pkt->token = buf + sizeof(coap_hdr_t);
     pkt->payload = buf + header_len;
     pkt->payload_len = len - header_len;
 }

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -256,7 +256,6 @@ static int _request_cb(void *arg, coap_pkt_t *pkt)
     memcpy(buf->iov_base, pkt->hdr, pkt_len);
 
     pkt->hdr = buf->iov_base;
-    pkt->token  = (uint8_t*)pkt->hdr + sizeof(coap_hdr_t);
     pkt->payload = (uint8_t*)pkt->hdr + (pkt_len - pkt->payload_len);
 
     return pkt_len;


### PR DESCRIPTION
this might need a deprecation period first

### Contribution description

remove the token ptr from nanocoap `coap_pkt_t` in favour of `coap_get_token()` introduced in #17976

### Testing procedure

murdock build 

### Issues/PRs references

 #17976
 
 wait for #17950
