### PR TITLE
gcoap/fileserver: add file and directory creation and deletion

### DIFF
--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14281,6 +14281,8 @@ sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_BLOCK1 \(macro definiti
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_BLOCK2 \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_CONTENT_FORMAT \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_ETAG \(macro definition\) of group net_coap is not documented\.
+sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_IF_MATCH \(macro definition\) of group net_coap is not documented\.
+sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_IF_NONE_MATCH \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_MAX_AGE \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_LOCATION_PATH \(macro definition\) of group net_coap is not documented\.
 sys/include/net/coap\.h:[0-9]+: warning: Member COAP_OPT_LOCATION_QUERY \(macro definition\) of group net_coap is not documented\.

--- a/examples/gcoap_fileserver/Makefile
+++ b/examples/gcoap_fileserver/Makefile
@@ -21,6 +21,8 @@ USEMODULE += shell_commands
 
 # enable the fileserver module
 USEMODULE += gcoap_fileserver
+USEMODULE += gcoap_fileserver_delete
+USEMODULE += gcoap_fileserver_put
 
 # select network modules
 USEMODULE += gnrc_ipv6_default

--- a/examples/gcoap_fileserver/main.c
+++ b/examples/gcoap_fileserver/main.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include "kernel_defines.h"
 #include "net/gcoap.h"
 #include "net/gcoap/fileserver.h"
 #include "shell.h"
@@ -27,7 +28,15 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/vfs", COAP_GET | COAP_PUT | COAP_DELETE | COAP_MATCH_SUBTREE,
+    { "/vfs",
+      COAP_GET |
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
+      COAP_PUT |
+#endif
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
+      COAP_DELETE |
+#endif
+      COAP_MATCH_SUBTREE,
       gcoap_fileserver_handler, VFS_DEFAULT_DATA },
 };
 

--- a/examples/gcoap_fileserver/main.c
+++ b/examples/gcoap_fileserver/main.c
@@ -27,7 +27,8 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
-    { "/vfs", COAP_GET | COAP_MATCH_SUBTREE, gcoap_fileserver_handler, VFS_DEFAULT_DATA },
+    { "/vfs", COAP_GET | COAP_PUT | COAP_DELETE | COAP_MATCH_SUBTREE,
+      gcoap_fileserver_handler, VFS_DEFAULT_DATA },
 };
 
 static gcoap_listener_t _listener = {

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -67,6 +67,8 @@ PSEUDOMODULES += fatfs_vfs_format
 PSEUDOMODULES += fmt_%
 PSEUDOMODULES += gcoap_forward_proxy
 PSEUDOMODULES += gcoap_fileserver
+PSEUDOMODULES += gcoap_fileserver_delete
+PSEUDOMODULES += gcoap_fileserver_put
 PSEUDOMODULES += gcoap_dtls
 ## Enable @ref net_gcoap_dns
 PSEUDOMODULES += gcoap_dns

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -652,6 +652,15 @@ ifneq (,$(filter gcoap_fileserver,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter gcoap_fileserver_delete,$(USEMODULE)))
+  USEMODULE += gcoap_fileserver
+  USEMODULE += vfs_util
+endif
+
+ifneq (,$(filter gcoap_fileserver_put,$(USEMODULE)))
+  USEMODULE += gcoap_fileserver
+endif
+
 ifneq (,$(filter gcoap_forward_proxy,$(USEMODULE)))
   USEMODULE += gcoap
   USEMODULE += uri_parser

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -35,8 +35,10 @@ extern "C" {
  * @name    CoAP option numbers
  * @{
  */
+#define COAP_OPT_IF_MATCH       (1)
 #define COAP_OPT_URI_HOST       (3)
 #define COAP_OPT_ETAG           (4)
+#define COAP_OPT_IF_NONE_MATCH  (5)
 #define COAP_OPT_OBSERVE        (6)
 #define COAP_OPT_LOCATION_PATH  (8)
 #define COAP_OPT_URI_PATH       (11)

--- a/sys/include/net/gcoap/fileserver.h
+++ b/sys/include/net/gcoap/fileserver.h
@@ -64,6 +64,8 @@
  *
  *   The allowed methods dictate whether it's read-only (``COAP_GET``) or
  *   read-write (``COAP_GET | COAP_PUT | COAP_DELETE``).
+ *   If you want to support ``PUT`` and `DELETE`, you need to enable the modules
+ *   ``gcoap_fileserver_put`` and ``gcoap_fileserver_delete``.
  *
  * @{
  *

--- a/sys/include/net/gcoap/fileserver.h
+++ b/sys/include/net/gcoap/fileserver.h
@@ -16,13 +16,18 @@
  * This maps files in the local file system onto a resources in CoAP. In that,
  * it is what is called a static web server in the unconstrained web.
  *
- * As usual, GET operations are used to read files<!-- WRITESUPPORT, and PUT writes to files.
+ * As usual, GET operations are used to read files and PUT writes to files.
  * In the current implementation, PUTs are expressed as random-access, meaning
- * that files are not updated atomically -->.
+ * that files are not updated atomically, although files are created atomically.
+ * The Content-Format option is not checked in the current implementation.
+ * Conditional file modification and deletion is supported using the If-Match
+ * option. The If-Match option carries a previously received Etag or in case of
+ * zero length, requires a request to be processed only if the resource exists.
+ * In opposite, the If-None-Match option requires a request to be processed,
+ * only if the resource does not yet exist, and is most useful for file creation.
  *
- * Directories are expressed to URIs with trailing slashes<!-- WRITESUPPORT, and are always
- * created implicitly when files are PUT under them; they can be DELETEd when
- * empty -->.
+ * Directories are expressed to URIs with trailing slashes and can be DELETEd
+ * when empty.
  *
  * @note The file server uses ETag for cache validation. The ETags are built
  * from the file system stat values. As clients rely on the ETag to differ when
@@ -55,8 +60,8 @@
  *   The path argument specifies under which path the folder is served via CoAP while
  *   the context argument contains the path on the local filesystem that will be served.
  *
- *   The allowed methods dictate whether it's read-only (``COAP_GET``) or (in the
- *   future<!-- WRITESUPPORT -->) read-write (``COAP_GET | COAP_PUT | COAP_DELETE``).
+ *   The allowed methods dictate whether it's read-only (``COAP_GET``) or
+ *   read-write (``COAP_GET | COAP_PUT | COAP_DELETE``).
  *
  * @{
  *

--- a/sys/include/net/gcoap/fileserver.h
+++ b/sys/include/net/gcoap/fileserver.h
@@ -26,8 +26,10 @@
  * In opposite, the If-None-Match option requires a request to be processed,
  * only if the resource does not yet exist, and is most useful for file creation.
  *
- * Directories are expressed to URIs with trailing slashes and can be DELETEd
- * when empty.
+ * Directories are expressed to URIs with trailing slashes. Directories and
+ * their content are deleted as if one would do an `$rm -r`. If you only would
+ * like to delete a directory if it is empty, you must supply an If-Match option
+ * with the special value @ref COAPFILESERVER_DIR_DELETE_ETAG.
  *
  * @note The file server uses ETag for cache validation. The ETags are built
  * from the file system stat values. As clients rely on the ETag to differ when
@@ -79,6 +81,12 @@ extern "C" {
 #endif
 
 #include "net/nanocoap.h"
+
+/**
+ * @brief   Randomly generated Etag, used by a client when a directory should only be
+ *          deleted, if it is empty
+ */
+#define COAPFILESERVER_DIR_DELETE_ETAG (0x6ce88b56u)
 
 /**
  * @brief File server handler

--- a/sys/include/vfs_util.h
+++ b/sys/include/vfs_util.h
@@ -101,6 +101,33 @@ int vfs_file_sha256(const char* file, void *digest,
                     void *work_buf, size_t work_buf_len);
 #endif
 
+/**
+ * @brief   Checks if @p path is a file or a directory.
+ *
+ * This function uses @ref vfs_stat(), so if you need @ref vfs_stat() anyway,
+ * you should not do double work and check it yourself.
+ *
+ * @param[in]   path        Path to check
+ *
+ * @return < 0 on FS error
+ * @return 0 if @p path is a file
+ * @return > 0 if @p path is a directory
+ */
+int vfs_is_dir(const char *path);
+
+/**
+ * @brief    Behaves like `rm -r @p root`.
+ *
+ * @param[in]   root        FS root directory to be deleted
+ * @param[in]   path_buf    Buffer that must be able to store the longest path
+ *                          of the file or directory being deleted
+ * @param[in]   max_size    Size of @p path_buf
+ *
+ * @return < 0 on error
+ * @return 0
+ */
+int vfs_unlink_recursive(const char *root, char *path_buf, size_t max_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include "kernel_defines.h"
 #include "checksum/fletcher32.h"
 #include "net/gcoap/fileserver.h"
 #include "net/gcoap.h"
@@ -225,6 +226,7 @@ late_err:
     return coap_get_total_hdr_len(pdu);
 }
 
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
 static ssize_t _put_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                          struct requestdata *request)
 {
@@ -327,7 +329,9 @@ unlink_on_error:
     }
     return gcoap_fileserver_error_handler(pdu, buf, len, ret);
 }
+#endif
 
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
 static ssize_t _delete_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                             struct requestdata *request)
 {
@@ -349,6 +353,7 @@ static ssize_t _delete_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     gcoap_resp_init(pdu, buf, len, COAP_CODE_DELETED);
     return coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
 }
+#endif
 
 static ssize_t gcoap_fileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                              struct requestdata *request)
@@ -356,10 +361,14 @@ static ssize_t gcoap_fileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size
     switch (coap_get_code(pdu)) {
         case COAP_METHOD_GET:
             return _get_file(pdu, buf, len, request);
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
         case COAP_METHOD_PUT:
             return _put_file(pdu, buf, len, request);
+#endif
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
         case COAP_METHOD_DELETE:
             return _delete_file(pdu, buf, len, request);
+#endif
         default:
             return gcoap_fileserver_error_handler(pdu, buf, len, COAP_CODE_METHOD_NOT_ALLOWED);
     }
@@ -428,6 +437,7 @@ static ssize_t _get_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     return (uintptr_t)buf - (uintptr_t)pdu->hdr;
 }
 
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
 static ssize_t _put_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                               struct requestdata *request)
 {
@@ -451,7 +461,9 @@ static ssize_t _put_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     }
     return coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
 }
+#endif
 
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
 static ssize_t _delete_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                  struct requestdata *request)
 {
@@ -474,6 +486,7 @@ static ssize_t _delete_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     gcoap_resp_init(pdu, buf, len, COAP_CODE_DELETED);
     return coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
 }
+#endif
 
 static ssize_t gcoap_fileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                                   struct requestdata *request,
@@ -482,10 +495,14 @@ static ssize_t gcoap_fileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf,
     switch (coap_get_code(pdu)) {
         case COAP_METHOD_GET:
             return _get_directory(pdu, buf, len, request, root, resource_dir);
+#if IS_USED(MODULE_GCOAP_FILESERVER_PUT)
         case COAP_METHOD_PUT:
             return _put_directory(pdu, buf, len, request);
+#endif
+#if IS_USED(MODULE_GCOAP_FILESERVER_DELETE)
         case COAP_METHOD_DELETE:
             return _delete_directory(pdu, buf, len, request);
+#endif
         default:
             return gcoap_fileserver_error_handler(pdu, buf, len, COAP_CODE_METHOD_NOT_ALLOWED);
     }

--- a/sys/net/application_layer/gcoap/fileserver.c
+++ b/sys/net/application_layer/gcoap/fileserver.c
@@ -561,6 +561,9 @@ ssize_t gcoap_fileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                     }
                     request.options.exists.if_none_match = true;
                     break;
+                case COAP_OPT_URI_HOST:
+                    /* ignore host name option */
+                    continue;
                 case COAP_OPT_URI_PATH:
                     if (strip_remaining != 0) {
                         strip_remaining -= 1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

With this PR I added write support for the `gcoap` fileserver, using `POST`, `PUT` and `DELETE` methods.

~`POST`: used to create files and directories~
`PUT` : creates files or directories or updates files in a random access fashion
`DELETE`: delete files and directories

CoAP options `If-Match` and `If-None-Match` are added and handled in `PUT` requests.

Somehow directory deletion does not work for me. I end up in `littlefs2/lfs.c:1457`.
```C
// check if we fit
lfs_size_t dsize = lfs_tag_dsize(tag);
if (commit->off + dsize > commit->end) {
    return LFS_ERR_NOSPC;
}
```
~I don´t know why. Maybe it works for you.~
Works with #18141

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Flash `examples/gcoap_fileserver` to a board with Ethernet support, connect with your PC and use a CoAP client to upload some files to the board´s VFS.

<details>
<summary>RIOT shell</summary>

```
> vfs ls /nvm0
2022-05-24 11:53:27,139 # vfs ls /nvm0
2022-05-24 11:53:27,144 # ./
2022-05-24 11:53:27,144 # ../
2022-05-24 11:53:27,163 # anotherdir/
2022-05-24 11:53:27,189 # cacert.der    425 B
2022-05-24 11:53:27,221 # cakey.der     121 B
2022-05-24 11:53:27,260 # capubkey.der  91 B
2022-05-24 11:53:27,263 # total 3 files
vfs ls /nvm0
2022-05-24 11:53:47,834 # vfs ls /nvm0
2022-05-24 11:53:47,839 # ./
2022-05-24 11:53:47,840 # ../
2022-05-24 11:53:47,854 # RIOT.txt      1402 B
2022-05-24 11:53:47,877 # anotherdir/
2022-05-24 11:53:47,908 # cacert.der    425 B
2022-05-24 11:53:47,944 # cakey.der     121 B
2022-05-24 11:53:47,986 # capubkey.der  91 B
2022-05-24 11:53:47,987 # total 4 files
> vfs ls /nvm0
2022-05-24 11:55:30,836 # vfs ls /nvm0
2022-05-24 11:55:30,843 # ./
2022-05-24 11:55:30,843 # ../
2022-05-24 11:55:30,864 # anotherdir/
2022-05-24 11:55:30,892 # cacert.der    425 B
2022-05-24 11:55:30,926 # cakey.der     121 B
2022-05-24 11:55:30,962 # capubkey.der  91 B
2022-05-24 11:55:31,007 # tmp/
2022-05-24 11:55:31,008 # total 3 files
```
</details>

I test with `libcoap` example client. and `CFLAGS += -DCONFIG_GNRC_IPV6_NIB_ARSM=1`

<details>
<summary>Host shell</summary>

```
$ coap-client -m put -O 27,0x00 -a fe80::3478:9157:9fd5:81c3%eth0 coap://[fe80::4c49:6fff:fe54:0]/vfs/RIOT.txt -f ~/RIOT.txt 
$ coap-client -m get -a fe80::3478:9157:9fd5:81c3%eth0 coap://[fe80::4c49:6fff:fe54:0]/vfs/RIOT.txt
                          ZZZZZZ
                        ZZZZZZZZZZZZ
                      ZZZZZZZZZZZZZZZZ
                     ZZZZZZZ     ZZZZZZ
                    ZZZZZZ        ZZZZZ
                    ZZZZZ          ZZZZ
                    ZZZZ           ZZZZZ
                    ZZZZ           ZZZZ
                    ZZZZ          ZZZZZ
                    ZZZZ        ZZZZZZ
                    ZZZZ     ZZZZZZZZ       777        7777       7777777777
              ZZ    ZZZZ   ZZZZZZZZ         777      77777777    77777777777
          ZZZZZZZ   ZZZZ  ZZZZZZZ           777     7777  7777       777
        ZZZZZZZZZ   ZZZZ    Z               777     777    777       777
       ZZZZZZ       ZZZZ                    777     777    777       777
      ZZZZZ         ZZZZ                    777     777    777       777
     ZZZZZ          ZZZZZ    ZZZZ           777     777    777       777
     ZZZZ           ZZZZZ    ZZZZZ          777     777    777       777
     ZZZZ           ZZZZZ     ZZZZZ         777     777    777       777
     ZZZZ           ZZZZ       ZZZZZ        777     777    777       777
     ZZZZZ         ZZZZZ        ZZZZZ       777     777    777       777
      ZZZZZZ     ZZZZZZ          ZZZZZ      777     7777777777       777
       ZZZZZZZZZZZZZZZ            ZZZZ      777      77777777        777
         ZZZZZZZZZZZ               Z
            ZZZZZ 

$ coap-client -m delete -a fe80::3478:9157:9fd5:81c3%eth0 coap://[fe80::4c49:6fff:fe54:0]/vfs/RIOT.txt
$ coap-client -m put -a fe80::3478:9157:9fd5:81c3%eth0 coap://[fe80::4c49:6fff:fe54:0]/vfs/tmp/
$ coap-client -m delete -a fe80::3478:9157:9fd5:81c3%eth0 coap://[fe80::4c49:6fff:fe54:0]/vfs/tmp/
```

</details>

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
