### PR TITLE
docker: don't export KCONFIG_ADD_CONFIG variable

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -86,7 +86,6 @@ export DOCKER_ENV_VARS_ALWAYS += \
   FEATURES_OPTIONAL \
   USEMODULE \
   USEPKG \
-  KCONFIG_ADD_CONFIG \
  #
 
 # Find which variables were set using the command line or the environment and


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When using `TEST_KCONFIG=1` along with `BUILD_IN_DOCKER=1` to build some test applications, the builds fails with this kind of error (here with `tests/shell`):

`make: *** No rule to make target '/work/riot/RIOT/tests/test_utils.config', needed by '/data/riotbuild/riotbase/tests/shell/bin/native/generated/out.config'`

This PR fixes the problem by using the docker path to `tests_utils.config` when using `BUILD_IN_DOCKER=1`.

I don't know if that's the better fix but that works.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `TEST_KCONFIG=1 BUILD_IN_DOCKER=1 make -C tests/shell --no-print-directory`

On master, you would get this:

```
TEST_KCONFIG=1 BUILD_IN_DOCKER=1 make -C tests/shell --no-print-directory 
=== [ATTENTION] Testing Kconfig dependency modelling ===
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/aabadie/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/aabadie/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'TEST_KCONFIG=1' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=app_metadata ps shell shell_commands' -e 'USEPKG=' -e 'KCONFIG_ADD_CONFIG=/work/riot/RIOT/tests/test_utils.config'  -w '/data/riotbuild/riotbase/tests/shell/' 'riot/riotbuild:latest' make     
=== [ATTENTION] Testing Kconfig dependency modelling ===
make: *** No rule to make target '/work/riot/RIOT/tests/test_utils.config', needed by '/data/riotbuild/riotbase/tests/shell/bin/native/generated/out.config'.  Stop.
make: *** [/work/riot/RIOT/makefiles/docker.inc.mk:350: ..in-docker-container] Error 2
```

With this PR, it builds fine:

```
TEST_KCONFIG=1 BUILD_IN_DOCKER=1 make -C tests/shell --no-print-directory 
=== [ATTENTION] Testing Kconfig dependency modelling ===
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/aabadie/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/aabadie/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'TEST_KCONFIG=1' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=app_metadata ps shell shell_commands' -e 'USEPKG=' -e 'KCONFIG_ADD_CONFIG=/data/riotbuild/riotbase/tests/test_utils.config'  -w '/data/riotbuild/riotbase/tests/shell/' 'riot/riotbuild:latest' make     
=== [ATTENTION] Testing Kconfig dependency modelling ===
Building application "tests_shell" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/boards/native
"make" -C /data/riotbuild/riotbase/boards/native/drivers
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/app_metadata
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/ps
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/test_utils/print_stack_usage
   text	   data	    bss	    dec	    hex	filename
  25189	   5370	  47764	  78323	  131f3	/data/riotbuild/riotbase/tests/shell/bin/native/tests_shell.elf
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found in #17992 when trying to build some cpp test application for esp32 with both TEST_KCONFIG and BUILD_IN_DOCKER enabled (I don't have the esp32 toolchain installed on my machine).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
