### PR TITLE
drivers/mcp2515: undefine rst_pin

### DIFF
--- a/drivers/mcp2515/include/mcp2515_params.h
+++ b/drivers/mcp2515/include/mcp2515_params.h
@@ -51,7 +51,7 @@ extern "C" {
 #endif
 
 #ifndef MCP2515_PARAM_RST
-#define MCP2515_PARAM_RST GPIO_PIN(0, 0)
+#define MCP2515_PARAM_RST GPIO_UNDEF
 #endif
 
 #ifndef MCP2515_PARAM_INT


### PR DESCRIPTION
### Contribution description

`mcp2515_params.h` sets a default value to `rst_pin` which will make it a valid gpio and thus a hardware reset will be always triggered. However the `rst_pin` from the MCP2515 is not available on all boards which makes the hardware reset not effective. This PR is undefining the `rst_pin` by default so that the software reset over SPI will be provided
