### PR TITLE
gnrc/ipv6_auto_subnets: improve wording in documentation, add to Doxygen

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -776,7 +776,8 @@ INPUT                  = ../../doc.txt \
                          src/release-cycle.md \
                          src/changelog.md \
                          ../../LOSTANDFOUND.md \
-                         ../../makefiles/pseudomodules.inc.mk
+                         ../../makefiles/pseudomodules.inc.mk \
+                         ../../sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -128,6 +128,9 @@
 #define CONFIG_GNRC_IPV6_AUTO_SUBNETS_NUMOF         (1)
 #endif
 
+/* Code below should not be included by Doxygen */
+#ifndef DOXYGEN
+
 #define SERVER_THREAD_STACKSIZE                     (THREAD_STACKSIZE_DEFAULT)
 #define SERVER_MSG_QUEUE_SIZE                       (CONFIG_GNRC_IPV6_AUTO_SUBNETS_PEERS_MAX)
 #define SERVER_MSG_TYPE_TIMEOUT                     (0x8fae)
@@ -645,4 +648,5 @@ void gnrc_ipv6_auto_subnets_init(void)
                                 _eventloop, NULL, "auto_subnets");
 }
 #endif /* !IS_USED(MODULE_GNRC_IPV6_AUTO_SUBNETS_SIMPLE) */
+#endif /* !DOXYGEN */
 /** @} */

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -17,9 +17,9 @@
  * This module provides an automatic configuration for networks with a (simple)
  * tree topology.
  *
- * If a sufficiently large IPv6 prefix (> /64) is provided via Router Advertisements,
- * a routing node with this module will automatically configure subnets from it
- * by dividing it into sub-prefixes for each downstream interface.
+ * If a sufficiently large IPv6 subnet (prefix length < /64) is provided via Router
+ * Advertisements, a routing node with this module will automatically configure
+ * subnets from it by dividing it into sub-prefixes for each downstream interface.
  *
  * When using the `gnrc_ipv6_auto_subnets_simple` module, there can only be a single
  * routing node on each level of the network but an arbitrary number of leaf nodes.
@@ -44,10 +44,10 @@
  *
  * The new subnet must no longer be considered on-link by the hosts in the
  * parent network.
- * Therefore the downstream router will send a router advertisement with only
- * a Route Information Option included to the upstream network.
+ * Therefore the downstream router will send a router advertisement, which only
+ * contains a Route Information Option, to the upstream network.
  * The Route Information Option contains the prefix of the downstream network
- * so that upstream routers will no longer consider hosts in this subnet on-link
+ * so that upstream routers will no longer consider hosts in this subnet on-link,
  * but instead will use the downstream router to route to the new subnet.
  *
  * Usage


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A *smaller* prefix makes a *larger* subnet and vice versa.
Make the wording in the documentation more precise. 


### Testing procedure

Only doc changes.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
