### PR TITLE
ztimer64_xtimer_compat: fix ztimer_msleep()

### DIFF
--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -123,7 +123,7 @@ static inline void xtimer_sleep(uint32_t seconds)
 static inline void xtimer_msleep(uint32_t milliseconds)
 {
     if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
-        ztimer_sleep(ZTIMER_USEC, milliseconds);
+        ztimer_sleep(ZTIMER_MSEC, milliseconds);
     }
     else {
         ztimer64_sleep(ZTIMER64_USEC, ((uint64_t)milliseconds) * 1000LLU);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`ztimer_msleep()` should use `ZTIMER_MSEC`, not `ZTIMER_USEC`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
