### PR TITLE
cpu/esp32: enforce MAXTHREADS is at least 3

### DIFF
--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -299,6 +299,8 @@ extern void IRAM_ATTR thread_yield_isr(void* arg);
 
 static NORETURN void IRAM system_init (void)
 {
+    static_assert(MAXTHREADS >= 3,
+            "ESP32 requires at least 3 threads, esp_timer, idle, and main");
     /* enable cached read from flash */
     Cache_Read_Enable(PRO_CPU_NUM);
 

--- a/tests/periph_gpio_ll/Makefile
+++ b/tests/periph_gpio_ll/Makefile
@@ -44,7 +44,13 @@ CFLAGS += -DPIN_IN_0=$(PIN_IN_0)
 CFLAGS += -DPIN_IN_1=$(PIN_IN_1)
 CFLAGS += -DPIN_OUT_0=$(PIN_OUT_0)
 CFLAGS += -DPIN_OUT_1=$(PIN_OUT_1)
-# We only need 1 thread (+ the Idle thread on some platforms) and we really want
-# this app working on all boards.
-CFLAGS += -DMAXTHREADS=2
 CFLAGS += -DLOW_ROM=$(LOW_ROM)
+
+ifneq ($(CPU_FAM),esp32)
+  # We only need 1 thread (+ the Idle thread on some platforms) and we really
+  # want this app working on all boards.
+  CFLAGS += -DMAXTHREADS=2
+else
+  # ESP32 uses an extra thread for esp_timer
+  CFLAGS += -DMAXTHREADS=3
+endif

--- a/tests/pkg_fff/Makefile
+++ b/tests/pkg_fff/Makefile
@@ -3,7 +3,12 @@ USEPKG += fff
 # If periph_i2c is pulled in the real implementation conflicts with the mock
 FEATURES_BLACKLIST += periph_i2c
 
-# only two threads used
-CFLAGS += -DMAXTHREADS=2
-
 include $(RIOTBASE)/Makefile.include
+
+ifneq ($(CPU_FAM),esp32)
+  # only two threads used
+  CFLAGS += -DMAXTHREADS=2
+else
+  # ESP32 uses an extra thread for esp_timer
+  CFLAGS += -DMAXTHREADS=3
+endif


### PR DESCRIPTION
### Contribution description

ESP32 has an esp_timer thread in addition to the main and the idle thread. So applications that work fine with 2 threads on other platforms will break on ESP32. This adds a `static_assert()` to enforce `MAXTHREADS` is never less than 3 on ESP32 and fixes the offenders.

### Testing procedure

Green Murdock and `tests/pkg_fff` should now pass on ESP32 boards.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/17076#issuecomment-1155787669