### PR TITLE
cpu/arm7_common: uncrustify vectors.c

### DIFF
--- a/cpu/arm7_common/vectors.c
+++ b/cpu/arm7_common/vectors.c
@@ -34,34 +34,34 @@ void isr_fio(void)
 {
     LOG_ERROR("Kernel Panic,\nEarly FIQ call\n");
 
-    while (1) {};
+    while (1) {}
 }
 
 void isr_swi(void)
 {
     LOG_ERROR("Kernel Panic,\nEarly SWI call\n");
 
-    while (1) {};
+    while (1) {}
 }
 
 void abtorigin(const char *vector, unsigned long *lnk_ptr1)
 {
     register unsigned long *lnk_ptr2;
     register unsigned long *sp;
-    register unsigned int   cpsr, spsr;
+    register unsigned int cpsr, spsr;
 
-    __asm__ __volatile__("mrs %0, cpsr" : "=r"(cpsr));          // copy current mode
-    __asm__ __volatile__("mrs %0, spsr" : "=r"(spsr));          // copy dabt generating mode
-    __asm__ __volatile__("msr cpsr_c, %0" :: "r"(spsr));        // switch to dabt generating mode
-    __asm__ __volatile__("mov %0, lr" : "=r"(lnk_ptr2));        // copy lr
-    __asm__ __volatile__("mov %0, sp" : "=r"(sp));              // copy sp
-    __asm__ __volatile__("msr cpsr_c, %0" :: "r"(cpsr));        // switch back to abt mode
+    __asm__ __volatile__ ("mrs %0, cpsr" : "=r" (cpsr));            // copy current mode
+    __asm__ __volatile__ ("mrs %0, spsr" : "=r" (spsr));            // copy dabt generating mode
+    __asm__ __volatile__ ("msr cpsr_c, %0" : : "r" (spsr));         // switch to dabt generating mode
+    __asm__ __volatile__ ("mov %0, lr" : "=r" (lnk_ptr2));          // copy lr
+    __asm__ __volatile__ ("mov %0, sp" : "=r" (sp));                // copy sp
+    __asm__ __volatile__ ("msr cpsr_c, %0" : : "r" (cpsr));         // switch back to abt mode
 
     LOG_ERROR("#!%s abort at %p (0x%08lX) originating from %p (0x%08lX) in mode 0x%X\n",
-           vector, (void *)lnk_ptr1, *(lnk_ptr1), (void *)lnk_ptr2, *(lnk_ptr2), spsr
-          );
+              vector, (void *)lnk_ptr1, *(lnk_ptr1), (void *)lnk_ptr2, *(lnk_ptr2), spsr
+              );
 
-    while (1) {};
+    while (1) {}
 }
 
 void isr_undef(void)
@@ -69,14 +69,15 @@ void isr_undef(void)
     /* cppcheck-suppress variableScope
      * (reason: used within __asm__ which cppcheck doesn't pick up) */
     register unsigned long *lnk_ptr;
-    __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
+
+    __asm__ __volatile__ ("sub %0, lr, #8" : "=r" (lnk_ptr));     // get aborting instruction
 
     if (arm_abortflag == 0) {
         arm_abortflag = 1;                                          // remember state (if printing should fail again)
         abtorigin("undef", lnk_ptr);
     }
 
-    while (1) {};
+    while (1) {}
 }
 
 void isr_pabt(void)
@@ -84,14 +85,15 @@ void isr_pabt(void)
     /* cppcheck-suppress variableScope
      * (reason: used within __asm__ which cppcheck doesn't pick up) */
     register unsigned long *lnk_ptr;
-    __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
+
+    __asm__ __volatile__ ("sub %0, lr, #8" : "=r" (lnk_ptr));     // get aborting instruction
 
     if (arm_abortflag == 0) {
         arm_abortflag = 1;                                          // remember state (if printing should fail again)
         abtorigin("pabt", lnk_ptr);
     }
 
-    while (1) {};
+    while (1) {}
 }
 
 void isr_dabt(void)
@@ -99,12 +101,13 @@ void isr_dabt(void)
     /* cppcheck-suppress variableScope
      * (reason: used within __asm__ which cppcheck doesn't pick up) */
     register unsigned long *lnk_ptr;
-    __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
+
+    __asm__ __volatile__ ("sub %0, lr, #8" : "=r" (lnk_ptr));     // get aborting instruction
 
     if (arm_abortflag == 0) {
         arm_abortflag = 1;                                          // remember state (if printing should fail again)
         abtorigin("data", lnk_ptr);
     }
 
-    while (1) {};
+    while (1) {}
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A minor PR that uncrustify the `cpu/arm7_common/vectors.c` file. The basic idea was to get rid of remaining use of `while (1) {};` in favor of `while (1) {}` (note the trailing semi-colon).

I just ran `uncrustify -c uncrustify-riot.cfg --replace cpu/arm7_common/vectors.c` to get these changes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- run `uncrustify -c uncrustify-riot.cfg --replace cpu/arm7_common/vectors.c` should keep the file untouched (in master it doesn't).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
