### PR TITLE
cpu/esp_{common,32,8266}: improve Kconfig submenu structure

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -131,10 +131,11 @@ menu "ESP32 specific configurations"
         bool "Enable JTAG debugging interface"
         depends on HAS_ESP_JTAG
 
+    rsource "bootloader/Kconfig"
+    rsource "esp-idf/Kconfig"
+    rsource "esp-idf-api/Kconfig"
+    rsource "periph/Kconfig"
+
 endmenu
 
-rsource "bootloader/Kconfig"
-rsource "esp-idf/Kconfig"
-rsource "esp-idf-api/Kconfig"
-rsource "periph/Kconfig"
 source "$(RIOTCPU)/esp_common/Kconfig"

--- a/cpu/esp32/periph/Kconfig
+++ b/cpu/esp32/periph/Kconfig
@@ -23,8 +23,12 @@ config MODULE_PERIPH_RTT_HW_RTC
     default y if MODULE_PERIPH_RTT
 
 config MODULE_ESP_HW_COUNTER
-    bool "Use hardware counter"
+    bool "Use hardware counter as low-level timer peripheral"
     depends on HAS_ESP_HW_COUNTER
     depends on MODULE_PERIPH_TIMER
+    help
+        ESP SoCs with Xtensa cores typically have a set of CCOUNT and CCOMPARE
+        registers that can be used as low-level timer peripherals. Use this
+        option to enable these CCOUNT and CCOMPARE register as low-level timer.
 
 endif # TEST_KCONFIG

--- a/cpu/esp8266/Kconfig
+++ b/cpu/esp8266/Kconfig
@@ -75,6 +75,13 @@ menu "ESP8266 specific configurations"
             bool "160 MHz"
     endchoice
 
+    config MODULE_ESP_SW_TIMER
+        bool "Use software timer as low-level timer peripheral"
+        depends on MODULE_PERIPH_TIMER
+
+    rsource "sdk/Kconfig"
+    rsource "vendor/Kconfig"
+
 endmenu
 
 source "$(RIOTCPU)/esp_common/Kconfig"
@@ -83,10 +90,3 @@ config MODULE_ESP_I2C_SW
     bool
     default y if MODULE_PERIPH_I2C
     select MODULE_PERIPH_I2C_SW
-
-config MODULE_ESP_SW_TIMER
-    bool "Use software timer"
-    depends on MODULE_PERIPH_TIMER
-
-rsource "sdk/Kconfig"
-rsource "vendor/Kconfig"

--- a/cpu/esp_common/Kconfig
+++ b/cpu/esp_common/Kconfig
@@ -116,14 +116,14 @@ config MODULE_ESP_LOG_TAGGED
 config MODULE_ESP_LOG_STARTUP
     bool "Add additional startup information to the log output"
 
-endmenu
-
 config MODULE_ESP_QEMU
     bool "Simulate ESP with QEMU"
-
-endif # TEST_KCONFIG
 
 rsource "esp-xtensa/Kconfig"
 rsource "freertos/Kconfig"
 rsource "periph/Kconfig"
 rsource "vendor/xtensa/Kconfig"
+
+endmenu
+
+endif # TEST_KCONFIG


### PR DESCRIPTION
### Contribution description

This PR improves the Kconfig submenu structure for ESP SoCs.

Without this PR, some ESP SoC specific configurations are shown in top menu and not in the ESP specific submenus:
- ESP8266
    ```
    (Top)
                                                                 RIOT Configuration
        ESP8266 specific configurations  --->
        ESP configurations  --->
    [ ] Simulate ESP with QEMU
    [ ] Use software timer
    [ ] gdbstub interface support
    [*] RIOT Core  --->
    ...
    ```
- ESP32
    ```
    (Top)
                                                                 RIOT Configuration
        ESP32 specific configurations  --->
    [ ] Use hardware counter
        ESP configurations  --->
    [ ] Simulate ESP with QEMU
    [*] RIOT Core  --->
    ...
    ```
With this PR, these ESP SoC specific configurations are moved to the appropriate submenus and give a much more structured view of the ESP specific configuration options:
- ESP8266
    ```
    (Top)
                                                                 RIOT Configuration
        ESP8266 specific configurations  --->
        ESP configurations  --->
    [*] RIOT Core  --->
    ...
    ```
    ```
    (Top) → ESP8266 specific configurations
                                                                 RIOT Configuration
        CPU clock frequency (80 MHz)  --->
    [ ] Use software timer as low-level timer peripheral
    [ ] gdbstub interface support
    ```
    ```
    (Top) → ESP configurations
                                                                 RIOT Configuration
    [ ] Add additional information to the log output
    [ ] Add additional startup information to the log output
    [ ] Simulate ESP with QEMU
    ```
- ESP32
    ```
        ESP32 specific configurations  --->
        ESP configurations  --->
    [*] RIOT Core  --->
    ...
    ```
    ```
    (Top) → ESP32 specific configurations
                                                                 RIOT Configuration
       CPU clock frequency (80 MHz)  --->
    [ ] SPI RAM support
    [*] Enable JTAG debugging interface
    [ ] Use hardware counter as low-level timer peripheral
    ```
    ```
    (Top) → ESP configurations
                                                                 RIOT Configuration
    [ ] Add additional information to the log output
    [ ] Add additional startup information to the log output
    [ ] Simulate ESP with QEMU
    ```

### Testing procedure

1. Green CI
2. Using
    ```
    TEST_KCONFIG=1 BOARD=esp8266-esp-12x make -C tests/periph_timer menuconfig
    TEST_KCONFIG=1 BOARD=esp32-wrover-kit make -C tests/periph_timer menuconfig
    ```
    should show the configuration menu structure.

### Issues/PRs references

