### PR TITLE
cpu/esp32: fixes for gcc 8.4.0

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -13,7 +13,7 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   DEFAULT_MODULE += newlib_nano
 endif
 
-ifneq (,$(filter libstdcpp,$(USEMODULE)))
+ifneq (,$(filter cpp,$(USEMODULE)))
   USEMODULE += pthread
 endif
 

--- a/cpu/esp32/vendor/esp-idf/ethernet/emac_dev.h
+++ b/cpu/esp32/vendor/esp-idf/ethernet/emac_dev.h
@@ -54,54 +54,54 @@ void emac_enable_flowctrl(void);
 void emac_disable_flowctrl(void);
 void emac_mac_enable_txrx(void);
 
-inline uint32_t emac_read_tx_cur_reg(void)
+static inline uint32_t emac_read_tx_cur_reg(void)
 {
     return REG_READ(EMAC_DMATXCURRDESC_REG);
 }
 
-inline uint32_t emac_read_rx_cur_reg(void)
+static inline uint32_t emac_read_rx_cur_reg(void)
 {
     return REG_READ(EMAC_DMARXCURRDESC_REG);
 }
 
-inline void emac_poll_tx_cmd(void)
+static inline void emac_poll_tx_cmd(void)
 {
     //write any to wake up dma
     REG_WRITE(EMAC_DMATXPOLLDEMAND_REG, 1);
 }
 
-inline void emac_poll_rx_cmd(void)
+static inline void emac_poll_rx_cmd(void)
 {
     //write any to wake up dma
     REG_WRITE(EMAC_DMARXPOLLDEMAND_REG, 1);
 }
 
-inline void emac_disable_rx_intr(void)
+static inline void emac_disable_rx_intr(void)
 {
     REG_CLR_BIT(EMAC_DMAIN_EN_REG, EMAC_DMAIN_RIE);
 }
 
-inline void emac_enable_rx_intr(void)
+static inline void emac_enable_rx_intr(void)
 {
     REG_SET_BIT(EMAC_DMAIN_EN_REG, EMAC_DMAIN_RIE);
 }
 
-inline void emac_disable_rx_unavail_intr(void)
+static inline void emac_disable_rx_unavail_intr(void)
 {
     REG_CLR_BIT(EMAC_DMAIN_EN_REG, EMAC_DMAIN_RBUE);
 }
 
-inline void emac_enable_rx_unavail_intr(void)
+static inline void emac_enable_rx_unavail_intr(void)
 {
     REG_SET_BIT(EMAC_DMAIN_EN_REG, EMAC_DMAIN_RBUE);
 }
 
-inline void IRAM_ATTR emac_send_pause_frame_enable(void)
+static inline void IRAM_ATTR emac_send_pause_frame_enable(void)
 {
     REG_SET_BIT(EMAC_EX_PHYINF_CONF_REG, EMAC_EX_SBD_FLOWCTRL);
 }
 
-inline void emac_send_pause_zero_frame_enable(void)
+static inline void emac_send_pause_zero_frame_enable(void)
 {
     REG_CLR_BIT(EMAC_EX_PHYINF_CONF_REG, EMAC_EX_SBD_FLOWCTRL);
 }


### PR DESCRIPTION
### Contribution description

This PR provides two fixes that are required to make the ESP32 code compilable with gcc 5.2.0 and gcc 8.2.0.

### Testing procedure

Green CI

### Issues/PRs references

Fixes the compilation problems occured in CI with https://github.com/RIOT-OS/riotdocker/pull/190.