### PR TITLE
tools/compile_commands.py: Improve clangd output

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -230,6 +230,7 @@ def generate_module_compile_commands(path, state, args):
 
     if args.clangd:
         cdetails.cflags.append('-Wno-unknown-warning-option')
+        cdetails.cflags.append('-Wno-unknown-attributes')
 
     c_extra_includes = []
     cxx_extra_includes = []


### PR DESCRIPTION
### Contribution description

Add `-Wno-unknown-attributes` to ignore warnings for GCC only attributes as e.g. used in avr-libc.

### Testing procedure

1. Run `make BOARD=arduino-mega2560 -C tests/periph_timer compile-commands`
2. Open `cpu/atmega_common/periph/timer.c` with a proper editor, e.g. neovim with [ALE](https://github.com/dense-analysis/ale)
3. There should be a warning for each `ISR()` macro in `master`, but none with this PR

### Issues/PRs references

None