### PR TITLE
slipdev: Support NETOPT_RX_END_IRQ option

### DIFF
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -228,6 +228,10 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     switch (opt) {
         case NETOPT_IS_WIRED:
             return 1;
+        case NETOPT_RX_END_IRQ:
+            assert(max_len == sizeof(netopt_enable_t));
+            *((netopt_enable_t *)value) = NETOPT_ENABLE;
+            return sizeof(netopt_enable_t);
         case NETOPT_DEVICE_TYPE:
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_SLIP;


### PR DESCRIPTION
### Contribution description

Since 80d56488ccca722a5bba30a79ba88406c3779d37, gnrc_netif prints a warning if the utilized netdev doesn't support `NETOPT_RX_END_IRQ`. According to the gnrc_netif documentation, the `NETOPT_RX_END_IRQ` option is used to check if the driver generates `NETDEV_EVENT_RX_COMPLETE` events. According to the implementation of the `_isr` function, the slipdev driver does actually generate these events:

https://github.com/RIOT-OS/RIOT/blob/2d0802e31fb08282aea7609c75eb5498562f0adf/drivers/slipdev/slipdev.c#L214-L221

However, it doesn't support the `NETOPT_RX_END_IRQ` option in _get, therefore causing a spurious warning to be emitted. This commit adds support for the `NETOPT_RX_END_IRQ` option to the `_get` implementation of slipdev, thus prevent the aforementioned warning to be emitted when using the slipdev driver.

### Testing procedure

Try any network example with the slipdev driver and `DEVELHELP=1`.

### Issues/PRs references

None.