### PR TITLE
sys/rtc_utils: small doc fix of rtc_mktime

### DIFF
--- a/sys/include/rtc_utils.h
+++ b/sys/include/rtc_utils.h
@@ -61,7 +61,7 @@ int rtc_tm_compare(const struct tm *a, const struct tm *b);
 /**
  * @brief Convert time struct into timestamp.
  *
- * @pre   The time structs @p a and @p b are assumed to be normalized.
+ * @pre   The time struct t is assumed to be normalized.
  *        Use @ref rtc_tm_normalize to normalize a struct tm that has been
  *        manually edited.
  *


### PR DESCRIPTION
### Contribution description

As the the title says, this PR fixes a copy and paste error in the documentation of function `rtc_mktime`.

### Testing procedure

`make doc` and check that the documented precondition for `rtc_mktime` is correct.

### Issues/PRs references
