### PR TITLE
asymcute: Fix deadlocks in REGACK, SUBACK and UNSUBACK handler

### DIFF
--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -415,6 +415,7 @@ static void _on_regack(asymcute_con_t *con, const uint8_t *data, size_t len)
         /* finish the registration by applying the topic id */
         asymcute_topic_t *topic = req->arg;
         if (topic == NULL) {
+            mutex_unlock(&con->lock);
             return;
         }
 
@@ -497,6 +498,7 @@ static void _on_suback(asymcute_con_t *con, const uint8_t *data, size_t len)
     /* parse and apply assigned topic id */
     asymcute_sub_t *sub = req->arg;
     if (sub == NULL) {
+        mutex_unlock(&con->lock);
         return;
     }
 
@@ -534,6 +536,7 @@ static void _on_unsuback(asymcute_con_t *con, const uint8_t *data, size_t len)
     /* remove subscription from list */
     asymcute_sub_t *sub = req->arg;
     if (sub == NULL) {
+        mutex_unlock(&con->lock);
         return;
     } else if (con->subscriptions == sub) {
         con->subscriptions = sub->next;


### PR DESCRIPTION
### Contribution description

The handlers for the `REGACK`, `SUBACK` and `UNSUBACK` MQTT message lock the connection mutex on function entry via `mutex_lock(&con->lock)`. During automated testing of `asymcute` with [SymEx-VP](https://github.com/agra-uni-bremen/symex-vp), I discovered return paths for these functions which do not unlock the connection mutex. This results in a deadlock which prevents asymcute from sending any further messages.

### Testing procedure

I think this is fairly obvious just by reading the code, i.e. check that there is a `mutex_lock(&con->lock)` but no matching `mutex_unlock(&con->lock)` for the modified return paths.

### Issues/PRs references

None.