### PR TITLE
sys/net: fix output of ipv6_addrs_print()

### DIFF
--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "fmt.h"
 #include "kernel_defines.h"
 #include "net/ipv6/addr.h"
 
@@ -145,12 +144,7 @@ void ipv6_addr_print(const ipv6_addr_t *addr)
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
     ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
 
-    if (IS_USED(MODULE_FMT)) {
-        print_str(addr_str);
-    }
-    else {
-        printf("%s", addr_str);
-    }
+    printf("%s", addr_str);
 }
 
 void ipv6_addrs_print(const ipv6_addr_t *addrs, size_t num,
@@ -160,26 +154,10 @@ void ipv6_addrs_print(const ipv6_addr_t *addrs, size_t num,
         return;
     }
 
-    num--;
     char buf[IPV6_ADDR_MAX_STR_LEN];
     for (size_t idx = 0; idx < (size_t)num; idx++) {
         ipv6_addr_to_str(buf, &addrs[idx], sizeof(buf));
-        if (IS_USED(MODULE_FMT)) {
-            print_str(buf);
-            print_str(separator);
-        }
-        else {
-            printf("%s%s", buf, separator);
-        }
-    }
-
-    ipv6_addr_to_str(buf, &addrs[num], sizeof(buf));
-    if (IS_USED(MODULE_FMT)) {
-        print_str(buf);
-        print_str(separator);
-    }
-    else {
-        printf("%s%s", buf, separator);
+        printf("%s%s", buf, idx + 1 == num ? "" : separator);
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Output of `ipv6_addrs_print()` is broken when the `fmt` module is used.
There is also a duplication, so the output without `fmt` will be

```
{"IPv6 addresses": ["fe80::7837:fcff:fe7d:1aaf", ""]}
```

Just get rid of the `fmt` fallback and simplify the code.

### Testing procedure

Run e.g. `examples/telnet_server`:

#### master

```
main(): This is RIOT! (Version: 2022.07-devel-726-g8e1f9)
RIOT telnet example application
╔═══════════════════════════════════════════════════╗
║telnet is entirely unencrypted and unauthenticated.║
║Do not use this on public networks.                ║
╚═══════════════════════════════════════════════════╝
{"IPv6 addresses": [""]}
All up, awaiting connection on port 23
```

#### this patch

```
main(): This is RIOT! (Version: 2022.07-devel-726-g8e1f9)
RIOT telnet example application
╔═══════════════════════════════════════════════════╗
║telnet is entirely unencrypted and unauthenticated.║
║Do not use this on public networks.                ║
╚═══════════════════════════════════════════════════╝
{"IPv6 addresses": ["fe80::7837:fcff:fe7d:1aaf"]}
All up, awaiting connection on port 23
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
