### PR TITLE
drivers/mtd_mapper: inherit physical properties

### DIFF
--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -74,11 +74,21 @@ static int _init(mtd_dev_t *mtd)
     mtd_mapper_region_t *region = container_of(mtd, mtd_mapper_region_t, mtd);
     mtd_dev_t *backing_mtd = region->parent->mtd;
 
-    /* Configuration sanity checks */
-    assert(backing_mtd->page_size == region->mtd.page_size);
-    assert(backing_mtd->pages_per_sector == region->mtd.pages_per_sector);
+    /* inherit physical properties */
+    if (region->mtd.page_size == 0) {
+        region->mtd.page_size = backing_mtd->page_size;
+    }
+    if (region->mtd.pages_per_sector == 0) {
+        region->mtd.pages_per_sector = backing_mtd->pages_per_sector;
+    }
+    region->mtd.write_size = backing_mtd->write_size;
+
+    /* Configuration sanity check */
+    assert(backing_mtd->page_size >= region->mtd.page_size);
+    assert(backing_mtd->write_size <= region->mtd.page_size);
+    assert(region->mtd.page_size * region->mtd.pages_per_sector
+        == backing_mtd->page_size * backing_mtd->pages_per_sector);
     assert(backing_mtd->sector_count >= region->mtd.sector_count);
-    assert(backing_mtd->write_size == region->mtd.write_size);
 
     /* offset + region size must not exceed the backing device */
     assert(region->sector + region->mtd.sector_count <= backing_mtd->sector_count);

--- a/tests/mtd_mapper/main.c
+++ b/tests/mtd_mapper/main.c
@@ -192,9 +192,6 @@ static mtd_mapper_region_t _region_a = {
     .mtd = {
         .driver = &mtd_mapper_driver,
         .sector_count = SECTOR_COUNT / 2,
-        .pages_per_sector = PAGE_PER_SECTOR,
-        .page_size = PAGE_SIZE,
-        .write_size = WRITE_SIZE,
     },
     .parent = &_parent,
     .sector = 0,
@@ -204,9 +201,6 @@ static mtd_mapper_region_t _region_b = {
     .mtd = {
         .driver = &mtd_mapper_driver,
         .sector_count = SECTOR_COUNT / 2,
-        .pages_per_sector = PAGE_PER_SECTOR,
-        .page_size = PAGE_SIZE,
-        .write_size = WRITE_SIZE,
     },
     .parent = &_parent,
     .sector = SECTOR_COUNT / 2,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A MTD mapper region must adhere to the same physical constraints as the underlying MTD device, so inherit it's physical properties instead of relying on the user to set them correctly.

### Testing procedure

`tests/mtd_mapper` still works without the redundant information

```
RIOT native interrupts/signals initialized.
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
s
START
main(): This is RIOT! (Version: 2022.07-devel-448-ge28040-drivers/mtd_mapper-inherit)
......
OK (6 tests)
{ "threads": [{ "name": "idle", "stack_size": 8192, "stack_used": 436 }]}
{ "threads": [{ "name": "main", "stack_size": 12288, "stack_used": 2508 }]}
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
