### PR TITLE
boards/im880b: im880b board clock definition

### DIFF
--- a/boards/im880b/include/periph_conf.h
+++ b/boards/im880b/include/periph_conf.h
@@ -26,6 +26,18 @@
 #define CONFIG_BOARD_HAS_LSE            1
 #endif
 
+/**
+ * @brief   This board has an HSE clock
+ */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE            1
+#endif
+
+/**
+ * @brief   Speed of the HSE clock in Hz
+ */
+#define CLOCK_HSE                       MHZ(16)
+
 #include "periph_cpu.h"
 #include "clk_conf.h"
 


### PR DESCRIPTION
Commit [c14d7ec7dbc2238ad251a70904407e503342b82d](https://github.com/RIOT-OS/RIOT/commit/c14d7ec7dbc2238ad251a70904407e503342b82d) requires the definition of the clock peripherals on a given board but the im880b does not provide such a definition in its configuration file. This PR defines the HSE clock as the 16 MHz external clock.
This PR aims at solving https://github.com/RIOT-OS/RIOT/pull/18293

Signed-off-by: Jean-Michel Friedt <friedtj@free.fr>