### PR TITLE
cpu/esp32: use ESP-IDF function esp_efuse_mac for CPU ID

### DIFF
--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -54,7 +54,7 @@ extern "C" {
 /**
  * @brief   Length of the CPU_ID in octets
  */
-#define CPUID_LEN           (7U)
+#define CPUID_LEN               (6U)
 
 /**
  * @name   GPIO configuration


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17841 and provides the changes to use the MAC address as returned by the ESP-IDF function `esp_efuse_mac_get_default` as CPU ID.

### Testing procedure

1. Green CI
2. Compile and test with
   ```
   BOARD=esp32-wroom-32 make -C tests/periph_cpuid flash term
   ```
### Issues/PRs references

Split-off from PR #17841