### PR TITLE
cpu/esp32: add ESP-IDF API

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -136,5 +136,6 @@ endmenu
 
 rsource "bootloader/Kconfig"
 rsource "esp-idf/Kconfig"
+rsource "esp-idf-api/Kconfig"
 rsource "periph/Kconfig"
 source "$(RIOTCPU)/esp_common/Kconfig"

--- a/cpu/esp32/Makefile
+++ b/cpu/esp32/Makefile
@@ -7,6 +7,7 @@ SRC = irq_arch.c startup.c syscalls.c
 DIRS += $(RIOTCPU)/esp_common
 DIRS += periph
 DIRS += esp-idf
+DIRS += esp-idf-api
 
 ifneq (, $(filter esp_bootloader, $(USEMODULE)))
     DIRS += bootloader

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -4,6 +4,7 @@ include $(RIOTCPU)/esp_common/Makefile.dep
 
 USEPKG += esp32_sdk
 
+USEMODULE += esp_idf_api
 USEMODULE += esp_idf_common
 USEMODULE += esp_bootloader
 

--- a/cpu/esp32/esp-idf-api/Kconfig
+++ b/cpu/esp32/esp-idf-api/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config MODULE_ESP_IDF_API
+    bool
+    depends on TEST_KCONFIG
+    depends on HAS_ARCH_ESP32
+    default y
+    help
+      ESP-IDF interface API

--- a/cpu/esp32/esp-idf-api/Makefile
+++ b/cpu/esp32/esp-idf-api/Makefile
@@ -1,0 +1,18 @@
+MODULE = esp_idf_api
+
+# ESP-IDF header files must be found first in this module. Therefore,
+# the ESP-IDF include paths must come before the RIOT include paths.
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_common/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/platform_port/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
+
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/$(CPU)/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/include
+
+include $(RIOTBASE)/Makefile.base
+
+INCLUDES := $(PRE_INCLUDES) $(INCLUDES)

--- a/cpu/esp32/esp-idf-api/doc.txt
+++ b/cpu/esp32/esp-idf-api/doc.txt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup        cpu_esp32_esp_idf_api ESP-IDF Interface API
+ * @ingroup         cpu_esp32
+ * @brief           ESP-IDF Interface API
+ *
+ * This module implements an interface for ESP-IDF types and functions that are
+ * required by RIOT-OS but cannot be included directly due to name conflicts.
+ *
+ * For this purpose, the header files of this module declare all the types and
+ * functions that are required from the ESP-IDF, but without using the ESP-IDF
+ * header files with conflicting names. The implementation of the module then
+ * uses the ESP-IDF. In most cases, simple wrapper functions are sufficient.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */

--- a/cpu/esp32/esp-idf-api/periph_ctrl.c
+++ b/cpu/esp32/esp-idf-api/periph_ctrl.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32_esp_idf_api
+ * @{
+ *
+ * @file
+ * @brief       Interface for ESP-IDF peripherals control API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "driver/periph_ctrl.h"
+
+void esp_idf_periph_module_enable(periph_module_t periph)
+{
+    periph_module_enable(periph);
+}
+
+void esp_idf_periph_module_disable(periph_module_t periph)
+{
+    periph_module_disable(periph);
+}

--- a/cpu/esp32/include/esp_idf_api/periph_ctrl.h
+++ b/cpu/esp32/include/esp_idf_api/periph_ctrl.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32_esp_idf_api
+ * @{
+ *
+ * @file
+ * @brief       Interface for ESP-IDF peripherals control API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#ifndef ESP_IDF_API_PERIPH_CTRL_H
+#define ESP_IDF_API_PERIPH_CTRL_H
+
+#ifndef DOXYGEN     /* Hide implementation details from doxygen */
+
+#include "soc/periph_defs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void esp_idf_periph_module_enable(periph_module_t periph);
+void esp_idf_periph_module_disable(periph_module_t periph);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+#endif /* ESP_IDF_API_PERIPH_CTRL_H */


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17841. It adds the basic structure for an API which is used for ESP-IDF types and functions that are required by RIOT-OS but cannot be included directly due to naming conflicts.

For this purpose, the header files of this API declare the types and functions that are required from the ESP-IDF, but without using the ESP-IDF header files to avoid conflicting names. The implementation of the API then uses the ESP-IDF. In most cases, simple wrapper functions are sufficient.

### Testing procedure

Since the basic structure of the API contains almost no functionality, a green CI is sufficient.

### Issues/PRs references

Split-off from PR #17841