### PR TITLE
net/gnrc_netif: clarify documentation of gnrc_netif_ipv6_addrs_get()

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -392,8 +392,9 @@ gnrc_netif_t *gnrc_netif_get_by_pid(kernel_pid_t pid);
  *                      @p CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF `* sizeof(ipv6_addr_t)
  *                      here (and have @p addrs of the according length).
  *
- * @return  Number of addresses in @p addrs times `sizeof(ipv6_addr_t)` on
- *          success (including 0).
+ * @return  Size of the array of addresses in @p addrs on success.
+ *          (number of addresses times `sizeof(ipv6_addr_t)`)
+ *          May be 0 if no addresses are configured.
  * @return  -ENOTSUP, if @p netif doesn't support IPv6.
  */
 static inline int gnrc_netif_ipv6_addrs_get(const gnrc_netif_t *netif,


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Reformulate the documentation to make it clear that this returns the *size* of the addresses, not the number of addresses.


### Testing procedure

Just read and see if this is less easy to misunderstand. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
