### PR TITLE
tools/edbg: bump version

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=73eb74785d57d7828f0d180b4875146c8e840eba
+PKG_VERSION=e2cd361327253808f130359e2f23fa50ef44dc63
 PKG_LICENSE=BSD-3-Clause
 
 # manually set some RIOT env vars, so this Makefile can be called stand-alone


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - adds a few more SAM D/L device IDs
 - add support for NXP MCU-LINK
 - add support for Lattice LCMCO2



### Testing procedure

Flashing still works

```
echo e2cd361327253808f130359e2f23fa50ef44dc63 > /home/benpicco/dev/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
[INFO] patch edbg
[INFO] edbg binary successfully built!
   text	   data	    bss	    dec	    hex	filename
  73612	    812	  26868	 101292	  18bac	/home/benpicco/dev/RIOT/examples/gcoap/bin/same54-xpro/gcoap_example.elf
/home/benpicco/dev/RIOT/dist/tools/edbg/edbg.sh flash /home/benpicco/dev/RIOT/examples/gcoap/bin/same54-xpro/gcoap_example.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2748071800007587 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM E54P20A (Rev D)
Verification...
at address 0x6c expected 0x65, read 0xed
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2748071800007587 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM E54P20A (Rev D)
Programming............. done.
Verification..................................................................................................................................................... done.
Done flashing

```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
