### PR TITLE
examples/gcoap_dtls: remove CFLAGS define of DTLS_PEER_MAX

### DIFF
--- a/examples/gcoap_dtls/Makefile
+++ b/examples/gcoap_dtls/Makefile
@@ -56,9 +56,6 @@ ifeq (1,$(GCOAP_ENABLE_DTLS))
   USEMODULE += gcoap_dtls
   # tinydtls needs crypto secure PRNG
   USEMODULE += prng_sha1prng
-
-  # Maximum number of DTLS sessions
-  CFLAGS += -DDTLS_PEER_MAX=1
 endif
 
 # Instead of simulating an Ethernet connection, we can also simulate


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
With the current configuration via CFLAGS it is impossible to change `DTLS_PEER_MAX` from console (without editing the Makefile) and even worse: config via Kconfig is not possible. This removes the definition of DLTS_PEER_MAX. It could make sense to add a `app.config` to this example, however, `CONFIG_DTLS_PEER_MAX` [already defaults to 1](https://github.com/RIOT-OS/RIOT/blob/d28a45e93964be8fdf03994b6ada27ffbcbed964/pkg/tinydtls/Kconfig#L41), so setting it to 1 really is not necessary.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/gcoap_dtls` should still compile, now compiling it with e.g.

```sh
RIOT_CONFIG_KCONFIG_USEPKG_TINYDTLS=y RIOT_CONFIG_DTLS_PEER_MAX=2 make -C examples/gcoap_dtls flash ter
```

should also work (or the corresponding `app.config`). Mind you, it did work before as well, the new value was just ignored.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Preparations for #18107 testing procedures.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
