### PR TITLE
fuzzing: fix parameter for second fuzzing instance in README.md

### DIFF
--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -78,7 +78,7 @@ Parallel fuzzing is supported through `AFL_FLAGS`, e.g.:
 	AFL_FLAGS="-M fuzzer01" make -C fuzzing/gnrc_tcp/ fuzz
 
 	# Start second AFL instance in a different terminal
-	AFL_FLAGS="-M fuzzer02" make -C fuzzing/gnrc_tcp/ fuzz
+	AFL_FLAGS="-S fuzzer02" make -C fuzzing/gnrc_tcp/ fuzz
 
 [sanitizers github]: https://github.com/google/sanitizers
 [afl homepage]: http://lcamtuf.coredump.cx/afl/


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The [documentation](https://aflplus.plus/docs/parallel_fuzzing/#2-single-system-parallelization
) says

> Note that you must always have one -M main instance!
> Running multiple -M instances is wasteful!



### Testing procedure

Run

    make -C fuzzing/gcoap AFL_SKIP_CPUFREQ=1 AFL_FLAGS="-M fuzzer0" all fuzz

and

    make -C fuzzing/gcoap AFL_SKIP_CPUFREQ=1 AFL_FLAGS="-S fuzzer01" fuzz


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
