### PR TITLE
makefiles/tests: use BINFILE for hash comparision instead of ELFFILE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -679,7 +679,7 @@ binfile: $(BINFILE)
 flashfile: $(FLASHFILE)
 
 ifeq (,$(FLASHFILE))
-  $(error FLASHFILE is not defined for this board: $(FLASHFILE))
+  $(error FLASHFILE is not defined for this board: $(BOARD))
 endif
 
 BUILD_FILES += $(ELFFILE) $(BINFILE) $(FLASHFILE) $(HASHFILE)

--- a/Makefile.include
+++ b/Makefile.include
@@ -395,11 +395,6 @@ ifneq (,$(IOTLAB_NODE))
   PROGRAMMER ?= iotlab
   # iotlab uses ELFFILE by default for flashing boards.
   FLASHFILE ?= $(ELFFILE)
-  # RIOT_CI_BUILD disables the build of BINFILE which is required for flashing
-  # on IoT-LAB
-  ifeq (1,$(RIOT_CI_BUILD))
-    BUILD_FILES += $(BINFILE)
-  endif
   # Disable IOTLAB_NODE if inside Docker to avoid including the
   # iotlab.single.inc.mk file which is useless there: it's only useful for
   # flashing and this is done outside of Docker.
@@ -654,6 +649,7 @@ endif
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
 BINFILE ?= $(ELFFILE:.elf=.bin)
+HASHFILE ?= $(BINFILE)
 MAPFILE ?= $(ELFFILE:.elf=.map)
 
 ifneq (,$(filter suit,$(USEMODULE)))
@@ -686,13 +682,7 @@ ifeq (,$(FLASHFILE))
   $(error FLASHFILE is not defined for this board: $(FLASHFILE))
 endif
 
-# By default always build ELFFILE, BINFILE and FLASHFILE
-ifeq ($(RIOT_CI_BUILD),1)
-  # Don't build BINFILE on the CI to save some computation time
-  BUILD_FILES += $(ELFFILE) $(FLASHFILE)
-else
-  BUILD_FILES += $(ELFFILE) $(BINFILE) $(FLASHFILE)
-endif
+BUILD_FILES += $(ELFFILE) $(BINFILE) $(FLASHFILE) $(HASHFILE)
 
 # variables used to compile and link c++
 ifneq (,$(filter cpp,$(USEMODULE)))

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -31,3 +31,6 @@ endif
 
 # system objcopy is not able to generate a binfile for MIPS
 BINFILE =
+
+# hence, use HEXFILE instead for hashing
+HASHFILE = $(HEXFILE)

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -34,3 +34,6 @@ endif
 
 # system objcopy is not able to generate a binfile for MIPS
 BINFILE =
+
+# hence, use HEXFILE instead for hashing
+HASHFILE = $(HEXFILE)

--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -74,7 +74,10 @@ test-with-config/check-config:
 # this target only makes sense if an ELFFILE is actually created, thus guard by
 # RIOTNOLINK="".
 ifeq (,$(RIOTNOLINK))
-test-input-hash: $(TESTS) $(TESTS_WITH_CONFIG) $(TESTS_AS_ROOT) $(ELFFILE) $(TEST_EXTRA_FILES)
+  ifeq (,$(HASHFILE))
+    $(error HASHFILE is empty for $(BOARD))
+  endif
+test-input-hash: $(TESTS) $(TESTS_WITH_CONFIG) $(TESTS_AS_ROOT) $(HASHFILE) $(TEST_EXTRA_FILES)
 	sha1sum $^ > $(BINDIR)/test-input-hash.sha1
 else
 test-input-hash:


### PR DESCRIPTION
### Contribution description
Let's consider firmwares as identical if their binfiles are matching, e.g. in case the `.debug` section ends up being different for whatever reason.

This hopefully makes sure false positives on hash mismatches are a thing of the past.

### Testing procedure

Murdock should be happy. Even for ESP32 builds, every time.

### Issues/PRs references

None