### PR TITLE
net/netopt: drop NETOPT_RX_END_IRQ

### DIFF
--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -302,7 +302,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_START_IRQ:
-        case NETOPT_RX_END_IRQ:
         case NETOPT_TX_START_IRQ:
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) = NETOPT_ENABLE;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -351,7 +351,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_RX_START_IRQ:
-        case NETOPT_RX_END_IRQ:
         case NETOPT_TX_START_IRQ:
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) = NETOPT_ENABLE;

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -217,7 +217,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             return opt_state(val, (dev->options & CC2420_OPT_PROMISCUOUS));
 
         case NETOPT_RX_START_IRQ:
-        case NETOPT_RX_END_IRQ:
         case NETOPT_TX_START_IRQ:
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) = NETOPT_ENABLE;

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -302,7 +302,6 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_START_IRQ:
-        case NETOPT_RX_END_IRQ:
         case NETOPT_TX_START_IRQ:
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)value) = NETOPT_ENABLE;

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -473,7 +473,6 @@ int kw41zrf_netdev_get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_START_IRQ:
-        case NETOPT_RX_END_IRQ:
         case NETOPT_TX_START_IRQ:
         case NETOPT_TX_END_IRQ:
             assert(len >= sizeof(netopt_enable_t));

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -237,7 +237,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_RX_START_IRQ:
-        case NETOPT_RX_END_IRQ:
         case NETOPT_TX_START_IRQ:
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) = NETOPT_ENABLE;

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -65,16 +65,6 @@ static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
 static void *_event_loop(void *arg);
 
-static void _configure_netdev(netdev_t *dev)
-{
-    /* Enable RX-complete interrupts */
-    static const netopt_enable_t enable = NETOPT_ENABLE;
-    int res = dev->driver->set(dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-    if (res < 0) {
-        DEBUG("lwip_netdev: enable NETOPT_RX_END_IRQ failed: %d\n", res);
-    }
-}
-
 err_t lwip_netdev_init(struct netif *netif)
 {
     LWIP_ASSERT("netif != NULL", (netif != NULL));
@@ -97,7 +87,6 @@ err_t lwip_netdev_init(struct netif *netif)
     /* initialize netdev and netif */
     netdev = netif->state;
     netdev->driver->init(netdev);
-    _configure_netdev(netdev);
     netdev->event_callback = _event_cb;
     if (netdev->driver->get(netdev, NETOPT_DEVICE_TYPE, &dev_type,
                             sizeof(dev_type)) < 0) {

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -89,7 +89,6 @@ static void *_openthread_event_loop(void *arg)
 
     netopt_enable_t enable = NETOPT_ENABLE;
     netdev->driver->set(netdev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
-    netdev->driver->set(netdev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
 
     /* init OpenThread */
     sInstance = otInstanceInitSingle();

--- a/pkg/openwsn/contrib/radio_netdev.c
+++ b/pkg/openwsn/contrib/radio_netdev.c
@@ -102,8 +102,6 @@ int openwsn_radio_init(void *radio_dev)
     enable = NETOPT_ENABLE;
     netdev->driver->set(netdev, NETOPT_RX_START_IRQ, &(enable), sizeof(enable));
     enable = NETOPT_ENABLE;
-    netdev->driver->set(netdev, NETOPT_RX_END_IRQ, &(enable), sizeof(enable));
-    enable = NETOPT_ENABLE;
     netdev->driver->set(netdev, NETOPT_TX_END_IRQ, &(enable), sizeof(enable));
     enable = NETOPT_DISABLE;
     /* Enable basic mode, no AUTOACK. no CSMA , no frame filtering */

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -251,18 +251,6 @@ typedef enum {
     NETOPT_RX_START_IRQ,
 
     /**
-     * @brief   (@ref netopt_enable_t) Used to check if the driver generates
-     *          NETDEV_EVENT_RX_COMPLETE events
-     *
-     * This interrupt is triggered after a complete frame is received.
-     *
-     * @note    In case a transceiver does not support this interrupt, the event
-     *          may be triggered by the driver
-     * @warning This value is read-only and cannot be configured at run-time
-     */
-    NETOPT_RX_END_IRQ,
-
-    /**
      * @brief   (@ref netopt_enable_t) Used to check if the driver generates NETDEV_EVENT_TX_STARTED
      *          events
      *

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -53,7 +53,6 @@ static const char *_netopt_strmap[] = {
     [NETOPT_STATE]                 = "NETOPT_STATE",
     [NETOPT_RAWMODE]               = "NETOPT_RAWMODE",
     [NETOPT_RX_START_IRQ]          = "NETOPT_RX_START_IRQ",
-    [NETOPT_RX_END_IRQ]            = "NETOPT_RX_END_IRQ",
     [NETOPT_TX_START_IRQ]          = "NETOPT_TX_START_IRQ",
     [NETOPT_TX_END_IRQ]            = "NETOPT_TX_END_IRQ",
     [NETOPT_AUTOCCA]               = "NETOPT_AUTOCCA",

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -154,8 +154,6 @@ static void gomach_reinit_radio(gnrc_netif_t *netif)
         netopt_enable_t enable;
         netif->dev->driver->get(netif->dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
         assert(enable == NETOPT_ENABLE);
-        netif->dev->driver->get(netif->dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-        assert(enable == NETOPT_ENABLE);
         netif->dev->driver->get(netif->dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
         assert(enable == NETOPT_ENABLE);
     }

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -112,8 +112,6 @@ static void lwmac_reinit_radio(gnrc_netif_t *netif)
         netopt_enable_t enable;
         netif->dev->driver->get(netif->dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
         assert(enable == NETOPT_ENABLE);
-        netif->dev->driver->get(netif->dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-        assert(enable == NETOPT_ENABLE);
         netif->dev->driver->get(netif->dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
         assert(enable == NETOPT_ENABLE);
     }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1439,13 +1439,9 @@ static void _check_netdev_capabilities(netdev_t *dev)
 {
     /* Check whether RX- and TX-complete interrupts are supported by the driver */
     if (IS_ACTIVE(DEVELHELP)) {
-        netopt_enable_t enable = NETOPT_ENABLE;
-        int res = dev->driver->get(dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
-        if ((res != sizeof(enable)) || (enable != NETOPT_ENABLE)) {
-            LOG_WARNING("NETOPT_RX_END_IRQ not implemented by driver\n");
-        }
         if (IS_USED(MODULE_NETSTATS_L2) || IS_USED(MODULE_GNRC_NETIF_PKTQ)) {
-            res = dev->driver->get(dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+            netopt_enable_t enable = NETOPT_ENABLE;
+            int res = dev->driver->get(dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
             if ((res != sizeof(enable)) || (enable != NETOPT_ENABLE)) {
                 LOG_WARNING("NETOPT_TX_END_IRQ not implemented by driver\n");
             }

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -91,7 +91,6 @@ int main(void)
 
     unsigned dev_success = 0;
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
-        netopt_enable_t en = NETOPT_ENABLE;
         const at86rf2xx_params_t *p = &at86rf2xx_params[i];
         netdev_t *dev = &devs[i].netdev.netdev;
 
@@ -101,7 +100,6 @@ int main(void)
         if (dev->driver->init(dev) < 0) {
             continue;
         }
-        dev->driver->set(dev, NETOPT_RX_END_IRQ, &en, sizeof(en));
         dev_success++;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The option makes no sense as there will always be an IRQ on RX end.
This option was only set by all network stacks, but no driver implemented the set function.
Some drivers implemented a get function that would always return true.

This means this option is entirely useless.

### Testing procedure

No change in behavior expected, but we save some bytes of ROM and a warning message on drivers that did not implement the GET function.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
