### PR TITLE
ztimer: deprecate ztimer_now64 and ztimer_now_t

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -3,3 +3,4 @@
 DEPRECATED_MODULES += event_thread_lowest
 DEPRECATED_MODULES += gnrc_netdev_default
 DEPRECATED_MODULES += sema_deprecated
+DEPRECATED_MODULES += ztimer_now64

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -302,9 +302,11 @@ struct ztimer_base {
 };
 
 #if MODULE_ZTIMER_NOW64
-typedef uint64_t ztimer_now_t;  /**< type for ztimer_now() result */
+typedef uint64_t ztimer_now_t;  /**< type for ztimer_now() result
+                                 * @deprecated use uint32_t or ztimer64 */
 #else
-typedef uint32_t ztimer_now_t;  /**< type for ztimer_now() result */
+typedef uint32_t ztimer_now_t;  /**< type for ztimer_now() result
+                                 * @deprecated use uint32_t or ztimer64 */
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

This deprecates `ztimer_now64`-module and `ztimer_now_t` in favour of ztimer64-module `ztimer64_now()` if 64Bit are need or 
`uint32_t` the return type of `ztimer_now()`

### Testing procedure

read doc and murdock green

### Issues/PRs references
