### PR TITLE
example/twr_aloha: fixes

### DIFF
--- a/examples/twr_aloha/control.c
+++ b/examples/twr_aloha/control.c
@@ -205,7 +205,7 @@ static void _rng_listen(void *arg)
     if (!ztimer_is_set(ZTIMER_MSEC, &_rng_request_event.periodic.timer.timer)) {
         _status &= ~TWR_STATUS_INITIATOR;
     }
-    if (_status && TWR_STATUS_RESPONDER) {
+    if (_status & TWR_STATUS_RESPONDER) {
         /* wake up if needed */
         if (_udev->status.sleeping) {
             uwb_wakeup(_udev);
@@ -217,8 +217,7 @@ static void _rng_listen(void *arg)
     }
     else {
         /* go to sleep if possible */
-        if (_rng_request_event.periodic.timer.interval > CONFIG_TWR_MIN_IDLE_SLEEP_MS ||
-            !(_status && TWR_STATUS_INITIATOR)) {
+        if (_rng_request_event.periodic.timer.interval > CONFIG_TWR_MIN_IDLE_SLEEP_MS) {
             uwb_sleep_config(_udev);
             uwb_enter_sleep(_udev);
         }
@@ -254,7 +253,7 @@ static void _rng_request(void *arg)
         uwb_phy_forcetrxoff(_udev);
     }
 
-   uwb_rng_request(_rng, event->addr, (uwb_dataframe_code_t)event->proto);
+    uwb_rng_request(_rng, event->addr, (uwb_dataframe_code_t)event->proto);
 }
 
 void uwb_core_rng_start(uint16_t addr, twr_protocol_t proto, uint32_t interval,
@@ -285,7 +284,8 @@ void uwb_core_rng_init(void)
     /* set initial status */
     _status = 0;
     /* got to sleep on boot */
-    struct uwb_dev*_udev = uwb_dev_idx_lookup(0);
+    struct uwb_dev *_udev = uwb_dev_idx_lookup(0);
+
     uwb_sleep_config(_udev);
     uwb_enter_sleep(_udev);
 }

--- a/examples/twr_aloha/control.c
+++ b/examples/twr_aloha/control.c
@@ -289,3 +289,9 @@ void uwb_core_rng_init(void)
     uwb_sleep_config(_udev);
     uwb_enter_sleep(_udev);
 }
+
+uint32_t uwb_core_rng_req_remaining(void)
+{
+    /* doesn't matter if its not atomic */
+    return _rng_request_event.periodic.count;
+}

--- a/examples/twr_aloha/control.h
+++ b/examples/twr_aloha/control.h
@@ -31,14 +31,21 @@ extern "C" {
  * @brief   Block after a request is sent
  */
 #ifndef CONFIG_TWR_SHELL_BLOCKING
-#define CONFIG_TWR_SHELL_BLOCKING       1
+#define CONFIG_TWR_SHELL_BLOCKING           1
 #endif
 
 /**
  * @brief   Minimum idle time to enable putting the radio to sleep
  */
 #ifndef CONFIG_TWR_MIN_IDLE_SLEEP_MS
-#define CONFIG_TWR_MIN_IDLE_SLEEP_MS    20
+#define CONFIG_TWR_MIN_IDLE_SLEEP_MS        20
+#endif
+
+/*
+ * @brief   Block after a request is sent
+ */
+#ifndef CONFIG_TWR_PRINTF_INITIATOR_ONLY
+#define CONFIG_TWR_PRINTF_INITIATOR_ONLY    1
 #endif
 
 /**

--- a/examples/twr_aloha/control.h
+++ b/examples/twr_aloha/control.h
@@ -100,6 +100,11 @@ void uwb_core_rng_listen_disable(void);
 void uwb_core_rng_start(uint16_t addr, twr_protocol_t proto, uint32_t interval,
                         uint32_t count);
 
+/**
+ * @brief   Returns remaining rng requests
+ */
+uint32_t uwb_core_rng_req_remaining(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/twr_aloha/tests-with-config/01-run.py
+++ b/examples/twr_aloha/tests-with-config/01-run.py
@@ -23,6 +23,7 @@ class TwrShell(Reboot, TwrCmd):
         "hwaddr": None,
         "hwaddr64": None,
         "panid": None,
+        "channel": None,
     }
 
     def parse_netif(self):
@@ -40,6 +41,9 @@ class TwrShell(Reboot, TwrCmd):
 
     def panid(self):
         return self._netif["panid"]
+
+    def channel(self):
+        return self._netif["channel"]
 
 
 class TestTWRBase(unittest.TestCase):
@@ -68,7 +72,7 @@ class TestTWR(TestTWRBase):
         assert self.shell.panid() == "DE:CA"
         assert self.shell.hwaddr() is not None
         assert self.shell.hwaddr64() is not None
-        assert self.shell.panid() is not None
+        assert self.shell.channel() == "5"  # default channel is 5
 
     def test_listen(self):
         assert "[twr]: start listening" in self.shell.twr_listen(on=True)

--- a/examples/twr_aloha/twr_shell.c
+++ b/examples/twr_aloha/twr_shell.c
@@ -181,7 +181,11 @@ int _twr_handler(int argc, char **argv)
         puts("[twr]: start ranging");
         uwb_core_rng_start(short_addr, proto, interval_ms, count);
         if (IS_ACTIVE(CONFIG_TWR_SHELL_BLOCKING)) {
-            ztimer_sleep(ZTIMER_MSEC, interval_ms * (count + 1));
+            while (uwb_core_rng_req_remaining()) {
+                ztimer_sleep(ZTIMER_MSEC, interval_ms);
+            }
+            /* some time to finish up */
+            ztimer_sleep(ZTIMER_MSEC, 100 + interval_ms);
         }
         return 0;
     }

--- a/examples/twr_aloha/twr_shell.c
+++ b/examples/twr_aloha/twr_shell.c
@@ -121,7 +121,8 @@ int _twr_handler(int argc, char **argv)
         uint32_t count = 1;
         uint32_t interval_ms = 1000;
         int proto = UWB_DATA_CODE_SS_TWR;
-        uint8_t addr[IEEE802154_SHORT_ADDRESS_LEN_STR_MAX];
+        uint8_t addr[IEEE802154_SHORT_ADDRESS_LEN];
+        uint16_t short_addr = 0x0000;
         int res = 0;
         if (argc < 3) {
             _print_usage();
@@ -136,6 +137,11 @@ int _twr_handler(int argc, char **argv)
                     puts("[Error]: unable to parse address.\n"
                          "Must be of format [0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*\n"
                          "(hex pairs delimited by colons)");
+                    res = 1;
+                }
+                short_addr = addr[1] + (addr[0] << 8);
+                if (short_addr == 0x0000) {
+                    printf("[ERROR]: invalid addr %s\n", arg);
                     res = 1;
                 }
             }
@@ -194,11 +200,10 @@ int _twr_handler(int argc, char **argv)
                 }
             }
         }
-        if (res != 0) {
+        if (res != 0 || (short_addr == 0x0000)) {
             _print_usage();
             return 1;
         }
-        uint16_t short_addr = addr[1] + (addr[0] << 8);
         puts("[twr]: start ranging");
         uwb_core_rng_start(short_addr, proto, interval_ms, count);
         if (IS_ACTIVE(CONFIG_TWR_SHELL_BLOCKING)) {

--- a/examples/twr_aloha/twr_shell.py
+++ b/examples/twr_aloha/twr_shell.py
@@ -55,9 +55,9 @@ class TwrCmd(ShellInteraction):
             args=("lst", "on" if on else "off"), timeout=timeout, async_=async_
         )
 
-    def twr_req(self, count=1, interval=1000, proto="ss", timeout=-1, async_=False):
+    def twr_req(self, addr="ff:ff", count=1, interval=1000, proto="ss", timeout=-1, async_=False):
         return self.twr_cmd(
-            args=("req", f"-c {count}", f"-p {proto}", f"-i {interval}"),
+            args=("req", f"{addr}", f"-c {count}", f"-p {proto}", f"-i {interval}"),
             timeout=timeout,
             async_=async_,
         )

--- a/examples/twr_aloha/twr_shell.py
+++ b/examples/twr_aloha/twr_shell.py
@@ -18,6 +18,7 @@ class TwrIfconfigParser(ShellInteractionParser):
     hwaddr_c = re.compile(r"HWaddr:\s+(?P<name>[0-9a-fA-F:]+)\s")
     hwaddr64_c = re.compile(r"Long HWaddr:\s+(?P<name>[0-9a-fA-F:]+)")
     panid_c = re.compile(r"NID:\s+(?P<name>[0-9a-fA-F:]+)")
+    channel_c = re.compile(r"Channel:\s+(?P<name>[0-9]+)")
 
     def parse(self, cmd_output):
         netif = {
@@ -25,6 +26,7 @@ class TwrIfconfigParser(ShellInteractionParser):
             "hwaddr": None,
             "hwaddr64": None,
             "panid": None,
+            "channel": None,
         }
         for line in cmd_output.splitlines():
             m = self.iface_c.search(line)
@@ -39,6 +41,9 @@ class TwrIfconfigParser(ShellInteractionParser):
             m = self.panid_c.search(line)
             if m is not None:
                 netif["panid"] = m.group("name")
+            m = self.channel_c.search(line)
+            if m is not None:
+                netif["channel"] = m.group("name")
         return netif
 
 


### PR DESCRIPTION
### Contribution description

This PR fixes some issues with the `examples/twr_aloha` example and some improvements to work better as read-eval-print-loops:

repl improvements:
- 359ad5e356d0a8a2f3456b6ca647fe52278f3820: only print distance values on initiator to avoid spurious data on the other node pexpect buffer
- 93f7066916497f1105313937be8b3f800d1503a3: make sure the function blocks for the whole request time

misc improvemtns:
- 5e7bb6c88ac4f98f4f23bd02baea9fc87c7484e8: error on invalid short address
- 1af9cdbef277d6c5240ab9b314997991afc69b98: extends ifconfig command

fixes:
- 26969e299bdbaadb7c5a0d8c3c780b8ba4c50f8e: should be `&` and not `&&`
- 544551de86543ff61c599f3c60c1f4d97bdfea78: adds missing request parameters

### Testing procedure

`examples/twr_aloha` still functions correctly

```
> main(): This is RIOT! (Version: 2022.07-devel-236-gbab476-pr_twr_aloha_fixes)
> ifconfig
ifconfig
Iface  3        HWaddr: 03:B4  Channel: 5  NID: DE:CA

                Long HWaddr: 08:2B:31:07:CC:53:03:B4
                TX-Power: 8.0dBm  TC-PGdelay: 0xb5
> twr lst on
twr lst on
[twr]: start listening
>
```

```
main(): This is RIOT! (Version: 2022.07-devel-236-gbab476-pr_twr_aloha_fixes)
> twr req -c 5 -i 100 03:B4
twr req -c 5 -i 100 03:B4
[twr]: start ranging
{"t": 15519, "src": "57:81", "dst": "03:B4", "d_cm": 27}
{"t": 15620, "src": "57:81", "dst": "03:B4", "d_cm": 28}
{"t": 15720, "src": "57:81", "dst": "03:B4", "d_cm": 30}
{"t": 15820, "src": "57:81", "dst": "03:B4", "d_cm": 26}
{"t": 15920, "src": "57:81", "dst": "03:B4", "d_cm": 32}
```

the test passes:

`make -C examples/twr_aloha/ flash test-with-config`
```
...
----------------------------------------------------------------------
Ran 3 tests in 9.262s

OK
```

