### PR TITLE
pkg/littlefs2: bump version to 2.5.0

### DIFF
--- a/pkg/littlefs2/Makefile
+++ b/pkg/littlefs2/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=littlefs2
 PKG_URL=https://github.com/ARMmbed/littlefs.git
-# v2.4.2
-PKG_VERSION=9c7e232086f865cff0bb96fe753deb66431d91fd
+# v2.5.0
+PKG_VERSION=40dba4a556e0d81dfbe64301a6aa4e18ceca896c
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Bump version to [2.5.0](https://github.com/littlefs-project/littlefs/releases/tag/v2.5.0)


### Testing procedure

`tests/pkg_littlefs2` still works

```
main(): This is RIOT! (Version: 2022.07-devel-309-gf3c364-pkg/littlefs2-bump)
........
OK (8 tests)
{ "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 436 }]}
{ "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2828 }]}
```

Old fs can also still be mounted.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
