### PR TITLE
drivers/atwinc15x0: add timeout to init

### DIFF
--- a/pkg/driver_atwinc15x0/patches/0007-nmasic-always-use-2000-retries.patch
+++ b/pkg/driver_atwinc15x0/patches/0007-nmasic-always-use-2000-retries.patch
@@ -1,0 +1,29 @@
+From 9664046ab3fb2355fc3058bef90cc8727a67730b Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Wed, 15 Jun 2022 18:06:09 +0200
+Subject: [PATCH 1/3] nmasic: always use 2000 retries
+
+---
+ src/driver/source/nmasic.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/driver/source/nmasic.c b/src/driver/source/nmasic.c
+index 91c0e5a..9f46398 100644
+--- a/src/driver/source/nmasic.c
++++ b/src/driver/source/nmasic.c
+@@ -59,11 +59,7 @@
+ 
+ 
+ 
+-#ifdef ARDUINO
+-#define TIMEOUT						(2000)
+-#else
+-#define TIMEOUT						(0xfffffffful)
+-#endif
++#define TIMEOUT				(2000)
+ #define WAKUP_TRAILS_TIMEOUT		(4)
+ 
+ sint8 chip_apply_conf(uint32 u32Conf)
+-- 
+2.34.1
+

--- a/pkg/driver_atwinc15x0/patches/0008-nmasic-limit-retries-in-wait_for_bootrom.patch
+++ b/pkg/driver_atwinc15x0/patches/0008-nmasic-limit-retries-in-wait_for_bootrom.patch
@@ -1,0 +1,50 @@
+From 142506c9ed4e2d3a1c59cf39cd86473074981c6a Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Wed, 15 Jun 2022 14:01:42 +0200
+Subject: [PATCH 2/3] nmasic: limit retries in wait_for_bootrom()
+
+If no device is connected or init failed, wait_for_bootrom() will
+be stuck in an infinite loop trying to get a result from nm_read_reg().
+
+Place an upper limit on the number of retries so we can recover from
+this instead of being stuck here.
+---
+ src/driver/source/nmasic.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/driver/source/nmasic.c b/src/driver/source/nmasic.c
+index 9f46398..b77dc5a 100644
+--- a/src/driver/source/nmasic.c
++++ b/src/driver/source/nmasic.c
+@@ -400,6 +400,7 @@ sint8 chip_reset(void)
+ sint8 wait_for_bootrom(uint8 arg)
+ {
+ 	sint8 ret = M2M_SUCCESS;
++	uint16 retries = TIMEOUT;
+ 	uint32 reg = 0, cnt = 0;
+ 	uint32 u32GpReg1 = 0;
+ 	uint32 u32DriverVerInfo = M2M_MAKE_VERSION_INFO(M2M_RELEASE_VERSION_MAJOR_NO,\
+@@ -409,13 +410,19 @@ sint8 wait_for_bootrom(uint8 arg)
+ 
+ 
+ 	reg = 0;
+-	while(1) {
++	while(--retries) {
+ 		reg = nm_read_reg(0x1014);	/* wait for efuse loading done */
+ 		if (reg & 0x80000000) {
+ 			break;
+ 		}
+ 		nm_bsp_sleep(1); /* TODO: Why bus error if this delay is not here. */
+ 	}
++
++	/* communication with device failed */
++	if(retries == 0) {
++		return M2M_ERR_INIT;
++	}
++
+ 	reg = nm_read_reg(M2M_WAIT_FOR_HOST_REG);
+ 	reg &= 0x1;
+ 
+-- 
+2.34.1
+

--- a/pkg/driver_atwinc15x0/patches/0009-nmasic-limit-retries-in-chip_apply_conf.patch
+++ b/pkg/driver_atwinc15x0/patches/0009-nmasic-limit-retries-in-chip_apply_conf.patch
@@ -1,0 +1,36 @@
+From c1efd943abeb7ddf643bdb0849d1d70ae748ac5d Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Wed, 15 Jun 2022 18:05:45 +0200
+Subject: [PATCH 3/3] nmasic: limit retries in chip_apply_conf()
+
+---
+ src/driver/source/nmasic.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/driver/source/nmasic.c b/src/driver/source/nmasic.c
+index b77dc5a..bcc766d 100644
+--- a/src/driver/source/nmasic.c
++++ b/src/driver/source/nmasic.c
+@@ -65,6 +65,7 @@
+ sint8 chip_apply_conf(uint32 u32Conf)
+ {
+ 	sint8 ret = M2M_SUCCESS;
++	uint16 retries = TIMEOUT;
+ 	uint32 val32 = u32Conf;
+ 	
+ #if (defined __ENABLE_PMU__) || (defined CONF_WINC_INT_PMU)
+@@ -98,9 +99,9 @@ sint8 chip_apply_conf(uint32 u32Conf)
+ 		} else {
+ 			break;
+ 		}
+-	} while(1);
++	} while(--retries);
+ 
+-	return M2M_SUCCESS;
++	return retries ? M2M_SUCCESS : M2M_ERR_TIME_OUT;
+ }
+ void chip_idle(void)
+ {
+-- 
+2.34.1
+


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This enables a timeout on init to not hang there forever if init fails but instead return an error.


### Testing procedure

Run `tests/driver_atwinc15x0` on any board without the module connected.
On `master` this would hang indefinitely, with this patch you get

```
[atwinc15x0] Driver initialization error -5
2022-06-15 18:18:09,854 - INFO # gnrc_netif: init failed: -5
2022-06-15 18:18:09,859 - INFO # main(): This is RIOT! (Version: 2022.07-devel-770-g9827e)
2022-06-15 18:18:09,859 - INFO # >
```

### Issues/PRs references

upstream PR https://github.com/arduino-libraries/WiFi101/pull/335

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
