### PR TITLE
gnrc_netif: move `option_tested` to default init function

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1598,6 +1598,9 @@ int gnrc_netif_default_init(gnrc_netif_t *netif)
 #ifdef MODULE_GNRC_IPV6_NIB
     gnrc_ipv6_nib_init_iface(netif);
 #endif
+#if DEVELHELP
+    assert(options_tested);
+#endif
     return 0;
 }
 
@@ -1816,9 +1819,6 @@ static void *_gnrc_netif_thread(void *args)
         LOG_ERROR("gnrc_netif: init failed: %d\n", ctx->result);
         return NULL;
     }
-#if DEVELHELP
-    assert(options_tested);
-#endif
 #ifdef MODULE_NETSTATS_L2
     memset(&netif->stats, 0, sizeof(netstats_t));
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR moves the netdev specific `options_tested` to the `gnrc_netif_default_init`.
Although the current implementation of `gnrc_netif` is still dependent to `netdev`, this allows to encapsulate all `netdev` specific calls in the `gnrc_netif_ops_t` functions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Probably a compile test should suffice...

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Required by #18156 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
