### PR TITLE
cpu/esp32: add ESP32-C3 support in makefiles

### DIFF
--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -1,6 +1,9 @@
 ifneq (,$(filter esp32,$(CPU_FAM)))
   CPU_ARCH = xtensa
   CPU_CORE = xtensa-lx6
+else ifneq (,$(filter esp32c3,$(CPU_FAM)))
+  CPU_ARCH = rv32
+  CPU_CORE = rv32imc
 else
   $(error Unkwnown ESP32x SoC variant (family))
 endif

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -22,7 +22,7 @@ include $(RIOTCPU)/esp_common/Makefile.include
 
 ifeq (xtensa,$(CPU_ARCH))
   TARGET_ARCH ?= xtensa-$(CPU_FAM)-elf
-else ifeq (riscv_esp32,$(CPU_ARCH))
+else ifeq (rv32,$(CPU_ARCH))
   TARGET_ARCH ?= riscv32-esp-elf
 else
   $(error Unkwnown ESP32x SoC architecture)

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -25,7 +25,7 @@ ifeq (xtensa,$(CPU_ARCH))
   USEMODULE += xtensa
 endif
 
-ifeq (riscv_esp32,$(CPU_ARCH))
+ifeq (rv32,$(CPU_ARCH))
   USEMODULE += esp_riscv
 endif
 

--- a/cpu/esp_common/Makefile.features
+++ b/cpu/esp_common/Makefile.features
@@ -26,7 +26,7 @@ ifeq (xtensa,$(CPU_ARCH))
   FEATURES_PROVIDED += arch_esp_xtensa
 endif
 
-ifeq (riscv_esp32,$(CPU_ARCH))
+ifeq (rv32,$(CPU_ARCH))
   FEATURES_PROVIDED += arch_esp_riscv
 endif
 


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844, which adds the support of ESP32-C3 in makefiles.

### Testing procedure

It is not yet possible to cover this PR when compiling in CI without having ESP32-C3 support and a board definition with an ESP32-C3. Vice versa, the ESP32-C3 port that needs this PR cannot be compiled in CI without it.

Therefore a green CI with the label `CI: skip compile test` must be sufficient for the moment. If it doesn't work, the problem will pop up as soon as ESP32-C3 support is provided. And of course, I have tested it together with the ESP32-C3 support in PR #17844.

### Issues/PRs references

Split-off from PR #17844