### PR TITLE
sys/vfs_util: add vfs_file_<hash>() functions and md5sum, sha1sum and sha256sum shell commands

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -197,6 +197,7 @@ PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += senml_cbor
 PSEUDOMODULES += senml_phydat
 PSEUDOMODULES += senml_saul
+PSEUDOMODULES += sha1sum
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio
 PSEUDOMODULES += slipdev_l2addr

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -139,6 +139,7 @@ PSEUDOMODULES += mpu_stack_guard
 ## This is a protection mechanism which makes exploitation of buffer overflows significantly harder.
 PSEUDOMODULES += mpu_noexec_ram
 
+PSEUDOMODULES += md5sum
 PSEUDOMODULES += mtd_write_page
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += netdev_default

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -198,6 +198,7 @@ PSEUDOMODULES += senml_cbor
 PSEUDOMODULES += senml_phydat
 PSEUDOMODULES += senml_saul
 PSEUDOMODULES += sha1sum
+PSEUDOMODULES += sha256sum
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio
 PSEUDOMODULES += slipdev_l2addr

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -334,6 +334,11 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter md5sum,$(USEMODULE)))
+  USEMODULE += vfs_util
+  USEMODULE += hashes
+endif
+
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   USEMODULE += sema_deprecated
   USEMODULE += ztimer64_usec

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -334,7 +334,7 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter md5sum,$(USEMODULE)))
+ifneq (,$(filter md5sum sha1sum sha256sum,$(USEMODULE)))
   USEMODULE += vfs_util
   USEMODULE += hashes
 endif

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -67,6 +67,22 @@ int vfs_file_to_buffer(const char* file, void* buf, size_t len);
  */
 int vfs_file_md5(const char* file, void *digest,
                  void *work_buf, size_t work_buf_len);
+
+/**
+ * @brief   Compute the SHA1 message digest of a file
+ *
+ *          Requires the `hashes` module.
+ *
+ * @param[in]  file     Source file path
+ * @param[out] digest   Destination buffer, must fit @ref SHA1_DIGEST_LENGTH bytes
+ * @param[out] work_buf Work buffer
+ * @param[in] work_buf_len  Size of the work buffer
+ *
+ * @return  0 on success
+ * @return  negative error
+ */
+int vfs_file_sha1(const char* file, void *digest,
+                  void *work_buf, size_t work_buf_len);
 #endif
 
 #ifdef __cplusplus

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -83,6 +83,22 @@ int vfs_file_md5(const char* file, void *digest,
  */
 int vfs_file_sha1(const char* file, void *digest,
                   void *work_buf, size_t work_buf_len);
+
+/**
+ * @brief   Compute the SHA256 message digest of a file
+ *
+ *          Requires the `hashes` module.
+ *
+ * @param[in]  file     Source file path
+ * @param[out] digest   Destination buffer, must fit @ref SHA256_DIGEST_LENGTH bytes
+ * @param[out] work_buf Work buffer
+ * @param[in] work_buf_len  Size of the work buffer
+ *
+ * @return  0 on success
+ * @return  negative error
+ */
+int vfs_file_sha256(const char* file, void *digest,
+                    void *work_buf, size_t work_buf_len);
 #endif
 
 #ifdef __cplusplus

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -51,6 +51,24 @@ int vfs_file_from_buffer(const char *file, const void *buf, size_t len);
  */
 int vfs_file_to_buffer(const char* file, void* buf, size_t len);
 
+#if MODULE_HASHES || DOXYGEN
+/**
+ * @brief   Compute the MD5 message digest of a file
+ *
+ *          Requires the `hashes` module.
+ *
+ * @param[in]  file     Source file path
+ * @param[out] digest   Destination buffer, must fit @ref MD5_DIGEST_LENGTH bytes
+ * @param[out] work_buf Work buffer
+ * @param[in] work_buf_len  Size of the work buffer
+ *
+ * @return  0 on success
+ * @return  negative error
+ */
+int vfs_file_md5(const char* file, void *digest,
+                 void *work_buf, size_t work_buf_len);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -672,4 +672,31 @@ int _vfs_md5sum_cmd(int argc, char **argv)
     return 0;
 }
 #endif
+
+#if MODULE_SHA1SUM
+#include "hashes/sha1.h"
+int _vfs_sha1sum_cmd(int argc, char **argv)
+{
+    int res;
+    uint8_t digest[SHA1_DIGEST_LENGTH];
+
+    if (argc < 2) {
+        printf("usage: %s [file] …\n", argv[0]);
+        return -1;
+    }
+
+    for (int i = 1; i < argc; ++i) {
+        const char *file = argv[i];
+        res = vfs_file_sha1(file, digest,
+                           _shell_vfs_data_buffer, sizeof(_shell_vfs_data_buffer));
+        if (res < 0) {
+            printf("%s: error %d\n", file, res);
+        } else {
+            _print_digest(digest, sizeof(digest), file);
+        }
+    }
+
+    return 0;
+}
+#endif
 #endif

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -699,4 +699,31 @@ int _vfs_sha1sum_cmd(int argc, char **argv)
     return 0;
 }
 #endif
+
+#if MODULE_SHA256SUM
+#include "hashes/sha256.h"
+int _vfs_sha256sum_cmd(int argc, char **argv)
+{
+    int res;
+    uint8_t digest[SHA256_DIGEST_LENGTH];
+
+    if (argc < 2) {
+        printf("usage: %s [file] …\n", argv[0]);
+        return -1;
+    }
+
+    for (int i = 1; i < argc; ++i) {
+        const char *file = argv[i];
+        res = vfs_file_sha256(file, digest,
+                              _shell_vfs_data_buffer, sizeof(_shell_vfs_data_buffer));
+        if (res < 0) {
+            printf("%s: error %d\n", file, res);
+        } else {
+            _print_digest(digest, sizeof(digest), file);
+        }
+    }
+
+    return 0;
+}
+#endif
 #endif

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -215,6 +215,10 @@ extern int _bootloader_handler(int argc, char **argv);
 extern int _gnrc_udp_cmd(int argc, char **argv);
 #endif
 
+#ifdef MODULE_MD5SUM
+extern int _vfs_md5sum_cmd(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
     {"version", "Prints current RIOT_VERSION", _version_handler},
@@ -267,6 +271,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_RTT_CMD
     {"rtt", "control RTC peripheral interface",  _rtt_handler},
+#endif
+#ifdef MODULE_MD5SUM
+    {"md5sum", "Compute and check MD5 message digest", _vfs_md5sum_cmd},
 #endif
 #ifdef MODULE_GNRC_IPV6_NIB
     {"nib", "Configure neighbor information base", _gnrc_ipv6_nib},

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -223,6 +223,10 @@ extern int _vfs_md5sum_cmd(int argc, char **argv);
 extern int _vfs_sha1sum_cmd(int argc, char **argv);
 #endif
 
+#ifdef MODULE_SHA256SUM
+extern int _vfs_sha256sum_cmd(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
     {"version", "Prints current RIOT_VERSION", _version_handler},
@@ -281,6 +285,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_SHA1SUM
     {"sha1sum", "Compute and check SHA1 message digest", _vfs_sha1sum_cmd},
+#endif
+#ifdef MODULE_SHA256SUM
+    {"sha256sum", "Compute and check SHA256 message digest", _vfs_sha256sum_cmd},
 #endif
 #ifdef MODULE_GNRC_IPV6_NIB
     {"nib", "Configure neighbor information base", _gnrc_ipv6_nib},

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -219,6 +219,10 @@ extern int _gnrc_udp_cmd(int argc, char **argv);
 extern int _vfs_md5sum_cmd(int argc, char **argv);
 #endif
 
+#ifdef MODULE_SHA1SUM
+extern int _vfs_sha1sum_cmd(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
     {"version", "Prints current RIOT_VERSION", _version_handler},
@@ -274,6 +278,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_MD5SUM
     {"md5sum", "Compute and check MD5 message digest", _vfs_md5sum_cmd},
+#endif
+#ifdef MODULE_SHA1SUM
+    {"sha1sum", "Compute and check SHA1 message digest", _vfs_sha1sum_cmd},
 #endif
 #ifdef MODULE_GNRC_IPV6_NIB
     {"nib", "Configure neighbor information base", _gnrc_ipv6_nib},

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -82,6 +82,7 @@ int vfs_file_to_buffer(const char* file, void* buf, size_t len)
 
 #if MODULE_HASHES
 #include "hashes/md5.h"
+#include "hashes/sha1.h"
 
 int vfs_file_md5(const char* file, void *digest,
                  void *work_buf, size_t work_buf_len)
@@ -104,5 +105,28 @@ int vfs_file_md5(const char* file, void *digest,
     vfs_close(fd);
 
     return res > 0 ? 0 : res;
+}
+
+int vfs_file_sha1(const char* file, void *digest,
+                  void *work_buf, size_t work_buf_len)
+{
+    sha1_context ctx;
+    int res, fd = vfs_open(file, O_RDONLY, 0);
+
+    if (fd < 0) {
+        DEBUG("can't open %s for reading\n", file);
+        return fd;
+    }
+
+    sha1_init(&ctx);
+    while ((res = vfs_read(fd, work_buf, work_buf_len)) > 0) {
+        sha1_update(&ctx, work_buf, res);
+    }
+    sha1_final(&ctx, digest);
+
+    vfs_close(fd);
+
+    return res > 0 ? 0 : res;
+
 }
 #endif /* MODULE_HASHES */

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -83,6 +83,7 @@ int vfs_file_to_buffer(const char* file, void* buf, size_t len)
 #if MODULE_HASHES
 #include "hashes/md5.h"
 #include "hashes/sha1.h"
+#include "hashes/sha256.h"
 
 int vfs_file_md5(const char* file, void *digest,
                  void *work_buf, size_t work_buf_len)
@@ -123,6 +124,29 @@ int vfs_file_sha1(const char* file, void *digest,
         sha1_update(&ctx, work_buf, res);
     }
     sha1_final(&ctx, digest);
+
+    vfs_close(fd);
+
+    return res > 0 ? 0 : res;
+
+}
+
+int vfs_file_sha256(const char* file, void *digest,
+                    void *work_buf, size_t work_buf_len)
+{
+    sha256_context_t ctx;
+    int res, fd = vfs_open(file, O_RDONLY, 0);
+
+    if (fd < 0) {
+        DEBUG("can't open %s for reading\n", file);
+        return fd;
+    }
+
+    sha256_init(&ctx);
+    while ((res = vfs_read(fd, work_buf, work_buf_len)) > 0) {
+        sha256_update(&ctx, work_buf, res);
+    }
+    sha256_final(&ctx, digest);
 
     vfs_close(fd);
 

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -79,3 +79,30 @@ int vfs_file_to_buffer(const char* file, void* buf, size_t len)
 
     return res;
 }
+
+#if MODULE_HASHES
+#include "hashes/md5.h"
+
+int vfs_file_md5(const char* file, void *digest,
+                 void *work_buf, size_t work_buf_len)
+{
+    md5_ctx_t ctx;
+
+    int res, fd = vfs_open(file, O_RDONLY, 0);
+
+    if (fd < 0) {
+        DEBUG("can't open %s for reading\n", file);
+        return fd;
+    }
+
+    md5_init(&ctx);
+    while ((res = vfs_read(fd, work_buf, work_buf_len)) > 0) {
+        md5_update(&ctx, work_buf, res);
+    }
+    md5_final(&ctx, digest);
+
+    vfs_close(fd);
+
+    return res > 0 ? 0 : res;
+}
+#endif /* MODULE_HASHES */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds helper functions to compute the hash of a file as well as accompanying shell functions `md5sum`, `sha1sum` and  `sha256sum`.


### Testing procedure

Just add the module with the name of the shell function, e.g

```
USEMODULE += md5sum
USEMODULE += sha1sum
USEMODULE += sha256sum
```

```
2022-04-30 18:22:26,944 # > md5sum /nvm0/image.bin /nvm0/old_image.bin
2022-04-30 18:22:27,025 # 927c31ba0e221b6b0ed916d0f6bb794f  /nvm0/image.bin
2022-04-30 18:22:27,098 # 0e4c7aaf386573e4a4a872d28afd066a  /nvm0/old_image.bin

2022-04-30 18:22:34,224 # > sha1sum /nvm0/image.bin /nvm0/old_image.bin
2022-04-30 18:22:34,334 # 6c1207ba448d380133ada360f42633d2bdfd83e4  /nvm0/image.bin
2022-04-30 18:22:34,433 # a3b4b6aafef50f0efcff0b0fc52fc98ef1c80217  /nvm0/old_image.bin

2022-04-30 18:22:48,370 # > sha256sum /nvm0/image.bin /nvm0/old_image.bin
2022-04-30 18:22:48,461 # 00848c421e9661a33b54e0905abdd3be9a1084f890fe0cef78dbbfbb5bf3e54a  /nvm0/image.bin
2022-04-30 18:22:48,544 # ceea881479bc0dd542393531e01a59a4397f06fab47550ecc818fc0059b6008b  /nvm0/old_image.bin
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
