### PR TITLE
ztimer64/xtimer_compat: fix ztimer64_msg_receive_timeout() use ZTIMER_USEC

### DIFF
--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -297,7 +297,7 @@ static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,
 
 static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout)
 {
-    return ztimer64_msg_receive_timeout(ZTIMER64_SEC, msg, timeout);
+    return ztimer64_msg_receive_timeout(ZTIMER64_USEC, msg, timeout);
 }
 
 #endif


### PR DESCRIPTION
### Contribution description

A fix for `xtimer64`. Correction for the clock argument in `xtimer_msg_receive_timeout64`: sec -> usec
