### PR TITLE
pkg/lv_drivers: cleanup Makefile

### DIFF
--- a/pkg/lv_drivers/Makefile
+++ b/pkg/lv_drivers/Makefile
@@ -5,14 +5,11 @@ PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-IGNORE_MODULES := \
-                  #
+LV_DRIVERS_MODULES := $(filter lv_drivers_%,$(USEMODULE))
 
-LV_DRIVERS_MODULES := $(filter-out $(IGNORE_MODULES),$(filter lv_drivers_%,$(USEMODULE)))
-
-.PHONY: lvgl_%
+.PHONY: lv_drivers_%
 
 all: $(LV_DRIVERS_MODULES)
 
-lv_drivers_sdl:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR)/sdl -f $(CURDIR)/Makefile.lv_drivers_module MODULE=$@ SRC=sdl.c
+lv_drivers_%:
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$* -f $(CURDIR)/Makefile.lv_drivers_module MODULE=$@ SRC=$*.c


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

While working on #18301, I noticed some inconsistencies in this Makefile. This PR addresses them:
- the IGNORE_MODULES variable is empty and there's no way to modify it. So let's just drop it
- the PHONY targets are wrong
- there's a tiny generalization of the `lv_drivers_%` target. I can drop that change if this is controversial. Normally each possible drivers (sdl, wayland, win32drv, gtkdrv) should work with that but I don't think they are used by this package anyway.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- `tests/pkg_lvgl` and `tests/pkg_lvgl_touch` are still working on native (so with the sdl driver)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
