### PR TITLE
cpu/esp32: ESP32x SoC variant independent makefiles

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -15,6 +15,7 @@ config CPU_FAM_ESP32
     select CPU_CORE_XTENSA_LX6
     select HAS_ARCH_ESP32
     select HAS_CPU_ESP32
+    select HAS_ESP_HW_COUNTER
     select HAS_ESP_WIFI_ENTERPRISE
     select HAS_PERIPH_ADC_CTRL
     select HAS_PUF_SRAM
@@ -62,6 +63,11 @@ config HAS_CPU_ESP32
     bool
     help
         Indicates that the current CPU is 'esp32'.
+
+config HAS_ESP_HW_COUNTER
+    bool
+    help
+        Indicates that HW counters can be used.
 
 config HAS_ESP_RTC_TIMER_32K
     bool
@@ -120,7 +126,6 @@ menu "ESP32 specific configurations"
     config MODULE_ESP_SPI_RAM
         bool "SPI RAM support"
         depends on HAS_ESP_SPI_RAM
-        select MODULE_ESP_IDF_EFUSE
         select MODULE_ESP_IDF_GPIO
         select MODULE_ESP_IDF_HEAP
         select MODULE_ESP_IDF_SPI_FLASH

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -5,6 +5,7 @@ include $(RIOTCPU)/esp_common/Makefile.dep
 USEPKG += esp32_sdk
 
 USEMODULE += esp_idf_common
+USEMODULE += esp_idf_efuse
 USEMODULE += esp_bootloader
 
 ifneq (,$(filter newlib,$(USEMODULE)))
@@ -16,7 +17,6 @@ ifneq (,$(filter cpp,$(USEMODULE)))
 endif
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))
-  USEMODULE += esp_idf_efuse
   USEMODULE += esp_idf_eth
   USEMODULE += esp_idf_event
   USEMODULE += esp_idf_gpio
@@ -30,7 +30,6 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   # add additional modules and packages used for any WiFi interface
   USEPKG += esp32_sdk_lib_phy
   USEPKG += esp32_sdk_lib_wifi
-  USEMODULE += esp_idf_efuse
   USEMODULE += esp_idf_event
   USEMODULE += esp_idf_heap
   USEMODULE += esp_idf_nvs_flash
@@ -48,6 +47,10 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   USEMODULE += esp_idf_wpa_supplicant_utils
   USEMODULE += esp_idf_wpa_supplicant_wps
   USEMODULE += pthread
+endif
+
+ifneq (,$(filter esp_hw_counter,$(USEMODULE)))
+  FEATURES_REQUIRED += esp_hw_counter
 endif
 
 ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
@@ -83,7 +86,6 @@ endif
 
 ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
   FEATURES_REQUIRED += esp_spi_ram
-  USEMODULE += esp_idf_efuse
   USEMODULE += esp_idf_gpio
   USEMODULE += esp_idf_heap
   USEMODULE += esp_idf_spi_flash

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -6,6 +6,7 @@ include $(RIOTCPU)/esp_common/Makefile.features
 
 FEATURES_PROVIDED += arch_esp32
 FEATURES_PROVIDED += esp_wifi_enterprise
+FEATURES_PROVIDED += esp_hw_counter
 FEATURES_PROVIDED += periph_adc_ctrl
 FEATURES_PROVIDED += puf_sram
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -1,9 +1,17 @@
-# ESP32 specific flashing options
+# ESP32x specific flashing options
 FLASH_CHIP  = $(CPU)
-FLASH_MODE ?= dout
-FLASH_FREQ  = 40m   # DO NOT CHANGE
-FLASH_SIZE ?= 4
-BOOTLOADER_POS = 0x1000
+ifneq (,$(filter esp32,$(CPU)))
+  FLASH_MODE ?= dout
+  FLASH_FREQ  = 40m   # DO NOT CHANGE
+  FLASH_SIZE ?= 4
+  BOOTLOADER_POS = 0x1000
+endif
+ifneq (,$(filter esp32c3,$(CPU)))
+  FLASH_MODE ?= dio
+  FLASH_FREQ  = 80m   # DO NOT CHANGE
+  FLASH_SIZE ?= 4
+  BOOTLOADER_POS = 0x0000
+endif
 
 ESPTOOL ?= $(RIOTTOOLS)/esptools/esptool_v3.2.py
 
@@ -11,7 +19,13 @@ include $(RIOTCPU)/esp_common/Makefile.include
 
 # regular Makefile
 
-TARGET_ARCH_$(CPU) ?= xtensa-$(CPU)-elf
+ifneq (,$(filter esp32,$(CPU)))
+  TARGET_ARCH_$(CPU) ?= xtensa-$(CPU)-elf
+endif
+ifneq (,$(filter esp32c3,$(CPU)))
+  TARGET_ARCH_$(CPU) ?= riscv32-esp-elf
+endif
+
 TARGET_ARCH ?= $(TARGET_ARCH_$(CPU))
 
 CPU_UC = $(shell echo '$(CPU)' | tr '[:lower:]' '[:upper:]')
@@ -19,6 +33,7 @@ CPU_UC = $(shell echo '$(CPU)' | tr '[:lower:]' '[:upper:]')
 PSEUDOMODULES += esp_bootloader
 PSEUDOMODULES += esp_gdbstub
 PSEUDOMODULES += esp_hw_counter
+PSEUDOMODULES += esp_idf_gpio_hal
 PSEUDOMODULES += esp_i2c_hw
 PSEUDOMODULES += esp_jtag
 PSEUDOMODULES += esp_rtc_timer_32k
@@ -28,13 +43,16 @@ PSEUDOMODULES += esp_wifi_enterprise
 INCLUDES += -I$(RIOTCPU)/$(CPU)/esp-idf/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/esp-idf/include/log
 
-INCLUDES += -I$(ESP32_SDK_DIR)/components/
+INCLUDES += -I$(ESP32_SDK_DIR)/components
+INCLUDES += -I$(ESP32_SDK_DIR)/components/bootloader_support/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_common/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/include/$(CPU)
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_system/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_system/port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_timer/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/$(CPU)/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/include
@@ -44,15 +62,21 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/log/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/newlib/platform_include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU)/include
+
+ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/riscv/include
+endif
+
+ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU)/include
+endif
 
 ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc/$(CPU)
 endif
 
 ifneq (,$(filter esp_idf_spi_flash,$(USEMODULE)))
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/bootloader_support/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/spi_flash/include
 endif
 
@@ -61,7 +85,6 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_eth/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_event/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_netif/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_system/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/nvs_flash/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/spi_flash/include
@@ -93,28 +116,48 @@ CFLAGS += -Dasm=__asm
 CFLAGS += -Dtypeof=__typeof__
 CFLAGS += -D_CONST=const
 
-LINKFLAGS += -L$(ESP32_SDK_DIR)/components/xtensa/$(CPU)
-ARCHIVES += -lxt_hal
+# TODO no relaxation yet
+ifneq (,$(filter riscv%,$(TARGET_ARCH)))
+  CFLAGS += -mno-relax -march=rv32imc -mabi=ilp32 -DRISCV_NO_RELAX
+endif
+
+ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
+  LINKFLAGS += -L$(ESP32_SDK_DIR)/components/xtensa/$(CPU)
+  ARCHIVES += -lxt_hal
+endif
 
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ld/
+LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/memory.ld
+LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/sections.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/soc/$(CPU)/ld/$(CPU).peripherals.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.api.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.ld
-LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-data.ld
-LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-funcs.ld
-LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-time.ld
-LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.spiflash.ld
-LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.redefined.ld
-LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/memory.ld
-LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/sections.ld
+
+ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-data.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-funcs.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-time.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.spiflash.ld
+endif
+
+ifneq (,$(filter riscv%,$(TARGET_ARCH)))
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.libgcc.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.version.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.eco3.ld
+endif
+
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
 # Libraries needed when using esp_wifi_any pseudomodule
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
   LINKFLAGS += -L$(ESP32_SDK_LIB_WIFI_DIR)/$(CPU)
   LINKFLAGS += -L$(ESP32_SDK_LIB_PHY_DIR)/$(CPU)
-  ARCHIVES += -lcore -lrtc -lnet80211 -lpp -lcoexist
+  ARCHIVES += -lcoexist -lcore -lmesh -lnet80211 -lpp
   ARCHIVES += -lphy -lstdc++
+  ifneq (,$(filter esp32,$(CPU)))
+    ARCHIVES += -lrtc
+  endif
 endif
 
 # Libraries needed when using esp_now module

--- a/cpu/esp32/esp-idf/Kconfig
+++ b/cpu/esp32/esp-idf/Kconfig
@@ -12,6 +12,7 @@ config MODULE_ESP_IDF
     depends on HAS_ARCH_ESP32
     default y
     select MODULE_ESP_IDF_COMMON
+    select MODULE_ESP_IDF_EFUSE
     select MODULE_ESP_IDF_SPI_FLASH if MODULE_MTD
     help
       Espressif IoT Development Framework.

--- a/cpu/esp32/esp-idf/Makefile
+++ b/cpu/esp32/esp-idf/Makefile
@@ -4,7 +4,9 @@ export ESP_IDF_PATH = $(shell pwd)
 
 # Add a list of subdirectories, that should also be built:
 
-DIRS += common
+ifneq (,$(filter esp_idf_common,$(USEMODULE)))
+  DIRS += common
+endif
 
 ifneq (,$(filter esp_idf_efuse,$(USEMODULE)))
   DIRS += efuse

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -2,31 +2,105 @@ MODULE = esp_idf_common
 
 # source files required from ESP-IDF in any case, regardless of additional modules
 ESP32_SDK_SRC = \
+  components/bootloader_support/src/bootloader_flash_config_$(CPU).c \
+  components/bootloader_support/src/bootloader_flash.c \
+  components/bootloader_support/src/bootloader_efuse_$(CPU).c \
+  components/bootloader_support/src/bootloader_mem.c \
+  components/bootloader_support/src/bootloader_random_$(CPU).c \
   components/driver/periph_ctrl.c \
   components/esp_hw_support/cpu_util.c \
-  components/esp_hw_support/sleep_modes.c \
-  components/esp_hw_support/port/$(CPU)/rtc_sleep.c \
   components/esp_hw_support/esp_clk.c \
   components/esp_hw_support/port/$(CPU)/rtc_clk.c \
   components/esp_hw_support/port/$(CPU)/rtc_clk_init.c \
   components/esp_hw_support/port/$(CPU)/rtc_init.c \
+  components/esp_hw_support/port/$(CPU)/rtc_sleep.c \
   components/esp_hw_support/port/$(CPU)/rtc_time.c \
-  components/esp_hw_support/port/$(CPU)/rtc_wdt.c \
   components/esp_hw_support/regi2c_ctrl.c \
+  components/esp_hw_support/sleep_modes.c \
   components/esp_pm/pm_impl.c \
+  components/esp_rom/patches/esp_rom_uart.c \
   components/esp_system/esp_err.c \
   components/esp_system/esp_system.c \
+  components/esp_system/port/soc/$(CPU)/cache_err_int.c \
   components/esp_system/port/soc/$(CPU)/clk.c \
   components/esp_system/port/soc/$(CPU)/reset_reason.c \
   components/esp_system/system_time.c \
+  components/esp_timer/src/esp_timer.c \
+  components/esp_timer/src/system_time.c \
+  components/hal/cpu_hal.c \
   components/hal/mpu_hal.c \
+  components/hal/timer_hal.c \
+  components/hal/uart_hal.c \
   components/hal/wdt_hal_iram.c \
   components/newlib/port/esp_time_impl.c \
-  components/soc/$(CPU)/rtc_io_periph.c \
   components/spi_flash/cache_utils.c \
-  components/esp_timer/src/esp_timer.c \
-  components/esp_timer/src/esp_timer_impl_frc_legacy.c \
+  components/spi_flash/flash_ops.c \
   #
+
+ifneq (,$(filter periph_adc periph_dac,$(USEMODULE)))
+  ESP32_SDK_SRC += components/hal/rtc_io_hal.c
+endif
+
+# TODO separate module
+ifneq (,$(filter periph_can,$(USEMODULE)))
+  ESP32_SDK_SRC += components/hal/twai_hal.c
+  ESP32_SDK_SRC += components/hal/twai_hal_iram.c
+endif
+
+# TODO separate module
+ifneq (,$(filter periph_dac,$(USEMODULE)))
+  ESP32_SDK_SRC += components/driver/dac_common.c
+  ESP32_SDK_SRC += components/soc/$(CPU)/dac_periph.c
+endif
+
+# TODO separate module
+ifneq (,$(filter periph_hwrng,$(USEMODULE)))
+  ESP32_SDK_SRC += components/esp_hw_support/hw_random.c
+endif
+
+# TODO separate module
+ifneq (,$(filter periph_i2c%,$(USEMODULE)))
+  ESP32_SDK_SRC += components/driver/i2c.c
+  ESP32_SDK_SRC += components/hal/i2c_hal.c
+  ESP32_SDK_SRC += components/hal/i2c_hal_iram.c
+  ESP32_SDK_SRC += components/soc/$(CPU)/i2c_periph.c
+endif
+
+# TODO separate module
+ifneq (,$(filter periph_pwm%,$(USEMODULE)))
+  ESP32_SDK_SRC += components/hal/ledc_hal.c
+  ESP32_SDK_SRC += components/hal/ledc_hal_iram.c
+  ESP32_SDK_SRC += components/soc/$(CPU)/ledc_periph.c
+endif
+
+# TODO separate module
+ifneq (,$(filter periph_spi,$(USEMODULE)))
+  ESP32_SDK_SRC += components/hal/spi_hal.c
+  ESP32_SDK_SRC += components/soc/$(CPU)/spi_periph.c
+endif
+
+ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU)/rtc_wdt.c
+  ESP32_SDK_SRC += components/soc/$(CPU)/rtc_io_periph.c
+endif
+
+ifneq (,$(filter riscv%,$(TARGET_ARCH)))
+  ESP32_SDK_SRC += components/riscv/interrupt.c
+  ESP32_SDK_ASMSRC += components/freertos/port/riscv/portasm.S
+  ESP32_SDK_ASMSRC += components/riscv/vectors.S
+endif
+
+ifneq (,$(filter esp32,$(CPU)))
+  ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_frc_legacy.c
+endif
+
+ifneq (,$(filter esp32c3,$(CPU)))
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU)/cpu_util_$(CPU).c
+  ESP32_SDK_SRC += components/esp_hw_support/sleep_retention.c
+  ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c
+  ESP32_SDK_SRC += components/hal/$(CPU)/rtc_cntl_hal.c
+  ESP32_SDK_SRC += components/hal/systimer_hal.c
+endif
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/esp32/esp-idf/esp_idf_cflags.mk
+++ b/cpu/esp32/esp-idf/esp_idf_cflags.mk
@@ -16,11 +16,27 @@ CFLAGS += -Wno-implicit-function-declaration
 # required for esp_wifi (components/esp_event/esp_event.c)
 CFLAGS += -Wno-old-style-declaration
 
-# required for esp-wifi (components/efuse/esp32/esp_efuse_utility.c)
+# required for esp_wifi (components/efuse/esp32/esp_efuse_utility.c)
 # required for esp_idf_heap (components/heap/multi_heap.c)
 # required for esp_idf_wpa_supplicant
 CFLAGS += -Wno-old-style-definition
 
+# required for esp_idf_common (components/bootloader_support/src/bootloader_flash.c)
+CFLAGS += -Wno-unused-variable
+
+# required for esp_idf_spi_flash (components/spi_flash/partition.c)
+CFLAGS += -Wno-enum-compare
+
 # vendor code contains casts that increase alignment requirements. Let's hope
 # those are false positives.
 CFLAGS += -Wno-cast-align
+
+# additional CFLAGS required for RISC-V architecture
+ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/riscv/include
+  CFLAGS += -DCONFIG_IDF_TARGET_ARCH_RISCV
+  CFLAGS += -march=rv32imc
+  CFLAGS += -Wno-error=format=
+  CFLAGS += -nostartfiles
+  CFLAGS += -Wno-format
+endif

--- a/cpu/esp32/esp-idf/nvs_flash/Kconfig
+++ b/cpu/esp32/esp-idf/nvs_flash/Kconfig
@@ -9,8 +9,9 @@ config MODULE_ESP_IDF_NVS_FLASH
     bool
     depends on TEST_KCONFIG
     depends on MODULE_ESP_IDF
-    select MODULE_CPP
+
     select MODULE_MTD
+
     help
         ESP-IDF non-volatile storage library. This library is required if
         the WiFi interface is used.

--- a/cpu/esp32/esp-idf/nvs_flash/Makefile
+++ b/cpu/esp32/esp-idf/nvs_flash/Makefile
@@ -28,3 +28,9 @@ include ../esp_idf.mk
 # vendor code contains casts that increase alignment requirements. Let's hope
 # those are false positives.
 CFLAGS += -Wno-cast-align
+
+# additional CFLAGS required for RISC-V architecture
+ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
+  CFLAGS += -Wno-error=format=
+  CFLAGS += -Wno-format
+endif

--- a/cpu/esp32/esp-idf/spi_flash/Makefile
+++ b/cpu/esp32/esp-idf/spi_flash/Makefile
@@ -3,16 +3,24 @@ MODULE = esp_idf_spi_flash
 # source files to be compiled for this module
 ESP32_SDK_SRC = \
   components/bootloader_support/src/bootloader_common.c \
-  components/bootloader_support/src/bootloader_efuse_$(CPU).c \
-  components/bootloader_support/src/bootloader_flash_config_$(CPU).c \
   components/driver/spi_common.c \
-  components/soc/$(CPU)/spi_periph.c \
+  components/spi_flash/$(CPU)/flash_ops_$(CPU).c \
   components/spi_flash/$(CPU)/spi_flash_rom_patch.c \
-  components/spi_flash/flash_ops.c \
   #
 
+ifeq (,$(filter periph_spi,$(USEMODULE)))
+  # no need to compile it here if it is already compiled for periph_spi
+  ESP32_SDK_SRC += components/soc/$(CPU)/spi_periph.c
+endif
+
+ifneq (,$(filter esp32,$(CPU)))
+  ESP32_SDK_SRC += components/spi_flash/flash_mmap.c
+endif
+
 # additional include pathes required by this module
+INCLUDES += -I$(ESP32_SDK_DIR)/components/app_update/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/bootloader_support/include_bootloader
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)
 INCLUDES += -I$(ESP32_SDK_DIR)/components/spi_flash/include/spi_flash
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-idf/wifi/Makefile
+++ b/cpu/esp32/esp-idf/wifi/Makefile
@@ -2,10 +2,7 @@ MODULE = esp_idf_wifi
 
 # source files to be compiled for this module
 ESP32_SDK_SRC = \
-  components/driver/adc_common.c \
-  components/driver/rtc_module.c \
   components/esp_event/event_send.c \
-  components/esp_hw_support/hw_random.c \
   components/esp_hw_support/port/$(CPU)/dport_access.c \
   components/esp_phy/src/phy_init.c \
   components/esp_wifi/$(CPU)/esp_adapter.c \

--- a/cpu/esp32/periph/Kconfig
+++ b/cpu/esp32/periph/Kconfig
@@ -29,6 +29,7 @@ config MODULE_PERIPH_RTT_HW_RTC
 
 config MODULE_ESP_HW_COUNTER
     bool "Use hardware counter"
+    depends on HAS_ESP_HW_COUNTER
     depends on MODULE_PERIPH_TIMER
 
 endif # TEST_KCONFIG

--- a/cpu/esp_common/Makefile
+++ b/cpu/esp_common/Makefile
@@ -1,6 +1,9 @@
 # add a list of subdirectories, that should also be build
 DIRS += periph
-DIRS += vendor
+
+ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
+  DIRS += vendor
+endif
 
 ifneq (,$(filter esp_freertos_common,$(USEMODULE)))
   DIRS += freertos

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -20,7 +20,9 @@ ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
   USEMODULE += stdio_uart
 endif
 
-USEMODULE += xtensa
+ifneq (,$(filter esp8266 esp32 esp32s%,$(CPU)))
+  USEMODULE += xtensa
+endif
 
 # Features used by ESP*
 

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -27,9 +27,16 @@ INCLUDES += -I$(RIOTCPU)/esp_common/vendor/esp
 
 # Flags
 
-CFLAGS += -Wno-unused-parameter -Wformat=0
-CFLAGS += -mlongcalls -mtext-section-literals -fstrict-volatile-bitfields
-CFLAGS += -fdata-sections -ffunction-sections -fzero-initialized-in-bss
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wformat=0
+CFLAGS += -fstrict-volatile-bitfields
+CFLAGS += -fdata-sections
+CFLAFS += -ffunction-sections
+CFLAGS += -fzero-initialized-in-bss
+
+ifeq (,$(filter esp32c% esp32h%,$(CPU)))
+  CFLAGS += -mlongcalls -mtext-section-literals
+endif
 
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
 OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
@@ -88,11 +95,6 @@ CFLAGS += $(if $(findstring dout,$(FLASH_MODE)),-DFLASH_MODE_DOUT=1)
 ARCHIVES += -lg -lc
 
 LINKFLAGS += $(CFLAGS_OPT) $(CFLAGS_DBG)
-#ifneq ($(CPU),esp8266)
-# esp8266 flags are added by the SDK pkg in pkg/esp8266_sdk
-#LINKFLAGS += -L$(ESP_SDK_DIR)/components/$(CPU)
-#LINKFLAGS += -L$(ESP_SDK_DIR)/components/$(CPU)/lib
-#endif
 LINKFLAGS += -nostdlib -Wl,-gc-sections -Wl,-static
 
 # use the wrapper functions for calloc to add correct overflow detection missing


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17841. It provides the changes of all makefiles and Kconfigs that are necessary to allow the compilation for different ESP32x SoC variants.

### Testing procedure

Green CI.

### Issues/PRs references

Split-off from PR #17841 