### PR TITLE
sys/fmt: fix output on native

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -508,22 +508,16 @@ uint32_t scn_u32_hex(const char *str, size_t n)
 
 void print(const char *s, size_t n)
 {
+    if (IS_USED(MODULE_STDIO_NATIVE)) {
+        /* native gets special treatment as native's stdio code is ...
+         * special */
+        printf("%.*s", (int)n, s);
+        return;
+    }
+
     while (n > 0) {
         ssize_t written;
-        if (IS_USED(MODULE_STDIO_NATIVE)) {
-            /* for native fwrite is not wrapped and would use the system's
-             * write directly, resulting in corrupted output. Instead, use the
-             * stdio_write wrapper directly here to force all output from
-             * puts() / printf() and fmt to be handled the same. */
-            extern ssize_t stdio_write(const void* buffer, size_t len);
-            written = stdio_write(s, n);
-        }
-        else {
-            /* For all but native: Use fwrite rather than the cheaper unbuffered
-             * write() to avoid corrupted output when mixing stdio and fmt
-             * for C libs that use buffered output */
-            written = fwrite(s, 1, n, stdout);
-        }
+        written = fwrite(s, 1, n, stdout);
         if (written < 0) {
             break;
         }

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -176,10 +176,9 @@ void ipv6_addrs_print(const ipv6_addr_t *addrs, size_t num,
     ipv6_addr_to_str(buf, &addrs[num], sizeof(buf));
     if (IS_USED(MODULE_FMT)) {
         print_str(buf);
-        print_str(separator);
     }
     else {
-        printf("%s%s", buf, separator);
+        printf("%s", buf);
     }
 }
 

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -45,7 +45,11 @@ int main(void)
     print_str("\n");
     print_float(1.2345, 5);
     print_str("\n");
-    printf("%s", "Test ");
+    /* test mixing of printf() and fmt's print() works fine */
+    printf("%s", "Test");
+    /* test fmt's print indeed only honors the length parameter and doesn't
+     * print until the terminated zero byte */
+    print(" not ", 1);
     print_str("successful.");
     puts("");
 


### PR DESCRIPTION
### Contribution description

As the title says (hopefully...). It works at least with `riot/riotbuild`, but it also did so before...

I also sneaked in a fix for `ipv6_addrs_print()` that is unrelated, but equally trivial.

### Testing procedure

E.g. `examples/telnet_server` should now print the IPv6 address.

### Issues/PRs references

Alternative to https://github.com/RIOT-OS/RIOT/pull/18183