### PR TITLE
tools/zep_dispatch: add Wireshark capture support (via mac802154_hwsim)

### DIFF
--- a/dist/tools/zep_dispatch/README.md
+++ b/dist/tools/zep_dispatch/README.md
@@ -45,6 +45,27 @@ There can only be as many nodes connected to the dispatcher as have been named i
 the topology file.
 Any additional nodes that try to connect will be ignored.
 
+
+Packet capture
+--------------
+
+To view traffic in Wireshark you need to create a virtual 802.15.4 device to which
+the network traffic is sent. This can then be selected as a capture source in Wireshark.
+
+To create the virtual device, load the `mac802154_hwsim` module
+
+    sudo modprobe mac802154_hwsim
+
+This will create two wpan devices, `wpan0` and `wpan1`.
+
+If you then run the dispatcher with
+
+    sudo zep_dispatch -w wpan0 ::1 17754
+
+all traffic on the simulated network will be also sent to the virtual `wpan0` interface
+where it can be captures with Wireshark.
+
+
 Network visualization
 ---------------------
 

--- a/dist/tools/zep_dispatch/zep_parser.c
+++ b/dist/tools/zep_dispatch/zep_parser.c
@@ -13,6 +13,39 @@
 
 #define SOCKET_ZEP_V2_TYPE_HELLO   (255)
 
+const void *zep_get_payload(const void *buffer, size_t *len)
+{
+    const void *payload;
+    const zep_v2_data_hdr_t *zep = buffer;
+
+    if (*len == 0) {
+        return NULL;
+    }
+
+    if ((zep->hdr.preamble[0] != 'E') || (zep->hdr.preamble[1] != 'X')) {
+        return NULL;
+    }
+
+    if (zep->hdr.version != 2) {
+        return NULL;
+    }
+
+    switch (zep->type) {
+    case ZEP_V2_TYPE_DATA:
+        payload = (zep_v2_data_hdr_t *)zep + 1;
+        break;
+    case ZEP_V2_TYPE_ACK:
+        payload = (zep_v2_ack_hdr_t *)zep + 1;
+        break;
+    default:
+        return NULL;
+    }
+
+    *len = zep->length - IEEE802154_FCS_LEN;
+
+    return payload;
+}
+
 bool zep_parse_mac(const void *buffer, size_t len, void *out, uint8_t *out_len)
 {
     const void *payload;

--- a/dist/tools/zep_dispatch/zep_parser.h
+++ b/dist/tools/zep_dispatch/zep_parser.h
@@ -16,6 +16,17 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Get the payload of a ZEP frame
+ *
+ * @param[in]  buffer   ZEP frame
+ * @param[in, out] len  size of buffer, will contain size of payload
+ *
+ * @return pointer to payload on success
+ *         NULL if no payload was found
+ */
+const void *zep_get_payload(const void *buffer, size_t *len);
+
+/**
  * @brief   Parse l2 source address of a ZEP frame
  *
  * @param[in]  buffer   ZEP frame


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds support to view the entire traffic of the simulated network in Wireshark.
For this all packets are sent to a virtual 802.15.4 device (`mac802154_hwsim`) that then acts as a capture source in Wireshark.

### Testing procedure

Create the simulated 802.15.4 device by loading the `mac802154_hwsim` module

    sudo modprobe mac802154_hwsim

Now start the dispatcher (needs elevated privileges to send raw 802.15.4 frames)

    sudo bin/zep_dispatch -w wpan1 ::1 17754

Start two `native` nodes that make use of ZEP

    make -C examples/gnrc_networking USE_ZEP=1 all term
    make -C examples/gnrc_networking USE_ZEP=1 all term

If you connect to the `wpan0` interface in Wireshak now, you should see the packets on the network:

![image](https://user-images.githubusercontent.com/1301112/174500914-ea854e7e-1e8c-444b-864c-ccd308a4c85f.png)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
