### PR TITLE
sys/vfs: add vfs_unmount_by_path()

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -921,6 +921,18 @@ int vfs_mount(vfs_mount_t *mountp);
 int vfs_mount_by_path(const char *path);
 
 /**
+ * @brief Unmount a file system with a pre-configured mount path
+ *
+ * @note This assumes mount points have been configured with @ref VFS_AUTO_MOUNT.
+ *
+ * @param[in]  path     Path of the pre-configured mount point
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int vfs_unmount_by_path(const char *path);
+
+/**
  * @brief Rename a file
  *
  * The file @p from_path will be renamed to @p to_path

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -1167,4 +1167,15 @@ int vfs_mount_by_path(const char *path)
     return -ENOENT;
 }
 
+int vfs_unmount_by_path(const char *path)
+{
+    for (unsigned i = 0; i < MOUNTPOINTS_NUMOF; ++i) {
+        if (strcmp(path, vfs_mountpoints_xfa[i].mount_point) == 0) {
+            return vfs_umount(&vfs_mountpoints_xfa[i]);
+        }
+    }
+
+    return -ENOENT;
+}
+
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If we mount a file system by path we also might want to unmount it, e.g. for clean shutdown or reboot.

Just adds a function that does the same as `vfs_mount_by_path()` but with unmount instead of mount.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Complements #17661
