### PR TITLE
dist/tools/cosy: allow to specify port

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -854,8 +854,9 @@ preflash: $(BUILD_BEFORE_FLASH)
 
 # graphical memory usage analyzer
 COSY_TOOL ?= $(PKGDIRBASE)/cosy/cosy.py
+COSY_PORT ?= 12345
 cosy: $(ELFFILE) $(COSY_TOOL)
-	$(COSY_TOOL) --riot-base $(RIOTBASE) $(APPDIR) $(BOARD) $(ELFFILE) $(MAPFILE)
+	$(COSY_TOOL) --port $(COSY_PORT) --riot-base $(RIOTBASE) $(APPDIR) $(BOARD) $(ELFFILE) $(MAPFILE)
 
 ifneq (,$(TERMLOG)$(TERMTEE))
   TERMTEE ?= | tee -a $(TERMLOG)

--- a/dist/tools/cosy/patches/0001-cosy-allow-to-specify-port.patch
+++ b/dist/tools/cosy/patches/0001-cosy-allow-to-specify-port.patch
@@ -1,0 +1,38 @@
+From 221c368153f2aaa73f2a474bb39f547835fdaa0d Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Sat, 11 Jun 2022 14:39:16 +0200
+Subject: [PATCH] cosy: allow to specify port
+
+---
+ cosy.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cosy.py b/cosy.py
+index b36c28a..6fcb118 100755
+--- a/cosy.py
++++ b/cosy.py
+@@ -28,7 +28,6 @@ import json
+ import frontend_server
+ 
+ ROOT = path.join(Path(path.abspath(__file__)).parent, "root")
+-PORT = 12345
+ 
+ 
+ def add_sym(target, sym):
+@@ -352,6 +351,7 @@ if __name__ == "__main__":
+     p.add_argument("-c", type=argparse.FileType('w'),
+                    help="Write module sizes to cvs file")
+     p.add_argument("-d", action="store_true", help="Don't run as web server")
++    p.add_argument("--port", default="12345", help="Webserver port", type=int)
+     args = p.parse_args()
+ 
+     # extract path to elf and map file
+@@ -407,4 +407,4 @@ if __name__ == "__main__":
+     print(subprocess.check_output((args.p + 'size', elffile)).decode("utf-8"))
+ 
+     if not args.d:
+-        frontend_server.run(ROOT, PORT, 'index.html')
++        frontend_server.run(ROOT, args.port, 'index.html')
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This allows to run multiple instances of `cosy` in parallel to compare binary sizes.


### Testing procedure

    make -C examples/hello-world cosy COSY_PORT=8888

```
Result validation: both size outputs below should match
Computed sums of parsed symbols:
   text    data     bss     dec     hex
  13384   11458  432958  457800   6fc48
Output of the 'size' command:
   text	   data	    bss	    dec	    hex	filename
  26878	    548	  47796	  75222	  125d6	/home/benpicco/dev/RIOT/examples/hello-world/bin/native/hello-world.elf

Started frontend server, connect you browser to http://localhost:8888
```



### Issues/PRs references

upstream PR https://github.com/haukepetersen/cosy/pull/14
