### PR TITLE
pkg/wamr: add riscv_esp32 architecture

### DIFF
--- a/pkg/wamr/Makefile
+++ b/pkg/wamr/Makefile
@@ -47,6 +47,8 @@ else ifeq ($(CPU_ARCH),xtensa)
   WAMR_BUILD_TARGET = XTENSA
 else ifeq ($(CPU_ARCH),rv32)
   WAMR_BUILD_TARGET = RISCV32
+else ifeq ($(CPU_ARCH),riscv_esp32)
+  WAMR_BUILD_TARGET = RISCV32
 else
   $(error "WASM is not supported for architecture $(CPU_ARCH)")
 endif


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844, which extends the makefile of `pkg/wamr` by ESP32 RISC-V architecture.

### Testing procedure

Here we have a Hen-and-egg problem. It is not possible to cover this PR by compiling it in CI without having a board definition with an ESP32-C3. Conversely, the ESP32-C3 port that requires this PR cannot be compiled in CI without it.

Therefore a green CI with the label `CI: skip compile test` must be sufficient for the moment. If it doesn't work, the problem will pop up as soon as ESP32-C3 support is provided. And of course, I have tested it together with the ESP32-C3 support.

### Issues/PRs references

Split-off from PR #17844