### PR TITLE
boards/iotlab-m3: fix mixed sensors in implementation status

### DIFF
--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -43,9 +43,9 @@
 |                   | RTT           | yes           |                       |
 |                   | Timer         | yes           |                       |
 | Radio Chip        | AT86RF231     | yes           |                       |
-| Accelerometer     | L3G4200D      | yes           |                       |
-| Magnetometer      | L3G4200D      | yes           |                       |
-| Gyroscope         | LSM303DLHC    | yes           |                       |
+| Accelerometer     | LSM303DLHC    | yes           |                       |
+| Magnetometer      | LSM303DLHC    | yes           |                       |
+| Gyroscope         | L3G4200D      | yes           |                       |
 | Pressure Sensor   | LPS331AP      | yes           |                       |
 | Light Sensor      | ISL29020      | yes           |                       |
 | SPI Flash         | N25Q128       | yes           |                       |


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The [lsm303dlhc](https://doc.riot-os.org/group__drivers__lsm303dlhc.html) is the accelerometer/magnetometer sensor and the [l3g4200d](https://doc.riot-os.org/group__drivers__l3g4200d.html) is the gyroscope. The sensor are switched in the documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read the documentation

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
