### PR TITLE
gcoap: forward_proxy: forward truncated responses

### DIFF
--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -245,7 +245,7 @@ static void _forward_resp_handler(const gcoap_request_memo_t *memo,
     (void) remote; /* this is the origin server */
     client_ep_t *cep = (client_ep_t *)memo->context;
 
-    if (memo->state == GCOAP_MEMO_RESP) {
+    if ((memo->state == GCOAP_MEMO_RESP) || (memo->state == GCOAP_MEMO_RESP_TRUNC)) {
         /* forward the response packet as-is to the client */
         gcoap_forward_proxy_dispatch((uint8_t *)pdu->hdr,
                                      (pdu->payload -


### PR DESCRIPTION
### Contribution description
#16378 introduced truncated responses for cases where the gcoap message buffer is too small.  This PR extends the proxy check to also forward these truncated responses.

### Testing procedure

The same way as described in #17801 (with sufficiently large files to trigger block-wise transfer)

### Issues/PRs references
