### PR TITLE
cpu/esp32: split cpu_conf.h into ESP32x common and ESP32 specific parts

### DIFF
--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2022 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -10,11 +10,11 @@
  * @defgroup    cpu_esp32_conf ESP32 compile configurations
  * @ingroup     cpu_esp32
  * @ingroup     config
- * @brief       Compile-time configuration macros for ESP32 modules
+ * @brief       Compile-time configuration macros for ESP32x SoCs
  * @{
  *
  * @file
- * @brief       CPU specific configuration options
+ * @brief       Compile compile-time configurations that are common for all ESP32x SoCs
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
@@ -22,22 +22,12 @@
 #ifndef CPU_CONF_H
 #define CPU_CONF_H
 
-#include <stdint.h>
-
-#include "cpu_conf_common.h"
-#include "esp_common_log.h"
-#include "xtensa_conf.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @name   Stack size configuration
  * @{
  */
 /** Extra thread stack size required if newlib-nano is not used */
-#ifdef CONFIG_NEWLIB_NANO_FORMAT
+#ifdef MODULE_NEWLIB_NANO
 #define THREAD_EXTRA_STACKSIZE          (0)
 #else
 #define THREAD_EXTRA_STACKSIZE          (512)
@@ -60,23 +50,26 @@ extern "C" {
 /** Stack size for the WiFi thread */
 #define ESP_WIFI_STACKSIZE              (THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE)
 #endif
-
 /** @} */
 
-/**
- * Buffer size used for printf functions (maximum length of formatted output).
- */
+/** Buffer size used for printf functions (maximum length of formatted output). */
 #define PRINTF_BUFSIZ 256
-
-/**
- * @brief   Remaining parts of the various DRAM sections can be used as heap.
- */
-#define NUM_HEAPS (4)
 
 /**
  * @brief   Attribute for memory sections required by SRAM PUF
  */
 #define PUF_SRAM_ATTRIBUTES __attribute__((used, section(".noinit")))
+
+/* include ESP32x SoC specific compile time configurations */
+#if defined(CPU_FAM_ESP32)
+#include "cpu_conf_esp32.h"
+#else
+#error "ESP32x family implementation missing"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/esp32/include/cpu_conf_esp32.h
+++ b/cpu/esp32/include/cpu_conf_esp32.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     config
+ * @brief       Compile-time configuration macros for ESP32 SoCs
+ * @{
+ *
+ * @file
+ * @brief       ESP32 specific compile-time configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef CPU_CONF_ESP32_H
+#define CPU_CONF_ESP32_H
+
+/** Number of DRAM sections that can be used as heap. */
+#define NUM_HEAPS (4)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_CONF_ESP32_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR is a split-off from #17842, providing the separation of of `cpu/esp32/include/cpu_conf.h` into a part common to all ESP32x SoCs and a part specific to ESP32 to support different ESP32x SoC variants.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from #17842