### PR TITLE
dist/tools/compile_commands: fix error handling

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -35,7 +35,7 @@ def detect_includes_and_version_gcc(compiler):
     except FileNotFoundError:
         msg = f"Compiler {compiler} not found, not adding system include paths\n"
         sys.stderr.write(msg)
-        return []
+        return ([], "")
 
     stderrdata = stderrdata.decode("utf-8")
     version = REGEX_VERSION.search(stderrdata).group(1)


### PR DESCRIPTION
### Contribution description

`detect_includes_and_version_gcc()` previously only detected the includes, but has been extended to also return the version. This is done by returning a tuple, with the first item being the list of include paths, and the second being the version. In the error handling the script still returns only an empty list of includes, but not an empty version. This
fixes the issue.

### Testing procedure

`make compile-commands` should now also work even when the toolchain is not installed, rather than crash.

#### Output in `master`

```
$ make BOARD=esp32-ttgo-t-beam compile-commands
[...]
Compiler xtensa-esp32-elf-gcc not found, not adding system include paths
Traceback (most recent call last):
  File "/home/maribu/Repos/software/RIOT/dist/tools/compile_commands/compile_commands.py", line 328, in <module>
    generate_compile_commands(_args)
  File "/home/maribu/Repos/software/RIOT/dist/tools/compile_commands/compile_commands.py", line 297, in generate_compile_commands
    generate_module_compile_commands(module.path, state, args)
  File "/home/maribu/Repos/software/RIOT/dist/tools/compile_commands/compile_commands.py", line 259, in generate_module_compile_commands
    c_extra_includes = get_built_in_include_flags(cdetails.cc, state, args)
  File "/home/maribu/Repos/software/RIOT/dist/tools/compile_commands/compile_commands.py", line 179, in get_built_in_include_flags
    state.def_includes[compiler] = detect_built_in_includes(compiler, args)
  File "/home/maribu/Repos/software/RIOT/dist/tools/compile_commands/compile_commands.py", line 97, in detect_built_in_includes
    includes, version = detect_includes_and_version_gcc(compiler)
ValueError: not enough values to unpack (expected 2, got 0)
make: *** [/home/maribu/Repos/software/RIOT/tests/thread_priority_inversion/../../Makefile.include:756: compile-commands] Error 1
```

#### Output with this PR

```
$ make BOARD=esp32-ttgo-t-beam compile-commands
[...]
make[3]: Nothing to be done for 'compile-commands'.
Compiler xtensa-esp32-elf-gcc not found, not adding system include paths
Compiler xtensa-esp32-elf-g++ not found, not adding system include paths
$ echo $?
0
```

### Issues/PRs references

None