### PR TITLE
gcoap: ensure response address is the same as request address

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -642,6 +642,7 @@ endif
 ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
   USEMODULE += sock_async_event
+  USEMODULE += sock_aux_local
   USEMODULE += sock_udp
   USEMODULE += sock_util
   USEMODULE += ztimer_msec

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -303,6 +303,21 @@ enum {
      * @ref sock_dtls_aux_rx_t::rssi.
      */
     SOCK_AUX_GET_RSSI = (1LU << 2),
+    /**
+     * @brief   Flag to set the local address/endpoint
+     *
+     * @note    Select module `sock_aux_local` and a compatible network stack
+     *          to use this
+     *
+     * This is the address/endpoint the packet/datagram/segment will be sent from.
+     * This flag will be cleared if the network stack stored the local
+     * address/endpoint as requested, otherwise the bit remains set.
+     *
+     * Depending on the family of the socket, the timestamp will be stored in
+     * @ref sock_udp_aux_tx_t::local, @ref sock_ip_aux_tx_t::local, or in
+     * @ref sock_dtls_aux_tx_t::local.
+     */
+    SOCK_AUX_SET_LOCAL = (1LU << 3),
 };
 
 /**

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -333,6 +333,14 @@ typedef struct {
  * @brief   Auxiliary data provided when sending using an IP sock object
  */
 typedef struct {
+#if defined(MODULE_SOCK_AUX_LOCAL) || defined(DOXYGEN)
+    /**
+     * @brief   The local endpoint from which the datagram will be sent
+     *
+     * @see SOCK_AUX_SET_LOCAL
+     */
+    sock_ip_ep_t local;
+#endif /* MODULE_SOCK_AUX_ENDPOINT */
 #if defined(MODULE_SOCK_AUX_TIMESTAMP) || defined(DOXYGEN)
     /**
      * @brief   System time the packet was send

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -335,6 +335,14 @@ typedef struct {
  * @brief   Auxiliary data provided when sending using an UDP sock object
  */
 typedef struct {
+#if defined(MODULE_SOCK_AUX_LOCAL) || defined(DOXYGEN)
+    /**
+     * @brief   The local endpoint from which the datagram will be sent
+     *
+     * @see SOCK_AUX_SET_LOCAL
+     */
+    sock_udp_ep_t local;
+#endif /* MODULE_SOCK_AUX_ENDPOINT */
 #if defined(MODULE_SOCK_AUX_TIMESTAMP) || defined(DOXYGEN)
     /**
      * @brief   System time the datagram was send

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -223,6 +223,13 @@ ssize_t sock_ip_send_aux(sock_ip_t *sock, const void *data, size_t len,
         }
         memcpy(&local, &sock->local, sizeof(local));
     }
+#if IS_USED(MODULE_SOCK_AUX_LOCAL)
+    /* user supplied local endpoint takes precedent */
+    if ((aux != NULL) && (aux->flags & SOCK_AUX_SET_LOCAL)) {
+        local = aux->local;
+        aux->flags &= ~SOCK_AUX_SET_LOCAL;
+    }
+#endif
     if (remote == NULL) {
         /* sock can't be NULL at this point */
         memcpy(&rem, &sock->remote, sizeof(rem));

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -346,6 +346,16 @@ ssize_t sock_udp_sendv_aux(sock_udp_t *sock,
         src_port = sock->local.port;
         memcpy(&local, &sock->local, sizeof(local));
     }
+#if IS_USED(MODULE_SOCK_AUX_LOCAL)
+    /* user supplied local endpoint takes precedent */
+    if ((aux != NULL) && (aux->flags & SOCK_AUX_SET_LOCAL)) {
+        local.family = aux->local.family;
+        local.netif = aux->local.netif;
+        memcpy(&local.addr, &aux->local.addr, sizeof(local.addr));
+
+        aux->flags &= ~SOCK_AUX_SET_LOCAL;
+    }
+#endif
     /* sock can't be NULL at this point */
     if (remote == NULL) {
         rem = (sock_ip_ep_t *)&sock->remote;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a node has multiple addresses we must reply to a request with the same address on which the request was received.


### Testing procedure

Run GCoAP on a node that has multiple addresses assigned to it's interface, or a second interface with a global address:

```
2022-04-27 18:01:21,824 # Iface  7 
2022-04-27 18:01:21,828 #           Long HWaddr: AA:EC:E6:8B:F9:BA:BD:C8 
2022-04-27 18:01:21,831 #           MTU:65535  HL:64  RTR  
2022-04-27 18:01:21,833 #           RTR_ADV  
2022-04-27 18:01:21,835 #           Link type: wired
2022-04-27 18:01:21,841 #           inet6 addr: fe80::a8ec:e68b:f9ba:bdc8  scope: link  VAL
2022-04-27 18:01:21,847 #           inet6 addr: fd11::a8ec:e68b:f9ba:bdc8  scope: global  VAL
2022-04-27 18:01:21,852 #           inet6 addr: fdea:dbee:f::1  scope: global  VAL
2022-04-27 18:01:21,855 #           inet6 group: ff02::2
2022-04-27 18:01:21,858 #           inet6 group: ff02::1
2022-04-27 18:01:21,861 #           inet6 group: ff02::1:ffba:bdc8
2022-04-27 18:01:21,864 #           inet6 group: ff02::1:ff00:1

2022-04-27 21:02:37,436 # Iface  6  HWaddr: FC:C2:3D:0B:D4:4F 
2022-04-27 21:02:37,441 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2022-04-27 21:02:37,444 #           Source address length: 6
2022-04-27 21:02:37,446 #           Link type: wired
2022-04-27 21:02:37,452 #           inet6 addr: fe80::fec2:3dff:fe0b:d44f  scope: link  VAL
2022-04-27 21:02:37,459 #           inet6 addr: 2001:16b8:4536:a600:fec2:3dff:fe0b:d44f  scope: global  VAL
2022-04-27 21:02:37,462 #           inet6 group: ff02::2
2022-04-27 21:02:37,464 #           inet6 group: ff02::1
2022-04-27 21:02:37,468 #           inet6 group: ff02::1:ff0b:d44f
```

We should be able to reach the CoAP server with any of these addresses:

```
2022-04-27 18:06:12,488 # > url get coap://[fe80::a8ec:e68b:f9ba:bdc8%4]/.well-known/core
2022-04-27 18:06:12,505 # offset 000: </fw>

2022-04-27 18:06:22,593 # > url get coap://[fd11::a8ec:e68b:f9ba:bdc8]/.well-known/core
2022-04-27 18:06:22,609 # offset 000: </fw>

2022-04-27 18:06:29,575 # > url get coap://[fdea:dbee:f::1]/.well-known/core
2022-04-27 18:06:29,590 # offset 000: </fw>

2022-04-27 21:03:26,429 # > url get coap://[2001:16b8:4536:a600:fec2:3dff:fe0b:d44f]/.well-known/core
2022-04-27 21:03:26,444 # offset 000: </fw>
```
And on the other interface, from Linux
```
% aiocoap-client coap://[2001:16b8:4536:a600:fec2:3dff:fe0b:d44f]/.well-known/core

application/link-format content was re-formatted
</fw>
```

On `master` we get `-EPROTO` from `sock_udp_recv_buf_aux()` because the response address does not match the request.

```
2022-04-27 18:09:47,333 # > url get coap://[fe80::a8ec:e68b:f9ba:bdc8%4]/.well-known/core
2022-04-27 18:09:47,348 # offset 000: </fw>

2022-04-27 18:09:52,285 # > url get coap://[fd11::a8ec:e68b:f9ba:bdc8]/.well-known/core
2022-04-27 18:09:52,299 # offset 000: </fw>

2022-04-27 18:09:55,108 # > url get coap://[fdea:dbee:f::1]/.well-known/core
[no response - error returned]

2022-04-27 21:05:19,315 # > url get coap://[2001:16b8:4536:a600:fec2:3dff:fe0b:d44f]/.well-known/core
[no response - error returned]
```

Let's try adding a second address to the Ethernet interface:

```
2022-04-27 21:08:45,396 # > ifconfig 6 add 2001:16b8:4536:a600::1234
2022-04-27 21:08:45,401 # success: added 2001:16b8:4536:a600::1234/64 to interface 6

2022-04-27 21:08:48,112 # > ifconfig 6
2022-04-27 21:08:48,116 # Iface  6  HWaddr: FC:C2:3D:0B:D4:4F 
2022-04-27 21:08:48,120 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2022-04-27 21:08:48,123 #           Source address length: 6
2022-04-27 21:08:48,125 #           Link type: wired
2022-04-27 21:08:48,131 #           inet6 addr: fe80::fec2:3dff:fe0b:d44f  scope: link  VAL
2022-04-27 21:08:48,138 #           inet6 addr: 2001:16b8:4536:a600:fec2:3dff:fe0b:d44f  scope: global  VAL
2022-04-27 21:08:48,144 #           inet6 addr: 2001:16b8:4536:a600::1234  scope: global  VAL
2022-04-27 21:08:48,147 #           inet6 group: ff02::2
2022-04-27 21:08:48,150 #           inet6 group: ff02::1
2022-04-27 21:08:48,153 #           inet6 group: ff02::1:ff0b:d44f
2022-04-27 21:08:48,157 #           inet6 group: ff02::1:ff00:1234
```

(with `CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=3`)

```
% ping 2001:16b8:4536:a600::1234      :(
PING 2001:16b8:4536:a600::1234(2001:16b8:4536:a600::1234) 56 data bytes
64 bytes from 2001:16b8:4536:a600::1234: icmp_seq=1 ttl=255 time=0.921 ms
64 bytes from 2001:16b8:4536:a600::1234: icmp_seq=2 ttl=255 time=0.367 ms
^C
--- 2001:16b8:4536:a600::1234 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 0.367/0.644/0.921/0.277 ms

% aiocoap-client coap://[2001:16b8:4536:a600::1234]/.well-known/core

WARNING:coap:Received Type.ACK from <UDP6EndpointAddress [2001:16b8:4536:a600:fec2:3dff:fe0b:d44f] (locally 2001:16b8:4536:a600:feb8:2c03:3621:69ed%eno1)>, but could not match it to a running exchange.
WARNING:coap:Received Type.ACK from <UDP6EndpointAddress [2001:16b8:4536:a600:fec2:3dff:fe0b:d44f] (locally 2001:16b8:4536:a600:feb8:2c03:3621:69ed%eno1)>, but could not match it to a running exchange.
^C%                                                                                                     3 benpicco@rechenknecht2k11 ~/dev/RIOT (git)-[gcoap_add_fix] % 
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
