### PR TITLE
boards/esp32: cleanup board_init_common

### DIFF
--- a/boards/common/esp32/board_common.c
+++ b/boards/common/esp32/board_common.c
@@ -30,10 +30,6 @@
 extern "C" {
 #endif
 
-void board_init_common(void)
-{
-}
-
 extern void adc_print_config(void);
 extern void dac_print_config(void);
 extern void pwm_print_config(void);

--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -148,13 +148,6 @@ extern mtd_dev_t *mtd0;
 #endif /* MODULE_SPIFFS || DOXYGEN */
 
 /**
- * @brief Initialize the hardware that is common for all ESP32 boards.
- *
- * This function has to be called from the board specific `board_init` function.
- */
-void board_init_common(void);
-
-/**
   * @brief Print the board configuration in a human readable format
   */
 void print_board_config(void);
@@ -170,9 +163,6 @@ void print_board_config(void);
 #ifdef __cplusplus
 extern "C"
 #endif
-
-/* declaration of `board_init_common` is required when compiling vendor code */
-extern void board_init_common(void);
 
 #ifdef __cplusplus
 }

--- a/boards/esp32-ttgo-t-beam/board.c
+++ b/boards/esp32-ttgo-t-beam/board.c
@@ -33,8 +33,6 @@
 
 void board_init(void)
 {
-    board_init_common();
-
 #if MODULE_ESP32_TTGO_T_BEAM_V1_0
     uint8_t reg;
 

--- a/boards/esp32-wrover-kit/board.c
+++ b/boards/esp32-wrover-kit/board.c
@@ -23,7 +23,4 @@ void board_init(void)
 #if MODULE_ILI9341
     gpio_init(LCD_BACKLIGHT, GPIO_OUT);
 #endif
-
-    /* there is nothing special to initialize on this board */
-    board_init_common();
 }


### PR DESCRIPTION
### Contribution description

This PR removes `board_init_common` for ESP32 as it is no longer needed.

### Testing procedure

Since `board_init_common` was empty, green CI should be sufficient.

### Issues/PRs references

Split off from PR #17841 