### PR TITLE
drivers/slipdev: fix off-by-one error in _recv()

### DIFF
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -199,7 +199,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
             tmp = slipdev_unstuff_readbyte(ptr, byte, &escaped);
             ptr += tmp;
             res += tmp;
-            if ((unsigned)res > len) {
+            if ((unsigned)res >= len) {
                 while (byte != SLIPDEV_END) {
                     /* clear out unreceived packet */
                     byte = tsrb_get_one(&dev->inbuf);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If the number of written bytes is greater than the length of the buffer, we have already written out-of bounds memory.

With pktbuf this means we will likely have corrupted the next free list entry.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #18066
