### PR TITLE
gnrc_netif: move msg_queue to gnrc_netif struct

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -133,6 +133,7 @@ typedef struct {
 #if IS_USED(MODULE_GNRC_NETIF_BUS) || DOXYGEN
     msg_bus_t bus[GNRC_NETIF_BUS_NUMOF];    /**< Event Message Bus */
 #endif
+    msg_t msg_queue[GNRC_NETIF_MSG_QUEUE_SIZE]; /**< netif thread msg queue */
     /**
      * @brief   Flags for the interface
      *

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1795,7 +1795,6 @@ static void *_gnrc_netif_thread(void *args)
     gnrc_netif_t *netif;
     int res;
     msg_t reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-    msg_t msg_queue[GNRC_NETIF_MSG_QUEUE_SIZE];
 
     DEBUG("gnrc_netif: starting thread %i\n", thread_getpid());
     netif = ctx->netif;
@@ -1807,7 +1806,7 @@ static void *_gnrc_netif_thread(void *args)
     event_queue_init(&netif->evq);
 
     /* setup the link-layer's message queue */
-    msg_init_queue(msg_queue, GNRC_NETIF_MSG_QUEUE_SIZE);
+    msg_init_queue(netif->msg_queue, ARRAY_SIZE(netif->msg_queue));
     /* initialize low-level driver */
     ctx->result = netif->ops->init(netif);
     /* signal that driver init is done */

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
@@ -29,22 +29,10 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifndef CC110X_EXTRA_STACKSIZE
-/**
- * @brief   Additional stack size required by the driver
- *
- * With increasing of GNRC_NETIF_MSG_QUEUE_SIZE the required stack size
- * increases as well. A queue size of 8 messages works with default stack size,
- * so we increase the stack by `sizeof(msg_t)` for each additional element
- */
-#define CC110X_EXTRA_STACKSIZE          ((GNRC_NETIF_MSG_QUEUE_SIZE - 8) * sizeof(msg_t))
-#endif
-
 /**
  * @brief   Calculate the stack size for the MAC layer thread(s)
  */
 #define CC110X_MAC_STACKSIZE            (THREAD_STACKSIZE_DEFAULT + \
-                                        CC110X_EXTRA_STACKSIZE + \
                                         DEBUG_EXTRA_STACKSIZE)
 #ifndef CC110X_MAC_PRIO
 /**

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
@@ -27,23 +27,10 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#ifndef NRF24L01P_NG_EXTRA_STACKSIZE
-/**
- * @brief   Additional stack size required by the driver
- *
- * With increasing of CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE the required stack size
- * increases as well. A queue size of 8 messages works with default stack size,
- * so we increase the stack by `sizeof(msg_t)` for each additional element
- */
-#define NRF24L01P_NG_EXTRA_STACKSIZE  ((GNRC_NETIF_MSG_QUEUE_SIZE - 8) \
-                                      * sizeof(msg_t))
-#endif
-
 /**
  * @brief   Calculate the stack size for the MAC layer thread(s)
  */
 #define NRF24L01P_NG_MAC_STACKSIZE          (THREAD_STACKSIZE_DEFAULT + \
-                                            NRF24L01P_NG_EXTRA_STACKSIZE + \
                                             DEBUG_EXTRA_STACKSIZE)
 #ifndef NRF24L01P_NG_MAC_PRIO
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Move the netif thread message queue to the gnrc_netif struct so we don't have to allocate it on the stack (and enlarge the stack when we use a larger queue).


### Testing procedure

Most drivers will now have more free stack space, cc110x and nrf24l01p_ng should stay roughly the same as they would handle this manually previously.


### Issues/PRs references

alternative to #17905