### PR TITLE
boards/common/{nrf52,cc26xx_cc13xx}: improve default programmer selection

### DIFF
--- a/boards/common/cc26xx_cc13xx/Makefile.include
+++ b/boards/common/cc26xx_cc13xx/Makefile.include
@@ -1,5 +1,9 @@
 # configure the flash tool
-PROGRAMMER ?= uniflash
+ifneq (,$(UNIFLASH_PATH))
+  PROGRAMMER ?= uniflash
+else
+  PROGRAMMER ?= openocd
+endif
 
 # uniflash and openocd programmers are supported
 PROGRAMMERS_SUPPORTED += openocd uniflash

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -8,7 +8,13 @@ ifeq (bmp,$(PROGRAMMER))
   PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
 endif
 
-PROGRAMMER ?= jlink
+# keep name of `JLINK` in sync with script jlink.sh in $(RIOTTOOLS)/jlink
+JLINK ?= JLinkExe
+ifneq (,$(command -v $(JLINK)))
+  PROGRAMMER ?= jlink
+else
+  PROGRAMMER ?= openocd
+endif
 # setup JLink for flashing
 JLINK_DEVICE = nrf52
 # setup OpenOCD for flashing. Version 0.10 of OpenOCD doesn't contain support


### PR DESCRIPTION
### Contribution description

For nRF52xxx and CC26xx and CC13xx MCUs J-Link and uniflash are currently chosen as default flashers, without checking if they are available. This adds a check and only picks them as default if they are available, falling back to OpenOCD when not. Behavior should remain unchanged for happy users of J-Link and uniflash, but life should be better for those who prefer to stick with OpenOCD.

### Testing procedure

`make flash` should now work out of the box when OpenOCD is installed but J-Link and uniflash are not, but should not change when there are available.

### Issues/PRs references

None