### PR TITLE
sys/vfs_util: add VFS helper functions

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -559,6 +559,10 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
   DEFAULT_MODULE += vfs_auto_mount
 endif
 
+ifneq (,$(filter vfs_util,$(USEMODULE)))
+  USEMODULE += vfs
+endif
+
 ifneq (,$(filter vfs,$(USEMODULE)))
   USEMODULE += posix_headers
   ifeq (native, $(BOARD))

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -794,6 +794,9 @@ int vfs_open(const char *name, int flags, mode_t mode);
  *
  * @return number of bytes read on success
  * @return <0 on error
+ *
+ * For simple cases of only a single read from a file, the @ref
+ * vfs_file_to_buffer function can be used.
  */
 ssize_t vfs_read(int fd, void *dest, size_t count);
 
@@ -806,6 +809,9 @@ ssize_t vfs_read(int fd, void *dest, size_t count);
  *
  * @return number of bytes written on success
  * @return <0 on error
+ *
+ * For simple cases of only a single write to a file, the @ref
+ * vfs_file_from_buffer function can be used.
  */
 ssize_t vfs_write(int fd, const void *src, size_t count);
 

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_vfs_util    VFS helper functions
+ * @ingroup     sys_vfs
+ * @{
+ *
+ * @file
+ * @brief       VFS helper functions
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef VFS_UTIL_H
+#define VFS_UTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Writes the content of a buffer to a file
+ *          If the file already exists, it will be overwritten.
+ *
+ * @param[in]  file     Destination file path
+ * @param[in]  buf      Source buffer
+ * @param[in]  len      Buffer size
+ *
+ * @return  0 on success
+ * @return  negative error from @ref vfs_open, @ref vfs_write
+ */
+int vfs_file_from_buffer(const char *file, const void *buf, size_t len);
+
+/**
+ * @brief   Reads the content of a file to a buffer
+ *
+ * @param[in]  file     Source file path
+ * @param[out] buf      Destination buffer
+ * @param[in]  len      Buffer size
+ *
+ * @return  number of bytes read on success
+ * @return  -ENOSPC if the file was read successfully but is larger than
+ *          the provided buffer. Only the first @p len bytes were read.
+ * @return  negative error from @ref vfs_open, @ref vfs_read
+ */
+int vfs_file_to_buffer(const char* file, void* buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VFS_UTIL_H */
+/** @} */

--- a/sys/vfs_util/Makefile
+++ b/sys/vfs_util/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_vfs_util
+ * @{
+ * @file
+ * @brief   VFS layer helper functions
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+
+#include "vfs.h"
+#include "vfs_util.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+int vfs_file_from_buffer(const char *file, const void *buf, size_t len)
+{
+    int res, fd = vfs_open(file, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+
+    if (fd < 0) {
+        DEBUG("can't open %s for writing\n", file);
+        return fd;
+    }
+
+    res = vfs_write(fd, buf, len);
+    vfs_close(fd);
+
+    if (res) {
+        return res;
+    }
+
+    return 0;
+}
+
+int vfs_file_to_buffer(const char* file, void* buf, size_t len)
+{
+    int res, fd = vfs_open(file, O_RDONLY, 0);
+
+    if (fd < 0) {
+        DEBUG("can't open %s for reading\n", file);
+        return fd;
+    }
+
+    res = vfs_read(fd, buf, len);
+
+    /* ENOSPC is used to signal truncation */
+    /* Just for future proofing - this error code is not returned by any fs in the read path. */
+    if (res == -ENOSPC) {
+        DEBUG("read returned -ENOSPC\n");
+        res = -ENOMEM;
+    }
+
+    if (res > 0) {
+        if (res < (int)len) {
+            /* fill remaining buffer with 0 */
+            memset((char *)buf + res, 0, len - res);
+        } else {
+            /* check if there are more bytes in the file */
+            char c;
+            if (vfs_read(fd, &c, sizeof(c)) > 0) {
+                res = -ENOSPC;
+            }
+        }
+    }
+
+    vfs_close(fd);
+
+    return res;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It is often quite handy to have a small file to store a flag or an instruction or similar.
Instead of writing the same sequence of commands each time, provide a small helper function so the job can be done with a single line of code.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

split off #17379
