### PR TITLE
net/nanocoap: deprecate coap_pkt token ptr

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -196,7 +196,9 @@ typedef struct {
  */
 typedef struct {
     coap_hdr_t *hdr;                                  /**< pointer to raw packet   */
-    uint8_t *token;                                   /**< pointer to token        */
+    uint8_t *token;                                   /**< pointer to token
+                                                       * @deprecated Use coap_get_token(),
+                                                       *     Will be removed after 2022.10. */
     uint8_t *payload;                                 /**< pointer to payload      */
     uint16_t payload_len;                             /**< length of payload       */
     uint16_t options_len;                             /**< length of options array */


### PR DESCRIPTION
### Contribution description

 deprecate the token ptr from nanocoap coap_pkt_t in favour of coap_get_token() introduced in #17976

### Testing procedure

check documentation

 [cricle-ci-artifact](https://output.circle-artifacts.com/output/job/016d43a3-7f2e-4abd-98fe-4b5604acb8d3/artifacts/0/doc/deprecated.html)

### Issues/PRs references

#17976
#17983 
