### PR TITLE
dist/tools/compile_commands: don't adds -nostdinc

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -251,8 +251,6 @@ def generate_module_compile_commands(path, state, args):
 
     if args.clangd:
         cdetails.cflags.append('-Wno-unknown-warning-option')
-        # avoid including host system headers
-        cdetails.cflags.append('-nostdinc')
 
     c_extra_includes = []
     cxx_extra_includes = []


### PR DESCRIPTION
### Contribution description

This fixes unintended side affects on rust compilation, which currently relies on this tool to generate appropriate flags.

### Testing procedure

Green Murdock on a full CI run

### Issues/PRs references

Partially reverts https://github.com/RIOT-OS/RIOT/pull/18063 - alternative to https://github.com/RIOT-OS/RIOT/pull/18079