### PR TITLE
drivers/dose: make RX buffer size configurable

### DIFF
--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -632,6 +632,15 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
                 *((netopt_enable_t *)value) = NETOPT_DISABLE;
             }
             return sizeof(netopt_enable_t);
+        case NETOPT_MAX_PDU_SIZE:
+            if (CONFIG_DOSE_RX_BUF_LEN < (ETHERNET_FRAME_LEN + DOSE_FRAME_CRC_LEN)) {
+                if (max_len < sizeof(uint16_t)) {
+                    return -EINVAL;
+                }
+                *((uint16_t *)value) = CONFIG_DOSE_RX_BUF_LEN - DOSE_FRAME_CRC_LEN;
+                return sizeof(uint16_t);
+            }
+            /* fall-through */
         default:
             return netdev_eth_get(dev, opt, value, max_len);
     }

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -160,7 +160,14 @@ typedef enum {
 /** @} */
 
 #define DOSE_FRAME_CRC_LEN          (2)     /**< CRC16 is used */
-#define DOSE_FRAME_LEN (ETHERNET_FRAME_LEN + DOSE_FRAME_CRC_LEN) /**< dose frame length */
+
+/**
+ * @brief   DOSE RX buffer length
+ *          Should be large enough to fit at least one Ethernet frame
+ */
+#ifndef CONFIG_DOSE_RX_BUF_LEN
+#define CONFIG_DOSE_RX_BUF_LEN (ETHERNET_FRAME_LEN + DOSE_FRAME_CRC_LEN)
+#endif
 
 /**
  * @brief   Hardware timer to use with the `dose_watchdog` module.
@@ -182,7 +189,7 @@ typedef struct {
     uint8_t opts;                           /**< Driver options */
     dose_state_t state;                     /**< Current state of the driver's state machine */
     mutex_t state_mtx;                      /**< Is unlocked every time a state is (re)entered */
-    uint8_t recv_buf[DOSE_FRAME_LEN];       /**< Receive buffer for incoming frames */
+    uint8_t recv_buf[CONFIG_DOSE_RX_BUF_LEN]; /**< Receive buffer for incoming frames */
     chunk_ringbuf_t rb;                     /**< Ringbuffer to store received frames.       */
                                             /* Written to from interrupts (with irq_disable */
                                             /* to prevent any simultaneous writes),         */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

To benefit from the chunked ringbuffer if large frames are being sent, we need to allocate more than one ethernet frame length to it.

Rename the define and make it overwriteable by the user.

### Testing procedure

Only a define was renamed, no change in code.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
