### PR TITLE
sys/net/gnrc_pktbuf_static: fix documentation of use-after-free detection

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -37,7 +37,7 @@
 #include "debug.h"
 
 /**
- * @brief enable use-after-free detection
+ * @brief enable use-after-free/out of bounds write detection
  */
 #ifndef CONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE
 #define CONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE (0)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The bug I was hunting wasn't a use after free after all. Don't let the user think that this is the only kind of malady that triggers this test. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
