### PR TITLE
gnrc/sock: return ERROR if no netif to send from could be found

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -288,6 +288,10 @@ ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
         netif_hdr->if_pid = iface;
         pkt = gnrc_pkt_prepend(pkt, netif);
     }
+    else {
+        return -EINVAL;
+    }
+
 #ifdef MODULE_GNRC_NETERR
     /* cppcheck-suppress uninitvar
      * (reason: pkt is initialized in AF_INET6 case above, otherwise function


### PR DESCRIPTION

### Contribution description

make gnrc report an error if nothing will be send 

### Testing procedure

see #18065 

### Issues/PRs references

partially improves around #11551

#15821 is also working in this realm