### PR TITLE
pkg/uwb-core: reduce default stacksize

### DIFF
--- a/pkg/uwb-core/include/uwb_core.h
+++ b/pkg/uwb-core/include/uwb_core.h
@@ -47,7 +47,7 @@ extern "C" {
  * @brief   Stacksize used for uwb-core event queue
  */
 #ifndef UWB_CORE_STACKSIZE
-#define UWB_CORE_STACKSIZE              (THREAD_STACKSIZE_LARGE)
+#define UWB_CORE_STACKSIZE              (THREAD_STACKSIZE_DEFAULT)
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

When support for this package was introduced printf calls inside the
uwb-core where bloating stack usage, but this is no longer the case,
so prefer lower stack usage.

### Testing procedure

The example still works fine:

```
twr req  03:B4 -c 100 -i 10 -p ds
[twr]: start ranging
{"t": 105120, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.2620086, "los": 1, "rssi": -80}
{"t": 105136, "src": "03:B4", "dst": "57:81", "d_cm": 38, "tof": 82.0272750, "los": 1, "rssi": -80}
{"t": 105150, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 76.2679443, "los": 1, "rssi": -80}
{"t": 105166, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.7902908, "los": 1, "rssi": -79}
{"t": 105179, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.5273514, "los": 1, "rssi": -79}
{"t": 105195, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 78.0354766, "los": 1, "rssi": -79}
{"t": 105209, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.0271072, "los": 1, "rssi": -79}
{"t": 105225, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.0331802, "los": 1, "rssi": -79}
{"t": 105239, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 76.5293503, "los": 1, "rssi": -80}
{"t": 105255, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.5232315, "los": 1, "rssi": -80}
{"t": 105268, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.7882080, "los": 1, "rssi": -79}
{"t": 105284, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 72.5209198, "los": 1, "rssi": -80}
{"t": 105298, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 74.0312957, "los": 1, "rssi": -80}
{"t": 105312, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 79.7924499, "los": 1, "rssi": -79}
{"t": 105328, "src": "03:B4", "dst": "57:81", "d_cm": 32, "tof": 69.7924118, "los": 1, "rssi": -80}
{"t": 105341, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 79.5393448, "los": 1, "rssi": -80}
{"t": 105357, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.5169754, "los": 1, "rssi": -80}
{"t": 105371, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 76.0253143, "los": 1, "rssi": -79}
{"t": 105387, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 73.0252914, "los": 1, "rssi": -80}
{"t": 105401, "src": "03:B4", "dst": "57:81", "d_cm": 33, "tof": 72.0250396, "los": 1, "rssi": -79}
{"t": 105416, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.0371704, "los": 1, "rssi": -80}
{"t": 105430, "src": "03:B4", "dst": "57:81", "d_cm": 32, "tof": 69.2721786, "los": 1, "rssi": -80}
{"t": 105446, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 78.3046417, "los": 1, "rssi": -79}
{"t": 105460, "src": "03:B4", "dst": "57:81", "d_cm": 38, "tof": 82.2944717, "los": 1, "rssi": -80}
{"t": 105476, "src": "03:B4", "dst": "57:81", "d_cm": 33, "tof": 70.5353088, "los": 1, "rssi": -79}
{"t": 105489, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 74.5231170, "los": 1, "rssi": -79}
{"t": 105505, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.2740936, "los": 1, "rssi": -80}
{"t": 105519, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 74.2783889, "los": 1, "rssi": -80}
{"t": 105535, "src": "03:B4", "dst": "57:81", "d_cm": 33, "tof": 71.5253296, "los": 1, "rssi": -80}
{"t": 105549, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.0169677, "los": 1, "rssi": -79}
{"t": 105565, "src": "03:B4", "dst": "57:81", "d_cm": 38, "tof": 81.7862396, "los": 1, "rssi": -79}
{"t": 105578, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.7885132, "los": 1, "rssi": -80}
{"t": 105594, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.2742767, "los": 1, "rssi": -79}
{"t": 105608, "src": "03:B4", "dst": "57:81", "d_cm": 38, "tof": 81.0270843, "los": 1, "rssi": -79}
{"t": 105624, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 72.7801208, "los": 1, "rssi": -80}
{"t": 105638, "src": "03:B4", "dst": "57:81", "d_cm": 38, "tof": 82.0273208, "los": 1, "rssi": -79}
{"t": 105651, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.2862320, "los": 1, "rssi": -80}
{"t": 105667, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 76.5352173, "los": 1, "rssi": -79}
{"t": 105681, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.7824325, "los": 1, "rssi": -79}
{"t": 105697, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 78.5131378, "los": 1, "rssi": -80}
{"t": 105711, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 74.5271377, "los": 1, "rssi": -80}
{"t": 105727, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 79.0230789, "los": 1, "rssi": -79}
{"t": 105740, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.0271759, "los": 1, "rssi": -79}
{"t": 105756, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 72.5251617, "los": 1, "rssi": -80}
{"t": 105770, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 78.2863617, "los": 1, "rssi": -79}
{"t": 105786, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 75.7741928, "los": 1, "rssi": -80}
{"t": 105800, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.2861709, "los": 1, "rssi": -79}
{"t": 105815, "src": "03:B4", "dst": "57:81", "d_cm": 31, "tof": 67.5250396, "los": 1, "rssi": -81}
{"t": 105829, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 79.0456237, "los": 1, "rssi": -79}
{"t": 105845, "src": "03:B4", "dst": "57:81", "d_cm": 33, "tof": 71.7743301, "los": 1, "rssi": -80}
{"t": 105859, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 76.2639846, "los": 1, "rssi": -80}
{"t": 105875, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 79.5353470, "los": 1, "rssi": -79}
{"t": 105888, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 79.7719497, "los": 1, "rssi": -79}
{"t": 105904, "src": "03:B4", "dst": "57:81", "d_cm": 32, "tof": 68.2659073, "los": 1, "rssi": -79}
{"t": 105918, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 72.7682266, "los": 1, "rssi": -80}
{"t": 105932, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 73.7680511, "los": 1, "rssi": -80}
{"t": 105948, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 74.0110015, "los": 1, "rssi": -80}
{"t": 105961, "src": "03:B4", "dst": "57:81", "d_cm": 32, "tof": 68.7780838, "los": 1, "rssi": -80}
{"t": 105977, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.2720489, "los": 1, "rssi": -80}
{"t": 105991, "src": "03:B4", "dst": "57:81", "d_cm": 34, "tof": 73.0170364, "los": 1, "rssi": -80}
{"t": 106007, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 76.2638244, "los": 1, "rssi": -80}
{"t": 106021, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.5192108, "los": 1, "rssi": -79}
{"t": 106036, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.7721023, "los": 1, "rssi": -80}
{"t": 106050, "src": "03:B4", "dst": "57:81", "d_cm": 33, "tof": 71.5150604, "los": 1, "rssi": -80}
{"t": 106066, "src": "03:B4", "dst": "57:81", "d_cm": 37, "tof": 80.0110702, "los": 1, "rssi": -80}
{"t": 106080, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 78.2660064, "los": 1, "rssi": -80}
{"t": 106096, "src": "03:B4", "dst": "57:81", "d_cm": 36, "tof": 77.2518615, "los": 1, "rssi": -80}
> {"t": 106117, "src": "03:B4", "dst": "57:81", "d_cm": 35, "tof": 74.7762069, "los": 1, "rssi": -80}
```

