### PR TITLE
sys/event: add post counter to event

### DIFF
--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -147,6 +147,7 @@ typedef void (*event_handler_t)(event_t *);
 struct event {
     clist_node_t list_node;     /**< event queue list entry             */
     event_handler_t handler;    /**< pointer to event handler function  */
+    unsigned num_posted;        /**< how often the event was posted     */
 };
 
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds a counter to event_t to count how often an event was posted.
That ensures that if multiple events of the same type have been posted, the event consumer will also be able to consume multiple events.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #18203
