### PR TITLE
gnrc_border_router: Fix syntax error in Kea configuration

### DIFF
--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -64,7 +64,7 @@ server e.g. you can use the following configuration:
        "subnet": "2001:db8::/16",
        "pd-pools": [ { "prefix": "2001:db8::",
                        "prefix-len": 16,
-                       "delegated-len": 64 } ] },
+                       "delegated-len": 64 } ] }
   ]
   ...
 }


### PR DESCRIPTION
The last element of a JSON array must not be terminated with a `,` character. As such, the configuration documented currently in the `README.md` file of gnrc_border_router is invalid and rejected by Kea.