### PR TITLE
cpu/sam0_common: adc: Automatically configure external reference pin

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -780,6 +780,23 @@ typedef struct {
 } adc_conf_chan_t;
 
 /**
+ * @brief Pin that can be used for external voltage reference A
+ */
+#define ADC_REFSEL_AREFA_PIN    GPIO_PIN(PA, 3)
+
+/**
+ * @brief Pin that can be used for external voltage reference B
+ */
+#define ADC_REFSEL_AREFB_PIN    GPIO_PIN(PA, 4)
+
+#if defined(ADC_REFCTRL_REFSEL_AREFC) || DOXYGEN
+/**
+ * @brief Pin that can be used for external voltage reference C
+ */
+#define ADC_REFSEL_AREFC_PIN    GPIO_PIN(PA, 6)
+#endif
+
+/**
  * @name Ethernet peripheral parameters
  * @{
  */

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -223,6 +223,21 @@ static int _adc_configure(Adc *dev, adc_res_t res)
         SUPC->VREF.reg |= SUPC_VREF_VREFOE;
     }
 #endif
+#ifdef ADC_REFCTRL_REFSEL_AREFA
+    if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_AREFA) {
+        gpio_init_mux(ADC_REFSEL_AREFA_PIN, GPIO_MUX_B);
+    }
+#endif
+#ifdef ADC_REFCTRL_REFSEL_AREFB
+    if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_AREFB) {
+        gpio_init_mux(ADC_REFSEL_AREFB_PIN, GPIO_MUX_B);
+    }
+#endif
+#ifdef ADC_REFCTRL_REFSEL_AREFC
+    if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_AREFC) {
+        gpio_init_mux(ADC_REFSEL_AREFC_PIN, GPIO_MUX_B);
+    }
+#endif
 
     /*  Enable ADC Module */
     dev->CTRLA.reg |= ADC_CTRLA_ENABLE;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The ADC can be configured to use an input pin for the external reference voltage.
Automatically configure this pin when `ADC_REF_DEFAULT` is set accordingly.

On all members of the family PA03 and P04 can be used as reference A and B respectively. SAM D5x/E5x also allows to use PA06 as reference C.

### Testing procedure

Set `ADC_REFSEL_AREFB_PIN` to e.g. `ADC_REFCTRL_REFSEL_AREFA` and connect a reference voltage to PA03, then run `tests/periph_adc`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
