### PR TITLE
gnrc/nib: don't add routers from WPAN as default router on the 6LBR

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -675,7 +675,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     }
 #endif  /* !CONFIG_GNRC_IPV6_NIB_6LBR */
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
-    if (rtr_adv->ltime.u16 != 0) {
+    if (!gnrc_netif_is_6lbr(netif) && rtr_adv->ltime.u16 != 0) {
         uint16_t rtr_ltime = byteorder_ntohs(rtr_adv->ltime);
 
         dr = _nib_drl_add(&ipv6->src, netif->pid);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This avoids a race condition where the default router slots for the 6LBR are used up by router advertisements from the 6Lo network that arrived before router advertisements from the upstream network.

The border router should ignore 'default routers' from the 6Lo network as it consitutes the uplink for that network.


### Testing procedure

You should no longer see

```
nib: default router list is full. Ignoring RA from fe80::fec2:3d00:0:bb1
nib: Handle packet (icmpv6->type = 134)
nib: Received valid router advertisement:
     - Source address: fe80::ac8d:fee1:6041:91f1
     - Destination address: fe80::a8cc:f47b:67c4:baf1
     - Cur Hop Limit: 0
     - Flags: --
     - Router Lifetime: 1800s
     - Reachable Time: 0ms
     - Retrans Timer: 0ms
nib: default router list is full. Ignoring RA from fe80::ac8d:fee1:6041:91f1
```

On the border router. In this case the RA from a 6LR was discarded, but sometimes this arrives before the RA from the upstream network, in that case it would fill the spot instead of the proper RA from the upstream router.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
