### PR TITLE
dist/tools/kconfiglib: add configuration evaluation function

### DIFF
--- a/dist/tools/kconfiglib/genconfig.py
+++ b/dist/tools/kconfiglib/genconfig.py
@@ -393,9 +393,7 @@ with error.""")
     kconf = RiotKconfig(args.kconfig_filename, warn_to_stderr=False)
     merge_configs(kconf, args.config_sources)
 
-    # HACK: Force all symbols to be evaluated, to catch warnings generated
-    # during evaluation (such as out-of-range integers)
-    kconf.write_config(os.devnull, save_old=False)
+    kconf.evaluate_config()
 
     if not check_configs(kconf) and not args.ignore_config_errors:
         sys.exit(1)

--- a/dist/tools/kconfiglib/riot_kconfig.py
+++ b/dist/tools/kconfiglib/riot_kconfig.py
@@ -28,6 +28,14 @@ class RiotKconfig(Kconfig):
         super(RiotKconfig, self).write_autoconf(filename, header)
         self.unique_defined_syms = tmp_unique_defined_syms
 
+    def evaluate_config(self):
+        """Evaluate the current configuration.
+
+        Useful to catch warnings (such as out-of-range integers) before writing
+        the configuration to a file.
+        """
+        self._config_contents(None)
+
 
 def standard_riot_kconfig(description=None):
     """


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This removes the existing hack, in which we wrote the configuration to `/dev/null` to trigger its evaluation. Instead a function for this specific purpose is added. Besides being cleaner, it avoids issues like the one reported at https://forum.riot-os.org/t/kconfig-issues-in-riot/3646.

### Testing procedure
- To verify that configuration issues are still being caught, you can apply an invalid one like the following in the kconfig test app, and run `make`:
```diff
diff --git a/tests/kconfig/Kconfig b/tests/kconfig/Kconfig
index c18dffdd8f..cbfec4b519 100644
--- a/tests/kconfig/Kconfig
+++ b/tests/kconfig/Kconfig
@@ -20,3 +20,8 @@ config APP_MSG_2
         Activate printing the second message
 
 endmenu # Application
+
+config FOO_VALUE
+    int "Foo"
+    range 1 3
+    default 4
```
- Green CI

### Issues/PRs references
Forum post https://forum.riot-os.org/t/kconfig-issues-in-riot/3646