### PR TITLE
gnrc: gnrc_netif etc. modules are not required by gnrc_netif_pktq

### DIFF
--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -455,7 +455,7 @@ ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
   endif
 endif
 
-ifneq (,$(filter gnrc_netif_%,$(USEMODULE)))
+ifneq (,$(filter gnrc_netif_%,$(filter-out gnrc_netif_pktq,$(USEMODULE))))
   USEMODULE += gnrc_netif
   USEMODULE += core_thread_flags
   USEMODULE += event

--- a/sys/net/gnrc/netif/Kconfig
+++ b/sys/net/gnrc/netif/Kconfig
@@ -49,19 +49,6 @@ config GNRC_NETIF_NONSTANDARD_6LO_MTU
         This is non compliant with RFC 4944 and RFC 7668 and might not be
         supported by other implementations.
 
-config GNRC_NETIF_PKTQ_POOL_SIZE
-    int "Packet queue pool size for all network interfaces"
-    depends on USEMODULE_GNRC_NETIF_PKTQ
-    default 16
-
-config GNRC_NETIF_PKTQ_TIMER_US
-    int "Time in microseconds for when to try to send a queued packet at the latest"
-    depends on USEMODULE_GNRC_NETIF_PKTQ
-    default 5000
-    help
-        Set to -1 to deactivate dequeing by timer. For this it has to be ensured
-        that none of the notifications by the driver are missed!
-
 config GNRC_NETIF_LORAWAN_NETIF_HDR
     bool "Encode LoRaWAN port in GNRC netif header"
     depends on USEMODULE_GNRC_LORAWAN
@@ -83,3 +70,5 @@ config GNRC_NETIF_IPV6_BR_AUTO_6CTX
         by prefix deligation at the border router.
 
 endif # KCONFIG_USEMODULE_GNRC_NETIF
+
+rsource "pktq/Kconfig"

--- a/sys/net/gnrc/netif/pktq/Kconfig
+++ b/sys/net/gnrc/netif/pktq/Kconfig
@@ -1,0 +1,20 @@
+menuconfig KCONFIG_USEMODULE_GNRC_NETIF_PKTQ
+    bool "Configure packet queues for GNRC network interface"
+    depends on USEMODULE_GNRC_NETIF_PKTQ
+    help
+        Configure packet queues for GNRC network interface using Kconfig.
+
+if KCONFIG_USEMODULE_GNRC_NETIF_PKTQ
+config GNRC_NETIF_PKTQ_POOL_SIZE
+    int "Packet queue pool size for all network interfaces"
+    depends on USEMODULE_GNRC_NETIF_PKTQ
+    default 16
+
+config GNRC_NETIF_PKTQ_TIMER_US
+    int "Time in microseconds for when to try to send a queued packet at the latest"
+    depends on USEMODULE_GNRC_NETIF_PKTQ
+    default 5000
+    help
+        Set to -1 to deactivate dequeing by timer. For this it has to be ensured
+        that none of the notifications by the driver are missed!
+endif # KCONFIG_USEMODULE_GNRC_NETIF_PKTQ


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This fixes an issue [uncovered in the recent release tests](https://github.com/RIOT-OS/RIOT/runs/6634316502?check_suite_focus=true#step:14:281), which according to `git bisect` is a problem ever since https://github.com/RIOT-OS/RIOT/commit/3a0e5fd7753475087cefec92c1ef155a23312273 was merged.

While this linking issue could also be solved by adding `USEMODULE += gnrc` to `tests/unittests/tests-gnrc_netif_pktq/Makefile.include`, removing `gnrc_netif` as a dependency for `gnrc_netif_pktq` keeps the unittests more minimal, so I decided to go for that direction.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run (1)

```console
$ make -C tests/unittests test-gnrc_netif_pktq
```

for `native` and then, if it succeeds (2)

```console
$ make -C tests/unittests test
```

(`make -C tests/unittests test-gnrc_netif_pktq test` may **not** work due to `test` not being a dependecy of `test-gnrc_netif_pktq`). On current master, (1) will fail due to a linking error.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
