### PR TITLE
net/gnrc: Fixing whitespace in the documentation

### DIFF
--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -131,8 +131,8 @@
  *                 pkt = msg.content.ptr;
  *                 _handle_outgoing_pkt(pkt);
  *                 break;
- *              case GNRC_NETAPI_MSG_TYPE_SET:
- *              case GNRC_NETAPI_MSG_TYPE_GET:
+ *             case GNRC_NETAPI_MSG_TYPE_SET:
+ *             case GNRC_NETAPI_MSG_TYPE_GET:
  *                 msg_reply(&msg, &reply);
  *                 break;
  *             default:


### PR DESCRIPTION
Hi 👋 

### Contribution description

In the example code given in [the documentation about gnrc](https://api.riot-os.org/group__net__gnrc.html) / receiving packets is unnecessary whitespace.
This PR touches a single file: `sys/include/net/gnrc.h`
It is a fix for the documentation, no "real" code is being touched.
The issue is resolved in this PR by removing the unneeded whitespace


### Testing procedure

I honestly did not test if doxygen still builds. 😅 
