### PR TITLE
cpu/esp_common: MODULE_XTENSA has to depend on HAS_ARCH_ESP_XTENSA

### DIFF
--- a/cpu/esp_common/vendor/xtensa/Kconfig
+++ b/cpu/esp_common/vendor/xtensa/Kconfig
@@ -8,8 +8,8 @@
 config MODULE_XTENSA
     bool
     depends on TEST_KCONFIG
-    depends on HAS_ARCH_ESP
+    depends on HAS_ARCH_ESP_XTENSA
     default y
     help
-        Third-party software components used by the RIOT port for ESP32 and
-        ESP8266.
+        Third-party software components used by the RIOT port for Xtensa-based
+        ESP SoCs.


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17842 and provides a change that is needed to support ESP32x SoCs that are RISC-V based.

ESP32x SoC use either Xtensa cores or RISC-V cores. The Xtensa vendor code has to be compiled only for ESP32x SoCs that are Xtensa-based. Therefore, `MODULE_XTENSA` in Kconfig has to depend on `HAS_ARCH_ESP_XTENSA` instead of `HAS_ARCH_ESP`.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from PR #17842