### PR TITLE
boards/{thingy52,ruuvitag}: allow OpenOCD as programmer

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -8,22 +8,14 @@ ifeq (bmp,$(PROGRAMMER))
   PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
 endif
 
-ifneq (,$(filter $(BOARD),ruuvitag thingy52))
-  # openocd doesn't fully work with ruuvitag and thingy52
-  PROGRAMMER ?= jlink
-  ifeq (openocd,$(PROGRAMMER))
-    $(error Cannot use OpenOCD with $(BOARD) board)
-  endif
+# set list of supported programmers
+PROGRAMMERS_SUPPORTED += openocd bmp
+# keep name of `JLINK` in sync with script jlink.sh in $(RIOTTOOLS)/jlink
+JLINK ?= JLinkExe
+ifneq (,$(command -v $(JLINK)))
+PROGRAMMER ?= jlink
 else
-  # no issues with OpenOCD for other nRF52 boards are known
-  PROGRAMMERS_SUPPORTED += openocd
-  # keep name of `JLINK` in sync with script jlink.sh in $(RIOTTOOLS)/jlink
-  JLINK ?= JLinkExe
-  ifneq (,$(command -v $(JLINK)))
-    PROGRAMMER ?= jlink
-  else
-    PROGRAMMER ?= openocd
-  endif
+PROGRAMMER ?= openocd
 endif
 
 # setup JLink for flashing
@@ -33,6 +25,3 @@ JLINK_DEVICE = nrf52
 # build from source (master > 2018, August the 13rd) is required.
 OPENOCD_DEBUG_ADAPTER ?= jlink
 OPENOCD_CONFIG = $(RIOTBOARD)/common/nrf52/dist/openocd.cfg
-
-# set list of supported programmers
-PROGRAMMERS_SUPPORTED += bmp

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -7,6 +7,3 @@ endif
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include
-
-# openocd doesn't fully work with this board
-PROGRAMMERS_SUPPORTED := $(filter-out openocd,$(PROGRAMMERS_SUPPORTED))

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -7,6 +7,3 @@ endif
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include
-
-# openocd doesn't fully work with this board
-PROGRAMMERS_SUPPORTED := $(filter-out openocd,$(PROGRAMMERS_SUPPORTED))


### PR DESCRIPTION
### Contribution description

In `master` OpenOCD is disabled for the thingy52 and the ruuvitag. At least for the thingy52 I can confirm that flashing works just fine with OpenOCD.

### Testing procedure

```
$ USEMODULE=stdio_uart make BOARD=thingy52 PROGRAMMER=openocd -C examples/default flash term

[...]
### Flashing Target ###
Open On-Chip Debugger 0.11.0+dev-08267-g7629a19e19-dirty (2022-03-08-20:45)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
swd
Info : J-Link EDU Mini V1 compiled Feb 18 2021 11:25:23
Info : Hardware version: 1.00
Info : VTarget = 3.299 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf52.cpu: Cortex-M4 r0p1 processor detected
Info : nrf52.cpu: target has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 41563 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          running

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000f9c msp: 0x20000200
Info : nRF52832-QFAA(build code: B0) 512kB Flash, 64kB RAM
Warn : Adding extra erase range, 0x0001b028 .. 0x0001bfff
auto erase enabled
wrote 110632 bytes from file /home/maribu/Repos/software/RIOT/examples/default/bin/thingy52/default.elf in 2.397724s (45.059 KiB/s)

verified 110632 bytes in 0.290888s (371.411 KiB/s)

shutdown command invoked
Done flashing
2022-06-21 15:01:44,880 # main(): This is RIOT! (Version: 2022.07-devel-825-g03dfa)
2022-06-21 15:01:44,882 # Welcome to RIOT!
> help
2022-06-21 15:03:48,266 # help
2022-06-21 15:03:48,269 # Command              Description
2022-06-21 15:03:48,273 # ---------------------------------------
2022-06-21 15:03:48,278 # ble                  Manage BLE connections for NimBLE
2022-06-21 15:03:48,282 # ifconfig             Configure network interfaces
2022-06-21 15:03:48,287 # pm                   interact with layered PM subsystem
2022-06-21 15:03:48,292 # ps                   Prints information about running threads.
2022-06-21 15:03:48,296 # reboot               Reboot the node
2022-06-21 15:03:48,301 # saul                 interact with sensors and actuators using SAUL
2022-06-21 15:03:48,307 # txtsnd               Sends a custom string as is over the link layer
2022-06-21 15:03:48,312 # version              Prints current RIOT_VERSION
> ble
2022-06-21 15:03:50,841 # ble
2022-06-21 15:03:50,847 # usage: ble [help|info|adv|adv_ext|adv_dir|scan|connect|close|update|chanmap]
> ble info
2022-06-21 15:03:54,030 # ble info
2022-06-21 15:03:54,033 # Own Address: CA:3C:AB:46:9D:82
2022-06-21 15:03:54,035 # Supported PHY modes: 1M
2022-06-21 15:03:54,036 #  Free slots: 3/3
2022-06-21 15:03:54,038 # Advertising: no
2022-06-21 15:03:54,039 # Connections: 0
2022-06-21 15:03:54,040 # Slots:
2022-06-21 15:03:54,042 # [ 0] state: 0x8000 - unused
2022-06-21 15:03:54,044 # [ 1] state: 0x8000 - unused
2022-06-21 15:03:54,047 # [ 2] state: 0x8000 - unused
```

I assume that the issue with the ruuvitag has been resolved in the meantime as well. In any case, I think it is questionable to disable use of OpenOCD outright if the scripts for OpenOCD are in place. A bug in one version of OpenOCD may not be present in others. But once disabled, no version (even those not affected by the bug) will work anymore.

### Issues/PRs references

None