### PR TITLE
gnrc_netreg: drain mbox on unregister

### DIFF
--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -73,6 +73,16 @@ void gnrc_netreg_unregister(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
     }
 
     LL_DELETE(netreg[type], entry);
+
+#if defined(MODULE_GNRC_NETAPI_MBOX)
+    /* drain packets still in the mbox */
+    if (entry->type == GNRC_NETREG_TYPE_MBOX) {
+        msg_t msg;
+        while (mbox_try_get(entry->target.mbox, &msg)) {
+            gnrc_pktbuf_release_error(msg.content.ptr, EBADF);
+        }
+    }
+#endif
 }
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If there are still messages in the mbox when `gnrc_netreg_unregister()` is called, we must release the associated pktbuf snips, otherwise they are leaked away forever.

E.g. `sock_udp_close()` was called without receiving all messages with `sock_udp_recv()`.


### Testing procedure

Move the `sock_udp_create()` into the sender thread loop of #18142, followed by a `sock_udp_close()` after the `ztimer_sleep()`.

The application will leak all the echo messages that are still in the mbox associated with the closed socket. With this patch, this pktbuf leak is gone.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
