### PR TITLE
sys/suit: avoid installing payload twice

### DIFF
--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -196,7 +196,8 @@ typedef struct {
 #define SUIT_COMPONENT_STATE_FETCHED       (1 << 0) /**< Component is fetched */
 #define SUIT_COMPONENT_STATE_FETCH_FAILED  (1 << 1) /**< Component fetched but failed */
 #define SUIT_COMPONENT_STATE_VERIFIED      (1 << 2) /**< Component is verified */
-#define SUIT_COMPONENT_STATE_FINALIZED     (1 << 3) /**< Component successfully installed */
+#define SUIT_COMPONENT_STATE_INSTALLED     (1 << 3) /**< Component is installed, but has not been verified */
+#define SUIT_COMPONENT_STATE_FINALIZED     (1 << 4) /**< Component successfully installed */
 /** @} */
 
 /**

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -488,8 +488,14 @@ static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
     LOG_INFO("Starting digest verification against image\n");
     res = _validate_payload(comp, digest, img_size);
     if (res == SUIT_OK) {
-        LOG_INFO("Install correct payload\n");
-        suit_storage_install(comp->storage_backend, manifest);
+        if (!suit_component_check_flag(comp, SUIT_COMPONENT_STATE_INSTALLED)) {
+            LOG_INFO("Install correct payload\n");
+            suit_storage_install(comp->storage_backend, manifest);
+            suit_component_set_flag(comp, SUIT_COMPONENT_STATE_INSTALLED);
+        }
+        if (suit_component_check_flag(comp, SUIT_COMPONENT_STATE_INSTALLED)) {
+            LOG_INFO("Verified installed payload\n");
+        }
     }
     else {
         LOG_INFO("Erasing bad payload\n");


### PR DESCRIPTION
### Contribution description

For some reason the generated manifest triggers the payload to be installed twice:

```
SUIT policy checks OK.
Formatted component name: .ram.0
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
Verifying image digest
Starting digest verification against image
Install correct payload
```

Why I'm not sure is whether this is an issue in the manifest generation or if it's something to handle in code. Pinging @bergzand on this.

### Testing procedure

Run `examples/suit_update` payload is installed once:

```
SUIT policy check OK.
Formatted component name: .ram.0
Fetching firmware |█████████████████████████| 100%
Finalizing payload store
Verifying image digest
Starting digest verification against image
Install correct payload
```

