### PR TITLE
pkg/pkg.mk: silence info if QUIETER

### DIFF
--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -4,6 +4,7 @@ FLASH_ADDR ?= 0x0
 export Q                     # Used in front of Makefile lines to suppress the printing of the command if user did not opt-in to see them.
 export QQ                    # as Q, but be more quiet
 export QUIET                 # The parameter to use whether to show verbose makefile commands or not.
+export QUIETER               # The parameter to use to hide most makefile output
 
 export OS                    # The operating system of the build host
 export OS_ARCH               # The build host's hardware architecture

--- a/pkg/c25519/Makefile
+++ b/pkg/c25519/Makefile
@@ -20,11 +20,11 @@ all: $(PKG_SOURCE_DIR)/
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
 
 $(PKG_SOURCE_DIR)/: $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
-	test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "${PKG_ZIPFILE}")"
+	$(QQ)test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "${PKG_ZIPFILE}")"
 	$(Q)$(UNZIP_HERE) -D -d $(PKGDIRBASE) $<
 
 $(PKG_ZIPFILE):
-	mkdir -p $(PKGDIRBASE)
+	$(QQ)mkdir -p $(PKGDIRBASE)
 	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
 
 clean::

--- a/pkg/edhoc-c/Makefile
+++ b/pkg/edhoc-c/Makefile
@@ -12,10 +12,10 @@ CFLAGS += -Wno-newline-eof
 EDHOC_C_MODULES := $(filter edhoc-c_%,$(USEMODULE))
 
 all: $(EDHOC_C_MODULES)
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=edhoc-c
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=edhoc-c
 
 edhoc-c_crypto_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/crypto -f $(RIOTBASE)/Makefile.base MODULE=$@ SRC=$*.c
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/crypto -f $(RIOTBASE)/Makefile.base MODULE=$@ SRC=$*.c
 
 edhoc-c_cbor_%:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/cbor -f $(RIOTBASE)/Makefile.base MODULE=$@ SRC=$*.c
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/cbor -f $(RIOTBASE)/Makefile.base MODULE=$@ SRC=$*.c

--- a/pkg/mynewt-core/Makefile
+++ b/pkg/mynewt-core/Makefile
@@ -31,7 +31,7 @@ all: $(filter $(MYNEWT_CORE_MODULES),$(USEMODULE))
 	@true
 
 mynewt-core_%: rm_riot_provided_headers
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(MYNEWT_CORE_PATH_$*) -f $(RIOTPKG)/$(PKG_NAME)/$@.mk MODULE=$@
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(MYNEWT_CORE_PATH_$*) -f $(RIOTPKG)/$(PKG_NAME)/$@.mk MODULE=$@
 
 # The following mynewt-core headers are provided by RIOT, remove them from
 # mynewt-core include paths to avoid header conflicts


### PR DESCRIPTION
### Contribution description

Silence most pkg clonning/handling related logs when QUIETER is set.

For some reason event though `--quiet` is passed I still get the progress report:

```
Building application "tests_pkg_edhoc_c" for "native" with MCU "native".

2022-04-28 14:07:29 URL:https://www.dlbeer.co.nz/downloads/c25519-2017-10-05.zip [68419/68419] -> "/home/francisco/workspace/RIOT/build/pkg/c25519-2017-10-05.zip" [1]
remote: Enumerating objects: 111, done.
remote: Counting objects: 100% (111/111), done.
remote: Compressing objects: 100% (103/103), done.
remote: Total 111 (delta 14), reused 71 (delta 7), pack-reused 0
Receiving objects: 100% (111/111), 188.56 KiB | 3.85 MiB/s, done.
Resolving deltas: 100% (14/14), done.
remote: Enumerating objects: 27, done.
remote: Counting objects: 100% (27/27), done.
remote: Compressing objects: 100% (23/23), done.
remote: Total 27 (delta 0), reused 12 (delta 0), pack-reused 0
Receiving objects: 100% (27/27), 24.35 KiB | 24.35 MiB/s, done.
remote: Enumerating objects: 55, done.
remote: Counting objects: 100% (55/55), done.
remote: Compressing objects: 100% (53/53), done.
remote: Total 55 (delta 14), reused 6 (delta 0), pack-reused 0
Receiving objects: 100% (55/55), 694.12 KiB | 4.34 MiB/s, done.
Resolving deltas: 100% (14/14), done.
   text	   data	    bss	    dec	    hex	filename
 258985	   1460	 169800	 430245	  690a5	/home/francisco/workspace/RIOT/tests/pkg_edhoc_c/bin/native/tests_pkg_edhoc_c.elf
```

So I redirected the output so it does not see a tty, now it's completely silent.

```
RIOT_CI_BUILD=1 make -C tests/pkg_nanocbor/
Building application "tests_pkg_nanocbor" for "native" with MCU "native".
   text    data     bss     dec     hex filename
  36388     721   47884   84993   14c01 /home/francisco/workspace/RIOT/tests/pkg_nanocbor/bin/native/tests_pkg_nanocbor.elf

```

Not sure if this is a bug with my git version or I'm missing something?

### Testing procedure

Build an application with `RIOT_CI_BUILD`, it should be much more silent now.