### PR TITLE
gnrc/ipv6_auto_subnets: only use prefixes meant for automatic address configuration

### DIFF
--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -351,6 +351,11 @@ void gnrc_ipv6_nib_rtr_adv_pio_cb(gnrc_netif_t *upstream, const ndp_opt_pi_t *pi
         return;
     }
 
+    /* only consider prefix meant for autonomous address configuration */
+    if (!(pio->flags & NDP_OPT_PI_FLAGS_A)) {
+        return;
+    }
+
 #if IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_SIMPLE)
     /* if we are the only router on this bus, we can directly choose a prefix */
     _configure_subnets(subnets, 0, upstream, pio);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When a single address is added to an interface, it will be included in the RA as a /128 prefix

```
2022-05-10 16:45:00,550 # Iface  8 
2022-05-10 16:45:00,554 #           Long HWaddr: AA:EC:E6:8B:F9:BA:BD:C8 
2022-05-10 16:45:00,557 #           MTU:65535  HL:64  RTR  
2022-05-10 16:45:00,559 #           RTR_ADV  
2022-05-10 16:45:00,562 #           Link type: wired
2022-05-10 16:45:00,567 #           inet6 addr: fe80::a8ec:e68b:f9ba:bdc8  scope: link  VAL
2022-05-10 16:45:00,573 #           inet6 addr: fd11::a8ec:e68b:f9ba:bdc8  scope: global  VAL
2022-05-10 16:45:00,578 #           inet6 addr: fdea:dbee:f::1  scope: global  VAL
2022-05-10 16:45:00,581 #           inet6 group: ff02::2
2022-05-10 16:45:00,584 #           inet6 group: ff02::1
2022-05-10 16:45:00,587 #           inet6 group: ff02::1:ffba:bdc8
2022-05-10 16:45:00,591 #           inet6 group: ff02::1:ff00:1
```

This is not used for SLAAC because it does not have the `A` flag set, so it should also not used for auto-subnetting.

### Testing procedure

Prevents issues like

```
2022-05-10 16:35:24,145 # nib: Received valid router advertisement:
2022-05-10 16:35:24,149 #      - Source address: fe80::a8ec:e68b:f9ba:bdc8
2022-05-10 16:35:24,152 #      - Destination address: ff02::1
2022-05-10 16:35:24,154 #      - Cur Hop Limit: 0
2022-05-10 16:35:24,156 #      - Flags: --
2022-05-10 16:35:24,158 #      - Router Lifetime: 1800s
2022-05-10 16:35:24,161 #      - Reachable Time: 0ms
2022-05-10 16:35:24,163 #      - Retrans Timer: 0ms
2022-05-10 16:35:24,167 # nib: received valid Prefix Information option:
2022-05-10 16:35:24,170 #      - Prefix: fdea:dbee:f::1/128
2022-05-10 16:35:24,172 #      - Flags: L-
2022-05-10 16:35:24,174 #      - Valid lifetime: 4294967295
2022-05-10 16:35:24,178 #      - Preferred lifetime: 4294967295
2022-05-10 16:35:24,182 # nib: received valid Prefix Information option:
2022-05-10 16:35:24,184 #      - Prefix: fd11::/16
2022-05-10 16:35:24,186 #      - Flags: LA
2022-05-10 16:35:24,189 #      - Valid lifetime: 4294967295
2022-05-10 16:35:24,192 #      - Preferred lifetime: 4294967295
2022-05-10 16:35:24,199 # auto_subnets: no space left in PIO cache, increase CONFIG_GNRC_IPV6_AUTO_SUBNETS_NUMOF
2022-05-10 16:35:24,209 # auto_subnets: announce sent, next timeout in 44666 µs
2022-05-10 16:35:24,258 # auto_subnets: announce sent, next timeout in 29666 µs
2022-05-10 16:35:24,292 # auto_subnets: announce sent, next timeout in 43506 µs
2022-05-10 16:35:24,335 # auto_subnets: create 1 subnets, start with 0
2022-05-10 16:35:24,339 # auto_subnets: can't split /128 into 1 subnets
```

With this patch the correct prefix is used:

```
2022-05-10 17:11:33,770 # nib: Received valid router advertisement:
2022-05-10 17:11:33,774 #      - Source address: fe80::a8ec:e68b:f9ba:bdc8
2022-05-10 17:11:33,777 #      - Destination address: ff02::1
2022-05-10 17:11:33,779 #      - Cur Hop Limit: 0
2022-05-10 17:11:33,781 #      - Flags: --
2022-05-10 17:11:33,783 #      - Router Lifetime: 1800s
2022-05-10 17:11:33,786 #      - Reachable Time: 0ms
2022-05-10 17:11:33,788 #      - Retrans Timer: 0ms
2022-05-10 17:11:33,792 # nib: received valid Prefix Information option:
2022-05-10 17:11:33,795 #      - Prefix: fdea:dbee:f::1/128
2022-05-10 17:11:33,797 #      - Flags: L-
2022-05-10 17:11:33,800 #      - Valid lifetime: 4294967295
2022-05-10 17:11:33,803 #      - Preferred lifetime: 4294967295
2022-05-10 17:11:33,807 # nib: received valid Prefix Information option:
2022-05-10 17:11:33,809 #      - Prefix: fd11::/16
2022-05-10 17:11:33,811 #      - Flags: LA
2022-05-10 17:11:33,814 #      - Valid lifetime: 4294967295
2022-05-10 17:11:33,817 #      - Preferred lifetime: 4294967295
2022-05-10 17:11:33,823 # nib: Handle timer event (ctx = 0x20003476, type = 0x4fd2, now = 1093ms)
2022-05-10 17:11:33,830 # nib: Handle timer event (ctx = 0x2000232a, type = 0x4fd1, now = 1099ms)
2022-05-10 17:11:33,845 # auto_subnets: announce sent, next timeout in 32405 µs
2022-05-10 17:11:33,882 # auto_subnets: announce sent, next timeout in 43695 µs
2022-05-10 17:11:33,930 # auto_subnets: announce sent, next timeout in 39950 µs
2022-05-10 17:11:33,969 # auto_subnets: create 1 subnets, start with 0
2022-05-10 17:11:33,974 # auto_subnets: configure prefix fd11:8000::/17 on 7
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
