### PR TITLE
cpu/sam0_common: uart: loop over DR as long as RXC is set

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -508,7 +508,7 @@ static inline void irq_handler(unsigned uartnum)
 {
     uint32_t status = dev(uartnum)->INTFLAG.reg;
     /* TXC is used by uart_write() */
-    dev(uartnum)->INTFLAG.reg = status & ~SERCOM_USART_INTFLAG_TXC;
+    dev(uartnum)->INTFLAG.reg = status & ~(SERCOM_USART_INTFLAG_TXC | SERCOM_USART_INTFLAG_RXC);
 
 #if !defined(UART_HAS_TX_ISR) && defined(MODULE_PERIPH_UART_NONBLOCKING)
     if ((status & SERCOM_USART_INTFLAG_DRE) && dev(uartnum)->INTENSET.bit.DRE) {
@@ -522,7 +522,7 @@ static inline void irq_handler(unsigned uartnum)
     }
 #endif
 
-    if (status & SERCOM_USART_INTFLAG_RXC) {
+    while (dev(uartnum)->INTFLAG.reg & SERCOM_USART_INTFLAG_RXC) {
         /* interrupt flag is cleared by reading the data register */
         uart_ctx[uartnum].rx_cb(uart_ctx[uartnum].arg,
                                 (uint8_t)(dev(uartnum)->DATA.reg));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When using SLIP and DOSE on routing nodes, I would often see very long routing delays:

```
2022-06-08 19:15:52,658 - INFO # > ping -i 2000 fd11:a000::e858:4ed2:564e:215b
2022-06-08 19:15:52,658 - INFO # 
2022-06-08 19:15:54,667 - INFO # 12 bytes from fd11:a000::e858:4ed2:564e:215b: icmp_seq=0 ttl=64 time=2001.958 ms
2022-06-08 19:15:56,667 - INFO # 12 bytes from fd11:a000::e858:4ed2:564e:215b: icmp_seq=1 ttl=64 time=2001.959 ms
2022-06-08 19:15:59,658 - INFO # 
2022-06-08 19:15:59,662 - INFO # --- fd11:a000::e858:4ed2:564e:215b PING statistics ---
2022-06-08 19:15:59,667 - INFO # 3 packets transmitted, 2 packets received, 33% packet loss
2022-06-08 19:15:59,672 - INFO # round-trip min/avg/max = 2001.958/2001.958/2001.959 ms
```

I suspected that some byte(s) might be stuck in the RX fifo as the extra time is very close to the interval between (in this case) two ping requests - and changes if I change the interval.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
