### PR TITLE
cpu/esp32: fix pm_reboot function

### DIFF
--- a/cpu/esp32/periph/pm.c
+++ b/cpu/esp32/periph/pm.c
@@ -91,9 +91,8 @@ void pm_reboot(void)
         esp_wifi_stop();
     }
 
-    /* suspend and flush UARTs */
-    for (int i = 0; i < 3; ++i) {
-        REG_SET_BIT(UART_FLOW_CONF_REG(i), UART_FORCE_XOFF);
+    /* flush all UARTs of the SoC, there is no problem to do it for uninitialized UARTs */
+    for (int i = 0; i < SOC_UART_NUM; ++i) {
         uart_tx_wait_idle(i);
     }
 


### PR DESCRIPTION
### Contribution description

This PR fixes the blocking when the `reboot` command is used in shell under certain conditions and the `pm_reboot` function tries to reboot the system.

In the test run of PR #18202 in CI the test of `tests/shell` failed because the system blocks when executing command `reboot` if another command was executed before, see the log, see the [log](https://ci.riot-os.org/RIOT-OS/RIOT/18202/4cf3e1a06c9c05e8a92aed6e938b3cfe90efe69a/output/run_test/tests/shell/esp32-wroom-32:gnu.txt). The reason for this is that the system will block while waiting for the UART interfaces to become idle.

### Testing procedure

1. Make `BOARD=esp32-wroom-32 make -C tests/shell flash term` and execute:
   ```
   > reboot
   > help
   > reboot
   ```
   Without this PR, the system blocks on second `reboot` command. With this PR, the command sequence works as expected.
   
2. Execute `BOARD=esp32-wroom-32 make -C tests/shell test`
   Without this PR, the test fails. With this PR, the test should succeed.

### Issues/PRs references

Found when testing PR #18202