### PR TITLE
bitarithm: Move `extern const` out of static inline functions

### DIFF
--- a/core/lib/bitarithm.c
+++ b/core/lib/bitarithm.c
@@ -62,7 +62,7 @@ uint8_t bitarithm_bits_set_u32(uint32_t v)
 }
 #endif
 
-const uint8_t MultiplyDeBruijnBitPosition[32] =
+const uint8_t bitarithm_MultiplyDeBruijnBitPosition[32] =
 {
     0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
     31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9


### PR DESCRIPTION
### Contribution description

Work around a [transpilation issue](https://github.com/immunant/c2rust/issues/423) in bitarithm.h that'd be triggered if bitarithm.h were included through any header file transpiled through C2Rust.

This is a temporary workaround that unblocks cases when this would make Rust builds fail; once a newer C2Rust version is in CI, it can be reverted.

### Testing procedure

* Make bitarithm.h visible to C2Rust, eg. by working from https://github.com/RIOT-OS/RIOT/pull/17962, or more easily by applying

```patch
diff --git a/core/lib/include/irq.h b/core/lib/include/irq.h
index 25b609f95b..b84bf6819f 100644
--- a/core/lib/include/irq.h
+++ b/core/lib/include/irq.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 #include "cpu_conf.h"
+#include <bitarithm.h>
 
 #ifdef __cplusplus
 extern "C" {
```

* Build the rust-hello-world example for BOARD=samr30-xpro -- before, that failed inside the Rust build parts (riot-sys), now it builds.

### Issues/PRs references

* Unblocks: https://github.com/RIOT-OS/RIOT/pull/17962
* Workaround-For: https://github.com/immunant/c2rust/issues/423