### PR TITLE
build system: no periph_init for periph_gpio_ll*

### DIFF
--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -11,23 +11,28 @@ USEMODULE += $(PERIPH_FEATURES)
 
 # Add all USED periph_% init modules unless they are blacklisted
 PERIPH_IGNORE_MODULES := \
-  periph_init% \
+  periph_clic \
   periph_common \
+  periph_coretimer \
+  periph_flash \
   periph_flexcomm \
+  periph_gpio_ll \
+  periph_gpio_ll_irq \
+  periph_gpio_ll_irq_level_triggered_high \
+  periph_gpio_ll_irq_level_triggered_low \
+  periph_gpio_ll_irq_unmask \
   periph_gpio_mux \
   periph_i2c_hw \
   periph_i2c_sw \
-  periph_rtc_ms \
+  periph_init% \
   periph_mcg \
-  periph_wdog \
-  periph_flash \
+  periph_plic \
+  periph_rtc_ms \
   periph_rtc_rtt \
   periph_rtt_hw_rtc \
   periph_rtt_hw_sys \
-  periph_clic \
-  periph_coretimer \
-  periph_plic \
-  periph_spi_on_qspi
+  periph_spi_on_qspi \
+  periph_wdog \
   #
 PERIPH_MODULES := $(filter-out $(PERIPH_IGNORE_MODULES),\
                                $(filter periph_%,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

None of the periph_gpio_ll* features provides or requires a `periph_init` hook. Hence, blacklist them for `periph_init` conversion.

### Testing procedure

E.g. run `$ make BOARD=nucleo-f767zi info-modules -C tests/periph_gpio_ll/ | grep gpio_ll`.

In addition, this should not change binaries in any way.

#### Result on `master`:

```
$ make BOARD=nucleo-f767zi info-modules -C tests/periph_gpio_ll/ | grep gpio_ll
make: Entering directory '/home/maribu/Repos/software/RIOT/tests/periph_gpio_ll'
periph_gpio_ll
periph_gpio_ll_irq
periph_gpio_ll_irq_level_triggered_high
periph_gpio_ll_irq_level_triggered_low
periph_init_gpio_ll
periph_init_gpio_ll_irq
periph_init_gpio_ll_irq_level_triggered_high
periph_init_gpio_ll_irq_level_triggered_low
make: Leaving directory '/home/maribu/Repos/software/RIOT/tests/periph_gpio_ll'
```

#### Result with this PR

```
$ make BOARD=nucleo-f767zi info-modules -C tests/periph_gpio_ll/ | grep gpio_ll
make: Entering directory '/home/maribu/Repos/software/RIOT/tests/periph_gpio_ll'
periph_gpio_ll
periph_gpio_ll_irq
periph_gpio_ll_irq_level_triggered_high
periph_gpio_ll_irq_level_triggered_low
make: Leaving directory '/home/maribu/Repos/software/RIOT/tests/periph_gpio_ll'
```

### Issues/PRs references

None