### PR TITLE
pkg/uwb-core: adjust holdoff time when rxdiag_enabled

### DIFF
--- a/examples/twr_aloha/Makefile
+++ b/examples/twr_aloha/Makefile
@@ -27,6 +27,8 @@ USEMODULE += uwb-core_twr_ss_ack
 USEMODULE += uwb-core_twr_ss_ext
 USEMODULE += uwb-core_twr_ds
 USEMODULE += uwb-core_twr_ds_ext
+## Uncomment to enable trx info such as rssi, los, fppl calculation
+# USEMODULE += uwb-core_rng_trx_info
 
 # System modules used by this application
 USEMODULE += shell

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief tx holdoff delay for DS TWR (usec)
  */
 #ifndef MYNEWT_VAL_TWR_DS_TX_HOLDOFF
-#define MYNEWT_VAL_TWR_DS_TX_HOLDOFF (((uint32_t)0x0300))
+#define MYNEWT_VAL_TWR_DS_TX_HOLDOFF (((uint32_t)0x0300 + 0xA0 * IS_USED(MODULE_UWB_CORE_RNG_TRX_INFO)))
 #endif
 
 #ifdef __cplusplus

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds_ext.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds_ext.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief tx holdoff delay for DS TWR extended frame (usec)
  */
 #ifndef MYNEWT_VAL_TWR_DS_EXT_TX_HOLDOFF
-#define MYNEWT_VAL_TWR_DS_EXT_TX_HOLDOFF (((uint32_t)0x0400))
+#define MYNEWT_VAL_TWR_DS_EXT_TX_HOLDOFF (((uint32_t)0x0400 + 0xA0 * IS_USED(MODULE_UWB_CORE_RNG_TRX_INFO)))
 #endif
 
 #ifdef __cplusplus

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief tx holdoff delay for SS TWR (usec)
  */
 #ifndef MYNEWT_VAL_TWR_SS_TX_HOLDOFF
-#define MYNEWT_VAL_TWR_SS_TX_HOLDOFF (((uint32_t)0x0300))
+#define MYNEWT_VAL_TWR_SS_TX_HOLDOFF (((uint32_t)0x0300 + 0xA0 * IS_USED(MODULE_UWB_CORE_RNG_TRX_INFO)))
 #endif
 
 #ifdef __cplusplus

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ack.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ack.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief TOA timeout delay for SS TWR (usec)
  */
 #ifndef MYNEWT_VAL_TWR_SS_ACK_TX_HOLDOFF
-#define MYNEWT_VAL_TWR_SS_ACK_TX_HOLDOFF (((uint32_t)0x800))
+#define MYNEWT_VAL_TWR_SS_ACK_TX_HOLDOFF (((uint32_t)0x800 + 0xA0 * IS_USED(MODULE_UWB_CORE_RNG_TRX_INFO)))
 #endif
 
 #ifdef __cplusplus

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ext.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ext.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief tx holdoff delay for SS EXT TWR (usec)
  */
 #ifndef MYNEWT_VAL_TWR_SS_EXT_TX_HOLDOFF
-#define MYNEWT_VAL_TWR_SS_EXT_TX_HOLDOFF (((uint32_t)0x0400))
+#define MYNEWT_VAL_TWR_SS_EXT_TX_HOLDOFF (((uint32_t)0x0400 + 0xA0 * IS_USED(MODULE_UWB_CORE_RNG_TRX_INFO)))
 #endif
 
 #ifdef __cplusplus

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_uwb_rng.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_uwb_rng.h
@@ -43,7 +43,7 @@ extern "C" {
  * @brief worstcase tx holdoff delay for all TWR modes (usec)
  */
 #ifndef MYNEWT_VAL_RNG_TX_HOLDOFF
-#define MYNEWT_VAL_RNG_TX_HOLDOFF (((uint32_t)0x0320))
+#define MYNEWT_VAL_RNG_TX_HOLDOFF (((uint32_t)0x0320 + 0xA0 * IS_USED(MODULE_UWB_CORE_RNG_TRX_INFO)))
 #endif
 
 /**


### PR DESCRIPTION

### Contribution description

Currently if enabling `uwb-core_rng_trx_info` module (which enables RX_DIAGNOSTICS in the uwb-dw1000 package), then TWR exchange procedure fails since it adds some processing delay that is not accounter for in the holdoff time (time before a responder node answers to an initiator TWR request). This PR fixes it by accounting for that in the holdoff configuration values.

### Testing procedure

The following fails in master: `USEMODULE=uwb-core_rng_trx_info make -C examples/twr_aloha/ flash term -j7`

```
> twr lst on
2022-04-25 13:13:11,759 # twr lst on
2022-04-25 13:13:11,761 # [twr]: start listening
2022-04-25 13:13:32,217 # twr req 03:B4 -p ds -c 5 -i 200
2022-04-25 13:13:32,218 # [twr]: start ranging
2022-04-25 13:13:32,432 # {"t": 32186, "src": "03:B4", "dst": "57:81", "d_cm": 56, "tof": 119.8907700, "los": 0, "rssi": 0}
2022-04-25 13:13:32,632 # {"t": 32386, "src": "03:B4", "dst": "57:81", "d_cm": 57, "tof": 121.8883286, "los": 0, "rssi": 0}
2022-04-25 13:13:32,832 # {"t": 32586, "src": "03:B4", "dst": "57:81", "d_cm": 62, "tof": 134.1226348, "los": 0, "rssi": 0}
2022-04-25 13:13:33,032 # {"t": 32786, "src": "03:B4", "dst": "57:81", "d_cm": 54, "tof": 116.6292953, "los": 0, "rssi": 0}
2022-04-25 13:13:33,232 # {"t": 32986, "src": "03:B4", "dst": "57:81", "d_cm": 58, "tof": 124.8940277, "los": 0, "rssi": 0}
```

### Issues/PRs references

Split from #17988.
