### PR TITLE
drivers/rtt_rtc: normalize tm struct in rtc_set_alarm

### DIFF
--- a/drivers/rtt_rtc/rtt_rtc.c
+++ b/drivers/rtt_rtc/rtt_rtc.c
@@ -182,6 +182,8 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 
     uint32_t now = rtt_get_counter();
 
+    rtc_tm_normalize(time);
+
     alarm_time   = rtc_mktime(time);
     alarm_cb_arg = arg;
     alarm_cb     = cb;


### PR DESCRIPTION
### Contribution description

This PR provides a small fix of function `rtc_set_alarm` in module `rtt_rtc`.

Function `rtc_set_alarm` in module `rtt_rtc` calls function `rtc_mktime` which expects that the given time structure is normalized.

### Testing procedure

Use an ESP32 module to compile and test `tests/periph_rtc` where the alarm time is calculated by incrementing the seconds only.

Output without this PR:
```
RIOT RTC low-level driver test
This test will display 'Alarm!' every 2 seconds for 4 times
  Setting clock to   2020-02-28 23:59:57
Clock value is now   2020-02-28 23:59:57
  Setting alarm to   2020-02-28 23:59:59
   Alarm is set to   2020-02-28 23:59:59
  Alarm cleared at   2020-02-28 23:59:57
       No alarm at   2020-02-28 23:59:59
  Setting alarm to   2020-02-29 23:59:61     <================
```

Output with this PR:
```
RIOT RTC low-level driver test
This test will display 'Alarm!' every 2 seconds for 4 times
  Setting clock to   2020-02-28 23:59:57
Clock value is now   2020-02-28 23:59:57
  Setting alarm to   2020-02-28 23:59:59
   Alarm is set to   2020-02-28 23:59:59
  Alarm cleared at   2020-02-28 23:59:57
       No alarm at   2020-02-28 23:59:59
  Setting alarm to   2020-02-29 00:00:01
```


### Issues/PRs references

Found out while testing the peripherals of the ESP32-S2 port.