### PR TITLE
core/xfa: Silence clangd warning

### DIFF
--- a/core/lib/include/xfa.h
+++ b/core/lib/include/xfa.h
@@ -25,6 +25,8 @@
 #ifndef XFA_H
 #define XFA_H
 
+#include <inttypes.h>
+
 /*
  * Unfortunately, current gcc trips over accessing XFA's because of their
  * zero-size start/end array that are used of symbol markers, with an "array
@@ -177,7 +179,7 @@ _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
  * @brief Calculate number of entries in cross-file array
  */
 #define XFA_LEN(type, \
-                name) (((const char *)name ## _end - (const char *)name) / \
+                name) (((uintptr_t)name ## _end - (uintptr_t)name) / \
                        sizeof(type))
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Use `uintptr_t` for arithmetic rather than `const char *` to fix the following warning:

> comparePointers: Subtracting pointers that point to different objects

### Testing procedure

1. `make -C tests/xfa compile-commands`
2. nvim tests/xfa/main.c
3. In `master` clangd should complain at the use of `XFA_LEN()` with "comparePointers: Subtracting pointers that point to different objects", but no longer with this PR.

This should have no impact on generated binaries.

### Issues/PRs references

None