### PR TITLE
net/eui_provider: provide netif index to EUI provder function

### DIFF
--- a/sys/net/link_layer/eui_provider/eui_provider.c
+++ b/sys/net/link_layer/eui_provider/eui_provider.c
@@ -19,6 +19,16 @@
 #include "luid.h"
 #include "net/eui_provider.h"
 
+static inline unsigned _get_idx(netdev_t *netdev)
+{
+#ifdef MODULE_NETDEV_REGISTER
+    return netdev->index;
+#else
+    (void)netdev;
+    return 0;
+#endif
+}
+
 void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
 {
     unsigned i = EUI48_PROVIDER_NUMOF;
@@ -38,10 +48,8 @@ void netdev_eui48_get(netdev_t *netdev, eui48_t *addr)
             eui48_conf[i].index != NETDEV_INDEX_ANY) {
             continue;
         }
-#else
-        (void) netdev;
 #endif
-        if (eui48_conf[i].provider(i, addr) == 0) {
+        if (eui48_conf[i].provider(_get_idx(netdev), addr) == 0) {
             return;
         }
     }
@@ -68,10 +76,8 @@ void netdev_eui64_get(netdev_t *netdev, eui64_t *addr)
             eui64_conf[i].index != NETDEV_INDEX_ANY) {
             continue;
         }
-#else
-        (void) netdev;
 #endif
-        if (eui64_conf[i].provider(i, addr) == 0) {
+        if (eui64_conf[i].provider(_get_idx(netdev), addr) == 0) {
             return;
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

An EUI provider can provide EUIs for multiple interfaces based on their index.

For this is should get the index of the interface, not the index of the EUI provider.

### Testing procedure

Before both interfaces would get the same L2 address

```
2022-06-23 13:43:20,211 # Iface 5 HWaddr: 02:00:00:00:20:C7
2022-06-23 13:43:20,215 # L2-PDU:1500 MTU:1500 HL:64 RTR
2022-06-23 13:43:20,218 # Source address length: 6
2022-06-23 13:43:20,219 # Link type: wired
2022-06-23 13:43:20,225 # inet6 addr: fe80::ff:fe00:20c7 scope: link VAL
2022-06-23 13:43:20,228 # inet6 group: ff02::2
2022-06-23 13:43:20,230 # inet6 group: ff02::1
2022-06-23 13:43:20,234 # inet6 group: ff02::1:ff00:20c7
2022-06-23 13:43:20,235 #
2022-06-23 13:43:20,239 # Iface 4 HWaddr: 02:00:00:00:20:C7
2022-06-23 13:43:20,243 # L2-PDU:1500 MTU:1500 HL:64 RTR
2022-06-23 13:43:20,245 # Source address length: 6
2022-06-23 13:43:20,248 # Link type: wired
2022-06-23 13:43:20,254 # inet6 addr: fe80::ff:fe00:20c7 scope: link TNT[1]
2022-06-23 13:43:20,256 # inet6 group: ff02::2
2022-06-23 13:43:20,259 # inet6 group: ff02::1
2022-06-23 13:43:20,263 # inet6 group: ff02::1:ff00:20c7
```

Now they are different

```
2022-06-23 14:24:25,550 - INFO # Iface  5  HWaddr: 02:00:FF:FF:FF:FF 
2022-06-23 14:24:25,557 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2022-06-23 14:24:25,559 - INFO #           RTR_ADV  
2022-06-23 14:24:25,563 - INFO #           Source address length: 6
2022-06-23 14:24:25,565 - INFO #           Link type: wired
2022-06-23 14:24:25,571 - INFO #           inet6 addr: fe80::ffff:feff:ffff  scope: link  VAL
2022-06-23 14:24:25,574 - INFO #           inet6 group: ff02::2
2022-06-23 14:24:25,577 - INFO #           inet6 group: ff02::1
2022-06-23 14:24:25,581 - INFO #           inet6 group: ff02::1:ffff:ffff
2022-06-23 14:24:25,582 - INFO #           
2022-06-23 14:24:25,611 - INFO # 
2022-06-23 14:24:25,615 - INFO # Iface  6  HWaddr: 02:01:FF:FF:FF:FF 
2022-06-23 14:24:25,622 - INFO #           L2-PDU:1500  MTU:1500  HL:64  RTR  
2022-06-23 14:24:25,624 - INFO #           RTR_ADV  
2022-06-23 14:24:25,628 - INFO #           Source address length: 6
2022-06-23 14:24:25,630 - INFO #           Link type: wired
2022-06-23 14:24:25,636 - INFO #           inet6 addr: fe80::1:ffff:feff:ffff  scope: link  VAL
2022-06-23 14:24:25,639 - INFO #           inet6 group: ff02::2
2022-06-23 14:24:25,642 - INFO #           inet6 group: ff02::1
2022-06-23 14:24:25,646 - INFO #           inet6 group: ff02::1:ffff:ffff
```

(different node, doesn't have serial number set yet)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
