### PR TITLE
drivers/{dose, slipdev, sam0_eth}: generate RX event for queued packets

### DIFF
--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -323,6 +323,11 @@ int sam0_eth_receive_blocking(char *data, unsigned max_len)
     return _try_receive(data, max_len, 1);
 }
 
+bool sam0_eth_has_queued_pkt(void)
+{
+    return _try_receive(NULL, 0, 0) > 0;
+}
+
 int sam0_eth_init(void)
 {
     /* Enable clocks */

--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -40,6 +40,7 @@ extern void sam0_eth_poweron(void);
 extern void sam0_eth_poweroff(void);
 extern int sam0_eth_send(const struct iolist *iolist);
 extern int sam0_eth_receive_blocking(char *data, unsigned max_len);
+extern bool sam0_eth_has_queued_pkt(void);
 extern void sam0_eth_set_mac(const eui48_t *mac);
 extern void sam0_eth_get_mac(char *out);
 extern void sam0_clear_rx_buffers(void);
@@ -68,6 +69,12 @@ static int _sam0_eth_recv(netdev_t *netdev, void *buf, size_t len, void *info)
     (void)info;
     (void)netdev;
     unsigned ret = sam0_eth_receive_blocking((char *)buf, len);
+
+    /* frame received, check if another frame is queued */
+    if (buf && sam0_eth_has_queued_pkt()) {
+        netdev_trigger_event_isr(netdev);
+    }
+
     return ret;
 }
 

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -98,6 +98,8 @@ typedef struct {
      * @see     [Device state definitions](@ref drivers_slipdev_states)
      */
     uint8_t state;
+    uint8_t rx_queued;                      /**< pkt queued in inbuf */
+    uint8_t rx_done;                        /**< pkt processed */
 } slipdev_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I was debugging the issue that packets where stuck in the RX path until the next packet was received, turns out they were stuck in the driver's RX queue:

```
2022-06-08 19:15:52,658 - INFO # > ping -i 2000 fd11:a000::e858:4ed2:564e:215b
2022-06-08 19:15:52,658 - INFO # 
2022-06-08 19:15:54,667 - INFO # 12 bytes from fd11:a000::e858:4ed2:564e:215b: icmp_seq=0 ttl=64 time=2001.958 ms
2022-06-08 19:15:56,667 - INFO # 12 bytes from fd11:a000::e858:4ed2:564e:215b: icmp_seq=1 ttl=64 time=2001.959 ms
2022-06-08 19:15:59,658 - INFO # 
2022-06-08 19:15:59,662 - INFO # --- fd11:a000::e858:4ed2:564e:215b PING statistics ---
2022-06-08 19:15:59,667 - INFO # 3 packets transmitted, 2 packets received, 33% packet loss
2022-06-08 19:15:59,672 - INFO # round-trip min/avg/max = 2001.958/2001.958/2001.959 ms
```

To fix this, generate another `NETDEV_EVENT_RX_COMPLETE` complete event if there is still a packet in the rx buffer when we finished processing the current one.

### Testing procedure

![IMG_0176](https://user-images.githubusercontent.com/1301112/173366814-701efb72-b3fc-47b4-b68f-fe73336c69fc.jpg)

The issue can be triggered by heavy network traffic, e.g.

    sudo ping -f fd11:9c00::e858:4ed2:564e:215a
    sudo ping -A fd11:9800::e858:4ed2:564e:215b

With this patch, we don't have packets stuck in the RX buffer after that anymore

```
2022-06-13 15:42:47,841 - INFO # > ping fd11::1
2022-06-13 15:42:47,841 - INFO # 
2022-06-13 15:42:47,855 - INFO # 12 bytes from fd11::1: icmp_seq=0 ttl=61 time=8.472 ms
2022-06-13 15:42:48,855 - INFO # 12 bytes from fd11::1: icmp_seq=1 ttl=61 time=8.367 ms
2022-06-13 15:42:49,856 - INFO # 12 bytes from fd11::1: icmp_seq=2 ttl=61 time=8.557 ms
2022-06-13 15:42:49,856 - INFO # 
2022-06-13 15:42:49,859 - INFO # --- fd11::1 PING statistics ---
2022-06-13 15:42:49,864 - INFO # 3 packets transmitted, 3 packets received, 0% packet loss
2022-06-13 15:42:49,869 - INFO # round-trip min/avg/max = 8.367/8.465/8.557 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
