### PR TITLE
boards/esp32: cleanup CI compilation for esp_wifi_enterprise

### DIFF
--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -125,23 +125,6 @@
 #endif
 /** @} */
 
-#ifndef DOXYGEN
-/**
- * @name    Default configuration parameters for ESP WiFi Enterprise netdev
- * @{
- */
-#ifndef ESP_WIFI_EAP_USER
-/** User name used in phase 2 (inner) EAP authentication. */
-#define ESP_WIFI_EAP_USER   "riot-os@riot-os.org"
-#endif /* ESP_WIFI_EAP_USER */
-
-#ifndef ESP_WIFI_EAP_PASS
-/** Password used in phase 2 (inner) EAP authentication. */
-#define ESP_WIFI_EAP_PASS   "riot-os"
-#endif /* ESP_WIFI_EAP_PASS */
-/** @} */
-#endif /* !DOXYGEN */
-
 /* include common board definitions as last step */
 #include "board_common.h"
 

--- a/tests/external_board_dirs/esp-ci-boards/esp32-ci/Makefile.include
+++ b/tests/external_board_dirs/esp-ci-boards/esp32-ci/Makefile.include
@@ -2,4 +2,9 @@
 # to also include the main board header
 INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/esp32-wrover-kit/include))
 
+# ESP_WIFI_EAP_USER and ESP_WIFI_EAP_PASS have to be defined to compile the
+# optional module esp_wifi_enterprise in CI
+CFLAGS += -DESP_WIFI_EAP_USER=\"riot@riot-os.org\"
+CFLAGS += -DESP_WIFI_EAP_PASS=\"riot\"
+
 include $(RIOTBOARD)/esp32-wrover-kit/Makefile.include


### PR DESCRIPTION
### Contribution description

This PR is a cleanup of the CI compilation of optional ESP module `esp_wifi_enterprise`.

In the board definition of `esp32_wrover_kit`, default values for `ESP_WIFI_EAP_USER` and `ESP_WIFI_EAP_PASS` had to be defined because this board was used in the CI to compile the optional module `esp_wifi_enterprise` (PR #17314).

Now where the CI compilation for the `esp_wifi_enterprise` module is realized by an external board definition `esp32-ci`, these default values should be removed from `esp32_wrover_kit` to let the compilation fail if the user did not define these required variables. Instead, the variables are defined for the CI compilation in `Makefile.include` of external board definition `esp32-ci`.

### Testing procedure

1. GreenCI
2. `USEMODULE=esp_wifi_enterprise BOARD=esp32-wrover-kit make -j8 -C examples/gnrc_minimal` should fail.

### Issues/PRs references

Cleanup of PR #17314