### PR TITLE
sys/net/netopt: change NETOPT_STATS semantics

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -391,11 +391,12 @@ typedef enum {
     NETOPT_CCA_MODE,
 
     /**
-     * @brief   (@ref netstats_t*) get statistics about sent and received packets and data of the
-     *          device or protocol
+     * @brief   (@ref netstats_t) get statistics about sent and received packets
+     *          and data of the device or protocol
      *
-     * Expects a pointer to a @ref netstats_t struct that will be pointed to
-     * the corresponding @ref netstats_t of the module.
+     * A get operation expects a @ref netstats_t and will copy the current
+     * statistics into it, atomically. A set operation resets the statistics
+     * (zeros it out) regardless of the parameter given.
      */
     NETOPT_STATS,
 

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -152,16 +152,18 @@ static const char *_netstats_module_to_str(uint8_t module)
 
 static int _netif_stats(netif_t *iface, unsigned module, bool reset)
 {
-    netstats_t *stats;
+    netstats_t stats;
     int res = netif_get_opt(iface, NETOPT_STATS, module, &stats,
-                            sizeof(&stats));
+                            sizeof(stats));
 
     if (res < 0) {
         puts("           Protocol or device doesn't provide statistics.");
     }
     else if (reset) {
-        memset(stats, 0, sizeof(netstats_t));
-        printf("Reset statistics for module %s!\n", _netstats_module_to_str(module));
+        res = netif_set_opt(iface, NETOPT_STATS, module, NULL, 0);
+        printf("Reset statistics for module %s: %s!\n",
+               _netstats_module_to_str(module),
+               (res < 0) ? "failed" : "succeeded");
     }
     else {
         printf("          Statistics for %s\n"
@@ -169,13 +171,13 @@ static int _netif_stats(netif_t *iface, unsigned module, bool reset)
                "            TX packets %u (Multicast: %u)  bytes %u\n"
                "            TX succeeded %u errors %u\n",
                _netstats_module_to_str(module),
-               (unsigned) stats->rx_count,
-               (unsigned) stats->rx_bytes,
-               (unsigned) (stats->tx_unicast_count + stats->tx_mcast_count),
-               (unsigned) stats->tx_mcast_count,
-               (unsigned) stats->tx_bytes,
-               (unsigned) stats->tx_success,
-               (unsigned) stats->tx_failed);
+               (unsigned)stats.rx_count,
+               (unsigned)stats.rx_bytes,
+               (unsigned)(stats.tx_unicast_count + stats.tx_mcast_count),
+               (unsigned)stats.tx_mcast_count,
+               (unsigned)stats.tx_bytes,
+               (unsigned)stats.tx_success,
+               (unsigned)stats.tx_failed);
         res = 0;
     }
     return res;


### PR DESCRIPTION
### Contribution description
Instead of retrieving a pointer with NETOPT_STATS, retrieve the current
data. This avoids data corruptions when reading from one thread (e.g.
the thread running the shell (ifconfig command)) while another thread
is updating it (e.g. the netif thread).

The issue affects all boards, as users typically expect the count of
TX packets and the number of TX bytes to refer to the same state. For
16 bit and 8 bit platforms even a single netstat entry can read back
corrupted.

This fixes the issue by just copying the whole netstat_t struct over
without requiring explicit locking on the user side. A multi-threaded
network stack still needs to synchronize the thread responding to
netopt_get with the thread writing to the netstat_t structure, but that
is an implementation detail no relevant to the user of the API.

### Testing procedure

E.g. in `examples/gnrc_networking` the shell command `ifconfig` should still provide stats that look reasonable, but without occasional corruptions.

### Issues/PRs references

None