### PR TITLE
drivers/mtd: move write_size assertion after init call

### DIFF
--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -36,6 +36,10 @@ int mtd_init(mtd_dev_t *mtd)
 
     int res = -ENOTSUP;
 
+    if (mtd->driver->init) {
+        res = mtd->driver->init(mtd);
+    }
+
     /* Drivers preceding the introduction of write_size need to set it. While
      * this assert breaks applications that previously worked, it is likely
      * that these applications silently assumed a certain write size and would
@@ -44,10 +48,6 @@ int mtd_init(mtd_dev_t *mtd)
      * in your application for whether the backend allows sufficiently small
      * writes. */
     assert(mtd->write_size != 0);
-
-    if (mtd->driver->init) {
-        res = mtd->driver->init(mtd);
-    }
 
 #ifdef MODULE_MTD_WRITE_PAGE
     if ((mtd->driver->flags & MTD_DRIVER_FLAG_DIRECT_WRITE) == 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

MTD drivers set their `write_size` member in their `init()` function, so the assertion should be checked afterwards.

### Testing procedure

For example look at `mtd_spi_nor_init()`, `_mtd_at24cxxx_init()`,  `mtd_sdcard_init()`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
