### PR TITLE
drivers/mcp2515: fix set bittiming

### DIFF
--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -305,6 +305,11 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
         }
         else {
             memcpy(&candev->bittiming, value, sizeof(candev->bittiming));
+            if (can_device_calc_bittiming(dev->conf->clk / 2 /* f_quantum = f_osc / 2 */,
+                            &bittiming_const, &candev->bittiming) < 0) {
+                DEBUG_PUTS("set0_Failed to calculate bittiming");
+                return -ERANGE;
+            }
             res = _init(candev);
             if (res == 0) {
                 res = sizeof(candev->bittiming);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

- apply hardware dependent parameters to bittiming struct before
  reinitializing the hardware with the new parameter set
- this normalizes the bittiming struct wrt. `can_device_calc_bittiming` which may be undesired in very
  experimental conditions
- normal users will set the bitrate and assume that the setting is honored which is not the case
  without running `can_device_calc_bittiming`
- another way of fixing this issue would be to expose the `bittiming_const` struct and add information
  to the documentation about the requirements and `can_device_calc_bittiming`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

- without this change, the bitrate is not actually changed when solely changing this parameter in the `bittiming` struct & using the `set` method of the device interface
- with this change, modifying the bitrate as sole parameter change will result in the desired bitrate change

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
