### PR TITLE
pkg/lwip: Add basic version of netif_get/set_opt

### DIFF
--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -71,4 +71,16 @@ int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
     return res;
 }
 
+int netif_set_opt(netif_t *iface, netopt_t opt, uint16_t context,
+                  void *value, size_t value_len)
+{
+    (void)iface;
+    (void)opt;
+    (void)context;
+    (void)value;
+    (void)value_len;
+
+    return -ENOTSUP;
+}
+
 /** @} */

--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -13,6 +13,7 @@
  *
  * @file
  * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author  Erik Ekman <eekman@google.com>
  */
 
 #include "fmt.h"
@@ -29,6 +30,39 @@ int netif_get_name(netif_t *iface, char *name)
     name[1] = netif->name[1];
     res += fmt_u16_dec(&name[res], netif->num);
     name[res] = '\0';
+    return res;
+}
+
+int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
+                  void *value, size_t max_len)
+{
+    (void)context;
+    lwip_netif_t *lwip_netif = (lwip_netif_t*) iface;
+    struct netif *netif = &lwip_netif->lwip_netif;
+    int res = -ENOTSUP;
+    switch (opt) {
+#ifdef MODULE_LWIP_IPV6
+        case NETOPT_IPV6_ADDR: {
+                assert(max_len >= sizeof(ipv6_addr_t));
+                ipv6_addr_t *tgt = value;
+
+                res = 0;
+                for (unsigned i = 0;
+                     ((res + sizeof(ipv6_addr_t)) <= max_len) &&
+                     (i < LWIP_IPV6_NUM_ADDRESSES);
+                     i++) {
+                    if (netif_ip6_addr_state(netif, i) != IP6_ADDR_INVALID) {
+                        memcpy(tgt, &(netif_ip6_addr(netif, i)->addr), sizeof(ipv6_addr_t));
+                        res += sizeof(ipv6_addr_t);
+                        tgt++;
+                    }
+                }
+            }
+            break;
+#endif
+        default:
+            break;
+    }
     return res;
 }
 

--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -39,6 +39,7 @@ int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
     (void)context;
     lwip_netif_t *lwip_netif = (lwip_netif_t*) iface;
     struct netif *netif = &lwip_netif->lwip_netif;
+    struct netdev *dev = netif->state;
     int res = -ENOTSUP;
     switch (opt) {
 #ifdef MODULE_LWIP_IPV6
@@ -62,6 +63,10 @@ int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
 #endif
         default:
             break;
+    }
+    if (res == -ENOTSUP) {
+        // Ask underlying netdev
+        res = dev->driver->get(dev, opt, value, max_len);
     }
     return res;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Add basic netif get/set opt implementation for lwIP. 

Only supporting getting IPv6 addresses and underlying netif options. Setting options not supported.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Apply e22fe428b4da8f6cc058577ffe0d27b5ed065ced and f502b031f2935e50306fa083e8f9ddebaa98930d, and build and flash `tests/lwip` (l2util module needs to be added).
The gnrc version of `ifconfig` then prints the lwIP netifs including IPv6 addresses, link type and channel for WiFi:

```
> ifconfig 
Iface  ET1  HWaddr: 24:0A:C4:E6:0E:9C  Channel: 11  Link: up 
          L2-PDU:1500  Source address length: 6
          Link type: wireless
          inet6 addr: fe80::260a:c4ff:fee6:e9c  scope: link
          inet6 addr: 2001:db8:0:0:260a:c4ff:fee6:e9c  scope: global
[..]
```

### Issues/PRs references

Part of #9287 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
