### PR TITLE
dist/tools/esptools: add ESP32-C3 toolchain

### DIFF
--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -24,6 +24,9 @@ export_arch()
         esp32)
             TARGET_ARCH="xtensa-esp32-elf"
             ;;
+        esp32c3)
+            TARGET_ARCH="riscv32-esp-elf"
+            ;;
         *)
             echo "Unknown architecture $1"
             exit 1
@@ -71,9 +74,9 @@ export_qemu()
 
 if [ -z $1 ]; then
     echo "Usage: export.sh <tool>"
-    echo "tool = all | esp32 | openocd | qemu"
+    echo "tool = all | esp32 | esp32c3 | openocd | qemu"
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp32"
+    ARCH_ALL="esp32 esp32c3"
     for arch in ${ARCH_ALL}; do
         export_arch $arch
     done

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -82,6 +82,9 @@ install_arch()
         esp32)
             TARGET_ARCH="xtensa-esp32-elf"
             ;;
+        esp32c3)
+            TARGET_ARCH="riscv32-esp-elf"
+            ;;
         *)
             echo "error: Unknown architecture $1"
             exit 1
@@ -152,10 +155,10 @@ install_qemu()
 
 if [ -z $1 ]; then
     echo "Usage: install.sh <tool>"
-    echo "tool = all | esp32 | openocd | qemu"
+    echo "tool = all | esp32 | esp32c3 | openocd | qemu"
     exit 1
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp32"
+    ARCH_ALL="esp32 esp32c3"
     for arch in ${ARCH_ALL}; do
         install_arch $arch
     done


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844, which extends
- the script for the installation of the vendor toolchain for ESP32-C3 and
- the script for setting set environment to use the vendor toolchain for ESP32-C3.

### Testing procedure

1. Use command
    ```
    $(RIOTBASE)/dist/tools/esptools/install.sh esp32c3
    ```
    to install the ESP32-C3 vendor toolchain.

2. Use command
    ```
    . $(RIOTBASE)/dist/tools/esptools/export.sh all
    ```
    to set the environment for ESP32-C3 vendor toolchain and check that `riscv32-esp-elf-gcc` is found:
    ```
    which riscv32-esp-elf-gcc
    ```

### Issues/PRs references

Split-off from PR #17844