### PR TITLE
build system: deprecate ztimer_now64

### DIFF
--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -3,3 +3,4 @@
 DEPRECATED_MODULES += event_thread_lowest
 DEPRECATED_MODULES += gnrc_netdev_default
 DEPRECATED_MODULES += sema_deprecated
+DEPRECATED_MODULES += ztimer_now64 # use ztimer64 instead


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

Try using `ztimer_now64`. You should be warned that it is deprecated.

### Issues/PRs references

None