### PR TITLE
gh_action/test-on-iotlab: update available boards

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -36,14 +36,10 @@ jobs:
           - riot: dwm1001
             iotlab:
               archi: dwm1001:dw1000
-              site: saclay
+              site: lille
           - riot: iotlab-m3
             iotlab:
               archi: m3:at86rf231
-              site: saclay
-          - riot: nrf51dk
-            iotlab:
-              archi: nrf51dk:ble
               site: saclay
           - riot: nrf52dk
             iotlab:
@@ -52,10 +48,6 @@ jobs:
           - riot: nrf52840dk
             iotlab:
               archi: nrf52840dk:multi
-              site: saclay
-          - riot: nrf52832-mdk
-            iotlab:
-              archi: nrf52832mdk:ble
               site: saclay
           - riot: nucleo-wl55jc
             iotlab:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

After today's maintenance on IoT-LAB some boards are no longer available on the Saclay site and some are now only available in Lille. This PR updates the test-on-iotlab build matrix to reflect that change.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- test-on-iotlab should run as expected, e.g use dwm1001 from lille and don't build on nrf51dk and nrf52832mdk

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
