### PR TITLE
unittests: fix assertion for nanocoap_cache_key_compare()

### DIFF
--- a/tests/unittests/tests-nanocoap_cache/tests-nanocoap_cache.c
+++ b/tests/unittests/tests-nanocoap_cache/tests-nanocoap_cache.c
@@ -70,9 +70,9 @@ static void test_nanocoap_cache__cachekey(void)
     nanocoap_cache_key_generate((const coap_pkt_t *) &pkt2, digest2);
 
     /* compare 1. and 3. packet */
-    TEST_ASSERT_EQUAL_INT(-1, nanocoap_cache_key_compare(digest1, digest2));
+    TEST_ASSERT(nanocoap_cache_key_compare(digest1, digest2) < 0);
     /* compare 3. and 1. packet */
-    TEST_ASSERT_EQUAL_INT(1,  nanocoap_cache_key_compare(digest2, digest1));
+    TEST_ASSERT(nanocoap_cache_key_compare(digest2, digest1) > 0);
 }
 static void test_nanocoap_cache__add(void)
 {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
The doc states only that the result is <0, not -1. The result isn't the latter for some platforms (see https://github.com/RIOT-OS/RIOT/runs/6534330788?check_suite_focus=true#step:13:696)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run unittests on e.g. an ARM-Cortex-based platform. On my system there is another failure for `tests-pkt` ATM which I will also investigate.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, showed up in weekly release tests.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
