### PR TITLE
drivers/saul: use const qualifier for data to write

### DIFF
--- a/cpu/efm32/drivers/coretemp/coretemp_saul.c
+++ b/cpu/efm32/drivers/coretemp/coretemp_saul.c
@@ -35,7 +35,7 @@ static int _read(const void *dev, phydat_t *res)
 
 const saul_driver_t efm32_coretemp_saul_driver = {
     .read = _read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 

--- a/cpu/nrf5x_common/periph/temperature.c
+++ b/cpu/nrf5x_common/periph/temperature.c
@@ -63,6 +63,6 @@ const saul_reg_info_t nrf_temperature_saul_info = {
 
 const saul_driver_t nrf_temperature_saul_driver = {
     .read = _read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/ad7746/ad7746_saul.c
+++ b/drivers/ad7746/ad7746_saul.c
@@ -78,18 +78,18 @@ static int _read_volt(const void *dev, phydat_t *res)
 
 const saul_driver_t ad7746_saul_driver_cap = {
     .read = _read_cap,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CAPACITANCE,
 };
 
 const saul_driver_t ad7746_saul_driver_temp = {
     .read = _read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t ad7746_saul_driver_volt = {
     .read = _read_volt,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_VOLTAGE
 };

--- a/drivers/adcxx1c/adcxx1c_saul.c
+++ b/drivers/adcxx1c/adcxx1c_saul.c
@@ -38,6 +38,6 @@ static int read_adc(const void *dev, phydat_t *res)
 
 const saul_driver_t adcxx1c_saul_driver = {
     .read = read_adc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ANALOG,
 };

--- a/drivers/ads101x/ads101x_saul.c
+++ b/drivers/ads101x/ads101x_saul.c
@@ -66,6 +66,6 @@ static int read_adc(const void *dev, phydat_t *res)
 
 const saul_driver_t ads101x_saul_driver = {
     .read = read_adc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ANALOG,
 };

--- a/drivers/adxl345/adxl345_saul.c
+++ b/drivers/adxl345/adxl345_saul.c
@@ -32,6 +32,6 @@ static int read_acc(const void *dev, phydat_t *res)
 
 const saul_driver_t adxl345_saul_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/apds99xx/apds99xx_saul.c
+++ b/drivers/apds99xx/apds99xx_saul.c
@@ -68,20 +68,20 @@ static int read_rgb(const void *dev, phydat_t *res)
 
 const saul_driver_t apds99xx_saul_prx_driver = {
     .read = read_prx,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PROXIMITY,
 };
 
 const saul_driver_t apds99xx_saul_als_driver = {
     .read = read_als,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT,
 };
 
 #if MODULE_APDS9900 || MODULE_APDS9901 || MODULE_APDS9930
 const saul_driver_t apds99xx_saul_lux_driver = {
     .read = read_lux,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT,
 };
 #endif
@@ -89,7 +89,7 @@ const saul_driver_t apds99xx_saul_lux_driver = {
 #if MODULE_APDS9950 || MODULE_APDS9960
 const saul_driver_t apds99xx_saul_rgb_driver = {
     .read = read_rgb,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT,
 };
 #endif

--- a/drivers/bme680/bme680_saul.c
+++ b/drivers/bme680/bme680_saul.c
@@ -187,24 +187,24 @@ static int read_gas(const void *dev, phydat_t *data)
 
 const saul_driver_t bme680_saul_driver_temperature = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t bme680_saul_driver_pressure = {
     .read = read_press,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS
 };
 
 const saul_driver_t bme680_saul_driver_humidity = {
     .read = read_hum,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM
 };
 
 const saul_driver_t bme680_saul_driver_gas = {
     .read = read_gas,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GAS
 };

--- a/drivers/bmp180/bmp180_saul.c
+++ b/drivers/bmp180/bmp180_saul.c
@@ -42,12 +42,12 @@ static int read_pressure(const void *dev, phydat_t *res)
 
 const saul_driver_t bmp180_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t bmp180_pressure_saul_driver = {
     .read = read_pressure,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS
 };

--- a/drivers/bmx055/bmx055_saul.c
+++ b/drivers/bmx055/bmx055_saul.c
@@ -60,18 +60,18 @@ static int read_gyro(const void *dev, phydat_t *res)
 
 const saul_driver_t bmx055_magnetometer_saul_driver = {
     .read = read_mag,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };
 
 const saul_driver_t bmx055_accelerometer_saul_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t bmx055_gyroscope_saul_driver = {
     .read = read_gyro,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GYRO,
 };

--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -57,20 +57,20 @@ static int read_relative_humidity(const void *dev, phydat_t *res)
 
 const saul_driver_t bmx280_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t bmx280_pressure_saul_driver = {
     .read = read_pressure,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS,
 };
 
 #if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
 const saul_driver_t bme280_relative_humidity_saul_driver = {
     .read = read_relative_humidity,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM,
 };
 #endif

--- a/drivers/ccs811/ccs811_saul.c
+++ b/drivers/ccs811/ccs811_saul.c
@@ -66,12 +66,12 @@ static int read_eco2(const void *dev, phydat_t *res)
 
 const saul_driver_t ccs811_saul_driver_eco2 = {
     .read = read_eco2,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CO2
 };
 
 const saul_driver_t ccs811_saul_driver_tvoc = {
     .read = read_tvoc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TVOC
 };

--- a/drivers/dht/dht_saul.c
+++ b/drivers/dht/dht_saul.c
@@ -53,12 +53,12 @@ static int read_hum(const void *dev, phydat_t *res)
 
 const saul_driver_t dht_temp_saul_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t dht_hum_saul_driver = {
     .read = read_hum,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM
 };

--- a/drivers/ds18/ds18_saul.c
+++ b/drivers/ds18/ds18_saul.c
@@ -37,6 +37,6 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t ds18_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };

--- a/drivers/ds75lx/ds75lx_saul.c
+++ b/drivers/ds75lx/ds75lx_saul.c
@@ -39,6 +39,6 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t ds75lx_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -61,12 +61,12 @@ static int read_acc(const void *dev, phydat_t *res)
 
 const saul_driver_t fxos8700_saul_mag_driver = {
     .read = read_mag,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };
 
 const saul_driver_t fxos8700_saul_acc_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/gp2y10xx/gp2y10xx_saul.c
+++ b/drivers/gp2y10xx/gp2y10xx_saul.c
@@ -41,6 +41,6 @@ static int _read(const void *dev, phydat_t *res)
 
 const saul_driver_t gp2y10xx_saul_driver = {
     .read = _read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM,
 };

--- a/drivers/grove_ledbar/grove_ledbar_saul.c
+++ b/drivers/grove_ledbar/grove_ledbar_saul.c
@@ -24,7 +24,7 @@
 #include "saul.h"
 #include "grove_ledbar.h"
 
-static int set_ledbar(const void *dev, phydat_t *res)
+static int set_ledbar(const void *dev, const phydat_t *res)
 {
     uint8_t lvl = (uint8_t)res->val[0];
     grove_ledbar_set((grove_ledbar_t *)dev, lvl);
@@ -32,7 +32,7 @@ static int set_ledbar(const void *dev, phydat_t *res)
 }
 
 const saul_driver_t grove_ledbar_saul_driver = {
-    .read = saul_notsup,
+    .read = saul_read_notsup,
     .write = set_ledbar,
     .type = SAUL_ACT_LED_RGB,
 };

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -51,12 +51,12 @@ static int read_hum(const void *dev, phydat_t *res)
 
 const saul_driver_t hdc1000_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t hdc1000_saul_hum_driver = {
     .read = read_hum,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM,
 };

--- a/drivers/hm330x/hm330x_saul.c
+++ b/drivers/hm330x/hm330x_saul.c
@@ -138,38 +138,38 @@ static int read_nc_pm_10(const void *_dev, phydat_t *data)
 
 const saul_driver_t hm330x_saul_driver_mc_pm_1 = {
     .read = read_mc_pm_1,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM
 };
 
 const saul_driver_t hm330x_saul_driver_mc_pm_2p5 = {
     .read = read_mc_pm_2p5,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM
 };
 
 const saul_driver_t hm330x_saul_driver_mc_pm_10 = {
     .read = read_mc_pm_10,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM
 };
 
 #if IS_USED(MODULE_HM3302)
 const saul_driver_t hm330x_saul_driver_nc_pm_1 = {
     .read = read_nc_pm_1,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_COUNT
 };
 
 const saul_driver_t hm330x_saul_driver_nc_pm_2p5 = {
     .read = read_nc_pm_2p5,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_COUNT
 };
 
 const saul_driver_t hm330x_saul_driver_nc_pm_10 = {
     .read = read_nc_pm_10,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_COUNT
 };
 #endif

--- a/drivers/hmc5883l/hmc5883l_saul.c
+++ b/drivers/hmc5883l/hmc5883l_saul.c
@@ -35,6 +35,6 @@ static int read(const void *dev, phydat_t *res)
 
 const saul_driver_t hmc5883l_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/hsc/hsc_saul.c
+++ b/drivers/hsc/hsc_saul.c
@@ -45,12 +45,12 @@ static int read_pressure(const void *dev, phydat_t *res)
 
 const saul_driver_t hsc_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t hsc_pressure_saul_driver = {
     .read = read_pressure,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS
 };

--- a/drivers/hts221/hts221_saul.c
+++ b/drivers/hts221/hts221_saul.c
@@ -47,12 +47,12 @@ static int read_hum(const void *dev, phydat_t *res)
 
 const saul_driver_t hts221_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t hts221_saul_hum_driver = {
     .read = read_hum,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM,
 };

--- a/drivers/ina2xx/ina2xx_saul.c
+++ b/drivers/ina2xx/ina2xx_saul.c
@@ -69,18 +69,18 @@ static int read_voltage(const void *_dev, phydat_t *res)
 
 const saul_driver_t ina2xx_saul_current_driver = {
     .read = read_current,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CURRENT
 };
 
 const saul_driver_t ina2xx_saul_power_driver = {
     .read = read_power,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_POWER
 };
 
 const saul_driver_t ina2xx_saul_voltage_driver = {
     .read = read_voltage,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_VOLTAGE
 };

--- a/drivers/ina3221/ina3221_saul.c
+++ b/drivers/ina3221/ina3221_saul.c
@@ -96,7 +96,7 @@ static int read_shunt_voltage_sum(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int configure_channel(const void *dev, phydat_t *data)
+static int configure_channel(const void *dev, const phydat_t *data)
 {
     ina3221_ch_t ch = (data->val[0] ? INA3221_CH1 : 0) |
                       (data->val[1] ? INA3221_CH2 : 0) |
@@ -107,7 +107,7 @@ static int configure_channel(const void *dev, phydat_t *data)
     return INA3221_NUM_CH;
 }
 
-static int configure_channel_sum(const void *dev, phydat_t *data)
+static int configure_channel_sum(const void *dev, const phydat_t *data)
 {
     ina3221_ch_t ch = (data->val[0] ? INA3221_CH1 : 0) |
                       (data->val[1] ? INA3221_CH2 : 0) |

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -275,7 +275,7 @@ typedef int(*saul_read_t)(const void *dev, phydat_t *res);
  * @return  -ENOTSUP if the device does not support this operation
  * @return  -ECANCELED on other errors
  */
-typedef int(*saul_write_t)(const void *dev, phydat_t *data);
+typedef int(*saul_write_t)(const void *dev, const phydat_t *data);
 
 /**
  * @brief   Definition of the RIOT actuator/sensor interface
@@ -297,9 +297,18 @@ typedef struct {
 void saul_init_devs(void);
 
 /**
- * @brief   Default not supported function
+ * @brief   Fallback function when write is not supported
+ *
+ * @details Returns `-NOTSUP` without evaluating arguments.
  */
-int saul_notsup(const void *dev, phydat_t *dat);
+int saul_write_notsup(const void *dev, const phydat_t *dat);
+
+/**
+ * @brief   Fallback function when read is not supported
+ *
+ * @details Returns `-NOTSUP` without evaluating arguments.
+ */
+int saul_read_notsup(const void *dev, phydat_t *dat);
 
 /**
  * @brief   Helper function converts a class ID to a string

--- a/drivers/io1_xplained/io1_xplained_saul.c
+++ b/drivers/io1_xplained/io1_xplained_saul.c
@@ -38,6 +38,6 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t io1_xplained_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };

--- a/drivers/isl29020/isl29020_saul.c
+++ b/drivers/isl29020/isl29020_saul.c
@@ -35,6 +35,6 @@ static int read(const void *dev, phydat_t *res)
 
 const saul_driver_t isl29020_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT,
 };

--- a/drivers/itg320x/itg320x_saul.c
+++ b/drivers/itg320x/itg320x_saul.c
@@ -48,12 +48,12 @@ static int read_temp(const void *dev, phydat_t *res)
 
 const saul_driver_t itg320x_saul_gyro_driver = {
     .read = read_gyro,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GYRO,
 };
 
 const saul_driver_t itg320x_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/jc42/jc42_saul.c
+++ b/drivers/jc42/jc42_saul.c
@@ -36,6 +36,6 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t jc42_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };

--- a/drivers/l3g4200d/l3g4200d_saul.c
+++ b/drivers/l3g4200d/l3g4200d_saul.c
@@ -33,6 +33,6 @@ static int read(const void *dev, phydat_t *res)
 
 const saul_driver_t l3g4200d_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GYRO,
 };

--- a/drivers/l3gxxxx/l3gxxxx_saul.c
+++ b/drivers/l3gxxxx/l3gxxxx_saul.c
@@ -37,6 +37,6 @@ static int read(const void *dev, phydat_t *res)
 
 const saul_driver_t l3gxxxx_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GYRO,
 };

--- a/drivers/lis2dh12/lis2dh12_saul.c
+++ b/drivers/lis2dh12/lis2dh12_saul.c
@@ -44,12 +44,12 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t lis2dh12_saul_driver = {
     .read = read_accelerometer,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t lis2dh12_saul_temp_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/lis3dh/lis3dh_saul.c
+++ b/drivers/lis3dh/lis3dh_saul.c
@@ -46,6 +46,6 @@ static int read_acc(const void *dev, phydat_t *res)
 
 const saul_driver_t lis3dh_saul_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/lis3mdl/lis3mdl_saul.c
+++ b/drivers/lis3mdl/lis3mdl_saul.c
@@ -36,6 +36,6 @@ static int read_mag(const void *dev, phydat_t *res)
 
 const saul_driver_t lis3mdl_saul_mag_driver = {
     .read = read_mag,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/lm75/lm75_saul.c
+++ b/drivers/lm75/lm75_saul.c
@@ -36,6 +36,6 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t lm75_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };

--- a/drivers/lpsxxx/lpsxxx_saul.c
+++ b/drivers/lpsxxx/lpsxxx_saul.c
@@ -50,12 +50,12 @@ static int read_temp(const void *dev, phydat_t *res)
 
 const saul_driver_t lpsxxx_saul_pres_driver = {
     .read = read_pres,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS,
 };
 
 const saul_driver_t lpsxxx_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -70,12 +70,12 @@ static int read_mag(const void *dev, phydat_t *res)
 
 const saul_driver_t lsm303dlhc_saul_acc_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t lsm303dlhc_saul_mag_driver = {
     .read = read_mag,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/lsm6dsl/lsm6dsl_saul.c
+++ b/drivers/lsm6dsl/lsm6dsl_saul.c
@@ -62,18 +62,18 @@ static int read_temp(const void *dev, phydat_t *res)
 
 const saul_driver_t lsm6dsl_saul_acc_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t lsm6dsl_saul_gyro_driver = {
     .read = read_gyro,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GYRO,
 };
 
 const saul_driver_t lsm6dsl_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/ltc4150/ltc4150_saul.c
+++ b/drivers/ltc4150/ltc4150_saul.c
@@ -56,12 +56,12 @@ static int read_current(const void *dev, phydat_t *res)
 
 const saul_driver_t ltc4150_saul_charge_driver = {
     .read = read_charge,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CHARGE
 };
 
 const saul_driver_t ltc4150_saul_current_driver = {
     .read = read_current,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CURRENT
 };

--- a/drivers/mag3110/mag3110_saul.c
+++ b/drivers/mag3110/mag3110_saul.c
@@ -36,6 +36,6 @@ static int read_mag(const void *dev, phydat_t *res)
 
 const saul_driver_t mag3110_saul_driver = {
     .read = read_mag,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/mcp47xx/mcp47xx_saul.c
+++ b/drivers/mcp47xx/mcp47xx_saul.c
@@ -21,7 +21,7 @@
 
 extern mcp47xx_t mcp47xx_devs[];
 
-static int set(const void *dev, phydat_t *data)
+static int set(const void *dev, const phydat_t *data)
 {
     const mcp47xx_saul_dac_params_t *p = (const mcp47xx_saul_dac_params_t *)dev;
     mcp47xx_dac_set(&mcp47xx_devs[p->dev], p->channel, (uint16_t)data->val[0]);

--- a/drivers/mhz19/mhz19_saul.c
+++ b/drivers/mhz19/mhz19_saul.c
@@ -37,6 +37,6 @@ static int read_ppm(const void *dev, phydat_t *res)
 
 const saul_driver_t mhz19_ppm_saul_driver = {
     .read = read_ppm,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CO2
 };

--- a/drivers/mma7660/mma7660_saul.c
+++ b/drivers/mma7660/mma7660_saul.c
@@ -36,6 +36,6 @@ static int read_acc(const void *dev, phydat_t *res)
 
 const saul_driver_t mma7660_saul_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/mma8x5x/mma8x5x_saul.c
+++ b/drivers/mma8x5x/mma8x5x_saul.c
@@ -37,6 +37,6 @@ static int read_acc(const void *dev, phydat_t *res)
 
 const saul_driver_t mma8x5x_saul_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/mpl3115a2/mpl3115a2_saul.c
+++ b/drivers/mpl3115a2/mpl3115a2_saul.c
@@ -59,12 +59,12 @@ static int read_temperature(const void *dev, phydat_t *res)
 
 const saul_driver_t mpl3115a2_pressure_saul_driver = {
     .read = read_pressure,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS,
 };
 
 const saul_driver_t mpl3115a2_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/mpu9x50/mpu9x50_saul.c
+++ b/drivers/mpu9x50/mpu9x50_saul.c
@@ -66,18 +66,18 @@ static int read_mag(const void *dev, phydat_t *res)
 
 const saul_driver_t mpu9x50_saul_acc_driver = {
     .read = read_acc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t mpu9x50_saul_gyro_driver = {
     .read = read_gyro,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_GYRO,
 };
 
 const saul_driver_t mpu9x50_saul_mag_driver = {
     .read = read_mag,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/opt3001/opt3001_saul.c
+++ b/drivers/opt3001/opt3001_saul.c
@@ -43,6 +43,6 @@ static int read_lux(const void *dev, phydat_t *res)
 
 const saul_driver_t opt3001_saul_driver = {
     .read = read_lux,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT,
 };

--- a/drivers/pca9685/pca9685_saul.c
+++ b/drivers/pca9685/pca9685_saul.c
@@ -21,7 +21,7 @@
 
 extern pca9685_t pca9685_devs[];
 
-static int set(const void *dev, phydat_t *data)
+static int set(const void *dev, const phydat_t *data)
 {
     const pca9685_saul_pwm_params_t *p = (const pca9685_saul_pwm_params_t *)dev;
     pca9685_pwm_set(&pca9685_devs[p->dev], p->channel, (uint16_t)data->val[0]);
@@ -29,7 +29,7 @@ static int set(const void *dev, phydat_t *data)
 }
 
 const saul_driver_t pca9685_pwm_saul_driver = {
-    .read = saul_notsup,
+    .read = saul_read_notsup,
     .write = set,
     .type = SAUL_ACT_SERVO
 };

--- a/drivers/pcf857x/pcf857x_saul.c
+++ b/drivers/pcf857x/pcf857x_saul.c
@@ -33,7 +33,7 @@ static int read(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int write(const void *dev, phydat_t *state)
+static int write(const void *dev, const phydat_t *state)
 {
     const pcf857x_saul_gpio_params_t *p = (const pcf857x_saul_gpio_params_t *)dev;
     int inverted = (p->gpio.flags & SAUL_GPIO_INVERTED);
@@ -51,7 +51,7 @@ const saul_driver_t pcf857x_gpio_out_saul_driver = {
 
 const saul_driver_t pcf857x_gpio_in_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_BTN
 };
 #endif /* MODULE_SAUL_GPIO */

--- a/drivers/ph_oem/ph_oem_saul.c
+++ b/drivers/ph_oem/ph_oem_saul.c
@@ -52,7 +52,7 @@ static int read_ph(const void *dev, phydat_t *res)
 
 /* Sets the temperature compensation for taking accurate pH readings.
  * Valid temperature range is 1 - 20000 (0.01 °C  to  200.0 °C) */
-static int set_temp_compensation(const void *dev, phydat_t *res)
+static int set_temp_compensation(const void *dev, const phydat_t *res)
 {
     const ph_oem_t *mydev = dev;
 

--- a/drivers/pir/pir_saul.c
+++ b/drivers/pir/pir_saul.c
@@ -38,6 +38,6 @@ static int read_occup(const void *dev, phydat_t *res) {
 
 const saul_driver_t pir_saul_occup_driver = {
     .read = read_occup,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_OCCUP,
 };

--- a/drivers/pulse_counter/pulse_counter_saul.c
+++ b/drivers/pulse_counter/pulse_counter_saul.c
@@ -33,7 +33,7 @@ static int read_pulse_counter(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int write_pulse_counter(const void *dev, phydat_t *data)
+static int write_pulse_counter(const void *dev, const phydat_t *data)
 {
     /* Using non-const dev !! */
     pulse_counter_t *mydev = (pulse_counter_t *)dev;

--- a/drivers/qmc5883l/qmc5883l_saul.c
+++ b/drivers/qmc5883l/qmc5883l_saul.c
@@ -36,6 +36,6 @@ static int read(const void *dev, phydat_t *res)
 
 const saul_driver_t qmc5883l_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/saul/adc_saul.c
+++ b/drivers/saul/adc_saul.c
@@ -37,6 +37,6 @@ static int read_adc(const void *dev, phydat_t *res)
 
 const saul_driver_t adc_saul_driver = {
     .read = read_adc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_ANALOG,
 };

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -37,7 +37,7 @@ static int read(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int write(const void *dev, phydat_t *state)
+static int write(const void *dev, const phydat_t *state)
 {
     const saul_gpio_params_t *p = (const saul_gpio_params_t *)dev;
     int inverted = (p->flags & SAUL_GPIO_INVERTED);
@@ -55,6 +55,6 @@ const saul_driver_t gpio_out_saul_driver = {
 
 const saul_driver_t gpio_in_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_BTN
 };

--- a/drivers/saul/init_devs/auto_init_saul_nrf_vddh.c
+++ b/drivers/saul/init_devs/auto_init_saul_nrf_vddh.c
@@ -43,7 +43,7 @@ static int _read_voltage(const void *dev, phydat_t *res)
 
 static saul_driver_t nrf_vddh_saul_driver = {
     .read = _read_voltage,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_VOLTAGE,
 };
 

--- a/drivers/saul/pwm_saul.c
+++ b/drivers/saul/pwm_saul.c
@@ -74,7 +74,7 @@ static inline void setchan(const saul_pwm_channel_t *chan, uint16_t value)
             (chan->flags & SAUL_PWM_INVERTED) ? saul_pwm_resolution - value : value);
 }
 
-static int write_dimmer(const void *dev, phydat_t *state)
+static int write_dimmer(const void *dev, const phydat_t *state)
 {
     const saul_pwm_dimmer_params_t *p = dev;
 
@@ -94,12 +94,12 @@ static int write_dimmer(const void *dev, phydat_t *state)
 }
 
 const saul_driver_t dimmer_saul_driver = {
-    .read = saul_notsup,
+    .read = saul_read_notsup,
     .write = write_dimmer,
     .type = SAUL_ACT_DIMMER
 };
 
-static int write_rgb(const void *dev, phydat_t *state)
+static int write_rgb(const void *dev, const phydat_t *state)
 {
     const saul_pwm_rgb_params_t *p = dev;
 
@@ -123,7 +123,7 @@ static int write_rgb(const void *dev, phydat_t *state)
 }
 
 const saul_driver_t rgb_saul_driver = {
-    .read = saul_notsup,
+    .read = saul_read_notsup,
     .write = write_rgb,
     .type = SAUL_ACT_LED_RGB
 };

--- a/drivers/saul/saul.c
+++ b/drivers/saul/saul.c
@@ -22,9 +22,14 @@
 
 #include "saul.h"
 
-int saul_notsup(const void *dev, phydat_t *dat)
+int saul_write_notsup(const void *dev, const phydat_t *dat)
 {
     (void)dev;
     (void)dat;
     return -ENOTSUP;
 }
+
+/* No need to consume ROM for a second implementation, just create an
+ * alias symbol to saul_write_notsup */
+__attribute__((alias("saul_write_notsup")))
+int saul_read_notsup(const void *dev, phydat_t *dat);

--- a/drivers/scd30/scd30_saul.c
+++ b/drivers/scd30/scd30_saul.c
@@ -86,18 +86,18 @@ static int _hum_read(const void *dev, phydat_t *res)
 
 const saul_driver_t scd30_co2_saul_driver = {
     .read = _co2_read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CO2,
 };
 
 const saul_driver_t scd30_temp_saul_driver = {
     .read = _temp_read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t scd30_hum_saul_driver = {
     .read = _hum_read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM,
 };

--- a/drivers/sdp3x/sdp3x_saul.c
+++ b/drivers/sdp3x/sdp3x_saul.c
@@ -49,12 +49,12 @@ static int read_differential_pressure(const void *dev, phydat_t *res)
 
 const saul_driver_t sdp3x_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t sdp3x_differential_pressure_saul_driver = {
     .read = read_differential_pressure,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PRESS,
 };

--- a/drivers/sds011/sds011_saul.c
+++ b/drivers/sds011/sds011_saul.c
@@ -40,6 +40,6 @@ static int _read(const void *dev, phydat_t *res)
 
 const saul_driver_t sds011_saul_driver = {
     .read = _read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM
 };

--- a/drivers/seesaw_soil/seesaw_soil_saul.c
+++ b/drivers/seesaw_soil/seesaw_soil_saul.c
@@ -38,6 +38,6 @@ static int read_temp(const void *dev, phydat_t *res)
 
 const saul_driver_t seesaw_soil_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };

--- a/drivers/sgp30/sgp30_saul.c
+++ b/drivers/sgp30/sgp30_saul.c
@@ -54,12 +54,12 @@ static int _read_eco2(const void *dev, phydat_t *res)
 
 const saul_driver_t sgp30_saul_driver_eco2 = {
     .read = _read_eco2,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_CO2
 };
 
 const saul_driver_t sgp30_saul_driver_tvoc = {
     .read = _read_tvoc,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TVOC
 };

--- a/drivers/sht1x/sht1x_saul.c
+++ b/drivers/sht1x/sht1x_saul.c
@@ -77,12 +77,12 @@ static int read_hum(const void *dev, phydat_t *res)
 
 const saul_driver_t sht1x_saul_temp_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t sht1x_saul_hum_driver = {
     .read = read_hum,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM
 };

--- a/drivers/sht2x/sht2x_saul.c
+++ b/drivers/sht2x/sht2x_saul.c
@@ -42,12 +42,12 @@ static int read_relative_humidity(const void *dev, phydat_t *res)
 
 const saul_driver_t sht2x_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t sht2x_relative_humidity_saul_driver = {
     .read = read_relative_humidity,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM,
 };

--- a/drivers/sht3x/sht3x_saul.c
+++ b/drivers/sht3x/sht3x_saul.c
@@ -110,12 +110,12 @@ static int read_hum(const void *dev, phydat_t *data)
 
 const saul_driver_t sht3x_saul_driver_temperature = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t sht3x_saul_driver_humidity = {
     .read = read_hum,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM
 };

--- a/drivers/shtcx/shtcx_saul.c
+++ b/drivers/shtcx/shtcx_saul.c
@@ -45,12 +45,12 @@ static int read_relative_humidity(const void *dev, phydat_t *res)
 
 const saul_driver_t shtcx_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP,
 };
 
 const saul_driver_t shtcx_relative_humidity_saul_driver = {
     .read = read_relative_humidity,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM,
 };

--- a/drivers/si1133/si1133_saul.c
+++ b/drivers/si1133/si1133_saul.c
@@ -90,18 +90,18 @@ static int read_white(const void *dev, phydat_t *res)
 
 const saul_driver_t si1133_uv_saul_driver = {
     .read = read_uv,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_UV
 };
 
 const saul_driver_t si1133_ir_saul_driver = {
     .read = read_ir,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };
 
 const saul_driver_t si1133_visible_saul_driver = {
     .read = read_white,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };

--- a/drivers/si114x/si114x_saul.c
+++ b/drivers/si114x/si114x_saul.c
@@ -64,24 +64,24 @@ static int read_distance(const void *dev, phydat_t *res)
 
 const saul_driver_t si114x_uv_saul_driver = {
     .read = read_uv,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_UV
 };
 
 const saul_driver_t si114x_ir_saul_driver = {
     .read = read_ir,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };
 
 const saul_driver_t si114x_visible_saul_driver = {
     .read = read_visible,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };
 
 const saul_driver_t si114x_distance_saul_driver = {
     .read = read_distance,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_DISTANCE
 };

--- a/drivers/si70xx/si70xx_saul.c
+++ b/drivers/si70xx/si70xx_saul.c
@@ -44,14 +44,14 @@ static int read_relative_humidity(const void *dev, phydat_t *res)
 
 const saul_driver_t si70xx_temperature_saul_driver = {
     .read = read_temperature,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 #if SI70XX_HAS_HUMIDITY_SENSOR
 const saul_driver_t si70xx_relative_humidity_saul_driver = {
     .read = read_relative_humidity,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_HUM
 };
 #endif /* SI70XX_HAS_HUMIDITY_SENSOR */

--- a/drivers/sm_pwm_01c/sm_pwm_01c_saul.c
+++ b/drivers/sm_pwm_01c/sm_pwm_01c_saul.c
@@ -53,12 +53,12 @@ static int read_mc_pm_10(const void *_dev, phydat_t *data)
 
 const saul_driver_t sm_pwm_01c_saul_driver_mc_pm_10 = {
     .read = read_mc_pm_10,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM,
 };
 
 const saul_driver_t sm_pwm_01c_saul_driver_mc_pm_2p5 = {
     .read = read_mc_pm_2p5,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM,
 };

--- a/drivers/sps30/sps30_saul.c
+++ b/drivers/sps30/sps30_saul.c
@@ -156,30 +156,30 @@ static int read_ps(const void *dev, phydat_t *data)
 
 const saul_driver_t sps30_saul_driver_mc_pm_1_2p5_4 = {
     .read = read_mc_pm_1_2p5_4,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM
 };
 
 const saul_driver_t sps30_saul_driver_mc_pm_10 = {
     .read = read_mc_pm_10,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PM
 };
 
 const saul_driver_t sps30_saul_driver_nc_pm_0p5_1_2p5 = {
     .read = read_nc_pm_0p5_1_2p5,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_COUNT
 };
 
 const saul_driver_t sps30_saul_driver_nc_pm_4_10 = {
     .read = read_nc_pm_4_10,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_COUNT
 };
 
 const saul_driver_t sps30_saul_driver_ps = {
     .read = read_ps,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_SIZE
 };

--- a/drivers/tcs37727/tcs37727_saul.c
+++ b/drivers/tcs37727/tcs37727_saul.c
@@ -40,6 +40,6 @@ static int read(const void *dev, phydat_t *res)
 
 const saul_driver_t tcs37727_saul_driver = {
     .read = read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_COLOR,
 };

--- a/drivers/tmp00x/tmp00x_saul.c
+++ b/drivers/tmp00x/tmp00x_saul.c
@@ -44,6 +44,6 @@ static int read_temp(const void *dev, phydat_t *res)
 
 const saul_driver_t tmp00x_saul_driver = {
     .read = read_temp,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_OBJTEMP,
 };

--- a/drivers/tsl2561/tsl2561_saul.c
+++ b/drivers/tsl2561/tsl2561_saul.c
@@ -32,6 +32,6 @@ static int read_illuminance(const void *dev, phydat_t *res)
 
 const saul_driver_t tsl2561_illuminance_saul_driver = {
     .read = read_illuminance,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };

--- a/drivers/tsl4531x/tsl4531x_saul.c
+++ b/drivers/tsl4531x/tsl4531x_saul.c
@@ -35,6 +35,6 @@ static int _read(const void *dev, phydat_t *data)
 
 const saul_driver_t tsl4531x_saul_driver = {
     .read = _read,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };

--- a/drivers/vcnl40x0/vcnl40x0_saul.c
+++ b/drivers/vcnl40x0/vcnl40x0_saul.c
@@ -47,12 +47,12 @@ static int read_illuminance(const void *dev, phydat_t *res)
 
 const saul_driver_t vcnl40x0_proximity_saul_driver = {
     .read = read_proximity,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_PROXIMITY
 };
 
 const saul_driver_t vcnl40x0_illuminance_saul_driver = {
     .read = read_illuminance,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_LIGHT
 };

--- a/drivers/veml6070/veml6070_saul.c
+++ b/drivers/veml6070/veml6070_saul.c
@@ -33,6 +33,6 @@ static int read_uv(const void *dev, phydat_t *res)
 
 const saul_driver_t veml6070_uv_saul_driver = {
     .read = read_uv,
-    .write = saul_notsup,
+    .write = saul_write_notsup,
     .type = SAUL_SENSE_UV
 };

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -134,7 +134,7 @@ int saul_reg_read(saul_reg_t *dev, phydat_t *res);
  * @return      -ENOTSUP if read operation is not supported by the device
  * @return      -ECANCELED on device errors
  */
-int saul_reg_write(saul_reg_t *dev, phydat_t *data);
+int saul_reg_write(saul_reg_t *dev, const phydat_t *data);
 
 #ifdef __cplusplus
 }

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -110,7 +110,7 @@ int saul_reg_read(saul_reg_t *dev, phydat_t *res)
     return dev->driver->read(dev->dev, res);
 }
 
-int saul_reg_write(saul_reg_t *dev, phydat_t *data)
+int saul_reg_write(saul_reg_t *dev, const phydat_t *data)
 {
     if (dev == NULL) {
         return -ENODEV;


### PR DESCRIPTION
### Contribution description

Basically

```diff
- typedef int(*saul_write_t)(const void *dev, phydat_t *data);
+ typedef int(*saul_write_t)(const void *dev, const phydat_t *data);
```
This makes life easier when calling e.g. `saul_reg_write()` with data stored in flash.

As now the signatures for reading and writing differ (in that `const` qualifier only), `saul_notsup()` is split into `saul_write_notsup()` and `saul_read_notsup()`. However, one is implemented as a symbol alias of the other, so that ROM consumption remains unchanged.

### Testing procedure

The binaries generated prior and after this PR should not be changed.

#### This PR

```
$ BOARD=samr21-xpro RIOT_CI_BUILD=1 make -C examples/saul
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/saul'
Building application "saul_example" for "samr21-xpro" with MCU "samd21".

   text	  data	   bss	   dec	   hex	filename
  18172	   132	  2396	 20700	  50dc	/home/maribu/Repos/software/RIOT/examples/saul/bin/samr21-xpro/saul_example.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/saul'
```

#### In `master`

```
$ BOARD=samr21-xpro RIOT_CI_BUILD=1 make -C examples/saul
make: Entering directory '/home/maribu/Repos/software/RIOT/examples/saul'
Building application "saul_example" for "samr21-xpro" with MCU "samd21".

   text	  data	   bss	   dec	   hex	filename
  18172	   132	  2396	 20700	  50dc	/home/maribu/Repos/software/RIOT/examples/saul/bin/samr21-xpro/saul_example.elf
make: Leaving directory '/home/maribu/Repos/software/RIOT/examples/saul'
```

### Issues/PRs references

None