### PR TITLE
net/sock/udp: designated intializer, C++ compatibility

### DIFF
--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -683,8 +683,9 @@ static inline ssize_t sock_udp_send_aux(sock_udp_t *sock,
                                         sock_udp_aux_tx_t *aux)
 {
     const iolist_t snip = {
-        .iol_base = (void *)data,
-        .iol_len  = len,
+        NULL,
+        (void *)data,
+        len,
     };
 
     return sock_udp_sendv_aux(sock, &snip, remote, aux);


### PR DESCRIPTION
### Contribution description

Compiling RIOT for native while including `sys/include/net/sock/udp.h` from a C++ file will result in this error:
```
<RIOTBASE>/sys/include/net/sock/udp.h: In function ‘ssize_t sock_udp_send_aux(sock_udp_t*, const void*, size_t, const sock_udp_ep_t*, sock_udp_aux_tx_t*)’:
<RIOTBASE>/sys/include/net/sock/udp.h:686:9: error: C++ designated initializers only available with ‘-std=c++2a’ or ‘-std=gnu++2a’ [-Werror=pedantic]
  686 |         .iol_base = (void *)data,
      |         ^
<RIOTBASE>/sys/include/net/sock/udp.h:687:9: error: C++ designated initializers only available with ‘-std=c++2a’ or ‘-std=gnu++2a’ [-Werror=pedantic]
  687 |         .iol_len  = len,
      |         ^
<RIOTBASE>/sys/include/net/sock/udp.h:688:5: error: missing initializer for member ‘iolist::iol_next’ [-Werror=missing-field-initializers]
  688 |     };
      |     ^
```

Like [jenswet](https://github.com/jenswet) said in #17636 

> I know the code change makes the code less readable. If you have better ideas on fixing it, I am happy for suggestions. We could also think about removing the ISO C++ requirement from the compiler flags for native.

### Testing procedure

Green Murdock
