### PR TITLE
cpu/esp_common: use LittleFS2 as default FS

### DIFF
--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -66,6 +66,11 @@ ifneq (,$(filter 4 5,$(LOG_LEVEL)))
   USEMODULE += esp_log_startup
 endif
 
+# default to using littlefs2 on the SPI flash
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += littlefs2
+endif
+
 # each device has SPI flash memory, but it has to be enabled explicitly
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
   USEMODULE += spiffs

--- a/cpu/esp_common/periph/flash.c
+++ b/cpu/esp_common/periph/flash.c
@@ -63,6 +63,11 @@ mtd_dev_t* mtd0 = 0;
 static mtd_dev_t  _flash_dev;
 static mtd_desc_t _flash_driver;
 
+#ifdef MODULE_VFS_DEFAULT
+#include "vfs_default.h"
+VFS_AUTO_MOUNT(littlefs2, { .dev = &_flash_dev }, VFS_DEFAULT_NVM(0), 0);
+#endif
+
 #ifdef MCU_ESP8266
 
 /* for source code compatibility with ESP32 SDK */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

SPIFFS appears to be what's configured by default on the SPI flash of the esp* boards, so also configure that in RIOT.

LittleFS2 would IMHO be a better choice as it's the faster, more advanced and better maintained filesystem, but it appears as if the esp* boards ship with SPIFFS by default.

I don't have any esp* board still in mint condition to confirm that though.
If there is no such thing as a 'default fs' on those boards, I think we should go with littlefs2 instead.

### Testing procedure

Run `tests/vfs_default`.
The SPI flash should be mounted to `/nvm0`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
