### PR TITLE
gnrc_dhcpv6_client: Fix out-of-bounds access during option parsing

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -988,6 +988,7 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
         DEBUG("DHCPv6 client: packet too small or transaction ID wrong\n");
         return false;
     }
+    len = orig_len - sizeof(dhcpv6_msg_t);
     for (dhcpv6_opt_t *opt = (dhcpv6_opt_t *)(&rep[sizeof(dhcpv6_msg_t)]);
          len > 0; len -= _opt_len(opt), opt = _opt_next(opt)) {
         if (len > orig_len) {
@@ -1078,6 +1079,10 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
                  }
             default:
                 break;
+        }
+        /* 0 option is used as an end marker, len can include bogus bytes */
+        if (!byteorder_ntohs(opt->type)) {
+            break;
         }
     }
     return true;


### PR DESCRIPTION
### Contribution description

The `_parse_reply` function provided by `gnrc_dhcpv6_client` has two parsing loops for the DHCPv6 message options:

https://github.com/RIOT-OS/RIOT/blob/37a4fffb1796a67dff70cf337128a6e9dfd60cb5/sys/net/application_layer/dhcpv6/client.c#L991-L1023

and:

https://github.com/RIOT-OS/RIOT/blob/37a4fffb1796a67dff70cf337128a6e9dfd60cb5/sys/net/application_layer/dhcpv6/client.c#L1053-L1082

Only the first parsing loop performs a sanity check on the length field of the DHCPv6 option:

https://github.com/RIOT-OS/RIOT/blob/37a4fffb1796a67dff70cf337128a6e9dfd60cb5/sys/net/application_layer/dhcpv6/client.c#L993-L996

In the second parsing loop it is assumed that all options have a valid length field and no further sanity checks are performed. However, there are two problems with this assumption:

1. The second parsing loop correctly decrements the `orig_len` by `sizeof(dhcpv6_msg_t)`. The first parsing loop doesn't do this which is wrong since it also (correctly) skips the message type and transaction ID headers when parsing the options. As such, both loops operate on different `len` values. I believe this to be an oversight which was missed in https://github.com/RIOT-OS/RIOT/pull/13622.
2. Since https://github.com/RIOT-OS/RIOT/pull/17736, the first parsing loop stops parsing when encountering a zero option. However, the second parsing loop continues parsing even after the zero option. As such, the length field of all options after a zero option are not checked and can cause an out-of-bounds memory read in the second option parsing loop.

### Testing procedure

This is somewhat difficult to test since transaction ID etc. need to match.

However, I can demonstrate this issue through "unit testing" of `_parse_reply`.

Compile the following application:

```C
#include <stdbool.h>
#include <stdint.h>

uint8_t input[] = {
0x07, 0x02, 0x20, 0x8E, 0x00, 0x01, 0x00, 0x04, 0x00, 0x03, 0x00, 0x14, 0x00, 0x02, 0x00, 0x04,
0xAA, 0xBB, 0x0C, 0x1D, 0x58, 0x5E, 0x00, 0x02, 0xDE, 0x9C, 0x00, 0x00, 0xB8, 0x10, 0x00, 0x06,
0x9C, 0x1C, 0x1C, 0x1C
};

extern bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type);

int main(void)
{
    _parse_reply(input, sizeof(input), 0);
    return 0;
}
```

With the following `Makefile`:

```make
APPLICATION = parse-reply
BOARD = native

RIOTBASE ?= $(CURDIR)/../..

DEVELHELP ?= 1

USEMODULE += gnrc_ipv6_default
USEMODULE += gnrc_dhcpv6_client

include $(RIOTBASE)/Makefile.include
```

and make the following modifications to `_parse_reply` to disable some sanity checks on the transaction ID etc:

```diff
diff --git a/sys/net/application_layer/dhcpv6/client.c b/sys/net/application_layer/dhcpv6/client.c
index 237a86a44a..885d9963df 100644
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -33,7 +33,7 @@
 #include "xtimer/implementation.h"
 #endif

-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 #include "debug.h"

 #include "_dhcpv6.h"
@@ -974,7 +974,7 @@ static bool _parse_ia_na_option(dhcpv6_opt_ia_na_t *ia_na)
     return true;
 }

-static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
+bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
 {
     dhcpv6_opt_duid_t *cid = NULL, *sid = NULL;
     dhcpv6_opt_status_t *status = NULL;
@@ -984,7 +984,7 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
     size_t orig_len = len;

     DEBUG("DHCPv6 client: received REPLY\n");
-    if ((len < sizeof(dhcpv6_msg_t)) || !_is_tid((dhcpv6_msg_t *)rep)) {
+    if ((len < sizeof(dhcpv6_msg_t))) {
         DEBUG("DHCPv6 client: packet too small or transaction ID wrong\n");
         return false;
     }
@@ -1027,7 +1027,9 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
         return false;
     }
     if (!_check_cid_opt(cid) || !_check_sid_opt(sid)) {
+#if 0
         return false;
+#endif
     }
     if (smr != NULL) {
         sol_max_rt = byteorder_ntohl(smr->value);
@@ -1047,9 +1049,7 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
         }
         _set_event_timeout_sec(&information_refresh_timeout, &refresh_information, refresh_time);
     }
-    if (!_check_status_opt(status)) {
-        return false;
-    }
+    (void)status;
     len = orig_len - sizeof(dhcpv6_msg_t);
     for (dhcpv6_opt_t *opt = (dhcpv6_opt_t *)(&rep[sizeof(dhcpv6_msg_t)]);
          len > 0; len -= _opt_len(opt), opt = _opt_next(opt)) {
```

Afterwards, run:

```
$ make -C examples/parse_reply/ all-valgrind
$ make -C examples/parse_reply/ term-valgrind
main(): This is RIOT! (Version: 2022.07-devel-1001-g1ba2ef)
DHCPv6 client: received REPLY
DHCPv6 client: message is not for me
==21654== Invalid read of size 2
==21654==    at 0x804E712: byteorder_swaps (sys/include/byteorder.h:405)
==21654==    by 0x804E712: byteorder_ntohs (sys/include/byteorder.h:548)
==21654==    by 0x804E712: _parse_reply (sys/net/application_layer/dhcpv6/client.c:1056)
==21654==    by 0x804964C: main (examples/parse_reply/main.c:15)
==21654==  Address 0x8079000 is on thread 1's stack
==21654==
==21654== Invalid read of size 2
==21654==    at 0x804E6FC: byteorder_swaps (sys/include/byteorder.h:405)
==21654==    by 0x804E6FC: byteorder_ntohs (sys/include/byteorder.h:548)
==21654==    by 0x804E6FC: _opt_len (sys/net/application_layer/dhcpv6/client.c:547)
==21654==    by 0x804E6FC: _parse_reply (sys/net/application_layer/dhcpv6/client.c:1055)
==21654==    by 0x804964C: main (examples/parse_reply/main.c:15)
==21654==  Address 0x8079002 is on thread 1's stack
==21654==
==21654==
==21654== Process terminating with default action of signal 11 (SIGSEGV)
==21654==  Access not within mapped region at address 0x807A000
==21654==    at 0x804E712: byteorder_swaps (sys/include/byteorder.h:405)
==21654==    by 0x804E712: byteorder_ntohs (sys/include/byteorder.h:548)
==21654==    by 0x804E712: _parse_reply (sys/net/application_layer/dhcpv6/client.c:1056)
```

### Issues/PRs references

* https://github.com/RIOT-OS/RIOT/pull/13622
* https://github.com/RIOT-OS/RIOT/pull/17736