### PR TITLE
boards/nucleo-X: enable cpy2remed programmer

### DIFF
--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -6,3 +6,10 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # Setup of programmer and serial is shared between STM32 based boards
 include $(RIOTMAKE)/boards/stm32.inc.mk
+
+# variable needed by cpy2remed PROGRAMMER
+# it contains name of ST-Link removable media
+
+DIR_NAME_AT_REMED = "NODE$(call uppercase,$(subst -,_,$(subst nucleo,,$(BOARD))))"
+
+PROGRAMMERS_SUPPORTED += cpy2remed

--- a/boards/nucleo-f303k8/doc.txt
+++ b/boards/nucleo-f303k8/doc.txt
@@ -50,6 +50,9 @@ STM32F303K8 microcontroller with 12Kb of RAM and 64Kb of ROM.
 
 
 ## Flashing the device
+
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-F303K8 board includes an on-board ST-LINK V2 programmer.
 The easiest way to program the board is to use OpenOCD. Once you have
 installed OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
@@ -62,7 +65,18 @@ and debug via GDB by simply typing
 ```
 BOARD=nucleo-f303k8 make debug
 ```
+### Flashing the Board Using ST-LINK Removable Media
 
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f303k8 PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
 ## Supported Toolchains
 For using the ST Nucleo-F303K8 board we strongly recommend the usage of the

--- a/boards/nucleo-f334r8/Makefile.include
+++ b/boards/nucleo-f334r8/Makefile.include
@@ -1,8 +1,2 @@
-#variable needed by cpy2remed PROGRAMMER
-#it contains name of ST-Link removable media
-DIR_NAME_AT_REMED = "NODE_F334R8"
-
-PROGRAMMERS_SUPPORTED += cpy2remed
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-f429zi/Makefile.include
+++ b/boards/nucleo-f429zi/Makefile.include
@@ -1,9 +1,2 @@
-#variable needed by cpy2remed PROGRAMMER
-#it contains name of ST-Link removable media
-DIR_NAME_AT_REMED = "NODE_F429ZI"
-
-PROGRAMMERS_SUPPORTED += cpy2remed
-
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-f446ze/Makefile.include
+++ b/boards/nucleo-f446ze/Makefile.include
@@ -1,8 +1,2 @@
-#variable needed by cpy2remed PROGRAMMER
-#it contains name of ST-Link removable media
-DIR_NAME_AT_REMED = "NODE_F446ZE"
-
-PROGRAMMERS_SUPPORTED += cpy2remed
-
 # load the common Makefile.include for Nucleo-144 boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include

--- a/boards/nucleo-l031k6/doc.txt
+++ b/boards/nucleo-l031k6/doc.txt
@@ -2,4 +2,25 @@
 @defgroup    boards_nucleo-l031k6 STM32 Nucleo-L031K6
 @ingroup     boards_common_nucleo32
 @brief       Support for the STM32 Nucleo-L031K6
- */
+
+## Overview
+
+The Nucleo-L031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
+STM32L031K6T6 microcontroller with 8kB or RAM and 32Kb of Flash.
+
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l031k6 PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
+
+*/

--- a/boards/nucleo-l073rz/doc.txt
+++ b/boards/nucleo-l073rz/doc.txt
@@ -2,4 +2,24 @@
 @defgroup    boards_nucleo-l073rz STM32 Nucleo-L073RZ
 @ingroup     boards_common_nucleo64
 @brief       Support for the STM32 Nucleo-L073RZ
+
+
+## Overview
+
+The Nucleo-L073RZ is a board from ST's Nucleo family supporting ARM Cortex-M0
+STM32L073RZT6 microcontroller with 20kB or RAM and 192Kb of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l073rz PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-l432kc/doc.txt
+++ b/boards/nucleo-l432kc/doc.txt
@@ -2,4 +2,24 @@
 @defgroup    boards_nucleo-l432kc STM32 Nucleo-L432KC
 @ingroup     boards_common_nucleo32
 @brief       Support for the STM32 Nucleo-L432KC
+
+## Overview
+
+The Nucleo-L432KC is a board from ST's Nucleo family supporting ARM Cortex-M4
+STM32L432KCU6 microcontroller with 64kB or RAM and 256Kb of Flash.
+
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l432kc PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-l552ze-q/Makefile.include
+++ b/boards/nucleo-l552ze-q/Makefile.include
@@ -1,8 +1,6 @@
-#variable needed by cpy2remed PROGRAMMER
-#it contains name of ST-Link removable media
-DIR_NAME_AT_REMED = "NODE_L552ZE"
-
-PROGRAMMERS_SUPPORTED += cpy2remed
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.include
+
+#Automatic flash directory name generation failed for this board
+#and it should be set manually - see PR #18057
+DIR_NAME_AT_REMED = "NODE_L552ZE"

--- a/boards/p-nucleo-wb55/Makefile.include
+++ b/boards/p-nucleo-wb55/Makefile.include
@@ -12,3 +12,7 @@ OPENOCD_RESET_USE_CONNECT_ASSERT_SRST ?= 1
 
 # include shared global Nucleo Makefile
 include $(RIOTBOARD)/common/nucleo/Makefile.include
+
+#Automatic flash directory name generation failed for this board
+#and it should be set manually - see PR #18057
+DIR_NAME_AT_REMED = "NODE_WB55RG"


### PR DESCRIPTION
### Contribution description

This PR enables **_cpy2remed_** programmer (see #17550) to four STM Nucleo boards: l031k8, l073rz, f303k8 and l432kc .
All boards have initially older ST-LINK firmware - the oldest was:
```
Version: 0221
Build:   Nov 19 2015 15:23:07
``` 
All are updated (without any problems) to minimal firmware which works with **_cpy2remed_** programmer - 2.37.36 (V2.J37.M26 - shown in the  ST-LinkUpgrade program).  

### Testing procedure

Go to RIOT/examples/blinky and run command
```
make BOARD=nucleo-l031k8 PROGRAMMER=cpy2remed flash
make BOARD=nucleo-l073rz PROGRAMMER=cpy2remed flash
make BOARD=nucleo-f303k8 PROGRAMMER=cpy2remed flash
make BOARD=nucleo-l432kc  PROGRAMMER=cpy2remed flash
```
After a while, green LED (LED0) should start blinking.

Changes in documentaion can be observed using commands:
```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-l031k8.html
xdg-open doc/doxygen/html/group__boards__nucleo-l073rz.html
xdg-open doc/doxygen/html/group__boards__nucleo-f303k8.html
xdg-open doc/doxygen/html/group__boards__nucleo-l432kc .html
```

### Issues/PRs references

#17550