### PR TITLE
boards/samd20-xpro: add definition for UART on EXT2

### DIFF
--- a/boards/samd20-xpro/include/periph_conf.h
+++ b/boards/samd20-xpro/include/periph_conf.h
@@ -164,11 +164,26 @@ static const uart_conf_t uart_config[] = {
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_MAIN,
     },
+    {    /* EXT2 */
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PA,9),
+        .tx_pin   = GPIO_PIN(PA,8),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
 };
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom3
 #define UART_1_ISR          isr_sercom4
+#define UART_2_ISR          isr_sercom0
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -4834,6 +4834,7 @@ boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_1_ISR \
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member TIMER_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_0_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_1_ISR \(macro definition\) of file periph_conf\.h is not documented\.
+boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_2_ISR \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member UART_NUMOF \(macro definition\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member adc_channels\[\] \(variable\) of file periph_conf\.h is not documented\.
 boards/samd20\-xpro/include/periph_conf\.h:[0-9]+: warning: Member i2c_config\[\] \(variable\) of file periph_conf\.h is not documented\.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We can't use PB13/PB12 which would be the 'standard' UART pins on the -xpro EXT connectors since only SERCOM4 can map to those - and that's already used on EXT1.

So use the adjacent PA08/PA09 with SERCOM0.


### Testing procedure

Run `tests/periph_uart` with the UART pins connected

```
2022-06-09 13:10:58,792 - INFO # Manual UART driver test application
2022-06-09 13:10:58,795 - INFO # ===================================
2022-06-09 13:10:58,800 - INFO # This application is intended for testing additional UART
2022-06-09 13:10:58,806 - INFO # interfaces, that might be defined for a board. The 'primary' UART
2022-06-09 13:10:58,811 - INFO # interface is tested implicitly, as it is running the shell...
2022-06-09 13:10:58,811 - INFO # 
2022-06-09 13:10:58,817 - INFO # When receiving data on one of the additional UART interfaces, this
2022-06-09 13:10:58,823 - INFO # data will be outputted via STDIO. So the easiest way to test an 
2022-06-09 13:10:58,829 - INFO # UART interface, is to simply connect the RX with the TX pin. Then 
2022-06-09 13:10:58,835 - INFO # you can send data on that interface and you should see the data 
2022-06-09 13:10:58,837 - INFO # being printed to STDOUT
2022-06-09 13:10:58,837 - INFO # 
2022-06-09 13:10:58,841 - INFO # NOTE: all strings need to be '\n' terminated!
2022-06-09 13:10:58,841 - INFO # 
2022-06-09 13:10:59,098 - INFO # UARD_DEV(0): test uart_poweron() and uart_poweroff()  ->  [OK]
2022-06-09 13:10:59,099 - INFO # 
2022-06-09 13:10:59,100 - INFO # UART INFO:
2022-06-09 13:10:59,103 - INFO # Available devices:               3
2022-06-09 13:10:59,107 - INFO # UART used for STDIO (the shell): UART_DEV(0)

2022-06-09 13:11:18,024 - INFO # > test 2
2022-06-09 13:11:18,024 - INFO # 
2022-06-09 13:11:18,024 - INFO # [START]
2022-06-09 13:11:18,104 - INFO # [SUCCESS]
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
