### PR TITLE
nanocoap_sock: fix debug output

### DIFF
--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -173,8 +173,10 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
             /* fall-through */
         case STATE_RESPONSE_RCVD:
         case STATE_RESPONSE_OK:
-            DEBUG("nanocoap: waiting for response (timeout: %"PRIu32" µs)\n",
-                  _deadline_left_us(deadline));
+            if (ctx == NULL) {
+                DEBUG("nanocoap: waiting for response (timeout: %"PRIu32" µs)\n",
+                      _deadline_left_us(deadline));
+            }
             const void *old_ctx = ctx;
             tmp = sock_udp_recv_buf(sock, &payload, &ctx, _deadline_left_us(deadline), NULL);
             /* sock_udp_recv_buf() is supposed to return multiple packet fragments
@@ -198,7 +200,7 @@ ssize_t nanocoap_sock_request_cb(nanocoap_sock_t *sock, coap_pkt_t *pkt,
             }
             res = tmp;
             if (res == -ETIMEDOUT) {
-                DEBUG("nanocoap: timeout\n");
+                DEBUG("nanocoap: timeout, %u retries left\n", tries_left - 1);
                 timeout *= 2;
                 deadline = _deadline_from_interval(timeout);
                 state = STATE_REQUEST_SEND;

--- a/sys/net/application_layer/nanocoap/vfs.c
+++ b/sys/net/application_layer/nanocoap/vfs.c
@@ -66,12 +66,12 @@ int nanocoap_vfs_get(nanocoap_sock_t *sock, const char *path, const char *dst)
     int fd, res;
     char dst_tmp[CONFIG_SOCK_URLPATH_MAXLEN];
 
-    DEBUG("nanocoap: downloading %s to %s\n", path, dst_tmp);
-
     fd = _prepare_file(dst, dst_tmp, sizeof(dst_tmp));
     if (fd < 0) {
         return fd;
     }
+
+    DEBUG("nanocoap: downloading %s to %s\n", path, dst_tmp);
     res = nanocoap_sock_get_blockwise(sock, path, CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT,
                                       _2file, &fd);
     return _finalize_file(fd, res, dst, dst_tmp);
@@ -82,12 +82,12 @@ int nanocoap_vfs_get_url(const char *url, const char *dst)
     int fd, res;
     char dst_tmp[CONFIG_SOCK_URLPATH_MAXLEN];
 
-    DEBUG("nanocoap: downloading %s to %s\n", url, dst_tmp);
-
     fd = _prepare_file(dst, dst_tmp, sizeof(dst_tmp));
     if (fd < 0) {
         return fd;
     }
+
+    DEBUG("nanocoap: downloading %s to %s\n", url, dst_tmp);
     res = nanocoap_get_blockwise_url(url, CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT,
                                      _2file, &fd);
     return _finalize_file(fd, res, dst, dst_tmp);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - only print the 'waiting for response' text when we are actually waiting for a response, not freeing the packet
 - don't print buffer *before* destination file name has been written to it
 -  print remaining retries


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
