### PR TITLE
cpu/cortexm_common: enable FPU on cortexm33

### DIFF
--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -90,6 +90,7 @@ config CPU_CORE_CORTEX_M33
     bool
     select CPU_ARCH_ARMV8M
     select CPU_CORE_CORTEX_M
+    select HAS_CORTEXM_FPU
     #select HAS_RUST_TARGET
 
 config CPU_CORE_CORTEX_M4

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -12,8 +12,8 @@ FEATURES_PROVIDED += puf_sram
 FEATURES_PROVIDED += picolibc
 FEATURES_PROVIDED += ssp
 
-# cortex-m4f and cortex-m7 provide FPU support
-ifneq (,$(filter $(CPU_CORE),cortex-m4f cortex-m7))
+# cortex-m33, cortex-m4f and cortex-m7 provide FPU support
+ifneq (,$(filter $(CPU_CORE),cortex-m33 cortex-m4f cortex-m7))
   FEATURES_PROVIDED += cortexm_fpu
 endif
 

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -63,7 +63,7 @@ CFLAGS += -DCPU_CORE_$(call uppercase_and_underscore,$(CPU_CORE))
 
 # Add soft or hard FPU CFLAGS depending on the module
 ifneq (,$(filter cortexm_fpu,$(USEMODULE)))
-  ifeq ($(CPU_CORE),cortex-m7)
+  ifneq (,$(filter $(CPU_CORE),cortex-m33 cortex-m7))
     CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
   else
     CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

[Cortex-M33 CPUs provide an FPU](https://developer.arm.com/documentation/100230/0002/functional-description/floating-point-unit/about-the-fpu?lang=en). This PR enables this feature for this CPU core.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- `tests/float` is working on CortexM33 boards:

<details><summary>b-u585i-iot02a</summary>

```
$ BUILD_IN_DOCKER=1 BOARD=b-u585i-iot02a make -C tests/float flash test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/aabadie/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/aabadie/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=b-u585i-iot02a' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/tests/float/' 'riot/riotbuild:latest' make     
Building application "tests_float" for "b-u585i-iot02a" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/b-u585i-iot02a
"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/malloc_thread_safe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/test_utils/print_stack_usage
"make" -C /data/riotbuild/riotbase/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  12440	    140	   2392	  14972	   3a7c	/data/riotbuild/riotbase/tests/float/bin/b-u585i-iot02a/tests_float.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/float/bin/b-u585i-iot02a/tests_float.elf
### Flashing Target ###
Open On-Chip Debugger 0.11.0+dev-00551-gaad871805 (2022-01-06-14:44)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V3J7M3 (API v3) VID:PID 0483:374E
Info : Target voltage: 3.276368
Info : stm32u5x.cpu: Cortex-M33 r0p4 processor detected
Info : stm32u5x.cpu: target has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32u5x.cpu on 0
Info : Listening on port 40831 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32u5x.cpu       hla_target little stm32u5x.cpu       reset

Info : Unable to match requested speed 480 kHz, using 200 kHz
Info : Unable to match requested speed 480 kHz, using 200 kHz
stm32u5x.dap
Error executing event halted on target stm32u5x.cpu:
/usr/local/bin/../share/openocd/scripts/target/stm32u5x.cfg:122: Error: 
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 854
in procedure 'ahb_ap_non_secure_access' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32u5x.cfg", line 158
at file "/usr/local/bin/../share/openocd/scripts/target/stm32u5x.cfg", line 122
target halted due to debug-request, current mode: Thread 
xPSR: 0xf9000000 pc: 0x080008cc msp: 0x20000200
Info : device idcode = 0x20006482 (STM32U57/U58xx - Rev B : 0x2000)
Info : TZEN = 0 : TrustZone disabled by option bytes
Info : RDP level 0 (0xAA)
Info : flash size = 2048kbytes
Info : flash mode : dual-bank
Info : Padding image section 2 at 0x08003124 with 12 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08003130 .. 0x08003fff
auto erase enabled
wrote 12592 bytes from file /work/riot/RIOT/tests/float/bin/b-u585i-iot02a/tests_float.elf in 1.100670s (11.172 KiB/s)

verified 12580 bytes in 0.909135s (13.513 KiB/s)

Info : Unable to match requested speed 480 kHz, using 200 kHz
Info : Unable to match requested speed 480 kHz, using 200 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
/work/riot/RIOT/dist/tools/pyterm/pyterm:289: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  receiver_thread.setDaemon(1)
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2022.07-devel-349-gdd043-pr/cpu/cortexm33_fpu)
Testing floating point arithmetic...

[SUCCESS]
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
