### PR TITLE
cpu/sam0_common: mtd_sdhc: ensure source address alignment

### DIFF
--- a/cpu/sam0_common/sam0_sdhc/mtd_sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/mtd_sdhc.c
@@ -69,7 +69,7 @@ static int _read_page(mtd_dev_t *dev, void *buff, uint32_t page,
     DEBUG("%s(%lu, %lu, %lu)\n", __func__, page, offset, size);
 
     /* emulate unaligned / sub-page read */
-    if (pages == 0 || offset) {
+    if (pages == 0 || offset || ((uintptr_t)buff & 0x3)) {
 #if IS_USED(MODULE_MTD_WRITE_PAGE)
         if (dev->work_area == NULL) {
             DEBUG("mtd_sdhc: no work area\n");
@@ -105,7 +105,7 @@ static int _write_page(mtd_dev_t *dev, const void *buff, uint32_t page,
     DEBUG("%s(%lu, %lu, %lu)\n", __func__, page, offset, size);
 
     /* emulate unaligned / sub-page write */
-    if (pages == 0 || offset) {
+    if (pages == 0 || offset || ((uintptr_t)buff & 0x3)) {
 #if IS_USED(MODULE_MTD_WRITE_PAGE)
         if (dev->work_area == NULL) {
             DEBUG("mtd_sdhc: no work area\n");


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The source / destination address of the SDHC transfer needs to be word-aligned.

Use the mtd buffer to fix the alignment if `mtd_write_page` is used, otherwise return `-ENOTSUP`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
