### PR TITLE
cpu/esp32: fix dependency for periph/rtt and module esp_rtc_timer_32k

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -65,7 +65,7 @@ ifneq (,$(filter esp_idf_wifi,$(USEMODULE)))
   USEMODULE += esp_idf_adc
 endif
 
-ifneq (,$(filter periph_rtc,$(USEMODULE)))
+ifneq (,$(filter periph_rtt,$(USEMODULE)))
   FEATURES_OPTIONAL += esp_rtc_timer_32k
 endif
 

--- a/cpu/esp32/periph/Kconfig
+++ b/cpu/esp32/periph/Kconfig
@@ -10,7 +10,7 @@ if TEST_KCONFIG
 config MODULE_ESP_RTC_TIMER_32K
     bool
     depends on HAS_ESP_RTC_TIMER_32K
-    default y if MODULE_PERIPH_RTC
+    default y if MODULE_PERIPH_RTT
     help
       Use RTC timer with external 32.768 kHz crystal as RTT.
 


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844, which provides a fix of module dependency for `periph_rtt`.

If the ESP32 has an external 32k crystal connected, the clock from this crystal should be used for the RTT peripheral and not only for the RTC peripheral. Since the ESP32 RTC implementation uses RTT on top of RTT (module `rtc_rtt`), with this change the 32k crystal will be used for both RTT and RTC if present.

### Testing procedure

1. Use command:
    ```
    BOARD=esp32-wrover-kit make -j8 -C tests/periph_rtt info-modules | grep esp_rtc_timer_32k
    BOARD=esp32-wroom-32 make -j8 -C tests/periph_rtt info-modules | grep esp_rtc_timer_32k
    ```
    Module `esp_rtc_timer_32k` is used for board `esp32-wrover-kit` but not for board `esp32-wroom-32` with this PR. Without this PR it is not used at all.
    
2. Use command:
    ```
    TEST_KCONFIG=1 BOARD=esp32-wrover-kit make -j8 -C tests/periph_rtc info-modules | grep esp_rtc_timer_32k
    TEST_KCONFIG=1 BOARD=esp32-wroom-32 make -j8 -C tests/periph_rtc info-modules | grep esp_rtc_timer_32k
    ```
    Module `esp_rtc_timer_32k` is used for board `esp32-wrover-kit` but not for board `esp32-wroom-32` with this PR. Without this PR it is not used at all.

3. Use command:
    ```
    BOARD=esp32-wrover-kit make -j8 -C tests/periph_rtc info-modules | grep esp_rtc_timer_32k
    BOARD=esp32-wroom-32 make -j8 -C tests/periph_rtc info-modules | grep esp_rtc_timer_32k
    ```
    Module `esp_rtc_timer_32k` is still used for board `esp32-wrover-kit` but not for board `esp32-wroom-32` with this PR.

4. Compile and flash `tests/periph_rtt` for any ESP32 board that has connected an external 32k crystal:
    ```
    BOARD=esp32-wrover-kit make -j8 -C tests/periph_rtc flash term
    ```
    The test should still work with this change.

### Issues/PRs references

Split-off from PR #17844