### PR TITLE
cpu/esp: add compilation tests for optional ESP modules

### DIFF
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -34,6 +34,8 @@ CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=2 \
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+EXTERNAL_BOARD_DIRS += $(RIOTBASE)/tests/external_board_dirs/esp-ci-boards
+
 include $(RIOTBASE)/Makefile.include
 
 # Set GNRC_PKTBUF_SIZE via CFLAGS if not being set via Kconfig.

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -68,6 +68,8 @@ endif
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+EXTERNAL_BOARD_DIRS += $(RIOTBASE)/tests/external_board_dirs/esp-ci-boards
+
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -59,4 +59,7 @@ endif
 TIMER_SPEED ?= 1000000
 
 CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
+
+EXTERNAL_BOARD_DIRS += $(CURDIR)/../external_board_dirs/esp-ci-boards
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This PR adds `esp32-ci` and `esp8266-ci` as external boards to following tests/examples to cover all optional modules by CI compilation:
- `tests/periph_timer` to compile `esp_hw_counter` (ESP32)
- `tests/periph_timer` to compile `esp_sw_timer` (ESP8266)
- `examples/gnrc_networking` to compile `esp_wifi_ap` (ESP32 and ESP8266)
- `examples/gnrc_minimal` to compile `esp_wifi_enterprise` (ESP32)

### Testing procedure

Green CI

### Issues/PRs references

Missing compilations were found in PR https://github.com/RIOT-OS/RIOT/pull/17601#issuecomment-1139553202