### PR TITLE
unittests: enable ASAN on native

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -132,9 +132,11 @@ all-valgrind: CFLAGS += -DHAVE_VALGRIND_H
 all-valgrind: NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
 all-gprof: CFLAGS += -pg
 all-gprof: LINKFLAGS += -pg
-all-asan: CFLAGS += -fsanitize=address -fno-omit-frame-pointer
-all-asan: CFLAGS += -DNATIVE_MEMORY
-all-asan: LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer
+
+CFLAGS_ASAN += -fsanitize=address -fno-omit-frame-pointer -DNATIVE_MEMORY
+LINKFLAGS_ASAN += -fsanitize=address -fno-omit-frame-pointer
+all-asan: CFLAGS += $(CFLAGS_ASAN)
+all-asan: LINKFLAGS += $(LINKFLAGS_ASAN)
 all-asan: export AFL_USE_ASAN=1
 
 INCLUDES += $(NATIVEINCLUDES)

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -28,6 +28,13 @@ INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 # some tests need more stack
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=THREAD_STACKSIZE_LARGE
 
+# for these boards, enable asan (Address Sanitizer)
+ASAN_BOARDS ?= native
+ifneq (, $(filter $(BOARD), $(ASAN_BOARDS)))
+  CFLAGS += $(CFLAGS_ASAN)
+  LINKFLAGS += $(LINKFLAGS_ASAN)
+endif
+
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: $(UNIT_TESTS)

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -48,8 +48,7 @@
         }                                                                   \
     } while (0)
 
-#define VEC_MSG_LEN (sizeof("Unexpected userinfo member \"\" for \"\"") + \
-                     64U + 8U)
+#define VEC_MSG_LEN   (256)
 
 typedef struct {
     char uri[64];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR wires up the Address Sanitizer for the unittests on native.

Another ~~PR~~ commit fixes the last remaining issue ASAN reported (a scratch buffer was too small in tests-uri_parser).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

This only affects native, and makes it running unittests more likely to fail. CI tests all of it.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
 #17800