### PR TITLE
sys/phydat: fix phydat_to_json precondition

### DIFF
--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -277,11 +277,11 @@ void phydat_fit(phydat_t *dat, const int32_t *values, unsigned int dim);
  * for @ref UNIT_NONE.
  *
  * @param[in]  data     data to encode
- * @param[in]  dim      dimensions used in @p data, MUST be > 0 and < PHYDAT_DIM
+ * @param[in]  dim      dimensions used in @p data, MUST be > 0 and <= PHYDAT_DIM
  * @param[out] buf      target buffer for the JSON string, or NULL
  *
  * @pre     @p dim > 0
- * @pre     @p dim < PHYDAT_DIM
+ * @pre     @p dim <= PHYDAT_DIM
  *
  * @return  number of bytes (potentially) written to @p buf, including `\0`
  *          terminator

--- a/sys/phydat/phydat_json.c
+++ b/sys/phydat/phydat_json.c
@@ -43,7 +43,7 @@ static size_t _bool_to_str(int16_t val, char *buf)
 
 size_t phydat_to_json(const phydat_t *data, size_t dim, char *buf)
 {
-    assert((dim > 0) && (dim < PHYDAT_DIM));
+    assert((dim > 0) && (dim <= PHYDAT_DIM));
 
     size_t pos = 0;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

RIOT kernel panics when calling phydat_to_json with dim=3:

```
sys/phydat/phydat_json.c:46 => 0x8049c14
*** RIOT kernel panic:
FAILED ASSERTION.

*** halted.
```

The precondition/assertion for parameter 'dim' in phydat_to_json is to restrictive. Calling phydat_to_json with dim=3 should be valid as can be seen in the documentation of phydat_to_json itself:
https://doc.riot-os.org/group__sys__phydat.html#gad7a5978e5119e3976addffd2891c76fa

This pull request allows phydat_to_json to be called with dim=3.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Just call phydat_to_json with dim=3. For example:

```
#include <stdio.h>
#include <phydat.h>

int main(void)
{
    char json[100];
    phydat_t data = {0};
    phydat_to_json(&data, 3, json);
    puts(json);
}
```

Expected output would be:

```
{"d":[0,0,0],"u":"undefined"}
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

(no references)