### PR TITLE
drivers/mcp2515: enable filtering

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -10969,6 +10969,7 @@ drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_BUKT
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_BUKT1 \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_FILHIT0 \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_MODE_RECV_ALL \(macro definition\) of file mcp2515_defines\.h is not documented\.
+drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_MODE_RECV_FILTER \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_MODE_RECV_EXT \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_MODE_RECV_STD \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB0CTRL_MODE_RECV_STD_OR_EXT \(macro definition\) of file mcp2515_defines\.h is not documented\.
@@ -10993,6 +10994,7 @@ drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_FILH
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_FILHIT1 \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_FILHIT2 \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_MODE_RECV_ALL \(macro definition\) of file mcp2515_defines\.h is not documented\.
+drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_MODE_RECV_FILTER \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_MODE_RECV_EXT \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_MODE_RECV_STD \(macro definition\) of file mcp2515_defines\.h is not documented\.
 drivers/mcp2515/mcp2515_defines\.h:[0-9]+: warning: Member MCP2515_RXB1CTRL_MODE_RECV_STD_OR_EXT \(macro definition\) of file mcp2515_defines\.h is not documented\.

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -421,7 +421,6 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
 static int _set_filter(candev_t *dev, const struct can_filter *filter)
 {
     DEBUG("inside _set_filter of MCP2515\n");
-    bool filter_added = true;
     struct can_filter f = *filter;
     int res = -1;
     enum mcp2515_mode mode;
@@ -453,7 +452,7 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
     /* Browse on each mailbox to find an empty space */
     int mailbox_index = 0;
 
-    while (mailbox_index < MCP2515_RX_MAILBOXES && !filter_added) {
+    while (mailbox_index < MCP2515_RX_MAILBOXES) {
         /* mask unused */
         if (dev_mcp->masks[mailbox_index] == 0) {
             /* set mask */
@@ -467,7 +466,7 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
             dev_mcp->filter_ids[mailbox_index][0] = f.can_id;
 
             /* function succeeded */
-            filter_added = true;
+            break;
         }
 
         /* mask existed and same mask */
@@ -498,7 +497,7 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
                 dev_mcp->filter_ids[mailbox_index][filter_pos] = f.can_id;
 
                 /* function succeeded */
-                filter_added = true;
+                break;
             }
         }
         mailbox_index++;
@@ -513,7 +512,8 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
         return -1;
     }
 
-    return filter_added;
+    /* Filter added */
+    return 0;
 }
 
 static int _remove_filter(candev_t *dev, const struct can_filter *filter)

--- a/drivers/mcp2515/mcp2515.c
+++ b/drivers/mcp2515/mcp2515.c
@@ -108,7 +108,15 @@ int mcp2515_init(candev_mcp2515_t *dev, void (*irq_handler_cb)(void *))
         return -1;
     }
 
-    uint8_t cmd = MCP2515_RXB0CTRL_MODE_RECV_ALL;
+    uint8_t cmd;
+    if (IS_ACTIVE(MCP2515_RECV_FILTER_EN)) {
+        DEBUG_PUTS("filtering enabled");
+        cmd = MCP2515_RXB0CTRL_MODE_RECV_FILTER;
+    }
+    else {
+        DEBUG_PUTS("filtering disabled");
+        cmd = MCP2515_RXB0CTRL_MODE_RECV_ALL;
+    }
 
     res = mcp2515_spi_write(dev, MCP2515_RXB0CTRL, &cmd, 1);
     if (res < 0) {

--- a/drivers/mcp2515/mcp2515.h
+++ b/drivers/mcp2515/mcp2515.h
@@ -71,6 +71,11 @@ enum mcp2515_error {
 /** Wake up source */
 #define MCP2515_WKUP_SRC_INTERNAL 1
 
+/** Acceptance mode (enable/disable filtering) */
+#ifndef MCP2515_RECV_FILTER_EN
+#define MCP2515_RECV_FILTER_EN  0
+#endif
+
 /**
  * @brief Initialize pins and SPI interface
  *

--- a/drivers/mcp2515/mcp2515_defines.h
+++ b/drivers/mcp2515/mcp2515_defines.h
@@ -300,6 +300,7 @@ extern "C" {
 #define MCP2515_RXB0CTRL_BUKT1                  0x02
 #define MCP2515_RXB0CTRL_BUKT                   0x04
 #define MCP2515_RXB0CTRL_RXRTR                  0x08
+#define MCP2515_RXB0CTRL_MODE_RECV_FILTER       0x00
 #define MCP2515_RXB0CTRL_RXM0                   0x20
 #define MCP2515_RXB0CTRL_RXM1                   0x40
 #define MCP2515_RXB0CTRL_MODE_RECV_STD_OR_EXT   0x00
@@ -312,6 +313,7 @@ extern "C" {
 #define MCP2515_RXB1CTRL_FILHIT1                0x02
 #define MCP2515_RXB1CTRL_FILHIT2                0x04
 #define MCP2515_RXB1CTRL_RXRTR                  0x08
+#define MCP2515_RXB1CTRL_MODE_RECV_FILTER       0x00
 #define MCP2515_RXB1CTRL_RXM0                   0x20
 #define MCP2515_RXB1CTRL_RXM1                   0x40
 #define MCP2515_RXB1CTRL_MODE_RECV_STD_OR_EXT   0x00

--- a/tests/candev/Makefile.board.dep
+++ b/tests/candev/Makefile.board.dep
@@ -9,6 +9,8 @@ ifeq ($(CAN_DRIVER), PERIPH_CAN)
   FEATURES_REQUIRED += periph_can
 else ifeq ($(CAN_DRIVER), MCP2515)
   USEMODULE += mcp2515
+  # Uncomment to enable MCP2515 reception filtering
+  # CFLAGS += "-DMCP2515_RECV_FILTER_EN=1"
 else ifeq ($(CAN_DRIVER), CAN_ALT)
   # other can modules can be defined here
 endif

--- a/tests/candev/main.c
+++ b/tests/candev/main.c
@@ -219,12 +219,22 @@ if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
     /* set to loopback test mode */
     canopt_state_t mode = CANOPT_STATE_LOOPBACK;
     candev->driver->set(candev, CANOPT_STATE, &mode, sizeof(mode));
-
-    /* do not care, receive all message id */
-    struct can_filter filter;
-    filter.can_mask = 0;
-    candev->driver->set_filter(candev, &filter);
 }
+
+    if (IS_ACTIVE(MCP2515_RECV_FILTER_EN)) {
+        /* CAN filters examples */
+        struct can_filter filter[3];
+        filter[0].can_mask = 0x7FF;
+        filter[0].can_id = 0x001;   /* messages with CAN ID 0x001 will be received in mailbox 0 */
+        filter[1].can_mask = 0x7FF;
+        filter[1].can_id = 0x003;   /* messages with CAN ID 0x003 will be received in mailbox 0 */
+        filter[2].can_mask = 0x7FF;
+        filter[2].can_id = 0x002;   /* messages with CAN ID 0x002 will be received in mailbox 1 */
+        for (uint8_t i = 0; i < 3; i++) {
+            candev->driver->set_filter(candev, &filter[i]);
+        }
+        /* All other messages won't be received */
+    }
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);


### PR DESCRIPTION
### Contribution description

The MCP2515 driver initialization sets the acceptance mode to receiving all packets without checking the filters set for each mailbox. This leads to the situation where the node is receiving all messages on the CAN bus.
This PR goal is to enable filtering the CAN messages that are having a CAN ID that matches the CAN filters.

### Testing procedure

This was tested using a SAME54-xpro and a MCP2515 breakout board following these steps:
- Enable filtering macro `MCP2515_RECV_FILTER_EN`
- Set the CAN filters for both mailboxes to reject totally the CAN message. If not, the message will be accepted on the second mailbox (according to Figure4.3 in the MCP2515 datasheet)
- Send CAN messages with matching and not matching CAN IDs
