### PR TITLE
cpu/samd21: handle NVM block errata

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -117,7 +117,14 @@ static void clk_init(void)
 
     /* adjust NVM wait states */
     PM->APBBMASK.reg |= PM_APBBMASK_NVMCTRL;
-    NVMCTRL->CTRLB.reg |= NVMCTRL_CTRLB_RWS(WAITSTATES);
+    NVMCTRL->CTRLB.reg = NVMCTRL_CTRLB_RWS(WAITSTATES)
+#ifdef CPU_SAMD20
+    /* errata: In Standby, Idle1 and Idle2 Sleep modes,
+               the device might not wake up from sleep. */
+                       | NVMCTRL_CTRLB_SLEEPPRM_DISABLED
+#endif
+    /* errata: Default value of MANW in NVM.CTRLB is 0. */
+                       | NVMCTRL_CTRLB_MANW;
     PM->APBBMASK.reg &= ~PM_APBBMASK_NVMCTRL;
 
 #if CLOCK_8MHZ


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - The `periph_flashpage` driver expects the manual write bit to be set
   This should be set by default, but the SAM D20/SAM D21 errata sheets
   correct that this is indeed *not* set by default, which may cause
   spurious writes.

 - SAM D20 may not wake up from any sleep mode if sleep power reduction
   is enabled for the NVM block.


### Testing procedure

`samd20-xpro` does no longer randomly hang with this patch.
As for the spurious writes, those should only happen when we write to the end of the flashpage (and not the bytes before that), this might not happen in practice.

`tests/periph_flashpage` still works

``` 
2022-06-09 18:33:48,513 - INFO # ROM flash read write test
2022-06-09 18:33:48,513 - INFO # 
2022-06-09 18:33:48,517 - INFO # Please refer to the README.md for further information
2022-06-09 18:33:48,518 - INFO # 
2022-06-09 18:33:48,520 - INFO # Flash start addr:		0x00000000
2022-06-09 18:33:48,522 - INFO # Page size:			256
2022-06-09 18:33:48,524 - INFO # Number of pages:		1024
2022-06-09 18:33:48,525 - INFO # AUX page size:		64
2022-06-09 18:33:48,527 - INFO #     user area:		56
2022-06-09 18:33:48,530 - INFO # Number of first free page: 	86 
2022-06-09 18:33:48,533 - INFO # Number of last free page: 	1023 

2022-06-09 18:33:55,442 - INFO # > test_last_raw
2022-06-09 18:33:55,442 - INFO # 
2022-06-09 18:33:55,447 - INFO # wrote raw short buffer to last flash page

2022-06-09 18:34:05,116 - INFO # > test_last_pagewise
2022-06-09 18:34:05,117 - INFO # 
2022-06-09 18:34:05,122 - INFO # wrote local page buffer to last flash page

2022-06-09 18:34:17,281 - INFO # > test 90
2022-06-09 18:34:17,281 - INFO # 
2022-06-09 18:34:17,287 - INFO # wrote local page buffer to flash page 90 at addr 0x5a00
```  


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
