### PR TITLE
nanocoap_link_format: add helper function to parse Link Format

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -703,6 +703,10 @@ ifneq (,$(filter nanocoap_cache,$(USEMODULE)))
   USEMODULE += hashes
 endif
 
+ifneq (,$(filter nanocoap_link_format,$(USEMODULE)))
+  USEMODULE += fmt
+endif
+
 ifneq (,$(filter nanocoap_vfs,$(USEMODULE)))
   USEMODULE += nanocoap_sock
   USEMODULE += vfs

--- a/sys/include/net/nanocoap/link_format.h
+++ b/sys/include/net/nanocoap/link_format.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_nanosock
+ * @brief       NanoCoAP Link Format helper functions
+ *
+ * @{
+ *
+ * @file
+ * @brief       NanoCoAP Link Format ([RFC 6690](https://www.rfc-editor.org/rfc/rfc6690.html))
+ *              helper functions
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+#ifndef NET_NANOCOAP_LINK_FORMAT_H
+#define NET_NANOCOAP_LINK_FORMAT_H
+
+#include "net/nanocoap_sock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Callback function called for each resource on the directory
+ *
+ * @param[in]   entry   Resource entry from the server
+ * @param[in]   ctx     Optional function context
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+typedef int (*coap_link_format_handler_t)(char *entry, void *ctx);
+
+/**
+ * @brief   Downloads the resource behind @p path via blockwise GET
+ *
+ * @param[in]   sock    Connection to the server
+ * @param[in]   path    path of the resource
+ * @param[in]   cb      Callback to execute for each resource entry
+ * @param[in]   arg     Optional callback argument
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
+                             coap_link_format_handler_t cb, void *arg);
+
+/**
+ * @brief   Downloads the resource behind @p url via blockwise GET
+ *
+ * @param[in]   url     URL to the resource
+ * @param[in]   cb      Callback to execute for each resource entry
+ * @param[in]   arg     Optional callback argument
+ *
+ * @returns     0 on success
+ * @returns     <0 on error
+ */
+int nanocoap_link_format_get_url(const char *url,
+                                 coap_link_format_handler_t cb, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* NET_NANOCOAP_LINK_FORMAT_H */
+/** @} */

--- a/sys/net/application_layer/nanocoap/link_format.c
+++ b/sys/net/application_layer/nanocoap/link_format.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_nanocoap
+ * @{
+ *
+ * @file
+ * @brief       NanoCoAP Link Format parser
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "fmt.h"
+#include "net/nanocoap/link_format.h"
+#include "net/nanocoap_sock.h"
+#include "net/sock/util.h"
+
+struct dir_list_ctx {
+    char *buf;
+    char *cur;
+    char *end;
+    coap_link_format_handler_t cb;
+    void *ctx;
+    char esc_buf[2];
+    uint8_t esc_idx;
+};
+
+static int _dirlist_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
+{
+    (void)offset;
+
+    struct dir_list_ctx *ctx = arg;
+
+    char *end = (char *)buf + len;
+    for (char *c = (char *)buf; c != end; ++c) {
+
+        /* start of escape sequence */
+        if (*c == '%') {
+            ctx->esc_idx = 1;
+            continue;
+        }
+        if (ctx->esc_idx) {
+            /* fill escape buffer */
+            ctx->esc_buf[ctx->esc_idx - 1] = *c;
+            if (++ctx->esc_idx == 3) {
+                ctx->esc_idx = 0;
+                *c = scn_u32_hex(ctx->esc_buf, 2);
+            } else {
+                continue;
+            }
+        }
+
+        if (*c == ',' || ctx->cur == ctx->end) {
+            int res;
+            *ctx->cur = 0;
+            res = ctx->cb(ctx->buf, ctx->ctx);
+            ctx->cur = ctx->buf;
+            if (res < 0) {
+                return res;
+            }
+        } else {
+            *ctx->cur++ = *c;
+        }
+    }
+
+    if (!more) {
+        *ctx->cur = 0;
+        return ctx->cb(ctx->buf, ctx->ctx);
+    }
+
+    return 0;
+}
+
+int nanocoap_link_format_get(nanocoap_sock_t *sock, const char *path,
+                             coap_link_format_handler_t cb, void *arg)
+{
+    char buffer[CONFIG_NANOCOAP_QS_MAX];
+    struct dir_list_ctx ctx = {
+        .buf = buffer,
+        .end = buffer + sizeof(buffer),
+        .cur = buffer,
+        .cb = cb,
+        .ctx = arg,
+    };
+    return nanocoap_sock_get_blockwise(sock, path, CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT,
+                                       _dirlist_cb, &ctx);
+}
+
+int nanocoap_link_format_get_url(const char *url, coap_link_format_handler_t cb, void *arg)
+{
+    nanocoap_sock_t sock;
+    int res = nanocoap_sock_url_connect(url, &sock);
+    if (res) {
+        return res;
+    }
+
+    res = nanocoap_link_format_get(&sock, sock_urlpath(url), cb, arg);
+    nanocoap_sock_close(&sock);
+
+    return res;
+}

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -216,6 +216,7 @@ endif
 ifneq (,$(filter shell_cmd_nanocoap_vfs,$(USEMODULE)))
   USEMODULE += nanocoap_vfs
   USEMODULE += vfs_util
+  USEMODULE += nanocoap_link_format
 endif
 ifneq (,$(filter shell_cmd_netstats_neighbor,$(USEMODULE)))
   USEMODULE += netstats_neighbor

--- a/sys/shell/cmds/nanocoap_vfs.c
+++ b/sys/shell/cmds/nanocoap_vfs.c
@@ -23,8 +23,10 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "net/nanocoap/link_format.h"
 #include "net/nanocoap_sock.h"
 #include "net/nanocoap_vfs.h"
+
 #include "shell.h"
 #include "vfs_default.h"
 #include "vfs_util.h"
@@ -48,6 +50,21 @@ static bool _is_dir(const char *url)
     return url[len - 1] == '/';
 }
 
+static int _resource_cb(char *entry, void *ctx)
+{
+    (void)ctx;
+
+    char *start = strchr(entry, '<');
+    if (start) {
+        char *end = strchr(entry, '>');
+        *end = '\0';
+        entry = start + 1;
+    }
+
+    puts(entry);
+    return 0;
+}
+
 static int _print_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
 {
     (void)arg;
@@ -59,41 +76,6 @@ static int _print_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int mor
     }
 
     return 0;
-}
-
-static int _print_dir_cb(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
-{
-    (void)offset;
-    (void)more;
-
-    struct dir_list_ctx *ctx = arg;
-
-    char *end = (char *)buf + len;
-    for (char *c = (char *)buf; c < end; ++c) {
-        if (ctx->cur) {
-            if (*c == '>' || ctx->cur == ctx->end) {
-                *ctx->cur = 0;
-                puts(ctx->buf);
-                ctx->cur = NULL;
-            } else {
-                *ctx->cur++ = *c;
-            }
-        } else if (*c == '<') {
-            ctx->cur = ctx->buf;
-        }
-    }
-
-    return 0;
-}
-
-static int _print_dir(const char *url, char *buf, size_t len)
-{
-    struct dir_list_ctx ctx = {
-        .buf = buf,
-        .end = buf + len,
-    };
-    return nanocoap_get_blockwise_url(url, CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT,
-                                      _print_dir_cb, &ctx);
 }
 
 static int _nanocoap_get_handler(int argc, char **argv)
@@ -109,7 +91,7 @@ static int _nanocoap_get_handler(int argc, char **argv)
     }
 
     if (_is_dir(url) && argc < 3) {
-        res = _print_dir(url, buffer, sizeof(buffer));
+        res = nanocoap_link_format_get_url(url, _resource_cb, NULL);
         if (res) {
             printf("Request failed: %s\n", strerror(-res));
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This moves the code to parse the [link format](https://www.rfc-editor.org/rfc/rfc6690.html) from the `ncget` shell command to a common location and makes it more general.

A callback is called for each resource path in the directory.


### Testing procedure

`ncget` still works as before for listing directories:

```
> ncget coap://[fe80::2454:cfff:fea7:4598]/
/fw/
/suit_manifest.signed
/suit_manifest
/payload.bin

> ncget coap://[fe80::2454:cfff:fea7:4598]/fw/
/fw/suit_update/

> ncget coap://[fe80::2454:cfff:fea7:4598]/fw/suit_update/
/fw/suit_update/same54-xpro/
/fw/suit_update/saml21-xpro/
``` 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
