### PR TITLE
sys/net/gnrc_pktbuf_static: add use-after-free detection

### DIFF
--- a/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
+++ b/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
@@ -64,7 +64,8 @@ extern uint8_t *gnrc_pktbuf_static_buf;
 static inline bool gnrc_pktbuf_contains(void *ptr)
 {
 #if IS_USED(MODULE_GNRC_PKTBUF_STATIC)
-    return (unsigned)((uint8_t *)ptr - gnrc_pktbuf_static_buf) < CONFIG_GNRC_PKTBUF_SIZE;
+    return ((uintptr_t)ptr >= (uintptr_t)gnrc_pktbuf_static_buf) &&
+           ((uintptr_t)ptr < (uintptr_t)gnrc_pktbuf_static_buf + CONFIG_GNRC_PKTBUF_SIZE);
 #else
     (void)ptr;
     return true;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This overwrites the memory of the pktbuf chunk with a canary value and checks if the value is still there on allocation.


### Testing procedure

Enable the option with `CFLAGS += -DCONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE=1`.

This should now catch errors where a pktbuf chunk is written to after its been freed:

```
2022-06-17 19:52:45,990 # [0x2000ebf4] mismatch at offset 392/600
2022-06-17 19:52:45,997 # 00000000  55  55  55  55  DD  16  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,002 # 00000010  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,009 # 00000020  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,015 # 00000030  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,022 # 00000040  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,028 # 00000050  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,034 # 00000060  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,041 # 00000070  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,047 # 00000080  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,054 # 00000090  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,060 # 000000A0  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,067 # 000000B0  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,073 # 000000C0  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,080 # 000000D0  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,086 # 000000E0  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,092 # 000000F0  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,098 # 00000100  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,105 # 00000110  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,112 # 00000120  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,118 # 00000130  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,124 # 00000140  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,131 # 00000150  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,137 # 00000160  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,144 # 00000170  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55  55
2022-06-17 19:52:46,150 # 00000180  55  55  55  55  55  55  55  55  D0  40  00  00  80  ED  00  20
2022-06-17 19:52:46,157 # 00000190  84  ED  00  20  88  ED  00  20  8C  ED  00  20  90  ED  00  20
2022-06-17 19:52:46,163 # 000001A0  94  ED  00  20  98  ED  00  20  9C  ED  00  20  A0  ED  00  20
2022-06-17 19:52:46,169 # 000001B0  A4  ED  00  20  A8  ED  00  20  AC  ED  00  20  B0  ED  00  20
2022-06-17 19:52:46,176 # 000001C0  B4  ED  00  20  B8  ED  00  20  BC  ED  00  20  C0  ED  00  20
2022-06-17 19:52:46,182 # 000001D0  C4  ED  00  20  C8  ED  00  20  CC  ED  00  20  D0  ED  00  20
2022-06-17 19:52:46,188 # 000001E0  D4  ED  00  20  D8  ED  00  20  DC  ED  00  20  E0  ED  00  20
2022-06-17 19:52:46,195 # 000001F0  E4  ED  00  20  E8  ED  00  20  EC  ED  00  20  F0  ED  00  20
2022-06-17 19:52:46,202 # 00000200  F4  ED  00  20  F8  ED  00  20  FC  ED  00  20  00  EE  00  20
2022-06-17 19:52:46,208 # 00000210  04  EE  00  20  08  EE  00  20  0C  EE  00  20  10  EE  00  20
2022-06-17 19:52:46,214 # 00000220  14  EE  00  20  18  EE  00  20  1C  EE  00  20  20  EE  00  20
2022-06-17 19:52:46,221 # 00000230  24  EE  00  20  28  EE  00  20  2C  EE  00  20  30  EE  00  20
2022-06-17 19:52:46,227 # 00000240  34  EE  00  20  38  EE  00  20  3C  EE  00  20  40  EE  00  20
2022-06-17 19:52:46,231 # 00000250  44  EE  00  20  48  EE  00  20
2022-06-17 19:52:46,231 # 0x17009
2022-06-17 19:52:46,233 # *** RIOT kernel panic:
2022-06-17 19:52:46,235 # FAILED ASSERTION.
2022-06-17 19:52:46,235 # 
2022-06-17 19:52:46,244 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2022-06-17 19:52:46,252 # 	  - | isr_stack            | -        - |   - |   1024 (  228) (  796) | 0x20000000 | 0x200003c8
2022-06-17 19:52:46,261 # 	  1 | idle                 | pending  Q |  15 |    256 (  148) (  108) | 0x200053c0 | 0x2000542c 
2022-06-17 19:52:46,270 # 	  2 | main                 | bl mutex _ |   7 |   4096 ( 1948) ( 2148) | 0x200054c0 | 0x20006244 
2022-06-17 19:52:46,279 # 	  3 | pktdump              | bl rx    _ |   6 |   4096 ( 3892) (  204) | 0x2000ed80 | 0x2000fc8c 
2022-06-17 19:52:46,287 # 	  4 | 6lo                  | bl rx    _ |   3 |   1152 (  416) (  736) | 0x2000ffd4 | 0x200102cc 
2022-06-17 19:52:46,296 # 	  5 | ipv6                 | bl rx    _ |   4 |   1152 (  844) (  308) | 0x20008284 | 0x200085fc 
2022-06-17 19:52:46,305 # 	  6 | udp                  | bl rx    _ |   5 |   1152 (  304) (  848) | 0x20010454 | 0x200107d4 
2022-06-17 19:52:46,314 # 	  7 | coap                 | bl anyfl _ |   6 |   4096 (  204) ( 3892) | 0x20006df0 | 0x20007d24 
2022-06-17 19:52:46,322 # 	  8 | at86rf215 [sub GHz]  | bl anyfl _ |   2 |   1280 (  664) (  616) | 0x20008afc | 0x20008e3c 
2022-06-17 19:52:46,331 # 	  9 | at86rf215 [2.4 GHz]  | bl anyfl _ |   2 |   1280 (  672) (  608) | 0x20008ffc | 0x2000933c 
2022-06-17 19:52:46,339 # 	 10 | atwinc15x0           | bl mutex _ |   2 |   1280 (  960) (  320) | 0x200099f0 | 0x20009ce4 
2022-06-17 19:52:46,348 # 	 11 | slipdev              | bl mutex _ |   2 |   1280 (  768) (  512) | 0x2000a034 | 0x2000a344 
2022-06-17 19:52:46,357 # 	 12 | data server          | bl mbox  _ |   7 |   4608 ( 4300) (  308) | 0x20003b48 | 0x20004704 
2022-06-17 19:52:46,366 # 	 13 | data sender          | running  Q |   8 |   6912 ( 2508) ( 4404) | 0x20002048 | 0x20003234 
2022-06-17 19:52:46,375 # 	 14 | auto reboot          | bl mutex _ |   6 |   1152 (  188) (  964) | 0x200013c8 | 0x2000178c 
2022-06-17 19:52:46,383 # 	 15 | mt3333               | bl rx    _ |   6 |   2048 ( 1156) (  892) | 0x20013148 | 0x20013634 
2022-06-17 19:52:46,389 # 	    | SUM                  |            |     |  36864 (19200) (17664)
2022-06-17 19:52:46,390 # 
2022-06-17 19:52:46,390 # *** halted.
``` 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
