### PR TITLE
drivers/st7735/kconfig: add hardware feature symbol

### DIFF
--- a/drivers/st7735/Kconfig
+++ b/drivers/st7735/Kconfig
@@ -16,6 +16,12 @@ config MODULE_ST7735
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
 
+config HAVE_ST7735
+    bool
+    select MODULE_ST7735 if MODULE_DISP_DEV
+    help
+      Indicates that an ST7735 display is present.
+
 menuconfig KCONFIG_USEMODULE_ST7735
     bool "Configure ST7735 driver"
     depends on USEMODULE_ST7735


### PR DESCRIPTION
### Contribution description
In #17903 the st7735 feature was selected, but the symbol was actually not defined. Seems to be the cause for the current failures in the nightlies CI run.

### Testing procedure
- Green CI
- Compare that the list of modules with and without Kconfig

### Issues/PRs references
#17903
