### PR TITLE
buid system: improve serial port selection

### DIFF
--- a/boards/common/cc26xx_cc13xx/Makefile.include
+++ b/boards/common/cc26xx_cc13xx/Makefile.include
@@ -4,5 +4,10 @@ PROGRAMMER ?= uniflash
 # uniflash and openocd programmers are supported
 PROGRAMMERS_SUPPORTED += openocd uniflash
 
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of XDS110 debuggers, which is the
+# embedded debugger of these launchpad boards.
+TTY_BOARD_FILTER := --model XDS110 --iface-num 0
+
 OPENOCD_CONFIG ?= $(RIOTBOARD)/common/cc26xx_cc13xx/dist/openocd.cfg
 UNIFLASH_CONFIG ?= $(RIOTBOARD)/common/cc26xx_cc13xx/dist

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -7,6 +7,10 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 # Setup of programmer and serial is shared between STM32 based boards
 include $(RIOTMAKE)/boards/stm32.inc.mk
 
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of embedded STLink debuggers.
+TTY_BOARD_FILTER := --model 'STM32 STLink'
+
 # variable needed by cpy2remed PROGRAMMER
 # it contains name of ST-Link removable media
 

--- a/boards/nrf52840dk/Makefile.include
+++ b/boards/nrf52840dk/Makefile.include
@@ -1,1 +1,5 @@
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of integrated J-Link debugger.
+TTY_BOARD_FILTER := --model J-Link
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/same54-xpro/Makefile.include
+++ b/boards/same54-xpro/Makefile.include
@@ -1,1 +1,6 @@
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of the embedded EDBG CMSIS-DAP
+# debugger.
+TTY_BOARD_FILTER := --model 'EDBG CMSIS-DAP'
+
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -1,1 +1,6 @@
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of the embedded EDBG CMSIS-DAP
+# debugger.
+TTY_BOARD_FILTER := --model 'EDBG CMSIS-DAP'
+
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/dist/tools/usb-serial/ttys.py
+++ b/dist/tools/usb-serial/ttys.py
@@ -52,16 +52,6 @@ def filters_match(filters, tty):
     return True
 
 
-def shorten(string, length):
-    """
-    Shorten the given string to the given length, if needed
-    """
-    if len(string) > length:
-        return string[:length - 3] + "..."
-
-    return string
-
-
 def parse_args(args):
     """
     Parse the given command line style arguments with argparse

--- a/dist/tools/usb-serial/ttys.py
+++ b/dist/tools/usb-serial/ttys.py
@@ -36,6 +36,7 @@ def tty2dict(dev):
     result["model_db"] = dev.get("ID_MODEL_FROM_DATABASE")
     result["vendor"] = unescape(dev.get("ID_VENDOR_ENC"))
     result["vendor_db"] = dev.get("ID_VENDOR_FROM_DATABASE")
+    result["iface_num"] = str(int(dev.get("ID_USB_INTERFACE_NUM")))
 
     return result
 
@@ -68,6 +69,7 @@ def parse_args(args):
         "model_db",
         "driver",
         "ctime",
+        "iface_num",
     }
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument("--most-recent", action="store_true",
@@ -93,6 +95,9 @@ def parse_args(args):
     parser.add_argument("--vendor-db", default=None, type=str,
                         help="Print only devices with a vendor matching this "
                              "regex (DB entry)")
+    parser.add_argument("--iface-num", default=None, type=str,
+                        help="Print only devices with a USB interface number "
+                             "matching this regex (DB entry)")
     parser.add_argument("--exclude-serial", type=str, nargs='*', default=None,
                         help="Ignore devices with these serial numbers. "
                              + "Environment variable EXCLUDE_TTY_SERIAL can "
@@ -155,7 +160,7 @@ def print_results(args, ttys):
             tty["ctime"] = time.strftime("%H:%M:%S",
                                          time.localtime(tty["ctime"]))
         headers = ["path", "driver", "vendor", "model", "model_db", "serial",
-                   "ctime"]
+                   "ctime", "iface_num"]
         print_table(ttys, headers)
         return
 
@@ -187,6 +192,9 @@ def generate_filters(args):
 
     if args.vendor_db is not None:
         result.append(("vendor_db", re.compile(args.vendor_db)))
+
+    if args.iface_num is not None:
+        result.append(("iface_num", re.compile(args.iface_num)))
 
     return result
 

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,6 +1,7 @@
 # Select the most recently attached tty interface
 ifeq (1,$(MOST_RECENT_PORT))
-  PORT ?= $(shell $(RIOTTOOLS)/usb-serial/ttys.py --most-recent --format path)
+  TTYS_FLAGS := --most-recent --format path $(TTY_BOARD_FILTER)
+  PORT ?= $(shell $(RIOTTOOLS)/usb-serial/ttys.py $(TTYS_FLAGS))
 endif
 # Otherwise, use as default the most commonly used ports on Linux and OSX
 PORT_LINUX ?= /dev/ttyACM0


### PR DESCRIPTION
### Contribution description

- extend `dist/tools/usb-serial/ttys.py` with a `--ifcae-num` parameter
    - the CC2650-Launchpad exposes two USB serials, but only one is the UART bridge. The USB iface number is the only stable difference between the two
- introduce `TTY_BOARD_FILTER` to let boards provide flags for `dist/tools/usb-serial/ttys.py` to filter only matching USB serials
    - if port selection via `MOST_RECENT_PORT=1` is enabled, this will fist apply the filter and select the most recent port of the matching USB serials (if more than one)
- provide `TTY_BOARD_FILTER` for a couple of boards
    - This will allow having a `same54-xpro`, `nrf52840dk`, `nucleo-f767zi`, and a `cc2650-launchpad` plugged in and `make BOARD=<foo> MOST_RECENT_PORT=1 term` will always pick the right USB serial
    - Beware: It cannot tell apart two Atmel/Microchip Xpro boards or two Nulceos or two boards with an embedded J-Link debugger though. So no panacea, but still can avoid manual lookup in many cases

### Testing procedure

Plug in a Nucleo, a `samr21-xpro` (or `same54-xpro`), a random Nucleo, a cc2650-launchpad, and a nRF52840DK. `make BOARD=<foo> MOST_RECENT_PORT=1 term` should always pick the right board, no matter which order the boards were plugged in.

(I tested this successfully :))

### Issues/PRs references

None