### PR TITLE
gnrc_netif_pktq: protect against concurrent access

### DIFF
--- a/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
+++ b/sys/net/gnrc/netif/pktq/gnrc_netif_pktq.c
@@ -23,16 +23,24 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+static mutex_t _pool_lock = MUTEX_INIT;
 static gnrc_pktqueue_t _pool[CONFIG_GNRC_NETIF_PKTQ_POOL_SIZE];
 
-static gnrc_pktqueue_t *_get_free_entry(void)
+static gnrc_pktqueue_t *_get_free_entry(gnrc_pktsnip_t *pkt)
 {
+    gnrc_pktqueue_t *entry = NULL;
+
+    mutex_lock(&_pool_lock);
     for (unsigned i = 0; i < CONFIG_GNRC_NETIF_PKTQ_POOL_SIZE; i++) {
         if (_pool[i].pkt == NULL) {
-            return &_pool[i];
+            _pool[i].pkt = pkt;
+            entry = &_pool[i];
+            break;
         }
     }
-    return NULL;
+    mutex_unlock(&_pool_lock);
+
+    return entry;
 }
 
 unsigned gnrc_netif_pktq_usage(void)
@@ -52,12 +60,11 @@ int gnrc_netif_pktq_put(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     assert(netif != NULL);
     assert(pkt != NULL);
 
-    gnrc_pktqueue_t *entry = _get_free_entry();
+    gnrc_pktqueue_t *entry = _get_free_entry(pkt);
 
     if (entry == NULL) {
         return -1;
     }
-    entry->pkt = pkt;
     gnrc_pktqueue_add(&netif->send_queue.queue, entry);
     return 0;
 }
@@ -94,12 +101,11 @@ int gnrc_netif_pktq_push_back(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     assert(netif != NULL);
     assert(pkt != NULL);
 
-    gnrc_pktqueue_t *entry = _get_free_entry();
+    gnrc_pktqueue_t *entry = _get_free_entry(pkt);
 
     if (entry == NULL) {
         return -1;
     }
-    entry->pkt = pkt;
     LL_PREPEND(netif->send_queue.queue, entry);
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `_get_free_entry()` accesses a static buffer, so we must protect it from concurrent access to avoid corruption.


### Testing procedure

Run the `examples/gnrc_border_router` on e.g. a `nrf52840dk` with another node in the network, in my case an `avr-rss2` which got the address `2001:db8::fec2:3d00:0:bb1`.

Now start two pings in parallel on your host machine:

    ping -A 2001:db8::fec2:3d00:0:bb1 -s 512
    sudo ping -f 2001:db8::fec2:3d00:0:bb1

On `master` this will crash & burn:

```
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
Stack pointer corrupted, reset to top of stack
FSR/FAR:
 CFSR: 0x00000092
 HFSR: 0x40000000
 DFSR: 0x00000000
 AFSR: 0x00000000
MMFAR: 0x20000018
Misc
EXC_RET: 0xfffffff1
----> ethos: hello received
```

With this patch we also run out of queue space, but we manage to recover when we stop the flood ping.

```
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending
gnrc_netif: can't queue packet for sending

> ping -s 512 ff02::1
520 bytes from fe80::7837:fcff:fe7d:1aae%5: icmp_seq=0 ttl=64 time=107.856 ms
520 bytes from fe80::7837:fcff:fe7d:1aae%5: icmp_seq=1 ttl=64 time=114.955 ms
520 bytes from fe80::7837:fcff:fe7d:1aae%5: icmp_seq=2 ttl=64 time=107.774 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 107.774/110.195/114.955 ms
```

### Issues/PRs references

partially fixes #17924, when doing a `sudo ping -f 2001:db8::fec2:3d00:0:bb1 -s 512` the upstream interface remains 'dead' for several seconds after the flood ping was stopped.