### PR TITLE
cpu/{atmega_common,atxmega}: increase idle thread stack size

### DIFF
--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -49,10 +49,11 @@ extern "C" {
  * to avoid not printing of debug in interrupts
  */
 #ifndef THREAD_STACKSIZE_IDLE
-#if MODULE_XTIMER || MODULE_ZTIMER64
-/* xtimer's 64 bit arithmetic doesn't perform well on 8 bit archs. In order to
- * prevent a stack overflow when an timer triggers while the idle thread is
- * running, we have to increase the stack size then
+#if MODULE_XTIMER || MODULE_ZTIMER || MODULE_ZTIMER64
+/* For AVR no ISR stack is used, hence an IRQ will victimize the stack of
+ * whatever thread happens to be running with the IRQ kicks in. If more than
+ * trivial stuff is needed to be done in ISRs (e.g. when soft timers are used),
+ * the idle stack will overflow.
  */
 #define THREAD_STACKSIZE_IDLE      (192)
 #else

--- a/cpu/atxmega/include/cpu_conf.h
+++ b/cpu/atxmega/include/cpu_conf.h
@@ -41,10 +41,11 @@ extern "C" {
  * to avoid not printing of debug in interrupts
  */
 #ifndef THREAD_STACKSIZE_IDLE
-#if MODULE_XTIMER || MODULE_ZTIMER64
-/* xtimer's 64 bit arithmetic doesn't perform well on 8 bit archs. In order to
- * prevent a stack overflow when an timer triggers while the idle thread is
- * running, we have to increase the stack size then
+#if MODULE_XTIMER || MODULE_ZTIMER || MODULE_ZTIMER64
+/* For AVR no ISR stack is used, hence an IRQ will victimize the stack of
+ * whatever thread happens to be running with the IRQ kicks in. If more than
+ * trivial stuff is needed to be done in ISRs (e.g. when soft timers are used),
+ * the idle stack will overflow.
  */
 #define THREAD_STACKSIZE_IDLE           (384)
 #else

--- a/tests/slip/Makefile.ci
+++ b/tests/slip/Makefile.ci
@@ -6,6 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     atmega328p-xplained-mini \
+    atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
     msb-430 \


### PR DESCRIPTION
### Contribution description

Our AVR port doesn't make use of an ISR stack and just victimizes the
stack of whatever thread happens to be running, which in most cases is
the idle thread. Hence, the idle stack has to be large enough to
support the ztimer ISR.

### Testing procedure

Run program given in https://github.com/RIOT-OS/RIOT/pull/18245#issuecomment-1166608376 - with `master` you'll get something like

```
2022-06-27 12:49:44,725 # main(): This is RIOT! (Version: 2022.07-devel-898-gd9fc08)
2022-06-27 12:49:45,770 # scheduler(): stack overflow detected, pid=1
2022-06-27 12:49:46,815 # scheduler(): stack overflow detected, pid=1
2022-06-27 12:49:47,859 # scheduler(): stack overflow detected, pid=1
```

but with this PR the stack overflow should no longer be detected. (Test successfully with both Alpine's AVR toolchain in `BUILD_IN_DOCKER=1`.)

### Issues/PRs references

Reported in https://github.com/RIOT-OS/RIOT/pull/18245#issuecomment-1166608376