### PR TITLE
cpu/cortexm_common: allow to overwrite nmi_handler

### DIFF
--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -80,7 +80,7 @@ void reset_handler_default(void);
  * and can not be masked (surprise surprise...). They can be triggered by
  * software and some peripherals. So far, they are not used in RIOT.
  */
-void nmi_default(void);
+void nmi_handler(void);
 
 /**
  * @brief   Hard fault exception handler

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -209,7 +209,8 @@ void reset_handler_default(void)
     kernel_init();
 }
 
-void nmi_default(void)
+__attribute__((weak))
+void nmi_handler(void)
 {
     core_panic(PANIC_NMI_HANDLER, "NMI HANDLER");
 }
@@ -505,7 +506,7 @@ ISR_VECTOR(0) const cortexm_base_t cortex_vector_base = {
         /* entry point of the program */
         [ 0] = reset_handler_default,
         /* [-14] non maskable interrupt handler */
-        [ 1] = nmi_default,
+        [ 1] = nmi_handler,
         /* [-13] hard fault exception */
         [ 2] = hard_fault_default,
         /* [-5] SW interrupt, in RIOT used for triggering context switches */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If a user wants to handle NMI events, let them do so by providing an implementation for `nmi_handler()` instead of panicking.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
