### PR TITLE
sys/uri_parser: check port length

### DIFF
--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -109,6 +109,14 @@ bool _consume_port(uri_parser_result_t *result, const char *ipv6_end,
         }
         result->port = port_begin + 1;
         result->port_len = authority_end - result->port;
+
+        /* ports can't exceed 5 characters */
+        if (result->port_len > 5){
+            result->port = NULL;
+            result->port_len = 0;
+            return false;
+        }
+
         /* cut host part before port and ':' */
         result->host_len -= result->port_len + 1;
     }

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -423,6 +423,27 @@ static const validate_t validate_uris[] = {
         "",
         "",
         0),
+    VEC("coap://example.com:1234568910",
+        /* is URI */
+        true,
+        /* parsed scheme */
+        "coap",
+        /* parsed userinfo */
+        "",
+        /* parsed host */
+        "example.com",
+        /* parsed host without zoneid */
+        "",
+        /* parsed zoneid */
+        "",
+        /* parsed port */
+        "",
+        /* parsed path */
+        "",
+        /* parsed query */
+        "",
+        /* expected return value */
+        -1),
 };
 
 static char _failure_msg[VEC_MSG_LEN];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Ports cannot exceed "65535", thus five characters.
This PR adds enforcement and a regression test.

Thanks @Teufelchen1 for report and fix!

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
