### PR TITLE
sys/net/gnrc/rpl: sync access to netstats

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -540,7 +540,17 @@ extern const ipv6_addr_t ipv6_addr_all_rpl_nodes;
 
 #ifdef MODULE_NETSTATS_RPL
 /**
- * @brief Statistics for RPL control messages
+ * @brief   Statistics for RPL control messages
+ * @warning Access to this structure need to be synchronized with the RPL
+ *          thread to avoid reading corrupted valued. The RPL thread will
+ *          disable IRQs while updating the fields. A reader that disables
+ *          IRQs while reading values from here will read back correct and
+ *          consistent values.
+ * @details Note that on 32 bit platforms reading individual fields usually is
+ *          safe without locking, as a 32 bit read typically is an atomic
+ *          operation. However, reasoning about e.g. the relation between TX
+ *          packets and TX bytes will still require IRQs disabled, as the stats
+ *          could be updated between the two reads even on 32 bit platforms.
  */
 extern netstats_rpl_t gnrc_rpl_netstats;
 #endif

--- a/sys/include/net/rpl/rpl_netstats.h
+++ b/sys/include/net/rpl/rpl_netstats.h
@@ -28,45 +28,28 @@ extern "C" {
 #endif
 
 /**
+ * @brief       One block of RPL statistics
+ */
+typedef struct {
+    uint32_t rx_ucast_count;            /**< unicast packets received */
+    uint32_t rx_ucast_bytes;            /**< unicast bytes received */
+    uint32_t rx_mcast_count;            /**< multicast packets received */
+    uint32_t rx_mcast_bytes;            /**< multicast bytes received */
+    uint32_t tx_ucast_count;            /**< unicast packets sent */
+    uint32_t tx_ucast_bytes;            /**< unicast bytes sent */
+    uint32_t tx_mcast_count;            /**< multicast packets sent */
+    uint32_t tx_mcast_bytes;            /**< multicast bytes sent*/
+
+} netstats_rpl_block_t;
+
+/**
  * @brief       RPL statistics struct
  */
 typedef struct {
-    /* DIO */
-    uint32_t dio_rx_ucast_count;        /**< unicast dio received in packets */
-    uint32_t dio_rx_ucast_bytes;        /**< unicast dio received in bytes */
-    uint32_t dio_rx_mcast_count;        /**< multicast dio received in packets */
-    uint32_t dio_rx_mcast_bytes;        /**< multicast dio received in bytes */
-    uint32_t dio_tx_ucast_count;        /**< unicast dio sent in packets */
-    uint32_t dio_tx_ucast_bytes;        /**< unicast dio sent in bytes */
-    uint32_t dio_tx_mcast_count;        /**< multicast dio sent in packets */
-    uint32_t dio_tx_mcast_bytes;        /**< multicast dio sent in bytes*/
-    /* DIS */
-    uint32_t dis_rx_ucast_count;        /**< unicast dis received in packets */
-    uint32_t dis_rx_ucast_bytes;        /**< unicast dis received in bytes */
-    uint32_t dis_rx_mcast_count;        /**< multicast dis received in packets */
-    uint32_t dis_rx_mcast_bytes;        /**< multicast dis received in bytes */
-    uint32_t dis_tx_ucast_count;        /**< unicast dis sent in packets */
-    uint32_t dis_tx_ucast_bytes;        /**< unicast dis sent in bytes */
-    uint32_t dis_tx_mcast_count;        /**< multicast dis sent in packets */
-    uint32_t dis_tx_mcast_bytes;        /**< multicast dis sent in bytes*/
-    /* DAO */
-    uint32_t dao_rx_ucast_count;        /**< unicast dao received in packets */
-    uint32_t dao_rx_ucast_bytes;        /**< unicast dao received in bytes */
-    uint32_t dao_rx_mcast_count;        /**< multicast dao received in packets */
-    uint32_t dao_rx_mcast_bytes;        /**< multicast dao received in bytes */
-    uint32_t dao_tx_ucast_count;        /**< unicast dao sent in packets */
-    uint32_t dao_tx_ucast_bytes;        /**< unicast dao sent in bytes */
-    uint32_t dao_tx_mcast_count;        /**< multicast dao sent in packets */
-    uint32_t dao_tx_mcast_bytes;        /**< multicast dao sent in bytes*/
-    /* DAO-ACK */
-    uint32_t dao_ack_rx_ucast_count;    /**< unicast dao_ack received in packets */
-    uint32_t dao_ack_rx_ucast_bytes;    /**< unicast dao_ack received in bytes */
-    uint32_t dao_ack_rx_mcast_count;    /**< multicast dao_ack received in packets */
-    uint32_t dao_ack_rx_mcast_bytes;    /**< multicast dao_ack received in bytes */
-    uint32_t dao_ack_tx_ucast_count;    /**< unicast dao_ack sent in packets */
-    uint32_t dao_ack_tx_ucast_bytes;    /**< unicast dao_ack sent in bytes */
-    uint32_t dao_ack_tx_mcast_count;    /**< multicast dao_ack sent in packets */
-    uint32_t dao_ack_tx_mcast_bytes;    /**< multicast dao_ack sent in bytes*/
+    netstats_rpl_block_t dio;           /**< DIO statistics */
+    netstats_rpl_block_t dis;           /**< DIS statistics */
+    netstats_rpl_block_t dao;           /**< DAO statistics */
+    netstats_rpl_block_t dao_ack;       /**< DAO-ACK statistics */
 } netstats_rpl_t;
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/netstats.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/netstats.h
@@ -23,6 +23,7 @@
 extern "C" {
 #endif
 
+#include "irq.h"
 #include "net/rpl/rpl_netstats.h"
 
 #define GNRC_RPL_NETSTATS_MULTICAST (0)
@@ -38,12 +39,12 @@ extern "C" {
 static inline void gnrc_rpl_netstats_rx_DIO(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dio_rx_mcast_count++;
-        netstats->dio_rx_mcast_bytes += len;
+        netstats->dio.rx_mcast_count++;
+        netstats->dio.rx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dio_rx_ucast_count++;
-        netstats->dio_rx_ucast_bytes += len;
+        netstats->dio.rx_ucast_count++;
+        netstats->dio.rx_ucast_bytes += len;
     }
 }
 
@@ -57,12 +58,12 @@ static inline void gnrc_rpl_netstats_rx_DIO(netstats_rpl_t *netstats, size_t len
 static inline void gnrc_rpl_netstats_tx_DIO(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dio_tx_mcast_count++;
-        netstats->dio_tx_mcast_bytes += len;
+        netstats->dio.tx_mcast_count++;
+        netstats->dio.tx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dio_tx_ucast_count++;
-        netstats->dio_tx_ucast_bytes += len;
+        netstats->dio.tx_ucast_count++;
+        netstats->dio.tx_ucast_bytes += len;
     }
 }
 
@@ -76,12 +77,12 @@ static inline void gnrc_rpl_netstats_tx_DIO(netstats_rpl_t *netstats, size_t len
 static inline void gnrc_rpl_netstats_rx_DIS(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dis_rx_mcast_count++;
-        netstats->dis_rx_mcast_bytes += len;
+        netstats->dis.rx_mcast_count++;
+        netstats->dis.rx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dis_rx_ucast_count++;
-        netstats->dis_rx_ucast_bytes += len;
+        netstats->dis.rx_ucast_count++;
+        netstats->dis.rx_ucast_bytes += len;
     }
 }
 
@@ -95,12 +96,12 @@ static inline void gnrc_rpl_netstats_rx_DIS(netstats_rpl_t *netstats, size_t len
 static inline void gnrc_rpl_netstats_tx_DIS(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dis_tx_mcast_count++;
-        netstats->dis_tx_mcast_bytes += len;
+        netstats->dis.tx_mcast_count++;
+        netstats->dis.tx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dis_tx_ucast_count++;
-        netstats->dis_tx_ucast_bytes += len;
+        netstats->dis.tx_ucast_count++;
+        netstats->dis.tx_ucast_bytes += len;
     }
 }
 
@@ -114,12 +115,12 @@ static inline void gnrc_rpl_netstats_tx_DIS(netstats_rpl_t *netstats, size_t len
 static inline void gnrc_rpl_netstats_rx_DAO(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dao_rx_mcast_count++;
-        netstats->dao_rx_mcast_bytes += len;
+        netstats->dao.rx_mcast_count++;
+        netstats->dao.rx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dao_rx_ucast_count++;
-        netstats->dao_rx_ucast_bytes += len;
+        netstats->dao.rx_ucast_count++;
+        netstats->dao.rx_ucast_bytes += len;
     }
 }
 
@@ -133,12 +134,12 @@ static inline void gnrc_rpl_netstats_rx_DAO(netstats_rpl_t *netstats, size_t len
 static inline void gnrc_rpl_netstats_tx_DAO(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dao_tx_mcast_count++;
-        netstats->dao_tx_mcast_bytes += len;
+        netstats->dao.tx_mcast_count++;
+        netstats->dao.tx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dao_tx_ucast_count++;
-        netstats->dao_tx_ucast_bytes += len;
+        netstats->dao.tx_ucast_count++;
+        netstats->dao.tx_ucast_bytes += len;
     }
 }
 
@@ -152,12 +153,12 @@ static inline void gnrc_rpl_netstats_tx_DAO(netstats_rpl_t *netstats, size_t len
 static inline void gnrc_rpl_netstats_rx_DAO_ACK(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dao_ack_rx_mcast_count++;
-        netstats->dao_ack_rx_mcast_bytes += len;
+        netstats->dao_ack.rx_mcast_count++;
+        netstats->dao_ack.rx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dao_ack_rx_ucast_count++;
-        netstats->dao_ack_rx_ucast_bytes += len;
+        netstats->dao_ack.rx_ucast_count++;
+        netstats->dao_ack.rx_ucast_bytes += len;
     }
 }
 
@@ -171,12 +172,12 @@ static inline void gnrc_rpl_netstats_rx_DAO_ACK(netstats_rpl_t *netstats, size_t
 static inline void gnrc_rpl_netstats_tx_DAO_ACK(netstats_rpl_t *netstats, size_t len, int cast)
 {
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
-        netstats->dao_ack_tx_mcast_count++;
-        netstats->dao_ack_tx_mcast_bytes += len;
+        netstats->dao_ack.tx_mcast_count++;
+        netstats->dao_ack.tx_mcast_bytes += len;
     }
     else if (cast == GNRC_RPL_NETSTATS_UNICAST) {
-        netstats->dao_ack_tx_ucast_count++;
-        netstats->dao_ack_tx_ucast_bytes += len;
+        netstats->dao_ack.tx_ucast_count++;
+        netstats->dao_ack.tx_ucast_bytes += len;
     }
 }
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/netstats.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/netstats.h
@@ -38,6 +38,9 @@ extern "C" {
  */
 static inline void gnrc_rpl_netstats_rx_DIO(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dio.rx_mcast_count++;
         netstats->dio.rx_mcast_bytes += len;
@@ -46,6 +49,7 @@ static inline void gnrc_rpl_netstats_rx_DIO(netstats_rpl_t *netstats, size_t len
         netstats->dio.rx_ucast_count++;
         netstats->dio.rx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -57,6 +61,9 @@ static inline void gnrc_rpl_netstats_rx_DIO(netstats_rpl_t *netstats, size_t len
  */
 static inline void gnrc_rpl_netstats_tx_DIO(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dio.tx_mcast_count++;
         netstats->dio.tx_mcast_bytes += len;
@@ -65,6 +72,7 @@ static inline void gnrc_rpl_netstats_tx_DIO(netstats_rpl_t *netstats, size_t len
         netstats->dio.tx_ucast_count++;
         netstats->dio.tx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -76,6 +84,9 @@ static inline void gnrc_rpl_netstats_tx_DIO(netstats_rpl_t *netstats, size_t len
  */
 static inline void gnrc_rpl_netstats_rx_DIS(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dis.rx_mcast_count++;
         netstats->dis.rx_mcast_bytes += len;
@@ -84,6 +95,7 @@ static inline void gnrc_rpl_netstats_rx_DIS(netstats_rpl_t *netstats, size_t len
         netstats->dis.rx_ucast_count++;
         netstats->dis.rx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -95,6 +107,9 @@ static inline void gnrc_rpl_netstats_rx_DIS(netstats_rpl_t *netstats, size_t len
  */
 static inline void gnrc_rpl_netstats_tx_DIS(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dis.tx_mcast_count++;
         netstats->dis.tx_mcast_bytes += len;
@@ -103,6 +118,7 @@ static inline void gnrc_rpl_netstats_tx_DIS(netstats_rpl_t *netstats, size_t len
         netstats->dis.tx_ucast_count++;
         netstats->dis.tx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -114,6 +130,9 @@ static inline void gnrc_rpl_netstats_tx_DIS(netstats_rpl_t *netstats, size_t len
  */
 static inline void gnrc_rpl_netstats_rx_DAO(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dao.rx_mcast_count++;
         netstats->dao.rx_mcast_bytes += len;
@@ -122,6 +141,7 @@ static inline void gnrc_rpl_netstats_rx_DAO(netstats_rpl_t *netstats, size_t len
         netstats->dao.rx_ucast_count++;
         netstats->dao.rx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -133,6 +153,9 @@ static inline void gnrc_rpl_netstats_rx_DAO(netstats_rpl_t *netstats, size_t len
  */
 static inline void gnrc_rpl_netstats_tx_DAO(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dao.tx_mcast_count++;
         netstats->dao.tx_mcast_bytes += len;
@@ -141,6 +164,7 @@ static inline void gnrc_rpl_netstats_tx_DAO(netstats_rpl_t *netstats, size_t len
         netstats->dao.tx_ucast_count++;
         netstats->dao.tx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -152,6 +176,9 @@ static inline void gnrc_rpl_netstats_tx_DAO(netstats_rpl_t *netstats, size_t len
  */
 static inline void gnrc_rpl_netstats_rx_DAO_ACK(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dao_ack.rx_mcast_count++;
         netstats->dao_ack.rx_mcast_bytes += len;
@@ -160,6 +187,7 @@ static inline void gnrc_rpl_netstats_rx_DAO_ACK(netstats_rpl_t *netstats, size_t
         netstats->dao_ack.rx_ucast_count++;
         netstats->dao_ack.rx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 /**
@@ -171,6 +199,9 @@ static inline void gnrc_rpl_netstats_rx_DAO_ACK(netstats_rpl_t *netstats, size_t
  */
 static inline void gnrc_rpl_netstats_tx_DAO_ACK(netstats_rpl_t *netstats, size_t len, int cast)
 {
+    /* other threads (e.g. the shell thread via the rpl shell command) read
+     * out the data, so we have to sync accesses */
+    unsigned irq_state = irq_disable();
     if (cast == GNRC_RPL_NETSTATS_MULTICAST) {
         netstats->dao_ack.tx_mcast_count++;
         netstats->dao_ack.tx_mcast_bytes += len;
@@ -179,6 +210,7 @@ static inline void gnrc_rpl_netstats_tx_DAO_ACK(netstats_rpl_t *netstats, size_t
         netstats->dao_ack.tx_ucast_count++;
         netstats->dao_ack.tx_ucast_bytes += len;
     }
+    irq_restore(irq_state);
 }
 
 #ifdef __cplusplus

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -204,33 +204,23 @@ int _gnrc_rpl_send_dis(void)
 }
 
 #ifdef MODULE_NETSTATS_RPL
+static void _print_stats_block(netstats_rpl_block_t *block, const char *name)
+{
+    printf("%7s #packets: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
+           name, block->rx_ucast_count, block->tx_ucast_count,
+           block->rx_mcast_count, block->tx_mcast_count);
+    printf("%7s   #bytes: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
+           name, block->rx_ucast_bytes, block->tx_ucast_bytes,
+           block->rx_mcast_bytes, block->tx_mcast_bytes);
+}
+
 int _stats(void)
 {
     puts(  "Statistics        (ucast) RX / TX                  RX / TX (mcast)");
-    printf("DIO     #packets: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dio_rx_ucast_count, gnrc_rpl_netstats.dio_tx_ucast_count,
-           gnrc_rpl_netstats.dio_rx_mcast_count, gnrc_rpl_netstats.dio_tx_mcast_count);
-    printf("DIO       #bytes: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dio_rx_ucast_bytes, gnrc_rpl_netstats.dio_tx_ucast_bytes,
-           gnrc_rpl_netstats.dio_rx_mcast_bytes, gnrc_rpl_netstats.dio_tx_mcast_bytes);
-    printf("DIS     #packets: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dis_rx_ucast_count, gnrc_rpl_netstats.dis_tx_ucast_count,
-           gnrc_rpl_netstats.dis_rx_mcast_count, gnrc_rpl_netstats.dis_tx_mcast_count);
-    printf("DIS       #bytes: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dis_rx_ucast_bytes, gnrc_rpl_netstats.dis_tx_ucast_bytes,
-           gnrc_rpl_netstats.dis_rx_mcast_bytes, gnrc_rpl_netstats.dis_tx_mcast_bytes);
-    printf("DAO     #packets: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dao_rx_ucast_count, gnrc_rpl_netstats.dao_tx_ucast_count,
-           gnrc_rpl_netstats.dao_rx_mcast_count, gnrc_rpl_netstats.dao_tx_mcast_count);
-    printf("DAO       #bytes: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dao_rx_ucast_bytes, gnrc_rpl_netstats.dao_tx_ucast_bytes,
-           gnrc_rpl_netstats.dao_rx_mcast_bytes, gnrc_rpl_netstats.dao_tx_mcast_bytes);
-    printf("DAO-ACK #packets: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dao_ack_rx_ucast_count, gnrc_rpl_netstats.dao_ack_tx_ucast_count,
-           gnrc_rpl_netstats.dao_ack_rx_mcast_count, gnrc_rpl_netstats.dao_ack_tx_mcast_count);
-    printf("DAO-ACK   #bytes: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           gnrc_rpl_netstats.dao_ack_rx_ucast_bytes, gnrc_rpl_netstats.dao_ack_tx_ucast_bytes,
-           gnrc_rpl_netstats.dao_ack_rx_mcast_bytes, gnrc_rpl_netstats.dao_ack_tx_mcast_bytes);
+    _print_stats_block(&gnrc_rpl_netstats.dio, "DIO");
+    _print_stats_block(&gnrc_rpl_netstats.dis, "DIS");
+    _print_stats_block(&gnrc_rpl_netstats.dao, "DAO");
+    _print_stats_block(&gnrc_rpl_netstats.dao_ack, "DAO-ACK");
     return 0;
 }
 #endif

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -206,12 +206,38 @@ int _gnrc_rpl_send_dis(void)
 #ifdef MODULE_NETSTATS_RPL
 static void _print_stats_block(netstats_rpl_block_t *block, const char *name)
 {
+    /* In the following we need to sync with the RPL thread via disabling IRQs
+     * to avoid reading corrupted data. The simpler strategy would be to
+     * disable IRQs during the whole printing (so in _stats()_, but stdio could
+     * be via a slow UART and, hence, have severe impact on the real time
+     * capabilities of the system. The second and simplest strategy would be to
+     * memcpy the whole netstats_rpl_t on to the stack with IRQs disabled and
+     * print the stack copy with IRQs re-enabled. However, that structure is
+     * 128 B in size, so that we would easily provoke a stack-overflow.
+     *
+     * Our strategy instead is to read the data four values at a time with
+     * IRQs disabled, and print them with IRQs re-enabled. The disadvantage is
+     * that stats may get updated while printing one group of values. However,
+     * the stats are grouped such that closely related values are read together.
+     * Hence, related metrics will always refer to the same state of the stats.
+     */
+    unsigned irq_state = irq_disable();
+    uint32_t rx_ucast = block->rx_ucast_count;
+    uint32_t tx_ucast = block->tx_ucast_count;
+    uint32_t rx_mcast = block->rx_mcast_count;
+    uint32_t tx_mcast = block->tx_mcast_count;
+    irq_restore(irq_state);
     printf("%7s #packets: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           name, block->rx_ucast_count, block->tx_ucast_count,
-           block->rx_mcast_count, block->tx_mcast_count);
+           name, rx_ucast, tx_ucast, rx_mcast, tx_mcast);
+
+    irq_state = irq_disable();
+    rx_ucast = block->rx_ucast_bytes;
+    tx_ucast = block->tx_ucast_bytes;
+    rx_mcast = block->rx_mcast_bytes;
+    tx_mcast = block->tx_mcast_bytes;
+    irq_restore(irq_state);
     printf("%7s   #bytes: %10" PRIu32 " / %-10" PRIu32 "  %10" PRIu32 " / %-10" PRIu32 "\n",
-           name, block->rx_ucast_bytes, block->tx_ucast_bytes,
-           block->rx_mcast_bytes, block->tx_mcast_bytes);
+           name, rx_ucast, tx_ucast, rx_mcast, tx_mcast);
 }
 
 int _stats(void)


### PR DESCRIPTION
### Contribution description

This PR firsts refactors the `netstats_rpl_t` structure to avoid repeated blocks in that structure by declaring a `netstats_rpl_block_t` structure, which is than used for DIO, DIS, DAO, and DAO-ACK statistics. Building on that the printing of the statistics in the `rpl` shell command is refactored to avoid duplicated code.

On top of that the second commit synchronizes the RPL thread updating the RPL netstats with the RPL shell command reading the stats by disabling IRQs. This will prevent printing corrupted data on non-32bit platforms as well as printing inconsistent data (e.g. TX count of old state in conjunction with TX bytes of new state) for all platforms.

### Testing procedure

The statistics printed by the `rpl` shell command should still make sense and not being affected by rare data corruptions during print.

### Issues/PRs references

Suggested in https://github.com/RIOT-OS/RIOT/pull/18269#pullrequestreview-1021732597