### PR TITLE
cpu/esp32: use CPU_FAM and CPU_ARCH for ESP32x SoC variant dependent compilation

### DIFF
--- a/boards/common/esp32/Makefile.features
+++ b/boards/common/esp32/Makefile.features
@@ -1,4 +1,5 @@
 CPU = esp32
+CPU_FAM = esp32
 
 # additional features provided by all boards is at least one UART
 FEATURES_PROVIDED += periph_uart

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -1,5 +1,3 @@
-CPU_FAM = esp32
-
 # MCU defined features that are provided independent on board definitions
 
 include $(RIOTCPU)/esp_common/Makefile.features

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -1,3 +1,10 @@
+ifneq (,$(filter esp32,$(CPU_FAM)))
+  CPU_ARCH = xtensa
+  CPU_CORE = xtensa-lx6
+else
+  $(error Unkwnown ESP32x SoC variant (family))
+endif
+
 # MCU defined features that are provided independent on board definitions
 
 include $(RIOTCPU)/esp_common/Makefile.features

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -1,16 +1,17 @@
 # ESP32x specific flashing options
-FLASH_CHIP  = $(CPU)
-ifneq (,$(filter esp32,$(CPU)))
+FLASH_CHIP  = $(CPU_FAM)
+ifeq (esp32,$(CPU_FAM))
   FLASH_MODE ?= dout
   FLASH_FREQ  = 40m   # DO NOT CHANGE
   FLASH_SIZE ?= 4
   BOOTLOADER_POS = 0x1000
-endif
-ifneq (,$(filter esp32c3,$(CPU)))
+else ifeq (esp32c3,$(CPU_FAM))
   FLASH_MODE ?= dio
   FLASH_FREQ  = 80m   # DO NOT CHANGE
   FLASH_SIZE ?= 4
   BOOTLOADER_POS = 0x0000
+else
+  $(error Unkwnown ESP32x SoC variant (family))
 endif
 
 ESPTOOL ?= $(RIOTTOOLS)/esptools/esptool_v3.2.py
@@ -19,16 +20,13 @@ include $(RIOTCPU)/esp_common/Makefile.include
 
 # regular Makefile
 
-ifneq (,$(filter esp32,$(CPU)))
-  TARGET_ARCH_$(CPU) ?= xtensa-$(CPU)-elf
+ifeq (xtensa,$(CPU_ARCH))
+  TARGET_ARCH ?= xtensa-$(CPU_FAM)-elf
+else ifeq (riscv_esp32,$(CPU_ARCH))
+  TARGET_ARCH ?= riscv32-esp-elf
+else
+  $(error Unkwnown ESP32x SoC architecture)
 endif
-ifneq (,$(filter esp32c3,$(CPU)))
-  TARGET_ARCH_$(CPU) ?= riscv32-esp-elf
-endif
-
-TARGET_ARCH ?= $(TARGET_ARCH_$(CPU))
-
-CPU_UC = $(shell echo '$(CPU)' | tr '[:lower:]' '[:upper:]')
 
 PSEUDOMODULES += esp_bootloader
 PSEUDOMODULES += esp_gdbstub
@@ -49,20 +47,20 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_common/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc
-INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/include/$(CPU)
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/include/$(CPU_FAM)
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_system/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_system/port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_timer/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/$(CPU)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/$(CPU_FAM)/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/platform_port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/heap/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/log/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/newlib/platform_include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/include
 
 ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/riscv/include
@@ -70,11 +68,11 @@ endif
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU)/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU_FAM)/include
 endif
 
 ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc/$(CPU)
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc/$(CPU_FAM)
 endif
 
 ifneq (,$(filter esp_idf_spi_flash,$(USEMODULE)))
@@ -103,12 +101,14 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
 endif
 
+CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
+
 # we use ESP32 only in single core mode
 CFLAGS += -DCONFIG_ESP_SYSTEM_SINGLE_CORE_MODE
 CFLAGS += -DCONFIG_FREERTOS_UNICORE
 
 # other ESP-IDF configurations
-CFLAGS += -DCONFIG_IDF_TARGET_$(CPU_UC)
+CFLAGS += -DCONFIG_IDF_TARGET_$(call uppercase_and_underscore,$(CPU_FAM))
 CFLAGS += -DESP_PLATFORM
 CFLAGS += -DLOG_TAG_IN_BRACKETS
 
@@ -123,7 +123,7 @@ ifneq (,$(filter riscv%,$(TARGET_ARCH)))
 endif
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
-  LINKFLAGS += -L$(ESP32_SDK_DIR)/components/xtensa/$(CPU)
+  LINKFLAGS += -L$(ESP32_SDK_DIR)/components/xtensa/$(CPU_FAM)
   ARCHIVES += -lxt_hal
 endif
 
@@ -152,11 +152,11 @@ LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
 # Libraries needed when using esp_wifi_any pseudomodule
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
-  LINKFLAGS += -L$(ESP32_SDK_LIB_WIFI_DIR)/$(CPU)
-  LINKFLAGS += -L$(ESP32_SDK_LIB_PHY_DIR)/$(CPU)
+  LINKFLAGS += -L$(ESP32_SDK_LIB_WIFI_DIR)/$(CPU_FAM)
+  LINKFLAGS += -L$(ESP32_SDK_LIB_PHY_DIR)/$(CPU_FAM)
   ARCHIVES += -lcoexist -lcore -lmesh -lnet80211 -lpp
   ARCHIVES += -lphy -lstdc++
-  ifneq (,$(filter esp32,$(CPU)))
+  ifneq (,$(filter esp32,$(CPU_FAM)))
     ARCHIVES += -lrtc
   endif
 endif

--- a/cpu/esp32/bootloader/Makefile
+++ b/cpu/esp32/bootloader/Makefile
@@ -24,39 +24,39 @@ ESP_SDK_BOOTLOADER_SRCS = \
   components/bootloader_support/src/bootloader_common_loader.c \
   components/bootloader_support/src/bootloader_console.c \
   components/bootloader_support/src/bootloader_console_loader.c \
-  components/bootloader_support/src/bootloader_efuse_$(CPU).c \
+  components/bootloader_support/src/bootloader_efuse_$(CPU_FAM).c \
   components/bootloader_support/src/bootloader_flash.c \
-  components/bootloader_support/src/bootloader_flash_config_$(CPU).c \
+  components/bootloader_support/src/bootloader_flash_config_$(CPU_FAM).c \
   components/bootloader_support/src/bootloader_init.c \
   components/bootloader_support/src/bootloader_mem.c \
   components/bootloader_support/src/bootloader_panic.c \
   components/bootloader_support/src/bootloader_random.c \
-  components/bootloader_support/src/bootloader_random_$(CPU).c \
+  components/bootloader_support/src/bootloader_random_$(CPU_FAM).c \
   components/bootloader_support/src/bootloader_utility.c \
-  components/bootloader_support/src/$(CPU)/bootloader_$(CPU).c \
-  components/bootloader_support/src/$(CPU)/bootloader_sha.c \
-  components/bootloader_support/src/$(CPU)/bootloader_soc.c \
+  components/bootloader_support/src/$(CPU_FAM)/bootloader_$(CPU_FAM).c \
+  components/bootloader_support/src/$(CPU_FAM)/bootloader_sha.c \
+  components/bootloader_support/src/$(CPU_FAM)/bootloader_soc.c \
   components/bootloader_support/src/esp_image_format.c \
   components/bootloader_support/src/flash_encrypt.c \
   components/bootloader_support/src/flash_partitions.c \
   components/bootloader_support/src/flash_qio_mode.c \
   components/bootloader_support/src/secure_boot.c \
-  components/efuse/$(CPU)/esp_efuse_fields.c \
-  components/efuse/$(CPU)/esp_efuse_table.c \
-  components/efuse/$(CPU)/esp_efuse_utility.c \
+  components/efuse/$(CPU_FAM)/esp_efuse_fields.c \
+  components/efuse/$(CPU_FAM)/esp_efuse_table.c \
+  components/efuse/$(CPU_FAM)/esp_efuse_utility.c \
   components/efuse/src/esp_efuse_api.c \
   components/efuse/src/esp_efuse_fields.c \
   components/efuse/src/esp_efuse_utility.c \
   components/esp_common/src/esp_err_to_name.c \
   components/esp_hw_support/compare_set.c \
   components/esp_hw_support/cpu_util.c \
-  components/esp_hw_support/port/$(CPU)/chip_info.c \
-  components/esp_hw_support/port/$(CPU)/rtc_clk.c \
-  components/esp_hw_support/port/$(CPU)/rtc_clk_init.c \
-  components/esp_hw_support/port/$(CPU)/rtc_init.c \
-  components/esp_hw_support/port/$(CPU)/rtc_pm.c \
-  components/esp_hw_support/port/$(CPU)/rtc_sleep.c \
-  components/esp_hw_support/port/$(CPU)/rtc_time.c \
+  components/esp_hw_support/port/$(CPU_FAM)/chip_info.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_clk.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_clk_init.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_init.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_pm.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_sleep.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_time.c \
   components/esp_rom/patches/esp_rom_crc.c \
   components/esp_rom/patches/esp_rom_sys.c \
   components/esp_rom/patches/esp_rom_tjpgd.c \
@@ -69,54 +69,54 @@ ESP_SDK_BOOTLOADER_SRCS = \
   components/log/log.c \
   components/log/log_noos.c \
   components/newlib/syscalls.c \
-  components/soc/$(CPU)/adc_periph.c \
-  components/soc/$(CPU)/gpio_periph.c \
-  components/soc/$(CPU)/i2c_periph.c \
-  components/soc/$(CPU)/i2s_periph.c \
-  components/soc/$(CPU)/interrupts.c \
-  components/soc/$(CPU)/ledc_periph.c \
-  components/soc/$(CPU)/rmt_periph.c \
-  components/soc/$(CPU)/sigmadelta_periph.c \
-  components/soc/$(CPU)/spi_periph.c \
-  components/soc/$(CPU)/timer_periph.c \
-  components/soc/$(CPU)/uart_periph.c \
+  components/soc/$(CPU_FAM)/adc_periph.c \
+  components/soc/$(CPU_FAM)/gpio_periph.c \
+  components/soc/$(CPU_FAM)/i2c_periph.c \
+  components/soc/$(CPU_FAM)/i2s_periph.c \
+  components/soc/$(CPU_FAM)/interrupts.c \
+  components/soc/$(CPU_FAM)/ledc_periph.c \
+  components/soc/$(CPU_FAM)/rmt_periph.c \
+  components/soc/$(CPU_FAM)/sigmadelta_periph.c \
+  components/soc/$(CPU_FAM)/spi_periph.c \
+  components/soc/$(CPU_FAM)/timer_periph.c \
+  components/soc/$(CPU_FAM)/uart_periph.c \
   components/soc/lldesc.c \
-  components/spi_flash/$(CPU)/spi_flash_rom_patch.c \
+  components/spi_flash/$(CPU_FAM)/spi_flash_rom_patch.c \
   #
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
-  ESP_SDK_BOOTLOADER_SRCS += components/esp_hw_support/port/$(CPU)/rtc_wdt.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/lcd_periph.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/pcnt_periph.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/rtc_io_periph.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/touch_sensor_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/esp_hw_support/port/$(CPU_FAM)/rtc_wdt.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/lcd_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/pcnt_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/rtc_io_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/touch_sensor_periph.c
   ESP_SDK_BOOTLOADER_SRCS += components/xtensa/eri.c
   ESP_SDK_BOOTLOADER_SRCS += components/xtensa/xt_trax.c
 else
-  ESP_SDK_BOOTLOADER_SRCS += components/esp_hw_support/port/$(CPU)/cpu_util_$(CPU).c
+  ESP_SDK_BOOTLOADER_SRCS += components/esp_hw_support/port/$(CPU_FAM)/cpu_util_$(CPU_FAM).c
 endif
 
-ifneq (,$(filter esp32 esp32s2,$(CPU)))
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/dac_periph.c
+ifneq (,$(filter esp32 esp32s2,$(CPU_FAM)))
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/dac_periph.c
 endif
 
-ifneq (,$(filter esp32 esp32s3,$(CPU)))
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/mcpwm_periph.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/sdio_slave_periph.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/sdmmc_periph.c
+ifneq (,$(filter esp32 esp32s3,$(CPU_FAM)))
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/mcpwm_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/sdio_slave_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/sdmmc_periph.c
 endif
 
-ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU)))
-  ESP_SDK_BOOTLOADER_SRCS += components/efuse/$(CPU)/esp_efuse_rtc_calib.c
+ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
+  ESP_SDK_BOOTLOADER_SRCS += components/efuse/$(CPU_FAM)/esp_efuse_rtc_calib.c
 endif
 
-ifneq (,$(filter esp32,$(CPU)))
+ifneq (,$(filter esp32,$(CPU_FAM)))
   ESP_SDK_BOOTLOADER_SRCS += components/efuse/src/esp_efuse_api_key_esp32.c
   ESP_SDK_BOOTLOADER_ASMSRC = components/esp_rom/patches/esp_rom_longjmp.S
 else
   ESP_SDK_BOOTLOADER_SRCS += components/efuse/src/esp_efuse_api_key_esp32xx.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/dedic_gpio_periph.c
-  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU)/gdma_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/dedic_gpio_periph.c
+  ESP_SDK_BOOTLOADER_SRCS += components/soc/$(CPU_FAM)/gdma_periph.c
   ESP_SDK_BOOTLOADER_SRCS += components/soc/soc_include_legacy_warn.c
 endif
 
@@ -132,24 +132,24 @@ INCLUDES = \
   -I$(ESP32_SDK_DIR)/components/bootloader_support/include_bootloader \
   -I$(ESP32_SDK_DIR)/components/efuse/include \
   -I$(ESP32_SDK_DIR)/components/efuse/private_include \
-  -I$(ESP32_SDK_DIR)/components/efuse/$(CPU)/include \
-  -I$(ESP32_SDK_DIR)/components/efuse/$(CPU)/private_include \
+  -I$(ESP32_SDK_DIR)/components/efuse/$(CPU_FAM)/include \
+  -I$(ESP32_SDK_DIR)/components/efuse/$(CPU_FAM)/private_include \
   -I$(ESP32_SDK_DIR)/components/esp_common/include \
   -I$(ESP32_SDK_DIR)/components/esp_hw_support/include \
   -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc \
-  -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc/$(CPU) \
-  -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU) \
-  -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU)/private_include \
-  -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU) \
+  -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/soc/$(CPU_FAM) \
+  -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM) \
+  -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)/private_include \
+  -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM) \
   -I$(ESP32_SDK_DIR)/components/esp_rom/include \
-  -I$(ESP32_SDK_DIR)/components/esp_rom/include/$(CPU) \
-  -I$(ESP32_SDK_DIR)/components/hal/$(CPU)/include \
+  -I$(ESP32_SDK_DIR)/components/esp_rom/include/$(CPU_FAM) \
+  -I$(ESP32_SDK_DIR)/components/hal/$(CPU_FAM)/include \
   -I$(ESP32_SDK_DIR)/components/hal/include \
   -I$(ESP32_SDK_DIR)/components/hal/platform_port/include \
   -I$(ESP32_SDK_DIR)/components/log/include \
   -I$(ESP32_SDK_DIR)/components/newlib/platform_include \
-  -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/. \
-  -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/include \
+  -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/. \
+  -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/include \
   -I$(ESP32_SDK_DIR)/components/soc/include \
   -I$(ESP32_SDK_DIR)/components/spi_flash/include \
   -I$(ESP32_SDK_DIR)/components/spi_flash/include/spi_flash \
@@ -168,7 +168,7 @@ endif
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU)/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU_FAM)/include
   CFLAGS += -mlongcalls -mtext-section-literals
 endif
 
@@ -208,14 +208,14 @@ CFLAGS += \
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
   LINKFLAGS = -mlongcalls
-  ESP_SDK_BOOTLOADER_ADD_LINK_FLAGS += -L$(ESP32_SDK_DIR)/components/xtensa/$(CPU) -lxt_hal
+  ESP_SDK_BOOTLOADER_ADD_LINK_FLAGS += -L$(ESP32_SDK_DIR)/components/xtensa/$(CPU_FAM) -lxt_hal
 endif
 
-ifneq (,$(filter esp32 esp32s2,$(CPU)))
+ifneq (,$(filter esp32 esp32s2,$(CPU_FAM)))
   LINKFLAGS =
   ESP_SDK_BOOTLOADER_ADD_LINK_FLAGS += \
-    -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.newlib-funcs.ld \
-    -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.spiflash.ld \
+    -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-funcs.ld \
+    -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.spiflash.ld \
     #
 endif
 
@@ -240,12 +240,12 @@ LINKFLAGS += \
   $(ESP_SDK_BOOTLOADER_ASMOBJS) \
   -Lgcc \
   $(ESP_SDK_BOOTLOADER_ADD_LINK_FLAGS) \
-  -T$(ESP32_SDK_DIR)/components/bootloader/subproject/main/ld/$(CPU)/bootloader.ld \
-  -T$(ESP32_SDK_DIR)/components/bootloader/subproject/main/ld/$(CPU)/bootloader.rom.ld \
-  -T$(ESP32_SDK_DIR)/components/soc/$(CPU)/ld/$(CPU).peripherals.ld \
-  -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.ld \
-  -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.api.ld \
-  -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)/ld/$(CPU).rom.libgcc.ld \
+  -T$(ESP32_SDK_DIR)/components/bootloader/subproject/main/ld/$(CPU_FAM)/bootloader.ld \
+  -T$(ESP32_SDK_DIR)/components/bootloader/subproject/main/ld/$(CPU_FAM)/bootloader.rom.ld \
+  -T$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/ld/$(CPU_FAM).peripherals.ld \
+  -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.ld \
+  -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld \
+  -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld \
   -Wl,--end-group \
   -Wl,-EL \
 
@@ -309,7 +309,7 @@ $(ESP_SDK_BOOTLOADER_ELF): \
     $(ESP_SDK_BOOTLOADER_ADDOBJS) | $(ESP_SDK_BOOTLOADER_DIR)
 	$(Q)$(CC) -o $@ $(LINKFLAGS) -Wl,-Map=$(@:%.elf=%.map)
 
-FLASH_CHIP = $(CPU)
+FLASH_CHIP = $(CPU_FAM)
 ESPTOOL ?= $(RIOTTOOLS)/esptools/esptool_v3.2.py
 # TODO: These should be exported/configurable from the app side. That would
 # require to export these values.

--- a/cpu/esp32/esp-idf-api/Makefile
+++ b/cpu/esp32/esp-idf-api/Makefile
@@ -10,8 +10,8 @@ PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/include
 PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/platform_port/include
 PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
 
-PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/$(CPU)/include
-PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/hal/$(CPU_FAM)/include
+PRE_INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/include
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/esp32/esp-idf/adc/Makefile
+++ b/cpu/esp32/esp-idf/adc/Makefile
@@ -5,16 +5,16 @@ ESP32_SDK_SRC = \
   components/driver/adc.c \
   components/driver/adc_common.c \
   components/hal/adc_hal.c \
-  components/soc/$(CPU)/adc_periph.c \
+  components/soc/$(CPU_FAM)/adc_periph.c \
   #
 
-ifneq (,$(filter esp32c3 esp32s3,$(CPU)))
-  ESP32_SDK_SRC += components/driver/$(CPU)/adc2_init_cal.c
+ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
+  ESP32_SDK_SRC += components/driver/$(CPU_FAM)/adc2_init_cal.c
   INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/include/driver
 endif
 
-ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU)))
-  ESP32_SDK_SRC += components/efuse/$(CPU)/esp_efuse_rtc_calib.c
+ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
+  ESP32_SDK_SRC += components/efuse/$(CPU_FAM)/esp_efuse_rtc_calib.c
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -2,19 +2,19 @@ MODULE = esp_idf_common
 
 # source files required from ESP-IDF in any case, regardless of additional modules
 ESP32_SDK_SRC = \
-  components/bootloader_support/src/bootloader_flash_config_$(CPU).c \
+  components/bootloader_support/src/bootloader_flash_config_$(CPU_FAM).c \
   components/bootloader_support/src/bootloader_flash.c \
-  components/bootloader_support/src/bootloader_efuse_$(CPU).c \
+  components/bootloader_support/src/bootloader_efuse_$(CPU_FAM).c \
   components/bootloader_support/src/bootloader_mem.c \
-  components/bootloader_support/src/bootloader_random_$(CPU).c \
+  components/bootloader_support/src/bootloader_random_$(CPU_FAM).c \
   components/driver/periph_ctrl.c \
   components/esp_hw_support/cpu_util.c \
   components/esp_hw_support/esp_clk.c \
-  components/esp_hw_support/port/$(CPU)/rtc_clk.c \
-  components/esp_hw_support/port/$(CPU)/rtc_clk_init.c \
-  components/esp_hw_support/port/$(CPU)/rtc_init.c \
-  components/esp_hw_support/port/$(CPU)/rtc_sleep.c \
-  components/esp_hw_support/port/$(CPU)/rtc_time.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_clk.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_clk_init.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_init.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_sleep.c \
+  components/esp_hw_support/port/$(CPU_FAM)/rtc_time.c \
   components/esp_hw_support/regi2c_ctrl.c \
   components/esp_hw_support/sleep_modes.c \
   components/esp_pm/pm_impl.c \
@@ -22,9 +22,9 @@ ESP32_SDK_SRC = \
   components/esp_system/esp_err.c \
   components/esp_system/esp_system.c \
   components/esp_system/port/cpu_start.c \
-  components/esp_system/port/soc/$(CPU)/cache_err_int.c \
-  components/esp_system/port/soc/$(CPU)/clk.c \
-  components/esp_system/port/soc/$(CPU)/reset_reason.c \
+  components/esp_system/port/soc/$(CPU_FAM)/cache_err_int.c \
+  components/esp_system/port/soc/$(CPU_FAM)/clk.c \
+  components/esp_system/port/soc/$(CPU_FAM)/reset_reason.c \
   components/esp_system/system_time.c \
   components/esp_timer/src/esp_timer.c \
   components/esp_timer/src/system_time.c \
@@ -51,7 +51,7 @@ endif
 # TODO separate module
 ifneq (,$(filter periph_dac,$(USEMODULE)))
   ESP32_SDK_SRC += components/driver/dac_common.c
-  ESP32_SDK_SRC += components/soc/$(CPU)/dac_periph.c
+  ESP32_SDK_SRC += components/soc/$(CPU_FAM)/dac_periph.c
 endif
 
 # TODO separate module
@@ -64,25 +64,25 @@ ifneq (,$(filter periph_i2c%,$(USEMODULE)))
   ESP32_SDK_SRC += components/driver/i2c.c
   ESP32_SDK_SRC += components/hal/i2c_hal.c
   ESP32_SDK_SRC += components/hal/i2c_hal_iram.c
-  ESP32_SDK_SRC += components/soc/$(CPU)/i2c_periph.c
+  ESP32_SDK_SRC += components/soc/$(CPU_FAM)/i2c_periph.c
 endif
 
 # TODO separate module
 ifneq (,$(filter periph_pwm%,$(USEMODULE)))
   ESP32_SDK_SRC += components/hal/ledc_hal.c
   ESP32_SDK_SRC += components/hal/ledc_hal_iram.c
-  ESP32_SDK_SRC += components/soc/$(CPU)/ledc_periph.c
+  ESP32_SDK_SRC += components/soc/$(CPU_FAM)/ledc_periph.c
 endif
 
 # TODO separate module
 ifneq (,$(filter periph_spi,$(USEMODULE)))
   ESP32_SDK_SRC += components/hal/spi_hal.c
-  ESP32_SDK_SRC += components/soc/$(CPU)/spi_periph.c
+  ESP32_SDK_SRC += components/soc/$(CPU_FAM)/spi_periph.c
 endif
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
-  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU)/rtc_wdt.c
-  ESP32_SDK_SRC += components/soc/$(CPU)/rtc_io_periph.c
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/rtc_wdt.c
+  ESP32_SDK_SRC += components/soc/$(CPU_FAM)/rtc_io_periph.c
 endif
 
 ifneq (,$(filter riscv%,$(TARGET_ARCH)))
@@ -91,15 +91,15 @@ ifneq (,$(filter riscv%,$(TARGET_ARCH)))
   ESP32_SDK_ASMSRC += components/riscv/vectors.S
 endif
 
-ifneq (,$(filter esp32,$(CPU)))
+ifneq (,$(filter esp32,$(CPU_FAM)))
   ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_frc_legacy.c
 endif
 
-ifneq (,$(filter esp32c3,$(CPU)))
-  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU)/cpu_util_$(CPU).c
+ifneq (,$(filter esp32c3,$(CPU_FAM)))
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/cpu_util_$(CPU_FAM).c
   ESP32_SDK_SRC += components/esp_hw_support/sleep_retention.c
   ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c
-  ESP32_SDK_SRC += components/hal/$(CPU)/rtc_cntl_hal.c
+  ESP32_SDK_SRC += components/hal/$(CPU_FAM)/rtc_cntl_hal.c
   ESP32_SDK_SRC += components/hal/systimer_hal.c
 endif
 

--- a/cpu/esp32/esp-idf/efuse/Makefile
+++ b/cpu/esp32/esp-idf/efuse/Makefile
@@ -2,15 +2,15 @@ MODULE = esp_idf_efuse
 
 # source files to be compiled for this module
 ESP32_SDK_SRC = \
-  components/efuse/$(CPU)/esp_efuse_fields.c \
-  components/efuse/$(CPU)/esp_efuse_table.c \
-  components/efuse/$(CPU)/esp_efuse_utility.c \
+  components/efuse/$(CPU_FAM)/esp_efuse_fields.c \
+  components/efuse/$(CPU_FAM)/esp_efuse_table.c \
+  components/efuse/$(CPU_FAM)/esp_efuse_utility.c \
   components/efuse/src/esp_efuse_api.c \
   components/efuse/src/esp_efuse_utility.c \
   components/esp_hw_support/mac_addr.c \
   #
 
-ifneq (,$(filter esp32,$(CPU)))
+ifneq (,$(filter esp32,$(CPU_FAM)))
   ESP32_SDK_SRC += components/efuse/src/esp_efuse_api_key_esp32.c
 else
   ESP32_SDK_SRC += components/efuse/src/esp_efuse_api_key_esp32xx.c
@@ -19,7 +19,7 @@ endif
 # additional include pathes required by this module
 INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/private_include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/$(CPU)/private_include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/$(CPU_FAM)/private_include
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/esp32/esp-idf/esp_idf.mk
+++ b/cpu/esp32/esp-idf/esp_idf.mk
@@ -3,12 +3,12 @@
 # additional include pathes required by als ESP-IDF module
 INCLUDES += -I$(ESP32_SDK_DIR)/components/bootloader_support/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/bootloader_support/include_bootloader
-INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/$(CPU)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/$(CPU_FAM)/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/$(CPU)/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/$(CPU)/private_include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU)
-INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU)/private_include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/$(CPU_FAM)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/efuse/$(CPU_FAM)/private_include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)/private_include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_ipc/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_pm/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_system/port/public_compat
@@ -19,11 +19,11 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/spi_flash/include
 
 ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU)/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU_FAM)/include
 endif
 
-ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU)))
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU)/private_include
+ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)/private_include
 endif
 
 SRC := $(addprefix $(ESP32_SDK_DIR)/,$(ESP32_SDK_SRC))

--- a/cpu/esp32/esp-idf/gpio/Makefile
+++ b/cpu/esp32/esp-idf/gpio/Makefile
@@ -6,7 +6,7 @@ ESP32_SDK_SRC = \
   components/driver/rtc_io.c \
   components/driver/rtc_module.c \
   components/hal/gpio_hal.c \
-  components/soc/$(CPU)/gpio_periph.c \
+  components/soc/$(CPU_FAM)/gpio_periph.c \
   #
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-idf/heap/Makefile
+++ b/cpu/esp32/esp-idf/heap/Makefile
@@ -8,7 +8,7 @@ ESP32_SDK_SRC = \
   components/heap/heap_trace_standalone.c \
   components/heap/multi_heap.c \
   components/heap/multi_heap_poisoning.c \
-  components/heap/port/$(CPU)/memory_layout.c \
+  components/heap/port/$(CPU_FAM)/memory_layout.c \
   components/heap/port/memory_layout_utils.c \
   #
 

--- a/cpu/esp32/esp-idf/spi_flash/Makefile
+++ b/cpu/esp32/esp-idf/spi_flash/Makefile
@@ -4,25 +4,25 @@ MODULE = esp_idf_spi_flash
 ESP32_SDK_SRC = \
   components/bootloader_support/src/bootloader_common.c \
   components/driver/spi_common.c \
-  components/spi_flash/$(CPU)/flash_ops_$(CPU).c \
-  components/spi_flash/$(CPU)/spi_flash_rom_patch.c \
+  components/spi_flash/$(CPU_FAM)/flash_ops_$(CPU_FAM).c \
+  components/spi_flash/$(CPU_FAM)/spi_flash_rom_patch.c \
   components/spi_flash/esp_flash_api.c \
   components/spi_flash/partition.c \
   #
 
 ifeq (,$(filter periph_spi,$(USEMODULE)))
   # no need to compile it here if it is already compiled for periph_spi
-  ESP32_SDK_SRC += components/soc/$(CPU)/spi_periph.c
+  ESP32_SDK_SRC += components/soc/$(CPU_FAM)/spi_periph.c
 endif
 
-ifneq (,$(filter esp32,$(CPU)))
+ifneq (,$(filter esp32,$(CPU_FAM)))
   ESP32_SDK_SRC += components/spi_flash/flash_mmap.c
 endif
 
 # additional include pathes required by this module
 INCLUDES += -I$(ESP32_SDK_DIR)/components/app_update/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/bootloader_support/include_bootloader
-INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU)
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)
 INCLUDES += -I$(ESP32_SDK_DIR)/components/spi_flash/include/spi_flash
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-idf/spi_ram/Makefile
+++ b/cpu/esp32/esp-idf/spi_ram/Makefile
@@ -2,13 +2,13 @@ MODULE = esp_idf_spi_ram
 
 # source files to be compiled for this module
 ESP32_SDK_SRC = \
-  components/esp_hw_support/port/$(CPU)/spiram.c \
-  components/esp_hw_support/port/$(CPU)/spiram_psram.c \
-  components/esp_hw_support/port/$(CPU)/cache_sram_mmu.c \
+  components/esp_hw_support/port/$(CPU_FAM)/spiram.c \
+  components/esp_hw_support/port/$(CPU_FAM)/spiram_psram.c \
+  components/esp_hw_support/port/$(CPU_FAM)/cache_sram_mmu.c \
   #
 
 # additional include pathes required by this module
-INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/include
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/esp32/esp-idf/wifi/Makefile
+++ b/cpu/esp32/esp-idf/wifi/Makefile
@@ -3,15 +3,15 @@ MODULE = esp_idf_wifi
 # source files to be compiled for this module
 ESP32_SDK_SRC = \
   components/esp_event/event_send.c \
-  components/esp_hw_support/port/$(CPU)/dport_access.c \
+  components/esp_hw_support/port/$(CPU_FAM)/dport_access.c \
   components/esp_phy/src/phy_init.c \
-  components/esp_wifi/$(CPU)/esp_adapter.c \
+  components/esp_wifi/$(CPU_FAM)/esp_adapter.c \
   components/esp_wifi/src/wifi_init.c \
   #
 
 # additional include pathes required by this module
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/include
-INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU_FAM)/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/tcpip_adapter/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/include

--- a/cpu/esp32/include/adc_arch.h
+++ b/cpu/esp32/include/adc_arch.h
@@ -103,7 +103,7 @@ int adc_set_attenuation(adc_t line, adc_atten_t atten);
  */
 int adc_line_vref_to_gpio(adc_t line, gpio_t gpio);
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
 /**
  * @brief   Output ADC reference voltage to GPIO25
  *

--- a/cpu/esp32/irq_arch.c
+++ b/cpu/esp32/irq_arch.c
@@ -47,36 +47,36 @@ static const struct intr_handle_data_t _irq_data_table[] = {
     { ETS_FROM_CPU_INTR0_SOURCE, CPU_INUM_SOFTWARE, 1 },
     { ETS_TG0_WDT_LEVEL_INTR_SOURCE, CPU_INUM_WDT, 1 },
     { ETS_TG0_T0_LEVEL_INTR_SOURCE, CPU_INUM_RTT, 1 },
-#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32S3)
     { ETS_TG0_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
 #endif
-#if defined(MCU_ESP32) || defined(MCU_ESP32S2)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2)
     { ETS_TG0_LACT_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
 #endif
-#if !defined(MCU_ESP32C2)
+#if !defined(CPU_FAM_ESP32C2)
     { ETS_TG1_T0_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
 #endif
-#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32S3)
     { ETS_TG1_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
 #endif
     { ETS_UART0_INTR_SOURCE, CPU_INUM_UART, 1 },
     { ETS_UART1_INTR_SOURCE, CPU_INUM_UART, 1 },
-#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32S3)
     { ETS_UART2_INTR_SOURCE, CPU_INUM_UART, 1 },
 #endif
     { ETS_GPIO_INTR_SOURCE, CPU_INUM_GPIO, 1 },
     { ETS_I2C_EXT0_INTR_SOURCE, CPU_INUM_I2C, 1 },
-#if defined(MCU_ESP32) || defined(MCU_ESP32S2) || defined(MCU_ESP32S3)
+#if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32S3)
     { ETS_I2C_EXT1_INTR_SOURCE, CPU_INUM_I2C, 1 },
 #endif
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     { ETS_ETH_MAC_INTR_SOURCE, CPU_INUM_ETH, 1 },
 #endif
-#if !defined(MCU_ESP32C2)
+#if !defined(CPU_FAM_ESP32C2)
     { ETS_TWAI_INTR_SOURCE, CPU_INUM_CAN, 1 },
     { ETS_TIMER2_INTR_SOURCE, CPU_INUM_FRC2, 2 },
 #endif
-#if !defined(MCU_ESP32)
+#if !defined(CPU_FAM_ESP32)
     { ETS_SYSTIMER_TARGET2_EDGE_INTR_SOURCE, CPU_INUM_SYSTIMER, 2 },
 #endif
 };

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -62,7 +62,7 @@ typedef struct {
  * Table for resolution mapping
  */
 _adc_esp_res_map_t _adc_esp_res_map[] =  {
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     { .res = ADC_WIDTH_BIT_9,  .shift = 3 },    /* ADC_RES_6BIT  */
     { .res = ADC_WIDTH_BIT_9,  .shift = 1 },    /* ADC_RES_8BIT  */
     { .res = ADC_WIDTH_BIT_10, .shift = 0 },    /* ADC_RES_10BIT */

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -81,7 +81,7 @@ static bool _gpio_pin_pu[GPIO_PIN_NUMOF] = { };
 static bool _gpio_pin_pd[GPIO_PIN_NUMOF] = { };
 #endif
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
 
 #define GPIO_IN_GET(b)  (b < 32) ? GPIO.in & BIT(b) : GPIO.in1.val & BIT(b-32)
 #define GPIO_OUT_SET(b) if (b < 32) GPIO.out_w1ts = BIT(b); else GPIO.out1_w1ts.val = BIT(b-32)

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -393,7 +393,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len, uint
     return _i2c_status_to_errno(dev);
 }
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
 #define I2C_NACK_INT_ENA_M  I2C_ACK_ERR_INT_ENA_M
 #endif
 

--- a/cpu/esp32/periph/rtt_hw_rtc.c
+++ b/cpu/esp32/periph/rtt_hw_rtc.c
@@ -98,14 +98,14 @@ uint64_t _rtc_get_counter(void)
 {
     /* trigger timer register update */
     RTCCNTL.time_update.update = 1;
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     /* wait until values in registers are valid */
     while (!RTCCNTL.time_update.valid) {
         ets_delay_us(1);
     }
     /* read the time from 48-bit counter and return */
     return (((uint64_t)RTCCNTL.time1.val) << 32) + RTCCNTL.time0;
-#elif defined(MCU_ESP32C3)
+#elif defined(CPU_FAM_ESP32C3)
     /* read the time from 48-bit counter and return */
     return (((uint64_t)RTCCNTL.time_high0.val) << 32) + RTCCNTL.time_low0;
 #else

--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -267,7 +267,7 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
     spi_ll_master_set_clock_by_reg(_spi[bus].periph->hw,
                                    &_spi[bus].timing.clock_reg);
 
-#if defined(MCU_ESP32C3)
+#if defined(CPU_FAM_ESP32C3)
     /*
      * If the SPI mode has been changed, the clock signal is only set to the
      * correct level at the beginning of the transfer on the ESP32C3. However,
@@ -283,7 +283,7 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
         spi_transfer_bytes(bus, GPIO_UNDEF, false, &temp, &temp, 1);
         _spi[bus].mode_last = mode;
     }
-#elif defined(MCU_ESP32)
+#elif defined(CPU_FAM_ESP32)
     /* This workaround isn't needed on ESP32 */
 #else
 #error Platform implementation is missing
@@ -301,9 +301,9 @@ void IRAM_ATTR spi_release(spi_t bus)
     mutex_unlock(&_spi[bus].lock);
 }
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
 static const char* _spi_names[] = { "CSPI/FSPI", "HSPI", "VSPI"  };
-#elif defined(MCU_ESP32C3)
+#elif defined(CPU_FAM_ESP32C3)
 static const char* _spi_names[] = { "SPI", "FSPI"  };
 #else
 #error Platform implementation required

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -76,7 +76,7 @@
  * timer implementation together!
  */
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
 
 #define HW_TIMER_CORRECTION   (RTC_PLL_320M / CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
 #define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION << 1, 5))
@@ -106,7 +106,7 @@ struct _hw_timer_desc_t {
 
 static const struct _hw_timer_desc_t _timers_desc[] =
 {
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     {
         .module = PERIPH_TIMG0_MODULE,
         .group = TIMER_GROUP_0,

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -220,7 +220,7 @@ static NORETURN void IRAM system_init (void)
 {
     static_assert(MAXTHREADS >= 3,
             "ESP32 requires at least 3 threads, esp_timer, idle, and main");
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     /* enable cached read from flash */
     Cache_Read_Enable(PRO_CPU_NUM);
 #endif

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -264,10 +264,10 @@ void IRAM syscalls_init_arch(void)
     timer_hal_set_auto_reload(&sys_timer, false);
     timer_hal_set_counter_enable(&sys_timer, true);
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     syscall_table_ptr_pro = &s_stub_table;
     syscall_table_ptr_app = &s_stub_table;
-#elif defined(MCU_ESP32S2)
+#elif defined(CPU_FAM_ESP32S2)
     syscall_table_ptr_pro = &s_stub_table;
 #else
     syscall_table_ptr = &s_stub_table;
@@ -334,7 +334,7 @@ void system_wdt_init(void)
     wdt_hal_write_protect_enable(&mwdt);
     wdt_hal_write_protect_enable(&rwdt);
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     DEBUG("%s TIMERG0 wdtconfig0=%08x wdtconfig1=%08x wdtconfig2=%08x "
           "wdtconfig3=%08x wdtconfig4=%08x regclk=%08x\n", __func__,
           TIMERG0.wdt_config0.val, TIMERG0.wdt_config1.val,

--- a/cpu/esp8266/Makefile.features
+++ b/cpu/esp8266/Makefile.features
@@ -1,4 +1,6 @@
 CPU_FAM = esp8266
+CPU_ARCH = xtensa
+CPU_CORE = xtensa-l106
 
 # MCU defined features that are provided independent on board definitions
 

--- a/cpu/esp_common/Makefile.features
+++ b/cpu/esp_common/Makefile.features
@@ -1,5 +1,3 @@
-CPU_ARCH = xtensa
-
 # MCU defined features that are provided independent on board definitions
 
 FEATURES_PROVIDED += arch_32bit

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -34,7 +34,7 @@ CFLAGS += -fdata-sections
 CFLAFS += -ffunction-sections
 CFLAGS += -fzero-initialized-in-bss
 
-ifeq (,$(filter esp32c% esp32h%,$(CPU)))
+ifeq (xtensa,$(CPU_ARCH))
   CFLAGS += -mlongcalls -mtext-section-literals
 endif
 

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -26,7 +26,7 @@
 #endif
 #include "timex.h"
 
-#ifdef MCU_ESP32
+#ifdef CPU_FAM_ESP32
 #include "soc/soc.h"
 #endif
 

--- a/cpu/esp_common/include/esp_common.h
+++ b/cpu/esp_common/include/esp_common.h
@@ -107,10 +107,10 @@ extern "C" {
   * @brief  function name mappings for source code compatibility with ESP8266 port
   * @{
   */
-#ifdef MCU_ESP32
+#ifdef CPU_FAM_ESP32
 #define system_get_cpu_freq     ets_get_cpu_frequency
 #define system_update_cpu_freq  ets_update_cpu_frequency
-#endif /* MCU_ESP32 */
+#endif /* CPU_FAM_ESP32 */
 /** @} */
 
 /** @} */

--- a/cpu/esp_common/include/freertos/portmacro.h
+++ b/cpu/esp_common/include/freertos/portmacro.h
@@ -55,17 +55,17 @@ extern "C" {
 
 #define errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY    ( -1 )
 
-#ifdef MCU_ESP32
+#ifdef CPU_FAM_ESP32
 
 #define portNUM_PROCESSORS              2
 #define xPortGetCoreID()                PRO_CPU_NUM
 
-#else /* MCU_ESP32 */
+#else /* CPU_FAM_ESP32 */
 
 #define portNUM_PROCESSORS              1
 #define xPortGetCoreID()                PRO_CPU_NUM
 
-#endif /* MCU_ESP32 */
+#endif /* CPU_FAM_ESP32 */
 
 extern void vTaskEnterCritical(portMUX_TYPE *mux);
 extern void vTaskExitCritical(portMUX_TYPE *mux);

--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -109,7 +109,7 @@ static _i2c_bus_t _i2c_bus[I2C_NUMOF] = {};
 /* to ensure that I2C is always optimized with -O2 to use the defined delays */
 #pragma GCC optimize ("O2")
 
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
 #define I2C_CLK_CAL     62      /* clock calibration offset */
 #elif defined(MCU_ESP8266)
 #define I2C_CLK_CAL     47      /* clock calibration offset */

--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -124,7 +124,7 @@ static struct uart_hw_t _uarts[] = {
 #endif /* !MCU_ESP8266 */
     },
 #endif /* defined(UART1_TXD) || !defined(MCU_ESP8266) */
-#if defined(MCU_ESP32)
+#if defined(CPU_FAM_ESP32)
     {
         .regs = &UART2,
         .used = false,
@@ -137,7 +137,7 @@ static struct uart_hw_t _uarts[] = {
         .signal_rxd = U2RXD_IN_IDX,
         .int_src = ETS_UART2_INTR_SOURCE
     },
-#endif /* defined(MCU_ESP32) */
+#endif /* defined(CPU_FAM_ESP32) */
 };
 
 /* declaration of external functions */
@@ -322,7 +322,7 @@ static uint8_t IRAM _uart_rx_one_char(uart_t uart)
     /* wait until at least von byte is in RX FIFO */
     while (!_uarts[uart].regs->status.rxfifo_cnt) {}
 
-#if defined(MCU_ESP32) || defined(MCU_ESP8266)
+#if defined(CPU_FAM_ESP32) || defined(MCU_ESP8266)
     /* read the lowest byte from RX FIFO register */
     return _uarts[uart].regs->fifo.rw_byte;
 #else
@@ -429,11 +429,11 @@ static int _uart_set_baudrate(uart_t uart, uint32_t baudrate)
 #else
 
 /* TODO look for an HAL/LL API function */
-#ifdef MCU_ESP32
+#ifdef CPU_FAM_ESP32
     /* use APB_CLK */
     _uarts[uart].regs->conf0.tick_ref_always_on = 1;
 #endif
-#ifdef MCU_ESP32C3
+#ifdef CPU_FAM_ESP32C3
     _uarts[uart].regs->clk_conf.sclk_sel = 1; /* APB clock used instead of XTAL */
 #endif
     /* compute and set the integral and the decimal part */


### PR DESCRIPTION
### Contribution description

This PR provides the changes that are necessary to compile the ESP32 port for different ESP32x  SoC variants (families). It includes the following changes: 
- `CPU_FAM` is used instead of `CPU` in Makefiles
- `CPU_ARCH` is used instead of `CPU` in Makefiles to define architecture dependent compile options
- `CPU_FAM_*` is used instead of `MCU_*` in source code
- `CPU_FAM` definition is moved to board definition
-  `CPU_*` definitions are moved to CPU-specific `Makefile.features`

The PR could be splitted into 3 separate smaller PRs if necessary.

### Testing procedure

Green CI

### Issues/PRs references

