### PR TITLE
cpu/stm32/periph_eth: enable stm32_eth_link_up with lwip_ipv6

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -26,6 +26,12 @@ ifneq (,$(filter stm32_eth,$(USEMODULE)))
   USEMODULE += iolist
   USEMODULE += ztimer
   USEMODULE += ztimer_msec
+
+  # lwip IPv6 supports needs link up events to perform duplicate address
+  # detection
+  ifneq (,$(filter lwip_ipv6,$(USEMODULE)))
+    USEMODULE += stm32_eth_link_up
+  endif
 endif
 
 ifneq (,$(filter periph_can,$(FEATURES_USED)))


### PR DESCRIPTION
### Contribution description

An network devices that supports `netdev_driver_t::get(NETOPT_LINK, ...)`
also has to emit NETDEV_EVENT_LINK_UP and NETDEV_EVENT_LINK_DOWN with
lwip for IPv6 duplicate address detection to work. The background is
that the STM32 Ethernet MAC requires a periodic timer to poll for the
state to emit these events. For this reason, `stm32_eth_link_up` was
introduced to allow applications to select if they need these events.

With this dependency in place, IPv6 addresses won't get stuck in a
tentative state any more.

### Testing procedure

```
$ make BOARD=nucleo-f767zi LWIP=1 -C examples/gcoap flash term
[...]
> ifconfig
```

With `master`:

```
ifconfig
Iface ET0 HWaddr: aa:84:9d:12:bb:2d Link: down State: up
        Link type: wired
        inet6 addr: fe80:0:0:0:a884:9dff:fe12:bb2d scope: link state: tentative (0 probes send)
```

this PR:

```
ifconfig
Iface ET0 HWaddr: aa:84:9d:12:bb:2d Link: up State: up
        Link type: wired
        inet6 addr: fe80:0:0:0:a884:9dff:fe12:bb2d scope: link state: valid preferred
```

### Issues/PRs references

None