### PR TITLE
tests/pkg_tflite-micro: update list of low memory boards

### DIFF
--- a/tests/pkg_tflite-micro/Makefile.ci
+++ b/tests/pkg_tflite-micro/Makefile.ci
@@ -59,6 +59,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l053r8 \
     nucleo-l073rz \
     nucleo-l412kb \
+    nucleo-l432kc \
     nucleo-wl55jc \
     olimexino-stm32 \
     opencm904 \


### PR DESCRIPTION
### Contribution description

During execution of `./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` for nucleo-432kc i notice that this test cannot be programmed due to problems with insufficient flash memory. I see such error:

 ```
 . . .
"make" -C /data/RIOT-public/RIOT/tests/pkg_tflite-micro/external_modules/mnist
/usr/lib/gcc/arm-none-eabi/7.3.1/../../../arm-none-eabi/bin/ld: /data/RIOT-public/RIOT/tests/pkg_tflite-micro/bin/nucleo-l432kc/tests_pkg_tflite-micro.elf section `.text' will not fit in region `rom'
/usr/lib/gcc/arm-none-eabi/7.3.1/../../../arm-none-eabi/bin/ld: region `rom' overflowed by 16468 bytes
collect2: error: ld returned 1 exit status
make: *** [/data/RIOT-public/RIOT/tests/pkg_tflite-micro/../../Makefile.include:735: /data/RIOT-public/RIOT/tests/pkg_tflite-micro/bin/nucleo-l432kc/tests_pkg_tflite-micro.elf] Error 1
```

This PR adds nucleo-l432kc board to the Makefile.ci file.

### Testing procedure

Short:
Try to compile and flash this test for nucleo-l432kc using command 
`BOARD=nucleo-432kc' make flash test` - error should appear. This prove that board should be added to Makefile.ci.

Long:
Execute `./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` and before this PR you see in `/results/nucleo-l432kc/tests/pkg_tflite-micro` file `compilation.failed`. 

After this PR there should be file `skip.not_enought_memory`


