### PR TITLE
drivers/slipdev: make use of chunked ringbuffer

### DIFF
--- a/drivers/slipdev/Kconfig
+++ b/drivers/slipdev/Kconfig
@@ -11,8 +11,8 @@ menuconfig MODULE_SLIPDEV
     depends on HAS_PERIPH_UART
     depends on TEST_KCONFIG
     select MODULE_NETDEV_LEGACY_API
+    select MODULE_CHUNKED_RINGBUFFER
     select MODULE_PERIPH_UART
-    select MODULE_TSRB
 
 menuconfig KCONFIG_USEMODULE_SLIPDEV
     bool "Configure SLIPDEV driver"

--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -1,7 +1,7 @@
+USEMODULE += chunked_ringbuffer
 USEMODULE += eui_provider
 USEMODULE += netdev_legacy_api
 USEMODULE += netdev_register
-USEMODULE += tsrb
 FEATURES_REQUIRED += periph_uart
 
 ifneq (,$(filter slipdev_stdio,$(USEMODULE)))

--- a/drivers/slipdev/include/slipdev_internal.h
+++ b/drivers/slipdev/include/slipdev_internal.h
@@ -79,23 +79,6 @@ static inline void slipdev_write_byte(uart_t uart, uint8_t byte)
  */
 void slipdev_write_bytes(uart_t uart, const uint8_t *data, size_t len);
 
-/**
- * @brief   Unstuffs a (SLIP-escaped) byte.
- *
- * @param[out] buf          The buffer to write to. It must at least be able to
- *                          receive 1 byte.
- * @param[in] byte          The byte to unstuff.
- * @param[in,out] escaped   When set to `false` on in, @p byte will be read as
- *                          though it was not escaped, when set to `true` it
- *                          will be read as though it was escaped. On out it
- *                          will be `false` unless @p byte was `SLIPDEV_ESC`.
- *
- * @return  0, when @p byte did not resolve to an actual byte
- * @return  1, when @p byte resolves to an actual byte (or @p escaped was set to
- *          true on in and resolves to a byte that was previously escaped).
- */
-unsigned slipdev_unstuff_readbyte(uint8_t *buf, uint8_t byte, bool *escaped);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Just a test to see if this can increase performance with high data ingress.

But turns out this also solves two nasty SLIP bugs:

 - trivial solution for frames stuck in RX queue
 - fixes pktbuf corruption (#18229) by removing the offending code

### Testing procedure

SLIP should work as before, ideally a bit better.


### Issues/PRs references

alternative to #18826, #18229
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
