### PR TITLE
cpu/esp32: split modul esp_wpa supplicant into several modules

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -37,6 +37,16 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   USEMODULE += esp_idf_spi_flash
   USEMODULE += esp_idf_wifi
   USEMODULE += esp_idf_wpa_supplicant
+  USEMODULE += esp_idf_wpa_supplicant_esp_supplicant
+  USEMODULE += esp_idf_wpa_supplicant_port
+  USEMODULE += esp_idf_wpa_supplicant_ap
+  USEMODULE += esp_idf_wpa_supplicant_common
+  USEMODULE += esp_idf_wpa_supplicant_crypto
+  USEMODULE += esp_idf_wpa_supplicant_eap_peer
+  USEMODULE += esp_idf_wpa_supplicant_rsn_supp
+  USEMODULE += esp_idf_wpa_supplicant_tls
+  USEMODULE += esp_idf_wpa_supplicant_utils
+  USEMODULE += esp_idf_wpa_supplicant_wps
   USEMODULE += pthread
 endif
 

--- a/cpu/esp32/esp-idf/Makefile
+++ b/cpu/esp32/esp-idf/Makefile
@@ -1,5 +1,7 @@
 MODULE=esp_idf
 
+export ESP_IDF_PATH = $(shell pwd)
+
 # Add a list of subdirectories, that should also be built:
 
 DIRS += common

--- a/cpu/esp32/esp-idf/wpa_supplicant/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/Kconfig
@@ -12,3 +12,14 @@ config MODULE_ESP_IDF_WPA_SUPPLICANT
     depends on MODULE_ESP_IDF
     help
         ESP-IDF WPA supplicant.
+
+rsource "esp_supplicant/Kconfig"
+rsource "port/Kconfig"
+rsource "src/ap/Kconfig"
+rsource "src/common/Kconfig"
+rsource "src/crypto/Kconfig"
+rsource "src/eap_peer/Kconfig"
+rsource "src/rsn_supp/Kconfig"
+rsource "src/tls/Kconfig"
+rsource "src/utils/Kconfig"
+rsource "src/wps/Kconfig"

--- a/cpu/esp32/esp-idf/wpa_supplicant/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/Makefile
@@ -1,146 +1,18 @@
 MODULE = esp_idf_wpa_supplicant
 
-# source file list to be compiled as configured in component.mk
-ESP32_SDK_SRC = \
-  components/wpa_supplicant/esp_supplicant/src/esp_dpp.c \
-  components/wpa_supplicant/esp_supplicant/src/esp_hostap.c \
-  components/wpa_supplicant/esp_supplicant/src/esp_wpa2.c \
-  components/wpa_supplicant/esp_supplicant/src/esp_wpa3.c \
-  components/wpa_supplicant/esp_supplicant/src/esp_wpa_main.c \
-  components/wpa_supplicant/esp_supplicant/src/esp_wpas_glue.c \
-  components/wpa_supplicant/esp_supplicant/src/esp_wps.c \
-  components/wpa_supplicant/port/os_xtensa.c \
-  components/wpa_supplicant/src/ap/ap_config.c \
-  components/wpa_supplicant/src/ap/ieee802_1x.c \
-  components/wpa_supplicant/src/ap/wpa_auth.c \
-  components/wpa_supplicant/src/ap/wpa_auth_ie.c \
-  components/wpa_supplicant/src/common/dpp.c \
-  components/wpa_supplicant/src/common/sae.c \
-  components/wpa_supplicant/src/common/wpa_common.c \
-  components/wpa_supplicant/src/crypto/aes-cbc.c \
-  components/wpa_supplicant/src/crypto/aes-ccm.c \
-  components/wpa_supplicant/src/crypto/aes-ctr.c \
-  components/wpa_supplicant/src/crypto/aes-gcm.c \
-  components/wpa_supplicant/src/crypto/aes-internal.c \
-  components/wpa_supplicant/src/crypto/aes-internal-dec.c \
-  components/wpa_supplicant/src/crypto/aes-internal-enc.c \
-  components/wpa_supplicant/src/crypto/aes-omac1.c \
-  components/wpa_supplicant/src/crypto/aes-siv.c \
-  components/wpa_supplicant/src/crypto/aes-unwrap.c \
-  components/wpa_supplicant/src/crypto/aes-wrap.c \
-  components/wpa_supplicant/src/crypto/ccmp.c \
-  components/wpa_supplicant/src/crypto/crypto_internal.c \
-  components/wpa_supplicant/src/crypto/crypto_internal-cipher.c \
-  components/wpa_supplicant/src/crypto/crypto_internal-modexp.c \
-  components/wpa_supplicant/src/crypto/crypto_internal-rsa.c \
-  components/wpa_supplicant/src/crypto/crypto_ops.c \
-  components/wpa_supplicant/src/crypto/des-internal.c \
-  components/wpa_supplicant/src/crypto/dh_group5.c \
-  components/wpa_supplicant/src/crypto/dh_groups.c \
-  components/wpa_supplicant/src/crypto/md4-internal.c \
-  components/wpa_supplicant/src/crypto/md5.c \
-  components/wpa_supplicant/src/crypto/md5-internal.c \
-  components/wpa_supplicant/src/crypto/ms_funcs.c \
-  components/wpa_supplicant/src/crypto/rc4.c \
-  components/wpa_supplicant/src/crypto/sha1.c \
-  components/wpa_supplicant/src/crypto/sha1-internal.c \
-  components/wpa_supplicant/src/crypto/sha1-pbkdf2.c \
-  components/wpa_supplicant/src/crypto/sha1-prf.c \
-  components/wpa_supplicant/src/crypto/sha1-tlsprf.c \
-  components/wpa_supplicant/src/crypto/sha256.c \
-  components/wpa_supplicant/src/crypto/sha256-internal.c \
-  components/wpa_supplicant/src/crypto/sha256-kdf.c \
-  components/wpa_supplicant/src/crypto/sha256-prf.c \
-  components/wpa_supplicant/src/crypto/sha256-tlsprf.c \
-  components/wpa_supplicant/src/crypto/sha384-internal.c \
-  components/wpa_supplicant/src/crypto/sha384-prf.c \
-  components/wpa_supplicant/src/crypto/sha384-tlsprf.c \
-  components/wpa_supplicant/src/crypto/sha512-internal.c \
-  components/wpa_supplicant/src/eap_peer/chap.c \
-  components/wpa_supplicant/src/eap_peer/eap.c \
-  components/wpa_supplicant/src/eap_peer/eap_common.c \
-  components/wpa_supplicant/src/eap_peer/eap_mschapv2.c \
-  components/wpa_supplicant/src/eap_peer/eap_peap.c \
-  components/wpa_supplicant/src/eap_peer/eap_peap_common.c \
-  components/wpa_supplicant/src/eap_peer/eap_tls.c \
-  components/wpa_supplicant/src/eap_peer/eap_tls_common.c \
-  components/wpa_supplicant/src/eap_peer/eap_ttls.c \
-  components/wpa_supplicant/src/eap_peer/mschapv2.c \
-  components/wpa_supplicant/src/rsn_supp/pmksa_cache.c \
-  components/wpa_supplicant/src/rsn_supp/wpa.c \
-  components/wpa_supplicant/src/rsn_supp/wpa_ie.c \
-  components/wpa_supplicant/src/tls/asn1.c \
-  components/wpa_supplicant/src/tls/bignum.c \
-  components/wpa_supplicant/src/tls/pkcs1.c \
-  components/wpa_supplicant/src/tls/pkcs5.c \
-  components/wpa_supplicant/src/tls/pkcs8.c \
-  components/wpa_supplicant/src/tls/rsa.c \
-  components/wpa_supplicant/src/tls/tls_internal.c \
-  components/wpa_supplicant/src/tls/tlsv1_client.c \
-  components/wpa_supplicant/src/tls/tlsv1_client_read.c \
-  components/wpa_supplicant/src/tls/tlsv1_client_write.c \
-  components/wpa_supplicant/src/tls/tlsv1_common.c \
-  components/wpa_supplicant/src/tls/tlsv1_cred.c \
-  components/wpa_supplicant/src/tls/tlsv1_record.c \
-  components/wpa_supplicant/src/tls/tlsv1_server.c \
-  components/wpa_supplicant/src/tls/tlsv1_server_read.c \
-  components/wpa_supplicant/src/tls/tlsv1_server_write.c \
-  components/wpa_supplicant/src/tls/x509v3.c \
-  components/wpa_supplicant/src/utils/base64.c \
-  components/wpa_supplicant/src/utils/bitfield.c \
-  components/wpa_supplicant/src/utils/common.c \
-  components/wpa_supplicant/src/utils/ext_password.c \
-  components/wpa_supplicant/src/utils/json.c \
-  components/wpa_supplicant/src/utils/uuid.c \
-  components/wpa_supplicant/src/utils/wpabuf.c \
-  components/wpa_supplicant/src/utils/wpa_debug.c \
-  components/wpa_supplicant/src/wps/wps_attr_build.c \
-  components/wpa_supplicant/src/wps/wps_attr_parse.c \
-  components/wpa_supplicant/src/wps/wps_attr_process.c \
-  components/wpa_supplicant/src/wps/wps.c \
-  components/wpa_supplicant/src/wps/wps_common.c \
-  components/wpa_supplicant/src/wps/wps_dev_attr.c \
-  components/wpa_supplicant/src/wps/wps_enrollee.c \
-  components/wpa_supplicant/src/wps/wps_registrar.c \
-  components/wpa_supplicant/src/wps/wps_validate.c \
-  #
+export ESP_IDF_WPA_SUPPLICANT_PATH = $(shell pwd)
 
-# additional include pathes required by this module
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/src
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/port/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/src
-INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/src/utils
+DIRS += esp_supplicant
+DIRS += port
+DIRS += src/ap
+DIRS += src/common
+DIRS += src/crypto
+DIRS += src/eap_peer
+DIRS += src/rsn_supp
+DIRS += src/tls
+DIRS += src/utils
+DIRS += src/wps
 
 include $(RIOTBASE)/Makefile.base
 
 ESP32_SDK_BIN = $(BINDIR)/$(MODULE)
-
-# definitions for wpa_supplicant from components/wpa_supplicant/component.mk
-CFLAGS += -D__ets__
-CFLAGS += -DCONFIG_DPP
-CFLAGS += -DCONFIG_ECC
-CFLAGS += -DCONFIG_IEEE80211W
-CFLAGS += -DCONFIG_SHA256
-CFLAGS += -DCONFIG_WNM
-CFLAGS += -DCONFIG_WPS_PIN
-CFLAGS += -DCONFIG_WPS2
-CFLAGS += -DEAP_MSCHAPv2
-CFLAGS += -DEAP_PEAP
-CFLAGS += -DEAP_PEER_METHOD
-CFLAGS += -DEAP_TLS
-CFLAGS += -DEAP_TTLS
-CFLAGS += -DESP_SUPPLICANT
-CFLAGS += -DESP32_WORKAROUND
-CFLAGS += -DESPRESSIF_USE
-CFLAGS += -DIEEE8021X_EAPOL
-CFLAGS += -DUSE_WPA2_TASK
-CFLAGS += -DUSE_WPS_TASK
-CFLAGS += -Wno-strict-aliasing
-CFLAGS += -Wno-format-nonliteral
-CFLAGS += -Wno-format-security
-CFLAGS += -std=gnu99
-
-include ../esp_idf.mk
-include ../esp_idf_cflags.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/esp_idf_wpa_supplicant.mk
+++ b/cpu/esp32/esp-idf/wpa_supplicant/esp_idf_wpa_supplicant.mk
@@ -1,0 +1,39 @@
+# additional include pathes required by this module
+INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/src
+INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/port/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/src
+INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/src/utils
+
+include $(RIOTBASE)/Makefile.base
+
+ESP32_SDK_BIN = $(BINDIR)/$(MODULE)
+
+# definitions for wpa_supplicant from components/wpa_supplicant/component.mk
+CFLAGS += -D__ets__
+CFLAGS += -DCONFIG_DPP
+CFLAGS += -DCONFIG_ECC
+CFLAGS += -DCONFIG_IEEE80211W
+CFLAGS += -DCONFIG_SHA256
+CFLAGS += -DCONFIG_WNM
+CFLAGS += -DCONFIG_WPS_PIN
+CFLAGS += -DCONFIG_WPS2
+CFLAGS += -DEAP_MSCHAPv2
+CFLAGS += -DEAP_PEAP
+CFLAGS += -DEAP_PEER_METHOD
+CFLAGS += -DEAP_TLS
+CFLAGS += -DEAP_TTLS
+CFLAGS += -DESP_SUPPLICANT
+CFLAGS += -DESP32_WORKAROUND
+CFLAGS += -DESPRESSIF_USE
+CFLAGS += -DIEEE8021X_EAPOL
+CFLAGS += -DUSE_WPA2_TASK
+CFLAGS += -DUSE_WPS_TASK
+CFLAGS += -Wno-strict-aliasing
+CFLAGS += -Wno-format-nonliteral
+CFLAGS += -Wno-format-security
+CFLAGS += -std=gnu99
+
+include $(ESP_IDF_PATH)/esp_idf.mk
+include $(ESP_IDF_PATH)/esp_idf_cflags.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/esp_supplicant/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/esp_supplicant/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_ESP_SUPPLICANT
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      Additional ESP supplicant code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/esp_supplicant/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/esp_supplicant/Makefile
@@ -1,0 +1,14 @@
+MODULE = esp_idf_wpa_supplicant_esp_supplicant
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/esp_supplicant/src/esp_dpp.c \
+  components/wpa_supplicant/esp_supplicant/src/esp_hostap.c \
+  components/wpa_supplicant/esp_supplicant/src/esp_wpa2.c \
+  components/wpa_supplicant/esp_supplicant/src/esp_wpa3.c \
+  components/wpa_supplicant/esp_supplicant/src/esp_wpa_main.c \
+  components/wpa_supplicant/esp_supplicant/src/esp_wpas_glue.c \
+  components/wpa_supplicant/esp_supplicant/src/esp_wps.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/port/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/port/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_PORT
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      ESP-IDF WPA supplicant port code.

--- a/cpu/esp32/esp-idf/wpa_supplicant/port/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/port/Makefile
@@ -1,0 +1,8 @@
+MODULE = esp_idf_wpa_supplicant_port
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/port/os_xtensa.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/ap/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/ap/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_AP
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      AP code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/ap/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/ap/Makefile
@@ -1,0 +1,11 @@
+MODULE = esp_idf_wpa_supplicant_ap
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/ap/ap_config.c \
+  components/wpa_supplicant/src/ap/ieee802_1x.c \
+  components/wpa_supplicant/src/ap/wpa_auth.c \
+  components/wpa_supplicant/src/ap/wpa_auth_ie.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/common/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/common/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_COMMON
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      Common code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/common/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/common/Makefile
@@ -1,0 +1,10 @@
+MODULE = esp_idf_wpa_supplicant_common
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/common/dpp.c \
+  components/wpa_supplicant/src/common/sae.c \
+  components/wpa_supplicant/src/common/wpa_common.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/crypto/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/crypto/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_CRYPTO
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      Crypto code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/crypto/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/crypto/Makefile
@@ -1,0 +1,46 @@
+MODULE = esp_idf_wpa_supplicant_crypto
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/crypto/aes-cbc.c \
+  components/wpa_supplicant/src/crypto/aes-ccm.c \
+  components/wpa_supplicant/src/crypto/aes-ctr.c \
+  components/wpa_supplicant/src/crypto/aes-gcm.c \
+  components/wpa_supplicant/src/crypto/aes-internal.c \
+  components/wpa_supplicant/src/crypto/aes-internal-dec.c \
+  components/wpa_supplicant/src/crypto/aes-internal-enc.c \
+  components/wpa_supplicant/src/crypto/aes-omac1.c \
+  components/wpa_supplicant/src/crypto/aes-siv.c \
+  components/wpa_supplicant/src/crypto/aes-unwrap.c \
+  components/wpa_supplicant/src/crypto/aes-wrap.c \
+  components/wpa_supplicant/src/crypto/ccmp.c \
+  components/wpa_supplicant/src/crypto/crypto_internal.c \
+  components/wpa_supplicant/src/crypto/crypto_internal-cipher.c \
+  components/wpa_supplicant/src/crypto/crypto_internal-modexp.c \
+  components/wpa_supplicant/src/crypto/crypto_internal-rsa.c \
+  components/wpa_supplicant/src/crypto/crypto_ops.c \
+  components/wpa_supplicant/src/crypto/des-internal.c \
+  components/wpa_supplicant/src/crypto/dh_group5.c \
+  components/wpa_supplicant/src/crypto/dh_groups.c \
+  components/wpa_supplicant/src/crypto/md4-internal.c \
+  components/wpa_supplicant/src/crypto/md5.c \
+  components/wpa_supplicant/src/crypto/md5-internal.c \
+  components/wpa_supplicant/src/crypto/ms_funcs.c \
+  components/wpa_supplicant/src/crypto/rc4.c \
+  components/wpa_supplicant/src/crypto/sha1.c \
+  components/wpa_supplicant/src/crypto/sha1-internal.c \
+  components/wpa_supplicant/src/crypto/sha1-pbkdf2.c \
+  components/wpa_supplicant/src/crypto/sha1-prf.c \
+  components/wpa_supplicant/src/crypto/sha1-tlsprf.c \
+  components/wpa_supplicant/src/crypto/sha256.c \
+  components/wpa_supplicant/src/crypto/sha256-internal.c \
+  components/wpa_supplicant/src/crypto/sha256-kdf.c \
+  components/wpa_supplicant/src/crypto/sha256-prf.c \
+  components/wpa_supplicant/src/crypto/sha256-tlsprf.c \
+  components/wpa_supplicant/src/crypto/sha384-internal.c \
+  components/wpa_supplicant/src/crypto/sha384-prf.c \
+  components/wpa_supplicant/src/crypto/sha384-tlsprf.c \
+  components/wpa_supplicant/src/crypto/sha512-internal.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/eap_peer/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/eap_peer/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_RSN_SUPP
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      RSN support code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/eap_peer/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/eap_peer/Makefile
@@ -1,0 +1,17 @@
+MODULE = esp_idf_wpa_supplicant_eap_peer
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/eap_peer/chap.c \
+  components/wpa_supplicant/src/eap_peer/eap.c \
+  components/wpa_supplicant/src/eap_peer/eap_common.c \
+  components/wpa_supplicant/src/eap_peer/eap_mschapv2.c \
+  components/wpa_supplicant/src/eap_peer/eap_peap.c \
+  components/wpa_supplicant/src/eap_peer/eap_peap_common.c \
+  components/wpa_supplicant/src/eap_peer/eap_tls.c \
+  components/wpa_supplicant/src/eap_peer/eap_tls_common.c \
+  components/wpa_supplicant/src/eap_peer/eap_ttls.c \
+  components/wpa_supplicant/src/eap_peer/mschapv2.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/rsn_supp/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/rsn_supp/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_AP
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      AP code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/rsn_supp/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/rsn_supp/Makefile
@@ -1,0 +1,10 @@
+MODULE = esp_idf_wpa_supplicant_rsn_supp
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/rsn_supp/pmksa_cache.c \
+  components/wpa_supplicant/src/rsn_supp/wpa.c \
+  components/wpa_supplicant/src/rsn_supp/wpa_ie.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/tls/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/tls/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_TLS
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      TLS code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/tls/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/tls/Makefile
@@ -1,0 +1,24 @@
+MODULE = esp_idf_wpa_supplicant_tls
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/tls/asn1.c \
+  components/wpa_supplicant/src/tls/bignum.c \
+  components/wpa_supplicant/src/tls/pkcs1.c \
+  components/wpa_supplicant/src/tls/pkcs5.c \
+  components/wpa_supplicant/src/tls/pkcs8.c \
+  components/wpa_supplicant/src/tls/rsa.c \
+  components/wpa_supplicant/src/tls/tls_internal.c \
+  components/wpa_supplicant/src/tls/tlsv1_client.c \
+  components/wpa_supplicant/src/tls/tlsv1_client_read.c \
+  components/wpa_supplicant/src/tls/tlsv1_client_write.c \
+  components/wpa_supplicant/src/tls/tlsv1_common.c \
+  components/wpa_supplicant/src/tls/tlsv1_cred.c \
+  components/wpa_supplicant/src/tls/tlsv1_record.c \
+  components/wpa_supplicant/src/tls/tlsv1_server.c \
+  components/wpa_supplicant/src/tls/tlsv1_server_read.c \
+  components/wpa_supplicant/src/tls/tlsv1_server_write.c \
+  components/wpa_supplicant/src/tls/x509v3.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/utils/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/utils/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_UTILS
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      Utilities code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/utils/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/utils/Makefile
@@ -1,0 +1,15 @@
+MODULE = esp_idf_wpa_supplicant_utils
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/utils/base64.c \
+  components/wpa_supplicant/src/utils/bitfield.c \
+  components/wpa_supplicant/src/utils/common.c \
+  components/wpa_supplicant/src/utils/ext_password.c \
+  components/wpa_supplicant/src/utils/json.c \
+  components/wpa_supplicant/src/utils/uuid.c \
+  components/wpa_supplicant/src/utils/wpabuf.c \
+  components/wpa_supplicant/src/utils/wpa_debug.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/wps/Kconfig
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/wps/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_WPA_SUPPLICANT_WPS
+    bool
+    depends on TEST_KCONFIG
+    depends on MODULE_ESP_IDF
+    help
+      WPS code for ESP-IDF WPA supplicant.

--- a/cpu/esp32/esp-idf/wpa_supplicant/src/wps/Makefile
+++ b/cpu/esp32/esp-idf/wpa_supplicant/src/wps/Makefile
@@ -1,0 +1,16 @@
+MODULE = esp_idf_wpa_supplicant_wps
+
+# source file list to be compiled as configured in component.mk
+ESP32_SDK_SRC = \
+  components/wpa_supplicant/src/wps/wps_attr_build.c \
+  components/wpa_supplicant/src/wps/wps_attr_parse.c \
+  components/wpa_supplicant/src/wps/wps_attr_process.c \
+  components/wpa_supplicant/src/wps/wps.c \
+  components/wpa_supplicant/src/wps/wps_common.c \
+  components/wpa_supplicant/src/wps/wps_dev_attr.c \
+  components/wpa_supplicant/src/wps/wps_enrollee.c \
+  components/wpa_supplicant/src/wps/wps_registrar.c \
+  components/wpa_supplicant/src/wps/wps_validate.c \
+  #
+
+include $(ESP_IDF_WPA_SUPPLICANT_PATH)/esp_idf_wpa_supplicant.mk


### PR DESCRIPTION
### Contribution description

The module `esp_wpa_supplicant` is quite large and its compilation takes a long time. Therefore it is better to split the PR into several submodules.

### Testing procedure

1. Green CI
2. Compile and test a WiFi example, for example:
    ```
    USEMODULE=esp_wifi CFLAGS=-DESP_WIFI_SSID=\"ssid\" -DESP_WIFI_PASS=\"pass\" \
    BOARD=esp32-wroom-32 make -C examples/gnrc_networking flash term
    ```

### Issues/PRs references

Split off from PR #17841 