### PR TITLE
sys/ztimer: no log for stdio_rtt/semihosting

### DIFF
--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -49,6 +49,13 @@
 #include "ztimer/periph_rtc.h"
 #include "ztimer/config.h"
 
+/* both 'stdio_rtt' and 'stdio_semihosting' rely on ztimer for stdio output,
+   so not output is possible before 'ztimer' has been initiated, silence all
+   logs */
+#if IS_USED(MODULE_STDIO_RTT) || IS_USED(MODULE_STDIO_SEMIHOSTING)
+#undef LOG_LEVEL
+#define LOG_LEVEL   LOG_NONE
+#endif
 #include "log.h"
 
 #define WIDTH_TO_MAXVAL(width)  (UINT32_MAX >> (32 - width))


### PR DESCRIPTION
### Contribution description

Both modules use ztimer for stdio, so can't call stdio based functions before the module is initialized, spawn from #18116

### Testing procedure

If LOG_LEVEL > LOG_DEBUG there is no longer an assert when using `stdio_rtt` or `stdio_nimble`.

### Issues/PRs references
 
Fixes #18116
