### PR TITLE
dist/tools/compile_commands: fix clangd mode with ESP32

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -318,11 +318,21 @@ if __name__ == '__main__':
     if _args.clangd:
         _args.add_built_in_includes = True
         _args.add_libstdcxx_includes = True
-        _args.filter_out = ['-mno-thumb-interwork',
-                            # Only even included for versions of GCC that support it
-                            '-misa-spec=2.2',
-                            '-malign-data=natural',
-                            # Only supported starting with clang 11
-                            '-msmall-data-limit=8',
-                            ]
+        flags = [
+            '-mno-thumb-interwork',
+            # Only even included for versions of GCC that
+            # support it
+            '-misa-spec=2.2',
+            '-malign-data=natural',
+            # Only supported starting with clang 11
+            '-msmall-data-limit=8',
+            # not supported by clang, see
+            # https://gcc.gnu.org/onlinedocs/gcc-10.2.0/gcc/Xtensa-Options.html
+            '-mtext-section-literals',
+            '-fstrict-volatile-bitfields',
+            # it's called -mlong-calls in LLVM, but we don't need it for clangd
+            # as we do not generate code anyway
+            '-mlongcalls',
+        ]
+        _args.filter_out.extend(flags)
     generate_compile_commands(_args)


### PR DESCRIPTION
### Contribution description

In clangd mode drop a number of compiler flags not supported by LLVM.

### Testing procedure

Run `make compile-commands BOARD=<SOME-ESP32-board> -C examples/default` and open a C file with an editor that uses clangd as language server (e.g. vim/neovim with ALE, or VS Code). In `master` clangd should be really unhappy, with this it should provide decent linting/analysis/code completion/....

### Issues/PRs references

None