### PR TITLE
pkg/emlearn: Remove unused emlearn module

### DIFF
--- a/pkg/emlearn/Kconfig
+++ b/pkg/emlearn/Kconfig
@@ -9,10 +9,5 @@ config PACKAGE_EMLEARN
     bool "Machine Learning inference engine package"
     depends on TEST_KCONFIG
     depends on !HAS_ARCH_MSP430
-    select MODULE_EMLEARN
     help
         A header only Machine Learning inference engine package.
-
-config MODULE_EMLEARN
-    bool
-    depends on TEST_KCONFIG

--- a/pkg/emlearn/Makefile.include
+++ b/pkg/emlearn/Makefile.include
@@ -1,7 +1,3 @@
 INCLUDES += -I$(PKGDIRBASE)/emlearn/emlearn
 
 CFLAGS += -Wno-unused-parameter
-
-# There's nothing to build in this package, it's used as a header only library.
-# So it's declated as a pseudo-module
-PSEUDOMODULES += emlearn


### PR DESCRIPTION



### Contribution description

There was a mismatch between Kconfig and make, after some digging it
appears that the make never used the emlearn module, only the package.

This removes the emlearn pseudomodule from make since nothing selects it
and removes the MODULE_EMLEARN from Kconfig to match the make dependency
resolution.

### Testing procedure

Green murdock and I guess just understand it


### Issues/PRs references

