### PR TITLE
sntp: Switch to ztimer

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -155,11 +155,7 @@ endif
 
 ifneq (,$(filter sntp,$(USEMODULE)))
   USEMODULE += sock_udp
-  USEMODULE += xtimer
-  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-    # requires 64bit ftimestamps
-    USEMODULE += ztimer64_xtimer_compat
-  endif
+  USEMODULE += ztimer_msec
 endif
 
 ifneq (,$(filter sock_%,$(USEMODULE)))

--- a/sys/include/net/sntp.h
+++ b/sys/include/net/sntp.h
@@ -18,6 +18,7 @@
  *
  * @author      Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Christian Amsüss <chrysn@fsfe.org>
  */
 
 #ifndef NET_SNTP_H

--- a/sys/net/application_layer/sntp/sntp.c
+++ b/sys/net/application_layer/sntp/sntp.c
@@ -14,6 +14,7 @@
  *
  * @author      Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Christian Amsüss <chrysn@fsfe.org>
  *
  * @}
  */
@@ -22,16 +23,34 @@
 #include "net/sntp.h"
 #include "net/ntp_packet.h"
 #include "net/sock/udp.h"
-#include "xtimer.h"
+#include "ztimer.h"
 #include "mutex.h"
 #include "byteorder.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+static void _validity_expires(void);
+
 static sock_udp_t _sntp_sock;
-static int64_t _sntp_offset = 0;
+/* If set to this value, _sntp_offset is invalid. The choice of 0 is good
+ * because it is cheap to test for, and if the time machine to run this code in
+ * the 50 first days of 1970 is invented, we'll have bigger problems than this
+ * code failing. */
+#define SNTP_OFFSET_INVALID (0)
+/* This plus ztimer_now() will produce the current POSIX timestamp (seconds since UTC without leap seconds) */
+static int64_t _sntp_offset = SNTP_OFFSET_INVALID;
+/* Lock this when accessing _sntp_offset (yes, even when reading, for the
+ * alternative would be 64bit atomics) or _sntp_validity_timer */
 static mutex_t _sntp_mutex = MUTEX_INIT;
+/* Time for which the clock will be considered good. This could be decreased,
+ * and is not set to the absolute maximum a ztimer can have, but a minute less,
+ * because that allows users to trust that interrupts have been off in-between.
+ * (If the ZTimer interrupt has not had its chance to run in 60 seconds, the
+ * system is already stalled beyond hope) */
+#define SNTP_VALIDITY_TIMER_LENGTH (UINT32_MAX - 60 * MS_PER_SEC)
+/* Timer that keeps ZTIMER_MSEC alive */
+static ztimer_t _sntp_validity_timer = { .callback = _validity_expires };
 static ntp_packet_t _sntp_packet;
 
 int sntp_sync(sock_udp_ep_t *server, uint32_t timeout)
@@ -68,11 +87,17 @@ int sntp_sync(sock_udp_ep_t *server, uint32_t timeout)
     }
     sock_udp_close(&_sntp_sock);
     mutex_lock(&_sntp_mutex);
-    _sntp_offset = (((int64_t)byteorder_ntohl(_sntp_packet.transmit.seconds)) * US_PER_SEC) +
+    uint32_t now = ztimer_set(ZTIMER_MSEC, _sntp_validity_timer,
+            SNTP_VALIDITY_TIMER_LENGTH);
+    _sntp_offset = (((int64_t)byteorder_ntohl(_sntp_packet.transmit.seconds)) * MS_PER_SEC) +
                    ((((int64_t)byteorder_ntohl(_sntp_packet.transmit.fraction)) * 232)
-                   / 1000000) - xtimer_now_usec64();
+                   / 1000000000) - now;
     mutex_unlock(&_sntp_mutex);
     return 0;
+}
+
+static void _validity_expires(void) {
+    // FIXME how to clear the expiry field w/o waiting for a mutex? need better mutex setup.
 }
 
 int64_t sntp_get_offset(void)
@@ -82,5 +107,8 @@ int64_t sntp_get_offset(void)
     mutex_lock(&_sntp_mutex);
     result = _sntp_offset;
     mutex_unlock(&_sntp_mutex);
+    if (!ztimer_is_set(ZTIMER_MS, _sntp_validity_timer)) {
+        return SNTP_OFFSET_INVALID;
+    }
     return result;
 }


### PR DESCRIPTION
### Contribution description

SNTP still uses xtimer (with ztimer as backend); could use ztimer directly. This can also allow moving more calculations into the 32bit domain; if an SNTP obtained offset has not been updated for a 32bit wraparound of milliseconds (50 days), it stands to assume that there is no valid offset available any more anyway.

### Testing procedure

TBD

### Further development

I actually started this when looking into time-over-CoAP and had it sitting on a branch somewhere completely wrong; unsure if I'll continue this. It'll need some more thinking about concurrency and what can be done in a ztimer callback.