### PR TITLE
gnrc_sock: implicitly set netif if there is only a single one

### DIFF
--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -125,13 +125,15 @@ static inline void gnrc_ep_set(sock_ip_ep_t *out, const sock_ip_ep_t *in,
                                size_t in_size)
 {
     memcpy(out, in, in_size);
-    if (gnrc_netif_highlander() && (out->netif == 0)) {
-        /* set interface implicitly */
-        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+    if (out->netif != SOCK_ADDR_ANY_NETIF) {
+        return;
+    }
 
-        if (netif != NULL) {
-            out->netif = netif->pid;
-        }
+    /* set interface implicitly */
+    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+    if ((netif != NULL) &&
+        (gnrc_netif_highlander() || (gnrc_netif_iter(netif) == NULL))) {
+        out->netif = netif->pid;
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The interface is already set implicitly for the `gnrc_netif_highlander()` case - also set it implicitly if there is only a single interface.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #17927
