### PR TITLE
drivers/nrf802154: do not filter broadcast PAN ID

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -265,6 +265,10 @@ static int _confirm_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
 
         state = STATE_IDLE;
         enable_shorts = true;
+        if (info) {
+            info->status = (_state == STATE_CCA_BUSY) ? TX_STATUS_MEDIUM_BUSY : TX_STATUS_SUCCESS;
+        }
+
         break;
     case IEEE802154_HAL_OP_SET_RX:
         eagain = (radio_state == RADIO_STATE_STATE_RxRu);
@@ -290,10 +294,6 @@ static int _confirm_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
     }
 
     _state = state;
-
-    if (info) {
-        info->status = (_state == STATE_CCA_BUSY) ? TX_STATUS_MEDIUM_BUSY : TX_STATUS_SUCCESS;
-    }
 
     if (enable_shorts) {
         NRF_RADIO->SHORTS = DEFAULT_SHORTS;

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -124,6 +124,11 @@ static bool _l2filter(uint8_t *mhr)
 
     int addr_len = ieee802154_get_dst(mhr, dst_addr, &dst_pan);
 
+    if ((mhr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_BEACON) {
+        if ((memcmp(&nrf802154_pan_id, pan_bcast, 2) == 0)) {
+            return true;
+        }
+    }
     /* filter PAN ID */
     /* Will only work on little endian platform (all?) */
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -197,7 +197,7 @@ static int _request_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
     (void) dev;
 
     int res = -EBUSY;
-    int state;
+    int state = STATE_IDLE;
 
     switch (op) {
     case IEEE802154_HAL_OP_TRANSMIT:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This changes were (almost) cherry-picked from #18156.
It addresses three things:
- It fixes CCA result (before was just throwing garbage)
- It fixes a variable initialization
- It prevents the broadcast PAN ID being filtered.

These commits are required in order to run #18156.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Try running the cca command in `tests/ieee802154_hal`. It should report a mixture of "BUSY" and "CLEAR".
- Set the PAN address of any node to the PAN broadcast (0xffff). The node should still be able to receive frames.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#18156
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
