### PR TITLE
makefiles/rust: Err early, provide suggestions

### DIFF
--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -18,6 +18,15 @@ $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 
 
 $(CARGO_LIB): $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS) FORCE
+	$(Q)command -v cargo >/dev/null || ($(COLOR_ECHO) \
+		'$(COLOR_RED)Error: `cargo` command missing to build Rust modules.$(COLOR_RESET) Please install as described on <https://doc.riot-os.org/using-rust.html>.' ;\
+		exit 1)
+	$(Q)command -v $${C2RUST:-c2rust} >/dev/null || ($(COLOR_ECHO) \
+		'$(COLOR_RED)Error: `'$${C2RUST:-c2rust}'` command missing to build Rust modules.$(COLOR_RESET) Please install as described on <https://doc.riot-os.org/using-rust.html>.' ;\
+		exit 1)
+	$(Q)command -v rustup >/dev/null || ($(COLOR_ECHO) \
+		'$(COLOR_RED)Error: `rustup` command missing.$(COLOR_RESET) While it is not essential for building Rust modules, it is the only known way to install the target core libraries (or nightly for -Zbuild-std) needed to do so. If you do think that building should be possible, please edit this file, and file an issue about building Rust modules with the installation method you are using -- later checks in this file, based on rustup, will need to be adjusted for that.' ;\
+		exit 1)
 	$(Q)[ x"${RUST_TARGET}" != x"" ] || ($(COLOR_ECHO) "$(COLOR_RED)Error: No RUST_TARGET was set for this platform.$(COLOR_RESET) Set FEATURES_REQUIRED+=rust_target to catch this earlier."; exit 1)
 	$(Q)# If distribution installed cargos ever grow the capacity to build RIOT, this absence of `rustup` might be OK. But that'd need them to both have cross tools around and cross core libs, none of which is currently the case.
 	$(Q)# Ad grepping for "std": We're not *actually* checking for std but more for core -- but rust-stc-$TARGET is the name of any standard libraries that'd be available for that target.

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -18,7 +18,7 @@ $(CARGO_COMPILE_COMMANDS): $(BUILDDEPS)
 
 
 $(CARGO_LIB): $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS) FORCE
-	$(Q)[ x"${RUST_TARGET}" != x"" ] || (echo "Error: No RUST_TARGET was set for this platform. (Set FEATURES_REQUIRED+=rust_target to catch this earlier)."; exit 1)
+	$(Q)[ x"${RUST_TARGET}" != x"" ] || ($(COLOR_ECHO) "$(COLOR_RED)Error: No RUST_TARGET was set for this platform.$(COLOR_RESET) Set FEATURES_REQUIRED+=rust_target to catch this earlier."; exit 1)
 	$(Q)# If distribution installed cargos ever grow the capacity to build RIOT, this absence of `rustup` might be OK. But that'd need them to both have cross tools around and cross core libs, none of which is currently the case.
 	$(Q)# Ad grepping for "std": We're not *actually* checking for std but more for core -- but rust-stc-$TARGET is the name of any standard libraries that'd be available for that target.
 	$(Q)[ x"$(findstring build-std,$(CARGO_OPTIONS))" != x"" ] || \

--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -27,6 +27,14 @@ $(CARGO_LIB): $(RIOTBUILD_CONFIG_HEADER_C) $(BUILDDEPS) $(CARGO_COMPILE_COMMANDS
 		'$(COLOR_RED)Error: No Rust libraries are installed for the board'"'"'s CPU.$(COLOR_RESET) Run\n    $(COLOR_GREEN)$$$(COLOR_RESET) rustup target add $(RUST_TARGET) $(patsubst %,--toolchain %,$(CARGO_CHANNEL))\nor set `CARGO_OPTIONS=-Zbuild-std=core`.'; \
 		exit 1)
 	$(Q)CC= CFLAGS= CPPFLAGS= CXXFLAGS= RIOT_COMPILE_COMMANDS_JSON="$(CARGO_COMPILE_COMMANDS)" RIOT_USEMODULE="$(USEMODULE)" cargo $(patsubst +,,+${CARGO_CHANNEL}) build --target $(RUST_TARGET) `if [ x$(CARGO_PROFILE) = xrelease ]; then echo --release; else if [ x$(CARGO_PROFILE) '!=' xdebug ]; then echo "--profile $(CARGO_PROFILE)"; fi; fi` $(CARGO_OPTIONS)
+	$(Q)CC= CFLAGS= CPPFLAGS= CXXFLAGS= \
+		RIOT_COMPILE_COMMANDS_JSON="$(CARGO_COMPILE_COMMANDS)" \
+		RIOT_USEMODULE="$(USEMODULE)" \
+		cargo $(patsubst +,,+${CARGO_CHANNEL}) \
+			build \
+			--target $(RUST_TARGET) \
+			`if [ x$(CARGO_PROFILE) = xrelease ]; then echo --release; else if [ x$(CARGO_PROFILE) '!=' xdebug ]; then echo "--profile $(CARGO_PROFILE)"; fi; fi` \
+			$(CARGO_OPTIONS)
 
 $(APPLICATION_RUST_MODULE).module: $(CARGO_LIB) FORCE
 	$(Q)# Ensure no old object files persist. These would lead to duplicate


### PR DESCRIPTION
### Contribution description

Experienced RIOT users, when building Rust based examples for the first time, can easily miss subtle parts of the required tooling when not installing through BUILD_IN_DOCKER.

To enhance the user experience, this adds a few checks to the builds to ensure that usable error messages are produced before kicking off the Rust tools, which do generally provide good error output, but [currently not in the most concise way](https://github.com/rust-lang/rust/issues/97685) and generally not by pointing to the relevant RIOT related documentation).

[edit] To some extent the tests may be overly strict (eg. it tests for the presence of rustup, which technically is not required); the error message shown then explains why that is usually necessary and also guides about what to do if the ecosystem changes and that test (along with others) is not suitable any more.

### Testing procedure

* CI should still run through
* Someone who hasn't done it before could try `make -C examples/rust-hello-world` without reading the docs first and only react to obvious error messages.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/18200