### PR TITLE
suit/transport/vfs: add VFS as source for firmware updates

### DIFF
--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -41,6 +41,10 @@ QUIET ?= 1
 
 USEMODULE += suit suit_transport_coap
 
+# enable VFS transport (only works on boards with external storage)
+USEMODULE += suit_transport_vfs
+USEMODULE += vfs_default
+
 # Display a progress bar during firmware download
 USEMODULE += progress_bar
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -854,6 +854,10 @@ ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
   USEMODULE += sock_util
 endif
 
+ifneq (,$(filter suit_transport_vfs, $(USEMODULE)))
+  USEMODULE += vfs_util
+endif
+
 ifneq (,$(filter suit_storage_%, $(USEMODULE)))
   USEMODULE += suit_storage
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -846,6 +846,7 @@ endif
 
 ifneq (,$(filter suit_transport_%, $(USEMODULE)))
   USEMODULE += suit_transport
+  USEMODULE += suit_transport_worker
 endif
 
 ifneq (,$(filter suit_transport_coap, $(USEMODULE)))

--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -325,22 +325,6 @@ static inline bool suit_component_check_flag(suit_component_t *component,
 int suit_component_name_to_string(const suit_manifest_t *manifest,
                                   const suit_component_t *component,
                                   char separator, char *buf, size_t buf_len);
-
-/**
- * @brief Helper function for writing bytes on flash a specified offset
- *
- * @param[in]   arg     ptr to the SUIT manifest
- * @param[in]   offset  offset to write to on flash
- * @param[in]   buf     bytes to write
- * @param[in]   len     length of bytes to write
- * @param[in]   more    whether more data is coming
- *
- * @return              0 on success
- * @return              <0 on error
- */
-int suit_storage_helper(void *arg, size_t offset, uint8_t *buf, size_t len,
-                        int more);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -63,13 +63,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Maximum length of a SUIT resource URL
- */
-#ifndef SUIT_URL_MAX
-#define SUIT_URL_MAX            128
-#endif
-
-/**
  * @brief Current SUIT serialization format version
  *
  * see https://tools.ietf.org/html/draft-ietf-suit-manifest-03#section-7 for

--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -63,6 +63,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief Maximum length of a SUIT resource URL
+ */
+#ifndef SUIT_URL_MAX
+#define SUIT_URL_MAX            128
+#endif
+
+/**
  * @brief Current SUIT serialization format version
  *
  * see https://tools.ietf.org/html/draft-ietf-suit-manifest-03#section-7 for

--- a/sys/include/suit/transport/vfs.h
+++ b/sys/include/suit/transport/vfs.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @defgroup    sys_suit_transport_vfs SUIT secure firmware OTA VFS transport
+ * @ingroup     sys_suit
+ * @brief       SUIT firmware VFS transport
+ *
+ *              Allows to load firmware updates from the filesystem.
+ *              URL scheme: file://<path>/<to>/manifest.suit
+ *
+ *              e.g. set `SUIT_COAP_ROOT` to `file:///sd0/fw` and place the
+ *              update files to the folder fw/ on the first SD card.
+ * @{
+ *
+ * @brief       VFS transport backend definitions for SUIT manifests
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ */
+
+#ifndef SUIT_TRANSPORT_VFS_H
+#define SUIT_TRANSPORT_VFS_H
+
+#include "net/nanocoap.h"
+#include "suit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief fetch a payload from the filesystem
+ *
+ * @param[in]   manifest    suit manifest context
+ * @param[in]   cb          filesystem block callback
+ * @param[in]   ctx         callback context
+ *
+ * @returns     SUIT_OK if valid
+ * @returns     negative otherwise
+ */
+int suit_transport_vfs_fetch(const suit_manifest_t *manifest, coap_blockwise_cb_t cb, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_TRANSPORT_VFS_H */
+/** @} */

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -134,7 +134,7 @@ ifneq (,$(filter nimble_statconn,$(USEMODULE)))
   SRC += sc_nimble_statconn.c
 endif
 
-ifneq (,$(filter suit_transport_coap,$(USEMODULE)))
+ifneq (,$(filter suit_transport_worker,$(USEMODULE)))
   SRC += sc_suit.c
 endif
 

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -203,7 +203,7 @@ extern int _nimble_netif_handler(int argc, char **argv);
 extern int _nimble_statconn_handler(int argc, char **argv);
 #endif
 
-#ifdef MODULE_SUIT_TRANSPORT_COAP
+#ifdef MODULE_SUIT_TRANSPORT_WORKER
 extern int _suit_handler(int argc, char **argv);
 #endif
 
@@ -382,7 +382,7 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_NIMBLE_STATCONN
     { "statconn", "NimBLE netif statconn", _nimble_statconn_handler},
 #endif
-#ifdef MODULE_SUIT_TRANSPORT_COAP
+#ifdef MODULE_SUIT_TRANSPORT_WORKER
     { "suit", "Trigger a SUIT firmware update", _suit_handler },
 #endif
 #ifdef MODULE_CRYPTOAUTHLIB

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -41,7 +41,14 @@
 #endif
 #include "suit/transport/mock.h"
 
+#if defined(MODULE_PROGRESS_BAR)
+#include "progress_bar.h"
+#endif
+
 #include "log.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
 
 static int _get_component_size(suit_manifest_t *manifest,
                                suit_component_t *comp,
@@ -312,6 +319,72 @@ static int _start_storage(suit_manifest_t *manifest, suit_component_t *comp)
     return suit_storage_start(comp->storage_backend, manifest, img_size);
 }
 
+static inline void _print_download_progress(suit_manifest_t *manifest,
+                                            size_t offset, size_t len,
+                                            size_t image_size)
+{
+    (void)manifest;
+    (void)offset;
+    (void)len;
+    DEBUG("_suit_flashwrite(): writing %u bytes at pos %u\n", len, offset);
+#if defined(MODULE_PROGRESS_BAR)
+    if (image_size != 0) {
+        char _suffix[7] = { 0 };
+        uint8_t _progress = 100 * (offset + len) / image_size;
+        sprintf(_suffix, " %3d%%", _progress);
+        progress_bar_print("Fetching firmware ", _suffix, _progress);
+        if (_progress == 100) {
+            puts("");
+        }
+    }
+#else
+    (void) image_size;
+#endif
+}
+
+static int _storage_helper(void *arg, size_t offset, uint8_t *buf, size_t len,
+                           int more)
+{
+    suit_manifest_t *manifest = (suit_manifest_t *)arg;
+
+    uint32_t image_size;
+    nanocbor_value_t param_size;
+    size_t total = offset + len;
+    suit_component_t *comp = &manifest->components[manifest->component_current];
+    suit_param_ref_t *ref_size = &comp->param_size;
+
+    /* Grab the total image size from the manifest */
+    if ((suit_param_ref_to_cbor(manifest, ref_size, &param_size) == 0) ||
+            (nanocbor_get_uint32(&param_size, &image_size) < 0)) {
+        /* Early exit if the total image size can't be determined */
+        return -1;
+    }
+
+    if (image_size < offset + len) {
+        /* Extra newline at the start to compensate for the progress bar */
+        LOG_ERROR(
+            "\n_suit_coap(): Image beyond size, offset + len=%u, "
+            "image_size=%u\n", (unsigned)(total), (unsigned)image_size);
+        return -1;
+    }
+
+    if (!more && image_size != total) {
+        LOG_INFO("Incorrect size received, got %u, expected %u\n",
+                 (unsigned)total, (unsigned)image_size);
+        return -1;
+    }
+
+    _print_download_progress(manifest, offset, len, image_size);
+
+    int res = suit_storage_write(comp->storage_backend, manifest, buf, offset, len);
+    if (!more) {
+        LOG_INFO("Finalizing payload store\n");
+        /* Finalize the write if no more data available */
+        res = suit_storage_finish(comp->storage_backend, manifest);
+    }
+    return res;
+}
+
 static int _dtv_fetch(suit_manifest_t *manifest, int key,
                       nanocbor_value_t *_it)
 {
@@ -360,7 +433,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
 #ifdef MODULE_SUIT_TRANSPORT_COAP
     else if (strncmp(manifest->urlbuf, "coap://", 7) == 0) {
         res = nanocoap_get_blockwise_url(manifest->urlbuf, CONFIG_SUIT_COAP_BLOCKSIZE,
-                                         suit_storage_helper,
+                                         _storage_helper,
                                          manifest);
     }
 #endif

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -22,162 +22,15 @@
  * @}
  */
 
-#include <assert.h>
-#include <inttypes.h>
-#include <string.h>
-
-#include "msg.h"
 #include "log.h"
+#include "suit.h"
 #include "net/nanocoap.h"
-#include "net/nanocoap_sock.h"
-#include "thread.h"
-#include "periph/pm.h"
-#include "ztimer.h"
-
-#ifdef MODULE_SUIT_TRANSPORT_COAP
 #include "suit/transport/coap.h"
-#include "net/sock/util.h"
-#endif
-#ifdef MODULE_SUIT_TRANSPORT_VFS
-#include "vfs_util.h"
-#endif
+#include "kernel_defines.h"
 
 #ifdef MODULE_RIOTBOOT_SLOT
 #include "riotboot/slot.h"
 #endif
-
-#ifdef MODULE_SUIT
-#include "suit.h"
-#include "suit/handlers.h"
-#include "suit/storage.h"
-#endif
-
-#if defined(MODULE_PROGRESS_BAR)
-#include "progress_bar.h"
-#endif
-
-#define ENABLE_DEBUG 0
-#include "debug.h"
-
-#ifndef SUIT_COAP_STACKSIZE
-/* allocate stack needed to do manifest validation */
-#define SUIT_COAP_STACKSIZE (3 * THREAD_STACKSIZE_LARGE)
-#endif
-
-#ifndef SUIT_COAP_PRIO
-#define SUIT_COAP_PRIO THREAD_PRIORITY_MAIN - 1
-#endif
-
-#ifndef SUIT_URL_MAX
-#define SUIT_URL_MAX            128
-#endif
-
-#ifndef SUIT_MANIFEST_BUFSIZE
-#define SUIT_MANIFEST_BUFSIZE   640
-#endif
-
-#define SUIT_MSG_TRIGGER        0x12345
-
-static char _stack[SUIT_COAP_STACKSIZE];
-static char _url[SUIT_URL_MAX];
-static uint8_t _manifest_buf[SUIT_MANIFEST_BUFSIZE];
-
-static kernel_pid_t _suit_coap_pid;
-
-static void _suit_handle_url(const char *url, coap_blksize_t blksize)
-{
-    ssize_t size;
-    LOG_INFO("suit_coap: downloading \"%s\"\n", url);
-
-    if (0) {}
-#ifdef MODULE_SUIT_TRANSPORT_COAP
-    else if (strncmp(url, "coap://", 7) == 0) {
-        size = nanocoap_get_blockwise_url_to_buf(url, blksize,
-                                                 _manifest_buf,
-                                                 sizeof(_manifest_buf));
-    }
-#endif
-#ifdef MODULE_SUIT_TRANSPORT_VFS
-    else if (strncmp(url, "file:/", 6) == 0) {
-        size = vfs_file_to_buffer(&url[6], _manifest_buf, sizeof(_manifest_buf));
-    }
-#endif
-    else {
-        LOG_WARNING("suit_coap: unsupported URL scheme!\n)");
-        return;
-    }
-
-    if (size >= 0) {
-        LOG_INFO("suit_coap: got manifest with size %u\n", (unsigned)size);
-
-#ifdef MODULE_SUIT
-        suit_manifest_t manifest;
-        memset(&manifest, 0, sizeof(manifest));
-
-        manifest.urlbuf = _url;
-        manifest.urlbuf_len = SUIT_URL_MAX;
-
-        int res;
-        if ((res = suit_parse(&manifest, _manifest_buf, size)) != SUIT_OK) {
-            LOG_INFO("suit_parse() failed. res=%i\n", res);
-            return;
-        }
-
-#endif
-#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
-        if (res == 0) {
-            const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(
-                riotboot_slot_other());
-            riotboot_hdr_print(hdr);
-            ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
-
-            if (riotboot_hdr_validate(hdr) == 0) {
-                LOG_INFO("suit_coap: rebooting...\n");
-                pm_reboot();
-            }
-            else {
-                LOG_INFO("suit_coap: update failed, hdr invalid\n ");
-            }
-        }
-#endif
-    }
-    else {
-        LOG_INFO("suit_coap: error getting manifest\n");
-    }
-}
-
-static void *_suit_coap_thread(void *arg)
-{
-    (void)arg;
-
-    LOG_INFO("suit_coap: started.\n");
-    msg_t msg_queue[4];
-    msg_init_queue(msg_queue, 4);
-
-    _suit_coap_pid = thread_getpid();
-
-    msg_t m;
-    while (true) {
-        msg_receive(&m);
-        DEBUG("suit_coap: got msg with type %" PRIu32 "\n", m.content.value);
-        switch (m.content.value) {
-            case SUIT_MSG_TRIGGER:
-                LOG_INFO("suit_coap: trigger received\n");
-                _suit_handle_url(_url, CONFIG_SUIT_COAP_BLOCKSIZE);
-                break;
-            default:
-                LOG_WARNING("suit_coap: warning: unhandled msg\n");
-        }
-    }
-    return NULL;
-}
-
-void suit_coap_run(void)
-{
-    thread_create(_stack, SUIT_COAP_STACKSIZE, SUIT_COAP_PRIO,
-                  THREAD_CREATE_STACKTEST,
-                  _suit_coap_thread, NULL, "suit_coap");
-}
 
 static ssize_t _version_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                                 void *context)
@@ -186,25 +39,6 @@ static ssize_t _version_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
     return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
                              COAP_FORMAT_TEXT, (uint8_t *)"NONE", 4);
 }
-
-#ifdef MODULE_RIOTBOOT_SLOT
-static ssize_t _slot_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                             void *context)
-{
-    /* context is passed either as NULL or 0x1 for /active or /inactive */
-    char c = '0';
-
-    if (context) {
-        c += riotboot_slot_other();
-    }
-    else {
-        c += riotboot_slot_current();
-    }
-
-    return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
-                             COAP_FORMAT_TEXT, (uint8_t *)&c, 1);
-}
-#endif
 
 static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                                 void *context)
@@ -230,21 +64,31 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
                              COAP_FORMAT_NONE, NULL, 0);
 }
 
-void suit_coap_trigger(const uint8_t *url, size_t len)
+#ifdef MODULE_RIOTBOOT_SLOT
+static ssize_t _slot_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                             void *context)
 {
-    memcpy(_url, url, len);
-    _url[len] = '\0';
-    msg_t m = { .content.value = SUIT_MSG_TRIGGER };
-    msg_send(&m, _suit_coap_pid);
+    /* context is passed either as NULL or 0x1 for /active or /inactive */
+    char c = '0';
+
+    if (context) {
+        c += riotboot_slot_other();
+    }
+    else {
+        c += riotboot_slot_current();
+    }
+
+    return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
+                             COAP_FORMAT_TEXT, (uint8_t *)&c, 1);
 }
+#endif
 
 static const coap_resource_t _subtree[] = {
 #ifdef MODULE_RIOTBOOT_SLOT
     { "/suit/slot/active", COAP_METHOD_GET, _slot_handler, NULL },
     { "/suit/slot/inactive", COAP_METHOD_GET, _slot_handler, (void *)0x1 },
 #endif
-    { "/suit/trigger", COAP_METHOD_PUT | COAP_METHOD_POST, _trigger_handler,
-      NULL },
+    { "/suit/trigger", COAP_METHOD_PUT | COAP_METHOD_POST, _trigger_handler, NULL },
     { "/suit/version", COAP_METHOD_GET, _version_handler, NULL },
 };
 

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -47,7 +47,7 @@ static ssize_t _trigger_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
     unsigned code;
     size_t payload_len = pkt->payload_len;
     if (payload_len) {
-        if (payload_len >= SUIT_URL_MAX) {
+        if (payload_len >= CONFIG_SOCK_URLPATH_MAXLEN) {
             code = COAP_CODE_REQUEST_ENTITY_TOO_LARGE;
         }
         else {

--- a/sys/suit/transport/vfs.c
+++ b/sys/suit/transport/vfs.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit_transport_vfs
+ * @{
+ *
+ * @fil
+ * @brief       SUIT VFS
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <fcntl.h>
+#include <string.h>
+
+#include "suit/transport/vfs.h"
+#include "log.h"
+#include "vfs.h"
+
+int suit_transport_vfs_fetch(const suit_manifest_t *manifest, coap_blockwise_cb_t cb, void *ctx)
+{
+    const char *file = &manifest->urlbuf[7];
+    size_t offset = 0;
+    int res, fd;
+
+    LOG_DEBUG("suit_vfs: read firmware from %s\n", file);
+
+    fd = vfs_open(file, O_RDONLY, 0);
+    if (fd < 0) {
+        return fd;
+    }
+
+    void *buf = manifest->urlbuf;
+    size_t max_len = manifest->urlbuf_len;
+    while ((res = vfs_read(fd, buf, max_len)) > 0) {
+        size_t len = res;
+        res = cb(ctx, offset, buf, len, 1);
+        if (res < 0) {
+            LOG_ERROR("suit_vfs: write failed with %d\n", res);
+            break;
+        }
+        offset += len;
+    }
+
+    if (res < 0) {
+        LOG_ERROR("suit_vfs: read failed with %d\n", res);
+    } else {
+        res = cb(ctx, offset, buf, 0, 0);
+    }
+
+    vfs_close(fd);
+
+    return res;
+}

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -76,7 +76,7 @@
 #define SUIT_MSG_TRIGGER        0x12345
 
 static char _stack[SUIT_WORKER_STACKSIZE];
-static char _url[SUIT_URL_MAX];
+static char _url[CONFIG_SOCK_URLPATH_MAXLEN];
 static uint8_t _manifest_buf[SUIT_MANIFEST_BUFSIZE];
 
 static kernel_pid_t _suit_worker_pid;
@@ -113,7 +113,7 @@ static void _suit_handle_url(const char *url)
         memset(&manifest, 0, sizeof(manifest));
 
         manifest.urlbuf = _url;
-        manifest.urlbuf_len = SUIT_URL_MAX;
+        manifest.urlbuf_len = CONFIG_SOCK_URLPATH_MAXLEN;
 
         int res;
         if ((res = suit_parse(&manifest, _manifest_buf, size)) != SUIT_OK) {

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2019 Freie Universität Berlin
+ *               2019 Inria
+ *               2019 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit
+ * @{
+ *
+ * @file
+ * @brief       SUIT transport worker thread
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "msg.h"
+#include "log.h"
+#include "thread.h"
+#include "time_units.h"
+#include "periph/pm.h"
+#include "ztimer.h"
+
+#ifdef MODULE_SUIT_TRANSPORT_COAP
+#include "net/nanocoap_sock.h"
+#include "suit/transport/coap.h"
+#include "net/sock/util.h"
+#endif
+#ifdef MODULE_SUIT_TRANSPORT_VFS
+#include "vfs_util.h"
+#endif
+
+#ifdef MODULE_RIOTBOOT_SLOT
+#include "riotboot/slot.h"
+#endif
+
+#ifdef MODULE_SUIT
+#include "suit.h"
+#include "suit/handlers.h"
+#include "suit/storage.h"
+#endif
+
+#if defined(MODULE_PROGRESS_BAR)
+#include "progress_bar.h"
+#endif
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#ifndef SUIT_WORKER_STACKSIZE
+/* allocate stack needed to do manifest validation */
+#define SUIT_WORKER_STACKSIZE (3 * THREAD_STACKSIZE_LARGE)
+#endif
+
+#ifndef SUIT_COAP_WORKER_PRIO
+#define SUIT_COAP_WORKER_PRIO THREAD_PRIORITY_MAIN - 1
+#endif
+
+#ifndef SUIT_MANIFEST_BUFSIZE
+#define SUIT_MANIFEST_BUFSIZE   640
+#endif
+
+#define SUIT_MSG_TRIGGER        0x12345
+
+static char _stack[SUIT_WORKER_STACKSIZE];
+static char _url[SUIT_URL_MAX];
+static uint8_t _manifest_buf[SUIT_MANIFEST_BUFSIZE];
+
+static kernel_pid_t _suit_worker_pid;
+
+static void _suit_handle_url(const char *url)
+{
+    ssize_t size;
+    LOG_INFO("suit_worker: downloading \"%s\"\n", url);
+
+    if (0) {}
+#ifdef MODULE_SUIT_TRANSPORT_COAP
+    else if (strncmp(url, "coap://", 7) == 0) {
+        size = nanocoap_get_blockwise_url_to_buf(url,
+                                                 CONFIG_SUIT_COAP_BLOCKSIZE,
+                                                 _manifest_buf,
+                                                 sizeof(_manifest_buf));
+    }
+#endif
+#ifdef MODULE_SUIT_TRANSPORT_VFS
+    else if (strncmp(url, "file://", 7) == 0) {
+        size = vfs_file_to_buffer(&url[7], _manifest_buf, sizeof(_manifest_buf));
+    }
+#endif
+    else {
+        LOG_WARNING("suit_worker: unsupported URL scheme!\n)");
+        return;
+    }
+
+    if (size >= 0) {
+        LOG_INFO("suit_worker: got manifest with size %u\n", (unsigned)size);
+
+#ifdef MODULE_SUIT
+        suit_manifest_t manifest;
+        memset(&manifest, 0, sizeof(manifest));
+
+        manifest.urlbuf = _url;
+        manifest.urlbuf_len = SUIT_URL_MAX;
+
+        int res;
+        if ((res = suit_parse(&manifest, _manifest_buf, size)) != SUIT_OK) {
+            LOG_INFO("suit_worker: suit_parse() failed. res=%i\n", res);
+            return;
+        }
+
+#endif
+#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
+        if (res == 0) {
+            const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(
+                riotboot_slot_other());
+            riotboot_hdr_print(hdr);
+            ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
+
+            if (riotboot_hdr_validate(hdr) == 0) {
+                LOG_INFO("suit_worker: rebooting...\n");
+                pm_reboot();
+            }
+            else {
+                LOG_INFO("suit_worker: update failed, hdr invalid\n ");
+            }
+        }
+#endif
+    }
+    else {
+        LOG_INFO("suit_worker: error getting manifest\n");
+    }
+}
+
+static void *_suit_worker_thread(void *arg)
+{
+    (void)arg;
+
+    LOG_INFO("suit_worker: started.\n");
+    msg_t msg_queue[4];
+    msg_init_queue(msg_queue, 4);
+
+    _suit_worker_pid = thread_getpid();
+
+    msg_t m;
+    while (true) {
+        msg_receive(&m);
+        DEBUG("suit_worker: got msg with type %" PRIu32 "\n", m.content.value);
+        switch (m.content.value) {
+            case SUIT_MSG_TRIGGER:
+                LOG_INFO("suit_worker: trigger received\n");
+                _suit_handle_url(_url);
+                break;
+            default:
+                LOG_WARNING("suit_worker: warning: unhandled msg\n");
+        }
+    }
+    return NULL;
+}
+
+void suit_coap_run(void)
+{
+    thread_create(_stack, SUIT_WORKER_STACKSIZE, SUIT_COAP_WORKER_PRIO,
+                  THREAD_CREATE_STACKTEST,
+                  _suit_worker_thread, NULL, "suit worker");
+}
+
+void suit_coap_trigger(const uint8_t *url, size_t len)
+{
+    memcpy(_url, url, len);
+    _url[len] = '\0';
+    msg_t m = { .content.value = SUIT_MSG_TRIGGER };
+    msg_send(&m, _suit_worker_pid);
+}

--- a/tests/suit_manifest/main.c
+++ b/tests/suit_manifest/main.c
@@ -38,7 +38,6 @@
 
 #include TEST_MANIFEST_INCLUDE(file1.bin.h)
 #include TEST_MANIFEST_INCLUDE(file2.bin.h)
-#define SUIT_URL_MAX            128
 
 typedef struct {
     const unsigned char *data;
@@ -73,13 +72,13 @@ const size_t num_payloads = ARRAY_SIZE(payloads);
 static int test_suit_manifest(const unsigned char *manifest_bin,
                                 size_t manifest_bin_len)
 {
-    char _url[SUIT_URL_MAX];
+    char _url[CONFIG_SOCK_URLPATH_MAXLEN];
     suit_manifest_t manifest;
 
     memset(&manifest, 0, sizeof(manifest));
 
     manifest.urlbuf = _url;
-    manifest.urlbuf_len = SUIT_URL_MAX;
+    manifest.urlbuf_len = CONFIG_SOCK_URLPATH_MAXLEN;
 
     int res;
     if ((res =


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This allows to load firmware updates from files on local storage.


### Testing procedure

    make SUIT_COAP_ROOT=file:///sd0/fw suit/publish

Place the two slot files as well as the latest manifest on an SD card in the `fw/` folder.

```
> suit fetch file:///nvm0/fw/riot.suit.1653475132.bin
2022-05-25 12:52:51,855 # suit fetch file:///nvm0/fw/riot.suit.1653475132.bin
2022-05-25 12:52:51,858 # suit_worker: trigger received
2022-05-25 12:52:51,864 # suit_worker: downloading "file:///nvm0/fw/riot.suit.1653475132.bin"
2022-05-25 12:52:51,874 # suit_worker: got manifest with size 421
2022-05-25 12:52:51,877 # suit: verifying manifest signature
2022-05-25 12:52:53,020 # suit: validated manifest version
2022-05-25 12:52:53,025 # )Manifest seq_no: 1653475132, highest available: 1653474249
2022-05-25 12:52:53,028 # suit: validated sequence number
2022-05-25 12:52:53,031 # )Formatted component name: 
2022-05-25 12:52:53,035 # Comparing manifest offset 4000 with other slot offset
2022-05-25 12:52:53,040 # Comparing manifest offset 82000 with other slot offset
2022-05-25 12:52:53,042 # validating vendor ID
2022-05-25 12:52:53,051 # Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
2022-05-25 12:52:53,053 # validating vendor ID: OK
2022-05-25 12:52:53,055 # validating class id
2022-05-25 12:52:53,064 # Comparing 50244518-6a7c-5ce7-932b-88b318336c82 to 50244518-6a7c-5ce7-932b-88b318336c82 from manifest
2022-05-25 12:52:53,066 # validating class id: OK
2022-05-25 12:52:53,070 # Comparing manifest offset 4000 with other slot offset
2022-05-25 12:52:53,075 # Comparing manifest offset 82000 with other slot offset
2022-05-25 12:52:53,077 # SUIT policy check OK.
2022-05-25 12:52:53,079 # Formatted component name: 
2022-05-25 12:52:53,084 # riotboot_flashwrite: initializing update to target slot 1
2022-05-25 12:52:53,130 # Fetching firmware |█████████████████████████| 100%
2022-05-25 12:53:02,231 # Fetching firmware |█████████████████████████| 100%
2022-05-25 12:53:02,243 # Finalizing payload store
2022-05-25 12:53:02,245 # Verifying image digest
2022-05-25 12:53:02,249 # Starting digest verification against image
2022-05-25 12:53:02,341 # Install correct payload
2022-05-25 12:53:02,343 # Verified installed payload
2022-05-25 12:53:02,345 # Verifying image digest
2022-05-25 12:53:02,349 # Starting digest verification against image
2022-05-25 12:53:02,441 # Verified installed payload
2022-05-25 12:53:02,444 # Image magic_number: 0x544f4952
2022-05-25 12:53:02,446 # Image Version: 0x628e073c
2022-05-25 12:53:02,449 # Image start address: 0x00082400
2022-05-25 12:53:02,451 # Header chksum: 0xea1d2b74
2022-05-25 12:53:02,451 # 
> 2022-05-25 12:53:03,453 # suit_worker: rebooting...
2022-05-25 12:53:03,506 # main(): This is RIOT! (Version: 2022.07-devel-556-ga669bb-suit/transport-vfs)
2022-05-25 12:53:03,509 # RIOT SUIT update example application
2022-05-25 12:53:03,511 # Running from slot 1
2022-05-25 12:53:03,514 # Image magic_number: 0x544f4952
2022-05-25 12:53:03,516 # Image Version: 0x628e073c
2022-05-25 12:53:03,519 # Image start address: 0x00082400
2022-05-25 12:53:03,521 # Header chksum: 0xea1d2b74
2022-05-25 12:53:03,521 # 
2022-05-25 12:53:03,523 # suit_worker: started.
2022-05-25 12:53:03,525 # Starting the shell
```

### Issues/PRs references

includes #18038
