### PR TITLE
drivers/mcp2515: apply filters to target mailbox

### DIFF
--- a/drivers/mcp2515/mcp2515_defines.h
+++ b/drivers/mcp2515/mcp2515_defines.h
@@ -303,9 +303,6 @@ extern "C" {
 #define MCP2515_RXB0CTRL_MODE_RECV_FILTER       0x00
 #define MCP2515_RXB0CTRL_RXM0                   0x20
 #define MCP2515_RXB0CTRL_RXM1                   0x40
-#define MCP2515_RXB0CTRL_MODE_RECV_STD_OR_EXT   0x00
-#define MCP2515_RXB0CTRL_MODE_RECV_STD          MCP2515_RXB0CTRL_RXM0
-#define MCP2515_RXB0CTRL_MODE_RECV_EXT          MCP2515_RXB0CTRL_RXM1
 #define MCP2515_RXB0CTRL_MODE_RECV_ALL          (MCP2515_RXB0CTRL_RXM1 | \
                                                  MCP2515_RXB0CTRL_RXM0)
 
@@ -316,9 +313,6 @@ extern "C" {
 #define MCP2515_RXB1CTRL_MODE_RECV_FILTER       0x00
 #define MCP2515_RXB1CTRL_RXM0                   0x20
 #define MCP2515_RXB1CTRL_RXM1                   0x40
-#define MCP2515_RXB1CTRL_MODE_RECV_STD_OR_EXT   0x00
-#define MCP2515_RXB1CTRL_MODE_RECV_STD          MCP2515_RXB1CTRL_RXM0
-#define MCP2515_RXB1CTRL_MODE_RECV_EXT          MCP2515_RXB1CTRL_RXM1
 #define MCP2515_RXB1CTRL_MODE_RECV_ALL          (MCP2515_RXB1CTRL_RXM1 | \
                                                  MCP2515_RXB1CTRL_RXM0)
 /** @} */

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -101,6 +101,9 @@ struct can_frame {
 struct can_filter {
     canid_t can_id;    /**< CAN ID */
     canid_t can_mask;  /**< Mask */
+#if defined(MODULE_MCP2515)
+    uint8_t target_mailbox; /**< The mailbox to apply the filter to */
+#endif
 };
 
 /**

--- a/tests/candev/main.c
+++ b/tests/candev/main.c
@@ -223,14 +223,28 @@ if (IS_ACTIVE(CONFIG_USE_LOOPBACK_MODE)) {
 
     if (IS_ACTIVE(MCP2515_RECV_FILTER_EN)) {
         /* CAN filters examples */
-        struct can_filter filter[3];
+        struct can_filter filter[4];
         filter[0].can_mask = 0x7FF;
-        filter[0].can_id = 0x001;   /* messages with CAN ID 0x001 will be received in mailbox 0 */
+        filter[0].can_id = 0x001;
+#if defined(MODULE_MCP2515)
+        filter[0].target_mailbox = 0;   /* messages with CAN ID 0x001 will be received in mailbox 0 */
+#endif
         filter[1].can_mask = 0x7FF;
-        filter[1].can_id = 0x003;   /* messages with CAN ID 0x003 will be received in mailbox 0 */
+        filter[1].can_id = 0x002;
+#if defined(MODULE_MCP2515)
+        filter[1].target_mailbox = 1;   /* messages with CAN ID 0x002 will be received in mailbox 1 */
+#endif
         filter[2].can_mask = 0x7FF;
-        filter[2].can_id = 0x002;   /* messages with CAN ID 0x002 will be received in mailbox 1 */
-        for (uint8_t i = 0; i < 3; i++) {
+        filter[2].can_id = 0x003;
+#if defined(MODULE_MCP2515)
+        filter[2].target_mailbox = 0;   /* messages with CAN ID 0x003 will be received in mailbox 0 */
+#endif
+        filter[3].can_mask = 0x7FF;
+        filter[3].can_id = 0x004;
+#if defined(MODULE_MCP2515)
+        filter[3].target_mailbox = 0;   /* this filter won't be applied. Reason is no space found in the first mailbox as it supports only two filters */
+#endif
+        for (uint8_t i = 0; i < 4; i++) {
             candev->driver->set_filter(candev, &filter[i]);
         }
         /* All other messages won't be received */


### PR DESCRIPTION
### Contribution description

The MCP2515 presents two RX mailboxes, the first has two CAN filters and the second has four CAN filters. The current implementation of the driver obliges the user to apply all the filters for mailbox1 in order to be able to apply the filters for mailbox2. E.g: **If the user wants to accept only CAN messages with CAN ID 0x012, the filter 0x012 must be applied for the two mailboxes. However, to do that, two filters must be applied for the first mailbox and then the second mailbox will be accessible for filtering which means a second dummy filter is applied to the first mailbox.**
This PR allows to specify a target mailbox when applying the CAN filters, so there will be no need to apply dummy filters to be able to filter in the second mailbox

### Testing procedure

This was tested using a SAME54-xpro and a MCP2515 breakout board following these steps:
- Enable filtering macro `MCP2515_RECV_FILTER_EN` 
- Set a filter for the first mailbox and a filter for the second mailbox by defining the `target_mailbox` member
- Send CAN messages with matching CAN ID. The RX interrupt source will be the corresponding mailbox

### Issues/PRs references

Depends on PR #18062.

