### PR TITLE
unittest/sock_util: add test for missing addr variants

### DIFF
--- a/tests/unittests/tests-sock_util/tests-sock_util.c
+++ b/tests/unittests/tests-sock_util/tests-sock_util.c
@@ -63,6 +63,9 @@
 #define TEST_STR2EP_NETIF           "[fe80::1%45]"
 #define TEST_STR2EP_NETIF2          "[fe80::1%23]:243"
 #define TEST_STR2EP_NETIF_GLOBAL    "[2001:db8:a::1%75]"
+#define TEST_STR2EP_LL              "[fe80::1]"
+#define TEST_STR2EP_LL_PORT         "[fe80::1]:243"
+#define TEST_STR2EP_GLOBAL_PORT     "[2001:db8:a::1]:123"
 #define TEST_STR2EP_NETIF_INVALID   "[fe80::1%]:752"
 #define TEST_STR2EP_NETIF_INVALID2  "[fe80::1%56776]:1346"
 #define TEST_STR2EP_NETIF_INVALID3  "[fe80::1%53:4232"
@@ -175,7 +178,6 @@ static void test_sock_util_urlsplit__null_path_buffer(void)
 static void test_sock_util_str2ep__ipv6_noport(void)
 {
     sock_udp_ep_t ep;
-    ep.port = 0;
     TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
@@ -185,7 +187,6 @@ static void test_sock_util_str2ep__ipv6_noport(void)
 static void test_sock_util_str2ep__ipv4_noport(void)
 {
     sock_udp_ep_t ep;
-    ep.port = 0;
     TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_V4));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
@@ -268,6 +269,33 @@ static void test_sock_util_str2ep__netif_with_global_addr(void)
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
 }
 
+static void test_sock_util_str2ep__ll(void)
+{
+    sock_udp_ep_t ep;
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_LL));
+    TEST_ASSERT_EQUAL_INT(0, ep.port);
+    TEST_ASSERT_EQUAL_INT(0, ep.netif);
+    TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
+}
+
+static void test_sock_util_str2ep__ll_with_port(void)
+{
+    sock_udp_ep_t ep;
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_LL_PORT));
+    TEST_ASSERT_EQUAL_INT(243, ep.port);
+    TEST_ASSERT_EQUAL_INT(0, ep.netif);
+    TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
+}
+
+static void test_sock_util_str2ep__with_global_addr_port(void)
+{
+    sock_udp_ep_t ep;
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_GLOBAL_PORT));
+    TEST_ASSERT_EQUAL_INT(123, ep.port);
+    TEST_ASSERT_EQUAL_INT(0, ep.netif);
+    TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
+}
+
 Test *tests_sock_util_all(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -295,6 +323,9 @@ Test *tests_sock_util_all(void)
         new_TestFixture(test_sock_util_str2ep__netif),
         new_TestFixture(test_sock_util_str2ep__netif_with_port),
         new_TestFixture(test_sock_util_str2ep__netif_with_global_addr),
+        new_TestFixture(test_sock_util_str2ep__ll),
+        new_TestFixture(test_sock_util_str2ep__ll_with_port),
+        new_TestFixture(test_sock_util_str2ep__with_global_addr_port),
     };
 
     EMB_UNIT_TESTCALLER(sockutil_tests, setup, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

- this adds the missing tests to  unittest/sock_util (IPv6 without interface) 

they are missing was detected while reviewing #17927

### Testing procedure

run test / murdock 

### Issues/PRs references

in conflict with #17927 while writing this.