### PR TITLE
sys/net/gnrc_netif: Make use of confirm send

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -118,7 +118,7 @@ typedef struct {
     const gnrc_netif_ops_t *ops;            /**< Operations of the network interface */
     netdev_t *dev;                          /**< Network device of the network interface */
     rmutex_t mutex;                         /**< Mutex of the interface */
-#ifdef MODULE_NETSTATS_L2
+#if IS_USED(MODULE_NETSTATS_L2) || defined(DOXYGEN)
     netstats_t stats;                       /**< transceiver's statistics */
 #endif
 #if IS_USED(MODULE_GNRC_NETIF_LORAWAN) || defined(DOXYGEN)
@@ -147,6 +147,22 @@ typedef struct {
      * @brief   ISR event for the network device
      */
     event_t event_isr;
+#if IS_USED(MODULE_NETDEV_NEW_API) || defined(DOXYGEN)
+    /**
+     * @brief   TX done event for the network device
+     *
+     * @details Only provided with module `netdev_new_api`
+     */
+    event_t event_tx_done;
+    /**
+     * @brief   Outgoing frame that is currently transmitted
+     *
+     * @details Only provided with module `netdev_new_api`
+     *
+     * This needs to be freed by gnrc_netif once TX is done
+     */
+    gnrc_pktsnip_t *tx_pkt;
+#endif
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0) || DOXYGEN
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -91,6 +91,12 @@ enum {
 #define GNRC_NETIF_FLAGS_IPV6_ADV_O_FLAG           (0x00000080U)
 
 /**
+ * @brief   Used when module gnrc_netif_pktq is used to indicate that
+ *          @ref gnrc_netif_t::tx_pkt is from the packet queue.
+ */
+#define GNRC_NETIF_FLAGS_TX_FROM_PKTQUEUE          (0x00000100U)
+
+/**
  * @brief   This interface uses 6Lo header compression
  *
  * @see [RFC 6282](https://tools.ietf.org/html/rfc6282)

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -162,7 +162,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #endif
     res = dev->driver->send(dev, &iolist);
 
-    gnrc_pktbuf_release(pkt);
+    if (gnrc_netif_netdev_legacy_api(netif)) {
+        /* only for legacy drivers we need to release pkt here */
+        gnrc_pktbuf_release(pkt);
+    }
 
     return res;
 }

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -120,8 +120,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #endif
 
     res = dev->driver->send(dev, (iolist_t *)pkt);
-    /* release old data */
-    gnrc_pktbuf_release(pkt);
+    if (gnrc_netif_netdev_legacy_api(netif)) {
+        /* only for legacy drivers we need to release pkt here */
+        gnrc_pktbuf_release(pkt);
+    }
     return res;
 }
 

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -398,8 +398,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     res = dev->driver->send(dev, &iolist_header);
 #endif
 
-    /* release old data */
-    gnrc_pktbuf_release(pkt);
+    if (gnrc_netif_netdev_legacy_api(netif)) {
+        /* only for legacy drivers we need to release pkt here */
+        gnrc_pktbuf_release(pkt);
+    }
     return res;
 }
 /** @} */


### PR DESCRIPTION
### Contribution description

- Introduce modules `netdev_legacy_api` and `netdev_new_api` to allow optimizing for the "with `confirm_send()`" and "without `confirm_send()`" variant of the netdev API
    - Each netdev driver has to depend on exactly one of those
    - If both are used (because two or more netdevs are in use and one is migrated and the other not), the API version is checked at runtime
- With `netdev_new_api` translate `NETDEV_EVENT_TX_COMPLETE` into an `sys/event` event, so that this can be signaled from ISR. This safes a roundtrip to the ISR handler if the type of the event is known at ISR time (e.g. multiple signal pins or peripheral netdev)
- If the new API is used, wait for the `NETDEV_EVENT_TX_COMPLETE` event before signalling upper layers completion with `gnrc_tx_sync`.

### Testing procedure

This needs to be tested in conjunction with a driver actually being ported to the new API. However, we cannot port drivers to the new API until both GNRC and lwIP correctly operate with the new API.

https://github.com/RIOT-OS/RIOT/pull/18428 ports the STM32 Ethernet driver to the new API, so that this PR can be tested there.

### Issues/PRs references

Similar to https://github.com/RIOT-OS/RIOT/pull/15821 but uses the now existing sys/event infrastructure rather than thread_flags

- [x] Depends on and includes: https://github.com/RIOT-OS/RIOT/pull/18426

fixes https://github.com/RIOT-OS/RIOT/issues/7474