### PR TITLE
littlefs: make block size configurable at compile time

### DIFF
--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -62,7 +62,7 @@ static int littlefs_err_to_errno(ssize_t err)
 }
 
 static int _dev_read(const struct lfs_config *c, lfs_block_t block,
-                 lfs_off_t off, void *buffer, lfs_size_t size)
+                     lfs_off_t off, void *buffer, lfs_size_t size)
 {
     littlefs_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
@@ -70,12 +70,12 @@ static int _dev_read(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_read: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_read_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                         off, size);
+    uint32_t page = (fs->base_addr + block) * fs->sectors_per_block * mtd->pages_per_sector;
+    return mtd_read_page(mtd, buffer, page, off, size);
 }
 
 static int _dev_write(const struct lfs_config *c, lfs_block_t block,
-                  lfs_off_t off, const void *buffer, lfs_size_t size)
+                      lfs_off_t off, const void *buffer, lfs_size_t size)
 {
     littlefs_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
@@ -83,8 +83,8 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_write_page_raw(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                              off, size);
+    uint32_t page = (fs->base_addr + block) * fs->sectors_per_block * mtd->pages_per_sector;
+    return mtd_write_page_raw(mtd, buffer, page, off, size);
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
@@ -94,7 +94,8 @@ static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
 
     DEBUG("lfs_erase: c=%p, block=%" PRIu32 "\n", (void *)c, block);
 
-    return mtd_erase_sector(mtd, fs->base_addr + block, 1);
+    uint32_t sector = (fs->base_addr + block) * fs->sectors_per_block;
+    return mtd_erase_sector(mtd, sector, fs->sectors_per_block);
 }
 
 static int _dev_sync(const struct lfs_config *c)
@@ -117,11 +118,19 @@ static int prepare(littlefs_desc_t *fs)
 
     memset(&fs->fs, 0, sizeof(fs->fs));
 
-    if (!fs->config.block_count) {
-        fs->config.block_count = fs->dev->sector_count - fs->base_addr;
-    }
+    size_t block_size = fs->dev->pages_per_sector * fs->dev->page_size;
+#if LITTLEFS_MIN_BLOCK_SIZE_EXP >= 0
+    block_size = ((block_size - 1) + (1u << LITTLEFS_MIN_BLOCK_SIZE_EXP))
+                 / block_size * block_size;
+#endif
+    fs->sectors_per_block = block_size / (fs->dev->pages_per_sector * fs->dev->page_size);
+    size_t block_count = fs->dev->sector_count / fs->sectors_per_block;
+
     if (!fs->config.block_size) {
-        fs->config.block_size = fs->dev->page_size * fs->dev->pages_per_sector;
+        fs->config.block_size = block_size;
+    }
+    if (!fs->config.block_count) {
+        fs->config.block_count = block_count - fs->base_addr;
     }
     if (!fs->config.prog_size) {
         fs->config.prog_size = fs->dev->page_size;
@@ -443,7 +452,8 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
     mutex_unlock(&fs->lock);
 
     buf->f_bsize = fs->fs.cfg->block_size;      /* block size */
-    buf->f_frsize = fs->fs.cfg->block_size;     /* fundamental block size */
+    buf->f_frsize = fs->dev->page_size *
+                    fs->dev->pages_per_sector;  /* fundamental block size */
     buf->f_blocks = fs->fs.cfg->block_count;    /* Blocks total */
     buf->f_bfree = buf->f_blocks - nb_blocks;   /* Blocks free */
     buf->f_bavail = buf->f_blocks - nb_blocks;  /* Blocks available to non-privileged processes */

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -118,6 +118,11 @@ static int prepare(littlefs_desc_t *fs)
 
     memset(&fs->fs, 0, sizeof(fs->fs));
 
+    static_assert(0 > LITTLEFS_MIN_BLOCK_SIZE_EXP ||
+                  6 < LITTLEFS_MIN_BLOCK_SIZE_EXP,
+                  "LITTLEFS_MIN_BLOCK_SIZE_EXP must be at least 7, "
+                  "to configure a reasonable block size of at least 128 bytes.");
+
     size_t block_size = fs->dev->pages_per_sector * fs->dev->page_size;
 #if LITTLEFS_MIN_BLOCK_SIZE_EXP >= 0
     block_size = ((block_size - 1) + (1u << LITTLEFS_MIN_BLOCK_SIZE_EXP))

--- a/pkg/littlefs2/Kconfig
+++ b/pkg/littlefs2/Kconfig
@@ -54,4 +54,13 @@ config LITTLEFS2_BLOCK_CYCLES
         Sets the maximum number of erase cycles before blocks are evicted as a part
         of wear leveling. -1 disables wear-leveling.
 
+config LITTLEFS2_MIN_BLOCK_SIZE_EXP
+    int "Minimum acceptable block size"
+    range -1 15
+    default -1
+    help
+        Sets the exponent of the minimum acceptable block size in bytes (2^n).
+        The actual block size may be larger due to device properties.
+        The default value (-1) sets the block size to the smalles possible value.
+
 endif # MODULE_LITTLEFS2_FS

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -117,6 +117,11 @@ static int prepare(littlefs2_desc_t *fs)
 
     memset(&fs->fs, 0, sizeof(fs->fs));
 
+    static_assert(0 > CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP ||
+                  6 < CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP,
+                  "CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP must be at least 7, "
+                  "to configure a reasonable block size of at least 128 bytes.");
+
     size_t block_size = fs->dev->pages_per_sector * fs->dev->page_size;
 #if CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP >= 0
     block_size = ((block_size - 1) + (1u << CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP))

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -62,7 +62,7 @@ static int littlefs_err_to_errno(ssize_t err)
 }
 
 static int _dev_read(const struct lfs_config *c, lfs_block_t block,
-                 lfs_off_t off, void *buffer, lfs_size_t size)
+                     lfs_off_t off, void *buffer, lfs_size_t size)
 {
     littlefs2_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
@@ -70,12 +70,12 @@ static int _dev_read(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_read: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_read_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                         off, size);
+    uint32_t page = (fs->base_addr + block) * fs->sectors_per_block * mtd->pages_per_sector;
+    return mtd_read_page(mtd, buffer, page, off, size);
 }
 
 static int _dev_write(const struct lfs_config *c, lfs_block_t block,
-                  lfs_off_t off, const void *buffer, lfs_size_t size)
+                      lfs_off_t off, const void *buffer, lfs_size_t size)
 {
     littlefs2_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
@@ -83,8 +83,8 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_write_page_raw(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                              off, size);
+    uint32_t page = (fs->base_addr + block) * fs->sectors_per_block * mtd->pages_per_sector;
+    return mtd_write_page_raw(mtd, buffer, page, off, size);
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
@@ -94,8 +94,8 @@ static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
 
     DEBUG("lfs_erase: c=%p, block=%" PRIu32 "\n", (void *)c, block);
 
-    return mtd_erase_sector(mtd, fs->base_addr + block, 1);
-}
+    uint32_t sector = (fs->base_addr + block) * fs->sectors_per_block;
+    return mtd_erase_sector(mtd, sector, fs->sectors_per_block);}
 
 static int _dev_sync(const struct lfs_config *c)
 {
@@ -117,11 +117,19 @@ static int prepare(littlefs2_desc_t *fs)
 
     memset(&fs->fs, 0, sizeof(fs->fs));
 
-    if (!fs->config.block_count) {
-        fs->config.block_count = fs->dev->sector_count - fs->base_addr;
-    }
+    size_t block_size = fs->dev->pages_per_sector * fs->dev->page_size;
+#if CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP >= 0
+    block_size = ((block_size - 1) + (1u << CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP))
+                 / block_size * block_size;
+#endif
+    fs->sectors_per_block = block_size / (fs->dev->pages_per_sector * fs->dev->page_size);
+    size_t block_count = fs->dev->sector_count / fs->sectors_per_block;
+
     if (!fs->config.block_size) {
-        fs->config.block_size = fs->dev->page_size * fs->dev->pages_per_sector;
+        fs->config.block_size = block_size;
+    }
+    if (!fs->config.block_count) {
+        fs->config.block_count = block_count - fs->base_addr;
     }
     if (!fs->config.prog_size) {
         fs->config.prog_size = fs->dev->page_size;
@@ -449,7 +457,8 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
     mutex_unlock(&fs->lock);
 
     buf->f_bsize = fs->fs.cfg->block_size;      /* block size */
-    buf->f_frsize = fs->fs.cfg->block_size;     /* fundamental block size */
+    buf->f_frsize = fs->dev->page_size *
+                    fs->dev->pages_per_sector;  /* fundamental block size */
     buf->f_blocks = fs->fs.cfg->block_count;    /* Blocks total */
     buf->f_bfree = buf->f_blocks - nb_blocks;   /* Blocks free */
     buf->f_bavail = buf->f_blocks - nb_blocks;  /* Blocks available to non-privileged processes */

--- a/sys/include/fs/littlefs2_fs.h
+++ b/sys/include/fs/littlefs2_fs.h
@@ -74,6 +74,13 @@ extern "C" {
  * of wear leveling. -1 disables wear-leveling. */
 #define CONFIG_LITTLEFS2_BLOCK_CYCLES       (512)
 #endif
+
+#ifndef CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP
+/**
+ * The exponent of the minimum acceptable block size in bytes (2^n).
+ * The desired block size is not guaranteed to be applicable but will be respected. */
+#define CONFIG_LITTLEFS2_MIN_BLOCK_SIZE_EXP (-1)
+#endif
 /** @} */
 
 /**
@@ -88,6 +95,7 @@ typedef struct {
      * total number of block is defined in @p config.
      * if set to 0, the total number of sectors from the mtd is used */
     uint32_t base_addr;
+    uint16_t sectors_per_block; /**< number of sectors per block */
 #if CONFIG_LITTLEFS2_FILE_BUFFER_SIZE || DOXYGEN
     /** file buffer to use internally if CONFIG_LITTLEFS2_FILE_BUFFER_SIZE
      * is set */

--- a/sys/include/fs/littlefs_fs.h
+++ b/sys/include/fs/littlefs_fs.h
@@ -58,6 +58,13 @@ extern "C" {
  * If set, it must be program size */
 #define LITTLEFS_PROG_BUFFER_SIZE   (0)
 #endif
+
+#ifndef LITTLEFS_MIN_BLOCK_SIZE_EXP
+/**
+ * The exponent of the minimum acceptable block size in bytes (2^n).
+ * The desired block size is not guaranteed to be applicable but will be respected. */
+#define LITTLEFS_MIN_BLOCK_SIZE_EXP (-1)
+#endif
 /** @} */
 
 /**
@@ -72,6 +79,7 @@ typedef struct {
      * total number of block is defined in @p config.
      * if set to 0, the total number of sectors from the mtd is used */
     uint32_t base_addr;
+    uint16_t sectors_per_block; /**< number of sectors per block */
 #if LITTLEFS_FILE_BUFFER_SIZE || DOXYGEN
     /** file buffer to use internally if LITTLEFS_FILE_BUFFER_SIZE is set */
     uint8_t file_buf[LITTLEFS_FILE_BUFFER_SIZE];

--- a/tests/pkg_littlefs/main.c
+++ b/tests/pkg_littlefs/main.c
@@ -383,7 +383,10 @@ static void tests_littlefs_statvfs(void)
 
     int res = vfs_statvfs("/test-littlefs/", &stat1);
     TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat1.f_bsize);
+    TEST_ASSERT_EQUAL_INT(_dev->page_size *
+                          _dev->pages_per_sector *
+                          littlefs_desc.sectors_per_block,
+                          stat1.f_bsize);
     TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat1.f_frsize);
     TEST_ASSERT((_dev->pages_per_sector * _dev->page_size * _dev->sector_count) >=
                           stat1.f_blocks);
@@ -400,7 +403,10 @@ static void tests_littlefs_statvfs(void)
     res = vfs_statvfs("/test-littlefs/", &stat2);
     TEST_ASSERT_EQUAL_INT(0, res);
 
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat2.f_bsize);
+    TEST_ASSERT_EQUAL_INT(_dev->page_size *
+                          _dev->pages_per_sector *
+                          littlefs_desc.sectors_per_block,
+                          stat2.f_bsize);
     TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat2.f_frsize);
     TEST_ASSERT(stat1.f_bfree > stat2.f_bfree);
     TEST_ASSERT(stat1.f_bavail > stat2.f_bavail);

--- a/tests/pkg_littlefs2/main.c
+++ b/tests/pkg_littlefs2/main.c
@@ -383,7 +383,10 @@ static void tests_littlefs_statvfs(void)
 
     int res = vfs_statvfs("/test-littlefs/", &stat1);
     TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat1.f_bsize);
+    TEST_ASSERT_EQUAL_INT(_dev->page_size *
+                          _dev->pages_per_sector *
+                          littlefs_desc.sectors_per_block,
+                          stat1.f_bsize);
     TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat1.f_frsize);
     TEST_ASSERT((_dev->pages_per_sector * _dev->page_size * _dev->sector_count) >=
                           stat1.f_blocks);
@@ -402,7 +405,10 @@ static void tests_littlefs_statvfs(void)
     res = vfs_statvfs("/test-littlefs/", &stat2);
     TEST_ASSERT_EQUAL_INT(0, res);
 
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat2.f_bsize);
+    TEST_ASSERT_EQUAL_INT(_dev->page_size *
+                          _dev->pages_per_sector *
+                          littlefs_desc.sectors_per_block,
+                          stat2.f_bsize);
     TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat2.f_frsize);
     TEST_ASSERT(stat1.f_bfree > stat2.f_bfree);
     TEST_ASSERT(stat1.f_bavail > stat2.f_bavail);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The reason for me to create this PR was that I was experiencing problems when I tried to run `littlefs` and `littlefs2` on my `at24c256` EEPROM.
Currently, the block size is always equal to `mtd->page_size * mtd->pages_per_sector`, but in practice the block size must only be a multiple of the sector size.

In my case, the resulting block size was 64 bytes, equal to the sector size, equal to the page size.
I read some `littlefs` [documentation](https://github.com/ARMmbed/mbed-littlefs/blob/master/littlefs/DESIGN.md) and found out that the minimum block size must be 104 bytes.
With this patch, resulting in a block size of 128 bytes, problems seemed to be gone.
```diff
diff --git a/drivers/at24cxxx/mtd/mtd.c b/drivers/at24cxxx/mtd/mtd.c
index 73b530a98c..76588c8efd 100644
--- a/drivers/at24cxxx/mtd/mtd.c
+++ b/drivers/at24cxxx/mtd/mtd.c
@@ -38,9 +38,9 @@ static int _mtd_at24cxxx_init(mtd_dev_t *mtd)
         return init;
     }
     mtd->page_size = DEV(mtd)->params.page_size;
-    mtd->pages_per_sector = 1;
+    mtd->pages_per_sector = 2;
     mtd->sector_count = DEV(mtd)->params.eeprom_size /
-                        DEV(mtd)->params.page_size;
+                        (DEV(mtd)->params.page_size * mtd->pages_per_sector);
     mtd->write_size = 1;
     return 0;
 }
```
However, this is not a proper fix to set an imaginary sector size, that just happens to work for some filesystem.
So I concluded that the proper fix would be to have the opportunity to configure a reasonable logical block size for a filesystem and keep the device properties untouched, like it is the case for most common filesystems that run on Linux.

For `fatfs`, I did not find a way to configure the block size at first glace. Maybe they don´t support it.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

A ~~freshly formatted~~ filesystem must still work. ~~Existing filesystems may need to be formatted.~~
If you are using an `at24c256`on `stm32` like me, you must configure the block size to be `128` bytes, else 
```C
assert(dev < I2C_NUMOF && length < MAX_BYTES_PER_FRAME); /* MAX_BYTES_PER_FRAME = 256 */
```
will fire.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
