### PR TITLE
sys/shell/commands: add static qualifier where appropriate

### DIFF
--- a/sys/shell/commands/sc_app_metadata.c
+++ b/sys/shell/commands/sc_app_metadata.c
@@ -21,7 +21,7 @@
 #include "app_metadata.h"
 #include "shell.h"
 
-int _app_metadata_handler(int argc, char **argv)
+static int _app_metadata_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/sc_at30tse75x.c
+++ b/sys/shell/commands/sc_at30tse75x.c
@@ -31,7 +31,7 @@
 static bool initialized = false;
 static at30tse75x_t dev;
 
-int _at30tse75x_handler(int argc, char **argv)
+static int _at30tse75x_handler(int argc, char **argv)
 {
     if(argc <= 1) {
         printf("Usage: %s init|read|mode|resolution|save|restore|config\n", argv[0]);

--- a/sys/shell/commands/sc_benchmark_udp.c
+++ b/sys/shell/commands/sc_benchmark_udp.c
@@ -24,7 +24,7 @@
 static const char *bench_server = BENCH_SERVER_DEFAULT;
 static uint16_t bench_port = BENCH_PORT_DEFAULT;
 
-int _benchmark_udp_handler(int argc, char **argv)
+static int _benchmark_udp_handler(int argc, char **argv)
 {
     if (argc < 2) {
         goto usage;

--- a/sys/shell/commands/sc_blacklist.c
+++ b/sys/shell/commands/sc_blacklist.c
@@ -32,7 +32,7 @@ static void _usage(char *cmd)
     puts("         Print this.");
 }
 
-int _blacklist(int argc, char **argv)
+static int _blacklist(int argc, char **argv)
 {
     ipv6_addr_t addr;
     if (argc < 2) {

--- a/sys/shell/commands/sc_can.c
+++ b/sys/shell/commands/sc_can.c
@@ -162,7 +162,7 @@ static int _can_usage(void)
     return 0;
 }
 
-int _can_handler(int argc, char **argv)
+static int _can_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _can_usage();

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -41,7 +41,7 @@ static void _open_usage(void)
     puts("ccnl <interface>");
 }
 
-int _ccnl_open(int argc, char **argv)
+static int _ccnl_open(int argc, char **argv)
 {
     /* check if already running */
     if (ccnl_relay.ifcount >= CCNL_MAX_INTERFACES) {
@@ -84,7 +84,7 @@ static void _content_usage(char *argv)
             argv, argv);
 }
 
-int _ccnl_content(int argc, char **argv)
+static int _ccnl_content(int argc, char **argv)
 {
     if (argc < 2) {
         ccnl_cs_dump(&ccnl_relay);
@@ -202,7 +202,7 @@ static void _interest_usage(char *arg)
             arg, arg);
 }
 
-int _ccnl_interest(int argc, char **argv)
+static int _ccnl_interest(int argc, char **argv)
 {
     if (argc < 2) {
         _interest_usage(argv[0]);
@@ -241,7 +241,7 @@ static void _ccnl_fib_usage(char *argv)
             argv, argv, argv, argv, argv);
 }
 
-int _ccnl_fib(int argc, char **argv)
+static int _ccnl_fib(int argc, char **argv)
 {
     if (argc < 2) {
         ccnl_fib_show(&ccnl_relay);

--- a/sys/shell/commands/sc_cord_ep.c
+++ b/sys/shell/commands/sc_cord_ep.c
@@ -46,7 +46,7 @@ static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
     return 0;
 }
 
-int _cord_ep_handler(int argc, char **argv)
+static int _cord_ep_handler(int argc, char **argv)
 {
     int res;
 

--- a/sys/shell/commands/sc_cryptoauthlib.c
+++ b/sys/shell/commands/sc_cryptoauthlib.c
@@ -31,7 +31,7 @@ void get_bin(char *result, uint8_t byte)
     result[8] = '\0';
 }
 
-int _read_config(void)
+static int _read_config(void)
 {
     uint8_t data[ATCA_ECC_CONFIG_SIZE];
     uint8_t data_count = 0;
@@ -165,7 +165,7 @@ int _read_config(void)
     return 0;
 }
 
-int _check_lock_config(void)
+static int _check_lock_config(void)
 {
     bool is_locked = false;
     atcab_is_locked(LOCK_ZONE_CONFIG, &is_locked);
@@ -180,7 +180,7 @@ int _check_lock_config(void)
     return 0;
 }
 
-int _check_lock_data(void)
+static int _check_lock_data(void)
 {
     bool is_locked = false;
     atcab_is_locked(LOCK_ZONE_DATA, &is_locked);
@@ -195,7 +195,7 @@ int _check_lock_data(void)
     return 0;
 }
 
-int _lock_config(void)
+static int _lock_config(void)
 {
     bool is_locked = false;
     atcab_is_locked(LOCK_ZONE_CONFIG, &is_locked);
@@ -214,7 +214,7 @@ int _lock_config(void)
     return 0;
 }
 
-int _cryptoauth(int argc, char **argv)
+static int _cryptoauth(int argc, char **argv)
 {
     if (argc > 1) {
         if ((strcmp(argv[1], "read") == 0)) {

--- a/sys/shell/commands/sc_disk.c
+++ b/sys/shell/commands/sc_disk.c
@@ -45,7 +45,7 @@ static inline uint8_t sector_read(unsigned char *read_buf, unsigned long sector,
     return 0;
 }
 
-int _get_sectorsize(int argc, char **argv)
+static int _get_sectorsize(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
@@ -65,7 +65,7 @@ int _get_sectorsize(int argc, char **argv)
 
 SHELL_COMMAND(dget_ssize, "Get the sector size of inserted memory card", _get_sectorsize);
 
-int _get_blocksize(int argc, char **argv)
+static int _get_blocksize(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
@@ -85,7 +85,7 @@ int _get_blocksize(int argc, char **argv)
 
 SHELL_COMMAND(dget_bsize, "Get the block size of inserted memory card", _get_blocksize);
 
-int _get_sectorcount(int argc, char **argv)
+static int _get_sectorcount(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
@@ -105,7 +105,7 @@ int _get_sectorcount(int argc, char **argv)
 
 SHELL_COMMAND(dget_scount, "Get the sector count of inserted memory card", _get_sectorcount);
 
-int _read_sector(int argc, char **argv)
+static int _read_sector(int argc, char **argv)
 {
     if (argc == 2) {
         unsigned long scount;
@@ -132,7 +132,7 @@ int _read_sector(int argc, char **argv)
 
 SHELL_COMMAND(dread_sec, "Reads the specified sector of inserted memory card", _read_sector);
 
-int _read_bytes(int argc, char **argv)
+static int _read_bytes(int argc, char **argv)
 {
     unsigned long sector = 1, scount, offset;
     unsigned short ssize, length;

--- a/sys/shell/commands/sc_fib.c
+++ b/sys/shell/commands/sc_fib.c
@@ -129,7 +129,7 @@ static void _fib_add(const char *dest, const char *next, kernel_pid_t pid, uint3
                   nxt_size, nxt_flags, lifetime);
 }
 
-int _fib_route_handler(int argc, char **argv)
+static int _fib_route_handler(int argc, char **argv)
 {
     /* e.g. fibroute right now don't care about the address/protocol family */
     if (argc == 1) {

--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -49,7 +49,7 @@ static void _usage(char *cmd_str)
     puts("       reassigned after 5 min.");
 }
 
-int _gnrc_6ctx_list(void)
+static int _gnrc_6ctx_list(void)
 {
     puts("cid|prefix                                     |C|ltime");
     puts("-----------------------------------------------------------");
@@ -66,7 +66,7 @@ int _gnrc_6ctx_list(void)
     return 0;
 }
 
-int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_str)
+static int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_str)
 {
     ipv6_addr_t prefix;
     char *addr_str, *prefix_len_str, *save_ptr;
@@ -109,7 +109,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
     return 0;
 }
 
-int _gnrc_6ctx_del(char *cmd_str, char *ctx_str)
+static int _gnrc_6ctx_del(char *cmd_str, char *ctx_str)
 {
     gnrc_sixlowpan_ctx_t *ctx;
     unsigned cid = atoi(ctx_str);
@@ -143,7 +143,7 @@ int _gnrc_6ctx_del(char *cmd_str, char *ctx_str)
     return 0;
 }
 
-int _gnrc_6ctx(int argc, char **argv)
+static int _gnrc_6ctx(int argc, char **argv)
 {
     if (argc < 2) {
         _gnrc_6ctx_list();

--- a/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
+++ b/sys/shell/commands/sc_gnrc_6lo_frag_stats.c
@@ -21,7 +21,7 @@
 #include "net/gnrc/sixlowpan/frag/sfr.h"
 #endif
 
-int _gnrc_6lo_frag_stats(int argc, char **argv)
+static int _gnrc_6lo_frag_stats(int argc, char **argv)
 {
     gnrc_sixlowpan_frag_stats_t *stats = gnrc_sixlowpan_frag_stats_get();
 

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -85,7 +85,7 @@ static void _print_reply(_ping_data_t *data, gnrc_pktsnip_t *icmpv6, uint32_t no
 static void _handle_reply(_ping_data_t *data, gnrc_pktsnip_t *pkt, uint32_t now_us);
 static int _finish(_ping_data_t *data);
 
-int _gnrc_icmpv6_ping(int argc, char **argv)
+static int _gnrc_icmpv6_ping(int argc, char **argv)
 {
     _ping_data_t data = {
         .netreg = GNRC_NETREG_ENTRY_INIT_PID(ICMPV6_ECHO_REP,

--- a/sys/shell/commands/sc_gnrc_ipv6_frag_stats.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_frag_stats.c
@@ -18,7 +18,7 @@
 #include "net/gnrc/ipv6/ext/frag.h"
 #include "shell.h"
 
-int _gnrc_ipv6_frag_stats(int argc, char **argv)
+static int _gnrc_ipv6_frag_stats(int argc, char **argv)
 {
     (void)argc;
     (void)argv;

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -30,6 +30,8 @@ static int _nib_route(int argc, char **argv);
 static int _nib_abr(int argc, char **argv);
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C */
 
+/* TODO: updated tests/gnrc_dhcpv6_client to no longer abuse this shell command
+ * and add static qualifier */
 int _gnrc_ipv6_nib(int argc, char **argv)
 {
     int res = 1;

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1725,7 +1725,7 @@ static int _netif_del(netif_t *iface, char *addr_str)
 
 /* shell commands */
 #ifdef MODULE_GNRC_TXTSND
-int _gnrc_netif_send(int argc, char **argv)
+static int _gnrc_netif_send(int argc, char **argv)
 {
     netif_t *iface;
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
@@ -1786,6 +1786,8 @@ int _gnrc_netif_send(int argc, char **argv)
 SHELL_COMMAND(txtsnd, "Sends a custom string as is over the link layer", _gnrc_netif_send);
 #endif
 
+/* TODO: updated tests/gnrc_dhcpv6_client to no longer abuse this shell command
+ * and add static qualifier */
 int _gnrc_netif_config(int argc, char **argv)
 {
     if (argc < 2) {

--- a/sys/shell/commands/sc_gnrc_pktbuf.c
+++ b/sys/shell/commands/sc_gnrc_pktbuf.c
@@ -16,7 +16,7 @@
 #include "net/gnrc/pktbuf.h"
 #include "shell.h"
 
-int _gnrc_pktbuf_cmd(int argc, char **argv)
+static int _gnrc_pktbuf_cmd(int argc, char **argv)
 {
     (void)argc;
     (void)argv;

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -363,7 +363,7 @@ int _gnrc_rpl_set_pio(char *inst_id, bool status)
     return 0;
 }
 
-int _gnrc_rpl(int argc, char **argv)
+static int _gnrc_rpl(int argc, char **argv)
 {
     if ((argc < 2) || (strcmp(argv[1], "show") == 0)) {
         return _gnrc_rpl_dodag_show();

--- a/sys/shell/commands/sc_gnrc_udp.c
+++ b/sys/shell/commands/sc_gnrc_udp.c
@@ -155,7 +155,7 @@ static void _stop_server(void)
     puts("Success: stopped UDP server");
 }
 
-int _gnrc_udp_cmd(int argc, char **argv)
+static int _gnrc_udp_cmd(int argc, char **argv)
 {
     if (argc < 2) {
         printf("usage: %s [send|server]\n", argv[0]);

--- a/sys/shell/commands/sc_heap.c
+++ b/sys/shell/commands/sc_heap.c
@@ -27,7 +27,7 @@ extern void heap_stats(void);
 #include <stdio.h>
 #endif
 
-int _heap_handler(int argc, char **argv)
+static int _heap_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/sc_i2c_scan.c
+++ b/sys/shell/commands/sc_i2c_scan.c
@@ -52,7 +52,7 @@ static inline int is_addr_reserved(uint16_t addr)
     return 0;
 }
 
-int _i2c_scan(int argc, char **argv)
+static int _i2c_scan(int argc, char **argv)
 {
     i2c_t dev;
     if (get_dev(&dev, argc, argv)) {

--- a/sys/shell/commands/sc_loramac.c
+++ b/sys/shell/commands/sc_loramac.c
@@ -66,7 +66,7 @@ static void _loramac_get_usage(void)
          "class|dr|adr|public|netid|tx_power|rx2_freq|rx2_dr|ul_cnt|ch_mask>");
 }
 
-int _loramac_handler(int argc, char **argv)
+static int _loramac_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _loramac_usage();

--- a/sys/shell/commands/sc_lwip_netif.c
+++ b/sys/shell/commands/sc_lwip_netif.c
@@ -82,7 +82,7 @@ static void _netif_list(struct netif *netif) {
 #endif
 }
 
-int _lwip_netif_config(int argc, char **argv)
+static int _lwip_netif_config(int argc, char **argv)
 {
     if (argc < 2) {
         /* List in interface order, which is normally reverse of list order */

--- a/sys/shell/commands/sc_nanocoap_vfs.c
+++ b/sys/shell/commands/sc_nanocoap_vfs.c
@@ -88,7 +88,7 @@ static int _print_dir(const char *url, char *buf, size_t len)
                                       _print_dir_cb, &ctx);
 }
 
-int _nanocoap_get_handler(int argc, char **argv)
+static int _nanocoap_get_handler(int argc, char **argv)
 {
     int res;
     char buffer[CONFIG_NANOCOAP_QS_MAX];

--- a/sys/shell/commands/sc_netstats_nb.c
+++ b/sys/shell/commands/sc_netstats_nb.c
@@ -89,7 +89,7 @@ static void _print_neighbors(netif_t *dev)
     }
 }
 
-int _netstats_nb(int argc, char **argv)
+static int _netstats_nb(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/sc_nice.c
+++ b/sys/shell/commands/sc_nice.c
@@ -27,7 +27,7 @@
 #include "shell.h"
 #include "thread.h"
 
-int _sc_nice(int argc, char **argv)
+static int _sc_nice(int argc, char **argv)
 {
     if (argc != 3) {
         printf("Usage: %s <THREAD_ID> <PRIORITY>\n"

--- a/sys/shell/commands/sc_nimble_netif.c
+++ b/sys/shell/commands/sc_nimble_netif.c
@@ -515,7 +515,7 @@ void sc_nimble_netif_init(void)
 #endif
 }
 
-int _nimble_netif_handler(int argc, char **argv)
+static int _nimble_netif_handler(int argc, char **argv)
 {
     if ((argc == 1) || _ishelp(argv[1])) {
 #if FULL_CONTROL

--- a/sys/shell/commands/sc_nimble_statconn.c
+++ b/sys/shell/commands/sc_nimble_statconn.c
@@ -45,7 +45,7 @@ static uint8_t _parsephy(const char *phy_str)
     }
 }
 
-int _nimble_statconn_handler(int argc, char **argv)
+static int _nimble_statconn_handler(int argc, char **argv)
 {
     nimble_statconn_cfg_t cfg;
 

--- a/sys/shell/commands/sc_openwsn.c
+++ b/sys/shell/commands/sc_openwsn.c
@@ -93,7 +93,7 @@ static char *_get_component(int id)
     return NULL;
 }
 
-int _openwsn_ifconfig(int argc, char **argv)
+static int _openwsn_ifconfig(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -572,7 +572,7 @@ static void _print_usage(void)
 #endif
 }
 
-int _openwsn_handler(int argc, char **argv)
+static int _openwsn_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _print_usage();

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -149,7 +149,7 @@ static int cmd_off(char *arg)
     return 0;
 }
 
-int _pm_handler(int argc, char **argv)
+static int _pm_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _print_usage();

--- a/sys/shell/commands/sc_ps.c
+++ b/sys/shell/commands/sc_ps.c
@@ -21,7 +21,7 @@
 #include "ps.h"
 #include "shell.h"
 
-int _ps_handler(int argc, char **argv)
+static int _ps_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/sc_random.c
+++ b/sys/shell/commands/sc_random.c
@@ -31,7 +31,7 @@
 #include "xtimer.h"
 #endif
 
-int _random_init(int argc, char **argv)
+static int _random_init(int argc, char **argv)
 {
     int initval;
 
@@ -58,7 +58,7 @@ int _random_init(int argc, char **argv)
 
 SHELL_COMMAND(random_init, "initializes the PRNG", _random_init);
 
-int _random_get(int argc, char **argv)
+static int _random_get(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -149,7 +149,7 @@ static int _rtc_usage(void)
     return 0;
 }
 
-int _rtc_handler(int argc, char **argv)
+static int _rtc_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _rtc_usage();

--- a/sys/shell/commands/sc_rtt.c
+++ b/sys/shell/commands/sc_rtt.c
@@ -150,7 +150,7 @@ static int _rtt_cmd_usage(void)
     return 0;
 }
 
-int _rtt_handler(int argc, char **argv)
+static int _rtt_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _rtt_cmd_usage();

--- a/sys/shell/commands/sc_saul_reg.c
+++ b/sys/shell/commands/sc_saul_reg.c
@@ -145,7 +145,7 @@ static void write(int argc, char **argv)
     printf("data successfully written to device #%i\n", num);
 }
 
-int _saul(int argc, char **argv)
+static int _saul(int argc, char **argv)
 {
     if (argc < 2) {
         list();

--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -93,7 +93,7 @@ static int read_sensor(int16_t *temp, int16_t *hum, int argc, char **argv)
     return 0;
 }
 
-int _get_humidity_handler(int argc, char **argv)
+static int _get_humidity_handler(int argc, char **argv)
 {
     int16_t hum;
 
@@ -107,7 +107,7 @@ int _get_humidity_handler(int argc, char **argv)
 
 SHELL_COMMAND(hum, "Prints measured humidity.", _get_humidity_handler);
 
-int _get_temperature_handler(int argc, char **argv)
+static int _get_temperature_handler(int argc, char **argv)
 {
     int16_t temp;
 
@@ -121,7 +121,7 @@ int _get_temperature_handler(int argc, char **argv)
 
 SHELL_COMMAND(temp, "Prints measured temperature.", _get_temperature_handler);
 
-int _get_weather_handler(int argc, char **argv)
+static int _get_weather_handler(int argc, char **argv)
 {
     int16_t hum;
     int16_t temp;
@@ -175,7 +175,7 @@ static void invalid_argument(int index, char **argv, const char *valid)
            argv[index + 1], argv[index], valid, argv[0]);
 }
 
-int _sht_config_handler(int argc, char **argv)
+static int _sht_config_handler(int argc, char **argv)
 {
     uint8_t set_conf = 0;
     uint8_t unset_conf = 0;

--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -37,7 +37,7 @@ static void _usage(char *cmd)
     printf("default: timeout = %lu\n", _DEFAULT_TIMEOUT);
 }
 
-int _ntpdate(int argc, char **argv)
+static int _ntpdate(int argc, char **argv)
 {
     uint32_t timeout = _DEFAULT_TIMEOUT;
 

--- a/sys/shell/commands/sc_suit.c
+++ b/sys/shell/commands/sc_suit.c
@@ -32,7 +32,7 @@ static void _print_usage(char **argv)
     printf("       %s seq_no\n", argv[0]);
 }
 
-int _suit_handler(int argc, char **argv)
+static int _suit_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _print_usage(argv);

--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -27,7 +27,7 @@
 #include "usb_board_reset.h"
 #endif
 
-int _reboot_handler(int argc, char **argv)
+static int _reboot_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
@@ -40,7 +40,7 @@ int _reboot_handler(int argc, char **argv)
 SHELL_COMMAND(reboot, "Reboot the node", _reboot_handler);
 
 #ifdef MODULE_USB_BOARD_RESET
-int _bootloader_handler(int argc, char **argv)
+static int _bootloader_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
@@ -53,7 +53,7 @@ int _bootloader_handler(int argc, char **argv)
 SHELL_COMMAND(bootloader, "Reboot to bootloader", _bootloader_handler);
 #endif
 
-int _version_handler(int argc, char **argv)
+static int _version_handler(int argc, char **argv)
 {
     (void) argc;
     (void) argv;

--- a/sys/shell/commands/sc_vfs.c
+++ b/sys/shell/commands/sc_vfs.c
@@ -590,7 +590,7 @@ static int _mkdir_handler(int argc, char **argv)
     return 0;
 }
 
-int _ls_handler(int argc, char **argv)
+static int _ls_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _ls_usage(argv);
@@ -662,7 +662,7 @@ int _ls_handler(int argc, char **argv)
 
 SHELL_COMMAND(ls, "list files", _ls_handler);
 
-int _vfs_handler(int argc, char **argv)
+static int _vfs_handler(int argc, char **argv)
 {
     if (argc < 2) {
         _vfs_usage(argv);
@@ -720,7 +720,7 @@ static inline void _print_digest(const uint8_t *digest, size_t len, const char *
 
 #if MODULE_MD5SUM
 #include "hashes/md5.h"
-int _vfs_md5sum_cmd(int argc, char **argv)
+static int _vfs_md5sum_cmd(int argc, char **argv)
 {
     int res;
     uint8_t digest[MD5_DIGEST_LENGTH];
@@ -749,7 +749,7 @@ SHELL_COMMAND(md5sum, "Compute and check MD5 message digest", _vfs_md5sum_cmd);
 
 #if MODULE_SHA1SUM
 #include "hashes/sha1.h"
-int _vfs_sha1sum_cmd(int argc, char **argv)
+static int _vfs_sha1sum_cmd(int argc, char **argv)
 {
     int res;
     uint8_t digest[SHA1_DIGEST_LENGTH];
@@ -778,7 +778,7 @@ SHELL_COMMAND(sha1sum, "Compute and check SHA1 message digest", _vfs_sha1sum_cmd
 
 #if MODULE_SHA256SUM
 #include "hashes/sha256.h"
-int _vfs_sha256sum_cmd(int argc, char **argv)
+static int _vfs_sha256sum_cmd(int argc, char **argv)
 {
     int res;
     uint8_t digest[SHA256_DIGEST_LENGTH];

--- a/sys/shell/commands/sc_whitelist.c
+++ b/sys/shell/commands/sc_whitelist.c
@@ -31,7 +31,7 @@ static void _usage(char *cmd)
     puts("         Print this.");
 }
 
-int _whitelist(int argc, char **argv)
+static int _whitelist(int argc, char **argv)
 {
     ipv6_addr_t addr;
     if (argc < 2) {

--- a/tests/memarray/main.c
+++ b/tests/memarray/main.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include "memarray.h"
+#include "ps.h"
 
 #define MESSAGE_SIZE         (8U)
 
@@ -38,8 +39,6 @@
 #ifndef NUMBER_OF_LOOPS
 #define NUMBER_OF_LOOPS      (1)
 #endif
-
-extern int _ps_handler(int argc, char **argv);
 
 struct block_t {
     struct node *next;
@@ -114,7 +113,7 @@ int main(void)
     int loop = 0;
 
     printf("Starting (%d, %u)\n", MAX_NUMBER_BLOCKS, MESSAGE_SIZE);
-    _ps_handler(0, NULL);
+    ps();
 
     printf("LOOP #%i:\n", loop + 1);
     while (count <  NUMBER_OF_TESTS) {
@@ -184,7 +183,7 @@ int main(void)
            res, (unsigned)memarray_available(&block_storage));
 
     printf("Finishing\n");
-    _ps_handler(0, NULL);
+    ps();
 
     return 0;
 }

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -34,8 +34,6 @@
 #include "pm_layered.h"
 #endif
 
-extern int _pm_handler(int argc, char **argv);
-
 #include "shell.h"
 
 #ifndef BTN0_INT_FLANK
@@ -172,6 +170,23 @@ static const shell_command_t shell_commands[] = {
     { NULL, NULL, NULL }
 };
 
+#if IS_USED(MODULE_PM_LAYERED)
+static void _show_blockers(void)
+{
+    uint8_t lowest_allowed_mode = 0;
+
+    pm_blocker_t pm_blocker = pm_get_blocker();
+    for (unsigned i = 0; i < PM_NUM_MODES; i++) {
+        printf("mode %u blockers: %u \n", i, pm_blocker.blockers[i]);
+        if (pm_blocker.blockers[i]) {
+            lowest_allowed_mode = i + 1;
+        }
+    }
+
+    printf("Lowest allowed mode: %u\n", lowest_allowed_mode);
+}
+#endif /* MODULE_PM_LAYERED */
+
 /**
  * @brief   Application entry point.
  */
@@ -191,8 +206,7 @@ int main(void)
      * the state of PM blockers so that the user will know which power mode has
      * been entered and is presumably responsible for the unresponsive shell.
      */
-    _pm_handler(2, (char *[]){"pm", "show"});
-
+    _show_blockers();
 #else
     puts("This application allows you to test the CPU power management.\n"
          "Layered support is not unavailable for this CPU. Reset the CPU if\n"


### PR DESCRIPTION
### Contribution description

Due to the conversion to XFA based `SHELL_COMMAND()` much fewer function need to expose a symbol. Hence, spray `static` all over the place.


### Testing procedure

One could search for missing `static` using this regex:

```
$ rg '^[ \t]*int[ \t]*[a-zA-Z0-9_]*[ \t]*\([ \t]*int[ \t]*[a-zA-Z0-9_]*[ \t]*,[ \t]*char[ \t*]*[a-zA-Z0-9_]*[ \t]*\)'
```

Murdock will check that I didn't add a `static` where it shouldn't be.

### Issues/PRs references

Follow up to https://github.com/RIOT-OS/RIOT/pull/18152
