### PR TITLE
boards/common/arduino-atmega: fix issue with wrong port for LED0

### DIFF
--- a/boards/common/arduino-atmega/include/board_common.h
+++ b/boards/common/arduino-atmega/include/board_common.h
@@ -49,6 +49,9 @@ extern "C" {
 #ifdef CPU_ATMEGA328P
 #define LED0_PIN            GPIO_PIN(1, 5)
 #define LED0_MASK           (1 << DDB5)
+#define LED0_ON             (PORTB |=  LED0_MASK)
+#define LED0_OFF            (PORTB &= ~LED0_MASK)
+#define LED0_TOGGLE         (PORTB ^=  LED0_MASK)
 #endif
 
 #ifdef CPU_ATMEGA32U4
@@ -63,6 +66,9 @@ extern "C" {
 #ifdef CPU_ATMEGA2560
 #define LED0_PIN            GPIO_PIN(1, 7)
 #define LED0_MASK           (1 << DDB7)
+#define LED0_ON             (PORTB |=  LED0_MASK)
+#define LED0_OFF            (PORTB &= ~LED0_MASK)
+#define LED0_TOGGLE         (PORTB ^=  LED0_MASK)
 #endif
 
 #ifdef CPU_ATMEGA32U4
@@ -75,10 +81,6 @@ extern "C" {
 #define LED2_OFF            (PORTD |=  LED2_MASK) /**< TX LED */
 #define LED2_ON             (PORTD &= ~LED2_MASK)
 #define LED2_TOGGLE         (PORTD ^=  LED2_MASK)
-#else
-#define LED0_ON             (PORTD |=  LED0_MASK)
-#define LED0_OFF            (PORTD &= ~LED0_MASK)
-#define LED0_TOGGLE         (PORTD ^=  LED0_MASK)
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description

[valentinpi](https://github.com/valentinpi) in Issue #18228 reports BUG with arduino UNO and NANO LED0. 

Investigation of this bug reveals two independent problems:

1. There is a wrong port for LED0_ON, OFF and TOGGLE in **_board_common.h_** for atmega328p and atmega2560 - this PR fix this issue.
2. There are still some problems with _**periph_gpio**_ for atmega. In current RIOT master _**example/blinky**_ did not work. However, when **_2022.04-branch_** is used with fix from this PR everything works fine. Initial workaround for this problem could be merging this commit directly to **_2022.04-branch_**, and temporary using it for atmega. 

### Testing procedure

Compile and flash  _**example/blinky**_ for arduino uno or mega using current RIOT master - LED0 did not blink.

Switch to **_2022.04-branch_**, apply this PR, compile and flash  _**example/blinky**_ for arduino uno or mega - LED0 should blink.

### Issues/PRs references

Issue #18228