### PR TITLE
Revert "core/assert: remove panic include from assert.h"

### DIFF
--- a/core/lib/assert.c
+++ b/core/lib/assert.c
@@ -16,17 +16,15 @@
 #include <stdio.h>
 
 #include "assert.h"
-#include "panic.h"
 
-__NORETURN void _assert_failure(const char *file, unsigned line)
+#ifdef DEBUG_ASSERT_VERBOSE
+NORETURN void _assert_failure(const char *file, unsigned line)
 {
-    printf("%s:%u => ", file, line);
-    core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
+    printf("%s:%u => ", file, line); \
+    core_panic(PANIC_ASSERT_FAIL, assert_crash_message); \
 }
-
-__NORETURN void _assert_panic(void)
-{
-    core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
-}
+#else
+typedef int dont_be_pedantic;
+#endif
 
 /** @} */

--- a/core/lib/include/assert.h
+++ b/core/lib/include/assert.h
@@ -22,6 +22,8 @@
 #ifndef ASSERT_H
 #define ASSERT_H
 
+#include "panic.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,21 +51,9 @@ extern "C" {
 #endif
 
 /**
- * @def __NORETURN
- * @brief hidden (__) NORETURN definition
- * @internal
- *
- * Duplicating the definitions of kernel_defines.h as these are unsuitable for
- * system header files like the assert.h.
- * kernel_defines.h would define symbols that are not reserved.
+ * @brief   the string that is passed to panic in case of a failing assertion
  */
-#ifndef __NORETURN
-#ifdef __GNUC__
-#define __NORETURN __attribute__((noreturn))
-#else /*__GNUC__*/
-#define __NORETURN
-#endif /*__GNUC__*/
-#endif /*__NORETURN*/
+extern const char assert_crash_message[];
 
 #ifdef NDEBUG
 #define assert(ignore)((void)0)
@@ -78,7 +68,8 @@ extern "C" {
  * @param[in] file  The file name of the file the assertion failed in
  * @param[in] line  The code line of @p file the assertion failed in
  */
-__NORETURN void _assert_failure(const char *file, unsigned line);
+NORETURN void _assert_failure(const char *file, unsigned line);
+
 /**
  * @brief    abort the program if assertion is false
  *
@@ -112,10 +103,10 @@ __NORETURN void _assert_failure(const char *file, unsigned line);
  */
 #define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, \
                                                           __LINE__))
-#else /* DEBUG_ASSERT_VERBOSE */
-__NORETURN void _assert_panic(void);
-#define assert(cond) ((cond) ? (void)0 : _assert_panic())
-#endif /* DEBUG_ASSERT_VERBOSE */
+#else
+#define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, \
+                                                    assert_crash_message))
+#endif
 
 #if !defined __cplusplus
 #if __STDC_VERSION__ >= 201112L

--- a/core/lib/panic.c
+++ b/core/lib/panic.c
@@ -39,6 +39,8 @@
 #include "usb_board_reset.h"
 #endif
 
+const char assert_crash_message[] = "FAILED ASSERTION.";
+
 /* flag preventing "recursive crash printing loop" */
 static int crashed = 0;
 

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/tests/gnrc_sock_tcp/Makefile.ci
+++ b/tests/gnrc_sock_tcp/Makefile.ci
@@ -36,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This reverts commit 0b52b3e62e93075bc6c8fba369cde8636c04e524 from #17574 which broke the `assert()` memory location printing.

### Testing procedure

Add an `assert(0)` to e.g. `examples/hello-world`

```patch
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,11 +20,14 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
 
 int main(void)
 {
     puts("Hello World!");
 
+    assert(0);
+
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
```

On `master` this prints

```
2022-06-10 22:57:31,223 # main(): This is RIOT! (Version: 2022.04-devel-145-g0b52b-HEAD)
2022-06-10 22:57:31,224 # Hello World!
2022-06-10 22:57:31,224 # 0x2af
2022-06-10 22:57:31,226 # *** RIOT kernel panic:
2022-06-10 22:57:31,228 # FAILED ASSERTION.
2022-06-10 22:57:31,228 # 
2022-06-10 22:57:31,229 # *** halted.
```

    % arm-none-eabi-addr2line -e bin/same54-xpro/*.elf 0x2af
    /home/benpicco/dev/RIOT/core/assert.c:29

With this reverted it prints the location of the `assert()` again:

```
2022-06-10 23:01:03,009 # main(): This is RIOT! (Version: 2022.07-devel-748-g4c5bd)
2022-06-10 23:01:03,010 # Hello World!
2022-06-10 23:01:03,010 # 0x275
2022-06-10 23:01:03,012 # *** RIOT kernel panic:
2022-06-10 23:01:03,014 # FAILED ASSERTION.
2022-06-10 23:01:03,014 # 
2022-06-10 23:01:03,015 # *** halted.
```

    % arm-none-eabi-addr2line -e bin/same54-xpro/*.elf 0x275
    /home/benpicco/dev/RIOT/examples/hello-world/main.c:29

### Issues/PRs references
fixes #18175
