### PR TITLE
boards/native: allow to overwrite default fs

### DIFF
--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -12,9 +12,11 @@ ifneq (,$(filter periph_can,$(FEATURES_USED)))
   USEPKG += libsocketcan
 endif
 
-# default to using littlefs2 on the virtual flash
+# default to using littlefs2 on the virtual flash if no other fs was selected
 ifneq (,$(filter vfs_default,$(USEMODULE)))
-  USEPKG += littlefs2
+  ifeq (,$(filter spiffs littlefs fatfs_vfs,$(USEMODULE)))
+    USEMODULE += littlefs2
+  endif
   USEMODULE += mtd
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `native` board is special in that it creates a new storage instance for each test application and provides default mount pints for each file system, so the current hard default is rather arbitrary.

Make this soft default more easy to use by allowing to just supply a different file system without having to remove the `vfs_default` module (and then manually adding the auto-mount module).


### Testing procedure

Add e.g. `USEMODULE += fatfs_vfs` to `tests/vfs_default`

 - littlefs2 does not get build
 - an `MEMORY.bin` image with a FAT fs does not get auto-formatted with littlefs2


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
