### PR TITLE
sys/fmt: disarm footgun

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -74,6 +74,7 @@ size_t fmt_byte_hex(char *out, uint8_t byte)
 size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n)
 {
     size_t len = n * 2;
+
     if (out) {
         while (n--) {
             out += fmt_byte_hex(out, *ptr++);
@@ -86,7 +87,8 @@ size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n)
 size_t fmt_strlen(const char *str)
 {
     const char *tmp = str;
-    while(*tmp) {
+
+    while (*tmp) {
         tmp++;
     }
     return (tmp - str);
@@ -95,7 +97,8 @@ size_t fmt_strlen(const char *str)
 size_t fmt_strnlen(const char *str, size_t maxlen)
 {
     const char *tmp = str;
-    while(*tmp && maxlen--) {
+
+    while (*tmp && maxlen--) {
         tmp++;
     }
     return (tmp - str);
@@ -104,9 +107,11 @@ size_t fmt_strnlen(const char *str, size_t maxlen)
 size_t fmt_str(char *out, const char *str)
 {
     int len = 0;
+
     if (!out) {
         len = fmt_strlen(str);
-    } else {
+    }
+    else {
         char c;
         while ((c = *str++)) {
             *out++ = c;
@@ -119,10 +124,11 @@ size_t fmt_str(char *out, const char *str)
 size_t fmt_bytes_hex_reverse(char *out, const uint8_t *ptr, size_t n)
 {
     size_t i = n;
+
     while (i--) {
         out += fmt_byte_hex(out, ptr[i]);
     }
-    return (n<<1);
+    return (n << 1);
 }
 
 static uint8_t _byte_mod25(uint8_t x)
@@ -169,17 +175,17 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex)
 
 size_t fmt_u16_hex(char *out, uint16_t val)
 {
-    return fmt_bytes_hex_reverse(out, (uint8_t*) &val, 2);
+    return fmt_bytes_hex_reverse(out, (uint8_t *)&val, 2);
 }
 
 size_t fmt_u32_hex(char *out, uint32_t val)
 {
-    return fmt_bytes_hex_reverse(out, (uint8_t*) &val, 4);
+    return fmt_bytes_hex_reverse(out, (uint8_t *)&val, 4);
 }
 
 size_t fmt_u64_hex(char *out, uint64_t val)
 {
-    return fmt_bytes_hex_reverse(out, (uint8_t*) &val, 8);
+    return fmt_bytes_hex_reverse(out, (uint8_t *)&val, 8);
 }
 
 size_t fmt_u64_dec(char *out, uint64_t val)
@@ -188,10 +194,10 @@ size_t fmt_u64_dec(char *out, uint64_t val)
     uint32_t q;
     size_t len = 0;
 
-    d[0] = val       & 0xFFFF;
-    d[1] = (val>>16) & 0xFFFF;
-    d[2] = (val>>32) & 0xFFFF;
-    d[3] = (val>>48) & 0xFFFF;
+    d[0] = val         & 0xFFFF;
+    d[1] = (val >> 16) & 0xFFFF;
+    d[2] = (val >> 32) & 0xFFFF;
+    d[3] = (val >> 48) & 0xFFFF;
 
     d[0] = 656 * d[3] + 7296 * d[2] + 5536 * d[1] + d[0];
     q = d[0] / 10000;
@@ -223,11 +229,11 @@ size_t fmt_u64_dec(char *out, uint64_t val)
     if (out) {
         out += len;
         memset(out, '0', total_len - len);
-        while(first) {
+        while (first) {
             first--;
             if (d[first]) {
                 size_t tmp = fmt_u32_dec(NULL, d[first]);
-                fmt_u32_dec(out+(4-tmp), d[first]);
+                fmt_u32_dec(out + (4 - tmp), d[first]);
             }
             out += 4;
         }
@@ -270,6 +276,7 @@ size_t fmt_s64_dec(char *out, int64_t val)
 {
     unsigned negative = (val < 0);
     uint64_t sval;
+
     if (negative) {
         if (out) {
             *out++ = '-';
@@ -286,6 +293,7 @@ size_t fmt_s32_dec(char *out, int32_t val)
 {
     unsigned negative = (val < 0);
     uint32_t sval;
+
     if (negative) {
         if (out) {
             *out++ = '-';
@@ -374,7 +382,7 @@ size_t fmt_float(char *out, float f, unsigned precision)
         f = -f;
     }
 
-    integer = (uint32_t) f;
+    integer = (uint32_t)f;
     f -= integer;
 
     uint32_t fraction = f * _tenmap[precision];
@@ -413,9 +421,9 @@ size_t fmt_lpad(char *out, size_t in_len, size_t pad_len, char pad_char)
         }
         else {
             char *pos = out + pad_len - 1;
-            out += in_len -1;
+            out += in_len - 1;
 
-            while(in_len--) {
+            while (in_len--) {
                 *pos-- = *out--;
             }
 
@@ -460,7 +468,8 @@ size_t fmt_to_lower(char *out, const char *str)
 uint32_t scn_u32_dec(const char *str, size_t n)
 {
     uint32_t res = 0;
-    while(n--) {
+
+    while (n--) {
         char c = *str++;
         if (!fmt_is_digit(c)) {
             break;
@@ -527,6 +536,7 @@ void print_u32_dec(uint32_t val)
 {
     char buf[10]; /* "4294967295" */
     size_t len = fmt_u32_dec(buf, val);
+
     print(buf, len);
 }
 
@@ -534,12 +544,14 @@ void print_s32_dec(int32_t val)
 {
     char buf[11]; /* "-2147483648" */
     size_t len = fmt_s32_dec(buf, val);
+
     print(buf, len);
 }
 
 void print_byte_hex(uint8_t byte)
 {
     char buf[2];
+
     fmt_byte_hex(buf, byte);
     print(buf, sizeof(buf));
 }
@@ -547,13 +559,14 @@ void print_byte_hex(uint8_t byte)
 void print_u32_hex(uint32_t val)
 {
     char buf[8];
+
     fmt_u32_hex(buf, val);
     print(buf, sizeof(buf));
 }
 
 void print_u64_hex(uint64_t val)
 {
-    print_u32_hex(val>>32);
+    print_u32_hex(val >> 32);
     print_u32_hex(val);
 }
 
@@ -561,6 +574,7 @@ void print_u64_dec(uint64_t val)
 {
     char buf[20]; /* "18446744073709551615" */
     size_t len = fmt_u64_dec(buf, val);
+
     print(buf, len);
 }
 
@@ -568,6 +582,7 @@ void print_s64_dec(uint64_t val)
 {
     char buf[20]; /* "-9223372036854775808" */
     size_t len = fmt_s64_dec(buf, val);
+
     print(buf, len);
 }
 
@@ -575,10 +590,11 @@ void print_float(float f, unsigned precision)
 {
     char buf[19];
     size_t len = fmt_float(buf, f, precision);
+
     print(buf, len);
 }
 
-void print_str(const char* str)
+void print_str(const char *str)
 {
     print(str, fmt_strlen(str));
 }

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -21,15 +21,9 @@
 #include <assert.h>
 #include <stdarg.h>
 #include <stdint.h>
-#include <unistd.h>
+#include <stdio.h>
 #include <string.h>
-
-#if defined(__WITH_AVRLIBC__) || defined(__mips__)
-#include <stdio.h>  /* for fwrite() */
-#else
-/* work around broken sys/posix/unistd.h */
-ssize_t write(int fildes, const void *buf, size_t nbyte);
-#endif
+#include <unistd.h>
 
 #include "kernel_defines.h"
 #include "fmt.h"
@@ -505,19 +499,28 @@ uint32_t scn_u32_hex(const char *str, size_t n)
 
 void print(const char *s, size_t n)
 {
-#ifdef __WITH_AVRLIBC__
-    /* AVR's libc doesn't offer write(), so use fwrite() instead */
-    fwrite(s, n, 1, stdout);
-#else
     while (n > 0) {
-        ssize_t written = write(STDOUT_FILENO, s, n);
+        ssize_t written;
+        if (IS_USED(MODULE_STDIO_NATIVE)) {
+            /* for native fwrite is not wrapped and would use the system's
+             * write directly, resulting in corrupted output. Instead, use the
+             * stdio_write wrapper directly here to force all output from
+             * puts() / printf() and fmt to be handled the same. */
+            extern ssize_t stdio_write(const void* buffer, size_t len);
+            written = stdio_write(s, n);
+        }
+        else {
+            /* For all but native: Use fwrite rather than the cheaper unbuffered
+             * write() to avoid corrupted output when mixing stdio and fmt
+             * for C libs that use buffered output */
+            written = fwrite(s, 1, n, stdout);
+        }
         if (written < 0) {
             break;
         }
         n -= written;
         s += written;
     }
-#endif /* __WITH_AVRLIBC__ */
 }
 
 void print_u32_dec(uint32_t val)

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <stdio.h>
+
 #include "fmt.h"
 
 int main(void)
@@ -43,7 +45,9 @@ int main(void)
     print_str("\n");
     print_float(1.2345, 5);
     print_str("\n");
-    print_str("Test successful.\n");
+    printf("%s", "Test ");
+    print_str("successful.");
+    puts("");
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

Mixing `print*()` from `fmt.h` with `puts()` `*printf()` from `stdio.h` results in corrupted output even with only one thread printing. That's an obvious footgun. This fixes the issue.

### Testing procedure

The first commit extends `tests/fmt_print` to detect output corruptions when mixing with `stdio.h` (this should fail on `master`). The second fixes the issue (so it should pass again after the second commit).

### Issues/PRs references

Alternative to dropping the use of `fmt` in https://github.com/RIOT-OS/RIOT/pull/18161