### PR TITLE
boards/nucleo144: doc update - usage of cpy2remed programmer and short overview of board

### DIFF
--- a/boards/nucleo-f207zg/doc.txt
+++ b/boards/nucleo-f207zg/doc.txt
@@ -7,7 +7,7 @@
 
 The Nucleo-F207ZG is a board from ST's Nucleo family supporting a ARM
 Cortex-M3
-STM32F207ZG microcontroller with 128Kb of SRAM and 1Mb of ROM Flash.
+STM32F207ZG microcontroller with 128KiB of SRAM and 1MiB of ROM Flash.
 
 ## Hardware
 
@@ -19,8 +19,8 @@ STM32F207ZG microcontroller with 128Kb of SRAM and 1Mb of ROM Flash.
 |:---------- |:----------------- |
 | Family     | ARM Cortex-M3     |
 | Vendor     | ST Microelectronics |
-| RAM        | 128Kb             |
-| Flash      | 1Mb               |
+| RAM        | 128KiB            |
+| Flash      | 1MiB              |
 | Frequency  | up to 120MHz      |
 | FPU        | no                |
 | Timers     | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |

--- a/boards/nucleo-f207zg/doc.txt
+++ b/boards/nucleo-f207zg/doc.txt
@@ -53,6 +53,8 @@ STM32F207ZG microcontroller with 128Kb of SRAM and 1Mb of ROM Flash.
 
 ## Flashing the device
 
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-F207ZG board includes an on-board ST-LINK V2-1 programmer. The
 easiest way to program the board is to use OpenOCD. Once you have installed
 OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
@@ -65,6 +67,19 @@ and debug via GDB by simply typing
 ```
 make BOARD=nucleo-f207zg debug
 ```
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f207zg PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
 ## Supported Toolchains
 For using the ST Nucleo-F207ZG board we strongly recommend the usage of the

--- a/boards/nucleo-f303ze/doc.txt
+++ b/boards/nucleo-f303ze/doc.txt
@@ -53,6 +53,9 @@ microcontroller with 64Kb of RAM and 512Kb of ROM.
 
 
 ## Flashing the device
+
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-F303ZE board includes an on-board ST-LINK V2 programmer.
 The easiest way to program the board is to use OpenOCD. Once you have
 installed OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD)
@@ -65,6 +68,19 @@ and debug via GDB by simply typing
 ```
 BOARD=nucleo-f303ze make debug
 ```
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f303ze PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
 
 ## Supported Toolchains

--- a/boards/nucleo-f303ze/doc.txt
+++ b/boards/nucleo-f303ze/doc.txt
@@ -7,7 +7,7 @@
 
 The Nucleo-F303ZE is a board from ST's Nucleo family supporting a ARM Cortex-M4
 STM32F303ZE
-microcontroller with 64Kb of RAM and 512Kb of ROM.
+microcontroller with 64KiB of RAM and 512KiB of ROM.
 
 ## Hardware
 
@@ -19,8 +19,8 @@ microcontroller with 64Kb of RAM and 512Kb of ROM.
 |:---------- |:----------------- |
 | Family     | ARM Cortex-M4     |
 | Vendor     | ST Microelectronics |
-| RAM        | 64Kb              |
-| Flash      | 512Kb             |
+| RAM        | 64KiB             |
+| Flash      | 512KiB            |
 | Frequency  | up to 72MHz       |
 | FPU        | yes               |
 | Timers     | 14 (10x 16-bit, 1x 32-bit [TIM2], 1x Systick, 2x watchdog) |

--- a/boards/nucleo-f412zg/doc.txt
+++ b/boards/nucleo-f412zg/doc.txt
@@ -2,7 +2,7 @@
  @defgroup    boards_nucleo-f412zg STM32 Nucleo-F412ZG
  @ingroup     boards_common_nucleo144
  @brief       Support for the STM32 Nucleo-F412ZG
- 
+
 ## Overview
 
 The Nucleo-F412ZG is a board from ST's Nucleo family supporting ARM Cortex-M4

--- a/boards/nucleo-f412zg/doc.txt
+++ b/boards/nucleo-f412zg/doc.txt
@@ -2,4 +2,24 @@
  @defgroup    boards_nucleo-f412zg STM32 Nucleo-F412ZG
  @ingroup     boards_common_nucleo144
  @brief       Support for the STM32 Nucleo-F412ZG
- */
+ 
+## Overview
+
+The Nucleo-F412ZG is a board from ST's Nucleo family supporting ARM Cortex-M4
+STM32F412ZG microcontroller with 256KiB of RAM and 1MiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f412zg PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw
+-link007.html).
+
+*/

--- a/boards/nucleo-f413zh/doc.txt
+++ b/boards/nucleo-f413zh/doc.txt
@@ -2,4 +2,23 @@
  @defgroup    boards_nucleo-f413zh STM32 Nucleo-F413ZH
  @ingroup     boards_common_nucleo144
  @brief       Support for the STM32 Nucleo-F413ZH
+
+## Overview
+
+The Nucleo-F413ZH is a board from ST's Nucleo family supporting ARM Cortex-M4
+STM32F413ZH microcontroller with 256KiB of RAM and 1MiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f413zh PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER requires ST-LINK firmware 2.37.26 or newer. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
  */

--- a/boards/nucleo-f429zi/doc.txt
+++ b/boards/nucleo-f429zi/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-F429ZI is a board from ST's Nucleo family supporting ARM Cortex-M4
-STM32F429ZI microcontroller with 256kB or RAM and 2Mb of Flash.
+STM32F429ZI microcontroller with 256KiB of RAM and 2MiB of Flash.
 
 ##Hardware
 
@@ -18,8 +18,8 @@ STM32F429ZI microcontroller with 256kB or RAM and 2Mb of Flash.
 |:-------------|:--------------------|
 | Family       | ARM Cortex-M4       |
 | Vendor       | ST Microelectronics |
-| RAM          | 256kB               |
-| Flash        | 2MB                 |
+| RAM          | 256KiB              |
+| Flash        | 2MiB                |
 | Frequency    | up to 180 MHz       |
 | FPU          | yes                 |
 | Ethernet     | 10/100 Mbps         |

--- a/boards/nucleo-f439zi/doc.txt
+++ b/boards/nucleo-f439zi/doc.txt
@@ -3,6 +3,10 @@
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F439ZI
 
+## Overview
+
+The Nucleo-F439ZI is a board from ST's Nucleo family supporting ARM Cortex-M4
+STM32F439ZI microcontroller with, 256KiB or RAM and 2MiB of Flash.
 
 ## Flashing the device
 

--- a/boards/nucleo-f446ze/doc.txt
+++ b/boards/nucleo-f446ze/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-F446ZE is a board from ST's Nucleo family supporting a ARM Cortex-M4
-STM32F446ZE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
+STM32F446ZE microcontroller with 128KiB of RAM and 512KiB of ROM Flash.
 
 ## Hardware
 
@@ -18,8 +18,8 @@ STM32F446ZE microcontroller with 128Kb of RAM and 512Kb of ROM Flash.
 |:---------- |:----------------- |
 | Family     | ARM Cortex-M4     |
 | Vendor     | ST Microelectronics |
-| RAM        | 128Kb             |
-| Flash      | 512Kb             |
+| RAM        | 128KiB            |
+| Flash      | 512KiB            |
 | Frequency  | up to 180MHz      |
 | FPU        | yes               |
 | Timers     | 17 (2x watchdog, 1 SysTick, 12x 16-bit, 2x 32-bit [TIM2]) |

--- a/boards/nucleo-f722ze/doc.txt
+++ b/boards/nucleo-f722ze/doc.txt
@@ -2,4 +2,23 @@
 @defgroup    boards_nucleo-f722ze STM32 Nucleo-F722ZE
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F722ZE
+
+## Overview
+
+The Nucleo-F722ZE is a board from ST's Nucleo family supporting ARM Cortex-M7
+STM32F722ZE microcontroller with 256KiB of RAM and 512KiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f722ze PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+
  */

--- a/boards/nucleo-f722ze/doc.txt
+++ b/boards/nucleo-f722ze/doc.txt
@@ -19,6 +19,6 @@ this manner, use the command:
 make BOARD=nucleo-f722ze PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
  */

--- a/boards/nucleo-f746zg/doc.txt
+++ b/boards/nucleo-f746zg/doc.txt
@@ -2,4 +2,23 @@
 @defgroup    boards_nucleo-f746zg STM32 Nucleo-F746ZG
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F746ZG
+
+## Overview
+
+The Nucleo-F746ZG is a board from ST's Nucleo family supporting ARM Cortex-M7
+STM32F746ZG microcontroller with 320KiB of RAM and 1 MiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f746zg PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+
  */

--- a/boards/nucleo-f746zg/doc.txt
+++ b/boards/nucleo-f746zg/doc.txt
@@ -19,6 +19,6 @@ this manner, use the command:
 make BOARD=nucleo-f746zg PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
  */

--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -2,4 +2,23 @@
 @defgroup    boards_nucleo-f767zi STM32 Nucleo-F767ZI
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-F767ZI
+
+## Overview
+
+The Nucleo-F767ZI is a board from ST's Nucleo family supporting ARM Cortex-M7
+STM32F767ZI microcontroller with 512KiB of RAM and 2 MiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-f767zi PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+
  */

--- a/boards/nucleo-f767zi/doc.txt
+++ b/boards/nucleo-f767zi/doc.txt
@@ -19,6 +19,6 @@ this manner, use the command:
 make BOARD=nucleo-f767zi PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
 
  */

--- a/boards/nucleo-l496zg/doc.txt
+++ b/boards/nucleo-l496zg/doc.txt
@@ -2,4 +2,23 @@
 @defgroup    boards_nucleo-l496zg STM32 Nucleo-L496ZG
 @ingroup     boards_common_nucleo144
 @brief       Support for the STM32 Nucleo-l496zg
+
+## Overview
+
+The Nucleo-L496ZG is a board from ST's Nucleo family supporting ARM Cortex-M4
+STM32L496ZG ultra-low-pawer microcontroller with 320KiB of RAM and 1 MiB of Flash.
+
+## Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l496zg PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html
+
  */

--- a/boards/nucleo-l4r5zi/doc.txt
+++ b/boards/nucleo-l4r5zi/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L4R5ZI is a board from ST's Nucleo family supporting a ARM Cortex-M4
-STM32L4R5ZI microcontroller with 640Kb of RAM and 2Mb of ROM Flash.
+STM32L4R5ZI microcontroller with 640KiB of RAM and 2MiB of ROM Flash.
 
 ## Flashing the device
 

--- a/boards/nucleo-l4r5zi/doc.txt
+++ b/boards/nucleo-l4r5zi/doc.txt
@@ -10,6 +10,8 @@ STM32L4R5ZI microcontroller with 640Kb of RAM and 2Mb of ROM Flash.
 
 ## Flashing the device
 
+### Flashing the Board Using OpenOCD
+
 The ST Nucleo-L4R5ZI board includes an on-board ST-LINK programmer and can be
 flashed using OpenOCD.
 @note The latest release of OpenOCD doesn't contain support for this board,
@@ -21,6 +23,20 @@ To flash this board, just use the following command:
 ```
 make BOARD=nucleo-l4r5zi flash -C examples/hello-world
 ```
+
+### Flashing the Board Using ST-LINK Removable Media
+
+On-board ST-LINK programmer provides via composite USB device removable media.
+Copying the HEX file causes reprogramming of the board. This task
+could be performed manually; however, the cpy2remed (copy to removable
+media) PROGRAMMER script does this automatically. To program board in
+this manner, use the command:
+```
+make BOARD=nucleo-l4r5zi PROGRAMMER=cpy2remed flash
+```
+@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
+could be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+
 
 ### STDIO
 

--- a/boards/nucleo-l552ze-q/doc.txt
+++ b/boards/nucleo-l552ze-q/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Nucleo-L552ZE-Q is a board from ST's Nucleo family supporting ARM Cortex-M33
-STM32L552ZE ultra-low-pawer microcontroller with TrustZone, 256kB or RAM and 512Kb
+STM32L552ZE ultra-low-pawer microcontroller with TrustZone, 256KiB or RAM and 512KiB
 of Flash.
 
 ## Hardware
@@ -19,8 +19,8 @@ of Flash.
 |:-------------|:-----------------------------|
 | Family       | ARM Cortex-M33               |
 | Vendor       | ST Microelectronics          |
-| RAM          | 256Kb                        |
-| Flash        | 512Kb                        |
+| RAM          | 256KiB                       |
+| Flash        | 512KiB                       |
 | Frequency    | up tp 110MHz                 |
 | FPU          | yes                          |
 | TrustZone    | yes                          |


### PR DESCRIPTION
### Contribution description

PR #18057 enables **_cpy2remed_** programmer for all STM Nucleo boards.

This PR adds to nucleo144 boards documentation:

-  information about usage of **_cpy2remed_** programmer,
-  short information about board (used MCU, available RAM and Flash),
-  change all memory sizes to KiB (before kB or Kb are used) .
 
### Testing procedure

Changes in documentation can be observed using commands:
```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-f207zg.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f303ze.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f412zg.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f413zh.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f722ze.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f746zg.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f767zi.html
xdg-open doc/doxygen/html/group__boards__nucleo-l496zg.html 
xdg-open doc/doxygen/html/group__boards__nucleo144-l4r5.html
```
Or observed directly in documentation generated by [CI](https://output.circle-artifacts.com/output/job/6a535f98-7be9-44f8-bee3-d46d38a52246/artifacts/0/doc/group__boards__nucleo-f207zg.html)

### Issues/PRs references

Depends on PR #18057