### PR TITLE
boards/native: enable -Os

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -25,11 +25,15 @@ CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG) $(CFLAGS_OPT)
 CFLAGS += -U_FORTIFY_SOURCE
 CFLAGS_DBG ?= -g3
 
+ifeq ($(DEVELHELP),1)
+  CFLAGS_OPT ?= -Og
+else
+  CFLAGS_OPT ?= -Os
+endif
+
 ifneq (,$(filter backtrace,$(USEMODULE)))
   $(warning module backtrace is used, do not omit frame pointers)
-  CFLAGS_OPT ?= -Og -fno-omit-frame-pointer
-else
-  CFLAGS_OPT ?= -Og
+  CFLAGS_OPT += -fno-omit-frame-pointer
 endif
 
 # default std set to gnu11 if not overwritten by user


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

All our targets build with `-Os` except for `native`.
This can lead to deceptive results e.g. when comparing stack usage across changesets that turns out to go away with optimizations enabled (e.g. stack usage increase going from littlefs2.4 -> littlefs2.5 goes away with `-Os`).


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
