### PR TITLE
shell/cord_ep: Add user guidance & prevent accidental crash

### DIFF
--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -152,6 +152,7 @@ endif
 ifneq (,$(filter shell_cmd_cord_ep,$(USEMODULE)))
   USEMODULE += cord_ep
   USEMODULE += sock_util
+  USEMODULE += uri_parser
 endif
 ifneq (,$(filter shell_cmd_cryptoauthlib,$(USEPKG)))
   USEMODULE += cryptoauthlib

--- a/sys/shell/cmds/cord_ep.c
+++ b/sys/shell/cmds/cord_ep.c
@@ -26,9 +26,11 @@
 #include "net/gnrc/netif.h"
 #include "net/nanocoap.h"
 #include "net/sock/util.h"
+#include "uri_parser.h"
 #include "shell.h"
 
-static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
+
+static int _make_sock_ep(sock_udp_ep_t *ep, const char *addr)
 {
     ep->port = 0;
     if (sock_udp_name2ep(ep, addr) < 0) {
@@ -39,7 +41,7 @@ static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
         /* assign the single interface found in gnrc_netif_numof() */
         ep->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
     }
-    ep->family  = AF_INET6;
+    ep->family = AF_INET6;
     if (ep->port == 0) {
         ep->port = COAP_PORT;
     }
@@ -51,23 +53,48 @@ static int _cord_ep_handler(int argc, char **argv)
     int res;
 
     if ((argc > 1) && (strcmp(argv[1], "register") == 0)) {
-        char *regif = NULL;
         if (argc < 3) {
-            printf("usage: %s register <server address> [registration interface]\n",
-                   argv[0]);
+            printf("usage: %s register <registration uri>\n", argv[0]);
+            puts(
+                "If the registration URI's path is empty, the registration resource is auto-discovered");
+            printf("example: %s register coap://[2001:db8::1]:99\n", argv[0]);
+            return 1;
+        }
+
+        uri_parser_result_t uri_result;
+        if (uri_parser_process_string(&uri_result, argv[2]) != 0) {
+            puts("error: unable to parse uri");
             return 1;
         }
         sock_udp_ep_t remote;
-        if (make_sock_ep(&remote, argv[2]) < 0) {
-            printf("error: unable to parse address\n");
+        remote.family = AF_INET6;
+        remote.netif = SOCK_ADDR_ANY_NETIF;
+        remote.port = uri_result.port;
+
+        if ((uri_result.scheme_len == 4) && (strncmp(uri_result.scheme, "coap", 4) == 0)) {
+            if (uri_result.port == 0) {
+                remote.port = COAP_PORT;
+            }
+        }
+        else {
+            puts("error: Only coap schemes are supported");
             return 1;
         }
-        if (argc > 3) {
-            regif = argv[3];
+
+        if (uri_result.ipv6addr == NULL) {
+            puts("error: Only ipv6 addresses are supported");
+            return 1;
         }
+
+        if (!ipv6_addr_from_buf((ipv6_addr_t *)&remote.addr.ipv6, uri_result.ipv6addr,
+                                uri_result.ipv6addr_len)) {
+            puts("error: IPv6 address malformed");
+            return 1;
+        }
+
         puts("Registering with RD now, this may take a short while...");
-        if (cord_ep_register(&remote, regif) != CORD_EP_OK) {
-            puts("error: registration failed");
+        if (cord_ep_register(&remote, uri_result.path) != CORD_EP_OK) {
+            puts("failure: registration failed");
         }
         else {
             puts("registration successful\n");
@@ -81,7 +108,7 @@ static int _cord_ep_handler(int argc, char **argv)
         }
         char regif[CONFIG_NANOCOAP_URI_MAX];
         sock_udp_ep_t remote;
-        if (make_sock_ep(&remote, argv[2]) < 0) {
+        if (_make_sock_ep(&remote, argv[2]) < 0) {
             printf("error: unable to parse address\n");
             return 1;
         }


### PR DESCRIPTION

### Contribution description

* (Everything was done on the lastest master as of 2022-05-04T10:00)
* This PR only touches the shell command handling of `cord_ep`
* Not sure if I want to call it a fix; It fixes an issue where running the subcommand `cord_ep register` just slightly wrong, an assertion in [gcoap.c](https://github.com/RIOT-OS/RIOT/blob/a427d630f17799188c0caf95d8dd327846d39a23/sys/net/application_layer/gcoap/gcoap.c#L1134) would get triggered - resulting in a RIOT kernel panic.
* I consider this behaviour to be a bug, reasoning that a shell should be able to cope with users that do not exactly know what they are doing. (Go figure who that user was 😇)
* This PR corrects this behaviour by doing a short sanity check on the user input - yielding an error if necessary.


### Testing procedure

For reproducing the bug do:

1. Go to `RIOT/examples/cord_ep/` and run `make all flash term` for a board of your choice
2. Inside the RIOT shell, run `cord_ep register [fd00::1]:1234 foo` (the exact host:port combination does not matter, just have to be valid)
3. Make sure that the registration interface (in my example `foo`) does *not* start with a `/`
4. Observe a thrown failed assertion i.g., `*** RIOT kernel panic: FAILED ASSERTION.`

After applying my suggested fix:

1. Go to `RIOT/examples/cord_ep/` and run `make all flash term` for a board of your choice
2. Inside the RIOT shell, run `cord_ep register [fd00::1]:1234 foo` (the exact host:port combination does not matter, just have to be valid)
3. Make sure that the registration interface (in my example `foo`) does *not* start with a `/`
4. The command responds with an error: `error: registration interface must start with '/'`

