### PR TITLE
sys/net/sock: add a word of warning to sock_udp_create()

### DIFF
--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -367,6 +367,13 @@ typedef struct {
  * @pre `(sock != NULL)`
  * @pre `(remote == NULL) || (remote->port != 0)`
  *
+ * @warning If you create a socket you are responsible for receiving messages
+ *          sent to it by calling @ref sock_udp_recv.
+ *          Otherwise, the packet queue of the @p sock may congest until the
+ *          socket is closed.
+ *          If you only want to send without receiving, use @ref sock_udp_send
+ *          instead with `sock` set to NULL.
+ *
  * @param[out] sock     The resulting sock object.
  * @param[in] local     Local end point for the sock object.
  *                      May be NULL.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a socket is created we must also call sock_udp_recv() on it as otherwise messages will get stuck in it's queue until the socket is closed (which might be never).

If applications only want to send without receiving, they must use sock_udp_send().


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
