### PR TITLE
boards/nucleo32: doc update - usage of cpy2remed programmer and short overview of board

### DIFF
--- a/boards/nucleo-f031k6/doc.txt
+++ b/boards/nucleo-f031k6/doc.txt
@@ -2,4 +2,23 @@
  * @defgroup    boards_nucleo-f031k6 STM32 Nucleo-F031K6
  * @ingroup     boards_common_nucleo32
  * @brief       Support for the STM32 Nucleo-F031K6
+
+## Overview
+
+The Nucleo-F031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0 
+STM32F031K6 microcontroller with 4kB of RAM and 64kB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f031k6 PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-f031k6/doc.txt
+++ b/boards/nucleo-f031k6/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-F031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0 
-STM32F031K6 microcontroller with 4kB of RAM and 64kB of Flash.
+STM32F031K6 microcontroller with 4KiB of RAM and 64KiB of Flash.
 
 ## Flashing the Board Using ST-LINK Removable Media
 

--- a/boards/nucleo-f031k6/doc.txt
+++ b/boards/nucleo-f031k6/doc.txt
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The Nucleo-F031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0 
+The Nucleo-F031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
 STM32F031K6 microcontroller with 4KiB of RAM and 64KiB of Flash.
 
 ## Flashing the Board Using ST-LINK Removable Media

--- a/boards/nucleo-f042k6/doc.txt
+++ b/boards/nucleo-f042k6/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-F042K6 is a board from ST's Nucleo family supporting ARM Cortex-M0 
-STM32F042K6 microcontroller with 6kB of RAM and 32kB of Flash.
+STM32F042K6 microcontroller with 6KiB of RAM and 32KiB of Flash.
 
 ## Flashing the Board Using ST-LINK Removable Media
 

--- a/boards/nucleo-f042k6/doc.txt
+++ b/boards/nucleo-f042k6/doc.txt
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The Nucleo-F042K6 is a board from ST's Nucleo family supporting ARM Cortex-M0 
+The Nucleo-F042K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
 STM32F042K6 microcontroller with 6KiB of RAM and 32KiB of Flash.
 
 ## Flashing the Board Using ST-LINK Removable Media

--- a/boards/nucleo-f042k6/doc.txt
+++ b/boards/nucleo-f042k6/doc.txt
@@ -2,4 +2,23 @@
  * @defgroup    boards_nucleo-f042k6 STM32 Nucleo-F042K6
  * @ingroup     boards_common_nucleo32
  * @brief       Support for the STM32 Nucleo-F042K6
+
+## Overview
+
+The Nucleo-F042K6 is a board from ST's Nucleo family supporting ARM Cortex-M0 
+STM32F042K6 microcontroller with 6kB of RAM and 32kB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f042k6 PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-f303k8/doc.txt
+++ b/boards/nucleo-f303k8/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-F303K8 is a board from ST's Nucleo family supporting a ARM Cortex-M4
-STM32F303K8 microcontroller with 12Kb of RAM and 64Kb of ROM.
+STM32F303K8 microcontroller with 12KiB of RAM and 64KiB of ROM.
 
 ## Hardware
 
@@ -18,8 +18,8 @@ STM32F303K8 microcontroller with 12Kb of RAM and 64Kb of ROM.
 |:---------- |:--------------------- |
 | Family     | ARM Cortex-M4         |
 | Vendor     | ST Microelectronics   |
-| RAM        | 12Kb                  |
-| Flash      | 64Kb                  |
+| RAM        | 12KiB                 |
+| Flash      | 64KiB                 |
 | Frequency  | up to 72MHz           |
 | FPU        | yes                   |
 | Timers     | 8 (4x 16-bit, 1x 32-bit [TIM2], 2x watchdog, 1x Systick) |

--- a/boards/nucleo-l011k4/doc.txt
+++ b/boards/nucleo-l011k4/doc.txt
@@ -2,4 +2,23 @@
 @defgroup    boards_nucleo-l011k4 STM32 Nucleo-L011K4
 @ingroup     boards_common_nucleo32
 @brief       Support for the STM32 Nucleo-L011K4
+
+## Overview
+
+The Nucleo-L011K4 is a board from ST's Nucleo family supporting ARM-Cortex-M0+
+STM32L011K4 microcontroller with 2kB of RAM and 16kB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l011k4 PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-l011k4/doc.txt
+++ b/boards/nucleo-l011k4/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L011K4 is a board from ST's Nucleo family supporting ARM-Cortex-M0+
-STM32L011K4 microcontroller with 2kB of RAM and 16kB of Flash.
+STM32L011K4 microcontroller with 2KiB of RAM and 16KiB of Flash.
 
 ## Flashing the Board Using ST-LINK Removable Media
 

--- a/boards/nucleo-l031k6/doc.txt
+++ b/boards/nucleo-l031k6/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
-STM32L031K6T6 microcontroller with 8kB or RAM and 32Kb of Flash.
+STM32L031K6T6 microcontroller with 8KiB or RAM and 32KiB of Flash.
 
 
 ## Flashing the Board Using ST-LINK Removable Media

--- a/boards/nucleo-l412kb/doc.txt
+++ b/boards/nucleo-l412kb/doc.txt
@@ -2,4 +2,23 @@
 @defgroup    boards_nucleo-l412kb STM32 Nucleo-L412KB
 @ingroup     boards_common_nucleo32
 @brief       Support for the STM32 Nucleo-L412KB
+
+## Overview
+
+The Nucleo-L412KB is a board from ST's Nucleo family supporting ARM-Cortex-M4
+STM32L412KB microcontroller with 40KiB of RAM and 128KiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l412kb PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-l432kc/doc.txt
+++ b/boards/nucleo-l432kc/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L432KC is a board from ST's Nucleo family supporting ARM Cortex-M4
-STM32L432KCU6 microcontroller with 64kB or RAM and 256Kb of Flash.
+STM32L432KCU6 microcontroller with 64KiB or RAM and 256KiB of Flash.
 
 
 ## Flashing the Board Using ST-LINK Removable Media


### PR DESCRIPTION
### Contribution description

PR #18057 enables **_cpy2remed_** programmer for all STM Nucleo boards.

This PR adds to nucleo32 boards documentation:

-  information about usage of **_cpy2remed_** programmer,
-  short information about board (used MCU, available RAM and Flash),
-  change all memory sizes to KiB (before kB or Kb are used) .
 
### Testing procedure

Changes in documentation can be observed using commands:
```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f031k8.html
xdg-open doc/doxygen/html/group__boards__nucleo-l042k6.html
xdg-open doc/doxygen/html/group__boards__nucleo-l011k4.html
xdg-open doc/doxygen/html/group__boards__nucleo-l412kb .html
```
or direct link to files generated by [CI](https://output.circle-artifacts.com/output/job/7534b085-3830-4333-8a3f-667e689d0387/artifacts/0/doc/group__boards__nucleo-f031k6.html).

### Issues/PRs references

Depends on PR #18057