### PR TITLE
core/assert: print last instruction in assert()

### DIFF
--- a/core/lib/assert.c
+++ b/core/lib/assert.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 
 #include "assert.h"
+#include "cpu.h"
 #include "panic.h"
 
 __NORETURN void _assert_failure(const char *file, unsigned line)
@@ -26,6 +27,7 @@ __NORETURN void _assert_failure(const char *file, unsigned line)
 
 __NORETURN void _assert_panic(void)
 {
+    cpu_print_last_instruction();
     core_panic(PANIC_ASSERT_FAIL, "FAILED ASSERTION.");
 }
 

--- a/core/lib/panic.c
+++ b/core/lib/panic.c
@@ -61,11 +61,7 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
     if (crashed == 0) {
         /* print panic message to console (if possible) */
         crashed = 1;
-#ifndef NDEBUG
-        if (crash_code == PANIC_ASSERT_FAIL) {
-            cpu_print_last_instruction();
-        }
-#endif
+
         /* Call back app in case it wants to store some context */
         panic_app(crash_code, message);
         LOG_ERROR("*** RIOT kernel panic:\n%s\n\n", message);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Print the last instruction in `assert()` instead of `panic()` as suggested by https://github.com/RIOT-OS/RIOT/pull/18193#pullrequestreview-1003591068

### Testing procedure

Add an `assert(0)` to e.g. `examples/hello-world`

```patch
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,11 +20,14 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
 
 int main(void)
 {
     puts("Hello World!");
 
+    assert(0);
+
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
```


### Issues/PRs references
alternative to #18193
fixes https://github.com/RIOT-OS/RIOT/issues/18175
