### PR TITLE
gcoap: move tl_type to coap_request_ctx_t

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -230,13 +230,6 @@ typedef struct {
     BITFIELD(opt_crit, CONFIG_NANOCOAP_NOPTS_MAX);    /**< unhandled critical option */
 #ifdef MODULE_GCOAP
     uint32_t observe_value;                           /**< observe value           */
-    /**
-     * @brief   transport the packet was received over
-     * @see     @ref gcoap_socket_type_t for values.
-     * @note    @ref gcoap_socket_type_t can not be used, as this would
-     *          cyclically include the @ref net_gcoap header.
-     */
-    uint32_t tl_type;
 #endif
 } coap_pkt_t;
 
@@ -343,6 +336,16 @@ const char *coap_request_ctx_get_path(const coap_request_ctx_t *ctx);
  * @return  Resource context of the request
  */
 void *coap_request_ctx_get_context(const coap_request_ctx_t *ctx);
+
+/**
+ * @brief   Get transport the packet was received over
+ * @see     @ref gcoap_socket_type_t for values.
+ *
+ * @param[in]   ctx The request context
+ *
+ * @return  Transport Layer type of the request
+ */
+uint32_t coap_request_ctx_get_tl_type(const coap_request_ctx_t *ctx);
 
 /**
  * @brief   Block1 helper struct

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -684,13 +684,12 @@ static size_t _handle_req(gcoap_socket_t *sock, coap_pkt_t *pdu, uint8_t *buf,
         return -1;
     }
 
-    pdu->tl_type = (uint32_t)sock->type;
-
     ssize_t pdu_len;
     char *offset;
 
     coap_request_ctx_t ctx = {
         .resource = resource,
+        .tl_type = (uint32_t)sock->type,
     };
 
     if (coap_get_proxy_uri(pdu, &offset) > 0) {
@@ -899,7 +898,7 @@ static ssize_t _well_known_core_handler(coap_pkt_t* pdu, uint8_t *buf, size_t le
 
     plen += gcoap_get_resource_list_tl(pdu->payload, (size_t)pdu->payload_len,
                                        COAP_FORMAT_LINK,
-                                       (gcoap_socket_type_t)pdu->tl_type);
+                                       (gcoap_socket_type_t)coap_request_ctx_get_tl_type(ctx));
     return plen;
 }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1246,3 +1246,13 @@ void *coap_request_ctx_get_context(const coap_request_ctx_t *ctx)
 {
     return ctx->context;
 }
+
+uint32_t coap_request_ctx_get_tl_type(const coap_request_ctx_t *ctx)
+{
+#ifdef MODULE_GCOAP
+    return ctx->tl_type;
+#else
+    (void)ctx;
+    return 0;
+#endif
+}

--- a/sys/net/application_layer/nanocoap/nanocoap_internal.h
+++ b/sys/net/application_layer/nanocoap/nanocoap_internal.h
@@ -32,6 +32,15 @@ struct _coap_request_ctx {
     const coap_resource_t *resource;    /**< resource of the request */
     void *context;                      /**< request context, needed to supply
                                              the remote for the forward proxy */
+#if defined(MODULE_GCOAP) || DOXYGEN
+    /**
+     * @brief   transport the packet was received over
+     * @see     @ref gcoap_socket_type_t for values.
+     * @note    @ref gcoap_socket_type_t can not be used, as this would
+     *          cyclically include the @ref net_gcoap header.
+     */
+    uint32_t tl_type;
+#endif
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We don't have to carry this information inside every `coap_pkt_t`, it's enough to provide it via the request context information.


### Testing procedure

`examples/gcoap_dtls` still works

```
> coap get fe80::7837:fcff:fe7d:1aaf 5684 /.well-known/core
gcoap_cli: sending msg ID 7277, 23 bytes
gcoap: response Success, code 2.05, 46 bytes
</cli/stats>;ct=0;rt="count";obs,</riot/board>
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
