### PR TITLE
core/kernel_defines: drop CONST definition

### DIFF
--- a/core/lib/include/kernel_defines.h
+++ b/core/lib/include/kernel_defines.h
@@ -85,18 +85,6 @@ extern "C" {
 #endif
 
 /**
- * @def CONST
- * @brief A function declared as *CONST* is #PURE and also not allowed to
- *        examine global memory. I.e. a *CONST* function cannot even
- *        dereference a pointer parameter.
- */
-#ifdef __GNUC__
-#define CONST  __attribute__((const))
-#else
-#define CONST
-#endif
-
-/**
  * @def PURE
  * @brief The function has no effects except the return value and its return
  *        value depends only on the parameters and/or global variables. Such a

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -65,7 +65,7 @@ extern const int16_t TM_MON_DAYS_ACCU[12];
  * @param[in]       year   The year. Probably should be ≥ 1582, but needs to be ≥ 1.
  * @returns         `1` if it is a leap year, `0` if it is a common year.
  */
-int tm_is_leap_year(unsigned year) CONST;
+int tm_is_leap_year(unsigned year);
 
 /**
  * @brief           Returns the congruent weekday of the Doomsday (March 0).
@@ -73,7 +73,7 @@ int tm_is_leap_year(unsigned year) CONST;
  * @param[in]       year   The year. Probably should be ≥ 1582, but needs to be ≥ 1.
  * @returns         The result `% 7` is the weekday of the Doomsday of the given year.
  */
-int tm_doomsday(int year) CONST;
+int tm_doomsday(int year);
 
 /**
  * @brief           Calculates the day of the year and the weekday of a given date.
@@ -107,7 +107,7 @@ void tm_fill_derived_values(struct tm *tm);
  * @param[in]       mday   The day in the month.
  * @returns         0 if the date is invalid.
  */
-int tm_is_valid_date(int year, int mon, int mday) CONST;
+int tm_is_valid_date(int year, int mon, int mday);
 
 /**
  * @brief           Shallow test if a time is valid.
@@ -117,7 +117,7 @@ int tm_is_valid_date(int year, int mon, int mday) CONST;
  * @param[in]       sec    The seconds.
  * @returns         0 if the time is invalid.
  */
-int tm_is_valid_time(int hour, int min, int sec) CONST;
+int tm_is_valid_time(int hour, int min, int sec);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is not used anywhere in RIOT, but causes conflicts with external library code.

So let's just get rid of this.

### Testing procedure

Green CI

### Issues/PRs references

Was introduced by #689
