### PR TITLE
sys/fmt: fix return value mismatch in comments (1 byte is 8 bits, not 4 bits)

### DIFF
--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -162,6 +162,20 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex);
 /**
  * @brief   Convert a uint16 value to hex string.
  *
+ * Will write 2 bytes to @p out.
+ * If @p out is NULL, will only return the number of bytes that would have
+ * been written.
+ *
+ * @param[out]  out  Pointer to output buffer, or NULL
+ * @param[in]   val  Value to convert
+ *
+ * @return      2
+ */
+size_t fmt_u16_hex(char *out, uint16_t val);
+
+/**
+ * @brief Convert a uint32 value to hex string.
+ *
  * Will write 4 bytes to @p out.
  * If @p out is NULL, will only return the number of bytes that would have
  * been written.
@@ -171,10 +185,10 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex);
  *
  * @return      4
  */
-size_t fmt_u16_hex(char *out, uint16_t val);
+size_t fmt_u32_hex(char *out, uint32_t val);
 
 /**
- * @brief Convert a uint32 value to hex string.
+ * @brief Convert a uint64 value to hex string.
  *
  * Will write 8 bytes to @p out.
  * If @p out is NULL, will only return the number of bytes that would have
@@ -184,20 +198,6 @@ size_t fmt_u16_hex(char *out, uint16_t val);
  * @param[in]   val  Value to convert
  *
  * @return      8
- */
-size_t fmt_u32_hex(char *out, uint32_t val);
-
-/**
- * @brief Convert a uint64 value to hex string.
- *
- * Will write 16 bytes to @p out.
- * If @p out is NULL, will only return the number of bytes that would have
- * been written.
- *
- * @param[out]  out  Pointer to output buffer, or NULL
- * @param[in]   val  Value to convert
- *
- * @return      16
  */
 size_t fmt_u64_hex(char *out, uint64_t val);
 


### PR DESCRIPTION
### Contribution description

In RIOT, `1 byte == 8 bits` is strongly assumed:
  * [/sys/include/bcd.h](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/bcd.h) (Binary coded decimal)
  * [/sys/include/byteorder.h](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/byteorder.h) (Byte orders)

However, in [the latest `a8254d5`](https://github.com/RIOT-OS/RIOT/tree/a8254d52b8488a4d9edc3153b38634375585746b) [/sys/include/fmt.h](https://github.com/RIOT-OS/RIOT/blob/a8254d52b8488a4d9edc3153b38634375585746b/sys/include/fmt.h), comments are assuming that `1 byte == 4 bits`:
  * In comment, `uint16_t` bytes size is `4`, should be `2`: https://github.com/RIOT-OS/RIOT/blob/a8254d52b8488a4d9edc3153b38634375585746b/sys/include/fmt.h#L163-L165
  * In comment, `uint32_t` bytes size is `8`, should be `4`: https://github.com/RIOT-OS/RIOT/blob/a8254d52b8488a4d9edc3153b38634375585746b/sys/include/fmt.h#L177-L179
  * In comment, `uint64_t` bytes size is `16`, should be `8`: https://github.com/RIOT-OS/RIOT/blob/a8254d52b8488a4d9edc3153b38634375585746b/sys/include/fmt.h#L191-L193

So for matching with other RIOT codes `1 byte == 8 bits`, I fixed above comments by `/2`: