### PR TITLE
tests/{cpp_ext, cpp_exclude}: cleanup HAS_*

### DIFF
--- a/tests/cpp_exclude/external_modules/module_exclude/Kconfig
+++ b/tests/cpp_exclude/external_modules/module_exclude/Kconfig
@@ -8,5 +8,5 @@
 config MODULE_MODULE_EXCLUDE
     bool "Exclude module"
     depends on TEST_KCONFIG
-    select HAS_CPP
-    select HAS_LIBSTDCPP
+    depends on HAS_CPP
+    depends on HAS_LIBSTDCPP

--- a/tests/cpp_exclude/external_modules/module_exclude/Makefile.dep
+++ b/tests/cpp_exclude/external_modules/module_exclude/Makefile.dep
@@ -1,1 +1,1 @@
-FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += cpp libstdcpp

--- a/tests/cpp_ext/external_modules/module/Kconfig
+++ b/tests/cpp_ext/external_modules/module/Kconfig
@@ -8,5 +8,5 @@
 config MODULE_MODULE
     bool "Module"
     depends on TEST_KCONFIG
-    select HAS_CPP
-    select HAS_LIBSTDCPP
+    depends on HAS_CPP
+    depends on HAS_LIBSTDCPP

--- a/tests/cpp_ext/external_modules/module/Makefile.dep
+++ b/tests/cpp_ext/external_modules/module/Makefile.dep
@@ -1,1 +1,1 @@
-FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += cpp libstdcpp


### PR DESCRIPTION

### Contribution description

Follow up due to my slowness of reviewing.  
The HAS_* should only be selected by boards/cpus, at least in the cpp case.


### Testing procedure

- Green murdock
- `TEST_KCONFIG=1 BOARD=arduino-mega2560 make all -C tests/cpp_exclude/` should show unmet dependencies and not a compilation error

### Issues/PRs references

#17994
