### PR TITLE
nanocoap: add support for no-response option 

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -53,6 +53,11 @@ extern "C" {
 #define COAP_OPT_BLOCK1         (27)
 #define COAP_OPT_PROXY_URI      (35)
 #define COAP_OPT_PROXY_SCHEME   (39)
+/**
+ * @brief suppress CoAP response
+ * @see [RFC 7968](https://datatracker.ietf.org/doc/html/rfc7967)
+ */
+#define COAP_OPT_NO_RESPONSE    (258)
 /** @} */
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1817,6 +1817,13 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token,
  * @param[in]   payload_len length of payload
  *
  * @returns     size of reply packet on success
+ *
+ *              Note that this size can be severely shortened if due to a No-Response option there
+ *              is only an empty ACK to be sent back. The caller may just continue populating the
+ *              payload (the space was checked to suffice), but may also skip that needless step
+ *              if the returned length is less than the requested payload length.
+ *
+ * @returns     0 if no response should be sent due to a No-Response option in the request
  * @returns     <0 on error
  * @returns     -ENOSPC if @p rbuf too small
  */

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -241,6 +241,25 @@ ssize_t nanocoap_sock_put(nanocoap_sock_t *sock, const char *path,
                           void *response, size_t len_max);
 
 /**
+ * @brief   Simple non-confirmable PUT
+ *
+ * @param[in]   sock    socket to use for the request
+ * @param[in]   path    remote path
+ * @param[in]   request buffer containing the payload
+ * @param[in]   len     length of the payload to send
+ * @param[out]  response buffer for the response, may be NULL
+ * @param[in]   len_max length of @p response
+ *
+ * @returns     length of response payload on success
+ * @returns     0 if the request was sent and no response buffer was provided,
+ *              independently of success (because no response is requested in that case)
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_put_non(nanocoap_sock_t *sock, const char *path,
+                              const void *request, size_t len,
+                              void *response, size_t len_max);
+
+/**
  * @brief   Simple synchronous CoAP (confirmable) PUT to URL
  *
  * @param[in]   url     Absolute URL pointer to source path
@@ -272,6 +291,25 @@ ssize_t nanocoap_sock_put_url(const char *url,
 ssize_t nanocoap_sock_post(nanocoap_sock_t *sock, const char *path,
                            const void *request, size_t len,
                            void *response, size_t len_max);
+
+/**
+ * @brief   Simple non-confirmable POST
+ *
+ * @param[in]   sock    socket to use for the request
+ * @param[in]   path    remote path
+ * @param[in]   request buffer containing the payload
+ * @param[in]   len     length of the payload to send
+ * @param[out]  response buffer for the response, may be NULL
+ * @param[in]   len_max length of @p response
+ *
+ * @returns     length of response payload on success
+ * @returns     0 if the request was sent and no response buffer was provided,
+ *              independently of success (because no response is requested in that case)
+ * @returns     <0 on error
+ */
+ssize_t nanocoap_sock_post_non(nanocoap_sock_t *sock, const char *path,
+                               const void *request, size_t len,
+                               void *response, size_t len_max);
 
 /**
  * @brief   Simple synchronous CoAP (confirmable) POST to URL

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -32,12 +32,14 @@ extern int nanotest_client_cmd(int argc, char **argv);
 extern int nanotest_client_url_cmd(int argc, char **argv);
 extern int nanotest_server_cmd(int argc, char **argv);
 extern int nanotest_client_put_cmd(int argc, char **argv);
+extern int nanotest_client_put_non_cmd(int argc, char **argv);
 static int _list_all_inet6(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
     { "client", "CoAP client", nanotest_client_cmd },
     { "url", "CoAP client URL request", nanotest_client_url_cmd },
     { "put", "experimental put", nanotest_client_put_cmd },
+    { "put_non", "non-confirmable put", nanotest_client_put_non_cmd },
     { "server", "CoAP server", nanotest_server_cmd },
     { "inet6", "IPv6 addresses", _list_all_inet6 },
     { NULL, NULL, NULL }

--- a/tests/nanocoap_cli/nanocli_client.c
+++ b/tests/nanocoap_cli/nanocli_client.c
@@ -298,3 +298,22 @@ int nanotest_client_put_cmd(int argc, char **argv)
     nanocoap_block_request_done(&ctx);
     return res;
 }
+
+int nanotest_client_put_non_cmd(int argc, char **argv)
+{
+    int res;
+
+    if (argc < 3) {
+        printf("usage: %s <url> <data>\n", argv[0]);
+        return 1;
+    }
+
+    nanocoap_sock_t sock;
+    nanocoap_sock_url_connect(argv[1], &sock);
+
+    res = nanocoap_sock_put_non(&sock, sock_urlpath(argv[1]), argv[2], strlen(argv[2]),
+                                NULL, 0);
+    nanocoap_sock_close(&sock);
+
+    return res;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds support for the no-response option ([RFC 7968](https://datatracker.ietf.org/doc/rfc7967/)) in the nanoCoAP server.

To allow for testing and easy use, the two client functions `nanocoap_sock_put_non()` and `nanocoap_sock_post_non()` are also added which will add the no-response option if no payload response is requested. 


### Testing procedure

A new `put_non` command has been added to `tests/nanocoap_cli`:

```
> put_non coap://[fe80::58b0:8ff:fe67:ad82]/value 42
> ncget coap://[fe80::58b0:8ff:fe67:ad82]/value -
42
```

Verify in Wireshark that indeed no response was generated to the PUT request

![image](https://user-images.githubusercontent.com/1301112/192754900-604bbb60-0048-4723-8620-68a2374aca86.png)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
