### PR TITLE
gnrc_ipv6_nib: fix inconsistent ABR valid lifetime representation

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -196,9 +196,17 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
             }
         }
     }
-    ltime_min = (gnrc_netif_is_6lbr(netif)) ?
-                (SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT) :
-                _nib_abr_entry_valid_offset(abr);
+    if (gnrc_netif_is_6lbr(netif)) {
+        ltime_min = 0U;
+
+        /* update valid time */
+        abr->valid_until_ms = evtimer_now_msec() + (
+            SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT * MS_PER_SEC * SEC_PER_MIN
+        );
+    }
+    else {
+        ltime_min = _nib_abr_entry_valid_offset(abr);
+    }
     (void)ltime_min;    /* gnrc_sixlowpan_nd_opt_abr_build might evaluate to NOP */
     abro = gnrc_sixlowpan_nd_opt_abr_build(abr->version, ltime_min, &abr->addr,
                                            ext_opts);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -37,7 +37,9 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr)
         _nib_release();
         return -ENOMEM;
     }
-    abr->valid_until_ms = 0U;
+    abr->valid_until_ms = evtimer_now_msec() + (
+        SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT * MS_PER_SEC * SEC_PER_MIN
+    );
     /* Associate all existing prefixes in the prefix list of the border router's
      * downstream interface to the authoritative border router so they are
      * advertised in a Router Advertisement with the Authoritative Border Router
@@ -93,9 +95,7 @@ void gnrc_ipv6_nib_abr_print(gnrc_ipv6_nib_abr_t *abr)
     printf("%s v%" PRIu32 " expires %" PRIu32 "min\n",
            ipv6_addr_to_str(addr_str, &abr->addr, sizeof(addr_str)),
            abr->version,
-           (abr->valid_until_ms != 0) ?
-           gnrc_ipv6_nib_abr_valid_offset(abr) :
-           SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT);
+           gnrc_ipv6_nib_abr_valid_offset(abr));
 }
 #else
 typedef int dont_be_pedantic;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fixes inconsistent representation of the ABR valid lifetime as described in #17512.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run a `gnrc_border_router` and a `gnrc_networking` application on a 6LoWPAN-compatible device. `nib abr` should now list the lifetimes correctly and it should be updated to the original 10000min, whenever the BR sends another ABRO.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #17512.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
