### PR TITLE
cpu/esp32: make esp_hw_counter feature dependent on ESP32x SoC family

### DIFF
--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -9,13 +9,17 @@ config CPU_CORE_XTENSA_LX6
     bool
     select CPU_ARCH_XTENSA
 
+config CPU_ARCH_ESP32_XTENSA
+    bool
+    select HAS_ESP_HW_COUNTER
+
 config CPU_FAM_ESP32
     bool
     select CPU_COMMON_ESP
     select CPU_CORE_XTENSA_LX6
+    select CPU_ARCH_ESP32_XTENSA
     select HAS_ARCH_ESP32
     select HAS_CPU_ESP32
-    select HAS_ESP_HW_COUNTER
     select HAS_ESP_WIFI_ENTERPRISE
     select HAS_PUF_SRAM
 

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -6,8 +6,11 @@ include $(RIOTCPU)/esp_common/Makefile.features
 
 FEATURES_PROVIDED += arch_esp32
 FEATURES_PROVIDED += esp_wifi_enterprise
-FEATURES_PROVIDED += esp_hw_counter
 FEATURES_PROVIDED += puf_sram
+
+ifeq (xtensa,$(CPU_ARCH))
+  FEATURES_PROVIDED += esp_hw_counter
+endif
 
 ifneq (,$(filter esp32-wrover%,$(CPU_MODEL)))
   FEATURES_PROVIDED += esp_spi_ram


### PR DESCRIPTION
### Contribution description

Feature `esp_hw_counter` is not supported by all ESP32x SoC variants (families). Therefore, it has to be defined dependent on `CPU_FAM`.

This PR is a split-off from PR #17842.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from PR #17842