### PR TITLE
boards/{nrf52dk,msba2}: provide TTY_BOARD_FILTER

### DIFF
--- a/boards/msba2/Makefile.include
+++ b/boards/msba2/Makefile.include
@@ -1,1 +1,7 @@
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of integrated J-Link debugger.
+# (Note: This is not a typo, maybe the MSB-430 FTDI chips were reused for the
+#  MSB-A2 or so?)
+TTY_BOARD_FILTER := --model MSB430A
+
 include $(RIOTBOARD)/common/msba2/Makefile.include

--- a/boards/nrf52dk/Makefile.include
+++ b/boards/nrf52dk/Makefile.include
@@ -1,1 +1,5 @@
+# If port selection via ttys.py is enabled by `MOST_RECENT_PORT=1`, filter
+# USB serials to only select the UART bridge of integrated J-Link debugger.
+TTY_BOARD_FILTER := --model J-Link
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include


### PR DESCRIPTION
### Contribution description

As trivial as the title says.

### Testing procedure

I used this for testing:

```diff
diff --git a/Makefile.include b/Makefile.include
index d8fd372480..9ca4948a17 100644
--- a/Makefile.include
+++ b/Makefile.include
@@ -876,8 +876,13 @@ cleanterm: $(TERMDEPS)
     $(call check_cmd,$(TERMPROG),Terminal program)
     $(TERMPROG) $(TERMFLAGS) $(TERMTEE)
 
+# Allow testing TTY_BOARD_FILTER by explicitly setting the board from command
+# line.
+ifeq ($(origin BOARD),command line)
+  LIST_TTYS_FILTER := $(TTY_BOARD_FILTER)
+endif
 list-ttys:
-    $(Q)$(RIOTTOOLS)/usb-serial/ttys.py
+    $(Q)$(RIOTTOOLS)/usb-serial/ttys.py $(LIST_TTYS_FILTER)
 
 doc:
     $(MAKE) -BC $(RIOTBASE) doc
```

The `make list-ttys BOARD=msba` only listed the MSB-A2 board, and same for the nRF52DK.

### Issues/PRs references

None