### PR TITLE
gcoap_dns: Add DNS cache support

### DIFF
--- a/tests/gcoap_dns/main.c
+++ b/tests/gcoap_dns/main.c
@@ -533,6 +533,19 @@ static int _resp(int argc, char **argv)
     return 0;
 }
 
+static int _has_dns_cache(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    if (IS_USED(MODULE_DNS_CACHE)) {
+        puts("DNS cache exists");
+    }
+    else {
+        puts("DNS cache does not exist");
+    }
+    return 0;
+}
+
 static const coap_resource_t _resources[] = {
     { "/", COAP_FETCH, _mock_dns_server, NULL },
 };
@@ -553,6 +566,7 @@ static const shell_command_t _shell_commands[] = {
     { "proxy", "Sets proxy URI for DoC queries", _proxy},
     { "query", "Sends DoC query for a hostname", _query},
     { "resp", "Set static response for mock DoC server", _resp},
+    { "has_dns_cache", "Check if DNS cache is activated", _has_dns_cache},
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This adds DNS cache support to our DNS over CoAP implementation `gcoap_dns`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Both of the following commands should succeed:

```sh
make -C tests/gcoap_dns/ flash -j test                      # also tested by Murdock
USEMODULE=dns_cache make -C tests/gcoap_dns/ flash -j test  # NOT tested by Murdock
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #16705 and #18318.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
