### PR TITLE
core/assert: print backtrace on failed assertion

### DIFF
--- a/core/lib/assert.c
+++ b/core/lib/assert.c
@@ -19,16 +19,26 @@
 #include "architecture.h"
 #include "cpu.h"
 #include "panic.h"
+#if IS_USED(MODULE_BACKTRACE)
+#include "backtrace.h"
+#endif
 
 __NORETURN void _assert_failure(const char *file, unsigned line)
 {
     printf("%s:%u => ", file, line);
+#if IS_USED(MODULE_BACKTRACE)
+    printf("failed assertion. Backtrace:\n");
+    backtrace_print();
+#endif
     core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
 }
 
 __NORETURN void _assert_panic(void)
 {
     printf("%" PRIxTXTPTR "\n", cpu_get_caller_pc());
+#if IS_USED(MODULE_BACKTRACE)
+    backtrace_print();
+#endif
     core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
 }
 

--- a/core/lib/include/assert.h
+++ b/core/lib/include/assert.h
@@ -108,6 +108,9 @@ __NORETURN void _assert_failure(const char *file, unsigned line);
  * or `gdb` (with the command `info line *(0x89abcdef)`) to identify the line
  * the assertion failed in.
  *
+ * If the `backtrace` module is enabled (and implemented for architecture in use)
+ * a backtrace will be printed in addition to the location of the failed assertion.
+ *
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/assert.html
  */
 #define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If the `backtrace` module is enabled, use it to print a backtrace on a failed assertion. 


### Testing procedure

Add

    USEMODULE += backtrace

(currently only implemented on `native`).

Now if an assertion fails:

```
main(): This is RIOT! (Version: 2022.07-devel-395-g2b9c0-backtrace-assert)
Hello World!
You are running RIOT on a(n) native board.
This board features a(n) native MCU.
examples/hello-world/main.c:27 => 0x80497c7
0x8049621
0x8049681
0x804980e
0x80497d8
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
