### PR TITLE
sys/iolist: add helper functions

### DIFF
--- a/sys/include/iolist.h
+++ b/sys/include/iolist.h
@@ -82,6 +82,18 @@ struct iovec;
  */
 size_t iolist_to_iovec(const iolist_t *iolist, struct iovec *iov, unsigned *count);
 
+/**
+ * @brief   Copies the bytes of the iolist to a buffer
+ *
+ * @param[in]   iolist  iolist to read from
+ * @param[out]  dst     Destination buffer
+ * @param[in]   len     Size of the destination buffer
+ *
+ * @returns iolist_size(iolist) on success
+ *          -ENOBUFS if the buffer is too small
+ */
+ssize_t iolist_to_buffer(const iolist_t *iolist, void *dst, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -68,6 +68,7 @@
 
 #include "sched.h"
 #include "clist.h"
+#include "iolist.h"
 #include "mtd.h"
 #include "xfa.h"
 
@@ -808,6 +809,17 @@ ssize_t vfs_read(int fd, void *dest, size_t count);
  * @return <0 on error
  */
 ssize_t vfs_write(int fd, const void *src, size_t count);
+
+/**
+ * @brief Write bytes from an iolist to an open file
+ *
+ * @param[in]  fd       fd number obtained from vfs_open
+ * @param[in]  iolist   iolist to read from
+ *
+ * @return number of bytes written on success
+ * @return <0 on error
+ */
+ssize_t vfs_write_iol(int fd, const iolist_t *iolist);
 
 /**
  * @brief Synchronize a file on storage

--- a/sys/iolist/iolist.c
+++ b/sys/iolist/iolist.c
@@ -18,6 +18,9 @@
  * @}
  */
 
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
 #include <sys/uio.h>
 
 #include "iolist.h"
@@ -59,4 +62,21 @@ size_t iolist_to_iovec(const iolist_t *iolist, struct iovec *iov, unsigned *coun
     *count = _count;
 
     return bytes;
+}
+
+ssize_t iolist_to_buffer(const iolist_t *iolist, void *buf, size_t len)
+{
+    char *dst = buf;
+
+    while (iolist) {
+        if (iolist->iol_len > len) {
+            return -ENOBUFS;
+        }
+        memcpy(dst, iolist->iol_base, iolist->iol_len);
+        len -= iolist->iol_len;
+        dst += iolist->iol_len;
+        iolist = iolist->iol_next;
+    }
+
+    return (uintptr_t)dst - (uintptr_t)buf;
 }

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -289,7 +289,6 @@ ssize_t sock_udp_sendv_aux(sock_udp_t *sock,
     sock_ip_ep_t local;
     sock_udp_ep_t remote_cpy;
     sock_ip_ep_t *rem;
-    uint8_t *payload_buf;
 
     assert((sock != NULL) || (remote != NULL));
 
@@ -371,12 +370,7 @@ ssize_t sock_udp_sendv_aux(sock_udp_t *sock,
     }
 
     /* copy payload data into payload snip */
-    payload_buf = payload->data;
-    while (snips) {
-        memcpy(payload_buf, snips->iol_base, snips->iol_len);
-        payload_buf += snips->iol_len;
-        snips = snips->iol_next;
-    }
+    iolist_to_buffer(snips, payload->data, payload->size);
 
     pkt = gnrc_udp_hdr_build(payload, src_port, dst_port);
     if (pkt == NULL) {

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -355,6 +355,22 @@ ssize_t vfs_write(int fd, const void *src, size_t count)
     return filp->f_op->write(filp, src, count);
 }
 
+ssize_t vfs_write_iol(int fd, const iolist_t *snips)
+{
+    int res, sum = 0;
+
+    while (snips) {
+        res = vfs_write(fd, snips->iol_base, snips->iol_len);
+        if (res < 0) {
+            return res;
+        }
+        sum += res;
+        snips = snips->iol_next;
+    }
+
+    return sum;
+}
+
 int vfs_fsync(int fd)
 {
     DEBUG_NOT_STDOUT(fd, "vfs_fsync: %d\n", fd);

--- a/tests/driver_pcf857x/main.c
+++ b/tests/driver_pcf857x/main.c
@@ -257,7 +257,7 @@ static int enable_int(int argc, char **argv)
 }
 #endif /* MODULE_PCF857X_IRQ */
 
-static int read(int argc, char **argv)
+static int read_pin(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -285,7 +285,7 @@ static int read(int argc, char **argv)
     return 0;
 }
 
-static int set(int argc, char **argv)
+static int set_pin(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -304,7 +304,7 @@ static int set(int argc, char **argv)
     return 0;
 }
 
-static int clear(int argc, char **argv)
+static int clear_pin(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -323,7 +323,7 @@ static int clear(int argc, char **argv)
     return 0;
 }
 
-static int toggle(int argc, char **argv)
+static int toggle_pin(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -396,10 +396,10 @@ static const shell_command_t shell_commands[] = {
     { "init_int", "init as external INT w/o pull resistor", init_int },
     { "enable_int", "enable or disable gpio interrupt", enable_int },
 #endif
-    { "read", "read pin status", read },
-    { "set", "set pin to HIGH", set },
-    { "clear", "set pin to LOW", clear },
-    { "toggle", "toggle pin", toggle },
+    { "read", "read pin status", read_pin },
+    { "set", "set pin to HIGH", set_pin },
+    { "clear", "set pin to LOW", clear_pin },
+    { "toggle", "toggle pin", toggle_pin },
     { "bench", "run a set of predefined benchmarks", bench },
     { NULL, NULL, NULL }
 };

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -42,7 +42,7 @@
 
 static uint8_t dummy_memory[PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT];
 
-static int init(mtd_dev_t *dev)
+static int _init(mtd_dev_t *dev)
 {
     (void)dev;
 
@@ -50,7 +50,7 @@ static int init(mtd_dev_t *dev)
     return 0;
 }
 
-static int read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
+static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
 {
     (void)dev;
 
@@ -62,7 +62,7 @@ static int read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     return 0;
 }
 
-static int write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
+static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
 {
     (void)dev;
 
@@ -77,7 +77,7 @@ static int write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
     return 0;
 }
 
-static int erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
+static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 {
     (void)dev;
 
@@ -95,7 +95,7 @@ static int erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
     return 0;
 }
 
-static int power(mtd_dev_t *dev, enum mtd_power_state power)
+static int _power(mtd_dev_t *dev, enum mtd_power_state power)
 {
     (void)dev;
     (void)power;
@@ -103,11 +103,11 @@ static int power(mtd_dev_t *dev, enum mtd_power_state power)
 }
 
 static const mtd_desc_t driver = {
-    .init = init,
-    .read = read,
-    .write = write,
-    .erase = erase,
-    .power = power,
+    .init = _init,
+    .read = _read,
+    .write = _write,
+    .erase = _erase,
+    .power = _power,
 };
 
 static mtd_dev_t _dev = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

So I stopped worrying and learned to love iolist, but I noticed some useful functions could be needed.
This adds:

 - `iolist_to_buffer()` to copy the iolist to a buffer
 - `vfs_write_iol()` to write the iolist to a file


### Testing procedure

`gnrc_sock_udp` has been modified to make use of `iolist_to_buffer()`. With this, `tests/gnrc_sock_udp` still passes. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
