### PR TITLE
dist/tools/cosy: provide patch for PR #13

### DIFF
--- a/dist/tools/cosy/patches/0002-parse_elffile-fix-riot_base.patch
+++ b/dist/tools/cosy/patches/0002-parse_elffile-fix-riot_base.patch
@@ -1,0 +1,26 @@
+From ca34f5c4e808b9b6e61e1ceba5e7065bf71fe37a Mon Sep 17 00:00:00 2001
+From: Jana Eisoldt <jana.eisoldt@st.ovgu.de>
+Date: Mon, 21 Feb 2022 16:52:01 +0100
+Subject: [PATCH] parse_elffile: fix riot_base
+
+---
+ cosy.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/cosy.py b/cosy.py
+index b36c28a..2081f64 100755
+--- a/cosy.py
++++ b/cosy.py
+@@ -154,9 +154,9 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
+     rbase = ["riotbuild/riotproject"]
+     if riot_base:
+         rbase.append(riot_base.strip("/"))
+-    else:
+-        rbase.append("RIOT")
+-        rbase.append("riotbuild/riotbase")
++
++    rbase.append("RIOT")
++    rbase.append("riotbuild/riotbase")
+     riot_base = "|".join([f'{p}/build|{p}' for p in rbase])
+ 
+     c = re.compile(r"(?P<addr>[0-9a-f]+) "


### PR DESCRIPTION
### Contribution description

The upstream PR #13 is not yet merged but fixes classification to no
longer classify most of RIOT's object files "unspecified" in the
`.text` view.

Since @Jnae authored the fix, I added her as author in the commit adding the patch to not steal credit.

### Testing procedure

`make cosy` with a recent should now give sensible output. I can confirm that it fixes the issue for me.

Apparently on @benpicco 's machine it worked before. Maybe he can confirm it doesn't break anything.

### Issues/PRs references

Upstream PR: https://github.com/haukepetersen/cosy/pull/13

Implementation of @leandrolanzieri suggestion: https://forum.riot-os.org/t/suggestions-for-measuring-memory-usage/3666/7