### PR TITLE
drivers/at86rf2xx: fix NETOPT_RANDOM

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -461,9 +461,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 #endif /* MODULE_NETDEV_IEEE802154_OQPSK */
 #if AT86RF2XX_RANDOM_NUMBER_GENERATOR
         case NETOPT_RANDOM:
-            assert(max_len >= sizeof(uint32_t));
-            at86rf2xx_get_random(dev, (uint8_t*)val, sizeof(val));
-            break;
+            at86rf2xx_get_random(dev, (uint8_t*)val, max_len);
+            return max_len;
 #endif
         default:
             res = -ENOTSUP;


### PR DESCRIPTION
### Contribution description

A bug slipped past my review :/

- fix wrong return value
- fix wrong size parameter
    - note, the behavior is a bit relaxed in that it allows `NETOPT_RANDOM` with different size than `sizeof(uint32_t)`

### Testing procedure

The `tests/driver_at86rf2xx` the `random` command should  now succeed

### Issues/PRs references

None