### PR TITLE
drivers/at86rf2xx: Switch SRT mode to get random values.

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -151,17 +151,24 @@ static void at86rf2xx_disable_clock_output(at86rf2xx_t *dev)
 #endif
 }
 
-static void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
+void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
 {
 #if AT86RF2XX_SMART_IDLE_LISTENING
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_RPC);
-    tmp |= (AT86RF2XX_TRX_RPC_MASK__RX_RPC_EN |
-            AT86RF2XX_TRX_RPC_MASK__PDT_RPC_EN |
-            AT86RF2XX_TRX_RPC_MASK__PLL_RPC_EN |
-            AT86RF2XX_TRX_RPC_MASK__XAH_TX_RPC_EN |
-            AT86RF2XX_TRX_RPC_MASK__IPAN_RPC_EN);
+    tmp |= AT86RF2XX_TRX_RPC_MASK__RX_RPC__SMART_IDLE;
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_RPC, tmp);
     at86rf2xx_set_rxsensitivity(dev, RSSI_BASE_VAL);
+#else
+    (void) dev;
+#endif
+}
+
+void at86rf2xx_disable_smart_idle(at86rf2xx_t *dev)
+{
+#if AT86RF2XX_SMART_IDLE_LISTENING
+    uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_RPC);
+    tmp &= ~AT86RF2XX_TRX_RPC_MASK__RX_RPC__SMART_IDLE;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_RPC, tmp);
 #else
     (void) dev;
 #endif

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -221,8 +221,9 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
 }
 
 #if AT86RF2XX_RANDOM_NUMBER_GENERATOR
-void at86rf2xx_get_random(const at86rf2xx_t *dev, uint8_t *data, size_t len)
+void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, size_t len)
 {
+    at86rf2xx_disable_smart_idle(dev);
     for (size_t byteCount = 0; byteCount < len; ++byteCount) {
         uint8_t rnd = 0;
         for (uint8_t i = 0; i < 4; ++i) {
@@ -236,5 +237,6 @@ void at86rf2xx_get_random(const at86rf2xx_t *dev, uint8_t *data, size_t len)
         }
         data[byteCount] = rnd;
     }
+    at86rf2xx_enable_smart_idle(dev);
 }
 #endif

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -459,7 +459,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             return sizeof(uint8_t);
 
 #endif /* MODULE_NETDEV_IEEE802154_OQPSK */
-
+#if AT86RF2XX_RANDOM_NUMBER_GENERATOR
+        case NETOPT_RANDOM:
+            assert(max_len >= sizeof(uint32_t));
+            at86rf2xx_get_random(dev, (uint8_t*)val, sizeof(val));
+            break;
+#endif
         default:
             res = -ENOTSUP;
             break;

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -239,7 +239,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev);
  * @param[out] data     buffer to copy the random data to
  * @param[in]  len      number of random bytes to store in data
  */
-void at86rf2xx_get_random(const at86rf2xx_t *dev, uint8_t *data, size_t len);
+void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, size_t len);
 #endif
 
 #ifdef __cplusplus

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -533,6 +533,16 @@ extern "C" {
 #define AT86RF2XX_TRX_RPC_MASK__XAH_TX_RPC_EN                   (0x04)
 #define AT86RF2XX_TRX_RPC_MASK__IPAN_RPC_EN                     (0x02)
 
+/**
+ * @brief   Bits to set to enable smart idle
+ */
+#define AT86RF2XX_TRX_RPC_MASK__RX_RPC__SMART_IDLE \
+        (AT86RF2XX_TRX_RPC_MASK__RX_RPC_EN \
+        | AT86RF2XX_TRX_RPC_MASK__PDT_RPC_EN \
+        | AT86RF2XX_TRX_RPC_MASK__PLL_RPC_EN \
+        | AT86RF2XX_TRX_RPC_MASK__XAH_TX_RPC_EN \
+        | AT86RF2XX_TRX_RPC_MASK__IPAN_RPC_EN)
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -612,6 +612,24 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev);
  */
 bool at86rf2xx_cca(at86rf2xx_t *dev);
 
+/**
+ * @brief   Enable the smart receive tecnology (SRT)
+ *
+ * The SRT reduces the power consumption during RX listening periods.
+ *
+ * @param[in]  dev          device to use
+ *
+ */
+void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev);
+
+/**
+ * @brief   Disable the smart receive tecnology (SRT)
+ *
+ * @param[in]  dev          device to use
+ *
+ */
+void at86rf2xx_disable_smart_idle(at86rf2xx_t *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/driver_at86rf2xx/cmd.c
+++ b/tests/driver_at86rf2xx/cmd.c
@@ -20,7 +20,7 @@
 
 #include "net/netdev/ieee802154.h"
 #include "net/ieee802154.h"
-
+#include "at86rf2xx_internal.h"
 #include "common.h"
 
 #include "od.h"
@@ -303,4 +303,26 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst, size_t dst_len,
     return 0;
 }
 
+#if AT86RF2XX_SMART_IDLE_LISTENING
+void random_net_api(uint8_t idx, uint32_t *value)
+{
+    netdev_ieee802154_t *dev = &devs[idx].netdev;
+    dev->netdev.driver->get(&dev->netdev, NETOPT_RANDOM, value, sizeof(uint32_t));
+}
+
+int random_by_at86rf2xx(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    for (unsigned int i = 0; i < AT86RF2XX_NUM; i++) {
+        uint32_t test = 0;
+        at86rf2xx_get_random(&devs[i], (uint8_t *)&test, sizeof(test));
+        printf("Random number for device %u via native API: %" PRIx32 "\n", i, test);
+        test = 0;
+        random_net_api(i, &test);
+        printf("Random number for device %u via netopt: %" PRIx32 "\n", i, test);
+    }
+    return 0;
+}
+#endif
 /** @} */

--- a/tests/driver_at86rf2xx/common.h
+++ b/tests/driver_at86rf2xx/common.h
@@ -41,6 +41,9 @@ extern at86rf2xx_t devs[AT86RF2XX_NUM];
 void recv(netdev_t *dev);
 int ifconfig(int argc, char **argv);
 int txtsnd(int argc, char **argv);
+#if AT86RF2XX_RANDOM_NUMBER_GENERATOR
+int random_by_at86rf2xx(int argc, char **argv);
+#endif
 void print_addr(uint8_t *addr, size_t addr_len);
 /**
  * @}

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -38,6 +38,9 @@ at86rf2xx_t devs[AT86RF2XX_NUM];
 static const shell_command_t shell_commands[] = {
     { "ifconfig", "Configure netdev", ifconfig },
     { "txtsnd", "Send IEEE 802.15.4 packet", txtsnd },
+#if AT86RF2XX_SMART_IDLE_LISTENING
+    { "random", "Get a value from Random Number Generator", random_by_at86rf2xx },
+#endif
     { NULL, NULL, NULL }
 };
 
@@ -87,7 +90,6 @@ void *_recv_thread(void *arg)
 int main(void)
 {
     puts("AT86RF2xx device driver test");
-
     unsigned dev_success = 0;
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
         const at86rf2xx_params_t *p = &at86rf2xx_params[i];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This Pr is dedicated to resolve the random generation numbers from at86rf233, this should establish the device in a basic operation mode states. also needs to the preamble detector is disabled (RX_PDT_DIS=1). Something else that should be considered is the state of Smart Receiver Technology (SRT), this is an element used to manage the Reception Power Consumption (RPC) and it's affecting the `random_number_generator()` of the `at86rf2xx`. Well this Pull request add the functionality to disable temporarily the `smart_idle_mode` because the random number generator needs take values from RSSI register. When the SRT is active could won´t get the wished random values).

Also to integrate the number generator by the driver implementation, also let's to manipulate the functionality by network options (`netopts`), adding support in the `NETOPT_RANDOM`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
run and falsh the test/driver_at86rf_2xx.
```
make -C tests/driver_at86rf2xx flash term
```
When it has loaded the shell type `random` ( This is a command added only to the test ). 
```
2022-07-01 16:20:56,261 # random
2022-07-01 16:20:56,267 # Random number for device 0 via native API: a2f979f9
2022-07-01 16:20:56,271 # Random number for device 0 via netopt: c200fa9d
```
Also try checking resetting the device to be sure that the self value is not repeating.
```
2022-07-01 16:21:03,653 # main(): This is RIOT! (Version: 2022.07-devel-900-g162cf-feature/at86rf2xx_random_numbers)
2022-07-01 16:21:03,655 # AT86RF2xx device driver test
2022-07-01 16:21:03,659 # Initializing AT86RF2xx radio at SPI_0
2022-07-01 16:21:03,665 # gnrc_netdev: possibly lost interrupt.
2022-07-01 16:21:03,670 # Initialization successful - starting the shell now
> random
2022-07-01 16:21:06,149 # random
2022-07-01 16:21:06,154 # Random number for device 0 via native API: a8f63524
2022-07-01 16:21:06,159 # Random number for device 0 via netopt: c0fe3169
> reboot
2022-07-01 16:21:17,349 # reboot
2022-07-01 16:21:17,381 # main(): This is RIOT! (Version: 2022.07-devel-900-g162cf-feature/at86rf2xx_random_numbers)
2022-07-01 16:21:17,383 # AT86RF2xx device driver test
2022-07-01 16:21:17,386 # Initializing AT86RF2xx radio at SPI_0
2022-07-01 16:21:17,392 # gnrc_netdev: possibly lost interrupt.
2022-07-01 16:21:17,397 # Initialization successful - starting the shell now
> random
2022-07-01 16:21:19,013 # random
2022-07-01 16:21:19,018 # Random number for device 0 via native API: eccf2f1c
2022-07-01 16:21:19,023 # Random number for device 0 via netopt: 7abc92e6
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

Fix #18285 
You can get more information about the SRT in the samr21-xpro-datasheet in the page 1034, section 40.10.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
