### PR TITLE
boards/stm32f469i-disco: enable cpy2remed programmer

### DIFF
--- a/boards/stm32f469i-disco/Makefile.include
+++ b/boards/stm32f469i-disco/Makefile.include
@@ -7,5 +7,9 @@ PROGRAMMER ?= openocd
 # this board has an on-board ST-link adapter
 OPENOCD_DEBUG_ADAPTER ?= stlink
 
-# openocd programmer is supported
-PROGRAMMERS_SUPPORTED += openocd
+#variable needed by cpy2remed PROGRAMMER
+#it contains name of ST-Link removable media
+DIR_NAME_AT_REMED = "DIS_F469NI"
+
+# openocd and cpy2remed programmers are supported
+PROGRAMMERS_SUPPORTED += openocd cpy2remed

--- a/boards/stm32f469i-disco/doc.txt
+++ b/boards/stm32f469i-disco/doc.txt
@@ -84,16 +84,37 @@ Also provides some system signals and power.
 
 ## Working with this Dev-Kit
 
-There are two requirements to start,first of them is the **gcc-arm-embedded** toolchain,
+To start the **gcc-arm-embedded** toolchain have to be installed,
 we can follow the usual process [here](https://github.com/RIOT-OS/RIOT/wiki/Family:-ARM).
 
-The other requirement is **OpenOCD**, also we can follow the usual process
+## Flashing the device
+
+### Flashing the Board using OpenOCD
+
+The start install **OpenOCD**, also we can follow the usual process
 [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
 
-Once both things are installed and ready to work just connect the board through
+Once everything is installed and ready to work just connect the board through
 the USB Mini-B connector try to compile and flash some code, type:
 
 ```
 make flash BOARD=stm32f469i-disco
 ```
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=stm32f469i-disco PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware update
+s
+could be found on [this STM webpage](https://www.st.com/en/development-tools/sts
+w-link007.html).
+
+
 */


### PR DESCRIPTION
### Contribution description

I found old STM Disco board and check that **_cpy2remed_** works (after ST-LINK firmware upgrade).
This PR enables **_cpy2remed_** programmer (see #17550) to stm32f469i-disco.

Initial version of the ST-LINK firmware:
```
Version: 0221
Build:   Nov  4 2015 15:25:25
``` 
Firmware  upgraded without any problems.

### Testing procedure

Go to RIOT/examples/blinky and run command
```
make BOARD=stm32f469i-disco: PROGRAMMER=cpy2remed flash
```
After a while, green LED (LED0) should start blinking.

Changes in documentation can be observed using commands:
```
make doc
xdg-open doc/doxygen/html/group__boards__stm32f469i-disco.html
```

### Issues/PRs references

#17550