### PR TITLE
Documentation: Renaming OS X to macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ Please paste or specifically describe the actual output.
 
 #### Versions
 <!--
-Operating system: Mac OSX, Linux, Vagrant VM
+Operating system: macOS, Linux, Vagrant VM
 Build environment: GCC, CLang versions (you can run the following command from
 the RIOT base directory: make print-versions).
 -->

--- a/boards/cc2538dk/doc.txt
+++ b/boards/cc2538dk/doc.txt
@@ -77,6 +77,10 @@ JLinkExe tool, then specify `PROGRAMMER=jlink` when flashing:
 Be prevented that you'll need to disable Apple's System Integrity Protection
 to allow FTDI unsigned drivers to be loaded on your Mac.
 
+@warning    Caution, turning off the SIP may compromise your systems security and integrity.
+            See [developer.apple.com](https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection) for details.
+
+
 To do this, reboot in recovery mode, by pressing simultaneously `cmd + R`
 while booting.
 Then, on the recovery mode go to Utilities/Terminal and type:

--- a/boards/cc2650stk/doc.txt
+++ b/boards/cc2650stk/doc.txt
@@ -70,7 +70,7 @@ On Linux, there's an application called
 [Uniflash](https://www.ti.com/tool/uniflash). Sadly, you'll have to install the
 whole IDE just to get the scripting interface :-[
 
-No idea about MacOSX.
+No idea about macOS.
 
 In order to flash the CC2650STK you need to plug the XDS110 probe through the
 JTAG and so-called "DevPack" connectors. Note that the back of the SensorTag

--- a/boards/firefly/doc.txt
+++ b/boards/firefly/doc.txt
@@ -85,7 +85,7 @@ The Firefly has built-in support for USB 2.0 USB, Vendor and Product IDs are the
   * VID 0x0451
   * PID 0x16C8
 
-On Linux and OS X this is straightforward, on windows you need to install the following driver:
+On Linux and macOS this is straightforward, on windows you need to install the following driver:
 
 <https://github.com/alignan/lufa/blob/remote-zongle/LUFA/CodeTemplates/WindowsINF/LUFA%20CDC-ACM.inf>
 
@@ -100,7 +100,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On OS X, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.SLAB_USBtoUARTx`.
 
 On Linux:
 

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -158,7 +158,7 @@ Bash
 
 ## Troubleshooting
 
-For terminal output on OS X (`make term`) you need to install a driver:
+For terminal output on macOS (`make term`) you need to install a driver:
 http://www.ftdichip.com/Drivers/VCP.htm
 http://www.ftdichip.com/Drivers/VCP.htm
  */

--- a/boards/openmote-b/doc.txt
+++ b/boards/openmote-b/doc.txt
@@ -58,7 +58,7 @@ tool. Once you have this in place, you can simply flash by calling
 
 from your application folder.
 
-Mac OS users may experiment a command line expecting `connect`. Just type it
+macOS users may experiment a command line expecting `connect`. Just type it
 and the process will continue.
 
 ### Debugging

--- a/boards/openmote-cc2538/doc.txt
+++ b/boards/openmote-cc2538/doc.txt
@@ -56,6 +56,6 @@ tool. Once you have this in place, you can simply flash by calling
 
 from your application folder.
 
-Mac OS users may experiment a command line expecting `connect`. Just type it
+macOS users may experiment a command line expecting `connect`. Just type it
 and the process will continue.
  */

--- a/boards/remote-pa/README.md
+++ b/boards/remote-pa/README.md
@@ -83,7 +83,7 @@ The Re-Mote has built-in support for USB 2.0 USB, Vendor and Product IDs are the
   * VID 0x0451
   * PID 0x16C8
 
-On Linux and OS X this is straightforward, on windows you need to install the following driver:
+On Linux and macOS this is straightforward, on windows you need to install the following driver:
 
 <https://github.com/alignan/lufa/blob/remote-zongle/LUFA/CodeTemplates/WindowsINF/LUFA%20CDC-ACM.inf>
 
@@ -96,9 +96,9 @@ Once all drivers have been installed correctly:
 
 On windows, devices will appear as a virtual `COM` port.
 
-On Linux and OS X, devices will appear under `/dev/`.
+On Linux and macOS, devices will appear under `/dev/`.
 
-On OS X:
+On macOS:
 
 * XDS backchannel: `tty.usbserial-<serial number>`
 * EM in CDC-ACM: `tty.usbmodemf<X><ABC>` (X a letter, ABC a number e.g. `tty.usbmodemfd121`)

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -76,7 +76,7 @@ The RE-Mote has built-in support for USB 2.0 USB, Vendor and Product IDs are the
   * VID 0x0451
   * PID 0x16C8
 
-On Linux and OS X this is straightforward, on windows you need to install the following driver:
+On Linux and macOS this is straightforward, on windows you need to install the following driver:
 
 <https://github.com/alignan/lufa/blob/remote-zongle/LUFA/CodeTemplates/WindowsINF/LUFA%20CDC-ACM.inf>
 
@@ -91,7 +91,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On OS X, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.SLAB_USBtoUARTx`.
 
 On Linux:
 

--- a/boards/remote-revb/README.md
+++ b/boards/remote-revb/README.md
@@ -82,7 +82,7 @@ The RE-Mote has built-in support for USB 2.0 USB, Vendor and Product IDs are the
   * VID 0x0451
   * PID 0x16C8
 
-On Linux and OS X this is straightforward, on windows you need to install the following driver:
+On Linux and macOS this is straightforward, on windows you need to install the following driver:
 
 <https://github.com/alignan/lufa/blob/remote-zongle/LUFA/CodeTemplates/WindowsINF/LUFA%20CDC-ACM.inf>
 
@@ -97,7 +97,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On OS X, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.SLAB_USBtoUARTx`.
 
 On Linux:
 

--- a/boards/samr21-xpro/doc.txt
+++ b/boards/samr21-xpro/doc.txt
@@ -205,10 +205,10 @@ clock configuration or low power modes. In this case you can use
 instructions to build it and run `./edbg -e` to erase the flash. Then press the
 reset button and you're able to program via OpenOCD again.
 
-### Flashing might not work in Virtual Box with Mac OS X as host
+### Flashing might not work in Virtual Box with macOS as host
 It might happen that flashing through OpenOCD works once inside Virtual Box.
 But when you try to flash again, you could get a CMSIS-DAP related error. It
 seems to only happen with USB 3.0 ports. You can take a look at
 [Vagrant](http://en.wikipedia.org/wiki/Vagrant_%28software%29) and use a virtual
-Linux to run the virtual RIOT, and flash from OS X.
+Linux to run the virtual RIOT, and flash from macOS.
  */

--- a/boards/stm32f4discovery/doc.txt
+++ b/boards/stm32f4discovery/doc.txt
@@ -183,7 +183,7 @@ time, the internal pull-up resistors are not sufficient for stable bus
 operation. You probably have to connect external pull-ups to both bus lines. 10K
 is a good value to start with.
 
-### OS X & make term
+### macOS & make term
 If you want the terminal to work using `make term` command and get a message
 about missing tty device install the driver from
 https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers .

--- a/cpu/native/README.md
+++ b/cpu/native/README.md
@@ -55,14 +55,14 @@ To create a bridge and two (or count at your option) tap interfaces:
 
     sudo ../../dist/tools/tapsetup/tapsetup [-c [<count>]]
 
-On OSX you need to start the RIOT instance at some point during the script's
+On macOS you need to start the RIOT instance at some point during the script's
 execution. The script will instruct you when to do that.
 
 To delete the bridge and all tap interfaces:
 
     sudo ../../dist/tools/tapsetup/tapsetup -d
 
-For OSX you **have** to run this after killing your RIOT instance and rerun
+For macOS you **have** to run this after killing your RIOT instance and rerun
 `sudo ../../dist/tools/tapsetup [-c [<count>]]` before restarting.
 
 **Please note:** If you want to communicate between RIOT and your host

--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -85,7 +85,7 @@ void native_async_read_add_handler(int fd, void *arg, native_async_read_callback
 
     _add_handler(fd, arg, handler);
 
-    /* tuntap signalled IO is not working in OSX,
+    /* tuntap signalled IO is not working in macOS,
      * * check http://sourceforge.net/p/tuntaposx/bugs/18/ */
 #ifdef __MACH__
     _sigio_child(_next_index);
@@ -98,7 +98,7 @@ void native_async_read_add_handler(int fd, void *arg, native_async_read_callback
     if (real_fcntl(fd, F_SETFL, O_NONBLOCK | O_ASYNC) == -1) {
         err(EXIT_FAILURE, "native_async_read_add_handler(): fcntl(F_SETFL)");
     }
-#endif /* not OSX */
+#endif /* not macOS */
 
     _next_index++;
 }

--- a/cpu/native/include/clang_compat.h
+++ b/cpu/native/include/clang_compat.h
@@ -1,5 +1,5 @@
 /*
- * clang_compat.h Undefines macros of clang on OSX to use RIOT's macros
+ * clang_compat.h Undefines macros of clang on macOS to use RIOT's macros
  *
  * Copyright (C) 2014 Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  *

--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -27,7 +27,7 @@ extern "C" {
  *
  * @{
  */
-#ifdef __MACH__ /* OSX */
+#ifdef __MACH__ /* macOS */
 #ifndef THREAD_STACKSIZE_DEFAULT
 #define THREAD_STACKSIZE_DEFAULT            (163840)
 #endif

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -340,7 +340,7 @@ static int _init(netdev_t *netdev)
     }
 
     char *name = dev->tap_name;
-#ifdef __MACH__ /* OSX */
+#ifdef __MACH__ /* macOS */
     char clonedev[255] = "/dev/"; /* XXX bad size */
     strncpy(clonedev + 5, name, 250);
 #elif defined(__FreeBSD__)
@@ -356,7 +356,7 @@ static int _init(netdev_t *netdev)
     if ((dev->tap_fd = real_open(clonedev, O_RDWR | O_NONBLOCK)) == -1) {
         err(EXIT_FAILURE, "open(%s)", clonedev);
     }
-#if (defined(__MACH__) || defined(__FreeBSD__)) /* OSX/FreeBSD */
+#if (defined(__MACH__) || defined(__FreeBSD__)) /* macOS/FreeBSD */
     struct ifaddrs *iflist;
     if (real_getifaddrs(&iflist) == 0) {
         for (struct ifaddrs *cur = iflist; cur; cur = cur->ifa_next) {

--- a/cpu/native/osx-libc-extra/malloc.h
+++ b/cpu/native/osx-libc-extra/malloc.h
@@ -9,7 +9,7 @@
 /**
  * @ingroup     cpu_native
  *
- * @brief       Malloc header for use with native on OSX since there is no
+ * @brief       Malloc header for use with native on macOS since there is no
  *              malloc.h file in the standard include path.
  *
  * @{

--- a/cpu/native/periph/qdec.c
+++ b/cpu/native/periph/qdec.c
@@ -24,7 +24,7 @@
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
 #include <mach/mach_host.h>
-/* Both OS X and RIOT typedef thread_t. timer.c does not use either thread_t. */
+/* Both macOS and RIOT typedef thread_t. timer.c does not use either thread_t. */
 #define thread_t riot_thread_t
 #endif
 

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -31,7 +31,7 @@
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
 #include <mach/mach_host.h>
-/* Both OS X and RIOT typedef thread_t. timer.c does not use either thread_t. */
+/* Both macOS and RIOT typedef thread_t. timer.c does not use either thread_t. */
 #define thread_t riot_thread_t
 #endif
 

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -29,10 +29,10 @@ A set of common tools and a toolchain for the hardware you target needs to be in
 ### Choosing an Operating System for the Development PC
 
 Most of the RIOT OS developers are using Linux on their development PCs, so you can expect the
-most streamlined experience here. Other POSIX-compliant OSes such as current versions of Mac OS or
+most streamlined experience here. Other POSIX-compliant OSes such as current versions of macOS or
 the various BSD flavours will also be fine - however, we rely on users to report bugs regarding
 tooling incompatibilities here. So expect occasional issues for the development branch and please
-help testing during the feature freeze period, if you develop on Mac OS or BSD.
+help testing during the feature freeze period, if you develop on macOS or BSD.
 
 Native development on Windows machines is not officially supported. What works well is using Linux
 in a virtual machine, but at much lower performance than running Linux natively. For development
@@ -144,8 +144,7 @@ For example, in Ubuntu the above tools can be installed with the following comma
   headers
     * Alternatively: Compile with `BUILD_IN_DOCKER=1`. Note that for running the executable you
       still need a multilib system (or 32 bit Linux) with glibc a standard C library.
-* A C library supporting the deprecated POSIX.1-2001 ucontext library (e.g. glibc, FreeBSD's libc,
-  Mac OS's libc)
+* A C library supporting the deprecated POSIX.1-2001 ucontext library (e.g. glibc, FreeBSD's libc)
 * Optional: GDB for debugging. (Prefer the multiarch version, this will also work for other boards)
 
 The build system                                            {#the-build-system}

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -50,7 +50,7 @@ RIOT is developed by an open community that anyone is welcome to join:
 The quickest start                                        {#the-quickest-start}
 ==================
 You can run RIOT on most IoT devices, on open-access testbed hardware (e.g.
-IoT-lab), and also directly as a process on your Linux/FreeBSD/OSX machine (we
+IoT-lab), and also directly as a process on your Linux/FreeBSD/macOS machine (we
 call this the `native` port). Try it right now in your terminal window:
 
 ~~~~~~~{.sh}

--- a/examples/emcute_mqttsn/README.md
+++ b/examples/emcute_mqttsn/README.md
@@ -62,7 +62,7 @@ sudo ./RIOTDIR/dist/tools/tapsetup/tapsetup
 ```
 
 2. Assign a site-global prefix to the `tapbr0` interface (the name could be
-   different on OSX etc):
+   different on macOS etc):
 ```
 sudo ip a a fec0:affe::1/64 dev tapbr0
 ```

--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -46,7 +46,7 @@ to using `esp_now` for the downstream interface.
 
 ## Requirements
 This functionality works only on Linux machines.
-Mac OSX support will be added in the future (lack of native `tap` interface).
+macOS support will be added in the future (lack of native `tap` interface).
 
 If you want to use DHCPv6, you also need a DHCPv6 server configured for prefix
 delegation from the interface facing the border router. With the [KEA] DHCPv6

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -707,7 +707,7 @@ static void test_fib_16_prefix_match(void)
 */
 static void test_fib_17_get_entry_set(void)
 {
-    /* FIXME: init as enum to fix folding-constant compiler error on OS X */
+    /* FIXME: init as enum to fix folding-constant compiler error on macOS */
     enum { addr_buf_size = 16 };
     char addr_dst[addr_buf_size];
     char addr_nxt[addr_buf_size];


### PR DESCRIPTION

### Areas of change

- Renaming some occurrences of "OS X" (and other variations) to "macOS". 
    - I wasn't sure about changing the old release notes too (so I didn't).
    - Patches and packages were also excluded, e.g. sys/embunit/readme_en.txt
    - limited to txt|c|h|md files
    - I tried to keep specific version names, e.g. `Mac OSX El Capitan users`.
        - Some of these files should be checked® in the future if they are still needed / up to date
- I added a warning to guidance that instructed users to disable Apple's macOS System Integrity Protection. I do not believe this is something that RIOT should casually advise. (Somebody® should check if this section is even still needed)

### Reason for change

Apple changed the name of the operating system to "macOS" in 2016 to match the branding of Apple's other operating systems.
Users might search the codebase for `macOS` to find areas of interest. Currently, one would have a hard time finding all `macOS` related comments or code sections.
Minor but everything looks better maintained if the naming is up to date.
And last, I personally just found it ugly. 😉

Off course, such PRs are always kind of annoying as they touch a lot of files / leave a mark in the history without adding that much benefit - so no hurt feelings if one is arguing against it.