### PR TITLE
cpu/esp32: platform independent code for thread_arch, irq_arch and exception

### DIFF
--- a/cpu/esp32/esp_ztimer.c
+++ b/cpu/esp32/esp_ztimer.c
@@ -141,7 +141,7 @@ void ets_timer_done(ETSTimer *ptimer)
 
 void ets_timer_arm_us(ETSTimer *timer, uint32_t tmout, bool repeat)
 {
-    DEBUG("%s timer=%p tmout=%u repeat=%d\n", __func__, timer, tmout, repeat);
+    DEBUG("%s timer=%p tmout=%"PRIu32" repeat=%d\n", __func__, timer, tmout, repeat);
 
     struct _ets_to_ztimer* e2xt = _ets_to_ztimer_get(timer);
 

--- a/cpu/esp32/include/irq_arch.h
+++ b/cpu/esp32/include/irq_arch.h
@@ -39,14 +39,21 @@ extern "C" {
 #define CPU_INUM_GPIO       2   /**< Level interrupt with low priority 1 */
 #define CPU_INUM_CAN        3   /**< Level interrupt with low priority 1 */
 #define CPU_INUM_UART       5   /**< Level interrupt with low priority 1 */
-#define CPU_INUM_RTC        9   /**< Level interrupt with low priority 1 */
+#define CPU_INUM_RTT        9   /**< Level interrupt with low priority 1 */
 #define CPU_INUM_I2C        12  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_WDT        13  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_SOFTWARE   17  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_ETH        18  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_TIMER      19  /**< Level interrupt with medium priority 2 */
 #define CPU_INUM_FRC2       20  /**< Level interrupt with medium priority 2 */
+#define CPU_INUM_SYSTIMER   20  /**< Level interrupt with medium priority 2 */
+#define CPU_INUM_CACHEERR   25  /**< Level interrupt with high priority 4 */
 /** @} */
+
+/**
+ * @brief   Initialize architecture specific interrupt handling
+ */
+void esp_irq_init(void);
 
 #ifdef __cplusplus
 }

--- a/cpu/esp32/irq_arch.c
+++ b/cpu/esp32/irq_arch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2022 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,58 +19,101 @@
  */
 
 #include "irq_arch.h"
+
+#include "esp_attr.h"
 #include "esp_err.h"
-#include "esp32/rom/ets_sys.h"
-#include "soc/dport_reg.h"
-#include "xtensa/xtensa_api.h"
+#include "freertos/FreeRTOS.h"
+#include "hal/interrupt_controller_types.h"
+#include "hal/interrupt_controller_ll.h"
+#include "rom/ets_sys.h"
+#include "soc/periph_defs.h"
+#include "esp_intr_alloc.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-struct _irq_alloc_table_t {
+#ifndef ETS_CAN_INTR_SOURCE
+#define ETS_CAN_INTR_SOURCE     ETS_TWAI_INTR_SOURCE
+#endif
+
+typedef struct intr_handle_data_t {
     int      src;   /* peripheral interrupt source */
     uint32_t intr;  /* interrupt number */
+    uint8_t  level;
+} intr_handle_data_t;
+
+/* TODO change to a clearer approach */
+static struct intr_handle_data_t _irq_data_table[] = {
+    { ETS_FROM_CPU_INTR0_SOURCE, CPU_INUM_SOFTWARE, 1 },
+    { ETS_TG0_WDT_LEVEL_INTR_SOURCE, CPU_INUM_WDT, 1 },
+    { ETS_TG0_T0_LEVEL_INTR_SOURCE, CPU_INUM_RTT, 1 },
+#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+    { ETS_TG0_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
+#endif
+#if defined(MCU_ESP32) || defined(MCU_ESP32S2)
+    { ETS_TG0_LACT_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
+#endif
+#if !defined(MCU_ESP32C2)
+    { ETS_TG1_T0_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
+#endif
+#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+    { ETS_TG1_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
+#endif
+    { ETS_UART0_INTR_SOURCE, CPU_INUM_UART, 1 },
+    { ETS_UART1_INTR_SOURCE, CPU_INUM_UART, 1 },
+#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+    { ETS_UART2_INTR_SOURCE, CPU_INUM_UART, 1 },
+#endif
+    { ETS_GPIO_INTR_SOURCE, CPU_INUM_GPIO, 1 },
+    { ETS_I2C_EXT0_INTR_SOURCE, CPU_INUM_I2C, 1 },
+#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+    { ETS_I2C_EXT1_INTR_SOURCE, CPU_INUM_I2C, 1 },
+#endif
+#if defined(MCU_ESP32)
+    { ETS_ETH_MAC_INTR_SOURCE, CPU_INUM_ETH, 1 },
+#endif
+#if !defined(MCU_ESP32C2)
+    { ETS_TWAI_INTR_SOURCE, CPU_INUM_CAN, 1 },
+    { ETS_TIMER2_INTR_SOURCE, CPU_INUM_FRC2, 2 },
+#endif
+#if !defined(MCU_ESP32)
+    { ETS_SYSTIMER_TARGET2_EDGE_INTR_SOURCE, CPU_INUM_SYSTIMER, 2 },
+#endif
 };
 
-static const struct _irq_alloc_table_t _irq_alloc_table[] = {
-    { ETS_FROM_CPU_INTR0_SOURCE, CPU_INUM_SOFTWARE },
-    { ETS_TG0_WDT_LEVEL_INTR_SOURCE, CPU_INUM_WDT },
-    { ETS_TG0_LACT_LEVEL_INTR_SOURCE, CPU_INUM_RTC },
-    { ETS_TG0_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER },
-    { ETS_TG1_T0_LEVEL_INTR_SOURCE, CPU_INUM_TIMER },
-    { ETS_TG1_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER },
-    { ETS_UART0_INTR_SOURCE, CPU_INUM_UART },
-    { ETS_UART1_INTR_SOURCE, CPU_INUM_UART },
-    { ETS_UART2_INTR_SOURCE, CPU_INUM_UART },
-    { ETS_GPIO_INTR_SOURCE, CPU_INUM_GPIO },
-    { DPORT_PRO_RTC_CORE_INTR_MAP_REG, CPU_INUM_RTC },
-    { ETS_I2C_EXT0_INTR_SOURCE, CPU_INUM_I2C },
-    { ETS_I2C_EXT1_INTR_SOURCE, CPU_INUM_I2C },
-    { ETS_ETH_MAC_INTR_SOURCE, CPU_INUM_ETH },
-    { ETS_CAN_INTR_SOURCE, CPU_INUM_CAN },
-    { ETS_TIMER2_INTR_SOURCE, CPU_INUM_FRC2 },
-};
+#define IRQ_DATA_TABLE_SIZE        ARRAY_SIZE(_irq_data_table)
 
-typedef void (*intr_handler_t)(void *arg);
+void esp_irq_init(void)
+{
+#ifdef SOC_CPU_HAS_FLEXIBLE_INTC
+    /* to avoid to do it in every component, we initialize levels here once */
+    for (unsigned i = 0; i < IRQ_DATA_TABLE_SIZE; i++) {
+        intr_cntrl_ll_set_int_level(_irq_data_table[i].intr, _irq_data_table[i].level);
+    }
+#endif
+}
 
-#define IRQ_ALLOC_TABLE_SIZE ARRAY_SIZE(_irq_alloc_table)
-#define ESP_INTR_FLAG_INTRDISABLED    (1<<11)
+void esp_intr_enable_source(int inum)
+{
+    intr_cntrl_ll_enable_interrupts(BIT(inum));
+}
 
-typedef unsigned intr_handle_t;
+void esp_intr_disable_source(int inum)
+{
+    intr_cntrl_ll_disable_interrupts(BIT(inum));
+}
 
 esp_err_t esp_intr_enable(intr_handle_t handle)
 {
-    assert(handle < IRQ_ALLOC_TABLE_SIZE);
-    const struct _irq_alloc_table_t *entry = &_irq_alloc_table[handle];
-    xt_ints_on(BIT(entry->intr));
+    assert(handle != NULL);
+    esp_intr_enable_source(handle->intr);
     return ESP_OK;
 }
 
 esp_err_t esp_intr_disable(intr_handle_t handle)
 {
-    assert(handle < IRQ_ALLOC_TABLE_SIZE);
-    const struct _irq_alloc_table_t *entry = &_irq_alloc_table[handle];
-    xt_ints_off(BIT(entry->intr));
+    assert(handle != NULL);
+    esp_intr_disable_source(handle->intr);
     return ESP_OK;
 }
 
@@ -88,29 +131,34 @@ esp_err_t esp_intr_alloc(int source, int flags, intr_handler_t handler,
                          void *arg, intr_handle_t *ret_handle)
 {
     unsigned i;
-    for (i = 0; i < IRQ_ALLOC_TABLE_SIZE; i++) {
-        if (_irq_alloc_table[i].src == source) {
+    for (i = 0; i < IRQ_DATA_TABLE_SIZE; i++) {
+        if (_irq_data_table[i].src == source) {
             break;
         }
     }
 
-    if (i == IRQ_ALLOC_TABLE_SIZE) {
+    if (i == IRQ_DATA_TABLE_SIZE) {
         return ESP_ERR_NOT_FOUND;
     }
 
     /* route the interrupt source to the CPU interrupt */
-    intr_matrix_set(PRO_CPU_NUM, _irq_alloc_table[i].src, _irq_alloc_table[i].intr);
+    intr_matrix_set(PRO_CPU_NUM, _irq_data_table[i].src, _irq_data_table[i].intr);
 
     /* set the interrupt handler */
-    xt_set_interrupt_handler(_irq_alloc_table[i].intr, handler, arg);
+    intr_cntrl_ll_set_int_handler(_irq_data_table[i].intr, handler, arg);
+
+#ifdef SOC_CPU_HAS_FLEXIBLE_INTC
+    /* set interrupt level given by flags */
+    intr_cntrl_ll_set_int_level(_irq_data_table[i].intr, esp_intr_flags_to_level(flags));
+#endif
 
     /* enable the interrupt if ESP_INTR_FLAG_INTRDISABLED is not set */
     if ((flags & ESP_INTR_FLAG_INTRDISABLED) == 0) {
-        xt_ints_on(BIT(_irq_alloc_table[i].intr));
+        intr_cntrl_ll_enable_interrupts(BIT(_irq_data_table[i].intr));
     }
 
     if (ret_handle) {
-        *((intr_handle_t *)ret_handle) = i;
+        *((intr_handle_t *)ret_handle) = &_irq_data_table[i];
     }
 
     return ESP_OK;
@@ -119,4 +167,9 @@ esp_err_t esp_intr_alloc(int source, int flags, intr_handler_t handler,
 esp_err_t esp_intr_free(intr_handle_t handle)
 {
     return esp_intr_disable(handle);
+}
+
+int esp_intr_get_cpu(intr_handle_t handle)
+{
+    return PRO_CPU_NUM;
 }

--- a/cpu/esp32/periph/rtt.c
+++ b/cpu/esp32/periph/rtt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
+ * Copyright (C) 2022 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -82,7 +82,8 @@ void rtt_init(void)
         }
     }
 
-    DEBUG("%s rtt_offset=%u @rtc=%llu rtc_active=%d @sys_time=%llu\n", __func__,
+    DEBUG("%s rtt_offset=%" PRIu32 " @rtc=%" PRIu64
+          " rtc_active=%d @sys_time=%" PRIi64 "\n", __func__,
           _rtt_offset, _rtc_get_counter(),
           (_rtt_hw == &_rtt_hw_sys_driver) ? 1 : 0, system_get_time_64());
 
@@ -132,7 +133,8 @@ uint32_t rtt_get_counter(void)
 {
     /* we use only the lower 32 bit of the 48-bit RTC counter */
     uint32_t counter = _rtt_hw->get_counter() + _rtt_offset;
-    DEBUG("%s counter=%u @sys_time=%u\n", __func__, counter, system_get_time());
+    DEBUG("%s counter=%" PRIu32 " @sys_time=%" PRIu32" \n",
+          __func__, counter, system_get_time());
     return counter;
 }
 
@@ -141,7 +143,7 @@ void rtt_set_counter(uint32_t counter)
     uint32_t _rtt_current = _rtt_hw->get_counter();
     _rtt_offset = counter - _rtt_current;
 
-    DEBUG("%s set=%u rtt_offset=%u @rtt=%u\n",
+    DEBUG("%s set=%" PRIu32 " rtt_offset=%" PRIu32 " @rtt=%" PRIu32 "\n",
           __func__, counter, _rtt_offset, _rtt_current);
 
     _rtt_update_hw_alarm();
@@ -154,7 +156,7 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     rtt_counter.alarm_cb = cb;
     rtt_counter.alarm_arg = arg;
 
-    DEBUG("%s alarm=%u @rtt=%u\n", __func__, alarm, counter);
+    DEBUG("%s alarm=%" PRIu32 " @rtt=%" PRIu32 "\n", __func__, alarm, counter);
 
     _rtt_update_hw_alarm();
 }
@@ -166,7 +168,7 @@ void rtt_clear_alarm(void)
     rtt_counter.alarm_cb = NULL;
     rtt_counter.alarm_arg = NULL;
 
-    DEBUG("%s @rtt=%u\n", __func__, (uint32_t)_rtt_hw->get_counter());
+    DEBUG("%s @rtt=%" PRIu32 "\n", __func__, (uint32_t)_rtt_hw->get_counter());
 
     _rtt_update_hw_alarm();
 }
@@ -197,7 +199,7 @@ uint64_t rtt_pm_sleep_enter(unsigned mode)
     uint32_t counter = rtt_get_counter();
     uint64_t t_diff = RTT_TICKS_TO_US(rtt_counter.alarm_active - counter);
 
-    DEBUG("%s rtt_alarm=%u @rtt=%u t_diff=%llu\n", __func__,
+    DEBUG("%s rtt_alarm=%" PRIu32 " @rtt=%" PRIu32 " t_diff=%llu\n", __func__,
           rtt_counter.alarm_active, counter, t_diff);
 
     if (t_diff) {
@@ -250,7 +252,7 @@ static void IRAM_ATTR _rtt_isr(void *arg)
 
     if (rtt_counter.wakeup) {
         rtt_counter.wakeup = false;
-        DEBUG("%s wakeup alarm alarm=%u rtt_alarm=%u @rtt=%u\n",
+        DEBUG("%s wakeup alarm alarm=%" PRIu32 " rtt_alarm=%" PRIu32 " @rtt=%" PRIu32 "\n",
               __func__, alarm, rtt_counter.alarm_active, rtt_get_counter());
     }
 
@@ -276,7 +278,7 @@ static void IRAM_ATTR _rtt_isr(void *arg)
         }
     }
 
-   DEBUG("%s next rtt=%u\n", __func__, rtt_counter.alarm_active);
+   DEBUG("%s next rtt=%" PRIu32 "\n", __func__, rtt_counter.alarm_active);
 }
 
 uint32_t _rtt_hw_to_rtt_counter(uint32_t hw_counter)

--- a/cpu/esp32/periph/rtt_hw_rtc.c
+++ b/cpu/esp32/periph/rtt_hw_rtc.c
@@ -74,18 +74,18 @@ static void _rtc_init(void)
 static void _rtc_poweron(void)
 {
     /* route all interrupt sources to the same RTT level type interrupt */
-    intr_matrix_set(PRO_CPU_NUM, ETS_RTC_CORE_INTR_SOURCE, CPU_INUM_RTC);
+    intr_matrix_set(PRO_CPU_NUM, ETS_RTC_CORE_INTR_SOURCE, CPU_INUM_RTT);
 
     /* set interrupt handler and enable the CPU interrupt */
-    xt_set_interrupt_handler(CPU_INUM_RTC, _rtc_isr, NULL);
-    xt_ints_on(BIT(CPU_INUM_RTC));
+    xt_set_interrupt_handler(CPU_INUM_RTT, _rtc_isr, NULL);
+    xt_ints_on(BIT(CPU_INUM_RTT));
 }
 
 static void _rtc_poweroff(void)
 {
     /* reset interrupt handler and disable the CPU interrupt */
-    xt_ints_off(BIT(CPU_INUM_RTC));
-    xt_set_interrupt_handler(CPU_INUM_RTC, NULL, NULL);
+    xt_ints_off(BIT(CPU_INUM_RTT));
+    xt_set_interrupt_handler(CPU_INUM_RTT, NULL, NULL);
 }
 
 uint64_t _rtc_get_counter(void)

--- a/cpu/esp32/periph/rtt_hw_sys.c
+++ b/cpu/esp32/periph/rtt_hw_sys.c
@@ -74,18 +74,18 @@ static void _sys_init(void)
 static void _sys_poweron(void)
 {
     /* route all interrupt sources to the same RTT level type interrupt */
-    intr_matrix_set(PRO_CPU_NUM, TIMER_SYSTEM_INT_SRC, CPU_INUM_RTC);
+    intr_matrix_set(PRO_CPU_NUM, TIMER_SYSTEM_INT_SRC, CPU_INUM_RTT);
 
     /* set interrupt handler and enable the CPU interrupt */
-    xt_set_interrupt_handler(CPU_INUM_RTC, _sys_isr, NULL);
-    xt_ints_on(BIT(CPU_INUM_RTC));
+    xt_set_interrupt_handler(CPU_INUM_RTT, _sys_isr, NULL);
+    xt_ints_on(BIT(CPU_INUM_RTT));
 }
 
 static void _sys_poweroff(void)
 {
     /* reset interrupt handler and disable the CPU interrupt */
-    xt_ints_off(BIT(CPU_INUM_RTC));
-    xt_set_interrupt_handler(CPU_INUM_RTC, NULL, NULL);
+    xt_ints_off(BIT(CPU_INUM_RTT));
+    xt_set_interrupt_handler(CPU_INUM_RTT, NULL, NULL);
 }
 
 static uint64_t _sys_get_counter(void)

--- a/cpu/esp_common/exceptions_riscv.c
+++ b/cpu/esp_common/exceptions_riscv.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp_common
+ * @{
+ *
+ * @file
+ * @brief       Exception handling for RISC-V-based ESP SoCs
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#if __riscv
+
+#include <inttypes.h>
+
+#include "kernel_defines.h"
+#include "periph/pm.h"
+
+#include "esp_attr.h"
+#include "riscv/rvruntime-frames.h"
+#include "rom/ets_sys.h"
+
+static const char *exceptions[] = {
+    "nil",
+    "0x1: PMP Instruction access fault",
+    "0x2: Illegal Instruction",
+    "0x3: Hardware Breakpoint/Watchpoint or EBREAK",
+    "nil",
+    "0x5: PMP Load access fault",
+    "nil",
+    "0x7: PMP Store access fault",
+    "0x8: ECALL from U mode",
+    "nil",
+    "nil",
+    "0xb: ECALL from M mode",
+};
+
+void init_exceptions (void)
+{
+}
+
+void IRAM_ATTR xt_unhandled_exception(RvExcFrame *frame)
+{
+    /* TODO */
+    ets_printf("#! Unhandled exception @0x%08"PRIx32", cause %s, "
+               "powering off\n", frame->mepc, exceptions[frame->mcause]);
+    if (!IS_USED(MODULE_ESP_GDB)) {
+        pm_off();
+    }
+    while (1) { };
+}
+
+void IRAM_ATTR panicHandler(RvExcFrame *frame)
+{
+    /* TODO */
+    ets_printf("#! panicHandler called from 0x%08"PRIx32", cause: %08"
+               PRIx32", powering off", frame->mepc, frame->mcause);
+    if (!IS_USED(MODULE_ESP_GDB)) {
+        pm_off();
+    }
+    while (1) { };
+}
+
+#endif /* __riscv */

--- a/cpu/esp_common/exceptions_xtensa.c
+++ b/cpu/esp_common/exceptions_xtensa.c
@@ -11,11 +11,13 @@
  * @{
  *
  * @file
- * @brief       ESP SoCs exception handling
+ * @brief       Exception handling for Xtensa-based ESP SoCs
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @}
  */
+
+#if __xtensa__
 
 #include <malloc.h>
 #include <string.h>
@@ -216,3 +218,5 @@ void _panic_handler(uint32_t addr)
     pm_off();
     while (1) { };
 }
+
+#endif /* __xtensa__ */

--- a/cpu/esp_common/irq_arch.c
+++ b/cpu/esp_common/irq_arch.c
@@ -21,13 +21,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "irq.h"
-#include "cpu.h"
-
-#include "esp_common.h"
 #include "esp/common_macros.h"
-#include "esp/xtensa_ops.h"
-#include "xtensa/xtensa_context.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -38,75 +32,10 @@
 volatile uint32_t irq_interrupt_nesting = 0;
 
 /**
- * @brief Disable all maskable interrupts
- */
-unsigned int IRAM irq_disable(void)
-{
-    uint32_t state;
-
-    /* read and set interrupt level (RSIL) */
-    __asm__ volatile ("rsil %0, " XTSTR(XCHAL_EXCM_LEVEL) : "=a" (state) :: "memory");
-    /* mask out everything else of the PS register that do not belong to
-       interrupt level (bits 3..0) */
-    state &= 0xf;
-
-    DEBUG("%s %02x(%02x)\n", __func__, XCHAL_EXCM_LEVEL, state);
-    return state;
-}
-
-/**
- * @brief Enable all maskable interrupts
- */
-unsigned int IRAM irq_enable(void)
-{
-    uint32_t state;
-
-    /* read and set interrupt level (RSIL) */
-    __asm__ volatile ("rsil %0, 0" : "=a" (state) :: "memory");
-    /* mask out everything else of the PS register that do not belong to
-       interrupt level (bits 3..0) */
-    state &= 0xf;
-
-    DEBUG("%s %02x(%02x)\n", __func__, 0, state);
-    return state;
-}
-
-/**
- * @brief Restore the state of the IRQ flags
- */
-void IRAM irq_restore(unsigned int state)
-{
-    uint32_t old = 0;
-
-    /* write interrupt level and sync */
-    __asm__ volatile ("extui  %1, %1, 0, 4  \n" /* mask intlevel bits in param */
-                      "rsr.ps %0            \n" /* read current PS value */
-                      "movi.n a4, -16       \n"
-                      "and    a4, a4, %0    \n" /* mask out intlevel bits in PS */
-                      "or     a4, a4, %1    \n" /* or intlevel with PS */
-                      "wsr.ps a4            \n" /* write back PS */
-                      "rsync                \n"
-                     : "+a" (old) : "a" (state) : "memory");
-
-    DEBUG("%s %02x(%02x)\n", __func__, state, old & 0xf);
-}
-
-/**
  * @brief See if the current context is inside an ISR
  */
 bool IRAM irq_is_in(void)
 {
-    DEBUG("irq_interrupt_nesting = %d\n", irq_interrupt_nesting);
+    DEBUG("irq_interrupt_nesting = %" PRIu32 "\n", irq_interrupt_nesting);
     return irq_interrupt_nesting;
-}
-
-/**
- * @brief Test if IRQs are currently enabled
- */
-bool IRAM irq_is_enabled(void)
-{
-    uint32_t reg;
-
-    RSR(reg, 230);
-    return (reg & 0xf) == 0;
 }

--- a/cpu/esp_common/irq_arch_riscv.c
+++ b/cpu/esp_common/irq_arch_riscv.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels irq interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#if __riscv
+
+#include "irq_arch.h"
+
+#include "esp_attr.h"
+#include "hal/interrupt_controller_types.h"
+#include "hal/interrupt_controller_ll.h"
+#include "soc/periph_defs.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#define RVHAL_EXCM_LEVEL    4
+
+/**
+ * @brief Disable all maskable interrupts
+ */
+unsigned int IRAM_ATTR irq_disable(void)
+{
+    uint32_t mstatus;
+    /* clear MIE bit in register mstatus */
+    __asm__ volatile ("csrrc %0, mstatus, %1" : "=r"(mstatus) : "rK"(MSTATUS_MIE) : "memory");
+
+    /* save interrupt priority level threshold */
+    uint32_t state = *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG);
+    /* set interrupt priority level threshold to exception level */
+    *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG) = RVHAL_EXCM_LEVEL;
+
+    /* set MIE bit in register mstatus */
+    __asm__ volatile ("csrrs %0, mstatus, %1" : "=r"(mstatus) : "rK"(MSTATUS_MIE) : "memory");
+
+    DEBUG("%s %02x(%02x)\n", __func__, RVHAL_EXCM_LEVEL, (unsigned)state);
+    return state;
+}
+
+/**
+ * @brief Enable all maskable interrupts
+ */
+unsigned int IRAM_ATTR irq_enable(void)
+{
+    uint32_t state = *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG);
+
+    /* set interrupt priority level threshold to 0 */
+    *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG) = 0;
+
+    /* small delay needed here */
+    __asm__ volatile ( "nop" );
+    __asm__ volatile ( "nop" );
+    __asm__ volatile ( "nop" );
+
+    DEBUG("%s %02x(%02x)\n", __func__, 0, (unsigned)state);
+    return state;
+}
+
+/**
+ * @brief Restore the state of the IRQ flags
+ */
+void IRAM_ATTR irq_restore(unsigned int state)
+{
+    uint32_t old = *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG);
+
+    /* set interrupt priority level threshold to old level */
+    *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG) = state;
+
+    /* small delay needed here */
+    __asm__ volatile ( "nop" );
+    __asm__ volatile ( "nop" );
+    __asm__ volatile ( "nop" );
+
+    DEBUG("%s %02x(%02x)\n", __func__, (unsigned)state, (unsigned)old);
+}
+
+/**
+ * @brief Test if IRQs are currently enabled
+ */
+bool IRAM_ATTR irq_is_enabled(void)
+{
+    return *((volatile uint32_t *)INTERRUPT_CORE0_CPU_INT_THRESH_REG) == 0;
+}
+
+#endif /* __riscv */

--- a/cpu/esp_common/irq_arch_xtensa.c
+++ b/cpu/esp_common/irq_arch_xtensa.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp_common
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels irq interface
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#if __xtensa__
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "irq.h"
+#include "cpu.h"
+
+#include "esp_common.h"
+#include "esp/common_macros.h"
+
+#include "esp/xtensa_ops.h"
+#include "xtensa/xtensa_context.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief Disable all maskable interrupts
+ */
+unsigned int IRAM irq_disable(void)
+{
+    uint32_t state;
+
+    /* read and set interrupt level (RSIL) */
+    __asm__ volatile ("rsil %0, " XTSTR(XCHAL_EXCM_LEVEL) : "=a" (state) :: "memory");
+    /* mask out everything else of the PS register that do not belong to
+       interrupt level (bits 3..0) */
+    state &= 0xf;
+
+    DEBUG("%s %02x(%02x)\n", __func__, XCHAL_EXCM_LEVEL, state);
+    return state;
+}
+
+/**
+ * @brief Enable all maskable interrupts
+ */
+unsigned int IRAM irq_enable(void)
+{
+    uint32_t state;
+
+    /* read and set interrupt level (RSIL) */
+    __asm__ volatile ("rsil %0, 0" : "=a" (state) :: "memory");
+    /* mask out everything else of the PS register that do not belong to
+       interrupt level (bits 3..0) */
+    state &= 0xf;
+
+    DEBUG("%s %02x(%02x)\n", __func__, 0, state);
+    return state;
+}
+
+/**
+ * @brief Restore the state of the IRQ flags
+ */
+void IRAM irq_restore(unsigned int state)
+{
+    uint32_t old = 0;
+
+    /* write interrupt level and sync */
+    __asm__ volatile ("extui  %1, %1, 0, 4  \n" /* mask intlevel bits in param */
+                      "rsr.ps %0            \n" /* read current PS value */
+                      "movi.n a4, -16       \n"
+                      "and    a4, a4, %0    \n" /* mask out intlevel bits in PS */
+                      "or     a4, a4, %1    \n" /* or intlevel with PS */
+                      "wsr.ps a4            \n" /* write back PS */
+                      "rsync                \n"
+                     : "+a" (old) : "a" (state) : "memory");
+
+    DEBUG("%s %02x(%02x)\n", __func__, state, old & 0xf);
+}
+
+/**
+ * @brief Test if IRQs are currently enabled
+ */
+bool IRAM irq_is_enabled(void)
+{
+    uint32_t reg;
+
+    RSR(reg, 230);
+    return (reg & 0xf) == 0;
+}
+
+#endif /* __xtensa__ */

--- a/cpu/esp_common/thread_arch.c
+++ b/cpu/esp_common/thread_arch.c
@@ -18,33 +18,6 @@
  * @}
  */
 
-/*
- * PLEASE NOTE: Some parts of the code are taken from the FreeRTOS port for
- * Xtensa processors from Cadence Design Systems. These parts are marked
- * accordingly. For these parts, the following license is valid:
- *
- * Copyright (c) 2003-2015 Cadence Design Systems, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
 #include <stdio.h>
 #include <string.h>
 
@@ -61,275 +34,31 @@
 #include "tools.h"
 
 #include "esp_attr.h"
-#include "esp/xtensa_ops.h"
 #include "rom/ets_sys.h"
-
-#ifdef MCU_ESP32
-#include "soc/dport_access.h"
-#include "soc/dport_reg.h"
-#else /* MCU_ESP32 */
-#include "esp8266/rom_functions.h"
-#include "sdk/sdk.h"
-#endif /* MCU_ESP32 */
-
-#include "xtensa/xtensa_context.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
-
-/* User exception dispatcher when exiting */
-extern void _xt_user_exit(void);
-
-/* Switch context to the highest priority ready task without context save */
-extern void _frxt_dispatch(void);
-
-/* Set an flag indicating that a task switch is required on return from interrupt */
-extern void _frxt_setup_switch(void);
-
-/* Switch context to the highest priority ready task with context save */
-extern void vPortYield(void);
-extern void vPortYieldFromInt(void);
-
-#ifdef __XTENSA_CALL0_ABI__
-#define task_exit sched_task_exit
-#else /* __XTENSA_CALL0_ABI__ */
-/* forward declarations */
-NORETURN void task_exit(void);
-#endif /* __XTENSA_CALL0_ABI__ */
-
-char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size)
-{
-    /* Stack layout after task stack initialization
-     *
-     *                                            +------------------------+
-     *                                            |                        | TOP
-     *                                            |  thread_control_block  |
-     *        stack_start + stack_size        ==> |                        | top_of_stack+1
-     *                                            +------------------------+
-     *        top_of_stack                    ==> |                        |
-     *                                            |        XT_CP_SA        |
-     *                                            |       (optional)       |
-     *                                            | ...                    | ...
-     *                                            | cpstored               | XT_CPSTORED
-     *        top_of_stack + 1 - XT_CP_SIZE   ==> | cpenable               | XT_CPENABLE
-     *        (cp_state)                          +------------------------+
-     *                                            |                        |
-     *                                            |      XT_STK_FRAME      |
-     *                                            |                        | XT_STK_...
-     *                                            | a2 = arg               | XT_STK_A2
-     *                                            | a1 = sp + XT_STK_FRMSZ | XT_STK_A1
-     *                                            | a0 = sched_task_exit   | XT_STK_A0
-     *                                            | ps = PS_UM | PS_EXCM   | XT_STK_PS
-     *                                            | pc = task_func         | XT_STK_PC
-     *   sp = top_of_stack + 1 - XT_CP_SIZE   ==> | exit = _xt_user_exit   | XT_STK_EXIT
-     *                         - XT_STK_FRMSZ     +------------------------+
-     *                                            |                        |
-     *                                            | remaining stack space  |
-     *                                            |   available for data   |
-     *        stack_start (preallocated var)  ==> |                        | BOTTOM
-     *                                            +------------------------+
-     *
-     * Initialized stack frame represents the registers as set when the
-     * the task function would have been called.
-     *
-     * Registers in a called function
-     *
-     *   pc - PC at the beginning in the function
-     *   a0 - return address from the function (return address to caller)
-     *   a1 - current stack pointer at the beginning in the function
-     *   a2 - first argument of the function
-     */
-
-    /* stack is [stack_start+0 ... stack_start+stack_size-1] */
-    uint8_t *top_of_stack;
-    uint8_t *sp;
-
-    top_of_stack = (uint8_t*)((uintptr_t)stack_start + stack_size - 1);
-
-    /* BEGIN - code from FreeRTOS port for Xtensa from Cadence */
-
-    /* Create interrupt stack frame aligned to 16 byte boundary */
-    sp = (uint8_t*)(((uintptr_t)(top_of_stack + 1) - XT_STK_FRMSZ - XT_CP_SIZE) & ~0xf);
-
-    /* Clear whole stack with a known value to assist debugging */
-    #if !defined(DEVELHELP) && !IS_ACTIVE(SCHED_TEST_STACK)
-        /* Unfortunately, this affects thread_measure_stack_free function */
-        memset(stack_start, 0, stack_size);
-    #else
-        memset(sp, 0, XT_STK_FRMSZ + XT_CP_SIZE);
-    #endif
-
-    /* ensure that stack is big enough */
-    assert (sp > (uint8_t*)stack_start);
-
-    /* sp is aligned to 16 byte boundary, so cast is safe here. Use an
-     * intermediate cast to uintptr_t to silence -Wcast-align false positive */
-    XtExcFrame* exc_frame = (XtExcFrame*)(uintptr_t)sp;
-
-    /* Explicitly initialize certain saved registers for call0 ABI */
-    exc_frame->pc   = (uint32_t)task_func;         /* task entry point */
-    exc_frame->a0   = (uint32_t)task_exit;         /* task exit point*/
-    exc_frame->a1   = (uint32_t)sp + XT_STK_FRMSZ; /* physical top of stack frame */
-    exc_frame->exit = (uint32_t)_xt_user_exit;     /* user exception exit dispatcher */
-
-    /* Set initial PS to int level 0, EXCM disabled ('rfe' will enable), user mode. */
-    /* Also set entry point argument parameter. */
-    #ifdef __XTENSA_CALL0_ABI__
-    /* for CALL0 ABI set in parameter a2 to task argument */
-    exc_frame->ps = PS_UM | PS_EXCM;
-    exc_frame->a2 = (uint32_t)arg;                 /* parameters for task_func */
-    #else
-    /* for windowed ABI also set WOE and CALLINC (pretend task was 'call4'd). */
-    exc_frame->ps = PS_UM | PS_EXCM | PS_WOE | PS_CALLINC(1);
-    exc_frame->a4 = (uint32_t)task_exit;         /* task exit point*/
-    exc_frame->a6 = (uint32_t)arg;               /* parameters for task_func */
-    #endif
-
-    #ifdef XT_USE_SWPRI
-    /* Set the initial virtual priority mask value to all 1's. */
-    exc_frame->vpri = 0xFFFFFFFF;
-    #endif
-
-    #if XCHAL_CP_NUM > 0
-    /*
-     * Init the coprocessor save area (see xtensa_context.h)
-     * No access to TCB here, so derive indirectly. Stack growth is top to bottom.
-     * p = (uint32_t *) xMPUSettings->coproc_area;
-     */
-    uint32_t *p;
-
-    p = (uint32_t *)(((uint32_t)(top_of_stack + 1) - XT_CP_SIZE));
-    p[0] = 0;
-    p[1] = 0;
-    p[2] = (((uint32_t) p) + 12 + XCHAL_TOTAL_SA_ALIGN - 1) & -XCHAL_TOTAL_SA_ALIGN;
-    #endif
-
-    /* END - code from FreeRTOS port for Xtensa from Cadence */
-
-    DEBUG("%s start=%p size=%d top=%p sp=%p free=%u\n",
-          __func__, stack_start, stack_size, top_of_stack, sp, sp-(uint8_t*)stack_start);
-
-    return (char*)sp;
-}
-
-#ifdef MCU_ESP8266
-extern int MacIsrSigPostDefHdl(void);
-unsigned int ets_soft_int_type = ETS_SOFT_INT_NONE;
-#endif
-
-/**
- * Context switches are realized using software interrupts since interrupt
- * entry and exit functions are the only way to save and restore complete
- * context including spilling the register windows to the stack
- */
-void IRAM_ATTR thread_yield_isr(void* arg)
-{
-#ifdef MCU_ESP8266
-    ETS_NMI_LOCK();
-
-    if (ets_soft_int_type == ETS_SOFT_INT_HDL_MAC) {
-        ets_soft_int_type = MacIsrSigPostDefHdl() ? ETS_SOFT_INT_YIELD
-                                                  : ETS_SOFT_INT_NONE;
-    }
-
-    if (ets_soft_int_type == ETS_SOFT_INT_YIELD) {
-        /*
-         * set the context switch flag (indicates that context has to be
-         * switched on exit from interrupt in _frxt_int_exit
-         */
-        ets_soft_int_type = ETS_SOFT_INT_NONE;
-        _frxt_setup_switch();
-    }
-
-    ETS_NMI_UNLOCK();
-#else
-    /* clear the interrupt first */
-    DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, 0);
-    /* set the context switch flag (indicates that context has to be switched
-       is switch on exit from interrupt in _frxt_int_exit */
-
-    _frxt_setup_switch();
-#endif
-}
-
-/**
- * If we are already in an interrupt handler, the function simply sets the
- * context switch flag, which indicates that the context has to be switched
- * in the _frxt_int_exit function when exiting the interrupt. Otherwise, we
- * will generate a software interrupt to force the context switch when
- * terminating the software interrupt (see thread_yield_isr).
- */
-void IRAM_ATTR thread_yield_higher(void)
-{
-    /* reset hardware watchdog */
-    system_wdt_feed();
-
-    /* yield next task */
-    #if defined(ENABLE_DEBUG) && defined(DEVELHELP)
-    thread_t *active_thread = thread_get_active();
-    if (active_thread) {
-        DEBUG("%u old task %u %s %u\n", system_get_time(),
-               active_thread->pid, active_thread->name,
-               active_thread->sp - active_thread-> stack_start);
-    }
-    #endif
-    if (!irq_is_in()) {
-#ifdef MCU_ESP32
-        /* generate the software interrupt to switch the context */
-        DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, DPORT_CPU_INTR_FROM_CPU_0);
-#else /* MCU_ESP32 */
-        critical_enter();
-        ets_soft_int_type = ETS_SOFT_INT_YIELD;
-        WSR(BIT(ETS_SOFT_INUM), interrupt);
-        critical_exit();
-#endif /* MCU_ESP32 */
-    }
-    else {
-        /* set the context switch flag */
-        _frxt_setup_switch();
-    }
-
-    #if defined(ENABLE_DEBUG) && defined(DEVELHELP)
-    active_thread = thread_get_active();
-    if (active_thread) {
-        DEBUG("%u new task %u %s %u\n", system_get_time(),
-               active_thread->pid, active_thread->name,
-               active_thread->sp - active_thread-> stack_start);
-    }
-    #endif
-
-    /*
-     * Instruction fetch synchronize: Waits for all previously fetched load,
-     * store, cache, and special register write instructions that affect
-     * instruction fetch to be performed before fetching the next instruction.
-     */
-    __asm__("isync");
-
-    return;
-}
 
 void thread_stack_print(void)
 {
     /* Print the current stack to stdout. */
 
-    #if defined(DEVELHELP)
+#if defined(DEVELHELP)
     thread_t* task = thread_get_active();
     if (task) {
-
         char* stack_top = task->stack_start + task->stack_size;
         int   size = stack_top - task->sp;
         printf("Printing current stack of thread %" PRIkernel_pid "\n", thread_getpid());
         esp_hexdump((void*)(task->sp), size >> 2, 'w', 8);
     }
-    #else
+#else
     NOT_SUPPORTED();
-    #endif
+#endif
 }
 
 void thread_print_stack(void)
 {
     /* Prints human readable, ps-like thread information for debugging purposes. */
-    /* because of Xtensa stack structure and call0 ABI, it is not possible to implement */
     NOT_YET_IMPLEMENTED();
     return;
 }
@@ -342,11 +71,11 @@ extern uint8_t port_IntStackTop;
 void thread_isr_stack_init(void)
 {
     /* code from thread.c, please see the copyright notice there */
-#ifdef MCU_ESP32
+#ifndef MCU_ESP8266
     #define sp (&port_IntStackTop)
-#else /* MCU_ESP32 */
+#else /* !MCU_ESP8266 */
     register uint32_t *sp __asm__ ("a1");
-#endif /* MCU_ESP32 */
+#endif /* !MCU_ESP8266 */
 
     /* assign each int of the stack the value of it's address. We can safely
      * cast, as stack is aligned. Use an intermediate cast to uintptr_t to
@@ -383,7 +112,7 @@ void *thread_isr_stack_start(void)
 
 void thread_isr_stack_print(void)
 {
-    printf("Printing current ISR\n");
+    printf("Printing current ISR stack\n");
     /* cppcheck-suppress comparePointers
      * (reason: comes from ESP-SDK, so should be valid) */
     esp_hexdump(&port_IntStack, &port_IntStackTop-&port_IntStack, 'w', 8);
@@ -394,74 +123,3 @@ void thread_isr_stack_print(void)
 void thread_isr_stack_init(void) {}
 
 #endif /* DEVELHELP */
-
-#ifndef __XTENSA_CALL0_ABI__
-static bool _initial_exit = true;
-#endif /* __XTENSA_CALL0_ABI__ */
-
-NORETURN void cpu_switch_context_exit(void)
-{
-    DEBUG("%s\n", __func__);
-
-    /* Switch context to the highest priority ready task without context save */
-#ifdef __XTENSA_CALL0_ABI__
-    _frxt_dispatch();
-#else /* __XTENSA_CALL0_ABI__ */
-    if (_initial_exit) {
-        _initial_exit = false;
-        __asm__ volatile ("call0 _frxt_dispatch");
-    }
-    else {
-        task_exit();
-    }
-#endif /* __XTENSA_CALL0_ABI__ */
-    UNREACHABLE();
-}
-
-#ifndef __XTENSA_CALL0_ABI__
-/**
- * The function is used on task exit to switch to the context to the next
- * running task. It realizes only the second half of a complete context by
- * simulating the exit from an interrupt handling where a context switch is
- * forced. The old context is not saved here since it is no longer needed.
- */
-NORETURN void task_exit(void)
-{
-    extern volatile thread_t *sched_active_thread;
-    extern volatile kernel_pid_t sched_active_pid;
-    DEBUG("sched_task_exit: ending thread %" PRIkernel_pid "...\n",
-          thread_getpid());
-
-    (void) irq_disable();
-
-    /* remove old task from scheduling if it is not already done */
-    if (sched_active_thread) {
-        sched_threads[sched_active_pid] = NULL;
-        sched_num_threads--;
-        sched_set_status((thread_t *)sched_active_thread, STATUS_STOPPED);
-        sched_active_thread = NULL;
-    }
-
-    /* determine the new running task */
-    sched_run();
-
-    /* set the context switch flag (indicates that context has to be switched
-       is switch on exit from interrupt in _frxt_int_exit */
-    _frxt_setup_switch();
-
-    /* set interrupt nesting level to the right value */
-    irq_interrupt_nesting++;
-
-    /* reset windowed registers */
-    __asm__ volatile ("movi a2, 0\n"
-                      "wsr a2, windowstart\n"
-                      "wsr a2, windowbase\n"
-                      "rsync\n");
-
-    /* exit from simulated interrupt to switch to the new context */
-    __asm__ volatile ("call0 _frxt_int_exit");
-
-    /* should not be executed */
-    UNREACHABLE();
-}
-#endif /* __XTENSA_CALL0_ABI__ */

--- a/cpu/esp_common/thread_arch_riscv.c
+++ b/cpu/esp_common/thread_arch_riscv.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp_common
+ * @{
+ *
+ * @file
+ * @brief       Implementation of kernel's architecture dependent interface
+ *
+ * This file implements kernel's architecture dependent interface for RISC-V
+ * based ESP32x SoCs
+ *
+ * @note The implementation in `$(RIOTCPU)/risc_common/thread_arch.c` cannot
+ *       be used because
+ *       - it requires some modifications for compatibility with ESP-IDF code
+ *       - the ESP-IDF uses a different context frame
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#if __riscv
+
+#include <string.h>
+
+#include "esp_attr.h"
+
+#include "irq.h"
+#include "thread.h"
+#include "sched.h"
+#include "syscalls.h"
+
+#include "freertos/FreeRTOS.h"
+#include "riscv/rvruntime-frames.h"
+#include "soc/soc.h"
+#include "soc/system_reg.h"
+
+/*
+ * The FreeRTOS implementation for interrupt/exception handling of ESP-IDF,
+ * which is also used for RIOT to ensure compatibility with other ESP-IDF code,
+ * uses a separate stack in the interrupt context. Therefore, the stack and
+ * a pointer to the top of this stack are defined here.
+ *
+ * For compatibility reasons with xtensa implementation, we call them
+ * port_IntStack and port_IntStackTop.
+ */
+
+/* bottom and top of ISR stack */
+extern uint8_t port_IntStack;
+extern uint8_t port_IntStackTop;
+
+/* pointer the top of the ISR stack as required by ESP-IDF */
+uint8_t *xIsrStackTop = &port_IntStackTop;
+
+/* context frame as used by the ESP-IDF */
+typedef struct context_switch_frame {
+    uint32_t mepc;  /**< machine exception program counter instead of x0 */
+    uint32_t ra;    /**< x1  - return address (caller saved) */
+    uint32_t gp;    /**< x3  - global pointer (-) */
+    uint32_t sp;    /**< x2  - stack pointer  (callee saved) */
+    uint32_t tp;    /**< x4  - thread pointer (-) */
+    uint32_t t0;    /**< x5  - temporary register (caller saved) */
+    uint32_t t1;    /**< x6  - temporary register (caller saved) */
+    uint32_t t2;    /**< x7  - temporary register (caller saved) */
+    uint32_t s0;    /**< x8  - saved register / frame pointer (callee saved) */
+    uint32_t s1;    /**< x9  - saved register (callee saved) */
+    uint32_t a0;    /**< x10 - function argument / return value (caller saved) */
+    uint32_t a1;    /**< x11 - function argument / return value (caller saved) */
+    uint32_t a2;    /**< x12 - function argument (caller saved) */
+    uint32_t a3;    /**< x13 - function argument (caller saved) */
+    uint32_t a4;    /**< x14 - function argument (caller saved) */
+    uint32_t a5;    /**< x15 - function argument (caller saved) */
+    uint32_t a6;    /**< x16 - function argument (caller saved) */
+    uint32_t a7;    /**< x17 - function argument (caller saved) */
+    uint32_t s2;    /**< x18 - saved register (callee saved) */
+    uint32_t s3;    /**< x19 - saved register (callee saved) */
+    uint32_t s4;    /**< x20 - saved register (callee saved) */
+    uint32_t s5;    /**< x21 - saved register (callee saved) */
+    uint32_t s6;    /**< x22 - saved register (callee saved) */
+    uint32_t s7;    /**< x23 - saved register (callee saved) */
+    uint32_t s8;    /**< x24 - saved register (callee saved) */
+    uint32_t s9;    /**< x25 - saved register (callee saved) */
+    uint32_t s10;   /**< x26 - saved register (callee saved) */
+    uint32_t s11;   /**< x27 - saved register (callee saved) */
+    uint32_t t3;    /**< x28 - temporary register (caller saved) */
+    uint32_t t4;    /**< x29 - temporary register (caller saved) */
+    uint32_t t5;    /**< x30 - temporary register (caller saved) */
+    uint32_t t6;    /**< x31 - temporary register (caller saved) */
+} context_switch_frame_t;
+
+/*
+ * The following function is a modified copy of function `thread_stack_init`
+ * in `$(RIOTCPU)/risc_common/thread_arch.c`, which is under the following
+ * copyright:
+ *
+ * Copyright (C) 2017, 2019 Ken Rabold, JP Bonn
+ *
+ * Modifications:
+ * - For compatibility with ESP-IDF, the context frame is defined as
+ *   used by the ESP-IDF.
+ * - The `STACK_MARKER` is not used to identify the top of the stack.
+ *   Instead, the stack is initialized in the `thread_create` function in
+ *   `$(RIOTBASE)/core/thread.c` as expected in the `thread_measure_stack_free`
+ *   function.
+ * - Support for `__global_pointer$` and TLS has been added.
+ */
+char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size)
+{
+    _Static_assert(sizeof(context_switch_frame_t) == 32 * sizeof(uint32_t),
+                   "context frame has to store 32 registers");
+
+    context_switch_frame_t *sf;
+    uint8_t *stk_top;
+
+    /* calculate the top of the stack */
+    stk_top = (uint8_t *)stack_start + stack_size;
+    /* per ABI align stack pointer to 16 byte boundary. */
+    stk_top = (uint8_t *)((uintptr_t)stk_top & ~((uintptr_t)0xf));
+
+    /* prepare thread local storage and the thread pointer */
+    extern uint32_t __global_pointer$;
+
+#if !defined(RISCV_NO_RELAX)
+    extern char _thread_local_start, _thread_local_end, _flash_rodata_start;
+
+    uint8_t *_local_start;
+    uint32_t _local_size = (uint32_t)(&_thread_local_end - &_thread_local_start);
+
+    _local_size = ALIGNUP(0x10, _local_size);
+    stk_top -= _local_size;
+
+    _local_start = stk_top;
+    memcpy(_local_start, &_thread_local_start, _local_size);
+
+    uint8_t *tp;
+    tp = _local_start - (&_thread_local_start - &_flash_rodata_start);
+#else
+    uint8_t *tp = NULL;
+#endif
+
+    /* reserve space for the stack frame. */
+    stk_top = stk_top - sizeof(*sf);
+
+    /* populate the stack frame with default values for starting the thread. */
+    sf = (struct context_switch_frame *)((uintptr_t)stk_top);
+
+    /* Clear stack frame */
+    memset(sf, 0, sizeof(*sf));
+
+    /* set initial reg values */
+    sf->mepc = (uint32_t)task_func;
+    sf->a0 = (uint32_t)arg;
+    sf->gp = (uint32_t)__global_pointer$;
+    sf->tp = (uint32_t)tp;
+    /* if the thread exits go to sched_task_exit() */
+    sf->ra = (uint32_t)sched_task_exit;
+
+    return (char *)stk_top;
+}
+
+void IRAM_ATTR thread_yield_isr(void* arg)
+{
+    (void)arg;
+    /**
+     * Context switches are realized using software interrupts since interrupt
+     * entry and exit functions are used save and restore complete
+     * context.
+     */
+    /* clear the interrupt first */
+    WRITE_PERI_REG(SYSTEM_CPU_INTR_FROM_CPU_0_REG, 0);
+    /* set the context switch flag (indicates that context has to be switched
+       is switch on exit from interrupt in rtos_int_exit */
+    sched_context_switch_request = 1;
+}
+
+void IRAM_ATTR thread_yield_higher(void)
+{
+    /* reset hardware watchdog */
+    system_wdt_feed();
+
+    /**
+     * If we are already in an interrupt handler, the function simply sets the
+     * context switch flag, which indicates that the context has to be switched
+     * in the rtos_int_exit function when exiting the interrupt. Otherwise, we
+     * will generate a software interrupt to force the context switch when
+     * exiting from the software interrupt (see thread_yield_isr).
+     */
+    if (irq_is_in()) {
+        /* if already in ISR, only set the sched_context_switch_request flag */
+        sched_context_switch_request = 1;
+    }
+    else {
+        /* otherwise trigger a software interrupt for context switch */
+        WRITE_PERI_REG(SYSTEM_CPU_INTR_FROM_CPU_0_REG, 1);
+        /* small delay of 3-4 instructions required here before we return */
+        __asm__ volatile ( "nop" );
+        __asm__ volatile ( "nop" );
+        __asm__ volatile ( "nop" );
+        __asm__ volatile ( "nop" );
+    }
+}
+
+NORETURN void cpu_switch_context_exit(void)
+{
+    /* enable interrupts */
+    irq_enable();
+
+    /* force a context switch to another thread */
+    thread_yield_higher();
+    UNREACHABLE();
+}
+
+#endif /* __riscv */

--- a/cpu/esp_common/thread_arch_xtensa.c
+++ b/cpu/esp_common/thread_arch_xtensa.c
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp_common
+ * @{
+ *
+ * @file
+ * @brief       Implementation of kernel's architecture dependent interface
+ *
+ * This file implements kernel's architecture dependent interface for Xtensa
+ * based ESP32x and ESP8266 SoCs
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+/*
+ * PLEASE NOTE: Some parts of the code are taken from the FreeRTOS port for
+ * Xtensa processors from Cadence Design Systems. These parts are marked
+ * accordingly. For these parts, the following license is valid:
+ *
+ * Copyright (c) 2003-2015 Cadence Design Systems, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "board.h"
+#include "cpu.h"
+#include "irq.h"
+#include "log.h"
+#include "thread.h"
+#include "sched.h"
+
+#include "esp_common.h"
+#include "irq_arch.h"
+#include "syscalls.h"
+#include "tools.h"
+
+#include "esp_attr.h"
+#include "rom/ets_sys.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#if __xtensa__
+
+#if defined(MCU_ESP32)
+#include "soc/dport_access.h"
+#include "soc/dport_reg.h"
+#elif defined(MCU_ESP8266)
+#include "esp8266/rom_functions.h"
+#include "sdk/sdk.h"
+#endif /* MCU_ESP32 */
+
+#include "esp/xtensa_ops.h"
+#include "xtensa/xtensa_context.h"
+
+/* User exception dispatcher when exiting */
+extern void _xt_user_exit(void);
+
+/* Switch context to the highest priority ready task without context save */
+extern void _frxt_dispatch(void);
+
+/* Set an flag indicating that a task switch is required on return from interrupt */
+extern void _frxt_setup_switch(void);
+
+/* Switch context to the highest priority ready task with context save */
+extern void vPortYield(void);
+extern void vPortYieldFromInt(void);
+
+#ifdef __XTENSA_CALL0_ABI__
+#define task_exit sched_task_exit
+#else /* __XTENSA_CALL0_ABI__ */
+/* forward declarations */
+NORETURN void task_exit(void);
+#endif /* __XTENSA_CALL0_ABI__ */
+
+char* thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size)
+{
+    /* Stack layout after task stack initialization
+     *
+     *                                            +------------------------+
+     *                                            |                        | TOP
+     *                                            |  thread_control_block  |
+     *        stack_start + stack_size        ==> |                        | top_of_stack+1
+     *                                            +------------------------+
+     *        top_of_stack                    ==> |                        |
+     *                                            |        XT_CP_SA        |
+     *                                            |       (optional)       |
+     *                                            | ...                    | ...
+     *                                            | cpstored               | XT_CPSTORED
+     *        top_of_stack + 1 - XT_CP_SIZE   ==> | cpenable               | XT_CPENABLE
+     *        (cp_state)                          +------------------------+
+     *                                            |                        |
+     *                                            |      XT_STK_FRAME      |
+     *                                            |                        | XT_STK_...
+     *                                            | a2 = arg               | XT_STK_A2
+     *                                            | a1 = sp + XT_STK_FRMSZ | XT_STK_A1
+     *                                            | a0 = sched_task_exit   | XT_STK_A0
+     *                                            | ps = PS_UM | PS_EXCM   | XT_STK_PS
+     *                                            | pc = task_func         | XT_STK_PC
+     *   sp = top_of_stack + 1 - XT_CP_SIZE   ==> | exit = _xt_user_exit   | XT_STK_EXIT
+     *                         - XT_STK_FRMSZ     +------------------------+
+     *                                            |                        |
+     *                                            | remaining stack space  |
+     *                                            |   available for data   |
+     *        stack_start (preallocated var)  ==> |                        | BOTTOM
+     *                                            +------------------------+
+     *
+     * Initialized stack frame represents the registers as set when the
+     * the task function would have been called.
+     *
+     * Registers in a called function
+     *
+     *   pc - PC at the beginning in the function
+     *   a0 - return address from the function (return address to caller)
+     *   a1 - current stack pointer at the beginning in the function
+     *   a2 - first argument of the function
+     */
+
+    /* stack is [stack_start+0 ... stack_start+stack_size-1] */
+    uint8_t *top_of_stack;
+    uint8_t *sp;
+
+    top_of_stack = (uint8_t*)((uintptr_t)stack_start + stack_size - 1);
+
+    /* BEGIN - code from FreeRTOS port for Xtensa from Cadence */
+
+    /* Create interrupt stack frame aligned to 16 byte boundary */
+    sp = (uint8_t*)(((uintptr_t)(top_of_stack + 1) - XT_STK_FRMSZ - XT_CP_SIZE) & ~0xf);
+
+    /* Clear whole stack with a known value to assist debugging */
+#if !defined(DEVELHELP) && !IS_ACTIVE(SCHED_TEST_STACK)
+        /* Unfortunately, this affects thread_measure_stack_free function */
+        memset(stack_start, 0, stack_size);
+#else
+        memset(sp, 0, XT_STK_FRMSZ + XT_CP_SIZE);
+#endif
+
+    /* ensure that stack is big enough */
+    assert (sp > (uint8_t*)stack_start);
+
+    /* sp is aligned to 16 byte boundary, so cast is safe here. Use an
+     * intermediate cast to uintptr_t to silence -Wcast-align false positive */
+    XtExcFrame* exc_frame = (XtExcFrame*)(uintptr_t)sp;
+
+    /* Explicitly initialize certain saved registers for call0 ABI */
+    exc_frame->pc   = (uint32_t)task_func;         /* task entry point */
+    exc_frame->a0   = (uint32_t)task_exit;         /* task exit point*/
+    exc_frame->a1   = (uint32_t)sp + XT_STK_FRMSZ; /* physical top of stack frame */
+    exc_frame->exit = (uint32_t)_xt_user_exit;     /* user exception exit dispatcher */
+
+    /* Set initial PS to int level 0, EXCM disabled ('rfe' will enable), user mode. */
+    /* Also set entry point argument parameter. */
+#ifdef __XTENSA_CALL0_ABI__
+    /* for CALL0 ABI set in parameter a2 to task argument */
+    exc_frame->ps = PS_UM | PS_EXCM;
+    exc_frame->a2 = (uint32_t)arg;                 /* parameters for task_func */
+#else
+    /* for windowed ABI also set WOE and CALLINC (pretend task was 'call4'd). */
+    exc_frame->ps = PS_UM | PS_EXCM | PS_WOE | PS_CALLINC(1);
+    exc_frame->a4 = (uint32_t)task_exit;         /* task exit point*/
+    exc_frame->a6 = (uint32_t)arg;               /* parameters for task_func */
+#endif
+
+#ifdef XT_USE_SWPRI
+    /* Set the initial virtual priority mask value to all 1's. */
+    exc_frame->vpri = 0xFFFFFFFF;
+#endif
+
+#if XCHAL_CP_NUM > 0
+    /*
+     * Init the coprocessor save area (see xtensa_context.h)
+     * No access to TCB here, so derive indirectly. Stack growth is top to bottom.
+     * p = (uint32_t *) xMPUSettings->coproc_area;
+     */
+    uint32_t *p;
+
+    p = (uint32_t *)(((uint32_t)(top_of_stack + 1) - XT_CP_SIZE));
+    p[0] = 0;
+    p[1] = 0;
+    p[2] = (((uint32_t) p) + 12 + XCHAL_TOTAL_SA_ALIGN - 1) & -XCHAL_TOTAL_SA_ALIGN;
+#endif
+
+    /* END - code from FreeRTOS port for Xtensa from Cadence */
+
+    DEBUG("%s start=%p size=%d top=%p sp=%p free=%u\n",
+          __func__, stack_start, stack_size, top_of_stack, sp, sp-(uint8_t*)stack_start);
+
+    return (char*)sp;
+}
+
+#ifdef MCU_ESP8266
+extern int MacIsrSigPostDefHdl(void);
+unsigned int ets_soft_int_type = ETS_SOFT_INT_NONE;
+#endif
+
+/**
+ * Context switches are realized using software interrupts since interrupt
+ * entry and exit functions are the only way to save and restore complete
+ * context including spilling the register windows to the stack
+ */
+void IRAM_ATTR thread_yield_isr(void* arg)
+{
+#ifdef MCU_ESP8266
+    ETS_NMI_LOCK();
+
+    if (ets_soft_int_type == ETS_SOFT_INT_HDL_MAC) {
+        ets_soft_int_type = MacIsrSigPostDefHdl() ? ETS_SOFT_INT_YIELD
+                                                  : ETS_SOFT_INT_NONE;
+    }
+
+    if (ets_soft_int_type == ETS_SOFT_INT_YIELD) {
+        /*
+         * set the context switch flag (indicates that context has to be
+         * switched on exit from interrupt in _frxt_int_exit
+         */
+        ets_soft_int_type = ETS_SOFT_INT_NONE;
+        _frxt_setup_switch();
+    }
+
+    ETS_NMI_UNLOCK();
+#else
+    /* clear the interrupt first */
+    DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, 0);
+    /* set the context switch flag (indicates that context has to be switched
+       is switch on exit from interrupt in _frxt_int_exit */
+
+    _frxt_setup_switch();
+#endif
+}
+
+/**
+ * If we are already in an interrupt handler, the function simply sets the
+ * context switch flag, which indicates that the context has to be switched
+ * in the _frxt_int_exit function when exiting the interrupt. Otherwise, we
+ * will generate a software interrupt to force the context switch when
+ * terminating the software interrupt (see thread_yield_isr).
+ */
+void IRAM_ATTR thread_yield_higher(void)
+{
+    /* reset hardware watchdog */
+    system_wdt_feed();
+
+    /* yield next task */
+#if defined(ENABLE_DEBUG) && defined(DEVELHELP)
+    thread_t *active_thread = thread_get_active();
+    if (active_thread) {
+        DEBUG("%u old task %u %s %u\n", system_get_time(),
+               active_thread->pid, active_thread->name,
+               active_thread->sp - active_thread-> stack_start);
+    }
+#endif
+    if (!irq_is_in()) {
+#ifdef MCU_ESP8266
+        critical_enter();
+        ets_soft_int_type = ETS_SOFT_INT_YIELD;
+        WSR(BIT(ETS_SOFT_INUM), interrupt);
+        critical_exit();
+#else /* MCU_ESP8266 */
+        /* generate the software interrupt to switch the context */
+        DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, DPORT_CPU_INTR_FROM_CPU_0);
+#endif /* MCU_ESP8266 */
+    }
+    else {
+        /* set the context switch flag */
+        _frxt_setup_switch();
+    }
+
+#if defined(ENABLE_DEBUG) && defined(DEVELHELP)
+    active_thread = thread_get_active();
+    if (active_thread) {
+        DEBUG("%u new task %u %s %u\n", system_get_time(),
+               active_thread->pid, active_thread->name,
+               active_thread->sp - active_thread-> stack_start);
+    }
+#endif
+
+    /*
+     * Instruction fetch synchronize: Waits for all previously fetched load,
+     * store, cache, and special register write instructions that affect
+     * instruction fetch to be performed before fetching the next instruction.
+     */
+    __asm__("isync");
+
+    return;
+}
+
+#ifndef __XTENSA_CALL0_ABI__
+static bool _initial_exit = true;
+#endif /* __XTENSA_CALL0_ABI__ */
+
+NORETURN void cpu_switch_context_exit(void)
+{
+    DEBUG("%s\n", __func__);
+
+    /* Switch context to the highest priority ready task without context save */
+#ifdef __XTENSA_CALL0_ABI__
+    _frxt_dispatch();
+#else /* __XTENSA_CALL0_ABI__ */
+    if (_initial_exit) {
+        _initial_exit = false;
+        __asm__ volatile ("call0 _frxt_dispatch");
+    }
+    else {
+        task_exit();
+    }
+#endif /* __XTENSA_CALL0_ABI__ */
+    UNREACHABLE();
+}
+
+#ifndef __XTENSA_CALL0_ABI__
+/**
+ * The function is used on task exit to switch to the context to the next
+ * running task. It realizes only the second half of a complete context by
+ * simulating the exit from an interrupt handling where a context switch is
+ * forced. The old context is not saved here since it is no longer needed.
+ */
+NORETURN void task_exit(void)
+{
+    extern volatile thread_t *sched_active_thread;
+    extern volatile kernel_pid_t sched_active_pid;
+    DEBUG("sched_task_exit: ending thread %" PRIkernel_pid "...\n",
+          thread_getpid());
+
+    (void) irq_disable();
+
+    /* remove old task from scheduling if it is not already done */
+    if (sched_active_thread) {
+        sched_threads[sched_active_pid] = NULL;
+        sched_num_threads--;
+        sched_set_status((thread_t *)sched_active_thread, STATUS_STOPPED);
+        sched_active_thread = NULL;
+    }
+
+    /* determine the new running task */
+    sched_run();
+
+    /* set the context switch flag (indicates that context has to be switched
+       is switch on exit from interrupt in _frxt_int_exit */
+    _frxt_setup_switch();
+
+    /* set interrupt nesting level to the right value */
+    irq_interrupt_nesting++;
+
+    /* reset windowed registers */
+    __asm__ volatile ("movi a2, 0\n"
+                      "wsr a2, windowstart\n"
+                      "wsr a2, windowbase\n"
+                      "rsync\n");
+
+    /* exit from simulated interrupt to switch to the new context */
+    __asm__ volatile ("call0 _frxt_int_exit");
+
+    /* should not be executed */
+    UNREACHABLE();
+}
+#endif /* __XTENSA_CALL0_ABI__ */
+#endif /* __xtensa__ */


### PR DESCRIPTION
### Contribution description

This PR is a splitt-off from PR #17841. It provides a platform independent implementation of `thread_arch.c`, `irq_arch.c` and `exception.c` so that it can be used for Xtensa-based and RISC-V based ESP32x SoC variants.

For that purpose the platform dependent code is moved from `thread_arch.c`, `irq_arch.c`, `exception.c` to  `thread_arch_xtensa.c`, `irq_arch_xtensa.c`, `exception_xtensa.c` and `thread_arch_riscv.c`, `irq_arch_riscv.c`, `exception.c_riscv`, respectively. Furthermore, some `DEBUG` messages are fixed to be platform independent.

**Background:**

- The file `thread_arch_xtensa.c` is not really independent of the used ESP SoC. Although ESP8266 and ESP32 share most of the code, that's why `thread_arch_xtensa.c` is defined in `cpu/esp_common`, they require some SoC specific code, especially in `thread_yield_*` functions. These functions are something very special to ESP SoCs and not common for Xtensa cores.
- We have to use `vectors.S` for for RISC-V interrupt handling and `portasm.S` for RISC-V context switching from ESP-IDF, because they are needed by other ESP-IDF functions, e.g. by the startup function, which we also use directly from ESP-IDF. Unfortunately, they are not compatible with the RISC-V implementation in `cpu/riscv_common`. They use a different context frame structure, a different interrupt context structure, a different interrupt/exception handling and a different startup function. Even if we could reuse some parts of `riscv_common`, including a common folder in the compilation always means all or nothing. Therefore we can't use `cpu/riscv_common` at all.
- Another problem is that the implementation of `irq_disable`/`irq_restore` in `riscv_common` only reset/set the `MIE` bit in `mstatus` register while the implementation for RISC-V based ESPs requires to change the value of the SoC specific interrupt level register `INTERRUPT_CORE0_CPU_INT_THRESH_REG`.

Thus, neither is the Xtensa code general enough to justify a `cpu/xtensa_common` folder, nor are the thread or interrupt handling for RISC-V based ESP compatible with the implementation in `riscv_common`. 
Therefore,  `thread_arch.c`, `irq_arch.c`, `exception.c` to  `thread_arch_xtensa.c`, `irq_arch_xtensa.c`, `exception_xtensa.c` and `thread_arch_riscv.c`, `irq_arch_riscv.c`, `exception.c_riscv`, respectively. 

### Testing procedure

1. Green CI
2. Compile and check any simple test app, for example:
    ```
    BOARD=esp32-wroom-32 make -j8 -C tests/shell flash term
   ```

### Issues/PRs references

Split-off from PR https://github.com/RIOT-OS/RIOT/pull/17841