### PR TITLE
unittest/sock_util: move test_strings to their tests

### DIFF
--- a/tests/unittests/tests-sock_util/tests-sock_util.c
+++ b/tests/unittests/tests-sock_util/tests-sock_util.c
@@ -54,21 +54,6 @@
                                     "path/that/doesnt/fit/inside/sixtyfour/" \
                                     "chars/of/buffer/space"
 
-#define TEST_STR2EP                 "[2001:db8::1]"
-#define TEST_STR2EP_V4              "10.0.0.1"
-#define TEST_STR2EP_V4_2            "10.0.0.1:53"
-#define TEST_STR2EP_V4_INVALID      "[10.0.0.1]:53"
-#define TEST_STR2EP_INVALID         "[2001:db8:a:b:c:d:e:f:1]"
-#define TEST_STR2EP_INVALID2        "[2001:db8:a:b:c:d:e:f]:66000"
-#define TEST_STR2EP_NETIF           "[fe80::1%45]"
-#define TEST_STR2EP_NETIF2          "[fe80::1%23]:243"
-#define TEST_STR2EP_NETIF_GLOBAL    "[2001:db8:a::1%75]"
-#define TEST_STR2EP_LL              "[fe80::1]"
-#define TEST_STR2EP_LL_PORT         "[fe80::1]:243"
-#define TEST_STR2EP_GLOBAL_PORT     "[2001:db8:a::1]:123"
-#define TEST_STR2EP_NETIF_INVALID   "[fe80::1%]:752"
-#define TEST_STR2EP_NETIF_INVALID2  "[fe80::1%56776]:1346"
-#define TEST_STR2EP_NETIF_INVALID3  "[fe80::1%53:4232"
 
 static char addr[CONFIG_SOCK_URLPATH_MAXLEN];
 static char urlpath[CONFIG_SOCK_URLPATH_MAXLEN];
@@ -175,10 +160,12 @@ static void test_sock_util_urlsplit__null_path_buffer(void)
     TEST_ASSERT_EQUAL_STRING(TEST_URL_LOCALPART, (char*)urlpath);
 }
 
+
 static void test_sock_util_str2ep__ipv6_noport(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP));
+    const char * test_str = "[2001:db8::1]";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
@@ -187,7 +174,8 @@ static void test_sock_util_str2ep__ipv6_noport(void)
 static void test_sock_util_str2ep__ipv4_noport(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_V4));
+    const char * test_str = "10.0.0.1";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET, ep.family);
@@ -196,7 +184,8 @@ static void test_sock_util_str2ep__ipv4_noport(void)
 static void test_sock_util_str2ep__ipv4_port(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_V4_2));
+    const char * test_str = "10.0.0.1:53";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(53, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET, ep.family);
@@ -205,47 +194,57 @@ static void test_sock_util_str2ep__ipv4_port(void)
 static void test_sock_util_str2ep__ipv4_bracketed(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep,
-                                                   TEST_STR2EP_V4_INVALID));
+    /* IPv4 addr enclosed in IPv6 Brackets */
+    const char * test_str =  "[10.0.0.1]:53";
+    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, test_str));
 }
+
 
 static void test_sock_util_str2ep__invalid_bracket_missing(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep,
-                                                   TEST_STR2EP_NETIF_INVALID3));
+    /* IPv6 addr missing closing bracket */
+    const char * test_str = "[fe80::1%53:4232";
+    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, test_str));
 }
 
 static void test_sock_util_str2ep__invalid_ipv6(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, TEST_STR2EP_INVALID));
+    /* IPv6 addr has too many parts 9 > 8 */
+    const char * test_str = "[2001:db8:a:b:c:d:e:f:1]";
+    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, test_str));
 }
 
 static void test_sock_util_str2ep__invalid_netif_missing(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep,
-                                                   TEST_STR2EP_NETIF_INVALID));
+    /* netif part is 0 length/missing */
+    const char * test_str = "[fe80::1%]:752";
+    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, test_str));
 }
 
 static void test_sock_util_str2ep__invalid_netif(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep,
-                                                   TEST_STR2EP_NETIF_INVALID2));
+    /* netif_str longer than NETIF_STR_LEN - 1 (>4) */
+    const char * test_str = "[fe80::1%56776]:1346";
+    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, test_str));
 }
 
 static void test_sock_util_str2ep__invalid_port(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, TEST_STR2EP_INVALID2));
+    /* port > UINT16_MAX */
+    const char * test_str = "[2001:db8:a:b:c:d:e:f]:66000";
+    TEST_ASSERT_EQUAL_INT(-EINVAL, sock_udp_str2ep(&ep, test_str));
 }
 
 static void test_sock_util_str2ep__netif(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_NETIF));
+    const char * test_str = "[fe80::1%45]";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(45, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
@@ -254,7 +253,8 @@ static void test_sock_util_str2ep__netif(void)
 static void test_sock_util_str2ep__netif_with_port(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_NETIF2));
+    const char * test_str = "[fe80::1%23]:243";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(243, ep.port);
     TEST_ASSERT_EQUAL_INT(23, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
@@ -263,7 +263,8 @@ static void test_sock_util_str2ep__netif_with_port(void)
 static void test_sock_util_str2ep__netif_with_global_addr(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_NETIF_GLOBAL));
+    const char * test_str = "[2001:db8:a::1%75]";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(75, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
@@ -272,7 +273,8 @@ static void test_sock_util_str2ep__netif_with_global_addr(void)
 static void test_sock_util_str2ep__ll(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_LL));
+    const char * test_str = "[fe80::1]";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(0, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
@@ -281,7 +283,8 @@ static void test_sock_util_str2ep__ll(void)
 static void test_sock_util_str2ep__ll_with_port(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_LL_PORT));
+    const char * test_str = "[fe80::1]:243";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(243, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
@@ -290,7 +293,8 @@ static void test_sock_util_str2ep__ll_with_port(void)
 static void test_sock_util_str2ep__with_global_addr_port(void)
 {
     sock_udp_ep_t ep;
-    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, TEST_STR2EP_GLOBAL_PORT));
+    const char * test_str = "[2001:db8:a::1]:123";
+    TEST_ASSERT_EQUAL_INT(0, sock_udp_str2ep(&ep, test_str));
     TEST_ASSERT_EQUAL_INT(123, ep.port);
     TEST_ASSERT_EQUAL_INT(0, ep.netif);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);


### PR DESCRIPTION
### Contribution description

I moved the test stings to their tests to ease read ablility  (not scroling from line 200 to 20 and back again)
Also added some comments why a certain case is invalid.

### Testing procedure
read and murdock 

### Issues/PRs references

inspired while adding tests in #18061