### PR TITLE
cpu/esp_common: FreeRTOS adaptation layer changes/extension required for ESP-IDF HAL/LL

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -60,7 +60,6 @@ endif
 
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
   ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
-    USEMODULE += core_thread_flags
     USEMODULE += ztimer_msec
     USEMODULE += periph_i2c_hw
   else

--- a/cpu/esp_common/Kconfig
+++ b/cpu/esp_common/Kconfig
@@ -81,6 +81,7 @@ config MODULE_ESP_COMMON
     select MODULE_LOG # override default log implementation by default
     select MODULE_PERIPH
     select MODULE_ESP_IDF
+    select MODULE_CORE_THREAD_FLAGS if MODULE_ZTIMER_MSEC
     help
       Common code module for ESP SoCs.
 

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -93,3 +93,9 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   USEMODULE += netopt
   USEMODULE += ztimer_msec
 endif
+
+ifneq (,$(filter esp_freertos_common,$(USEMODULE)))
+  ifneq (,$(filter ztimer_msec,$(USEMODULE)))
+    USEMODULE += core_thread_flags
+  endif
+endif

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -53,6 +53,13 @@ ifneq (,$(filter esp_qemu,$(USEMODULE)))
   CFLAGS += -DQEMU
 endif
 
+ifneq (,$(filter esp_freertos_common,$(USEMODULE)))
+  # thread_t.name required by FreeRTOS adaptation layer and esp_gdbstub
+  CFLAGS += -DCONFIG_THREAD_NAMES
+  # thread_t.stack_start required by FreeRTOS adaptation layer
+  CFLAGS += -DSCHED_TEST_STACK
+endif
+
 # use 32 priority levels if any WiFi interface or the ETH interface is used
 ifneq (,$(filter esp_wifi_any esp_eth,$(USEMODULE)))
   CFLAGS += -DSCHED_PRIO_LEVELS=32

--- a/cpu/esp_common/freertos/ringbuf.c
+++ b/cpu/esp_common/freertos/ringbuf.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * FreeRTOS to RIOT-OS adaption module for source code compatibility
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "irq_arch.h"
+#include "ringbuffer.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/ringbuf.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+typedef struct {
+    ringbuffer_t rbuf;
+    uint16_t item_size;
+    char *buf;
+} rbuf_handle_t;
+
+RingbufHandle_t xRingbufferCreate(size_t xBufferSize, RingbufferType_t xBufferType)
+{
+    /* only byte buffer supported for now */
+    assert(xBufferType == RINGBUF_TYPE_BYTEBUF);
+
+    /* allocate the space for rbuf_handle_t including the buffer */
+    rbuf_handle_t *handle = malloc(xBufferSize + sizeof(uint16_t) + sizeof(ringbuffer_t));
+    if (handle == NULL) {
+        return NULL;
+    }
+    handle->item_size = 0;
+    ringbuffer_init((ringbuffer_t *)handle, handle->buf, xBufferSize);
+
+    return handle;
+}
+
+void vRingbufferDelete(RingbufHandle_t xRingbuffer)
+{
+    assert(xRingbuffer != NULL);
+    free(xRingbuffer);
+}
+
+void *xRingbufferReceiveUpToFromISR(RingbufHandle_t xRingbuffer,
+                                    size_t *pxItemSize, size_t xMaxSize)
+{
+    rbuf_handle_t *handle = xRingbuffer;
+    size_t data_len = 0;
+
+    assert(handle != NULL);
+
+    /* determine the number of bytes to be read */
+    if (handle->rbuf.avail) {
+        data_len = ((xMaxSize == 0) || (handle->rbuf.avail < xMaxSize)) ? handle->rbuf.avail
+                                                                        : xMaxSize;
+    }
+    /* ESP-IDF ring buffers require two read operation if the data wrap around */
+    if (data_len > (handle->rbuf.size - handle->rbuf.start)) {
+        data_len = handle->rbuf.size - handle->rbuf.start;
+    }
+    handle->item_size = data_len;
+    *pxItemSize = data_len;
+
+    return handle->rbuf.buf + handle->rbuf.start;
+}
+
+void *xRingbufferReceiveFromISR(RingbufHandle_t xRingbuffer, size_t *pxItemSize)
+{
+    return xRingbufferReceiveUpToFromISR(xRingbuffer, pxItemSize, 0);
+}
+
+void vRingbufferReturnItemFromISR(RingbufHandle_t xRingbuffer, void *pvItem,
+                                  BaseType_t *pxHigherPriorityTaskWoken)
+{
+    rbuf_handle_t *handle = xRingbuffer;
+    if (handle->item_size) {
+        ringbuffer_remove(&handle->rbuf, handle->item_size);
+    }
+}
+
+BaseType_t xRingbufferSendFromISR(RingbufHandle_t xRingbuffer,
+                                  const void *pvItem,
+                                  size_t xItemSize,
+                                  BaseType_t *pxHigherPriorityTaskWoken)
+{
+    rbuf_handle_t *handle = xRingbuffer;
+
+    assert(handle != NULL);
+
+    /* return immediately if there is not enough space in the ring buffer */
+    if (ringbuffer_get_free(&handle->rbuf) < xItemSize) {
+        return pdFALSE;
+    }
+
+    /* add data to the ringbuffer */
+    return ringbuffer_add(&handle->rbuf, pvItem, xItemSize) == xItemSize;
+}

--- a/cpu/esp_common/freertos/semphr.c
+++ b/cpu/esp_common/freertos/semphr.c
@@ -32,26 +32,29 @@
  * objects.
  */
 typedef struct {
-    uint8_t     type;    /* type of the mutex, MUST be the first element */
-    mutex_t     mutex;   /* the mutex */
-} _mutex_t;
+    uint8_t      type;   /* type of the mutex, MUST be the first element */
+    kernel_pid_t pid;    /* PID of the holder if the mutex is locked */
+    mutex_t      mutex;  /* the RIOT mutex */
+} _sem_t;
 
 typedef struct {
-    uint8_t     type;    /* type of the mutex, MUST be the first element */
-    rmutex_t    rmutex;  /* the mutex */
-} _rmutex_t;
+    uint8_t      type;   /* type of the mutex, MUST be the first element */
+    kernel_pid_t pid;    /* PID of the holder if the mutex is locked */
+    rmutex_t     rmutex; /* the RIOT mutex */
+} _rsem_t;
 
 SemaphoreHandle_t xSemaphoreCreateMutex(void)
 {
-    _mutex_t* _tmp = (_mutex_t*)malloc (sizeof(_mutex_t));
+    _sem_t* _tmp = (_sem_t*)malloc (sizeof(_sem_t));
     _tmp->type = queueQUEUE_TYPE_MUTEX;
+    _tmp->pid = KERNEL_PID_UNDEF;
     mutex_init(&_tmp->mutex);
 
     DEBUG("%s mutex=%p\n", __func__, _tmp);
     return _tmp;
 }
 
-void vSemaphoreDelete( SemaphoreHandle_t xSemaphore )
+void vSemaphoreDelete(SemaphoreHandle_t xSemaphore)
 {
     DEBUG("%s mutex=%p\n", __func__, xSemaphore);
 
@@ -59,21 +62,23 @@ void vSemaphoreDelete( SemaphoreHandle_t xSemaphore )
     free(xSemaphore);
 }
 
-BaseType_t xSemaphoreGive (SemaphoreHandle_t xSemaphore)
+BaseType_t xSemaphoreGive(SemaphoreHandle_t xSemaphore)
 {
     DEBUG("%s mutex=%p\n", __func__, xSemaphore);
 
     assert(xSemaphore != NULL);
 
-    uint8_t  type = ((_mutex_t*)xSemaphore)->type;
-    mutex_t* mutex= &((_mutex_t*)xSemaphore)->mutex;
+    _sem_t* sem = (_sem_t*)xSemaphore;
 
-    switch (type) {
+    switch (sem->type) {
         case queueQUEUE_TYPE_MUTEX:
-            mutex_unlock(mutex);
+            mutex_unlock(&sem->mutex);
+            if (sem->mutex.queue.next == NULL) {
+                sem->pid = KERNEL_PID_UNDEF;
+            }
             break;
         case queueQUEUE_TYPE_RECURSIVE_MUTEX:
-            return xSemaphoreGiveRecursive (xSemaphore);
+            return xSemaphoreGiveRecursive(xSemaphore);
         default:
             return xQueueGenericSend(xSemaphore, NULL, 0, queueSEND_TO_BACK);
     }
@@ -81,31 +86,37 @@ BaseType_t xSemaphoreGive (SemaphoreHandle_t xSemaphore)
     return pdTRUE;
 }
 
-BaseType_t xSemaphoreTake (SemaphoreHandle_t xSemaphore,
-                           TickType_t xTicksToWait)
+BaseType_t xSemaphoreTake(SemaphoreHandle_t xSemaphore,
+                          TickType_t xTicksToWait)
 {
     DEBUG("%s mutex=%p wait=%"PRIu32"\n", __func__, xSemaphore, xTicksToWait);
 
     assert(xSemaphore != NULL);
 
-    uint8_t  type = ((_mutex_t*)xSemaphore)->type;
-    mutex_t* mutex= &((_mutex_t*)xSemaphore)->mutex;
+    _sem_t* sem = (_sem_t*)xSemaphore;
 
-    switch (type) {
+    switch (sem->type) {
         case queueQUEUE_TYPE_MUTEX:
         {
             if (xTicksToWait == 0) {
-                return (mutex_trylock(mutex) == 1) ? pdPASS : pdFAIL;
+                if (mutex_trylock(&sem->mutex) == 1) {
+                    sem->pid = thread_getpid();
+                    return pdPASS;
+                }
+                else {
+                    return pdFAIL;
+                }
             }
             else {
-                mutex_lock(mutex);
+                mutex_lock(&sem->mutex);
+                sem->pid = thread_getpid();
                 /* TODO timeout handling */
                 return pdTRUE;
             }
             break;
         }
         case queueQUEUE_TYPE_RECURSIVE_MUTEX:
-            return xSemaphoreTakeRecursive (xSemaphore, xTicksToWait);
+            return xSemaphoreTakeRecursive(xSemaphore, xTicksToWait);
 
         default:
             return xQueueGenericReceive(xSemaphore, NULL, xTicksToWait, pdFALSE);
@@ -114,8 +125,9 @@ BaseType_t xSemaphoreTake (SemaphoreHandle_t xSemaphore,
 
 SemaphoreHandle_t xSemaphoreCreateRecursiveMutex(void)
 {
-    _rmutex_t* _tmp = (_rmutex_t*)malloc (sizeof(_rmutex_t));
+    _rsem_t* _tmp = (_rsem_t*)malloc (sizeof(_rsem_t));
     _tmp->type = queueQUEUE_TYPE_RECURSIVE_MUTEX;
+    _tmp->pid = KERNEL_PID_UNDEF;
     rmutex_init(&_tmp->rmutex);
 
     DEBUG("%s rmutex=%p\n", __func__, _tmp);
@@ -123,37 +135,55 @@ SemaphoreHandle_t xSemaphoreCreateRecursiveMutex(void)
     return _tmp;
 }
 
-BaseType_t xSemaphoreGiveRecursive (SemaphoreHandle_t xSemaphore)
+BaseType_t xSemaphoreGiveRecursive(SemaphoreHandle_t xSemaphore)
 {
     DEBUG("%s rmutex=%p\n", __func__, xSemaphore);
 
-    assert(xSemaphore != NULL);
-    assert(((_rmutex_t*)xSemaphore)->type == queueQUEUE_TYPE_RECURSIVE_MUTEX);
+    _rsem_t* rsem = (_rsem_t*)xSemaphore;
 
-    rmutex_unlock(&((_rmutex_t*)xSemaphore)->rmutex);
+    assert(rsem != NULL);
+    assert(rsem->type == queueQUEUE_TYPE_RECURSIVE_MUTEX);
+
+    rmutex_unlock(&rsem->rmutex);
+    if (rsem->rmutex.mutex.queue.next == NULL) {
+        rsem->pid = KERNEL_PID_UNDEF;
+    }
     return pdTRUE;
 }
 
-BaseType_t xSemaphoreTakeRecursive (SemaphoreHandle_t xSemaphore,
-                                    TickType_t xTicksToWait)
+BaseType_t xSemaphoreTakeRecursive(SemaphoreHandle_t xSemaphore,
+                                   TickType_t xTicksToWait)
 {
     DEBUG("%s rmutex=%p wait=%"PRIu32"\n", __func__, xSemaphore, xTicksToWait);
 
-    assert(xSemaphore != NULL);
-    assert(((_rmutex_t*)xSemaphore)->type == queueQUEUE_TYPE_RECURSIVE_MUTEX);
+    _rsem_t* rsem = (_rsem_t*)xSemaphore;
+
+    assert(rsem != NULL);
+    assert(rsem->type == queueQUEUE_TYPE_RECURSIVE_MUTEX);
 
     BaseType_t ret = pdTRUE;
-    rmutex_t*  rmutex = &((_rmutex_t*)xSemaphore)->rmutex;
 
     if (xTicksToWait == 0) {
-        ret = (rmutex_trylock(rmutex) == 1) ? pdPASS : pdFAIL;
+        ret = (rmutex_trylock(&rsem->rmutex) == 1) ? pdPASS : pdFAIL;
+        if (ret == pdPASS) {
+            rsem->pid = thread_getpid();
+        }
     }
     else {
-        rmutex_lock(&((_rmutex_t*)xSemaphore)->rmutex);
+        rmutex_lock(&rsem->rmutex);
+        rsem->pid = thread_getpid();
         /* TODO timeout handling */
     }
 
     return ret;
+}
+
+TaskHandle_t xSemaphoreGetMutexHolder(SemaphoreHandle_t xMutex)
+{
+    DEBUG("%s mutex=%p\n", __func__, xMutex);
+
+    assert(xMutex != NULL);
+    return (TaskHandle_t)(0L + ((_sem_t*)xMutex)->pid);
 }
 
 void vPortCPUAcquireMutex(portMUX_TYPE *mux)

--- a/cpu/esp_common/freertos/semphr.c
+++ b/cpu/esp_common/freertos/semphr.c
@@ -84,7 +84,7 @@ BaseType_t xSemaphoreGive (SemaphoreHandle_t xSemaphore)
 BaseType_t xSemaphoreTake (SemaphoreHandle_t xSemaphore,
                            TickType_t xTicksToWait)
 {
-    DEBUG("%s mutex=%p wait=%u\n", __func__, xSemaphore, xTicksToWait);
+    DEBUG("%s mutex=%p wait=%"PRIu32"\n", __func__, xSemaphore, xTicksToWait);
 
     assert(xSemaphore != NULL);
 
@@ -137,7 +137,7 @@ BaseType_t xSemaphoreGiveRecursive (SemaphoreHandle_t xSemaphore)
 BaseType_t xSemaphoreTakeRecursive (SemaphoreHandle_t xSemaphore,
                                     TickType_t xTicksToWait)
 {
-    DEBUG("%s rmutex=%p wait=%u\n", __func__, xSemaphore, xTicksToWait);
+    DEBUG("%s rmutex=%p wait=%"PRIu32"\n", __func__, xSemaphore, xTicksToWait);
 
     assert(xSemaphore != NULL);
     assert(((_rmutex_t*)xSemaphore)->type == queueQUEUE_TYPE_RECURSIVE_MUTEX);

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -21,7 +21,7 @@
 #include "log.h"
 #include "syscalls.h"
 #include "thread.h"
-#if defined(MODULE_ESP_WIFI_ANY) || defined(MODULE_ESP_ETH)
+#if defined(MODULE_ZTIMER_MSEC) || defined(MODULE_ZTIMER_USEC)
 #include "ztimer.h"
 #endif
 #include "timex.h"
@@ -48,10 +48,11 @@ typedef struct {
     uint32_t saved_int_state;
     uint32_t critical_nesting;
     uint32_t notification_value;
-    bool notification_wait_for;
+    bool notification_waiting;
+    bool notification_pending;
 } thread_arch_ext_t;
 
-volatile thread_arch_ext_t threads_arch_exts[KERNEL_PID_LAST + 1] = {};
+volatile thread_arch_ext_t threads_arch_exts[KERNEL_PID_LAST + 1] = { };
 
 BaseType_t xTaskCreatePinnedToCore(TaskFunction_t pvTaskCode,
                                    const char * const pcName,
@@ -114,19 +115,16 @@ void vTaskDelete(TaskHandle_t xTaskToDelete)
     extern volatile thread_t *sched_active_thread;
     DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToDelete);
 
-    assert(xTaskToDelete != NULL);
-
     uint32_t pid = (uint32_t)xTaskToDelete;
+    assert(pid_is_valid(pid));
 
-    /* remove old task from scheduling */
+    /* remove the task from scheduling */
     thread_t* thread = (thread_t*)sched_threads[pid];
     sched_set_status(thread, STATUS_STOPPED);
     sched_threads[pid] = NULL;
     sched_num_threads--;
-    sched_active_thread = NULL;
 
-    /* determine the new running task */
-    sched_run();
+    free(thread->stack_start);
 }
 
 void vTaskSuspend(TaskHandle_t xTaskToSuspend)
@@ -134,19 +132,17 @@ void vTaskSuspend(TaskHandle_t xTaskToSuspend)
     extern volatile thread_t *sched_active_thread;
     DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToSuspend);
 
-    uint32_t pid = (xTaskToSuspend == NULL) ? (uint32_t)thread_getpid()
-                                            : (uint32_t)xTaskToSuspend;
-
-    assert(pid <= KERNEL_PID_LAST);
+    thread_t *thread = thread_get((xTaskToSuspend == NULL) ? (uint32_t)thread_getpid()
+                                                           : (uint32_t)xTaskToSuspend);
+    assert(thread != NULL);
 
     /* set status to sleeping to suspend it */
-    thread_t* thread = (thread_t*)sched_threads[pid];
     sched_set_status(thread, STATUS_SLEEPING);
 
-    /* trigger rescheduling */
-    sched_active_thread = NULL;
-    /* determine the new running task */
-    sched_run();
+    /* trigger rescheduling if a task suspends itself */
+    if (xTaskToSuspend == NULL) {
+        thread_yield_higher();
+    }
 }
 
 void vTaskResume(TaskHandle_t xTaskToResume)
@@ -155,8 +151,21 @@ void vTaskResume(TaskHandle_t xTaskToResume)
     DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToResume);
 
     uint32_t pid = (uint32_t)xTaskToResume;
-    assert(pid <= KERNEL_PID_LAST);
+    assert(pid_is_valid(pid));
     thread_wakeup (pid);
+}
+
+void vTaskDelay(const TickType_t xTicksToDelay)
+{
+    DEBUG("%s xTicksToDelay=%"PRIu32"\n", __func__, xTicksToDelay);
+
+#if defined(MODULE_ZTIMER_MSEC)
+    uint64_t ms = xTicksToDelay * portTICK_PERIOD_MS;
+    ztimer_sleep(ZTIMER_MSEC, ms);
+#elif defined(MODULE_ZTIMER_USEC)
+    uint64_t us = xTicksToDelay * portTICK_PERIOD_MS * US_PER_MS;
+    ztimer_sleep(ZTIMER_USEC, us);
+#endif
 }
 
 TaskHandle_t xTaskGetCurrentTaskHandle(void)
@@ -167,14 +176,50 @@ TaskHandle_t xTaskGetCurrentTaskHandle(void)
     return (TaskHandle_t)pid;
 }
 
-void vTaskDelay( const TickType_t xTicksToDelay )
+const char *pcTaskGetTaskName(TaskHandle_t xTaskToQuery)
 {
-    DEBUG("%s xTicksToDelay=%d\n", __func__, xTicksToDelay);
-#if defined(MODULE_ESP_WIFI_ANY) || defined(MODULE_ESP_ETH)
-    uint64_t ms = xTicksToDelay * MS_PER_SEC / xPortGetTickRateHz();
-    ztimer_sleep(ZTIMER_MSEC, ms);
-#endif
+    DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToQuery);
+
+    thread_t *thread = thread_get((xTaskToQuery == NULL) ? (uint32_t)thread_getpid()
+                                                         : (uint32_t)xTaskToQuery);
+    assert(thread != NULL);
+    return thread->name;
 }
+
+#ifdef DEVELHELP
+UBaseType_t uxTaskGetStackHighWaterMark(TaskHandle_t xTask)
+{
+    DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTask);
+
+    thread_t *thread = thread_get((xTask == NULL) ? (uint32_t)thread_getpid()
+                                                  : (uint32_t)xTask);
+    assert(thread != NULL);
+    return thread_measure_stack_free(thread->stack_start);
+}
+
+void *pvTaskGetThreadLocalStoragePointer(TaskHandle_t xTaskToQuery,
+                                         BaseType_t xIndex)
+{
+    (void)xTaskToQuery;
+    (void)xIndex;
+
+    /* TODO define TLS using thread_arch_t */
+    return NULL;
+}
+
+void vTaskSetThreadLocalStoragePointerAndDelCallback(TaskHandle_t xTaskToSet,
+                                                     BaseType_t xIndex,
+                                                     void *pvValue,
+                                                     TlsDeleteCallbackFunction_t pvDelCallback)
+{
+    (void)xTaskToSet;
+    (void)xIndex;
+    (void)pvValue;
+    (void)pvDelCallback;
+
+    /* TODO define TLS using thread_arch_t */
+}
+#endif /* DEVELHELP */
 
 TickType_t xTaskGetTickCount (void)
 {
@@ -269,6 +314,120 @@ TickType_t prvGetExpectedIdleTime(void)
     return 0;
 }
 
+BaseType_t xTaskNotify(TaskHandle_t xTaskToNotify, uint32_t ulValue,
+                       eNotifyAction eAction)
+{
+    uint32_t pid = (uint32_t)xTaskToNotify;
+    thread_t* thread = thread_get(pid);
+
+    DEBUG("%s task=%d notifies=%"PRIu32" value=%"PRIu32" action=%u\n", __func__,
+          thread_getpid(), pid, ulValue, eAction);
+
+    assert(pid_is_valid(pid));
+    assert(thread != NULL);
+
+    vTaskEnterCritical(0);
+
+    switch (eAction) {
+        case eSetBits:
+            threads_arch_exts[pid].notification_value |= ulValue;
+            break;
+        case eIncrement:
+            threads_arch_exts[pid].notification_value++;
+            break;
+        case eSetValueWithoutOverwrite:
+            if (threads_arch_exts[pid].notification_pending) {
+                /* if a notificatoin is pending, return with error */
+                vTaskExitCritical(0);
+                return pdFALSE;
+            }
+            /* fallthrough */
+        case eSetValueWithOverwrite:
+            threads_arch_exts[pid].notification_value = ulValue;
+            break;
+        default:
+            /* no action */
+            break;
+    }
+
+    if (threads_arch_exts[pid].notification_waiting) {
+        /* if the task is waiting for a notification, wake it up */
+        sched_set_status(thread, STATUS_PENDING);
+        vTaskExitCritical(0);
+        thread_yield_higher();
+        return pdTRUE;
+    }
+
+    threads_arch_exts[pid].notification_pending = true;
+
+    vTaskExitCritical(0);
+    return pdTRUE;
+}
+
+BaseType_t xTaskNotifyWait(uint32_t ulBitsToClearOnEntry,
+                           uint32_t ulBitsToClearOnExit,
+                           uint32_t *pulNotificationValue,
+                           TickType_t xTicksToWait)
+{
+    kernel_pid_t pid = thread_getpid();
+
+    DEBUG("%s task=%d entry=%08"PRIx32" exit=%08"PRIx32" wait=%u\n", __func__,
+          pid, ulBitsToClearOnEntry, ulBitsToClearOnExit, xTicksToWait);
+
+    assert(pid_is_valid(pid));
+    assert((xTicksToWait != 0) && !irq_is_in());
+
+    vTaskEnterCritical(0);
+
+    if (!threads_arch_exts[pid].notification_pending) {
+        /* bits to clear on entry if notification was not pending */
+        threads_arch_exts[pid].notification_value ^= ulBitsToClearOnEntry;
+
+        /* suspend the calling thread to wait for notification */
+        threads_arch_exts[pid].notification_waiting = true;
+        thread_t *me = thread_get_active();
+        sched_set_status(me, STATUS_SLEEPING);
+
+        DEBUG("%s pid=%d suspend calling thread\n", __func__, pid);
+
+#if IS_USED(MODULE_ZTIMER_MSEC)
+        ztimer_t tm = { };
+        uint32_t to = xTicksToWait * portTICK_PERIOD_MS;
+        /* set the timeout if given */
+        if (xTicksToWait < portMAX_DELAY) {
+            ztimer_set_timeout_flag(ZTIMER_MSEC, &tm, to);
+            ztimer_set_wakeup(ZTIMER_MSEC, &tm, to + 1, pid);
+        }
+#else
+        assert(xTicksToWait == portMAX_DELAY);
+#endif
+        vTaskExitCritical(0);
+        thread_yield_higher();
+
+#if IS_USED(MODULE_ZTIMER_MSEC)
+        vTaskEnterCritical(0);
+        if (xTicksToWait < portMAX_DELAY) {
+            ztimer_remove(ZTIMER_MSEC, &tm);
+            if (me->flags & THREAD_FLAG_TIMEOUT) {
+                vTaskExitCritical(0);
+                return pdFALSE;
+            }
+        }
+#else
+        assert(xTicksToWait == portMAX_DELAY);
+#endif
+    }
+
+    if (pulNotificationValue) {
+        /* save the notification value before clearing bits on exit */
+        *pulNotificationValue = threads_arch_exts[pid].notification_value;
+    }
+    threads_arch_exts[pid].notification_value ^= ulBitsToClearOnExit;
+
+    vTaskExitCritical(0);
+    return pdTRUE;
+}
+
 BaseType_t xTaskNotifyGive(TaskHandle_t xTaskToNotify)
 {
     DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToNotify);
@@ -279,19 +438,20 @@ BaseType_t xTaskNotifyGive(TaskHandle_t xTaskToNotify)
 void vTaskNotifyGiveFromISR(TaskHandle_t xTaskToNotify,
                             BaseType_t *pxHigherPriorityTaskWoken)
 {
-    DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToNotify);
-
     uint32_t pid = (uint32_t)xTaskToNotify;
+    thread_t* thread = thread_get(pid);
 
-    assert(pid <= KERNEL_PID_LAST);
+    DEBUG("%s task=%d notifies=%"PRIu32"\n", __func__, thread_getpid(), pid);
+
+    assert(pid_is_valid(pid));
+    assert(thread);
 
     vTaskEnterCritical(0);
 
     threads_arch_exts[pid].notification_value++;
 
-    if (threads_arch_exts[pid].notification_wait_for) {
+    if (threads_arch_exts[pid].notification_waiting) {
         /* if the task is waiting for notification, set its status to pending */
-        thread_t* thread = (thread_t*)sched_threads[pid];
         sched_set_status(thread, STATUS_PENDING);
 
         if (thread->priority < sched_threads[thread_getpid()]->priority) {
@@ -316,7 +476,7 @@ uint32_t ulTaskNotifyTake(BaseType_t xClearCountOnExit,
 
     kernel_pid_t pid = thread_getpid();
 
-    assert((pid >= 0) && (pid <= KERNEL_PID_LAST));
+    assert(pid_is_valid(pid));
 
     vTaskEnterCritical(0);
 
@@ -334,7 +494,7 @@ uint32_t ulTaskNotifyTake(BaseType_t xClearCountOnExit,
     }
     else {
         /* suspend the calling thread to wait for notification */
-        threads_arch_exts[pid].notification_wait_for = true;
+        threads_arch_exts[pid].notification_waiting = true;
         thread_t *me = thread_get_active();
         sched_set_status(me, STATUS_SLEEPING);
 
@@ -346,7 +506,7 @@ uint32_t ulTaskNotifyTake(BaseType_t xClearCountOnExit,
         /* TODO timeout handling with xTicksToWait */
         DEBUG("%s pid=%d continue calling thread\n", __func__, thread_getpid());
     }
-    threads_arch_exts[pid].notification_wait_for = false;
+    threads_arch_exts[pid].notification_waiting = false;
     if (xClearCountOnExit) {
         threads_arch_exts[pid].notification_value = 0;
     }

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -66,14 +66,14 @@ BaseType_t xTaskCreatePinnedToCore(TaskFunction_t pvTaskCode,
     /* FreeRTOS priority values have to be inverted */
     uxPriority = SCHED_PRIO_LEVELS - uxPriority - 1;
 
-    DEBUG("%s name=%s size=%d prio=%d pvCreatedTask=%p xCoreId=%d",
+    DEBUG("%s name=%s size=%"PRIu32" prio=%u pvCreatedTask=%p xCoreId=%d\n",
           __func__, pcName, usStackDepth, uxPriority, pvCreatedTask, xCoreID);
 
     char* stack = malloc(usStackDepth + sizeof(thread_t));
 
     if (!stack) {
         LOG_TAG_ERROR("freertos", "not enough memory to create task %s with "
-                      "stack size of %d bytes\n", pcName, usStackDepth);
+                      "stack size of %"PRIu32" bytes\n", pcName, usStackDepth);
         abort();
         return pdFALSE;
     }
@@ -249,7 +249,7 @@ void vTaskExitCritical( portMUX_TYPE *mux )
 
 void vTaskStepTick(const TickType_t xTicksToJump)
 {
-    DEBUG("%s xTicksToJump=%d\n", __func__, xTicksToJump);
+    DEBUG("%s xTicksToJump=%"PRIu32"\n", __func__, xTicksToJump);
     /*
      * TODO:
      * At the moment, only the calling task is set to sleep state. Usually, the

--- a/cpu/esp_common/freertos/timers.c
+++ b/cpu/esp_common/freertos/timers.c
@@ -71,13 +71,14 @@ TimerHandle_t xTimerCreate (const char * const pcTimerName,
     timer->ztimer.callback = _ztimer_callback;
     timer->ztimer.arg = timer;
 
-    DEBUG("%s %p %s %d %u\n", __func__, timer, pcTimerName, xTimerPeriod, uxAutoReload);
+    DEBUG("%s %p %s %"PRIu32" %u\n",
+          __func__, timer, pcTimerName, xTimerPeriod, uxAutoReload);
     return timer;
 }
 
 BaseType_t xTimerDelete(TimerHandle_t xTimer, TickType_t xBlockTime)
 {
-    DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
+    DEBUG("%s %p %"PRIu32"\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
     freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
@@ -89,7 +90,7 @@ BaseType_t xTimerDelete(TimerHandle_t xTimer, TickType_t xBlockTime)
 
 BaseType_t xTimerStart (TimerHandle_t xTimer, TickType_t xBlockTime)
 {
-    DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
+    DEBUG("%s %p %"PRIu32"\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
     freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
@@ -100,7 +101,7 @@ BaseType_t xTimerStart (TimerHandle_t xTimer, TickType_t xBlockTime)
 
 BaseType_t xTimerStop  (TimerHandle_t xTimer, TickType_t xBlockTime)
 {
-    DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
+    DEBUG("%s %p %"PRIu32"\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
     freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;
@@ -111,7 +112,7 @@ BaseType_t xTimerStop  (TimerHandle_t xTimer, TickType_t xBlockTime)
 
 BaseType_t xTimerReset (TimerHandle_t xTimer, TickType_t xBlockTime)
 {
-    DEBUG("%s %p %d\n", __func__, xTimer, xBlockTime);
+    DEBUG("%s %p %"PRIu32"\n", __func__, xTimer, xBlockTime);
     assert(xTimer != NULL);
 
     freertos_ztimer_t* timer = (freertos_ztimer_t*)xTimer;

--- a/cpu/esp_common/include/freertos/FreeRTOS.h
+++ b/cpu/esp_common/include/freertos/FreeRTOS.h
@@ -27,16 +27,19 @@ extern "C" {
 #endif
 
 #define portTICK_PERIOD_MS      10
-#define portTickType            TickType_t
 
 #define portTICK_RATE_MS        portTICK_PERIOD_MS
 
 #define BaseType_t              portBASE_TYPE
-#define UBaseType_t             unsigned portBASE_TYPE
+#define UBaseType_t             portUBASE_TYPE
+#define TickType_t              portTICK_TYPE
+#define StackType_t             portSTACK_TYPE
+
+#define portTickType            TickType_t
 
 #define pdMS_TO_TICKS(ms)       ((TickType_t)(ms / portTICK_PERIOD_MS))
 
-typedef uint32_t TickType_t;
+#define xSemaphoreHandle        SemaphoreHandle_t
 
 uint32_t xPortGetTickRateHz(void);
 BaseType_t xPortInIsrContext(void);

--- a/cpu/esp_common/include/freertos/portmacro.h
+++ b/cpu/esp_common/include/freertos/portmacro.h
@@ -17,6 +17,7 @@
 #include "stdint.h"
 
 #ifndef MCU_ESP8266
+#include "esp_heap_caps.h"
 #include "esp_timer.h"
 #endif
 
@@ -29,8 +30,10 @@ extern "C" {
 
 #define portBASE_TYPE                   int
 #define portUBASE_TYPE                  unsigned portBASE_TYPE
+#define portTICK_TYPE                   uint32_t
+#define portSTACK_TYPE                  uint8_t
 
-#define portMAX_DELAY                   0xFFFFFFFF
+#define portMAX_DELAY                   0xFFFFFFFFUL
 
 #define portMUX_TYPE                    mutex_t
 #define portMUX_INITIALIZE              mutex_init
@@ -49,6 +52,8 @@ extern "C" {
 
 #define portSET_INTERRUPT_MASK_FROM_ISR     xPortSetInterruptMaskFromISR
 #define portCLEAR_INTERRUPT_MASK_FROM_ISR   vPortClearInterruptMaskFromISR
+
+#define errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY    ( -1 )
 
 #ifdef MCU_ESP32
 

--- a/cpu/esp_common/include/freertos/queue.h
+++ b/cpu/esp_common/include/freertos/queue.h
@@ -32,7 +32,7 @@ QueueHandle_t xQueueCreateCountingSemaphore (const UBaseType_t uxMaxCount,
 
 void vQueueDelete (QueueHandle_t xQueue);
 
-BaseType_t xQueueGenericReset (QueueHandle_t xQueue, BaseType_t xNewQueue);
+BaseType_t xQueueReset (QueueHandle_t xQueue);
 
 BaseType_t xQueueGenericReceive (QueueHandle_t xQueue,
                                  void * const pvBuffer,
@@ -108,7 +108,10 @@ UBaseType_t uxQueueMessagesWaiting( QueueHandle_t xQueue );
                                   ( pxHigherPriorityTaskWoken ), \
                                   queueSEND_TO_BACK )
 
-#define xQueueReset( xQueue ) xQueueGenericReset( xQueue, pdFALSE )
+#define xQueueOverwriteFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken ) \
+        xQueueGenericSendFromISR( ( xQueue ), ( pvItemToQueue ), \
+                                  ( pxHigherPriorityTaskWoken ), \
+                                  queueOVERWRITE )
 
 #ifdef __cplusplus
 }

--- a/cpu/esp_common/include/freertos/ringbuf.h
+++ b/cpu/esp_common/include/freertos/ringbuf.h
@@ -21,6 +21,33 @@
 extern "C" {
 #endif
 
+#define RINGBUF_TYPE_BYTEBUF    2
+
+typedef unsigned RingbufferType_t;
+typedef void * RingbufHandle_t;
+
+RingbufHandle_t xRingbufferCreate(size_t xBufferSize, RingbufferType_t xBufferType);
+
+void vRingbufferDelete(RingbufHandle_t xRingbuffer);
+
+void *xRingbufferReceiveUpTo(RingbufHandle_t xRingbuffer,
+                             size_t *pxItemSize,
+                             TickType_t xTicksToWait,
+                             size_t xMaxSize);
+
+BaseType_t xRingbufferSendFromISR(RingbufHandle_t xRingbuffer,
+                                  const void *pvItem,
+                                  size_t xItemSize,
+                                  BaseType_t *pxHigherPriorityTaskWoken);
+
+void *xRingbufferReceiveUpToFromISR(RingbufHandle_t xRingbuffer,
+                                    size_t *pxItemSize, size_t xMaxSize);
+
+void *xRingbufferReceiveFromISR(RingbufHandle_t xRingbuffer, size_t *pxItemSize);
+
+void vRingbufferReturnItemFromISR(RingbufHandle_t xRingbuffer, void *pvItem,
+                                  BaseType_t *pxHigherPriorityTaskWoken);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp_common/include/freertos/semphr.h
+++ b/cpu/esp_common/include/freertos/semphr.h
@@ -14,6 +14,7 @@
 #ifndef DOXYGEN
 
 #include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include <stdlib.h>
 #include "mutex.h"
@@ -35,6 +36,8 @@ BaseType_t xSemaphoreTake (SemaphoreHandle_t xSemaphore,
 BaseType_t xSemaphoreGiveRecursive (SemaphoreHandle_t xSemaphore);
 BaseType_t xSemaphoreTakeRecursive (SemaphoreHandle_t xSemaphore,
                                     TickType_t xTicksToWait);
+
+TaskHandle_t xSemaphoreGetMutexHolder(SemaphoreHandle_t xMutex);
 
 #define vPortCPUInitializeMutex(m)  mutex_init(m)
 

--- a/cpu/esp_common/include/freertos/task.h
+++ b/cpu/esp_common/include/freertos/task.h
@@ -31,7 +31,18 @@ extern "C" {
 #define taskENTER_CRITICAL          portENTER_CRITICAL
 #define taskEXIT_CRITICAL           portEXIT_CRITICAL
 
+#define taskSCHEDULER_RUNNING       2
+
+typedef enum {
+    eNoAction = 0,
+    eSetBits,
+    eIncrement,
+    eSetValueWithOverwrite,
+    eSetValueWithoutOverwrite,
+} eNotifyAction;
+
 typedef void (*TaskFunction_t)(void *);
+typedef void (*TlsDeleteCallbackFunction_t)( int, void * );
 
 typedef void* TaskHandle_t;
 
@@ -58,10 +69,28 @@ void vTaskSuspendAll(void);
 
 TaskHandle_t xTaskGetCurrentTaskHandle(void);
 
+const char *pcTaskGetTaskName(TaskHandle_t xTaskToQuery);
+
+UBaseType_t uxTaskGetStackHighWaterMark(TaskHandle_t xTask);
+
+void *pvTaskGetThreadLocalStoragePointer(TaskHandle_t xTaskToQuery,
+                                         BaseType_t xIndex);
+void vTaskSetThreadLocalStoragePointerAndDelCallback(TaskHandle_t xTaskToSet,
+                                                     BaseType_t xIndex,
+                                                     void *pvValue,
+                                                     TlsDeleteCallbackFunction_t pvDelCallback);
+
 void vTaskEnterCritical(portMUX_TYPE *mux);
 void vTaskExitCritical(portMUX_TYPE *mux);
 
 TickType_t xTaskGetTickCount(void);
+
+BaseType_t xTaskNotify(TaskHandle_t xTaskToNotify, uint32_t ulValue,
+                       eNotifyAction eAction);
+BaseType_t xTaskNotifyWait(uint32_t ulBitsToClearOnEntry,
+                           uint32_t ulBitsToClearOnExit,
+                           uint32_t *pulNotificationValue,
+                           TickType_t xTicksToWait);
 
 BaseType_t xTaskNotifyGive(TaskHandle_t xTaskToNotify);
 void vTaskNotifyGiveFromISR(TaskHandle_t xTaskToNotify,


### PR DESCRIPTION
### Contribution description

As discussed in PR #17841, this PR is a split out of the changes and extensions that are required to use the ESP-IDF HAL or LL. It includes:

- fixes for platform independent compilation (figured out in PR #17844)
- implementation of additionally required function `xQueueReset`
- implementation of additionally required function `xSemaphoreGetMutexHolder`
- implementation of additionally required functions `pcTaskGetTaskName` and `uxTaskGetStackHighWaterMark`
- implementation of additionally required functions `pvTaskGetThreadLocalStoragePointer` and `vTaskSetThreadLocalStoragePointerAndDelCallback`
- implementation of additionally required task notification functions `xTaskNotify` and `xTaskNotifyWait`
- implementation of timeout handling in `xQueue*` functions
- implementation of ringbuffer functions `xRingbbuffer*`

### Testing procedure

Without using the ESP-IDF as provided by PR #17841, the only test is green CI.

### Issues/PRs references

Split out of PR #17841