### PR TITLE
sys/fs/constfs: allow to host arbitrary data

### DIFF
--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -197,7 +197,7 @@ static ssize_t constfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
     if (nbytes > (fp->size - filp->pos)) {
         nbytes = fp->size - filp->pos;
     }
-    memcpy(dest, fp->data + filp->pos, nbytes);
+    memcpy(dest, (const uint8_t *)fp->data + filp->pos, nbytes);
     DEBUG("constfs_read: read %lu bytes\n", (long unsigned)nbytes);
     filp->pos += nbytes;
     return nbytes;

--- a/sys/include/fs/constfs.h
+++ b/sys/include/fs/constfs.h
@@ -37,9 +37,9 @@ extern "C" {
  * @brief A file in ConstFS (file name + contents)
  */
 typedef struct {
-    const char *path; /**< file system relative path to file */
+    const char *path;  /**< file system relative path to file */
     const size_t size; /**< length of @c data */
-    const uint8_t *data; /**< pointer to file contents */
+    const void *data;  /**< pointer to file contents */
 } constfs_file_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Don't require data to be a `uint8_t` array to to be casted into one.



### Testing procedure

No changes to the binary, but `constfs` can be used a bit more ergonomically. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
