### PR TITLE
tests/thread_float: fix test script

### DIFF
--- a/tests/thread_float/tests/01-run.py
+++ b/tests/thread_float/tests/01-run.py
@@ -26,6 +26,14 @@ def same_computation_as_in_c_prog(thread_num):
     return f
 
 
+def parse_result_line(child):
+    child.expect(r"t(\d): (\d{3}\.\d+|[+-]*nan|[+-]inf)\r\n")
+    # Note: intentionally keeping the float output as string to also test that
+    # printf("%f", ...) prints the exact same char sequence for the same float
+    # value each time
+    return (int(child.match.group(1)), child.match.group(2))
+
+
 def testfunc(child):
     child.expect_exact("THREADS CREATED")
     # Threads are started with THREAD_CREATE_WOUT_YIELD, and thus prone starting
@@ -38,19 +46,18 @@ def testfunc(child):
         assert thread_num not in threads_started, "same thread must not be launched twice"
         threads_started.add(thread_num)
 
+    first_thread, first_result = parse_result_line(child)
     child.expect(r"t(\d): (\d{3}\.\d+)\r\n")
     first_thread = int(child.match.group(1))
-    # Note: intentionally keeping the float output as string to also test that printf("%f", ...)
-    # prints the exact same char sequence for the same float value each time
     first_result = child.match.group(2)
 
     # wait for second thread to print, but wait at most 50 messages
     second_thread = None
     for _ in range(50):
-        child.expect(r"t(\d): (\d{3}\.\d+)\r\n")
-        if int(child.match.group(1)) != first_thread:
-            second_thread = int(child.match.group(1))
-            second_result = child.match.group(2)
+        thread, result = parse_result_line(child)
+        if thread != first_thread:
+            second_thread = thread
+            second_result = result
             break
 
     assert second_thread is not None, "both threads t1 and t3 should print"
@@ -64,10 +71,8 @@ def testfunc(child):
 
     # wait for both threads to print at least MIN_PRINTS times, but wait at most 100 messages
     for _ in range(100):
-        child.expect(r"t(\d): (\d{3}\.\d+)\r\n")
-        thread = int(child.match.group(1))
+        thread, result = parse_result_line(child)
         assert thread in [1, 3], "only thread t1 and t3 should print"
-        result = child.match.group(2)
 
         if thread == first_thread:
             assert result == first_result, "same calculation but different result"


### PR DESCRIPTION
### Contribution description

Previously the test script expected runnable threads of the same
priority to be running in a specific order. But the only tool that is
guaranteed to enforce a specific order of runnable threads is assigning
them different priority levels.

This should fix a test failure in the nightlies.

### Testing procedure

Murdock will do so

### Issues/PRs references

None