### PR TITLE
nanocoap_sock: only abort nanocoap_sock_get_blockwise() on negative error

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -403,7 +403,7 @@ int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
         DEBUG("fetching block %u\n", num);
 
         int res = _fetch_block(sock, buf, sizeof(buf), path, blksize, num, &ctx);
-        if (res) {
+        if (res < 0) {
             DEBUG("error fetching block %u: %d\n", num, res);
             return res;
         }


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Some user callbacks might just return the result of some other operation that returns written bytes or negative error.

Let's not break those, only consider negative callback returns an error.


### Testing procedure

I discovered this when rebasing #17937 onto master.
Only the first block of a file would be written.
This is because the callback just returns the result of `vfs_write()`. This used to work fine (because `nanocoap_sock_request_cb()` would change the return code based on the CoAP response code), now it is handed through to the user, breaking `nanocoap_sock_get_blockwise()`.


### Issues/PRs references

follow-up to #17950
