### PR TITLE
sys/shell: drop `_builtin_cmds` define

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -54,12 +54,6 @@ XFA_INIT_CONST(shell_command_t*, shell_commands_xfa);
     #define flush_if_needed()
 #endif /* MODULE_NEWLIB || MODULE_PICOLIBC */
 
-#ifdef MODULE_SHELL_COMMANDS
-    #define _builtin_cmds _shell_command_list
-#else
-    #define _builtin_cmds NULL
-#endif
-
 #define SQUOTE '\''
 #define DQUOTE '"'
 #define ESCAPECHAR '\\'
@@ -117,8 +111,8 @@ static shell_command_handler_t find_handler(
         handler = search_commands(command_list, command);
     }
 
-    if (handler == NULL && _builtin_cmds != NULL) {
-        handler = search_commands(_builtin_cmds, command);
+    if (IS_USED(MODULE_SHELL_COMMANDS) && handler == NULL) {
+        handler = search_commands(_shell_command_list, command);
     }
 
     if (handler == NULL) {
@@ -152,8 +146,8 @@ static void print_help(const shell_command_t *command_list)
         print_commands(command_list);
     }
 
-    if (_builtin_cmds != NULL) {
-        print_commands(_builtin_cmds);
+    if (IS_USED(MODULE_SHELL_COMMANDS)) {
+        print_commands(_shell_command_list);
     }
 
     print_commands_xfa();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Arch just upgraded to arm-none-eabi-gcc  12.1.0, and a new warning popped up:

```
/home/kaspar/src/riot.rs/sys/shell/shell.c: In function 'find_handler':                                                                            
/home/kaspar/src/riot.rs/sys/shell/shell.c:120:42: error: the comparison will always evaluate as 'true' for the address of '_shell_command_list' wi
ll never be NULL [-Werror=address]                                                                                                                 
  120 |     if (handler == NULL && _builtin_cmds != NULL) {                                                                                        
      |                                          ^~                                                                                                
In file included from /home/kaspar/src/riot.rs/sys/shell/shell.c:41:                                                                               
/home/kaspar/src/riot.rs/sys/include/shell_commands.h:44:30: note: '_shell_command_list' declared here                                             
   44 | extern const shell_command_t _shell_command_list[];                                                                                        
      |                              ^~~~~~~~~~~~~~~~~~~                                                                                           
/home/kaspar/src/riot.rs/sys/shell/shell.c: In function 'print_help':                                                                              
/home/kaspar/src/riot.rs/sys/shell/shell.c:155:23: error: the comparison will always evaluate as 'true' for the address of '_shell_command_list' wi
ll never be NULL [-Werror=address]                                                                                                                 
  155 |     if (_builtin_cmds != NULL) {                                                                                                           
      |                       ^~                                                                                                                   
/home/kaspar/src/riot.rs/sys/include/shell_commands.h:44:30: note: '_shell_command_list' declared here                                             
   44 | extern const shell_command_t _shell_command_list[];                                                                                        
      |                              ^~~~~~~~~~~~~~~~~~~                                                                                           
cc1: all warnings being treated as errors                                                                                                          
```

The cause was `_builtin_cmds` being just a define for `_shell_command_list[]`, or, NULL.

That was dependend only on MODULE_SHELL_COMMANDS, so, just use that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
