### PR TITLE
cpu/esp32: invert MCU_* and CPU* conditionals

### DIFF
--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -615,7 +615,7 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
     /* send the the packet to the peer(s) mac address */
     if (esp_wifi_internal_tx(ESP_IF_WIFI_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
 #endif
-#ifdef MCU_ESP32
+#ifndef MCU_ESP8266
         /* for ESP8266 it is done in _esp_wifi_tx_cb */
         _esp_wifi_send_is_in = false;
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
@@ -872,7 +872,7 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
 
 #ifndef MODULE_ESP_NOW
     /* if module esp_now is used, the following part is already done */
-#ifdef MCU_ESP32
+#ifndef MCU_ESP8266
     extern portMUX_TYPE g_intr_lock_mux;
     mutex_init(&g_intr_lock_mux);
 #endif

--- a/cpu/esp_common/include/esp_common.h
+++ b/cpu/esp_common/include/esp_common.h
@@ -45,7 +45,7 @@ extern "C" {
 #define RTC_BSS_ATTR __attribute__((section(".rtc.bss")))
 #endif
 
-#ifndef MCU_ESP32
+#ifdef MCU_ESP8266
 #ifndef RTC_DATA_ATTR
 #define RTC_DATA_ATTR __attribute__((section(".rtc.data")))
 #endif

--- a/cpu/esp_common/include/gpio_arch_common.h
+++ b/cpu/esp_common/include/gpio_arch_common.h
@@ -39,12 +39,12 @@ extern "C" {
 typedef enum
 {
     _GPIO = 0,  /**< pin used as standard GPIO */
-#ifdef MCU_ESP32
+#ifndef MCU_ESP8266
     _ADC,       /**< pin is used as ADC input */
     _CAN,       /**< pin is used as CAN signal */
     _DAC,       /**< pin is used as DAC output */
     _EMAC,      /**< pin is used as EMAC signal */
-#endif /* MCU_ESP32 */
+#endif /* !MCU_ESP8266 */
     _I2C,       /**< pin is used as I2C signal */
     _PWM,       /**< pin is used as PWM output */
     _SPI,       /**< pin is used as SPI interface */

--- a/makefiles/tools/esptool.inc.mk
+++ b/makefiles/tools/esptool.inc.mk
@@ -1,14 +1,13 @@
-ifneq ($(CPU),esp32)
-
-ifneq (,$(filter esp_log_colored,$(USEMODULE)))
-  BOOTLOADER_COLOR = _colors
-endif
-ifneq (,$(filter esp_log_startup,$(USEMODULE)))
-  BOOTLOADER_INFO = _info
-endif
-# Full path to the bootloader binary. In the ESP32 case this is set by the
-# esp_bootloader module.
-BOOTLOADER_BIN ?= $(RIOTCPU)/$(CPU)/bin/bootloader$(BOOTLOADER_COLOR)$(BOOTLOADER_INFO).bin
+ifeq ($(CPU),esp8266)
+  ifneq (,$(filter esp_log_colored,$(USEMODULE)))
+    BOOTLOADER_COLOR = _colors
+  endif
+  ifneq (,$(filter esp_log_startup,$(USEMODULE)))
+    BOOTLOADER_INFO = _info
+  endif
+  # Full path to the bootloader binary. In the ESP32 case this is set by the
+  # esp_bootloader module.
+  BOOTLOADER_BIN ?= $(RIOTCPU)/$(CPU)/bin/bootloader$(BOOTLOADER_COLOR)$(BOOTLOADER_INFO).bin
 endif
 
 ESPTOOL ?= $(RIOTTOOLS)/esptools/esptool.py
@@ -33,7 +32,7 @@ endif
 .PHONY: esp-qemu
 
 esp-qemu:
-ifneq (,$(filter esp32,$(CPU_FAM)))
+ifeq (esp32,$(CPU))
 	$(Q)echo \
 		"--flash_mode $(FLASH_MODE) --flash_freq $(FLASH_FREQ) " \
 		"--flash_size $(FLASH_SIZE)MB" \
@@ -41,7 +40,7 @@ ifneq (,$(filter esp32,$(CPU_FAM)))
 		"0x8000 $(BINDIR)/partitions.bin" \
 		"0x10000 $(FLASHFILE)" > $(BINDIR)/qemu_flash_args
 	$(Q)$(ESPTOOL) \
-		--chip esp32 merge_bin \
+		--chip $(CPU_FAM) merge_bin \
 		--fill-flash-size 4MB \
 		-o $(BINDIR)/qemu_flash_image.bin @$(BINDIR)/qemu_flash_args
 	$(Q)cp $(RIOTCPU)/$(CPU)/bin/rom_0x3ff90000_0x00010000.bin $(BINDIR)/rom1.bin


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17841. It provides the following changes to allow the compilation for different ESP32x SoC variants:

- `MCU_*` conditionals in source code are inverted so that they can be tested for `MCU_ESP8266`. In all other cases the MCU is any ESP32x SoC variant.
- `CPU` conditionals in `esptool.mk` are inverted so that they can be tested for `esp8266`. In all other cases the MCU is any ESP32x SoC variant.

### Testing procedure

Green CI.

### Issues/PRs references

Split-off from PR #17841.