### PR TITLE
buildsystem: Improve RISC-V compilation handling with newer toolchain

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -320,6 +320,7 @@ if __name__ == '__main__':
         _args.add_libstdcxx_includes = True
         _args.filter_out = ['-mno-thumb-interwork',
                             # Only even included for versions of GCC that support it
+                            '-misa-spec=2.2',
                             '-malign-data=natural',
                             # Only supported starting with clang 11
                             '-msmall-data-limit=8',


### PR DESCRIPTION
### Contribution description

Use -misa-spec=2.2 on newer toolchains, which allows passing the same `-march=` value to both the linker and the compiler even when binutils and GCC support difference ISA specs.

### Testing procedure

Compilation for RISC-V should still work for all toolchains it works in `master`.

Note that the warnings at link time (e.g. `mis-matched ISA version 2.0 for 'a' extension, the output version is 2.1` on Arch Linux) will still pop up. Hopefully the ISA specs implemented by existing MCUs won't be touched much more, so that eventually binutils, GCC, and newlib/picolibc eventually converge to the same ISA spec eventually.

### Issues/PRs references

Suggested in https://github.com/RIOT-OS/RIOT/pull/17951#issuecomment-1124663834