### PR TITLE
pkg/esp32_sdk: additional patches required for ESP32-C3

### DIFF
--- a/pkg/esp32_sdk/patches/0017-esp_phy-add-missing-header-includes.patch
+++ b/pkg/esp32_sdk/patches/0017-esp_phy-add-missing-header-includes.patch
@@ -1,0 +1,24 @@
+From 15b1302039495a979c749fbdc464960901c68684 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Tue, 8 Mar 2022 11:36:06 +0100
+Subject: [PATCH 17/17] esp_phy: add missing header includes
+
+---
+ components/esp_phy/src/phy_init.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/esp_phy/src/phy_init.c b/components/esp_phy/src/phy_init.c
+index 7fd5b2c1247..f915b0e1b8f 100644
+--- a/components/esp_phy/src/phy_init.c
++++ b/components/esp_phy/src/phy_init.c
+@@ -11,6 +11,7 @@
+ #include <sys/lock.h>
+ 
+ #include "soc/rtc.h"
++#include "soc/soc_caps.h"
+ #include "esp_err.h"
+ #include "esp_phy_init.h"
+ #include "esp_system.h"
+-- 
+2.17.1
+

--- a/pkg/esp32_sdk/patches/0018-bootloader-changes-for-esp32c3.patch
+++ b/pkg/esp32_sdk/patches/0018-bootloader-changes-for-esp32c3.patch
@@ -1,0 +1,80 @@
+From 2ed829c7fdd2f31290094c1fe83267c7ca82330c Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Thu, 10 Mar 2022 12:38:51 +0100
+Subject: [PATCH 18/20] bootloader: changes for esp32c3
+
+Since RIOT directly links compiled objects, the archive/object file references must be replaced with the corresponding object file paths.
+---
+ .../subproject/main/ld/esp32c3/bootloader.ld  | 55 ++++++++++---------
+ 1 file changed, 28 insertions(+), 27 deletions(-)
+
+diff --git a/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld b/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld
+index c9b2da7612c..18b939322ba 100644
+--- a/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld
++++ b/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld
+@@ -23,34 +23,35 @@ SECTIONS
+     _loader_text_start = ABSOLUTE(.);
+     *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+      *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
+-    *liblog.a:(.literal .text .literal.* .text.*)
++    *components/log/*(.literal .text .literal.* .text.*)
+     *libgcc.a:(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_random.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
+-    *libbootloader_support.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
+-    *libbootloader_support.a:bootloader_efuse_esp32c3.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_panic.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_soc.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:esp_image_format.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:flash_partitions.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:secure_boot.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
+-    *libmicro-ecc.a:*.*(.literal .text .literal.* .text.*)
+-    *libspi_flash.a:*.*(.literal .text .literal.* .text.*)
+-    *libhal.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
+-    *libesp_hw_support.a:rtc_clk.*(.literal .text .literal.* .text.*)
+-    *libesp_hw_support.a:rtc_time.*(.literal .text .literal.* .text.*)
+-    *libesp_hw_support.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)
+-    *libefuse.a:*.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_clock_loader.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_common_loader.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_flash.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_random.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
++    *components/bootloader_support/*/bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
++    *components/esp_common/src/fpga_overrides.*(.literal.bootloader_fill_random .text.bootloader_fill_random)
++    *components/bootloader_support/*/bootloader_efuse_esp32c3.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_utility.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_sha.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_console_loader.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_panic.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_soc.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/esp_image_format.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/flash_encrypt.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/flash_partitions.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/secure_boot.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/secure_boot_secure_features.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
++    *components/*/micro-ecc/*(.literal .text .literal.* .text.*)
++    *components/spi_flash/*(.literal .text .literal.* .text.*)
++    *components/hal/wdt_hal_iram.*(.literal .text .literal.* .text.*)
++    *components/esp_hw_support/*/rtc_clk.*(.literal .text .literal.* .text.*)
++    *components/esp_hw_support/*/rtc_time.*(.literal .text .literal.* .text.*)
++    *components/esp_hw_support/*/regi2c_ctrl.*(.literal .text .literal.* .text.*)
++    *components/efuse/*(.literal .text .literal.* .text.*)
+     *(.fini.literal)
+     *(.fini)
+     *(.gnu.version)
+-- 
+2.17.1
+

--- a/pkg/esp32_sdk/patches/0019-hal-fix-spi_ll-compilation-errors-for-riscv32.patch
+++ b/pkg/esp32_sdk/patches/0019-hal-fix-spi_ll-compilation-errors-for-riscv32.patch
@@ -1,0 +1,34 @@
+From 367e4268b81a30c243628f8c99e94550bd291ec0 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Thu, 10 Mar 2022 12:39:51 +0100
+Subject: [PATCH 19/20] hal: fix spi_ll compilation errors for riscv32
+
+---
+ components/hal/esp32c3/include/hal/spi_ll.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/components/hal/esp32c3/include/hal/spi_ll.h b/components/hal/esp32c3/include/hal/spi_ll.h
+index 38e1676d041..a9154c4600a 100644
+--- a/components/hal/esp32c3/include/hal/spi_ll.h
++++ b/components/hal/esp32c3/include/hal/spi_ll.h
+@@ -332,7 +332,7 @@ static inline void spi_ll_dma_set_rx_eof_generation(spi_dev_t *hw, bool enable)
+  */
+ static inline void spi_ll_write_buffer(spi_dev_t *hw, const uint8_t *buffer_to_send, size_t bitlen)
+ {
+-    for (int x = 0; x < bitlen; x += 32) {
++    for (size_t x = 0; x < bitlen; x += 32) {
+         //Use memcpy to get around alignment issues for txdata
+         uint32_t word;
+         memcpy(&word, &buffer_to_send[x / 8], 4);
+@@ -384,7 +384,7 @@ static inline void spi_ll_write_buffer_byte(spi_dev_t *hw, int byte_id, uint8_t
+  */
+ static inline void spi_ll_read_buffer(spi_dev_t *hw, uint8_t *buffer_to_rcv, size_t bitlen)
+ {
+-    for (int x = 0; x < bitlen; x += 32) {
++    for (size_t x = 0; x < bitlen; x += 32) {
+         //Do a memcpy to get around possible alignment issues in rx_buffer
+         uint32_t word = hw->data_buf[x / 32];
+         int len = bitlen - x;
+-- 
+2.17.1
+

--- a/pkg/esp32_sdk/patches/0020-freertos-portasm-changes-for-RIOT-for-riscv32.patch
+++ b/pkg/esp32_sdk/patches/0020-freertos-portasm-changes-for-RIOT-for-riscv32.patch
@@ -1,0 +1,66 @@
+From ae4c3076113b0b746bea04206d0186bce99fb4d1 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Thu, 10 Mar 2022 13:10:23 +0100
+Subject: [PATCH 20/20] freertos/portasm: changes for RIOT for riscv32
+
+A number of symbols that are used by assembler code have to be mapped to existing symbols in RIOT implementation. Furthermore, the ISR stack `port_IntStack`has to be allocated.
+---
+ components/freertos/port/riscv/portasm.S | 27 ++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/components/freertos/port/riscv/portasm.S b/components/freertos/port/riscv/portasm.S
+index 20c094b7a68..8aeabb3dedc 100644
+--- a/components/freertos/port/riscv/portasm.S
++++ b/components/freertos/port/riscv/portasm.S
+@@ -12,6 +12,22 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+ 
++#ifdef RIOT_VERSION
++#include "cpu_conf.h"
++
++#define pxCurrentTCB            sched_active_thread
++#define uxSchedulerRunning      sched_num_threads
++#define xPortSwitchFlag         sched_context_switch_request
++#define vTaskSwitchContext      sched_run
++#define uxInterruptNesting      irq_interrupt_nesting
++#define configISR_STACK_SIZE    ESP_ISR_STACKSIZE
++
++.extern sched_active_thread
++.extern sched_num_threads
++.extern sched_context_switch_request
++.extern irq_interrupt_nesting
++#endif
++
+     .global uxInterruptNesting
+     .global uxSchedulerRunning
+     .global xIsrStackTop
+@@ -19,6 +35,14 @@
+     .global vTaskSwitchContext
+     .global xPortSwitchFlag
+ 
++    .data
++    .align      16
++    .global     port_IntStack
++port_IntStack:
++    .space      configISR_STACK_SIZE
++    .global     port_IntStackTop
++port_IntStackTop:
++
+     .section .text
+ 
+ /**
+@@ -50,7 +74,10 @@ rtos_int_enter:
+ 
+     /* Save current TCB and load the ISR stack */
+     lw  t0, pxCurrentTCB
++    beq t0, zero, rtos_enter_isr_stack
+     sw 	t2, 0x0(t0)
++
++rtos_enter_isr_stack:
+     lw  sp, xIsrStackTop
+ 
+ rtos_enter_end:
+-- 
+2.17.1
+


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844, which provides additional patches of `pkg/esp32_sdk` required for ESP32-C3.

### Testing procedure

It is not yet possible to cover this PR when compiling in CI without having ESP32-C3 support and a board definition with an ESP32-C3. Vice versa, the ESP32-C3 port that needs this PR cannot be compiled in CI without it.

Therefore a green CI with the label `CI: skip compile test` must be sufficient for the moment. If it doesn't work, the problem will pop up as soon as ESP32-C3 support is provided. And of course, I have tested it together with the ESP32-C3 support in PR #17844.

### Issues/PRs references

Split-off from PR #17844