### PR TITLE
nanocoap_sock: fix wrong assertion

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -175,6 +175,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
         case STATE_RESPONSE_OK:
             DEBUG("nanocoap: waiting for response (timeout: %"PRIu32" µs)\n",
                   _deadline_left_us(deadline));
+            const void *old_ctx = ctx;
             tmp = sock_udp_recv_buf(sock, &payload, &ctx, _deadline_left_us(deadline), NULL);
             /* sock_udp_recv_buf() is supposed to return multiple packet fragments
              * when called multiple times with the same context.
@@ -183,7 +184,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
              * releases the packet.
              * This assertion will trigger should the behavior change in the future.
              */
-            if (state != STATE_REQUEST_SEND) {
+            if (old_ctx) {
                 assert(tmp == 0 && ctx == NULL);
             }
             if (tmp == 0) {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The assertion is a bit overeager.
In case of receiving a wrong message ID, we re-try receive without entering the STATE_REQUEST_SEND state again, so it is expected that we get a non-NULL ctx/response from `sock_udp_recv_buf()`. 

What this assert should actually check is that we don't get a non-NULL ctx after calling `sock_udp_recv_buf()` with a non-NULL ctx.

So make this explicit to not falsely fail the assertion.


### Testing procedure

CoAP operations should no longer trigger the assertion in the wake of re-transmissions/wrong message IDs. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
