### PR TITLE
sys/posix/include/arpa: use `__restrict` instead of `restrict`

### DIFF
--- a/sys/posix/include/arpa/inet.h
+++ b/sys/posix/include/arpa/inet.h
@@ -59,7 +59,7 @@ extern "C" {
  * @return  NULL, if @p size was smaller than needed
  * @return  NULL, if @p src or @p dst was NULL
  */
-const char *inet_ntop(int af, const void *restrict src, char *restrict dst,
+const char *inet_ntop(int af, const void *__restrict src, char *__restrict dst,
                       socklen_t size);
 
 /**


### PR DESCRIPTION
### Contribution description

Replace `restrict` with `__restrict` in `sys/posix/include/arpa` because the `restrict` keyword is not available in C++.
Resolves this error message:
```
<RIOTBASE>/sys/posix/include/arpa/inet.h:62:52: error: expected ‘,’ or ‘...’ before ‘src’
   62 | const char *inet_ntop(int af, const void *restrict src, char *restrict dst,
      |                                                    ^~~
```

### Testing procedure

Green Murdock