### PR TITLE
.murdock: print hash input when hashes mismatch

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -457,9 +457,9 @@ compile() {
                         make -C${appdir} all test-input-hash -j${JOBS:-4}
         RES=$?
         if [ $RES -eq 0 ]; then
-            kconfig_test_hash=$(test_hash_calc "${BINDIR}")
+            kconfig_hashes="$(cat ${BINDIR}/test-input-hash.sha1)"
         else
-            kconfig_test_hash=0
+            kconfig_hashes="kconfig-build-failed"
             echo "An error occurred while compiling using Kconfig";
         fi
     fi
@@ -470,12 +470,20 @@ compile() {
         make -C${appdir} all test-input-hash -j${JOBS:-4}
     RES=$?
 
+    no_kconfig_hashes="$(cat ${BINDIR}/test-input-hash.sha1)"
+    # test hash is used to cache test results, not for comparing binaries
+    # generated with and without KConfig
     test_hash=$(test_hash_calc "$BINDIR")
 
+
     if [ ${should_check_kconfig_hash} != 0 ]; then
-        if [ ${kconfig_test_hash} != ${test_hash} ]; then
+        if [ ${kconfig_hashes} != ${no_kconfig_hashes} ]; then
             echo "Hashes of binaries with and without Kconfig mismatch for ${appdir} with ${board}";
             echo "Please check that all used modules are modelled in Kconfig and enabled";
+            echo "Input without KConfig:"
+            echo "${no_kconfig_hashes}"
+            echo "Input with KConfig:"
+            echo "${kconfig_hashes}"
             kconfig_module_packages_diff ${board} ${appdir}
             RES=1
         fi

--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -80,6 +80,8 @@ ifeq (,$(RIOTNOLINK))
 test-input-hash: $(TESTS) $(TESTS_WITH_CONFIG) $(TESTS_AS_ROOT) $(HASHFILE) $(TEST_EXTRA_FILES)
 	sha1sum $^ > $(BINDIR)/test-input-hash.sha1
 else
-test-input-hash:
-	true
+# .SECONDARY creates the bin folder, we depend on it to avoid writing to it
+# prior to it being created when concurrent building is used
+test-input-hash: .SECONDARY
+	$(file >$(BINDIR)/test-input-hash.sha1,no binary generated due to RIOTNOLINK=1)
 endif


### PR DESCRIPTION
### Contribution description

This prints the hash input when KConfig and non-KConfig builds differ in hash. Hopefully, this helps debugging the issue.

### Testing procedure

Murdock will do so.

### Issues/PRs references

None