### PR TITLE
drivers/mtd: return early if init fails

### DIFF
--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -38,6 +38,9 @@ int mtd_init(mtd_dev_t *mtd)
 
     if (mtd->driver->init) {
         res = mtd->driver->init(mtd);
+        if (res < 0) {
+            return res;
+        }
     }
 
     /* Drivers preceding the introduction of write_size need to set it. While


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If init fails (e.g. because an SD card was not inserted) don't fail the `mtd->write_size != 0` assertion but instead return early.


### Testing procedure

Run `tests/mtd_raw` without an SD card on `same54-xpro`

#### master

```
2022-06-07 00:47:51,353 # Manual MTD test
2022-06-07 00:47:51,356 # init MTD_0… OK (8 MiB)
2022-06-07 00:47:51,360 # init MTD_1… OK (256 byte)
2022-06-07 00:47:51,362 # init MTD_2… 0xd5f
2022-06-07 00:47:51,364 # *** RIOT kernel panic:
2022-06-07 00:47:51,365 # FAILED ASSERTION.
2022-06-07 00:47:51,366 # 
2022-06-07 00:47:51,367 # *** halted.
2022-06-07 00:47:51,367 # 
2022-06-07 00:47:51,367 # 
2022-06-07 00:47:51,369 # Context before hardfault:
2022-06-07 00:47:51,371 #    r0: 0x0000000a
2022-06-07 00:47:51,372 #    r1: 0x00000000
2022-06-07 00:47:51,374 #    r2: 0xc0000000
2022-06-07 00:47:51,375 #    r3: 0x00000000
2022-06-07 00:47:51,377 #   r12: 0x00000001
2022-06-07 00:47:51,378 #    lr: 0x00000e01
2022-06-07 00:47:51,380 #    pc: 0x00001268
2022-06-07 00:47:51,381 #   psr: 0x01000000
2022-06-07 00:47:51,382 # 
2022-06-07 00:47:51,382 # FSR/FAR:
2022-06-07 00:47:51,384 #  CFSR: 0x00000000
2022-06-07 00:47:51,385 #  HFSR: 0x80000000
2022-06-07 00:47:51,387 #  DFSR: 0x00000002
2022-06-07 00:47:51,389 #  AFSR: 0x00000000
2022-06-07 00:47:51,389 # Misc
2022-06-07 00:47:51,391 # EXC_RET: 0xfffffffd
2022-06-07 00:47:51,393 # Active thread: 1 "main"
2022-06-07 00:47:51,397 # Attempting to reconstruct state for debugging...
2022-06-07 00:47:51,398 # In GDB:
2022-06-07 00:47:51,399 #   set $pc=0x1268
2022-06-07 00:47:51,400 #   frame 0
2022-06-07 00:47:51,401 #   bt
2022-06-07 00:47:51,401 # 
2022-06-07 00:47:51,405 # ISR stack overflowed by at least 16 bytes.
```

#### this PR

```
2022-06-07 00:46:16,010 # Manual MTD test
2022-06-07 00:46:16,013 # init MTD_0… OK (8 MiB)
2022-06-07 00:46:16,017 # init MTD_1… OK (256 byte)
2022-06-07 00:46:16,020 # init MTD_2… error: -5
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
