### PR TITLE
rust: Explicitly select nightly

### DIFF
--- a/doc/doxygen/src/using-rust.md
+++ b/doc/doxygen/src/using-rust.md
@@ -95,7 +95,6 @@ and the core library for the CPU (**target**) of your choice available:
 ```
 $ rustup toolchain add nightly
 $ rustup toolchain add stable
-$ rustup default nightly
 $ rustup target add thumbv7m-none-eabi --toolchain nightly
 $ rustup target add thumbv7m-none-eabi --toolchain stable
 ```

--- a/examples/rust-gcoap/Makefile
+++ b/examples/rust-gcoap/Makefile
@@ -41,6 +41,9 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
+# This example requires a nightly version because of the CoAP dependencies
+CARGO_CHANNEL ?= ${CARGO_CHANNEL_NIGHTLY}
+
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation
 BOARD_BLACKLIST := ek-lm4f120xl

--- a/examples/rust-hello-world/Makefile
+++ b/examples/rust-hello-world/Makefile
@@ -21,6 +21,11 @@ BASELIBS += $(APPLICATION_RUST_MODULE).module
 
 FEATURES_REQUIRED += rust_target
 
+# While this example can be built with stable Rust on many platforms, the
+# nightly channel is selected to smoothly transition from running this example
+# to experimenting with it (which might easily lead into nightly territory).
+CARGO_CHANNEL ?= $(CARGO_CHANNEL_NIGHTLY)
+
 # Currently unknown, something related to the LED_PORT definition that doesn't
 # pass C2Rust's transpilation
 BOARD_BLACKLIST := ek-lm4f120xl

--- a/makefiles/cargo-settings.inc.mk
+++ b/makefiles/cargo-settings.inc.mk
@@ -12,14 +12,26 @@ CARGO_EXTRACFLAGS ?=
 # -Z unstable-options as of 2021-03 nightlies.
 CARGO_PROFILE ?= release
 
+# Value for CARGO_CHANNEL when using nightly
+#
+# As different environments have different versions of nightly installed, but
+# rustup / cargo does not take "the latest installed nightly" for a toolchain,
+# a good value is determined dynamically. Typical values this takes are
+# `nightly` (on regular installations) and `nightly-2022-03-08` (or whichever
+# date it is currently pinned to) in riotbuild.
+#
+# Workaround-For: https://github.com/rust-lang/rustup/issues/3015
+#
+# This does not get evaluated unless actually used; if rustup is not installed,
+# the default value will likely not be usable but at least set the user on the
+# right track.
+CARGO_CHANNEL_NIGHTLY = $(shell rustup toolchain list | sed 's/ .*//' |grep nightly | tail -n1 || echo nightly)
+
 # The Rust version to use.
 #
-# As long as C2Rust and riot-wrappers require nightly, the only alternative
-# here is to pick a particular nightly when something breaks.
-#
-# (Default is empty, because the riotbuild container picks a particular nightly
-# and sets it as a default; users without a nightly default need to either
-# override this here or in rustup)
+# Examples should set this to either `stable` or `$(CARGO_CHANNEL_NIGHTLY)`.
+# The default is empty, which is suitable for applications that select their
+# version through a `rust-toolchain.yaml` file.
 CARGO_CHANNEL ?=
 
 # Note that if we did not set this explicitly, CARGO_LIB would have to


### PR DESCRIPTION
Examples have previously relied on the (really: some) nightly toolchain
to be the default. As that, in practice, is a problematic assumption,
the latest toolchain to use is now determined programmatically, and that
is set explicitly on the examples that use nightly.

Workaround-For: https://github.com/rust-lang/rustup/issues/3015

---

This is somewhat related to https://github.com/RIOT-OS/RIOT/pull/18220 -- but they should complement each other transparently enough that merging them in any order should do the right thing.

### Testing

* CI still passes
* Set your Rust to any of `rustup default nightly` or `rustup default stable`, or set a `rustup override`, and the examples should still all build, with and without BUILD_IN_DOCKER=1.

(Even a rust-toolchain.yaml file should be ignored in the examples -- if CARGO_CHANNEL is set empty, that would be used, but testing that is excessive at this stage)