### PR TITLE
cpu/esp32: use ESP-IDF interrupt HAL for periph/uart

### DIFF
--- a/cpu/esp32/esp-idf-api/uart.c
+++ b/cpu/esp32/esp-idf-api/uart.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32_esp_idf_api
+ * @{
+ *
+ * @file
+ * @brief       Interface for the ESP-IDF UART HAL API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "driver/uart.h"
+#include "hal/uart_hal.h"
+
+#include "esp_idf_api/uart.h"
+
+static uart_hal_context_t _uart_hal_ctx[] = {
+#if UART_NUM_MAX >= 1
+    {
+        .dev = UART_LL_GET_HW(0),
+    },
+#endif
+#if UART_NUM_MAX >= 2
+    {
+        .dev = UART_LL_GET_HW(1),
+    },
+#endif
+#if UART_NUM_MAX >= 3
+    {
+        .dev = UART_LL_GET_HW(2),
+    },
+#endif
+};
+
+void esp_idf_uart_set_wakeup_threshold(unsigned uart_num, uint32_t threshold)
+{
+    assert(uart_num < ARRAY_SIZE(_uart_hal_ctx));
+    uart_hal_set_wakeup_thrd(&_uart_hal_ctx[uart_num], threshold);
+}

--- a/cpu/esp32/include/esp_idf_api/uart.h
+++ b/cpu/esp32/include/esp_idf_api/uart.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32_esp_idf_api
+ * @{
+ *
+ * @file
+ * @brief       Interface for the ESP-IDF UART HAL API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#ifndef ESP_IDF_API_UART_H
+#define ESP_IDF_API_UART_H
+
+#ifndef DOXYGEN     /* Hide implementation details from doxygen */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void esp_idf_uart_set_wakeup_threshold(unsigned uart_num, uint32_t threshold);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+#endif /* ESP_IDF_API_UART_H */

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -560,7 +560,7 @@ typedef struct {
 /**
  * @brief   Maximum number of UART interfaces
  */
-#define UART_NUMOF_MAX  (3)
+#define UART_NUMOF_MAX  (SOC_UART_NUM)
 /** @} */
 
 #ifdef MODULE_PERIPH_CAN


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17841 that:
- provides the changes to use ESP-IDF interrupt HAL for `periph/uart` and
- inverts the `MCU_*` conditionals so that they can be tested for ESP8266. In all other cases the MCU is any ESP32x SoC.

### Testing procedure

1. Green CI
2. Compile and check any simple test app, for example:
    ```
    BOARD=esp32-wroom-32 make -j8 -C tests/shell flash term
    ```

### Issues/PRs references

Split-off from PR #17841 
Prerequisite for PR #18280