### PR TITLE
cpu/esp32: split the doc into ESP32x common and ESP32 specific parts

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2022 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,19 +7,23 @@
  */
 
 /**
-@defgroup   cpu_esp32 ESP32
+@defgroup   cpu_esp32 ESP32 SoC Series
 @ingroup    cpu
-@brief      Implementation for Espressif ESP32 MCUs
+@brief      Implementation for Espressif ESP32 SoC Series
+
+This document describes the RIOT implementation for supported variants
+(families) of Espressif's ESP32 SoC series.
+
 @author     Gunar Schorcht <gunar@schorcht.net>
 
-\section esp32_riot  RIOT-OS on ESP32 boards
+\section esp32_riot  RIOT-OS on ESP32 SoC Series Boards
 
 ## Table of Contents {#esp32_toc}
 
 1. [Overview](#esp32_overview)
 2. [Short Configuration Reference](#esp32_short_configuration_reference)
-3. [MCU ESP32](#esp32_mcu_esp32)
-    1. [Features of ESP32](#esp32_features)
+3. [ESP32x MCU](#esp32_mcu_esp32)
+    1. [Features of ESP32x SoCs](#esp32_features)
     2. [Features Supported by RIOT-OS](#esp32_supported_features)
     3. [Limitations of the RIOT-port](#esp32_limitations)
 4. [Toolchain](#esp32_toolchain)
@@ -63,25 +67,28 @@
 
 # Overview {#esp32_overview}
 
-The **RIOT port for Xtensa-ESP** is a bare metal implementation of **RIOT-OS**
-for **ESP32** SOCs which supports most features of RIOT-OS. The peripheral
-SPI and I2C interfaces allow to connect all external hardware modules supported
-by RIOT-OS, such as sensors and actuators. SPI interface can also be used
-to connect external IEEE802.15.4 modules to integrate ESP32 boards into a GNRC network.
+The **RIOT port for ESP32** is an implementation of **RIOT-OS** for
+the **Espressif ESP32 SoC series** (hereafter called ESP32x), which supports
+most of the functions of RIOT-OS.
 
-Although the port does not use the official **ESP-IDF** (Espresso IoT
-Development Framework) SDK, it must be installed for compilation. The reason
-is that the port uses most of the **ESP32 SOC definitions** provided by the
-ESP-IDF header files. In addition, it needs the hardware abstraction library
-(`libhal.a`), and the **ESP32 WiFi stack binary** libraries which are part
-of the ESP-IDF SDK.
+Due to the potential confusion caused by referring to the SoC series in
+exactly the same way as the namesaking SoC variant, we need to define a
+terminology in this document to distinguish between a variant and a set
+of variants:
+
+- **ESP32 SoC Series** denotes the set of all supported SoC variants (families).
+- **ESP32x SoC** or short **ESP32x** denotes any or a couple of SoC variants (families).
+- **EPS32 SoC** or short **ESP32** denotes the ESP32 SoC variant (family).
+
+@note Variants of Espressif's ESP32 SoC Series are called ESP32x families
+      in RIOT's terminology.
 
 [Back to table of contents](#esp32_toc)
 
 # Short Configuration Reference {#esp32_short_configuration_reference}
 
-The following table gives a short reference of all board configuration parameters used by the ESP32
-port in alphabetical order.
+The following table gives a short reference of all board configuration
+parameters used by the RIOT port for ESP32x SoCs in alphabetical order.
 
 <center>
 
@@ -145,20 +152,34 @@ Module                                              | Default   | Short descript
 [esp_wifi_ap](#esp32_wifi_ap_network_interface)     | not used  | enable the WiFi SoftAP network device
 [esp_wifi_enterprise](#esp32_wifi_network_interface)| not used  | enable the Wifi network device in WPA2 enterprise mode
 
-</center>
-
-
-[Back to table of contents](#esp32_toc)
-
-# MCU ESP32 {#esp32_mcu_esp32}
-
-ESP32 is a low-cost, ultra-low-power, single or dual-core SoCs from Espressif Systems with
-integrated WiFi and dual-mode BT module. The processor core is based on the Tensilica Xtensa LX6
-32-bit Controller Processor Core.
+</center><br>
 
 [Back to table of contents](#esp32_toc)
 
-## Features of ESP32 {#esp32_features}
+# ESP32x MCU {#esp32_mcu_esp32}
+
+ESP32x SoCs are low-cost, ultra-low-power, single or dual-core SoCs from
+Espressif Systems with integrated WiFi and Bluetooth BLE module. The SoCs are
+either based on
+
+- Tensilica Xtensa 32-bit LX6 microprocessor (ESP32),
+- Tensilica Xtensa 32-bit LX7 microprocessor (ESP32-S2, ESP32-S3), or
+- 32-bit RISC-V CPU (ESP32-C3, ESP32-H2).
+
+At the moment, ESP32 variant is supported by RIOT-OS.
+
+@note Even if the used ESP32x SoC is a dual-core version, RIOT-OS uses only
+      one core.
+
+[Back to table of contents](#esp32_toc)
+
+## Features of ESP32x SoCs {#esp32_features}
+
+The ESP32 SoC Series consists of different ESP32x SoC variants (families),
+which differ in the type and the number of processor cores used and the
+hardware modules supported.
+
+### Features of The ESP32 SoC variant (family)
 
 The key features of ESP32 are:
 
@@ -182,7 +203,7 @@ The key features of ESP32 are:
 | SPIs              | 4                                                                 | yes (2) |
 | UARTs             | 3                                                                 | yes |
 | WiFi              | IEEE 802.11 b/g/n built in                                        | yes |
-| Bluetooth         | v4.2 BR/EDR and BLE                                               | no |
+| Bluetooth         | v4.2 BR/EDR and BLE                                               | no  |
 | Ethernet          | MAC interface with dedicated DMA and IEEE 1588 support            | yes |
 | CAN               | version 2.0                                                       | yes |
 | IR                | up to 8 channels TX/RX                                            | no |
@@ -194,31 +215,66 @@ The key features of ESP32 are:
 
 </center><br>
 
-@note Even if used ESP32 SoC is a dual-core version, RIOT-OS uses only one core.
+### Features of The ESP32-C3 SoC variant (family)
 
-Rather than using the ESP32 SoC directly, ESP32 boards use an
-[ESP32 module from Espressif](https://www.espressif.com/en/products/hardware/modules) which
+The key features of ESP32-C3 are:
+
+<center>
+
+| MCU               | ESP32-C3                                                          | Supported by RIOT |
+| ------------------|-------------------------------------------------------------------|------------------ |
+| Vendor            | Espressif                                                         | |
+| Cores             | 1 32-bit RISC-V core                                              | yes |
+| FPU               | -                                                                 | -   |
+| RAM               | 400 KiB SRAM <br> 8 KiB RTC SRAM                                  | yes <br> yes |
+| ROM               | 384 KiB                                                           | yes |
+| Flash             | 8 MiB                                                             | yes |
+| Frequency         | 160 MHz, 80 MHz                                                   | yes |
+| Power Consumption | 20 mA @ 240 MHz <br> 15 mA @ 80 MHz <br> 130 uA in light sleep mode <br> 5 uA in deep sleep mode | yes <br> yes <br> yes <br> yes |
+| Timers            | 2 x 54 bit                                                        | yes |
+| ADCs              | 2 x SAR-ADC with up to 6 x 12 bit channels total                  | yes |
+| DACs              | -                                                                 | -   |
+| GPIOs             | 22                                                                | yes |
+| I2Cs              | 1                                                                 | yes |
+| SPIs              | 3                                                                 | yes (1) |
+| UARTs             | 2                                                                 | yes |
+| WiFi              | IEEE 802.11 b/g/n built in                                        | yes |
+| Bluetooth         | Bluetooth 5 (LE)                                                  | no  |
+| Ethernet          | -                                                                 | -   |
+| CAN               | version 2.0                                                       | yes |
+| IR                | up to 8 channels TX/RX                                            | no  |
+| Motor PWM         | -                                                                 | no  |
+| LED PWM           | 12 channels with 14 bit resolution in 1 channel group with 4 timers | yes |
+| Crypto            | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG                | no  |
+| Vcc               | 3.0 - 3.6 V                                                       | |
+| Documents         | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf) | |
+
+</center><br>
+
+Rather than using the ESP32x SoCs directly, ESP32x boards use an
+[ESP32x module from Espressif](https://www.espressif.com/en/products/hardware/modules) which
 integrates additionally to the SoC some key components, like SPI flash memory, SPI RAM, or crystal
-oscillator. Some of these components are optional. A good overview about available modules can be
-found in the [Online documentation of ESP-IDF](https://www.espressif.com/en/products/modules).
+oscillator. Some of these components are optional.
 
-Most common modules used by ESP32 boards are the
-[ESP32-WROOM-32](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32_datasheet_en.pdf)
-and
-[ESP32-WROVER](https://www.espressif.com/sites/default/files/documentation/esp32-wrover_datasheet_en.pdf).
+Most common modules used by ESP32x SoC boards are:
+
+- [ESP32-WROOM-32](https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32_datasheet_en.pdf)
+- [ESP32-WROVER](https://www.espressif.com/sites/default/files/documentation/esp32-wrover_datasheet_en.pdf)
+- [ESP32-C3-MINI-1](https://www.espressif.com/sites/default/files/documentation/esp32-c3-mini-1_datasheet_en.pdf)
+- [ESP32-C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf)
 
 [Back to table of contents](#esp32_toc)
 
 ## Features Supported by RIOT-OS {#esp32_supported_features}
 
-The RIOT-OS for ESP32 SoCs supports the following features at the moment:
+The RIOT-OS for ESP32x SoCs supports the following features at the moment:
 
 - I2C interfaces
 - SPI interfaces
 - UART interfaces
 - CAN interface
 - CPU ID access
-- RTC module
+- RTT module
 - ADC and DAC channels
 - PWM channels
 - SPI RAM
@@ -227,16 +283,18 @@ The RIOT-OS for ESP32 SoCs supports the following features at the moment:
 - Hardware number generator
 - Hardware timer devices
 - ESP-NOW netdev interface
+- ESP WiFi netdev interface in (WPA2 Personal Mode/Enterprise Mode, SoftAP mode)
 - ESP Ethernet MAC (EMAC) netdev interface
 
 [Back to table of contents](#esp32_toc)
 
 ## Limitations of the RIOT port {#esp32_limitations}
 
-The implementation of RIOT-OS for ESP32 SOCs has the following limitations at the moment:
+The implementation of RIOT-OS for ESP32x SoCs has the following limitations
+at the moment:
 
-- Only **one core** (the PRO CPU) is used because RIOT does not support running multiple threads
-  simultaneously.
+- Only **one core** (the PRO CPU) is used because RIOT does not support running
+  multiple threads simultaneously.
 - **Bluetooth** cannot be used at the moment.
 - **Flash encryption** is not yet supported.
 
@@ -244,7 +302,7 @@ The implementation of RIOT-OS for ESP32 SOCs has the following limitations at th
 
 # Toolchain {#esp32_toolchain}
 
-To build RIOT applications for ESP32, the following components are required:
+To build RIOT applications for ESP32x SoCs, the following components are required:
 
 - ESP32 Toolchain including GCC, GDB and optionally OpenOCD and QEMU
 - ESP32 SDK called ESP-IDF (Espressif IoT Development Framework)
@@ -270,22 +328,22 @@ Details on how to setup Docker can be found in section
 The building process using Docker comprises two steps:
 
 1. Building the RIOT application **in Docker** using command:
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    $ sudo docker run --rm -i -t -u $UID -v $(pwd):/data/riotbuild riot/riotbuild
    riotbuild@container-id:~$ make BOARD= ...
    riotbuild@container_id:~$ exit
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2. Flashing the RIOT application **on the host system** using command
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    $ make flash-only BOARD=...
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Both steps can also be performed with a single command on the host system
 by setting the `BUILD_IN_DOCKER` variable:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ BUILD_IN_DOCKER=1 DOCKER="sudo docker" \
   make flash BOARD=...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
 During the migration phase from the ESP32 toolchain with GCC 5.2.0, which was
@@ -297,18 +355,18 @@ has to be used instead of `riot/riotbuild` as this already contains the
 precompiled ESP32 vendor toolchain from Espressif while `riot/riotbuild`
 does not.
 Therefore, the RIOT Docker build image has to be pulled with command:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ sudo docker pull schorcht/riotbuild_esp32_espressif_gcc_8.4.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 and the RIOT Docker build image in step 1 has to be started with command:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ sudo docker run --rm -i -t -u $UID -v $(pwd):/data/riotbuild schorcht/riotbuild_esp32_espressif_gcc_8.4.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The single step build command on the host system has then to be:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ BUILD_IN_DOCKER=1 DOCKER="sudo docker" DOCKER_IMAGE=schorcht/riotbuild_esp32_espressif_gcc_8.4.0 \
   make flash BOARD=...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp32_toc)
 
@@ -331,23 +389,23 @@ toolchain (Debian/Ubuntu package names):
 The shell script `$RIOTBASE/dist/tools/esptools/install.sh` is used to
 install Espressif's precompiled versions of the following tools:
 
-- ESP32 vendor toolchain
-- OpenOCD for ESP32
-- QEMU for ESP32
+- ESP32 vendor toolchain (for ESP32 and ESP32-C3)
+- OpenOCD for ESP32 (for ESP32 and ESP32-C3)
+- QEMU for ESP32 (only for ESP32)
 
 `$RIOTBASE` defines the root directory of the RIOT repository. The shell
 script takes an argument that specifies which tools to download and install:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ dist/tools/esptools/install.sh
 
 install.sh <tool>
 tool = all | esp32 | openocd | qemu
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Thus, either all tools or only certain tools can be installed.
 
-The ESP32 tools are installed within a subdirectory of the directory specified
+The ESP32x tools are installed within a subdirectory of the directory specified
 by the environment variable `$IDF_TOOLS_PATH`. If the environment variable
 `$IDF_TOOLS_PATH` is not defined, `$HOME/.espressif` is used as default.
 
@@ -359,20 +417,20 @@ if you have already used ESP-IDF directly.
 
 ### Using the toolchain
 
-Once the ESP32 tools are installed in the directory specified by the
+Once the ESP32x tools are installed in the directory specified by the
 environment variable `$IDF_TOOLS_PATH`, the shell script
 `$RIOTBASE/dist/tools/esptools/install.sh` can be sourced to export the
 paths of the installed tools using again the environment variable
 `$IDF_TOOLS_PATH`.
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ . dist/tools/esptools/export.sh
 
 Usage: export.sh <tool>
 tool = all | esp32 | openocd | qemu
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All the tools required for building a RIOT application for ESP32 should then
+All the tools required for building a RIOT application for ESP32x SoCs should then
 be found in the path.
 
 [Back to table of contents](#esp32_toc)
@@ -398,13 +456,13 @@ For convenience, the build system uses always the version from this directory.
 Therefore, it is **not necessary to install** `esptool.py` explicitly. However
 `esptool.py` depends on `pySerial` which can be installed either
 using `pip`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ sudo pip3 install pyserial
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 or the package manager of your OS, for example on Debian/Ubuntu systems:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ apt install python3-serial
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For more information on `esptool.py`, please refer to the
 [git repository](https://github.com/espressif/esptool).
@@ -415,27 +473,30 @@ For more information on `esptool.py`, please refer to the
 
 ## Toolchain Usage {#esp32_toolchain_usage}
 
-Once the toolchain is installed either as RIOT docker build image or as local installation, a RIOT application can be compiled and flashed for an ESP32 boards. For that purpuse change to RIOT's root directory and execute the make
+Once the toolchain is installed either as RIOT docker build image or as local
+installation, a RIOT application can be compiled and flashed for an ESP32x
+boards. For that purpuse change to RIOT's root directory and execute the make
 command, for example:
 
 - RIOT Docker build image installation
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   $ BUILD_IN_DOCKER=1 DOCKER="sudo docker" \
     make flash BOARD=esp32-wroom-32 -C tests/shell [Compile Options]
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Local toolchain installation
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   $ make flash BOARD=esp32-wroom-32 -C tests/shell [Compile Options]
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `BOARD` variable in the example specifies the generic ESP32 board
-definition and option `-C` the directory of the application.
+The `BOARD` variable in the example specifies the generic ESP32 board that uses
+the ESP32-WROOM-32 module and option `-C` the directory of the application.
 
 [Back to table of contents](#esp32_toc)
 
 ## Compile Options {#esp32_compile_options}
 
-The compilation process can be controlled by a number of variables for the make command:
+The compilation process can be controlled by a number of variables for the
+make command:
 
 <center>
 
@@ -472,41 +533,48 @@ esp_wifi_enterprise | Enable the built-in WiFi module as `netdev` network device
 
 </center><br>
 
-For example, to activate a SPIFFS drive in on-board flash memory, the makefile of application has
-simply to add the `esp_spiffs` module to `USEMODULE` make variable:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For example, to activate a SPIFFS drive in on-board flash memory, the makefile
+of application has simply to add the `esp_spiffs` module to `USEMODULE` make
+variable:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_spiffs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Modules can be also be activated temporarily at the command line when calling the make command:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Modules can be also be activated temporarily at the command line when calling
+the make command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE="esp_spiffs" make BOARD=...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp32_toc)
 
 ## Flash Modes {#esp32_flash_modes}
 
-The `FLASH_MODE` make command variable determines the mode that is used for flash access in
-normal operation.
+The `FLASH_MODE` make command variable determines the mode that is used for
+flash access in normal operation.
 
-The flash mode determines whether 2 data lines (`dio` and `dout`) or 4 data lines
-(`qio` and `qout`) for addressing and data access. For each data line, one GPIO is required.
-Therefore, using `qio` or `qout` increases the performance of SPI Flash data transfers, but
-uses two additional GPIOs (GPIO9 and GPIO10). That is, in this flash modes these GPIOs are not
-available for other purposes. If you can live with lower flash data transfer rates, you should
-always use `dio` or `dout` to keep GPIO9 and GPIO10 free for other purposes.
+The flash mode determines whether 2 data lines (`dio` and `dout`) or 4 data
+lines (`qio` and `qout`) are used for flash addressing and data access. Since
+one GPIO is required for each data line, `qio` or `qout` increases the
+performance of SPI flash data transfers but uses two additional GPIOs.
+That means these GPIOs are not available for other purposes in `qio` or `qout`
+flash mode. If you can live with lower flash data transfer rates, you should
+always use `dio` or `dout` to keep them free for other purposes:
+
+- ESP32 GPIO9 and GPIO10
+- ESP32-C3 GPIO12 and GPIO13
 
 For more information about these flash modes, refer the documentation of
-[esptool.py](https://github.com/espressif/esptool/wiki/SPI-Flash-Modes).
+[esptool.py](https://docs.espressif.com/projects/esptool/en/latest/esp32/esptool/flash-modes.html).
 
 [Back to table of contents](#esp32_toc)
 
 ## Log output {#esp32_esp_log_module}
 
-The RIOT port for ESP32 implements a log module with a bunch of macros
+The RIOT port for ESP32x SoCs implements a log module with a bunch of macros
 to generate log output according to the interface as defined in
-\ref core_util_log "system logging header". These macros support colored and tagged log output.
+\ref core_util_log "system logging header". These macros support colored and
+tagged log output.
 
 The colored log output is enabled by module `esp_log_colored`. If colored log
 output is enabled, log messages are displayed in color according to their type:
@@ -517,9 +585,9 @@ When the `esp_log_tagged` module is used, all log messages are tagged with
 additional information: the type of message, the system time in ms, and the
 module or function in which the log message is generated. For example:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 I (663) [main_trampoline] main(): This is RIOT! (Version: 2019.10-devel-437-gf506a)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Either the `LOG_*` macros as defined in
 \ref core_util_log "system logging header" or the tagged
@@ -527,14 +595,14 @@ version `LOG_TAG_*` of these macros can be used to produce tagged log output.
 If the `LOG_*` macros are used, the function which generates the log message
 is used in the tag while a `tag` parameter is used for the `LOG_TAG_*` macros.
 For example,
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 LOG_ERROR("error message");
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 generates a log message in which the name of the calling function is used as
 tag. With
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 LOG_TAG_ERROR("mod", "error message");
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a log message with string `mod` in the tag is generated.
 
 The `esp_log_startup` module can be used to enable additional information
@@ -547,219 +615,157 @@ start as expected, this module should be used.
 
 ## ESP-IDF Heap Implementation {#esp32_esp_idf_heap_implementation}
 
-ESP-IDF SDK provides a complex heap implementation that supports multiple heap segments in different
-memory areas such as DRAM, IRAM, and PSRAM. Whenever you want to use these memory areas as heap, you
-have to use the heap implementation from the ESP-IDF SDK. ESP-IDF heap is not used by default.
-To use it, it has to be enabled by the the makefile of the application:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ESP-IDF SDK provides a complex heap implementation that supports multiple heap
+segments in different memory areas such as DRAM, IRAM, and PSRAM. Whenever you
+want to use these memory areas as heap, you have to use the heap implementation
+from the ESP-IDF SDK. ESP-IDF heap is not used by default. To use it, it has to
+be enabled by the the makefile of the application:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_heap
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
-ESP-IDF heap implementation is used by default, when the following modules are used:
-`esp_spi_ram`
+ESP-IDF heap implementation is used by default, when the following modules
+are used: `esp_spi_ram`, `esp_wifi_any`
 
 [Back to table of contents](#esp32_toc)
 
 # Common Peripherals {#esp32_peripherals}
 
-ESP32 is an SoC and has a lot of peripherals that are not all supported by the RIOT port. This
-section describes the supported peripherals and how they have to be configured.
+ESP32x SoCs have a lot of peripherals that are not all supported by the
+RIOT port. This section describes the supported peripherals and how they have
+to be configured.
 
 [Back to table of contents](#esp32_toc)
 
 ## GPIO pins {#esp32_gpio_pins}
 
-ESP32 has 34 GPIO pins, where only a subset can be used as output, as
-ADC channel, as DAC channel and as GPIOs in deep-sleep mode, the so-called
-RTC GPIOs. Some of them are used by special SoC components, e.g., as touch
-sensors. The following table gives a short overview.
+The number of GPIOs and their usage depends on the respective ESP32x SoC family.
+For details, see:
 
-<center>
-
-Pin    | Type   | ADC / RTC | PU / PD   | Special function      | Remarks
--------|:-------|:---------:|:---------:|-----------------------|--------
-GPIO0  | In/Out | yes       | yes       | Touch sensor          | Bootstrapping, pulled up
-GPIO1  | In/Out | -         | yes       | UART0 TxD             | Console
-GPIO2  | In/Out | yes       | yes       | Touch sensor          | Bootstrapping, pulled down
-GPIO3  | In/Out | -         | yes       | UART0 RxD             | Console
-GPIO4  | In/Out | yes       | yes       | Touch sensor          | -
-GPIO5  | In/Out | -         | yes       | -                     | -
-GPIO6  | In/Out | -         | yes       | Flash SD_CLK          | -
-GPIO7  | In/Out | -         | yes       | Flash SD_DATA0        | -
-GPIO8  | In/Out | -         | yes       | Flash SD_DATA1        | -
-GPIO9  | In/Out | -         | yes       | Flash SD_DATA2        | only in `qout`and `qio`mode, see section [Flash Modes](#esp32_flash_modes)
-GPIO10 | In/Out | -         | yes       | Flash SD_DATA3        | only in `qout`and `qio`mode, see section [Flash Modes](#esp32_flash_modes)
-GPIO11 | In/Out | -         | yes       | Flash SD_CMD          | -
-GPIO12 | In/Out | yes       | yes       | MTDI / Touch sensor   | JTAG interface / Bootstrapping, pulled down
-GPIO13 | In/Out | yes       | yes       | MTCK / Touch sensor   | JTAG interface
-GPIO14 | In/Out | yes       | yes       | MTMS / Touch sensor   | JTAG interface
-GPIO15 | In/Out | yes       | yes       | MTDO / Touch sensor   | JTAG interface / Bootstrapping, pulled up
-GPIO16 | In/Out | -         | yes       | -                     | usually not available when SPI RAM is used
-GPIO17 | In/Out | -         | yes       | -                     | usually not available when SPI RAM is used
-GPIO18 | In/Out | -         | yes       | -                     | -
-GPIO19 | In/Out | -         | yes       | -                     | -
-GPIO21 | In/Out | -         | yes       | -                     | -
-GPIO22 | In/Out | -         | yes       | -                     | -
-GPIO23 | In/Out | -         | yes       | -                     | -
-GPIO25 | In/Out | yes       | yes       | DAC1                  | -
-GPIO26 | In/Out | yes       | yes       | DAC2                  | -
-GPIO27 | In/Out | yes       | yes       | Touch sensor          | -
-GPIO32 | In/Out | yes       | yes       | XTAL32_P              | can be used to connect an external 32 kHz crystal
-GPIO33 | In/Out | yes       | -         | XTAL32_N              | can be used to connect an external 32 kHz crystal
-GPIO34 | In     | yes       | -         | VDET                  | -
-GPIO35 | In     | yes       | -         | VDET                  | -
-GPIO36 | In     | yes       | -         | SENSOR_VP             | -
-GPIO37 | In     | yes       | -         | SENSOR_CAPP           | usually not broken out
-GPIO38 | In     | yes       | -         | SENSOR_CAPN           | usually not broken out
-GPIO39 | In     | yes       | -         | SENSOR_VN             | -
-
-</center>
-
-<b>ADC:</b> these pins can be used as ADC inputs<br>
-<b>RTC:</b> these pins are RTC GPIOs and can be used in deep-sleep mode<br>
-<b>PU/PD:</b> these pins have software configurable pull-up/pull-down functionality.<br>
-
-@note GPIOs that can be used as ADC channels are also available as low power digital inputs/outputs
-      in deep sleep mode.
-
-GPIO0, GPIO2 are bootstrapping pins which are used to boot ESP32 in different modes:
-
-<center>
-
-GPIO0 | GPIO2 | Mode
-:----:|:-----:|------------------
-1     | X     | boot in FLASH mode to boot the firmware from flash (default mode)
-0     | 0     | boot in UART mode for flashing the firmware
-
-</center><br>
-
-@note GPIO2 becomes the SPI MISO signal for boards that use the HSPI interface as SD-Card interface
-      in 4-bit SD mode. On these boards all signals of the SD-Card interface are pulled up. Because
-      of the bootstrapping functionality of GPIO2, it can become necessary to either press the
-      **Boot** button, remove the SD card or remove the peripheral hardware to flash RIOT.
+- \ref esp32_gpio_pins_esp32 "ESP32"
 
 [Back to table of contents](#esp32_toc)
 
 ## ADC Channels {#esp32_adc_channels}
 
-ESP32 integrates two 12-bit ADCs (ADC1 and ADC2) capable of measuring up to 18 analog signals in
-total. Most of these ADC channels are either connected to a number of integrated sensors like a
-Hall sensors, touch sensors and a temperature sensor or can be connected with certain GPIOs.
-Integrated sensors are disabled in RIOT's implementation and are not accessible. Thus, up to 18
-GPIOs, can be used as ADC inputs:
+ESP32x SoCs integrate two SAR ADCs (ADC1 and ADC2). The bit width of the
+ADC devices, the number of channels per device and the GPIOs that can be
+used as ADC channels depend on the respective ESP32x SoC family. For
+details, see:
 
-- **ADC1** supports 8 channels: GPIOs 32-39
-- **ADC2** supports 10 channels: GPIOs 0, 2, 4, 12-15, 25-27
+- \ref esp32_adc_channels_esp32 "ESP32"
 
-These GPIOs are realized by the RTC unit and are therefore also called RTC GPIOs or RTCIO GPIOs.
-
-@note
-- GPIO37 and GPIO38 are usually not broken out on ESP32 boards and can not be
-  used therefore.
-- ADC2 is used by the WiFi module. The GPIOs connected to ADC2 are therefore not
-  available as ADC channels if the modules `esp_wifi` or `esp_now` are used.
-
-The GPIOs that can be used as ADC channels for a given board are defined by the `#ADC_GPIOS`
-macro in the board-specific peripheral configuration. This configuration can be changed by
-[application-specific configurations](#esp32_application_specific_configurations).
-
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#ADC_GPIOS in the board-specific peripheral configuration defines the
+list of GPIOs that can be used as ADC channels on the board, for example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #define ADC_GPIOS   { GPIO0, GPIO2, GPIO4 }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The order of the listed GPIOs determines the mapping between the RIOT's ADC lines and the GPIOs. The
-maximum number of GPIOs in the list is `#ADC_NUMOF_MAX` which is defined to be 16.
+Thereby the order of the listed GPIOs determines the mapping between the
+ADC lines of the RIOT and the GPIOs. The maximum number of GPIOs in the
+list is #ADC_NUMOF_MAX. The board specific configuration of #ADC_GPIOS
+can be overridden by [Application specific configurations]
+(#esp32_application_specific_configurations).
 
-`#ADC_NUMOF` is determined automatically from `#ADC_GPIOS` list and must not be changed.
+The number of defined ADC channels #ADC_NUMOF is determined automatically
+from the #ADC_GPIOS definition.
 
-@note
-- `#ADC_GPIOS` must be defined even if there are no GPIOs that could be used as ADC channels on
-  the board. In this case, an empty list hast to be defined which just contains the curly braces.
-- As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC channels with the
-  `#adc_init` function, they can be used for other purposes.
+@note As long as the GPIOs listed in #ADC_GPIOS are not initialized as ADC
+      channels with the #adc_init function, they can be used for other
+      purposes.
 
-For each ADC line, an attenuation of the input signal can be defined separately with the
-`#adc_set_attenuation` function.
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+With the function #adc_set_attenuation an attenuation of the input signal
+can be defined separately for each ADC channel.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 extern int adc_set_attenuation(adc_t line, adc_attenuation_t atten);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This results in different full ranges of the measurable voltage at the input. The attenuation can
-be set to 0 dB, 3 dB, 6 dB and 11 dB, with 11 dB being the standard attenuation. Since an ADC input
-is measured against a reference voltage Vref of 1.1 V, approximately the following measurement
-ranges are given when using a corresponding attenuation:
+This leads to different measurable maximum values for the voltage at the input.
+The higher the attenuation is, the higher the voltage measured at the input
+can be.
+
+The attenuation can be set to 4 fixed values 0 dB, 2.5/3 dB, 6 dB and
+11/12 dB, where 11 dB respectively 12 dB is the default attenuation.
 
 <center>
 
-Attenuation     | Voltage Range     | Symbol
-----------------|-------------------|----------------------
- 0 dB           | 0 ... 1.1V (Vref) | ADC_ATTENUATION_0_DB
- 3 dB           | 0 ... 1.5V        | ADC_ATTENUATION_3_DB
- 6 dB           | 0 ... 2.2V        | ADC_ATTENUATION_6_DB
-11 dB (default) | 0 ... 3.3V        | ADC_ATTENUATION_11_DB
+Attenuation | Voltage Range     | Symbol
+-----------:|-------------------|---------------------------
+      0 dB  | 0 ... 1.1V (Vref) | `ADC_ATTEN_DB_0`
+2.5 / 3 dB  | 0 ... 1.5V        | `ADC_ATTEN_DB_2_5`
+      6 dB  | 0 ... 2.2V        | `ADC_ATTEN_DB_6`
+11 / 12 dB  | 0 ... 3.3V        | `ADC_ATTEN_DB_11` (default)
 
 </center><br>
 
-@note The reference voltage Vref can vary from device to device in the range of 1.0V and 1.2V. The
-      Vref of a device can be read with the `#adc_line_vref_to_gpio` function at GPIO 25.<br>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-extern int adc_line_vref_to_gpio(adc_t line, gpio_t gpio);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@note The reference voltage Vref can vary from device to device in the range
+      of 1.0V and 1.2V.
 
-For that purpose GPIO25 is initialized automatically as ADC channel and is connected internally to
-Vref to measure the current voltage. Once the initialization is finished and the function returns
-with success, the current voltage can be read from GPIO25. The results of the ADC input can then be
-adjusted accordingly. The `#adc_line_vref_to_gpio` function can be used to determine the current
-voltage at ESP32.
+The Vref of a device can be read at a predefined GPIO with the function
+#adc_line_vref_to_gpio. The results of the ADC input can then be adjusted
+accordingly.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+extern int adc_line_vref_to_gpio(adc_t line, gpio_t gpio);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For the GPIO that can be used with this function, see:
+
+- \ref esp32_adc_channels_esp32 "ESP32"
+
+@note ADC2 is also used by the WiFi module. The GPIOs connected to ADC2 are
+      therefore not available as ADC channels if the modules `esp_wifi` or
+      `esp_now` are used.
 
 [Back to table of contents](#esp32_toc)
 
 ## DAC Channels {#esp32_dac_channels}
 
-ESP32 supports 2 DAC lines at GPIO25 and GPIO26. These DACs have a width of 8 bits and produce
-voltages in the range from 0 V to 3.3 V (VDD_A). The 16 bits DAC values given as parameter of
-function `#dac_set` are down-scaled to 8 bit.
+Some ESP32x SoCs support 2 DAC lines at predefined GPIOs, depending on the
+respective ESP32x SoC family. These DACs have a width of 8 bits and produce
+voltages in the range from 0 V to 3.3 V (VDD_A). The 16 bit DAC values
+given as parameter of function #dac_set are down-scaled to 8 bit.
 
-The GPIOs that can be used as DAC channels for a given board are defined by the `#DAC_GPIOS`
-macro in the board-specific peripheral configuration. This configuration can be changed by
-[application-specific configurations](#esp32_application_specific_configurations).
+The GPIOs that can be used as DAC channels for a given board are defined by
+the `#DAC_GPIOS` macro in the board-specific peripheral configuration.
+The specified GPIOs in the list must match the predefined GPIOs that can be
+used as DAC channels on the respective ESP32x SoC.
 
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #define DAC_GPIOS   { GPIO25, GPIO26 }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The order of the listed GPIOs determines the mapping between the RIOT's DAC lines and the GPIOs. The
-maximum number of GPIOs in the list is `#DAC_NUMOF_MAX` which is defined to be 16.
+This configuration can be changed by [application-specific configurations]
+(#esp32_application_specific_configurations).
 
-`#DAC_NUMOF` is determined automatically from `#DAC_GPIOS` list and must not be changed.
+The order of the listed GPIOs determines the mapping between the RIOT's
+DAC lines and the GPIOs. The maximum number of GPIOs in the list is
+#DAC_NUMOF_MAX.
 
-@note
-- `#DAC_GPIOS` must be defined even if there are no GPIOs that could be used as DAC channels on
-  the board. In this case, an empty list hast to be defined which just contains the curly braces.
-- As long as the GPIOs listed in `#DAC_GPIOS` are not initialized as DAC channels with the
-  `#dac_init` function, they can be used for other purposes.
+#DAC_NUMOF is determined automatically from the #DAC_GPIOS definition.
+
+@note As long as the GPIOs listed in #DAC_GPIOS are not initialized
+as DAC channels with the #dac_init function, they can be used for other
+purposes.
+
+DACs are currently only supported for the \ref esp32_dac_channels_esp32
+"ESP32 SoC" variant.
 
 [Back to table of contents](#esp32_toc)
 
 ## I2C Interfaces {#esp32_i2c_interfaces}
 
-The ESP32 has two built-in I2C hardware interfaces that support I2C bus speed up to 400 kbps
-(`I2C_SPEED_FAST`).
+ESP32x SoCs integrate up to two I2C hardware interfaces.
 
-The board-specific configuration of the I2C interface `I2C_DEV(n)` requires the definition of
+The board-specific configuration of the I2C interface I2C_DEV(n) requires
+the definition of
 
-- `I2Cn_SPEED`, the bus speed,
-- `I2Cn_SCL`, the GPIO used as SCL signal, and
-- `I2Cn_SDA`, the GPIO used as SDA signal,
+`I2Cn_SPEED`, the bus speed for I2C_DEV(n),
+`I2Cn_SCL`, the GPIO used as SCL signal for I2C_DEV(n), and
+`I2Cn_SDA`, the GPIO used as SDA signal for I2C_DEV(n),
 
-where `n` can be 0 or 1. If they are not defined, the I2C interface `I2C_DEV(n)` is not used.
-
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+where `n` can be 0 or 1. If they are not defined, the I2C interface
+I2C_DEV(n) is not used, for example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #define I2C0_SPEED  I2C_SPEED_FAST
 #define I2C0_SCL    GPIO22
 #define I2C0_SDA    GPIO21
@@ -767,69 +773,92 @@ Example:
 #define I2C1_SPEED  I2C_SPEED_NORMAL
 #define I2C1_SCL    GPIO13
 #define I2C1_SDA    GPIO16
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-@note The configuration of the I2C interfaces `I2C_DEV(n)` must be in continuous ascending order
-      of n.
+The board-specific pin configuration of I2C interfaces can be changed by
+[application specific configurations](#esp32_application_specific_configurations)
+by overriding the according `I2Cn_*` symbols.
 
-`#I2C_NUMOF` is determined automatically from board-specific peripheral definitions of
-`I2Cn_SPEED`, `I2Cn_SCK`, and `I2Cn_SDA`.
+The default configuration of I2C interfaces for ESP32x SoC boards depend
+on used ESP32x SoC family, for details see:
 
-The following table shows the default configuration of I2C interfaces used for a large number of
-boards. It can be changed by
-[application-specific configurations](#esp32_application_specific_configurations).
+- \ref esp32_i2c_interfaces_esp32 "ESP32"
 
-<center>
+@note
+- To ensure that the `I2Cn_*` symbols define the configuration for
+  I2C_DEV(n), the definition of the configuration of I2C interfaces
+  I2C_DEV(n) must be in continuous ascending order of `n`.
+  That is, if I2C_DEV(1) is used by defining the `I2C1_*` symbols,
+  I2C_DEV(0) must also be used by defining the `I2C0_*` symbols.
+- The GPIOs listed in the configuration are only initialized as I2C
+  signals when the `periph_i2c` module is used. Otherwise they are not
+  allocated and can be used for other purposes.
+- The same configuration is used when the I2C bit-banging software
+  implementation is used by enabling module `esp_i2c_sw` (default).
 
-Device          |Signal|Pin     |Symbol       |Remarks
-:---------------|:-----|:-------|:------------|:----------------
- I2C_DEV(0)     | SCL  | GPIO22 | `#I2C0_SCL` | -
- I2C_DEV(0)     | SDA  | GPIO21 | `#I2C0_SDA` | -
+The number of used I2C interfaces #I2C_NUMOF is determined automatically
+from board-specific peripheral definitions of I2C_DEV(n).
 
-</center><br>
-
-@note The GPIOs listed in the configuration are only initialized as I2C signals when the
-      `periph_i2c` module is used. Otherwise they are not allocated and can be used for other
-      purposes.
-
-Beside the I2C hardware implementation, a I2C bit-banging protocol software implementation can be
-used. This implementation allows bus speeds up to 1 Mbps (`#I2C_SPEED_FAST_PLUS`). It can be
-activated by adding
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Beside the I2C hardware implementation, a I2C bit-banging protocol software
+implementation can be used. This implementation allows bus speeds up to
+1 Mbps (`#I2C_SPEED_FAST_PLUS`). It can be activated by adding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_i2c_sw
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-to application's makefile. The Disadvantage of the software implementation is that it uses busy
-waiting.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+to application's makefile. The Disadvantage of the software implementation
+is that it uses busy waiting.
 
-@note The hardware implementation seems to be very poor and faulty. I2C commands in the I2C command
-      pipeline are sporadically not executed. A number of ACK errors and timeouts caused by protocol
-      errors are the result. The hardware implementation is recommended only if they can be
-      tolerated. Therefore, the software implementation is used by default.
+@note The hardware implementation seems to be very poor and faulty. I2C
+      commands in the I2C command pipeline are sporadically not executed.
+      A number of ACK errors and timeouts caused by protocol errors are
+      the result. The hardware implementation is recommended only if
+      they can be tolerated. Therefore, the software implementation is
+      used by default.
 
 [Back to table of contents](#esp32_toc)
 
 ## PWM Channels {#esp32_pwm_channels}
 
-ESP supports two types of PWM generators
+The PWM peripheral driver for ESP32x SoCs uses the LED PWM Controller (LEDC)
+module for implementation. The LEDC module has either 1 or 2 channel groups
+with 6 or 8 channels each, where the first channel group comprises the
+low-speed channels and the second channel group comprises the high-speed
+channels. The difference is that changes in the configuration of the
+high-speed channels take effect with the next PWM cycle, while the changes
+in the configuration of the low-speed channels must be explicitly updated
+by a trigger.
 
-The implementation of the PWM peripheral driver uses the LED PWM Controller
-(LEDC) module of the ESP32x SoC. This LEDC module has one or two channel
-groups with 6 or 8 channels each. The channels of each channel group can
-use one of 4 timers as clock source. Thus, it is possible to define at
-4 or 8 virtual PWM devices in RIOT with different frequencies and
-resolutions. Regardless of whether the LEDC module of the ESP32x SoC has
-one or two channel groups, the PWM driver implementation allows to organize
-the available channels into up to 4 virtual PWM devices.
+The low-speed channel group always exists while the existence high-speed
+channel depends on respective ESP32x SoC family. For details, see:
+
+- \ref esp32_pwm_channels_esp32 "ESP32"
+
+Each channel group has 4 timers which can be used as clock source by the
+channels of the respective channel group. Thus it would be possible to
+define a maximum of 4 virtual PWM devices in RIOT per channel group with
+different frequencies and resolutions. However, regardless of whether the
+LEDC module of the ESP32x SoC has one or two channel groups, the PWM driver
+implementation only allows the available channels to be organized into
+up to 4 virtual PWM devices.
 
 The assignment of the available channels to the virtual PWM devices is
 done in the board-specific peripheral configuration by defining the
 macros `PWM0_GPIOS`, `PWM1_GPIOS`, `PWM2_GPIOS` and `PWM3_GPIOS` These
-macros specify the GPIOs that are used as channels for the available
-virtual PWM devices PWM_DEV(0) ... PWM_DEV(3) in RIOT. The mapping of
-these channels to the available channel groups and channel group timers
-is done by the driver automatically as follows:
+macros specify the GPIOs that are used as channels for the 4 possible
+virtual PWM devices PWM_DEV(0) ... PWM_DEV(3) in RIOT, for example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#define PWM0_GPIOS  { GPIO0, GPIO2, GPIO4, GPIO16, GPIO17 }
+#define PWM1_GPIOS  { GPIO27, GPIO32, GPIO33 }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This configuration can be changed by [application-specific configurations]
+(#esp32_application_specific_configurations).
+
+The mapping of the GPIOs as channels of the available channel groups and
+channel group timers is organized by the driver automatically as follows:
 
 <center>
+
 Macro        | 1 Channel Group       | 2 Channel Groups       | Timer
 -------------|-----------------------|------------------------|---------------
 `PWM0_GPIOS` | `LEDC_LOW_SPEED_MODE` | `LEDC_LOW_SPEED_MODE`  | `LEDC_TIMER_0`
@@ -838,181 +867,105 @@ Macro        | 1 Channel Group       | 2 Channel Groups       | Timer
 `PWM3_GPIOS` | `LEDC_LOW_SPEED_MODE` | `LEDC_HIGH_SPEED_MODE` | `LEDC_TIMER_3`
 
 </center>
+
 For example, if the LEDC module of the ESP32x SoC has two channel groups,
-two virtual PWM devices with 2 x 6/8 channels could be used by defining
-'PWM0_GPIOS' and 'PWM1_GPIOS' with up to 6 or 8 GPIOs each.
+two virtual PWM devices with 2 x 6 (or 8) channels could be used by defining
+'PWM0_GPIOS' and 'PWM1_GPIOS' with 6 (or 8) GPIOs each.
 
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#define PWM0_GPIOS { GPIO0, GPIO2, GPIO4, GPIO16, GPIO17 }
-#define PWM1_GPIOS { GPIO27, GPIO32, GPIO33 }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This configuration can be changed by
-[application specific configurations](#esp32_application_specific_configurations).
+The number of used PWM devices #PWM_NUMOF is determined automatically from the
+definition of `PWM0_GPIOS`, `PWM1_GPIOS`, `PWM2_GPIOS` and `PWM3_GPIOS`.
 
 @note
 - The total number of channels defined for a channel group must not exceed
-  #PWM_CH_NUMOF_MAX.
+  #PWM_CH_NUMOF_MAX
 - The definition of `PWM0_GPIOS`, `PWM1_GPIOS`, `PWM2_GPIOS` and
-  `PWM3_GPIOS` can be omitted. In this case the existing macros should
-  be defined in ascending order, as the first defined macro is assigned
-  to PWM_DEV(0), the second defined macro is assigned to PWM_DEV(1)
-  and so on. So the minimal configuration would define all channels by
-  `PWM0_GPIOS` as PWM_DEV(0).
-- #PWM_NUMOF is determined automatically.
+  `PWM3_GPIOS` can be omitted. However, to ensure that `PWMn_GPIOS` defines
+  the configuration for PWM_DEV(n), the PWM channels must be defined in
+  continuous ascending order from `n`. That means, if `PWM1_GPIOS` is
+  defined, `PWM0_GPIOS` must be defined before, and so on. So a minimal
+  configuration would define all channels by `PWM0_GPIOS` as PWM_DEV(0).
 - The order of the GPIOs in these macros determines the mapping between
   RIOT's PWM channels and the GPIOs.
 - As long as the GPIOs listed in `PWM0_GPIOS`, `PWM1_GPIOS`,
   `PWM2_GPIOS` and `PWM3_GPIOS` are not initialized as PWM channels with
-  the #pwm_init function, they can be used for other purposes.
-
-
-- one LED PWM controller (LEDPWM) with 16 channels, and
-- two high-speed Motor Control PWM controllers (MCPWM) with 6 channels each.
-
-The PWM implementation uses the ESP32's high-speed MCPWM modules. Reason is that the LED PWM
-controller only supports resolutions of powers of two.
-
-ESP32 has 2 MCPWM modules, each with up to 6 channels (`PWM_CHANNEL_NUM_DEV_MAX`). Thus, the
-maximum number of PWM devices is 2 and the maximum total number of PWM channels is 12. These 2 MCPWM
-devices are used as RIOT PWM devices `#PWM_DEV(0)` and `#PWM_DEV(1)`.
-
-The GPIOs that can be used as PWM channels of RIOT's PWM devices are defined by the
-`#PWM0_GPIOS` and `PWM1_GPIOS` macros in the board-specific peripheral configuration.
-This configuration can be changed by
-[application specific configurations](#esp32_application_specific_configurations).
-
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#define PWM0_GPIOS { GPIO9, GPIO10 }
-#define PWM1_GPIOS { }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The order of the listed GPIOs determines the mapping between RIOT's PWM channels and the GPIOs.
-Board definitions usually declare a number of GPIOs as PWM channels.
-
-@note The definition of `#PWM0_GPIOS` and `PWM1_GPIOS` can be omitted or empty. In the latter
-      case, they must at least contain the curly braces. The corresponding PWM device can not be
-      used in this case.
-
-`#PWM_NUMOF` is determined automatically from the `#PWM0_GPIOS` and `PWM1_GPIOS` definitions and
-must not be changed.
-
-@note As long as the GPIOs listed in `#PWM0_GPIOS` and `PMW1_GPIOS` are not initialized as
-      PWM channels with the `#pwm_init` function, they are not allocated and can be used other
-      purposes.
+  the #pwm_init function, they can be used other purposes.
 
 [Back to table of contents](#esp32_toc)
 
 ## SPI Interfaces {#esp32_spi_interfaces}
 
-ESP32 integrates four SPI controllers:
+ESP32x SoCs have up to four SPI controllers dependent on the specific ESP32x
+SoC variant (family):
 
-- controller SPI0 is reserved for caching the flash memory
-- controller SPI1 is reserved for interface `FSPI` to external memories like flash and PSRAM
-- controller SPI2 realizes interface `HSPI` that can be used for peripherals
-- controller SPI3 realizes interface `VSPI` that can be used for peripherals
+- Controller SPI0 is reserved for caching external memories like Flash
+- Controller SPI1 is reserved for external memories like PSRAM
+- Controller SPI2 can be used as general purpose SPI (GPSPI)
+- Controller SPI3 can be used as general purpose SPI (GPSPI)
 
-Thus, a maximum of two SPI controllers can be used as peripheral interfaces:
+The controllers SPI0 and SPI1 share the same bus signals and can only
+operate in memory mode on most ESP32x SoC variants. Therefore, depending on
+the specific ESP32x SoC family, a maximum of two SPI controllers can be used
+as peripheral interfaces:
 
-- `VSPI`
-- `HSPI`
+- Controller SPI2 is identified by `SPI2_HOST` (also called FSPI or HSPI)
+- Controller SPI3 is identified by `SPI3_HOST` (also called VSPI)
 
-All SPI interfaces could be used in quad SPI mode, but RIOT's low level device driver doesn't
-support it.
+In former ESP-IDF versions, SPI interfaces were identified by the alias
+names `FSPI`, `HSPI` and `VSPI`, which are sometimes also used in data
+sheets. These alias names have been declared obsolete in ESP-IDF.
 
-The board-specific configuration of the SPI interface `SPI_DEV(n)` requires the definition of
+SPI interfaces could be used in quad SPI mode, but RIOT's low level
+device driver doesn't support it.
 
-- `SPIn_CTRL`, the SPI controller which is used for `SPI_DEV(n)`, can be `VSPI` or
-  `HSPI`,
-- `SPIn_SCK`, the GPIO used as clock signal for `SPI_DEV(n)`,
-- `SPIn_MISO`, the GPIO used as MISO signal for `SPI_DEV(n)`,
-- `SPIn_MOSI`, the GPIO used as MOSI signal for `SPI_DEV(n)`, and
-- `SPIn_CS0`, the GPIO used as CS signal for `SPI_DEV(n)` when the cs parameter in
-  spi_acquire is `#GPIO_UNDEF`,
+The board-specific configuration of the SPI interface SPI_DEV(n) requires
+the definition of
 
-where `n` can be 0 or 1. If they are not defined, the SPI interface `SPI_DEV(n)` is not
-used.
+- `SPIn_CTRL`, the SPI controller (`SPI_HOST2`/`SPI_HOST3`) used for SPI_DEV(n),
+- `SPIn_SCK`, the GPIO used as clock signal used for SPI_DEV(n)
+- `SPIn_MISO`, the GPIO used as MISO signal used for SPI_DEV(n)
+- `SPIn_MOSI`, the GPIO used as MOSI signal used for SPI_DEV(n), and
+- `SPIn_CS0`, the GPIO used as CS signal for SPI_DEV(n) when the `cs`
+  parameter in #spi_acquire is #GPIO_UNDEF,
 
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#define SPI0_CTRL   VSPI
-#define SPI0_SCK    GPIO18      // SCK  Periphery
-#define SPI0_MISO   GPIO19      // MISO Periphery
-#define SPI0_MOSI   GPIO23      // MOSI Periphery
-#define SPI0_CS0    GPIO5       // CS0  Periphery
+where `n` can be 0 and 1. If they are not defined, the according SPI interface
+SPI_DEV(n) is not used, for example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#define SPI0_CTRL   SPI3_HOST   // VSPI could also be used on ESP32 variant
+#define SPI0_SCK    GPIO18      // SCK  signal
+#define SPI0_MISO   GPIO19      // MISO signal
+#define SPI0_MOSI   GPIO23      // MOSI signal
+#define SPI0_CS0    GPIO5       // CS0  signal
 
-#define SPI1_CTRL   HSPI
+#define SPI1_CTRL   SPI2_HOST   // HSPI could also be used here on ESP32 variant
 #define SPI1_SCK    GPIO14      // SCK  Camera
 #define SPI1_MISO   GPIO12      // MISO Camera
 #define SPI1_MOSI   GPIO13      // MOSI Camera
 #define SPI1_CS0    GPIO15      // CS0  Camera
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The pin configuration of `VSPI` interface and the `HSPI` interface can be changed by
-[application specific configurations](#esp32_application_specific_configurations).
+The pin configuration of SPI interfaces can be changed by
+[application specific configurations](#esp32_application_specific_configurations)
+by overriding the according `SPIn_*` symbols.
+
+The default configuration of SPI interface for ESP32x SoC boards depend
+on used ESP32x SoC family, for details see:
+
+- \ref esp32_spi_interfaces_esp32 "ESP32"
 
 @note
-- The configuration of the SPI interfaces `SPI_DEV(n)` should be in
-  continuous ascending order of `n`.
-- The order in which the interfaces `VSPI` and `HSPI` are used doesn't
-  matter. For example, while one board may only use the `HSPI` interface as
-  `#SPI_DEV(0)`, another board may use the `VSPI` interface as
-  `#SPI_DEV(0)` and the `HSPI` interface as `SPI_DEV(1)`.
-- The GPIOs listed in the configuration are first initialized as SPI signals
-  when the corresponding SPI interface is used by calling either the
-  `#spi_init_cs` function or the `#spi_acquire` function. That is, they
-  are not allocated as SPI signals before and can be used for other purposes as
-  long as the SPI interface is not used.
-- GPIO2 becomes the MISO signal in SPI mode on boards that use the HSPI as the
-  SD card interface in 4-bit SD mode. Because of the bootstrapping
-  functionality of the GPIO2, it can be necessary to either press the **Boot**
-  button, remove the SD card or remove the peripheral hardware to flash RIOT.
+- To ensure that the `SPIn_*` symbols define the configuration for
+  SPI_DEV(n), the definition of the configuration of SPI interfaces
+  SPI_DEV(n) must be in continuous ascending order of `n`.
+  That is, if SPI_DEV(1) is used by defining the `SPI1_*` symbols,
+  SPI_DEV(0) must also be used by defining the `SPI0_*` symbols.
+- The order in which the available interfaces `SPI2_HOST` (alias `HSPI` or
+  `FSP`) and `SPI3_HOST` (alias `HSPI`) are assigned doesn't matter.
+- The GPIOs listed in the configuration are only initialized as SPI
+  signals when the `periph_spi` module is used. Otherwise they are not
+  allocated and can be used for other purposes.
 
 `#SPI_NUMOF` is determined automatically from the board-specific
 peripheral definitions of `SPI_DEV(n)`.
-
-The following table shows the pin configuration used for most boards, even
-though it **can vary** from board to board.
-
-<center>
-
-Device|Signal|Pin     |Symbol       | Remarks
-:-----|:----:|:-------|:-----------:|:---------------------------
-VSPI  | SCK  | GPIO18 |`#SPI0_SCK`  | can be used for peripherals
-VSPI  | MISO | GPIO19 |`#SPI0_MISO` | can be used for peripherals
-VSPI  | MOSI | GPIO23 |`#SPI0_MOSI` | can be used for peripherals
-VSPI  | CS0  | GPIO18 |`#SPI0_CS0`  | can be used for peripherals
-HSPI  | SCK  | GPIO14 |`#SPI1_SCK`  | can be used for peripherals
-HSPI  | MISO | GPIO12 |`#SPI1_MISO` | can be used for peripherals
-HSPI  | MOSI | GPIO13 |`#SPI1_MOSI` | can be used for peripherals
-HSPI  | CS0  | GPIO15 |`#SPI1_CS0`  | can be used for peripherals
-FSPI  | SCK  | GPIO6  |-            | reserved for flash and PSRAM
-FSPI  | CMD  | GPIO11 |-            | reserved for flash and PSRAM
-FSPI  | SD0  | GPIO7  |-            | reserved for flash and PSRAM
-FSPI  | SD1  | GPIO8  |-            | reserved for flash and PSRAM
-FSPI  | SD2  | GPIO9  |-            | reserved for flash and PSRAM (only in `qio` or `qout` mode)
-FSPI  | SD3  | GPIO10 |-            | reserved for flash and PSRAM (only in `qio` or `qout` mode)
-
-</center><br>
-
-Some boards use the HSPI as SD-Card interface (SDIO) in 4-bit SD mode.
-
-<center>
-Device|Pin     | SD 4-bit mode | SPI mode
-:-----|:------:|:-------------:|:----------:
-HSPI  | GPIO14 | CLK           | SCK
-HSPI  | GPIO15 | CMD           | CS0
-HSPI  | GPIO2  | DAT0          | MISO
-HSPI  | GPIO4  | DAT1          | -
-HSPI  | GPIO12 | DAT2          | -
-HSPI  | GPIO13 | DAT3          | MOSI
-</center><br>
-
-On these boards, all these signals are pulled up. This may cause flashing
-problems due to the bootstrap function of the GPIO2 pin, see section
-[GPIO pins](#esp32_gpio_pins).
 
 [Back to table of contents](#esp32_toc)
 
@@ -1020,20 +973,28 @@ problems due to the bootstrap function of the GPIO2 pin, see section
 
 There are two different implementations for hardware timers.
 
-- **Timer Module implementation** It provides 4 high-speed timers, where 1 timer
-  is used for system time. The remaining **3 timer devices** with **1 channel**
-  each can be used as RIOT timer devices with a clock rate of 1 MHz.
-- **Counter implementation** It uses CCOUNT/CCOMPARE registers to implement **2
-  timer devices** with **1 channel** each and a clock rate of 1 MHz.
+- **Timer Module implementation** Depending on the ESP32x SoC variant
+  (family) it provides up to 4 high speed timers, where 1 timer is used for
+  system time. The remaining timer devices with **1 channel** each can be
+  used as RIOT timer devices with a clock rate of 1 MHz.
+- **Counter implementation** Dependent on the ESP32x SoC variant (family),
+  the MCU has up to 3 CCOMPARE (cycle compare) registers. Two of them can be
+  used to implement up to **2 timer devices** with **1 channel** each and a
+  clock rate of 1 MHz. This is a feature of Xtensa-based ESP32x SoC variants.
 
-By default, the hardware timer module is used. To use the hardware counter
-implementation, add
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, the timer module is used. To use the counter implementation, add
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_hw_counter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 to application's makefile.
 
-Timers are MCU built-in features and not board-specific. There is nothing to be configured.
+The number of timers and available timer implementations depend on used
+ESP32x SoC family, for details see:
+
+- \ref esp32_timers_esp32 "ESP32"
+
+Timers are MCU built-in features and not board-specific. There is nothing to
+be configured.
 
 [Back to table of contents](#esp32_toc)
 
@@ -1041,10 +1002,10 @@ Timers are MCU built-in features and not board-specific. There is nothing to be 
 
 The RTT peripheral low-level driver provides a RTT (Real Time Timer) with
 a frequency of 32.768 kHz. It either uses the RTC hardware timer if an
-external 32.768 kHz crystal is connected to the ESP32 or the PLL-controlled
-64-bit microsecond system timer to emulate the RTC timer.
+external 32.768 kHz crystal is connected to the ESP32x SoC or the
+PLL-controlled 64-bit microsecond system timer to emulate the RTC timer.
 
-Whether an external 32.768 kHz crystal is connected to the ESP32 is
+Whether an external 32.768 kHz crystal is connected to the ESP32x SoC is
 specified as a feature by the board definition using the pseudomodule
 `esp_rtc_timer_32k`. If the feature `esp_rtc_timer_32k` is defined but the
 external 32.768 kHz crystal is not recognized during startup, the
@@ -1053,10 +1014,10 @@ RTC timer.
 
 The RTT is retained during light and deep sleep as well as during a restart.
 The RTC hardware timer is used for this purpose, regardless of whether an
-external 32.768 kHz crystal is connected to the ESP32 or the internal 150 kHz
-RC oscillator is used. All current timer values are saved in the RTC memory
-before entering a sleep mode or restart and are restored after when waking up
-or restarting.
+external 32.768 kHz crystal is connected to the ESP32x SoC or the internal
+150 kHz RC oscillator is used. All current timer values are saved in the
+RTC memory before entering a sleep mode or restart and are restored after
+when waking up or restarting.
 
 @note The RTT implementation is also used to implement a RTC (Real Time Clock)
 peripheral. For this purpose the module `rt_rtc` is automatically enabled
@@ -1066,68 +1027,76 @@ when the feature `periph_rtc` is used.
 
 ## UART Interfaces {#esp32_uart_interfaces}
 
-ESP32 supports up to three UART devices. `#UART_DEV(0)` has a fixed pin
-configuration and is always available. All ESP32 boards use it as standard
-configuration for the console.
+ESP32x SoCs integrate up to three UART devices, depending on the specific
+ESP32x SoC variant (family).
 
-The pin configuration of `#UART_DEV(1)` and `#UART_DEV(2)` are defined in board specific peripheral configuration by
+The pin configuration of the UART device UART_DEV(n) is defined in the
+board-specific peripheral configuration by
 
-- `UARTn_TXD`, the GPIO used as TxD signal, and
-- `UARTn_RXD`, the GPIO used as RxD signal,
+- `UARTn_TXD`, the GPIO used as TxD signal for UART_DEV(n), and
+- `UARTn_RXD`, the GPIO used as RxD signal for UART_DEV(n),
 
-where `n` can be 2 or 3. If they are not defined, the UART interface UART_DEV(n) is not used.
+where `n` can be in range of 0 and UART_NUMOF_MAX-1. If they are not defined,
+the according UART interface UART_DEV(n) is not used, for example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#define UART1_TX    GPIO10  // TxD signal of UART_DEV(1)
+#define UART1_RX    GPIO9   // RxD signal of UART_DEV(1)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#UART_NUMOF is determined automatically from the board-specific
-peripheral definitions of `UARTn_TXD` and `UARTn_RXD` and must not be
-changed.
+The pin configuration of UART interfaces can be changed by
+[application specific configurations](#esp32_application_specific_configurations)
+by overriding the according `UARTn_*` symbols.
 
-The following default pin configuration of UART interfaces as used by a most
-boards can be overridden by the application, see section [Application-Specific
-Configurations](#esp32_application_specific_configurations).
+The default configuration of the UART interfaces for ESP32x SoC boards depend
+on used ESP32x SoC family, for details see:
 
-Device      |Signal|Pin     |Symbol      |Remarks
-:-----------|:-----|:-------|:-----------|:----------------
-UART_DEV(0) | TxD  | GPIO1  |`#UART0_TXD`| cannot be changed
-UART_DEV(0) | RxD  | GPIO3  |`#UART0_RXD`| cannot be changed
-UART_DEV(1) | TxD  | GPIO10 |`#UART1_TXD`| optional, can be overridden
-UART_DEV(1) | RxD  | GPIO9  |`#UART1_RXD`| optional, can be overridden
-UART_DEV(2) | TxD  | GPIO17 |`UART2_TXD` | optional, can be overridden
-UART_DEV(2) | RxD  | GPIO16 |`UART2_RXD` | optional, can be overridden
+- \ref esp32_uart_interfaces_esp32 "ESP32"
 
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#define UART1_TXD   GPIO10      // UART_DEV(1) TxD
-#define UART1_RXD   GPIO9       // UART_DEV(1) RxD
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@note To ensure that the `UARTn_*` symbols define the configuration for
+      UART_DEV(n), the configuration of the UART interfaces UART_DEV(n)
+      must be in continuous ascending order of `n`. That is, if UART_DEV(1)
+      is to be used by defining the `UART1_*` symbols, UART_DEV(0) must also
+      be used by defining the `UART0_*` symbols, and if UART_DEV(2)
+      is to be used by defining the `UART2_*` symbols, UART_DEV(0) and
+      UART_DEV(1) must also be used by defining the `UART0_*` and
+     `UART1_*` symbols
+
+#UART_NUMOF is determined automatically from the board-specific peripheral
+configuration for UART_DEV(n).
+
+UART_DEV(0) has usually a fixed pin configuration that is used by all
+ESP32x boards as standard configuration for the console. The GPIOs
+used for UART_DEV(0) depend on the ESP32x SoC family.
 
 [Back to table of contents](#esp32_toc)
 
 ## CAN Interfaces {#esp32_can_interfaces}
 
-The ESP32 intregates a CAN controller which is compatible with the NXP SJA1000
-CAN controller. Thus, it is CAN 2.0B specification compliant and supports two
-message formats:
+ESP32x SoCs intregate a Two-Wire Automotive Interface (TWAI) controller
+which is compatible with the NXP SJA1000 CAN controller. Thus, it is
+CAN 2.0B specification compliant and supports two message formats:
 
 - Base Frame Format (11-bit ID)
 - Extended Frame Format (29-bit ID)
 
 @note
-- ESP32 CAN does not support CAN-FD and is not CAN-FD tolerant.
-- ESP32 CAN does not support SJA1000's sleep mode and wake-up functionality.
+- The TWAI controller does not support CAN-FD and is not CAN-FD tolerant.
+- The TWAI controller does not support SJA1000's sleep mode and wake-up
+  functionality.
 
-As with the SJA1000, the ESP32 CAN controller provides only the data link layer
+As with the SJA1000, the TWAI controller provides only the data link layer
 and the physical layer signaling sublayer. Therefore, depending on physical
-layer requirements, an external transceiver module is required which converts
-the `CAN-RX` and `CAN-TX` signals of the ESP32 into `CAN_H` and `CAN_L` bus
-signals, e.g., the MCP2551 or SN65HVD23X transceiver for compatibility with
-ISO 11898-2.
+layer requirements, an external CAN transceiver is required which converts
+the `CAN-RX` and `CAN-TX` signals of the TWAI controller into `CAN_H` and
+`CAN_L` bus signals, e.g., the MCP2551 or SN65HVD23X transceiver for
+compatibility with ISO 11898-2.
 
 If module `periph_can` is used, the low-level CAN driver for the
-ESP32 CAN controller is enabled. It provides a CAN DLL device that can be
-used with RIOT's CAN protocol stack. It uses the ESP32 CAN controller
+TWAI controller is enabled. It provides a CAN DLL device that can be
+used with RIOT's CAN protocol stack. It uses the TWAI CANcontroller
 in SJA1000 PeliCAN mode. Please refer the
 [SJA1000 Datasheet](https://www.nxp.com/documents/data_sheet/SJA1000.pdf)
-for detailed information about the CAN controller and its programming.
+for detailed information about the TWAI controller and its programming.
 
 The pin configuration of the CAN transceiver interface is usually defined
 in board specific peripheral configuration by
@@ -1135,26 +1104,27 @@ in board specific peripheral configuration by
 - `#CAN_TX`, the GPIO used as TX transceiver signal, and
 - `#CAN_RX`, the GPIO used as RX transceiver signal.
 
+Example:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#define CAN_TX      GPIO10      // CAN TX transceiver signal
+#define CAN_RX      GPIO9       // CAN RX transceiver signal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If the pin configuration is not defined, the following default configuration
 is used which can be overridden by the application, see section
 [Application-Specific Configurations](#esp32_application_specific_configurations).
 
 Device  |Signal|Pin     |Symbol         |Remarks
 :-------|:-----|:-------|:--------------|:----------------
-CAN     | TX   | GPIO5  |`CAN_TX`       | optional, can be overridden
-CAN     | RX   | GPIO35 |`CAN_RX`       | optional, can be overridden
+CAN     | TX   | GPIO5  | `CAN_TX`      | optional, can be overridden
+CAN     | RX   | GPIO35 | `CAN_RX`      | optional, can be overridden
 
-Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#define CAN_TX      GPIO10      // CAN TX transceiver signal
-#define CAN_RX      GPIO9       // CAN RX transceiver signal
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If the board has an external transceiver module connected to the ESP32 on-board,
-module `periph_can` should be provided as feature in board's `Makefile.features`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the board has an external transceiver module connected to the
+ESP32x SoC on-board, module `periph_can` should be provided as feature
+in board's `Makefile.features`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 FEATURES_PROVIDED += periph_can     # CAN peripheral interface
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Otherwise, the application has to add the `periph_can` module in its makefile
 when needed.
@@ -1165,7 +1135,7 @@ when needed.
 
 ### Power Modes
 
-The RIOT port for the ESP32 implements RIOT's layered power management. It
+The RIOT port for ESP32x SoCs implements RIOT's layered power management. It
 supports the following operating modes:
 
 - The **Modem-sleep** mode is the default operating mode when the WiFi
@@ -1279,11 +1249,11 @@ are held (`ESP_PM_GPIO_HOLD`) in _Deep-sleep_ mode. From _Light-sleep_ the
 system can be woken up by any of the GPIOs defined as input with enabled
 interrupt or if the RxD signal of UART0 goes HIGH at least 4 times
 (`ESP_PM_WUP_UART0=6`).
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CFLAGS='-DESP_PM_WUP_PINS=GPIO25 -DESP_PM_WUP_LEVEL=ESP_PM_WUP_PINS_ALL_LOW \
         -DESP_PM_WUP_UART0=6 -DESP_PM_GPIO_HOLD' \
 make BOARD=esp32-wroom-32 -C tests/periph_pm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp32_toc)
 
@@ -1294,21 +1264,21 @@ can be retained. Therefore, data that must be retained during _Deep-sleep_ and
 the subsequent system restart, must be stored in the slow RTC memory. For
 that purpose, use
 - `__attribute__((section(".rtc.bss")))` to place uninitialized
-data in section `.rtc.bss`, and
-- `__attribute__((section(".rtc.data")))` to
-place initialized data in section `.rtc.data`.
+   data in section `.rtc.bss`, and
+- `__attribute__((section(".rtc.data")))` to place initialized
+  data in section `.rtc.data`.
 
 For example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 static int _i_value __attribute__((section(".rtc.bss")));      // set to 0 at power on
 static int _u_value __attribute__((section(".rtc.data"))) = 1; // initialized
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp32_toc)
 
 ## Other Peripherals {#esp32_other_peripherals}
 
-The ESP32 port of RIOT also supports:
+The RIOT port for ESP32x SoCs also supports:
 
 - hardware number generator with 32 bit
 - CPU-ID function
@@ -1320,78 +1290,114 @@ The ESP32 port of RIOT also supports:
 
 ## SPI RAM Modules {#esp32_spi_ram}
 
-The ESP32 can use external SPI RAM connected through the FSPI interface. For example, all boards that use the [ESP32-WROVER modules](https://www.espressif.com/en/products/hardware/modules) have already integrated such SPI RAM.
+Dependent on the ESP32x SoC variant (family), external SPI RAM can be
+connected to the SPI interface that is driven by the SPI1 controller
+(`SPI1_HOST`). For example, all boards that use the [ESP32-WROVER modules]
+(https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf)
+have already integrated such SPI RAM. The connected SPI RAM is treated
+as PSRAM (pseudo-static RAM) and is integrated into the heap.
 
-However, the external SPI RAM requires 4 data lines and thus can only be used in QOUT (quad output) or QIO (quad input/output) flash mode, which makes GPIO9 and GPIO10 unavailable for other purposes. Therefore, if needed, the SPI RAM must be explicitly enabled in the makefile of the application.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+However, the external SPI RAM requires 4 data lines and thus can only be
+used in `qout` (quad output) or `qio` (quad input/output) flash mode, which
+makes GPIO9 and GPIO10 unavailable for other purposes. Therefore, if needed,
+the SPI RAM must be explicitly enabled in the makefile of the application.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_spi_ram
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
-- When the SPI RAM is enabled using the `esp_spi_ram`, the ESP32 uses four data lines to access the external SPI RAM in QOUT (quad output) flash mode. Therefore, GPIO9 and GPIO10 are used as SPI data lines and are not available for other purposes.
-- Enabling SPI RAM for modules that don't have SPI RAM may lead to boot problems for some modules. For others is simply throws an error message.
+- When the SPI RAM is enabled using the `esp_spi_ram`, the ESP32x SoC uses
+  four data lines to access the external SPI RAM in `qout` (quad output)
+  flash mode. Therefore, GPIO9 and GPIO10 are used as SPI data lines and
+  are not available for other purposes.
+- Enabling SPI RAM for modules that don't have SPI RAM may lead to boot
+  problems for some modules. For others is simply throws an error message.
 
 [Back to table of contents](#esp32_toc)
 
 ## SPIFFS Device {#esp32_spiffs_device}
 
-The RIOT port for ESP32 implements a MTD system drive `mtd0` using the on-board SPI flash memory. This MTD system drive can be used together with SPIFFS and VFS to realize a persistent file system.
+The RIOT port for ESP32x SoCs implements a MTD system drive `mtd0` using the
+on-board SPI flash memory. This MTD system drive can be used together with
+SPIFFS and VFS to realize a persistent file system.
 
-To use the MTD system drive with SPIFFS, the `esp_spiffs` module has to be enabled in the makefile of the application:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To use the MTD system drive with SPIFFS, the `esp_spiffs` module has to be
+enabled in the makefile of the application:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_spiffs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When SPIFFS is enabled, the MTD system drive is formatted with SPIFFS the first time the system is started. The start address of the MTD system drive in the SPI flash memory is defined by the board configuration:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+When SPIFFS is enabled, the MTD system drive is formatted with SPIFFS the
+first time the system is started. The start address of the MTD system drive
+in the SPI flash memory is defined by the board configuration:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #define SPI_FLASH_DRIVE_START  0x200000
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If this start address is set to 0, as in the default board configuration, the first possible multiple of 0x100000 (1 MiB) will be used in the free SPI flash memory determined from the partition table.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If this start address is set to 0, as in the default board configuration,
+the first possible multiple of 0x100000 (1 MiB) will be used in the free
+SPI flash memory determined from the partition table.
 
-Please refer file `$RIOTBASE/tests/unittests/test-spiffs/tests-spiffs.c` for more information on how to use SPIFFS and VFS together with a MTD device `mtd0` alias `MTD_0`.
+Please refer file `$RIOTBASE/tests/unittests/test-spiffs/tests-spiffs.c` for
+more information on how to use SPIFFS and VFS together with a MTD device `mtd0`
+alias `MTD_0`.
 
 [Back to table of contents](#esp32_toc)
 
 # Network Interfaces {#esp32_network_interfaces}
 
-ESP32 provides different built-in possibilities to realize network devices:
+ESP32x SoCs integrate different network interfaces:
 
 - **EMAC**, an Ethernet MAC implementation (requires an external PHY module)
-- **ESP WiFi**, usual AP-based wireless LAN
-- **ESP-NOW**, a WiFi based AP-less and connectionless peer to peer communication protocol
+- **ESP WiFi**, WiFi in infratructure mode (station or AP mode)
+- **ESP-NOW**, WiFi based ad-hoc connectionless peer to peer communication
+  protocol
 - **ESP-MESH**, a WiFi based mesh technology (not yet supported)
+
+@note EMAC interface is only available in ESP32 SoCs.
 
 [Back to table of contents](#esp32_toc)
 
 ## Ethernet MAC Network Interface {#esp32_ethernet_network_interface}
 
-ESP32 provides an **Ethernet MAC layer module (EMAC)** according to the
-IEEE 802.3 standard which can be used together with an external physical
-layer chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY
-chips are the Microchip LAN8710/LAN8720, the IC Plus 101G, and the Texas
-Instruments TLK110.
+ESP32 SoC variant (family) provides an **Ethernet MAC layer module (EMAC)**
+according to the IEEE 802.3 standard which can be used together with an
+external physical layer chip (PHY) to realize a 100/10 Mbps Ethernet
+interface. The following PHY layer chips are supported:
 
-The RIOT port for ESP32 realizes with module `esp_eth` a `netdev` driver for
-the EMAC which uses RIOT's standard Ethernet interface.
+- IC Plus 101G
+- Microchip KSZ8041/KSZ8081
+- Microchip LAN8710/LAN8720
+- Realtek RTL8201
+- Texas Instruments DP83848
+
+The RIOT port for ESP32 SoCs realizes a `netdev` driver for the EMAC
+(module `esp_eth`) which uses RIOT's standard Ethernet interface.
 
 If the board has one of the supported PHY layer chips connected to the ESP32,
-the `esp_eth` module should be enabled by default in board's `Makefile.dep`
+feature `esp_eth` should be enabled.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+FEATURES_PROVIDED += periph_eth
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Furthermore, module `esp_eth` should be by default in board's `Makefile.dep`
 when module `netdev_default` is used.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ifneq (,$(filter netdev_default,$(USEMODULE)))
-    USEMODULE += esp_eth
+  USEMODULE += esp_eth
 endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Otherwise, the application has to add the `esp_eth` module in its makefile when needed.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Otherwise, the application has to add the `esp_eth` module in its makefile
+when needed.
 
 @note
-The board has to have one of the supported PHY modules to be able to use the Ethernet MAC module.
+The board has to have one of the supported PHY chips to be able to use
+the Ethernet MAC module.
 
 [Back to table of contents](#esp32_toc)
 
 ## WiFi Network Interface {#esp32_wifi_network_interface}
 
-The RIOT port for ESP32 implements a `netdev` driver for the built-in WiFi
+The RIOT port for ESP32x SoC implements a `netdev` driver for the built-in WiFi
 interface. This `netdev` driver supports WPA2 personal mode as well as WPA2
 enterprise mode.
 
@@ -1402,9 +1408,9 @@ enterprise mode.
 To use the WiFi `netdev` driver in WPA2 personal mode with a
 preshared key (PSK), module `esp_wifi` has to be enabled.
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_wifi
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Furthermore, the following configuration parameters have to be defined:
 
@@ -1422,11 +1428,11 @@ These configuration parameter definitions, as well as enabling the `esp_wifi`
 module, can be done either in the makefile of the project or at make command
 line, for example:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi \
 CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\"' \
 make -C examples/gnrc_networking BOARD=...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
 - Module `esp_wifi` is not enabled automatically when module
@@ -1444,9 +1450,9 @@ a mesh network which uses ESP-NOW.
 To use the WiFi `netdev` driver in WPA2 enterprise mode with IEEE 802.1X/EAP
 authentication, module `esp_wifi_enterprise` has to be enabled.
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_wifi_enterprise
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It supports the following EAP authentication methods:
 
@@ -1479,11 +1485,11 @@ These configuration parameter definitions, as well as enabling the `esp_wifi`
 module, can be done either in the makefile of the project or at make command
 line, for example:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_enterprise \
 CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_EAP_ID=\"anonymous\" -DESP_WIFI_EAP_USER=\"MyUserName\" -DESP_WIFI_EAP_PASS=\"MyPassphrase\"' \
 make -C examples/gnrc_networking BOARD=...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
 - Since there is no possibility to add the CA certificate to the RIOT image,
@@ -1502,8 +1508,8 @@ the channel of the AP as value for the parameter 'ESP_NOW_CHANNEL'.
 
 ## WiFi SoftAP Network Interface {#esp32_wifi_ap_network_interface}
 
-The RIOT port for the ESP32 supports a `netdev` interface for the ESP32 WiFi
-SoftAP mode. Module `esp_wifi_ap` has to be enabled to use it.
+The RIOT port for the ESP32x SoCs supports a `netdev` interface for the
+ESP WiFi SoftAP mode. Module `esp_wifi_ap` has to be enabled to use it.
 
 The following parameters can be configured:
 
@@ -1531,11 +1537,11 @@ These configuration parameter definitions, as well as enabling the `esp_wifi_ap`
 module, can be done either in the makefile of the project or at make command
 line, for example:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE=esp_wifi_ap \
 CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1' \
 make -C examples/gnrc_networking BOARD=...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 @note
 - The `esp_wifi_ap` module is not used by default when `netdev_default` is used.
@@ -1558,31 +1564,32 @@ for more information.
 
 ## ESP-NOW Network Interface {#esp32_esp_now_network_interface}
 
-With ESP-NOW, the ESP32 provides a connectionless communication technology,
+With ESP-NOW, ESP32x SoCs provide a connectionless communication technology,
 featuring short packet transmission. It applies the IEEE802.11 Action Vendor
 frame technology, along with the IE function developed by Espressif, and CCMP
 encryption technology, realizing a secure, connectionless communication
 solution.
 
-The RIOT port for ESP32 implements in module `esp_now` a `netdev`
+The RIOT port for ESP32x SoCs implements in module `esp_now` a `netdev`
 driver which uses ESP-NOW to provide a link layer interface to a meshed network
-of ESP32 nodes. In this network, each node can send short packets with up to
+of ESP32x nodes. In this network, each node can send short packets with up to
 250 data bytes to all other nodes that are visible in its range.
 
 @note Module `esp_now`module is not enabled automatically if the
 `netdev_default` module is used. Instead, the application has to add the
 `esp_now` module in its makefile when needed.<br>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += esp_now
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For ESP-NOW, ESP32 nodes are used in WiFi SoftAP + Station mode to advertise
-their SSID and become visible to other ESP32 nodes. The SSID of an ESP32 node
+For ESP-NOW, ESP32x nodes are used in WiFi SoftAP + Station mode to advertise
+their SSID and become visible to other ESP32x nodes. The SSID of an ESP32x node
 is the concatenation of the prefix `RIOT_ESP_` with the MAC address of its
-SoftAP WiFi interface. The driver periodically scans all visible ESP32 nodes.
+SoftAP WiFi interface. The driver periodically scans all visible ESP32x nodes.
 
-The following parameters are defined for ESP-NOW nodes. These parameters can be overridden by
-[application-specific board configurations](#esp32_application_specific_board_configuration).
+The following parameters are defined for ESP-NOW nodes. These parameters can
+be overridden by [application-specific board configurations]
+(#esp32_application_specific_board_configuration).
 
 <center>
 
@@ -1596,9 +1603,9 @@ ESP_NOW_KEY             | NULL                      | Defines a key that is used
 </center><br>
 
 @note The ESP-NOW network interface (module `esp_now`) and the
-[Wifi network interface](#esp32_wifi_network_interface) (module `esp_wifi` or `esp_wifi_enterprise`)
-can be used simultaneously, for example, to realize a border router for
-a mesh network which uses ESP-NOW.
+[Wifi network interface](#esp32_wifi_network_interface) (module `esp_wifi` or
+`esp_wifi_enterprise`) can be used simultaneously, for example, to realize a
+border router for a mesh network which uses ESP-NOW.
 In this case the ESP-NOW interface must use the same channel as the AP of the
 infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled with
 the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
@@ -1609,7 +1616,7 @@ the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
 
 RIOT provides a number of driver modules for different types of network
 devices, e.g., IEEE 802.15.4 radio modules and Ethernet modules. The RIOT port
-for ESP32 has been tested with the following network devices:
+for ESP32x SoCs has been tested with the following network devices:
 
 - \ref drivers_mrf24j40 "mrf24j40" (driver for Microchip MRF24j40 based IEEE 802.15.4)
 - \ref drivers_enc28j60 "enc28j60" (driver for Microchip ENC28J60 based Ethernet modules)
@@ -1622,9 +1629,9 @@ To use MRF24J40 based IEEE 802.15.4 modules as network device, the
 `mrf24j40` driver module has to be added to the makefile of the
 application:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += mrf24j40
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The driver parameters that have to be defined by the board configuration for
 the MRF24J40 driver module are:
@@ -1639,7 +1646,7 @@ Since each board has different GPIO configurations, refer to the board
 documentation for the GPIOs recommended for the MRF24J40.
 
 @note The reset signal of the MRF24J40 based network device can be connected
-with the ESP32 RESET/EN pin  which is broken out on most boards. This keeps the
+with the ESP32x RESET/EN pin  which is broken out on most boards. This keeps the
 GPIO free defined by `MRF24J40_PARAM_RESET` free for other purposes.
 
 [Back to table of contents](#esp32_toc)
@@ -1649,11 +1656,12 @@ GPIO free defined by `MRF24J40_PARAM_RESET` free for other purposes.
 To use ENC28J60 Ethernet modules as network device, the `enc28j60` driver
 module has to be added to the makefile of the application:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 USEMODULE += enc28j60
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The parameters that have to be defined by board configuration for the ENC28J60 driver module are:
+The parameters that have to be defined by board configuration for the ENC28J60
+driver module are:
 
 Parameter            | Description
 ---------------------|------------
@@ -1665,7 +1673,7 @@ Since each board has different GPIO configurations, refer to the board
 documentation for the GPIOs recommended for the ENC28J60.
 
 @note The reset signal of the ENC28J60 based network device can be connected
-with the ESP32 RESET/EN pin  which is broken out on most boards. This keeps the
+with the ESP32x RESET/EN pin  which is broken out on most boards. This keeps the
 GPIO free defined by `#ENC28J60_PARAM_RESET` free for other purposes.
 
 [Back to table of contents](#esp32_toc)
@@ -1699,9 +1707,9 @@ Using the `CFLAGS` make variable at the command line, board or driver parameter
 definitions can be overridden.
 
 Example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CFLAGS='-DESP_LCD_PLUGGED_IN=1 -DLIS3DH_PARAM_INT2=GPIO4'
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a larger number of board definitions needs be overridden, this approach
 becomes impractical. In that case, an application-specific board configuration
@@ -1720,33 +1728,33 @@ add the `include_next` preprocessor directive as the **last** line.
 For example to override the default definition of the GPIOs that are used as
 PWM channels, the application-specific board configuration file
 `$APPDIR/board.h` could look like the following:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #ifdef CPU_ESP32
 #define PWM0_CHANNEL_GPIOS { GPIO12, GPIO13, GPIO14, GPIO15 }
 #endif
 
 #include_next "board.h"
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is important to ensure that the application-specific board
+It is important that the application-specific board
 configuration `$APPDIR/board.h` is included first. Insert the following
 line as the **first** line to the application makefile `$APPDIR/Makefile`.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 INCLUDES += -I$(APPDIR)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-@note To make such application-specific board configurations dependent on the
-ESP32 MCU or a particular ESP32 board, you should always enclose these
-definitions in the following constructs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#ifdef CPU_ESP32
+@note To make such application-specific board configurations dependent on a
+      certain ESP32x SoC variant (family) or a particular ESP32x board, you
+      should always enclose these definitions in the following constructs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#ifdef CPU_FAM_ESP32            // specific ESP32x SoC variant (family)
 ...
 #endif
 
-#ifdef BOARD_ESP32_WROVER_KIT
+#ifdef BOARD_ESP32_WROVER_KIT   // specific ESP32x board
 ...
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp32_toc)
 
@@ -1764,33 +1772,33 @@ to include driver's original `<device>_params.h` after that, add the
 For example, to override a GPIO used for LIS3DH sensor, the
 application-specific driver parameter file `$APPDIR/<device>_params.h`
 could look like the following:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#ifdef CPU_ESP32
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#ifdef CPU_FAM_ESP32
 #define LIS3DH_PARAM_INT2           (GPIO_PIN(0, 4))
 #endif
 
 #include_next "lis3dh_params.h"
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is important to ensure that the application-specific driver parameter file
 `$APPDIR/<device>_params.h` is included first. Insert the following line as
 the *first* line to the application makefile `$APPDIR/Makefile`.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 INCLUDES += -I$(APPDIR)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-\note To make such application-specific board configurations dependent on the ESP32 MCU or a
-      particular ESP32 board, you should always enclose these definitions in
-      the following constructs:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
-#ifdef CPU_ESP32
+@note To make such application-specific board configurations dependent on a
+      certain ESP32x SoC variant (family) or a particular ESP32x board, you
+      should always enclose these definitions in the following constructs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+#ifdef CPU_FAM_ESP32            // specific ESP32x SoC variant (family)
 ...
 #endif
 
-#ifdef BOARD_ESP32_WROVER_KIT
+#ifdef BOARD_ESP32_WROVER_KIT   // specific ESP32x board
 ...
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [Back to table of contents](#esp32_toc)
 
@@ -1798,16 +1806,11 @@ INCLUDES += -I$(APPDIR)
 
 ## JTAG Debugging {#esp32_jtag_debugging}
 
-ESP32 provides a JTAG interface at GPIOs 12 ... 15 for On-Chip Debugging.
+ESP32x SoCs integrate a JTAG interface for On-Chip Debugging. The GPIOs
+connected to this JTAG interface depend on the ESP32x SoC variant (family).
+For details, see:
 
-ESP32 Pin     | JTAG Signal
-:-------------|:-----------
-CHIP_PU       | TRST_N
-GPIO15 (MTDO) | TDO
-GPIO12 (MTDI) | TDI
-GPIO13 (MTCK) | TCK
-GPIO14 (MTMS) | TMS
-GND           | GND
+- \ref esp32_jtag_interface_esp32 "ESP32"
 
 This JTAG interface can be used with OpenOCD and GDB for On-Chip debugging
 of your software on instruction level. When you compile your software with
@@ -1818,13 +1821,18 @@ level as well.
 When debugging, the GPIOs used for the JTAG interface must not be used for
 anything else.
 
-Some boards like the \ref esp32_wrover_kit_toc "ESP-WROVER-KIT V3" or the
+Some ESP32 boards like the \ref esp32_wrover_kit_toc "ESP-WROVER-KIT V3" or the
 \ref esp32-ethernet-kit-v1_0 "ESP32-Ethernet-Kit " have a USB bridge with
 JTAG interface on-board that can be directly used for JTAG debugging.
 
+Other ESP32x SoC variants (families) have an built in USB-to-JTAG bridge
+that can be used without additional chips. For details, see:
+
+- \ref esp32_jtag_interface_esp32 "ESP32"
+
 To use the JTAG debugging, the precompiled version of OpenOCD for ESP32 has to
-be installed using the install script while being in RIOT's
-root directory, see also section
+be installed using the toolchain install script while being in RIOT's root
+directory, see also section
 [Using Local Toolchain Installation](#esp32_local_toolchain_installation).
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ dist/tools/esptools/install.sh openocd
@@ -1857,11 +1865,12 @@ $ PROGRAMMER=openocd USEMODULE=esp_jtag \
   make flash BOARD=esp32-wrover-kit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Detailed information on how to configure the JTAG interface of the ESP32
-can be found in section JTAG Debugging in the [ESP-IDF Programming Guide]
-(https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html).
+Detailed information on how to configure the JTAG interface of the respective
+ESP32x SoC variant (family) can be found in ESP-IDF Programming Guide:
 
-[Back to table of contents](#esp32_wrover_kit_toc)
+- [ESP32](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html)
+
+[Back to table of contents](#esp32_toc)
 
 ## QEMU Mode and GDB {#esp32_qemu_mode_and_gdb}
 

--- a/cpu/esp32/doc_esp32.txt
+++ b/cpu/esp32/doc_esp32.txt
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+@defgroup   cpu_esp32_esp32 ESP32 family
+@ingroup    cpu_esp32
+@brief      Specific properties of ESP32 variant (family)
+@author     Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32_riot_esp32  Specific properties of ESP32 variant (family)
+
+## GPIO pins {#esp32_gpio_pins_esp32}
+
+ESP32 has 34 GPIO pins, where only a subset can be used as output, as
+ADC channel, as DAC channel and as GPIOs in deep-sleep mode, the so-called
+RTC GPIOs. Some of them are used by special SoC components, e.g., as touch
+sensors. The following table gives a short overview.
+
+<center>
+
+Pin    | Type   | ADC / RTC | PU / PD   | Special function      | Remarks
+-------|:-------|:---------:|:---------:|-----------------------|--------
+GPIO0  | In/Out | yes       | yes       | Touch sensor          | Bootstrapping, pulled up
+GPIO1  | In/Out | -         | yes       | UART0 TxD             | Console
+GPIO2  | In/Out | yes       | yes       | Touch sensor          | Bootstrapping, pulled down
+GPIO3  | In/Out | -         | yes       | UART0 RxD             | Console
+GPIO4  | In/Out | yes       | yes       | Touch sensor          | -
+GPIO5  | In/Out | -         | yes       | -                     | -
+GPIO6  | In/Out | -         | yes       | Flash SD_CLK          | -
+GPIO7  | In/Out | -         | yes       | Flash SD_DATA0        | -
+GPIO8  | In/Out | -         | yes       | Flash SD_DATA1        | -
+GPIO9  | In/Out | -         | yes       | Flash SD_DATA2        | only in `qout`and `qio`mode, see section [Flash Modes](#esp32_flash_modes)
+GPIO10 | In/Out | -         | yes       | Flash SD_DATA3        | only in `qout`and `qio`mode, see section [Flash Modes](#esp32_flash_modes)
+GPIO11 | In/Out | -         | yes       | Flash SD_CMD          | -
+GPIO12 | In/Out | yes       | yes       | MTDI / Touch sensor   | JTAG interface / Bootstrapping, pulled down
+GPIO13 | In/Out | yes       | yes       | MTCK / Touch sensor   | JTAG interface
+GPIO14 | In/Out | yes       | yes       | MTMS / Touch sensor   | JTAG interface
+GPIO15 | In/Out | yes       | yes       | MTDO / Touch sensor   | JTAG interface / Bootstrapping, pulled up
+GPIO16 | In/Out | -         | yes       | -                     | usually not available when SPI RAM is used
+GPIO17 | In/Out | -         | yes       | -                     | usually not available when SPI RAM is used
+GPIO18 | In/Out | -         | yes       | -                     | -
+GPIO19 | In/Out | -         | yes       | -                     | -
+GPIO21 | In/Out | -         | yes       | -                     | -
+GPIO22 | In/Out | -         | yes       | -                     | -
+GPIO23 | In/Out | -         | yes       | -                     | -
+GPIO25 | In/Out | yes       | yes       | DAC1                  | -
+GPIO26 | In/Out | yes       | yes       | DAC2                  | -
+GPIO27 | In/Out | yes       | yes       | Touch sensor          | -
+GPIO32 | In/Out | yes       | yes       | XTAL32_P              | can be used to connect an external 32 kHz crystal
+GPIO33 | In/Out | yes       | -         | XTAL32_N              | can be used to connect an external 32 kHz crystal
+GPIO34 | In     | yes       | -         | VDET                  | -
+GPIO35 | In     | yes       | -         | VDET                  | -
+GPIO36 | In     | yes       | -         | SENSOR_VP             | -
+GPIO37 | In     | yes       | -         | SENSOR_CAPP           | usually not broken out
+GPIO38 | In     | yes       | -         | SENSOR_CAPN           | usually not broken out
+GPIO39 | In     | yes       | -         | SENSOR_VN             | -
+
+</center>
+
+<b>ADC:</b> these pins can be used as ADC inputs<br>
+<b>RTC:</b> these pins are RTC GPIOs and can be used in deep-sleep mode<br>
+<b>PU/PD:</b> these pins have software configurable pull-up/pull-down functionality.<br>
+
+@note GPIOs that can be used as ADC channels are also available as low power digital inputs/outputs
+      in deep sleep mode.
+
+GPIO0, GPIO2 are bootstrapping pins which are used to boot ESP32 in different modes:
+
+<center>
+
+GPIO0 | GPIO2 | Mode
+:----:|:-----:|------------------
+1     | X     | boot in FLASH mode to boot the firmware from flash (default mode)
+0     | 0     | boot in UART mode for flashing the firmware
+
+</center><br>
+
+@note GPIO2 becomes the SPI MISO signal for boards that use the HSPI interface
+      as SD-Card interface in 4-bit SD mode. On these boards all signals of the
+      SD-Card interface are pulled up. Because of the bootstrapping
+      functionality of GPIO2, it can become necessary to either press the
+      **Boot** button, remove the SD card or remove the peripheral hardware
+      to flash RIOT.
+
+## ADC Channels {#esp32_adc_channels_esp32}
+
+ESP32 integrates two 12-bit ADCs (ADC1 and ADC2) capable of measuring up to
+18 analog signals in total. Most of these ADC channels are either connected
+to a number of integrated sensors like a Hall sensors, touch sensors and a
+temperature sensor or can be connected with certain GPIOs. Integrated sensors
+are disabled in RIOT's implementation and are not accessible. Thus, up to 18
+GPIOs, can be used as ADC inputs:
+
+- **ADC1** supports 8 channels: GPIOs 32-39
+- **ADC2** supports 10 channels: GPIOs 0, 2, 4, 12-15, 25-27
+
+These GPIOs are realized by the RTC unit and are therefore also called RTC
+GPIOs or RTCIO GPIOs.
+
+The maximum number of ADC channels #ADC_NUMOF_MAX is 18
+
+@note
+- GPIO37 and GPIO38 are usually not broken out on ESP32 boards and can not
+  be used therefore.
+- ADC2 is also used by the WiFi module. The GPIOs connected to ADC2 are
+  therefore not available as ADC channels if the modules `esp_wifi` or
+  `esp_now` are used.
+- Vref can be read with function #adc_line_vref_to_gpio at GPIO25.
+
+## DAC Channels {#esp32_dac_channels_esp32}
+
+ESP32 SoC supports 2 DAC lines at GPIO25 and GPIO26.
+
+## I2C Interfaces {#esp32_i2c_interfaces_esp32}
+
+ESP32 has two built-in I2C interfaces.
+
+The following table shows the default configuration of I2C interfaces
+used for a large number of ESP32 boards. It can be overridden by
+[application-specific configurations](#esp32_application_specific_configurations).
+
+<center>
+
+Device     | Signal | Pin    | Symbol        | Remarks
+:----------|:-------|:-------|:--------------|:----------------
+I2C_DEV(0) |        |        | `#I2C0_SPEED` | default is `I2C_SPEED_FAST`
+I2C_DEV(0) | SCL    | GPIO22 | `#I2C0_SCL`   | -
+I2C_DEV(0) | SDA    | GPIO21 | `#I2C0_SDA`   | -
+
+</center><br>
+
+## PWM Channels {#esp32_pwm_channels_esp32}
+
+The ESP32 LEDC module has 2 channel groups with 8 channels each. Each of
+these channels can be clocked by one of the 4 timers.
+
+## SPI Interfaces {#esp32_spi_interfaces_esp32}
+
+ESP32 has four SPI controllers where SPI0 and SPI1 share the same bus and
+are used as interface for external memory:
+
+- Controller SPI0 is reserved for caching external memory like Flash
+- Controller SPI1 is reserved for external memory like PSRAM
+- Controller SPI2 can be used as general purpose SPI (also called HSPI)
+- Controller SPI3 can be used as general purpose SPI (also called VSPI)
+
+Thus, only SPI2 (HSPI) and SPI3 (VSPI) can be used as general purpose SPI
+in RIOT as SPI_DEV(0) and SPI_DEV(1) in arbitrary order.
+
+The following table shows the pin configuration used for most boards, even
+though it **can vary** from board to board.
+
+<center>
+
+Device                  |Signal| Pin    | Symbol      | Remarks
+:-----------------------|:----:|:-------|:-----------:|:---------------------------
+`SPI_HOST0`/`SPI_HOST1` | SCK  | GPIO6  |- | reserved for flash and PSRAM
+`SPI_HOST0`/`SPI_HOST1` | CMD  | GPIO11 |- | reserved for flash and PSRAM
+`SPI_HOST0`/`SPI_HOST1` | SD0  | GPIO7  |- | reserved for flash and PSRAM
+`SPI_HOST0`/`SPI_HOST1` | SD1  | GPIO8  |- | reserved for flash and PSRAM
+`SPI_HOST0`/`SPI_HOST1` | SD2  | GPIO9  |- | reserved for flash and PSRAM (only in `qio` or `qout` mode)
+`SPI_HOST0`/`SPI_HOST1` | SD3  | GPIO10 |- | reserved for flash and PSRAM (only in `qio` or `qout` mode)
+`SPI_HOST2` (`HSPI`)    | SCK  | GPIO14 |`#SPI1_SCK`  | can be used
+`SPI_HOST2` (`HSPI`)    | MISO | GPIO12 |`#SPI1_MISO` | can be used
+`SPI_HOST2` (`HSPI`)    | MOSI | GPIO13 |`#SPI1_MOSI` | can be used
+`SPI_HOST2` (`HSPI`)    | CS0  | GPIO15 |`#SPI1_CS0`  | can be used
+`SPI_HOST3` (`VSPI`)    | SCK  | GPIO18 |`#SPI0_SCK`  | can be used
+`SPI_HOST3` (`VSPI`)    | MISO | GPIO19 |`#SPI0_MISO` | can be used
+`SPI_HOST3` (`VSPI`)    | MOSI | GPIO23 |`#SPI0_MOSI` | can be used
+`SPI_HOST3` (`VSPI`)    | CS0  | GPIO5  |`#SPI0_CS0`  | can be used
+
+</center><br>
+
+Some boards use the `HSPI` (`SPI_HOST2`) as SD-Card interface (SDIO) in 4-bit SD mode.
+
+<center>
+
+Device                | Pin    | SD 4-bit mode | SPI mode
+:---------------------|:------:|:-------------:|:----------:
+`SPI_HOST2` (`HSPI`)  | GPIO14 | CLK           | SCK
+`SPI_HOST2` (`HSPI`)  | GPIO15 | CMD           | CS0
+`SPI_HOST2` (`HSPI`)  | GPIO2  | DAT0          | MISO
+`SPI_HOST2` (`HSPI`)  | GPIO4  | DAT1          | -
+`SPI_HOST2` (`HSPI`)  | GPIO12 | DAT2          | -
+`SPI_HOST2` (`HSPI`)  | GPIO13 | DAT3          | MOSI
+
+</center><br>
+
+@note On these boards, all these signals are pulled up. This may cause
+      flashing problems due to the bootstrap function of the GPIO2 pin,
+      see section [GPIO pins](#esp32_gpio_pins_esp32). Therefore, it can
+      be necessary to either press the **Boot** button, to remove the SD card
+      or to remove the peripheral hardware to flash RIOT.
+
+## Timers {#esp32_timers_esp32}
+
+ESP32 has two timer groups with two timers each, resulting in a total of
+four timers. Since one timer is used as system timer, up to three timers
+with one channel each can be used in RIOT as timer devices
+TIMER_DEV(0) ... TIMER_DEV(2).
+
+Additionally ESP32 has three CCOMPARE registers which can be used
+alternatively as timer devices TIMER_DEV(0) ... TIMER_DEV(2) can be used
+in RIOT if the module `esp_hw_counter` is enabled.
+
+## UART Interfaces {#esp32_uart_interfaces_esp32}
+
+ESP32 integrates three UART interfaces. The following default pin
+configuration of UART interfaces as used by a most boards can be overridden
+by the application, see section [Application-Specific Configurations]
+(#esp32_application_specific_configurations).
+
+<center>
+
+Device      |Signal|Pin     |Symbol      |Remarks
+:-----------|:-----|:-------|:-----------|:----------------
+UART_DEV(0) | TxD  | GPIO1  |`#UART0_TXD`| cannot be changed
+UART_DEV(0) | RxD  | GPIO3  |`#UART0_RXD`| cannot be changed
+UART_DEV(1) | TxD  | GPIO10 |`#UART1_TXD`| optional, can be overridden
+UART_DEV(1) | RxD  | GPIO9  |`#UART1_RXD`| optional, can be overridden
+UART_DEV(2) | TxD  | GPIO17 |`UART2_TXD` | optional, can be overridden
+UART_DEV(2) | RxD  | GPIO16 |`UART2_RXD` | optional, can be overridden
+
+</center><br>
+
+## JTAG Interface {#esp32_jtag_interface_esp32}
+
+The JTAG interface on ESP32 is connected to the following GPIOs:
+
+<center>
+
+JTAG Signal | ESP32 Pin
+:-----------|:-----------
+TRST_N      | CHIP_PU
+TDO         | GPIO15 (MTDO)
+TDI         | GPIO12 (MTDI)
+TCK         | GPIO13 (MTCK)
+TMS         | GPIO14 (MTMS)
+GND         | GND
+
+</center><br>
+
+*/


### PR DESCRIPTION
### Contribution description

This PR is a split-off from #17842, providing the separation of of the documentation into a part common to all ESP32x SoCs and a part specific to ESP32 to support different ESP32x SoC variants.

### Testing procedure

1. Green CI
2. `make doc` and check that there is a new sub-menu `RIOT OS -> Modules -> CPU -> ESP32x SoC Series -> ESP32 family` which contains specific information about ESP32.

### Issues/PRs references

Split-off from #17842