### PR TITLE
sys: add auto_init includes treewide

### DIFF
--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -52,6 +52,10 @@ ifneq (,$(filter app_metadata,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter auto_init,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/sys/auto_init/include
+endif
+
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/cpp11-compat/include
 endif

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -30,6 +30,4 @@ ifneq (,$(filter auto_init_screen,$(USEMODULE)))
   DIRS += screen
 endif
 
-INCLUDES += -I$(RIOTBASE)/sys/auto_init/include
-
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

Current headers are only visible in the `auto-init` compile unit, make them visible whenever the module is used.

### Testing procedure

green ci.

