### PR TITLE
cpu/sam0_common: RTC: wait for syncbusy in rtc_get_time()

### DIFF
--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -90,8 +90,8 @@ static void _read_req(void)
 {
 #ifdef RTC_READREQ_RREQ
     RTC->MODE0.READREQ.reg = RTC_READREQ_RREQ;
-    _wait_syncbusy();
 #endif
+    _wait_syncbusy();
 }
 #endif
 
@@ -644,7 +644,6 @@ void rtt_clear_overflow_cb(void)
 
 uint32_t rtt_get_counter(void)
 {
-    _wait_syncbusy();
     _read_req();
     return RTC->MODE0.COUNT.reg;
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`rtt_get_counter()` already waits for syncbusy before reading the time, but we also have to do this in RTC mode (`rtc_get_time()`) to avoid reading old values.

Thus, always wait for syncbusy to clear when accessing the COUNT register.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
