### PR TITLE
ieee802154: add default max frame retransmissions config

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -302,6 +302,13 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
 #endif
 
 /**
+ * @brief IEEE802.15.4 default value for maximum frame retries.
+ */
+#ifndef CONFIG_IEEE802154_DEFAULT_MAX_FRAME_RETRANS
+#define CONFIG_IEEE802154_DEFAULT_MAX_FRAME_RETRANS     (4U)
+#endif
+
+/**
  * @brief Disable Auto ACK support
  */
 #ifdef DOXYGEN

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -118,8 +118,6 @@ extern "C" {
 #include "net/ieee802154.h"
 #include "net/ieee802154/radio.h"
 
-#define IEEE802154_SUBMAC_MAX_RETRANSMISSIONS (4U)  /**< maximum number of frame retransmissions */
-
 /**
  * @brief IEEE 802.15.4 SubMAC forward declaration
  */

--- a/sys/net/link_layer/ieee802154/Kconfig
+++ b/sys/net/link_layer/ieee802154/Kconfig
@@ -103,6 +103,11 @@ if KCONFIG_USEMODULE_IEEE802154
     config IEEE802154_DEFAULT_CSMA_CA_MAX
         int "IEEE802.15.4 default CSMA-CA maximum backoff exponent"
         default 5
+
+    config IEEE802154_DEFAULT_MAX_FRAME_RETRANS
+        int "IEEE802.15.4 default maximum frame retransmissions"
+        default 4
+
     config IEEE802154_AUTO_ACK_DISABLE
         bool "Disable Auto ACK support" if !USEPKG_OPENWSN
         default y if USEPKG_OPENWSN

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -64,7 +64,7 @@ static inline bool _does_handle_csma(ieee802154_dev_t *dev)
 
 static bool _has_retrans_left(ieee802154_submac_t *submac)
 {
-    return submac->retrans < IEEE802154_SUBMAC_MAX_RETRANSMISSIONS;
+    return submac->retrans < CONFIG_IEEE802154_DEFAULT_MAX_FRAME_RETRANS;
 }
 
 static ieee802154_fsm_state_t _tx_end(ieee802154_submac_t *submac, int status,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds a IEEE 802.15.4 configuration for setting the maximum number of frame retransmissions.
Thereby the IEEE802154_SUBMAC_MAX_RETRANSMISSIONS is not needed anymore and the user can simply set the number of retransmissions from Kconfig/CFLAGS.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try e.g `examples/gnrc_networking` with any IEEE 802.15.4 HAL based radio (e.g nrf52840). Try pinging with a stress configuration (e.g `ping <addr> -c 50 -s 1024 -i 200`.
Then, set CONFIG_IEEE802154_DEFAULT_MAX_FRAME_RETRANS to a low value (e.g 1). Repeat the procedure. Packet losses should increase.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
