### PR TITLE
pkg/esp32_sdk: Update version to 4.4.1 

### DIFF
--- a/cpu/esp32/esp-idf/esp_idf_support.c
+++ b/cpu/esp32/esp-idf/esp_idf_support.c
@@ -64,6 +64,11 @@ int g_wpa_ca_cert_len;
 char *g_wpa_ttls_phase2_type;
 bool g_wpa_suiteb_certification;
 
+char *g_wpa_phase1_options;
+
+uint8_t *g_wpa_pac_file;
+int g_wpa_pac_file_len;
+
 /*
  * provided by: /path/to/esp-idf/components/log/log_freertos.c
  */

--- a/pkg/esp32_sdk/Makefile
+++ b/pkg/esp32_sdk/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk
 PKG_URL=https://github.com/espressif/esp-idf
-# This is a version in the v4.4 release branch
-PKG_VERSION=eb3797dc3ffebd9eaf873a01df63aed89fad58b6
+# v4.4.1
+PKG_VERSION=1329b19fe494500aeb79d19b27cfd99b40c37aec
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/esp32_sdk/patches/0001-esp_hw_support-rename-rtc_init.patch
+++ b/pkg/esp32_sdk/patches/0001-esp_hw_support-rename-rtc_init.patch
@@ -1,39 +1,29 @@
-From c1c2ff384f02d973624de0c8250eb49c73a3ea84 Mon Sep 17 00:00:00 2001
-From: Gunar Schorcht <gunar@schorcht.net>
-Date: Sun, 30 Jan 2022 07:59:30 +0100
-Subject: [PATCH 01/12] esp_hw_support: rename rtc_init
+From f3c3f97504da7d0bf25fa1e59d0350d130ca6eec Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Fri, 3 Jun 2022 00:02:07 +0200
+Subject: [PATCH] esp_hw_support: rename rtc_init
 
 Rename `rtc_init` to `rtc_init_module` due to name conflicts with RIOT `periph/rtc` module.
 ---
- components/bt/controller/lib_esp32                | 2 +-
  components/esp_hw_support/port/esp32/rtc_init.c   | 2 +-
  components/esp_hw_support/port/esp32c3/rtc_init.c | 2 +-
  components/esp_hw_support/port/esp32h2/rtc_init.c | 2 +-
  components/esp_hw_support/port/esp32s2/rtc_init.c | 2 +-
  components/esp_hw_support/port/esp32s3/rtc_init.c | 2 +-
- components/esp_phy/lib                            | 2 +-
  components/esp_system/port/soc/esp32/clk.c        | 2 +-
  components/esp_system/port/soc/esp32c3/clk.c      | 2 +-
  components/esp_system/port/soc/esp32h2/clk.c      | 2 +-
  components/esp_system/port/soc/esp32s2/clk.c      | 2 +-
  components/esp_system/port/soc/esp32s3/clk.c      | 2 +-
- components/esp_wifi/lib                           | 2 +-
  components/soc/esp32/include/soc/rtc.h            | 2 +-
  components/soc/esp32c3/include/soc/rtc.h          | 2 +-
  components/soc/esp32h2/include/soc/rtc.h          | 2 +-
  components/soc/esp32s2/include/soc/rtc.h          | 2 +-
  components/soc/esp32s3/include/soc/rtc.h          | 2 +-
- 18 files changed, 18 insertions(+), 18 deletions(-)
+ 15 files changed, 15 insertions(+), 15 deletions(-)
 
-diff --git a/components/bt/controller/lib_esp32 b/components/bt/controller/lib_esp32
-index ec4b716eb6..54a69e5361 160000
---- a/components/bt/controller/lib_esp32
-+++ b/components/bt/controller/lib_esp32
-@@ -1 +1 @@
--Subproject commit ec4b716eb60c50f14642f7b7ce9825791469e4c1
-+Subproject commit 54a69e53616cbd3e3f3bbf150e42930a7912349a
 diff --git a/components/esp_hw_support/port/esp32/rtc_init.c b/components/esp_hw_support/port/esp32/rtc_init.c
-index e66a493b3d..7f1d191554 100644
+index e66a493b..7f1d1915 100644
 --- a/components/esp_hw_support/port/esp32/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32/rtc_init.c
 @@ -14,7 +14,7 @@
@@ -46,7 +36,7 @@ index e66a493b3d..7f1d191554 100644
      CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_PVTMON_PU | RTC_CNTL_TXRF_I2C_PU |
              RTC_CNTL_RFRX_PBUS_PU | RTC_CNTL_CKGEN_I2C_PU | RTC_CNTL_PLL_I2C_PU);
 diff --git a/components/esp_hw_support/port/esp32c3/rtc_init.c b/components/esp_hw_support/port/esp32c3/rtc_init.c
-index 388399f107..f6fdc69244 100644
+index 388399f1..f6fdc692 100644
 --- a/components/esp_hw_support/port/esp32c3/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32c3/rtc_init.c
 @@ -25,7 +25,7 @@ static void set_ocode_by_efuse(int calib_version);
@@ -59,7 +49,7 @@ index 388399f107..f6fdc69244 100644
      REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
      REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
 diff --git a/components/esp_hw_support/port/esp32h2/rtc_init.c b/components/esp_hw_support/port/esp32h2/rtc_init.c
-index 7b684d3d3d..ff0b5f4912 100644
+index 7b684d3d..ff0b5f49 100644
 --- a/components/esp_hw_support/port/esp32h2/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32h2/rtc_init.c
 @@ -27,7 +27,7 @@ void pmu_ctl(void);
@@ -72,7 +62,7 @@ index 7b684d3d3d..ff0b5f4912 100644
      CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_PVTMON_PU);
      REG_SET_FIELD(RTC_CNTL_TIMER1_REG, RTC_CNTL_PLL_BUF_WAIT, cfg.pll_wait);
 diff --git a/components/esp_hw_support/port/esp32s2/rtc_init.c b/components/esp_hw_support/port/esp32s2/rtc_init.c
-index 7932a89aa0..8910f7a279 100644
+index 7932a89a..8910f7a2 100644
 --- a/components/esp_hw_support/port/esp32s2/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32s2/rtc_init.c
 @@ -24,7 +24,7 @@ __attribute__((unused)) static const char *TAG = "rtc_init";
@@ -85,7 +75,7 @@ index 7932a89aa0..8910f7a279 100644
      CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_PVTMON_PU);
      REG_SET_FIELD(RTC_CNTL_TIMER1_REG, RTC_CNTL_PLL_BUF_WAIT, cfg.pll_wait);
 diff --git a/components/esp_hw_support/port/esp32s3/rtc_init.c b/components/esp_hw_support/port/esp32s3/rtc_init.c
-index ed44fd7baa..f0b7f5c8c2 100644
+index ed44fd7b..f0b7f5c8 100644
 --- a/components/esp_hw_support/port/esp32s3/rtc_init.c
 +++ b/components/esp_hw_support/port/esp32s3/rtc_init.c
 @@ -31,7 +31,7 @@ static const char *TAG = "rtcinit";
@@ -97,18 +87,11 @@ index ed44fd7baa..f0b7f5c8c2 100644
  {
      REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
      REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
-diff --git a/components/esp_phy/lib b/components/esp_phy/lib
-index 4779ddaaf2..2d89c532cc 160000
---- a/components/esp_phy/lib
-+++ b/components/esp_phy/lib
-@@ -1 +1 @@
--Subproject commit 4779ddaaf29e1d6aa2d26980103a1c1bbaa29462
-+Subproject commit 2d89c532ccba0bb9988d1d1c6d719bbe1d8b65b8
 diff --git a/components/esp_system/port/soc/esp32/clk.c b/components/esp_system/port/soc/esp32/clk.c
-index 8015d50d98..aed4554a20 100644
+index 3b3f2b73..c891224a 100644
 --- a/components/esp_system/port/soc/esp32/clk.c
 +++ b/components/esp_system/port/soc/esp32/clk.c
-@@ -124,7 +124,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk)
+@@ -115,7 +115,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk)
   __attribute__((weak)) void esp_clk_init(void)
  {
      rtc_config_t cfg = RTC_CONFIG_DEFAULT();
@@ -118,10 +101,10 @@ index 8015d50d98..aed4554a20 100644
  #if (CONFIG_ESP32_COMPATIBLE_PRE_V2_1_BOOTLOADERS || CONFIG_ESP32_APP_INIT_CLK)
      /* Check the bootloader set the XTAL frequency.
 diff --git a/components/esp_system/port/soc/esp32c3/clk.c b/components/esp_system/port/soc/esp32c3/clk.c
-index 685c3a040b..187b1ce649 100644
+index d2181b58..36ab8a40 100644
 --- a/components/esp_system/port/soc/esp32c3/clk.c
 +++ b/components/esp_system/port/soc/esp32c3/clk.c
-@@ -80,7 +80,7 @@ static const char *TAG = "clk";
+@@ -72,7 +72,7 @@ static const char *TAG = "clk";
      if (rst_reas == RESET_REASON_CHIP_POWER_ON) {
          cfg.cali_ocode = 1;
      }
@@ -131,10 +114,10 @@ index 685c3a040b..187b1ce649 100644
      assert(rtc_clk_xtal_freq_get() == RTC_XTAL_FREQ_40M);
  
 diff --git a/components/esp_system/port/soc/esp32h2/clk.c b/components/esp_system/port/soc/esp32h2/clk.c
-index 52cb9e9c44..ee6c2f0a1b 100644
+index 7ea2dde1..0061e39b 100644
 --- a/components/esp_system/port/soc/esp32h2/clk.c
 +++ b/components/esp_system/port/soc/esp32h2/clk.c
-@@ -79,7 +79,7 @@ static const char *TAG = "clk";
+@@ -71,7 +71,7 @@ static const char *TAG = "clk";
      if (rst_reas == RESET_REASON_CHIP_POWER_ON) {
          cfg.cali_ocode = 1;
      }
@@ -144,10 +127,10 @@ index 52cb9e9c44..ee6c2f0a1b 100644
      assert(rtc_clk_xtal_freq_get() == RTC_XTAL_FREQ_32M);
  
 diff --git a/components/esp_system/port/soc/esp32s2/clk.c b/components/esp_system/port/soc/esp32s2/clk.c
-index 6a8e00b6e4..9b7128ca0a 100644
+index 68ad39c1..4fa1aac0 100644
 --- a/components/esp_system/port/soc/esp32s2/clk.c
 +++ b/components/esp_system/port/soc/esp32s2/clk.c
-@@ -81,7 +81,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
+@@ -72,7 +72,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
      if (rst_reas == RESET_REASON_CHIP_POWER_ON) {
          cfg.cali_ocode = 1;
      }
@@ -157,10 +140,10 @@ index 6a8e00b6e4..9b7128ca0a 100644
      rtc_clk_fast_freq_set(RTC_FAST_FREQ_8M);
  
 diff --git a/components/esp_system/port/soc/esp32s3/clk.c b/components/esp_system/port/soc/esp32s3/clk.c
-index 79b125cc04..89565eafc3 100644
+index 15610ae9..a5b2ddf3 100644
 --- a/components/esp_system/port/soc/esp32s3/clk.c
 +++ b/components/esp_system/port/soc/esp32s3/clk.c
-@@ -82,7 +82,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
+@@ -73,7 +73,7 @@ static void select_rtc_slow_clk(slow_clk_sel_t slow_clk);
      if (rst_reas == RESET_REASON_CHIP_POWER_ON) {
          cfg.cali_ocode = 1;
      }
@@ -169,15 +152,8 @@ index 79b125cc04..89565eafc3 100644
  
      assert(rtc_clk_xtal_freq_get() == RTC_XTAL_FREQ_40M);
  
-diff --git a/components/esp_wifi/lib b/components/esp_wifi/lib
-index cd7d14917f..5ae7e325b8 160000
---- a/components/esp_wifi/lib
-+++ b/components/esp_wifi/lib
-@@ -1 +1 @@
--Subproject commit cd7d14917f2c3d0ea4382f4a188cb290304faf47
-+Subproject commit 5ae7e325b89bc2d0799e2de6fcaccf41ffdbb408
 diff --git a/components/soc/esp32/include/soc/rtc.h b/components/soc/esp32/include/soc/rtc.h
-index bbbf3c7550..3b98346679 100644
+index bbbf3c75..3b983466 100644
 --- a/components/soc/esp32/include/soc/rtc.h
 +++ b/components/soc/esp32/include/soc/rtc.h
 @@ -685,7 +685,7 @@ typedef struct rtc_config_s {
@@ -190,10 +166,10 @@ index bbbf3c7550..3b98346679 100644
  #define RTC_VDDSDIO_TIEH_1_8V 0 //!< TIEH field value for 1.8V VDDSDIO
  #define RTC_VDDSDIO_TIEH_3_3V 1 //!< TIEH field value for 3.3V VDDSDIO
 diff --git a/components/soc/esp32c3/include/soc/rtc.h b/components/soc/esp32c3/include/soc/rtc.h
-index db67d3ac51..2142df2c2f 100644
+index dccd7a07..f4b4aa44 100644
 --- a/components/soc/esp32c3/include/soc/rtc.h
 +++ b/components/soc/esp32c3/include/soc/rtc.h
-@@ -839,7 +839,7 @@ typedef struct {
+@@ -831,7 +831,7 @@ typedef struct {
   * Initialize RTC clock and power control related functions
   * @param cfg configuration options as rtc_config_t
   */
@@ -203,7 +179,7 @@ index db67d3ac51..2142df2c2f 100644
  /**
   * Structure describing vddsdio configuration
 diff --git a/components/soc/esp32h2/include/soc/rtc.h b/components/soc/esp32h2/include/soc/rtc.h
-index 5585986ed2..7a1dd718c6 100644
+index 5585986e..7a1dd718 100644
 --- a/components/soc/esp32h2/include/soc/rtc.h
 +++ b/components/soc/esp32h2/include/soc/rtc.h
 @@ -925,7 +925,7 @@ typedef struct {
@@ -216,7 +192,7 @@ index 5585986ed2..7a1dd718c6 100644
  /**
   * Structure describing vddsdio configuration
 diff --git a/components/soc/esp32s2/include/soc/rtc.h b/components/soc/esp32s2/include/soc/rtc.h
-index 11b13fb6aa..73caf3395c 100644
+index 11b13fb6..73caf339 100644
 --- a/components/soc/esp32s2/include/soc/rtc.h
 +++ b/components/soc/esp32s2/include/soc/rtc.h
 @@ -854,7 +854,7 @@ typedef struct {
@@ -229,7 +205,7 @@ index 11b13fb6aa..73caf3395c 100644
  /**
   * Structure describing vddsdio configuration
 diff --git a/components/soc/esp32s3/include/soc/rtc.h b/components/soc/esp32s3/include/soc/rtc.h
-index aa09874f2c..eb8bbed68b 100644
+index aa09874f..eb8bbed6 100644
 --- a/components/soc/esp32s3/include/soc/rtc.h
 +++ b/components/soc/esp32s3/include/soc/rtc.h
 @@ -849,7 +849,7 @@ typedef struct {
@@ -242,5 +218,5 @@ index aa09874f2c..eb8bbed68b 100644
  /**
   * Structure describing vddsdio configuration
 -- 
-2.17.1
+2.34.1
 

--- a/pkg/esp32_sdk/patches/0003-wpa_supplicant-declare-variables-in-header-files-as-.patch
+++ b/pkg/esp32_sdk/patches/0003-wpa_supplicant-declare-variables-in-header-files-as-.patch
@@ -1,17 +1,18 @@
-From b3025f4b66cfb9d46a8199e0c85e137741262c86 Mon Sep 17 00:00:00 2001
-From: Gunar Schorcht <gunar@schorcht.net>
-Date: Sun, 30 Jan 2022 08:15:16 +0100
-Subject: [PATCH 03/12] wpa_supplicant: declare variables in header files as
- extern
+From 8b8faf52093843560c029759722e3f290aa57084 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Thu, 2 Jun 2022 23:42:40 +0200
+Subject: [PATCH] wpa_supplicant: declare variables in header files as extern
 
-The definition of variables in header files lead to multiple defined symbols if these header files are included multiple times. Variables in header files are therefore declared as extern.
+The definition of variables in header files lead to multiple defined
+symbols if these header files are included multiple times.
+Variables in header files are therefore declared as extern.
 ---
- .../esp_supplicant/include/esp_wpa.h          |  4 +--
- components/wpa_supplicant/src/eap_peer/eap.h  | 36 +++++++++----------
- 2 files changed, 20 insertions(+), 20 deletions(-)
+ .../esp_supplicant/include/esp_wpa.h          |  4 +-
+ components/wpa_supplicant/src/eap_peer/eap.h  | 42 +++++++++----------
+ 2 files changed, 23 insertions(+), 23 deletions(-)
 
 diff --git a/components/wpa_supplicant/esp_supplicant/include/esp_wpa.h b/components/wpa_supplicant/esp_supplicant/include/esp_wpa.h
-index f448b737c7..cdfd7abcd4 100644
+index f448b737..cdfd7abc 100644
 --- a/components/wpa_supplicant/esp_supplicant/include/esp_wpa.h
 +++ b/components/wpa_supplicant/esp_supplicant/include/esp_wpa.h
 @@ -42,9 +42,9 @@ extern "C" {
@@ -27,10 +28,10 @@ index f448b737c7..cdfd7abcd4 100644
  /**
    * @brief     Supplicant initialization
 diff --git a/components/wpa_supplicant/src/eap_peer/eap.h b/components/wpa_supplicant/src/eap_peer/eap.h
-index 9c488031ad..e664acc4c7 100644
+index f787e35d..90d1f845 100644
 --- a/components/wpa_supplicant/src/eap_peer/eap.h
 +++ b/components/wpa_supplicant/src/eap_peer/eap.h
-@@ -19,29 +19,29 @@ struct eap_method_type {
+@@ -19,33 +19,33 @@ struct eap_method_type {
  	EapType method;
  };
  
@@ -71,7 +72,14 @@ index 9c488031ad..e664acc4c7 100644
 +extern int g_wpa_new_password_len;
  
 -char *g_wpa_ttls_phase2_type;
+-char *g_wpa_phase1_options;
 +extern char *g_wpa_ttls_phase2_type;
++extern char *g_wpa_phase1_options;
+ 
+-u8 *g_wpa_pac_file;
+-int g_wpa_pac_file_len;
++extern u8 *g_wpa_pac_file;
++extern int g_wpa_pac_file_len;
  
 -bool g_wpa_suiteb_certification;
 +extern bool g_wpa_suiteb_certification;
@@ -79,5 +87,5 @@ index 9c488031ad..e664acc4c7 100644
  const u8 * eap_get_eapKeyData(struct eap_sm *sm, size_t *len);
  void eap_deinit_prev_method(struct eap_sm *sm, const char *txt);
 -- 
-2.17.1
+2.34.1
 

--- a/pkg/esp32_sdk/patches/0006-compilation-include-missing-header-files.patch
+++ b/pkg/esp32_sdk/patches/0006-compilation-include-missing-header-files.patch
@@ -1,7 +1,7 @@
-From 4e3d386bf242431a375c7dbac8661c7e1c8f31ed Mon Sep 17 00:00:00 2001
-From: Gunar Schorcht <gunar@schorcht.net>
-Date: Sun, 30 Jan 2022 08:16:15 +0100
-Subject: [PATCH 06/12] compilation: include missing header files
+From 0647c9d01c3e433d1b3abaf4774523ac0ef90a3c Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Thu, 2 Jun 2022 23:45:01 +0200
+Subject: [PATCH] compilation: include missing header files
 
 ---
  components/efuse/src/esp_efuse_api.c                 | 1 +
@@ -11,7 +11,7 @@ Subject: [PATCH 06/12] compilation: include missing header files
  4 files changed, 4 insertions(+)
 
 diff --git a/components/efuse/src/esp_efuse_api.c b/components/efuse/src/esp_efuse_api.c
-index a89205fc82..1b90deaf3d 100644
+index a89205fc..1b90deaf 100644
 --- a/components/efuse/src/esp_efuse_api.c
 +++ b/components/efuse/src/esp_efuse_api.c
 @@ -19,6 +19,7 @@ const static char *TAG = "efuse";
@@ -23,7 +23,7 @@ index a89205fc82..1b90deaf3d 100644
  static _lock_t s_efuse_lock;
  #define EFUSE_LOCK_ACQUIRE_RECURSIVE() _lock_acquire_recursive(&s_efuse_lock)
 diff --git a/components/esp_hw_support/regi2c_ctrl.c b/components/esp_hw_support/regi2c_ctrl.c
-index 4ffe67175f..0cb2f5e12f 100644
+index 6ce93cc5..a40b821e 100644
 --- a/components/esp_hw_support/regi2c_ctrl.c
 +++ b/components/esp_hw_support/regi2c_ctrl.c
 @@ -4,6 +4,7 @@
@@ -32,10 +32,10 @@ index 4ffe67175f..0cb2f5e12f 100644
  
 +#include "esp_attr.h"
  #include "regi2c_ctrl.h"
+ #include "esp_attr.h"
  #include <stdint.h>
- #include <freertos/FreeRTOS.h>
 diff --git a/components/esp_hw_support/sleep_modes.c b/components/esp_hw_support/sleep_modes.c
-index c192bf4d47..0728f1b92a 100644
+index f5a6b292..6f9fd2b1 100644
 --- a/components/esp_hw_support/sleep_modes.c
 +++ b/components/esp_hw_support/sleep_modes.c
 @@ -26,6 +26,7 @@
@@ -45,9 +45,9 @@ index c192bf4d47..0728f1b92a 100644
 +#include "soc/soc_memory_types.h"
  #include "soc/rtc.h"
  #include "soc/soc_caps.h"
- 
+ #include "regi2c_ctrl.h"
 diff --git a/components/nvs_flash/src/nvs_encrypted_partition.cpp b/components/nvs_flash/src/nvs_encrypted_partition.cpp
-index 26e8a3314d..4de077b94a 100644
+index 26e8a331..4de077b9 100644
 --- a/components/nvs_flash/src/nvs_encrypted_partition.cpp
 +++ b/components/nvs_flash/src/nvs_encrypted_partition.cpp
 @@ -13,6 +13,7 @@
@@ -59,5 +59,5 @@ index 26e8a3314d..4de077b94a 100644
  #include "nvs_types.hpp"
  
 -- 
-2.17.1
+2.34.1
 

--- a/pkg/esp32_sdk_lib_phy/Makefile
+++ b/pkg/esp32_sdk_lib_phy/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk_lib_phy
 PKG_URL=https://github.com/espressif/esp-phy-lib
-# This is a version in the v4.4 release branch
-PKG_VERSION=4779ddaaf29e1d6aa2d26980103a1c1bbaa29462
+# This is a version in the v4.4.1 release branch
+PKG_VERSION=dcbe6085e0215e2ea6a2e43b1106bdb15807f398
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/esp32_sdk_lib_wifi/Makefile
+++ b/pkg/esp32_sdk_lib_wifi/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=esp32_sdk_lib_wifi
 PKG_URL=https://github.com/espressif/esp32-wifi-lib
-# This is a version in the v4.4 release branch
-PKG_VERSION=cd7d14917f2c3d0ea4382f4a188cb290304faf47
+# This is a version in the v4.4.1 release branch
+PKG_VERSION=5a0d2aee49633b1a0c0374c2a01ed8c2a10e2fe4
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This updates the ESP-IDF package to the latest tagged version.
Only the [esp32-wifi-lib](https://github.com/espressif/esp32-wifi-lib) could not be updated to the latest version as the current RIOT drivers will crash after [c73ee33](https://github.com/espressif/esp32-wifi-lib/commit/c73ee337c334597378e79219c9f59525116437d2) - `Remove legacy system event framework(1948a1c7)`.


### Testing procedure

`examples/gnrc_border_router` still works with `esp_now` and `esp_wifi`.

```
2022-06-02 23:55:01,101 # main(): This is RIOT! (Version: 2022.07-devel-646-g95f8ce-pkg/esp32_sdk-4.4.1)
2022-06-02 23:55:01,105 # RIOT border router example application
2022-06-02 23:55:01,107 # All up, running the shell now

2022-06-02 23:57:14,345 # Iface  10  HWaddr: 3C:71:BF:9E:13:FC  Channel: 1  Link: up 
2022-06-02 23:57:14,349 #           L2-PDU:1500  MTU:1492  HL:255  RTR  
2022-06-02 23:57:14,352 #           Source address length: 6
2022-06-02 23:57:14,354 #           Link type: wireless
2022-06-02 23:57:14,360 #           inet6 addr: fe80::3e71:bfff:fe9e:13fc  scope: link  VAL
2022-06-02 23:57:14,367 #           inet6 addr: 2001:16b8:45eb:4800:3e71:bfff:fe9e:13fc  scope: global  VAL
2022-06-02 23:57:14,370 #           inet6 group: ff02::2
2022-06-02 23:57:14,373 #           inet6 group: ff02::1
2022-06-02 23:57:14,376 #           inet6 group: ff02::1:ff9e:13fc
2022-06-02 23:57:14,377 #           
2022-06-02 23:57:14,381 # Iface  9  HWaddr: 3E:71:BF:9E:13:FC  Channel: 1 
2022-06-02 23:57:14,385 #           L2-PDU:249  MTU:1280  HL:64  RTR  
2022-06-02 23:57:14,390 #           RTR_ADV  6LO  Source address length: 6
2022-06-02 23:57:14,392 #           Link type: wireless
2022-06-02 23:57:14,398 #           inet6 addr: fe80::3c71:bfff:fe9e:13fc  scope: link  VAL
2022-06-02 23:57:14,405 #           inet6 addr: 2001:16b8:45eb:48fc:3c71:bfff:fe9e:13fc  scope: global  VAL
2022-06-02 23:57:14,408 #           inet6 group: ff02::2
2022-06-02 23:57:14,410 #           inet6 group: ff02::1
2022-06-02 23:57:14,414 #           inet6 group: ff02::1:ff9e:13fc
2022-06-02 23:57:14,415 #           
> ping 2600::
2022-06-02 23:57:18,178 # ping 2600::
2022-06-02 23:57:18,401 # 12 bytes from 2600::: icmp_seq=0 ttl=53 time=217.642 ms
2022-06-02 23:57:19,418 # 12 bytes from 2600::: icmp_seq=1 ttl=53 time=234.909 ms
2022-06-02 23:57:20,341 # 12 bytes from 2600::: icmp_seq=2 ttl=53 time=158.359 ms
2022-06-02 23:57:20,342 # 
2022-06-02 23:57:20,344 # --- 2600:: PING statistics ---
2022-06-02 23:57:20,349 # 3 packets transmitted, 3 packets received, 0% packet loss
2022-06-02 23:57:20,354 # round-trip min/avg/max = 158.359/203.636/234.909 ms

2022-06-03 00:07:34,851 # ping ff02::1%9
2022-06-03 00:07:34,864 # 12 bytes from fe80::807d:3aff:fe7f:e01d%9: icmp_seq=0 ttl=64 time=7.463 ms
2022-06-03 00:07:35,866 # 12 bytes from fe80::807d:3aff:fe7f:e01d%9: icmp_seq=1 ttl=64 time=9.740 ms
2022-06-03 00:07:36,863 # 12 bytes from fe80::807d:3aff:fe7f:e01d%9: icmp_seq=2 ttl=64 time=6.814 ms
2022-06-03 00:07:36,863 # 
2022-06-03 00:07:36,866 # --- ff02::1%9 PING statistics ---
2022-06-03 00:07:36,871 # 3 packets transmitted, 3 packets received, 0% packet loss
2022-06-03 00:07:36,875 # round-trip min/avg/max = 6.814/8.005/9.740 ms


```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
