### PR TITLE
pkg/lwip: ease debugging & fix sending from socket bound to anyaddr

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -14,6 +14,11 @@ LWIP_MODULE_MAKEFILE = $(RIOTBASE)/Makefile.base
 .PHONY: $(LWIP_MODULES)
 
 CFLAGS += -Wno-address
+# When compiled e.g. with `CFLAGS += -DIP6_DEBUG=LWIP_DBG_ON`, debug output
+# does not use the correct format specifiers and compilation fails. (All
+# instances were differently named but same sized integer types, e.g. %lx
+# for printing int when sizeof(int) == sizeof(long int).)
+CFLAGS += -Wno-format
 
 make_module = +$(QQ)"$(MAKE)" -C $(2) -f $(LWIP_MODULE_MAKEFILE) MODULE=$(1)
 

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -641,7 +641,8 @@ ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
                 DEBUG("\"\n");
             }
             uint16_t netif = lwip_sock_bind_addr_to_netif(&addr);
-            if (remote->netif != netif) {
+            if ((remote->netif != netif)
+                    && (netif != SOCK_ADDR_ANY_NETIF)) {
                 DEBUG("[lwip_sock_sendv] lwip_sock_bind_addr_to_netif() "
                       "returned %u, but expected %u\n",
                       (unsigned)netif, (unsigned)remote->netif);


### PR DESCRIPTION
### Contribution description

This does three things:

- Add `-Wno-format` to the `CFLAGS` for LWIP, as it uses (from a pedantic point of view) incorrect format specifiers in its debug statements
    - This issue is not triggered without enabling debugging, so this did not show up in the CI
- Add a few debug prints to the `sock_lwip`code that can be enabled by setting `ENABLE_DEBUG` to `1`
- Fix sending from a socket bound to anyaddr

I mostly opened this PR so that I can reference it. But I guess it may be useful to have upstream anyway.

### Testing procedure

1. Set `ENABLE_DEBUG` to `1` and e.g. `examples/gcoap` with `LWIP=1` should print some output when sending.
2. `LWIP=1 make -C examples/gcoap` should now work, such that the server actually sends out the responses to requests it receives

Note: LWIP still does not implement module `sock_aux_local`, which `gcoap` makes use of. (E.g. when a request was received on interface A with both local and remote address being link-local, the response should certainly be send from interface A with the corresponding link-local address and not from interface B. `sock_aux_local` would fix the issue, provided that the IPv6 addresses on interface A and B are different.) But that certainly is out of scope.

### Issues/PRs references

None