### PR TITLE
drivers/wx281x: fix DEBUG format string for ESP32x SoCs

### DIFF
--- a/drivers/ws281x/esp32.c
+++ b/drivers/ws281x/esp32.c
@@ -53,8 +53,9 @@ void ws281x_write_buffer(ws281x_t *dev, const void *buf, size_t size)
     zero_on = freq / (NS_PER_SEC / WS281X_T_DATA_ZERO_NS);
     zero_off = total_cycles - zero_on;
 
-    DEBUG("[ws281x] esp32 freq=%d total=%d\n", freq, total_cycles);
-    DEBUG("[ws281x] esp32 cycles %d/%d/%d/%d\n", one_on, one_off, zero_on, zero_off);
+    DEBUG("[ws281x] esp32 freq=%d total=%"PRIu32"\n", freq, total_cycles);
+    DEBUG("[ws281x] esp32 cycles %"PRIu32"/%"PRIu32"/%"PRIu32"/%"PRIu32"\n",
+          one_on, one_off, zero_on, zero_off);
 
     uint32_t current_wait = 0, start = 0;
 


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844 and provides a fix in DEBUG format string to be compilable for different ESP32x SoCs.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from PR #17844