### PR TITLE
cpu/esp32: add support for ESP32-C3

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -35,6 +35,7 @@ dwm1001
 esp32-ci
 esp32-heltec-lora32-v2
 esp32-olimex-evb
+esp32c3-devkit
 esp8266-ci
 esp8266-esp-12x
 hamilton

--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -132,21 +132,6 @@ extern mtd_dev_t *mtd0;
 /** @} */
 #endif /* MODULE_MTD || DOXYGEN */
 
-#if MODULE_SPIFFS || DOXYGEN
-/**
- * @name    SPIFFS configuration for the system MTD device
- *
- * Configuration of the SPIFFS that can be used on the system MTD device.
- * @{
- */
-#define SPIFFS_ALIGNED_OBJECT_INDEX_TABLES 1
-#define SPIFFS_READ_ONLY 0
-#define SPIFFS_SINGLETON 0
-#define SPIFFS_HAL_CALLBACK_EXTRA 1
-#define SPIFFS_CACHE 1
-/** @} */
-#endif /* MODULE_SPIFFS || DOXYGEN */
-
 /**
   * @brief Print the board configuration in a human readable format
   */

--- a/boards/common/esp32c3/Kconfig
+++ b/boards/common/esp32c3/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ESP32C3
+    bool
+    select HAS_PERIPH_UART
+    select HAVE_SAUL_GPIO
+
+config MODULE_BOARDS_COMMON_ESP32C3
+    bool
+    depends on TEST_KCONFIG
+    depends on BOARD_COMMON_ESP32C3
+    depends on HAS_ARCH_ESP32
+    default y
+    help
+      Common ESP32-C3 boards code.

--- a/boards/common/esp32c3/Makefile
+++ b/boards/common/esp32c3/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_esp32c3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32c3/Makefile.dep
+++ b/boards/common/esp32c3/Makefile.dep
@@ -1,0 +1,5 @@
+USEMODULE += boards_common_esp32c3
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/common/esp32c3/Makefile.features
+++ b/boards/common/esp32c3/Makefile.features
@@ -1,0 +1,5 @@
+CPU = esp32
+CPU_FAM = esp32c3
+
+# additional features provided by all boards is at least one UART
+FEATURES_PROVIDED += periph_uart

--- a/boards/common/esp32c3/Makefile.include
+++ b/boards/common/esp32c3/Makefile.include
@@ -1,0 +1,5 @@
+INCLUDES += -I$(RIOTBOARD)/common/esp32c3/include
+
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/common/esp32c3/board_common.c
+++ b/boards/common/esp32c3/board_common.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32c3
+ * @{
+ *
+ * @file
+ * @brief       Common declarations and functions for all ESP32-C3 boards.
+ *
+ * This file contains default declarations and functions that are valid
+ * for all ESP32-C3 boards.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+#include "esp_common.h"
+#include "kernel_defines.h"
+#include "log.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void adc_print_config(void);
+extern void dac_print_config(void);
+extern void pwm_print_config(void);
+extern void i2c_print_config(void);
+extern void spi_print_config(void);
+extern void uart_print_config(void);
+extern void can_print_config(void);
+
+void print_board_config(void)
+{
+    ets_printf("\nBoard configuration:\n");
+
+#if IS_USED(MODULE_PERIPH_ADC)
+    adc_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_DAC)
+    dac_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_PWM)
+    pwm_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_I2C)
+    i2c_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_SPI)
+    spi_print_config();
+#endif
+#if IS_USED(MODULE_PERIPH_UART)
+    uart_print_config();
+#endif
+
+#if IS_USED(MODULE_PERIPH_CAN)
+    can_print_config();
+#endif
+
+    ets_printf("\tLED\t\tpins=[ ");
+#ifdef LED0_PIN
+    ets_printf("%d ", LED0_PIN);
+#endif
+#ifdef LED1_PIN
+    ets_printf("%d ", LED1_PIN);
+#endif
+#ifdef LED2_PIN
+    ets_printf("%d ", LED2_PIN);
+#endif
+    ets_printf("]\n");
+
+    ets_printf("\tBUTTONS\t\tpins=[ ");
+#ifdef BUTTON0_PIN
+    ets_printf("%d ", BUTTON0_PIN);
+#endif
+#ifdef BUTTON2_PIN
+    ets_printf("%d ", BUTTON1_PIN);
+#endif
+#ifdef BUTTON3_PIN
+    ets_printf("%d ", BUTTON2_PIN);
+#endif
+    ets_printf("]\n");
+
+    ets_printf("\n");
+}
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/common/esp32c3/doc.txt
+++ b/boards/common/esp32c3/doc.txt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_common_esp32c3  ESP32-C3 Common
+ * @ingroup     boards_common
+ * @ingroup     boards_esp32c3
+ * @brief       Definitions and configurations that are common for
+ *              all ESP32-C3 boards.
+ *
+ * For detailed information about the ESP32-C3, configuring and compiling RIOT
+ * for ESP32-C3 boards, please refer \ref esp32_riot.
+ */
+
+/**
+ * @defgroup    boards_esp32c3  ESP32-C3 Boards
+ * @ingroup     boards
+ * @brief       This group of boards contains the documentation of ESP32-C3 boards.
+ *
+ * @note        For detailed information about the ESP32-C3 SoC, the tool chain
+ *              as well as configuring and compiling RIOT for ESP32-C3 boards,
+ *              see \ref esp32_riot.
+ */

--- a/boards/common/esp32c3/include/arduino_board_common.h
+++ b/boards/common/esp32c3/include/arduino_board_common.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32c3
+ * @{
+ *
+ * @file
+ * @brief       Common board definitions for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_COMMON_H
+#define ARDUINO_BOARD_COMMON_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_COMMON_H */
+/** @} */

--- a/boards/common/esp32c3/include/board_common.h
+++ b/boards/common/esp32c3/include/board_common.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32c3
+ * @brief       Common board definitions for ESP32-C3 boards.
+ *
+ * This file contains board configurations that are valid for all
+ * ESP32-C3 boards.
+ *
+ * For detailed information about the configuration of ESP32-C3 boards, see
+ * section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+#if MODULE_ARDUINO
+#include "arduino_pinmap.h"
+#endif
+
+#include "periph/gpio.h"
+#include "sdkconfig.h"
+
+#if MODULE_MTD
+#include "mtd.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   LED configuration (three predefined LEDs at maximum)
+ *
+ * @note LEDx_ACTIVE value must be declared in board configuration.
+ * @{
+ */
+#if defined(LED0_PIN) || DOXYGEN
+#define LED0_MASK       (BIT(LED0_PIN))
+#define LED0_ON         (gpio_write(LED0_PIN,  LED0_ACTIVE))
+#define LED0_OFF        (gpio_write(LED0_PIN, !LED0_ACTIVE))
+#define LED0_TOGGLE     (gpio_toggle(LED0_PIN))
+#endif
+
+#if defined(LED1_PIN) || DOXYGEN
+#define LED1_MASK       (BIT(LED1_PIN))
+#define LED1_ON         (gpio_write(LED1_PIN,  LED1_ACTIVE))
+#define LED1_OFF        (gpio_write(LED1_PIN, !LED1_ACTIVE))
+#define LED1_TOGGLE     (gpio_toggle(LED1_PIN))
+#endif
+
+#if defined(LED2_PIN) || DOXYGEN
+#define LED2_MASK       (BIT(LED2_PIN))
+#define LED2_ON         (gpio_write(LED2_PIN,  LED2_ACTIVE))
+#define LED2_OFF        (gpio_write(LED2_PIN, !LED2_ACTIVE))
+#define LED2_TOGGLE     (gpio_toggle(LED2_PIN))
+#endif
+/** @} */
+
+/**
+ * @name    STDIO configuration
+ * @{
+ */
+/**< Default baudrate of UART for stdio */
+#ifndef STDIO_UART_BAUDRATE
+#define STDIO_UART_BAUDRATE      (115200)
+#endif
+/** @} */
+
+#if MODULE_MTD || DOXYGEN
+/**
+ * @name    MTD system drive configuration
+ *
+ * Built-in SPI flash memory is used as MTD system drive.
+ * @{
+ */
+
+/**
+ * @brief   MTD drive start address in SPI flash memory
+ *
+ * Defines the start address of the MTD system device in the SPI
+ * flash memory. It can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration"
+ *
+ * If the MTD start address is not defined or is 0, the first possible
+ * multiple of 0x100000 (1 MByte) is used in free SPI flash memory,
+ * which was determined from the partition table.
+ */
+#ifndef SPI_FLASH_DRIVE_START
+#define SPI_FLASH_DRIVE_START  0
+#endif
+
+/** Default MTD drive definition */
+#define MTD_0 mtd0
+
+/** Pointer to the default MTD drive structure */
+extern mtd_dev_t *mtd0;
+
+/** @} */
+#endif /* MODULE_MTD || DOXYGEN */
+
+/**
+  * @brief Print the board configuration in a human readable format
+  */
+void print_board_config(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_COMMON_H */
+/** @} */

--- a/boards/common/esp32c3/include/periph_conf_common.h
+++ b/boards/common/esp32c3/include/periph_conf_common.h
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_esp32c3
+ * @brief       Common peripheral configurations for ESP32-C3 boards
+ *
+ * This file contains the peripheral configurations that are valid for all
+ * ESP32-C3 boards.
+ *
+ * For detailed information about the peripheral configuration for ESP32-C3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef PERIPH_CONF_COMMON_H
+#define PERIPH_CONF_COMMON_H
+
+/* include periph_cpu.h to make it visible in any case */
+#include "periph_cpu.h"
+#include "kernel_defines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * ADC_GPIOS is defined in board-specific peripheral configuration. Since
+ * ADC_GPIOS must be defined even if there are no ADC channels, an empty
+ * list definition is done here as fallback configuration.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { }
+#endif
+
+/**
+ * @brief   Static array with declared ADC channels
+ */
+static const gpio_t adc_channels[] = ADC_GPIOS;
+
+/**
+ * @brief Number of GPIOs declared as ADC channels
+ *
+ * The number of GPIOs that are declared as ADC channels is determined from
+ * the ADC_GPIOS definition.
+ *
+ * @note ADC_NUMOF definition must not be changed.
+ */
+#define ADC_NUMOF   ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name    DAC configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * DAC_GPIOS is defined in board-specific peripheral configuration. Since
+ * DAC_GPIOS must be defined even if there are no DAC channels, an empty
+ * list definition is done here as fallback configuration.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { }
+#endif
+
+/**
+ * @brief   Static array with declared DAC channels
+ */
+static const gpio_t dac_channels[] = DAC_GPIOS;
+
+/**
+ * @brief Number of GPIOs declared as DAC channels
+ *
+ * The number of GPIOs that are declared as DAC channels is determined from
+ * the DAC_GPIOS definition.
+ *
+ * @note DAC_NUMOF definition must not be changed.
+ */
+#define DAC_NUMOF   ARRAY_SIZE(dac_channels)
+/** @} */
+
+/**
+ * @name   I2C configuration
+ * @{
+ */
+
+#if defined(I2C0_SCL) && !defined(I2C0_SCL_PULLUP)
+/** Define SCL pullup enabled by default */
+#define I2C0_SCL_PULLUP true
+#endif
+#if defined(I2C0_SDA) && !defined(I2C0_SDA_PULLUP)
+/** Define SDA pullup enabled by default */
+#define I2C0_SDA_PULLUP true
+#endif
+
+/**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const i2c_conf_t i2c_config[] = {
+#if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
+    {
+        .module = PERIPH_I2C0_MODULE,
+        .speed = I2C0_SPEED,
+        .scl = I2C0_SCL,
+        .sda = I2C0_SDA,
+        .scl_pullup = I2C0_SCL_PULLUP,
+        .sda_pullup = I2C0_SCL_PULLUP,
+    },
+#endif
+};
+
+/**
+ * @brief Number of I2C interfaces
+ *
+ * The number of I2C interfaces is determined from board-specific peripheral
+ * definitions of I2Cn_SPEED, I2Cn_SCK, and I2Cn_SDA.
+ *
+ * @note I2C_NUMOF definition must not be changed.
+ */
+#define I2C_NUMOF   ARRAY_SIZE(i2c_config)
+
+/** @} */
+
+/**
+ * @name   PWM configuration
+ * @{
+ */
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM0_GPIOS
+static const gpio_t pwm0_gpios[] = PWM0_GPIOS;
+#endif
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM1_GPIOS
+static const gpio_t pwm1_gpios[] = PWM1_GPIOS;
+#endif
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM2_GPIOS
+static const gpio_t pwm2_gpios[] = PWM2_GPIOS;
+#endif
+
+/**
+ * @brief   GPIOs used as channels for the according PWM device
+ */
+#ifdef PWM3_GPIOS
+static const gpio_t pwm3_gpios[] = PWM3_GPIOS;
+#endif
+
+/**
+ * @brief   PWM device configuration based on defined PWM channel GPIOs
+ */
+static const pwm_config_t pwm_config[] =
+{
+#ifdef PWM0_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+        .group = LEDC_LOW_SPEED_MODE,
+        .timer = LEDC_TIMER_0,
+        .ch_numof = ARRAY_SIZE(pwm0_gpios),
+        .gpios = pwm0_gpios,
+    },
+#endif
+#ifdef PWM1_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+#ifdef SOC_LEDC_SUPPORT_HS_MODE
+        .group = LEDC_HIGH_SPEED_MODE,
+#else
+        .group = LEDC_LOW_SPEED_MODE,
+#endif
+        .timer = LEDC_TIMER_1,
+        .ch_numof = ARRAY_SIZE(pwm1_gpios),
+        .gpios = pwm1_gpios,
+    },
+#endif
+#ifdef PWM2_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+        .group = LEDC_LOW_SPEED_MODE,
+        .timer = LEDC_TIMER_2,
+        .ch_numof = ARRAY_SIZE(pwm2_gpios),
+        .gpios = pwm2_gpios,
+    },
+#endif
+#ifdef PWM3_GPIOS
+    {
+        .module = PERIPH_LEDC_MODULE,
+#ifdef SOC_LEDC_SUPPORT_HS_MODE
+        .group = LEDC_HIGH_SPEED_MODE,
+#else
+        .group = LEDC_LOW_SPEED_MODE,
+#endif
+        .timer = LEDC_TIMER_3,
+        .ch_numof = ARRAY_SIZE(pwm3_gpios),
+        .gpios = pwm3_gpios,
+    },
+#endif
+};
+
+/**
+ * @brief   Number of PWM devices
+ *
+ * The number of PWM devices is determined from the PWM device configuration.
+ *
+ * @note PWM_NUMOF definition must not be changed.
+ */
+#define PWM_NUMOF   ARRAY_SIZE(pwm_config)
+
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+
+/**
+ * @brief   Static array with configuration for declared SPI devices
+ */
+static const spi_conf_t spi_config[] = {
+#ifdef SPI0_CTRL
+    {
+        .ctrl = SPI0_CTRL,
+        .sck = SPI0_SCK,
+        .mosi = SPI0_MOSI,
+        .miso = SPI0_MISO,
+        .cs = SPI0_CS0,
+    },
+#endif
+#ifdef SPI1_CTRL
+    {
+        .ctrl = SPI1_CTRL,
+        .sck = SPI1_SCK,
+        .mosi = SPI1_MOSI,
+        .miso = SPI1_MISO,
+        .cs = SPI1_CS0,
+    },
+#endif
+};
+
+/**
+ * @brief Number of SPI interfaces
+ *
+ * The number of SPI interfaces is determined from board-specific peripheral
+ * definitions of SPIn_*.
+ *
+ * @note SPI_NUMOF definition must not be changed.
+ */
+#define SPI_NUMOF   ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+
+#ifndef UART0_TXD
+#define UART0_TXD   (GPIO21)  /**< TxD of UART_DEV(0) used on all ESP32-C3 boards */
+#endif
+#ifndef UART0_RXD
+#define UART0_RXD   (GPIO20)  /**< RxD of UART_DEV(0) used on all ESP32-C3 boards */
+#endif
+
+/**
+ * @brief   Static array with configuration for declared UART devices
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .txd = UART0_TXD,
+        .rxd = UART0_RXD,
+    },
+#if defined(UART1_TXD) && defined(UART1_RXD)
+    {
+        .txd = UART1_TXD,
+        .rxd = UART1_RXD,
+    },
+#endif
+};
+
+/**
+ * @brief Number of UART interfaces
+ *
+ * The number of UART interfaces is determined from board-specific peripheral
+ * definitions of UARTn_*.
+ *
+ * @note UART_NUMOF definition must not be changed.
+ */
+#define UART_NUMOF  ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* PERIPH_CONF_COMMON_H */
+/** @} */

--- a/boards/esp32c3-devkit/Kconfig
+++ b/boards/esp32c3-devkit/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32c3-devkit" if BOARD_ESP32C3_DEVKIT
+
+config BOARD_ESP32C3_DEVKIT
+    bool
+    default y
+    select BOARD_COMMON_ESP32C3
+    select CPU_MODEL_ESP32C3_MINI_1X
+    select HAS_ARDUINO
+    select HAS_ESP_JTAG
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/esp32c3/Kconfig"

--- a/boards/esp32c3-devkit/Makefile
+++ b/boards/esp32c3-devkit/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32c3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32c3-devkit/Makefile.dep
+++ b/boards/esp32c3-devkit/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/esp32c3/Makefile.dep

--- a/boards/esp32c3-devkit/Makefile.features
+++ b/boards/esp32c3-devkit/Makefile.features
@@ -1,0 +1,15 @@
+CPU_MODEL = esp32c3_mini_1x
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32c3/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_jtag
+
+FEATURES_PROVIDED += arduino

--- a/boards/esp32c3-devkit/Makefile.include
+++ b/boards/esp32c3-devkit/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/esp32c3/Makefile.include

--- a/boards/esp32c3-devkit/doc.txt
+++ b/boards/esp32c3-devkit/doc.txt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32c3_devkit ESP32-C3-DevKit Board
+ * @ingroup     boards_esp32c3
+ * @brief       Support for generic ESP32-C3 boards
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32c3_devkit ESP32-C3-DevKit
+
+## Table of Contents {#esp32c3_devkit_toc}
+
+1. [Overview](#esp32c3_devkit_overview)
+2. [Hardware](#esp32c3_devkit_hardware)
+    1. [MCU](#esp32c3_devkit_mcu)
+    2. [Board Configuration](#esp32c3_devkit_board_configuration)
+    3. [Board Pinout](#esp32c3_devkit_pinout)
+3. [Flashing the Device](#esp32c3_devkit_flashing)
+
+## Overview {#esp32c3_devkit_overview}
+
+The Espressif ESP32-C3-DevKit boards are a couple of boards that use one of
+the following modules:
+
+- ESP32-C3-MINI-1x module (ESP32-C3-DevKitM-1 board)
+- ESP32-C3-WROOM-02x module (ESP32-C3-DevKitC-02 board)
+
+Since the number of GPIOs and their possible uses on the ESP32-C3 are quite
+limited, the ESP32-C3-DevKit should also work for most other ESP32-C3 boards.
+Any modifications required for specific applications could be overridden by
+\ref esp32_application_specific_configurations "application-specific board configuration".
+
+\image html "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/_images/esp32-c3-devkitm-1-v1-annotated-photo.png" "Espressif ESP32-C3-DevKitM-1" width=800px
+
+[Back to table of contents](#esp32c3_devkit_toc)
+
+## Hardware {#esp32c3_devkit_hardware}
+
+This section describes
+
+- the [MCU](#esp32c3_devkit_mcu),
+- the default [board configuration](#esp32c3_devkit_board_configuration),
+- [optional hardware configurations](#esp32c3_devkit_optional_hardware),
+- the [board pinout](#esp32c3_devkit_pinout).
+
+[Back to table of contents](#esp32c3_devkit_toc)
+
+### MCU {#esp32c3_devkit_mcu}
+
+Most features of the board are provided by the ESP32-C3 SoC. For detailed
+information about the ESP32-C3 variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32c3_devkit_toc)
+
+### Board Configuration {#esp32c3_devkit_board_configuration}
+
+ESP32-C3-DevKit boards have no special hardware on board with the exception
+of a single pin RGB-LED that uses a special bit-oriented protocol to
+control the RGB-LED by 24-bit RGB values which is not supported yet.
+
+All GPIOs are simply broken out for flexibility. Therefore, the board
+configuration is the most flexible one which provides:
+
+- 6 x ADC channels at maximum
+- 1 x SPI
+- 1 x I2C
+- 2 x UART
+- 1 RGB-LED
+
+Since all GPIOs have broken out, GPIOs can be used for different purposes
+in different applications. For flexibility, GPIOs can be listed in multiple
+peripheral configurations, but they can only be used for one peripheral
+at a time. For example, GPIO4 is used in the ADC channel definition, the
+PWM channel definition and the definition of the SCL signal for I2C_DEV(0).
+
+This is possible because GPIOs are only used for a specific peripheral
+interface when either
+
+- the corresponding peripheral module is used, e.g. `periph_i2c` and
+  `periph_spi`, or
+- the corresponding init function is called, e.g. `adc_init` and
+  `pwm_init`.
+
+That is, the purpose for which a GPIO is used depends on which module
+or function is used first.
+
+For example, if module `periph_i2c` is not used, the GPIOs listed in I2C
+configuration can be used for the other purposes, that is, GPIO4 can be
+used as ADC channel or PWM channel.
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO9  | | |
+ADC             | GPIO0, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5 | | see \ref esp32_adc_channels "ADC Channels"
+PWM_DEV(0)      | GPIO3, GPIO4 | - | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SCL  | GPIO4 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SDA  | GPIO5 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO6 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO2 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO7 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO10  | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO21  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO20 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+\n
+@note The configuration of ADC channels contains all ESP32-C3 GPIOs that could
+      be used as ADC channels.
+
+For detailed information about the peripheral configurations of ESP32-C3
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32c3_devkit_toc)
+
+### Board Pinout {#esp32c3_devkit_pinout}
+
+The following figures show the pinouts as configured by default board
+definition.
+
+@image html https://gitlab.com/gschorcht/RIOT.wiki-Images/-/raw/master/esp32/ESP32-C3-DevKitM-1_pinout.png "EPS32-C3-DevKitM-1x Pinout"
+@image html https://gitlab.com/gschorcht/RIOT.wiki-Images/-/raw/master/esp32/ESP32-C3-DevKitC-02_pinout.png "EPS32-C3-DevKitC-02x Pinout"
+
+The corresponding board schematics can be found:
+
+- [ESP32-C3-DevKitM-1](https://dl.espressif.com/dl/schematics/SCH_ESP32-C3-DEVKITM-1_V1_20200915A.pdf)
+- [ESP32-C3-DevKitC-02](https://dl.espressif.com/dl/schematics/SCH_ESP32-C3-DEVKITC-02_V1_1_20210126A.pdf)
+
+[Back to table of contents](#esp32c3_devkit_toc)
+
+## Flashing the Device {#esp32c3_devkit_flashing}
+
+Flashing RIOT is quite easy. The board has a Micro-USB connector with
+reset/boot/flash logic. Just connect the board to your host computer
+and type using the programming port:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+make flash BOARD=esp32c3-devkit ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For detailed information about ESP32-C3 as well as configuring and compiling
+RIOT for ESP32-C3 boards, see \ref esp32_riot.
+
+[Back to table of contents](#esp32c3_devkit_toc)
+ */

--- a/boards/esp32c3-devkit/include/arduino_board.h
+++ b/boards/esp32c3-devkit/include/arduino_board.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32c3_devkit
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is not available
+ */
+#define ARDUINO_LED         (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/esp32c3-devkit/include/arduino_pinmap.h
+++ b/boards/esp32c3-devkit/include/arduino_pinmap.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C)  2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32c3_devkit
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO20      /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO21      /**< Arduino Uno pin 1 (TxD) */
+#if !defined(MODULE_ESP_RTC_TIMER_32K)
+#define ARDUINO_PIN_2   GPIO0       /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO1       /**< Arduino Uno pin 3 (PWM) */
+#else
+#define ARDUINO_PIN_2   GPIO_UNDEF  /**< Arduino Uno pin 2 */
+#endif
+#define ARDUINO_PIN_4   GPIO_UNDEF  /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO3       /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO4       /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO8       /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO_UNDEF  /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO_UNDEF  /**< Arduino Uno pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO10      /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO7       /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO2       /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO6       /**< Arduino Uno pin 13 (SCK)  */
+
+#define ARDUINO_PIN_A0  GPIO0       /**< Arduino Uno pin A0 */
+#if !defined(MODULE_ESP_RTC_TIMER_32K)
+#define ARDUINO_PIN_A1  GPIO1       /**< Arduino Uno pin A1 */
+#else
+#define ARDUINO_PIN_A1  GPIO_UNDEF  /**< Arduino Uno pin A1 */
+#endif
+#define ARDUINO_PIN_A2  GPIO2       /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO3       /**< Arduino Uno pin A3 */
+
+#define ARDUINO_PIN_A4  GPIO5       /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO4       /**< Arduino Uno pin A5 (SCL) */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/esp32c3-devkit/include/board.h
+++ b/boards/esp32c3-devkit/include/board.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32c3_devkit
+ * @brief       Board definitions for ESP32-C3-DevKit boards
+ * @{
+ *
+ * The board definitions in this file are valid for Espressif
+ * ESP32-C3-DevKitx boards that use one of the following modules:
+ *
+ * - ESP32-C3-MINI-1x module (ESP32-C3-DevKitM-1 board)
+ * - ESP32-C3-WROOM-02x module (ESP32-C3-DevKitC-02 board)
+ *
+ * Since the number of GPIOs and their possible uses on the ESP32-C3 are quite
+ * limited, these board definitions can also be used for most other
+ * ESP32-C3 boards. Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * ESP32-C3-DevKit boards have a BOOT button connected to GPIO9, which can be
+ * used as button during normal operation. Since the GPIO9 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO9
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * ESP32-C3-DevKit boards have a SK68XXMINI-HS smart RGB-LED connected to
+ * GPIO8 on-board. This RGB-LEDs uses a special bit-oriented protocol to
+ * control the RGB-LED by 24-bit RGB values. Therefore, it can't be used as
+ * default LED definition for RIOT.
+ * @{
+ */
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32c3-devkit/include/gpio_params.h
+++ b/boards/esp32c3-devkit/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32c3_devkit
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32c3-devkit/include/periph_conf.h
+++ b/boards/esp32c3-devkit/include/periph_conf.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32c3_devkit
+ * @brief       Peripheral configurations for ESP32-C3-DevKit boards
+ * @{
+ *
+ * The peripheral configurations in this file are valid for Espressif
+ * ESP32-C3-DevKitx boards that use one of the following modules:
+ *
+ * - ESP32-C3-MINI-1x module (ESP32-C3-DevKitM-1 board)
+ * - ESP32-C3-WROOM-02x module (ESP32-C3-DevKitC-02 board)
+ *
+ * Since the number of GPIOs and their possible uses on the ESP32-C3 are quite
+ * limited, these peripheral configurations can also be used for most other
+ * ESP32-C3 boards. Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-C3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * For generic boards, all ADC pins that have broken out are declared as ADC
+ * channels.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO0, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * For generic boards, only one I2C interface I2C_DEV(0) is defined.
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO4           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO5           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * For generic boards, two PWM devices are configured. These devices
+ * contain all GPIOs that are not defined as I2C, SPI or UART for this board.
+ * Generally, all outputs pins could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO3, GPIO4 }
+#endif
+
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   FSPI    /**< FSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO6   /**< FSPI SCK (pin FSPICLK) */
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO2   /**< FSPI MISO (pin FSPIQ) */
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO7   /**< FSPI MOSI (pin FSPID) */
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO10  /**< FSPI CS0 (pin FSPICS0) */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-C3 provides 2 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO21  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO20  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -38,5 +38,6 @@ config CPU
     default "esp32" if HAS_CPU_ESP32
 
 rsource "Kconfig.esp32"
+rsource "Kconfig.esp32c3"
 
 source "$(RIOTCPU)/esp_common/Kconfig"

--- a/cpu/esp32/Kconfig.esp32c3
+++ b/cpu/esp32/Kconfig.esp32c3
@@ -1,0 +1,124 @@
+# Copyright (c) 2020 HAW Hamburg
+#               2022 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_ARCH_RISCV
+    bool
+    select HAS_ARCH_32BIT
+    select HAS_ARCH_ESP
+    select HAS_ARCH_ESP_RISCV
+    help
+        RISC-V based ESP32x SoC variant is used.
+
+config CPU_ARCH
+    default "rv32" if CPU_ARCH_RISCV
+
+config CPU_CORE_RV32IMC
+    bool
+    select CPU_ARCH_RISCV
+    help
+        CPU core of the ESP32x SoC is a RISC-V core.
+
+config CPU_CORE
+    default "rv32imc" if CPU_CORE_RV32IMC
+
+config CPU_FAM_ESP32C3
+    bool
+    select CPU_COMMON_ESP
+    select CPU_CORE_RV32IMC
+    select HAS_ARCH_ESP32
+    select HAS_CPU_ESP32
+    select HAS_ESP_WIFI_ENTERPRISE
+    select HAS_PUF_SRAM
+
+    select PACKAGE_ESP32_SDK if TEST_KCONFIG
+
+    select MODULE_MALLOC_THREAD_SAFE if !MODULE_ESP_IDF_HEAP && TEST_KCONFIG
+    select MODULE_PERIPH_RTT if HAS_PERIPH_RTT && MODULE_PM_LAYERED
+    select MODULE_PS if MODULE_SHELL
+    select MODULE_PTHREAD if MODULE_CPP
+    select MODULE_RTT_RTC if HAS_PERIPH_RTT && MODULE_PERIPH_RTC
+    imply MODULE_NEWLIB_NANO
+
+config CPU_FAM
+    default "esp32c3" if CPU_FAM_ESP32C3
+
+## CPU Models
+config CPU_MODEL_ESP32C3_WROOM_02X
+    bool
+    select CPU_FAM_ESP32C3
+
+config CPU_MODEL_ESP32C3_MINI_1X
+    bool
+    select CPU_FAM_ESP32C3
+
+config CPU_MODEL_ESP32C3
+    bool
+    select CPU_FAM_ESP32C3
+
+config CPU_MODEL_ESP32C3_FN4
+    bool
+    select CPU_FAM_ESP32C3
+
+config CPU_MODEL_ESP32C3_FH4
+    bool
+    select CPU_FAM_ESP32C3
+
+config CPU_MODEL
+    depends on CPU_FAM_ESP32C3
+    default "esp32c3_wroom_02x" if CPU_MODEL_ESP32C3_WROOM_02X
+    default "esp32c3_mini_1x" if CPU_MODEL_ESP32C3_MINI_1X
+    default "esp32c3" if CPU_MODEL_ESP32C3
+    default "esp32c3_fn4" if CPU_MODEL_ESP32C3_FN4
+    default "esp32c3_fh4" if CPU_MODEL_ESP32C3_FH4
+
+if CPU_FAM_ESP32C3
+
+menu "ESP32-C3 specific configurations"
+    depends on TEST_KCONFIG
+    depends on HAS_ARCH_ESP32
+
+    # define configuration menu entries for ESP32-C3 variant (family)
+
+    choice
+        bool "CPU clock frequency"
+        default ESP32C3_DEFAULT_CPU_FREQ_MHZ_80
+        help
+            CPU clock frequency used (default 80 MHz).
+            Please note that peripherals such as I2C or SPI might not work at
+            the specified clock frequency if the selected CPU clock frequency
+            is too low. These peripherals are clocked by the APB clock, which
+            has a clock rate of 80 MHz for CPU clock frequencies greater than
+            or equal to 80 MHz, but is equal to the CPU clock frequency for
+            CPU clock frequencies less than 80 MHz. Thus, for SPI, the APB
+            clock rate must be at least five times the SPI clock rate. For the
+            I2C hardware implementation, the APB clock rate must be at least
+            3 MHZ to use I2C in fast mode with a I2C clock rate of 400 kHz.
+            For the I2C software implementation, the maximum I2C clock rate
+            is 1/130 times the CPU clock rate.
+
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_2
+            bool "2 MHz"
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_5
+            bool "50 MHz"
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_10
+            bool "10 MHz"
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_20
+            bool "20 MHz"
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_40
+            bool "40 MHz"
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_80
+            bool "80 MHz"
+        config ESP32C3_DEFAULT_CPU_FREQ_MHZ_160
+            bool "160 MHz"
+    endchoice
+
+    # import configuration menu entries that are common for all ESP32x SoCs
+    rsource "Kconfig.common"
+
+endmenu
+
+endif # CPU_FAM_ESP32C3

--- a/cpu/esp32/bootloader/sdkconfig.h
+++ b/cpu/esp32/bootloader/sdkconfig.h
@@ -33,6 +33,8 @@
 
 #if defined(CPU_FAM_ESP32)
 #include "sdkconfig_default_esp32.h"
+#elif defined(CPU_FAM_ESP32C3)
+#include "sdkconfig_default_esp32c3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32c3.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32c3.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Default SDK configuration for the ESP32C3 SoC bootloader
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef SDKCONFIG_DEFAULT_ESP32C3_H
+#define SDKCONFIG_DEFAULT_ESP32C3_H
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ 160
+#endif
+
+#define CONFIG_BOOTLOADER_COMPILER_OPTIMIZATION_SIZE 1
+#define CONFIG_BOOTLOADER_FLASH_XMC_SUPPORT 1
+#define CONFIG_BOOTLOADER_OFFSET_IN_FLASH 0x0
+#define CONFIG_BOOTLOADER_RESERVE_RTC_SIZE 0x0
+#define CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V 1
+#define CONFIG_BOOTLOADER_WDT_ENABLE 1
+#define CONFIG_BOOTLOADER_WDT_TIME_MS 9000
+
+#define CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG 1
+#define CONFIG_ESP_CONSOLE_UART 1
+#define CONFIG_ESP_CONSOLE_UART_DEFAULT 1
+#define CONFIG_ESP_CONSOLE_UART_NUM 0
+
+#define CONFIG_CONSOLE_UART_NUM CONFIG_ESP_CONSOLE_UART_NUM
+#define CONFIG_CONSOLE_UART_DEFAULT CONFIG_ESP_CONSOLE_UART_DEFAULT
+
+#define CONFIG_EFUSE_MAX_BLK_LEN 192
+
+#define CONFIG_ESP32C3_DEBUG_OCDAWARE 1
+#define CONFIG_ESP32C3_REV_MIN 3
+
+#define CONFIG_IDF_FIRMWARE_CHIP_ID 0x0005
+
+#define CONFIG_LOG_DEFAULT_LEVEL 3
+#define CONFIG_LOG_TIMESTAMP_SOURCE_RTOS 1
+
+#define CONFIG_PARTITION_TABLE_OFFSET 0x8000
+#define CONFIG_PARTITION_TABLE_MD5 1
+
+#define CONFIG_SPI_FLASH_ROM_DRIVER_PATCH 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+#endif /* SDKCONFIG_DEFAULT_ESP32C3_H */
+/** @} */

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -63,6 +63,8 @@
 /* include ESP32x SoC specific compile time configurations */
 #if defined(CPU_FAM_ESP32)
 #include "cpu_conf_esp32.h"
+#elif defined(CPU_FAM_ESP32C3)
+#include "cpu_conf_esp32c3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/include/cpu_conf_esp32c3.h
+++ b/cpu/esp32/include/cpu_conf_esp32c3.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     config
+ * @brief       Compile-time configuration macros for ESP32-C3 SoCs
+ * @{
+ *
+ * @file
+ * @brief       ESP32-C3 specific compile-time configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef CPU_CONF_ESP32C3_H
+#define CPU_CONF_ESP32C3_H
+
+#ifndef ESP_ISR_STACKSIZE
+/** Stack size used in interrupt context */
+#define ESP_ISR_STACKSIZE               (THREAD_STACKSIZE_DEFAULT)
+#endif /* ESP_ISR_STACKSIZE */
+
+/** Number of DRAM sections that can be used as heap. */
+#define NUM_HEAPS (1)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_CONF_ESP32C3_H */
+/** @} */

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -153,6 +153,7 @@ typedef enum {
  * details, see:
  *
  * - \ref esp32_adc_channels_esp32 "ESP32"
+ * - \ref esp32_adc_channels_esp32c3 "ESP32-C3"
  *
  * #ADC_GPIOS in the board-specific peripheral configuration defines the
  * list of GPIOs that can be used as ADC channels on the board, for example:
@@ -209,6 +210,7 @@ typedef enum {
  * For the GPIO that can be used with this function, see:
  *
  * - \ref esp32_adc_channels_esp32 "ESP32"
+ * - \ref esp32_adc_channels_esp32c3 "ESP32-C3"
  *
  * @{
  */
@@ -735,6 +737,8 @@ typedef struct {
  */
 #if defined(CPU_FAM_ESP32)
 #include "periph_cpu_esp32.h"
+#elif defined(CPU_FAM_ESP32C3)
+#include "periph_cpu_esp32c3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/include/periph_cpu_esp32c3.h
+++ b/cpu/esp32/include/periph_cpu_esp32c3.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       ESP32-C3 specific peripheral configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_CPU_ESP32C3_H
+#define PERIPH_CPU_ESP32C3_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Predefined GPIO names
+ * @{
+ */
+#define GPIO0       (GPIO_PIN(PORT_GPIO, 0))
+#define GPIO1       (GPIO_PIN(PORT_GPIO, 1))
+#define GPIO2       (GPIO_PIN(PORT_GPIO, 2))
+#define GPIO3       (GPIO_PIN(PORT_GPIO, 3))
+#define GPIO4       (GPIO_PIN(PORT_GPIO, 4))
+#define GPIO5       (GPIO_PIN(PORT_GPIO, 5))
+#define GPIO6       (GPIO_PIN(PORT_GPIO, 6))
+#define GPIO7       (GPIO_PIN(PORT_GPIO, 7))
+#define GPIO8       (GPIO_PIN(PORT_GPIO, 8))
+#define GPIO9       (GPIO_PIN(PORT_GPIO, 9))
+#define GPIO10      (GPIO_PIN(PORT_GPIO, 10))
+#define GPIO11      (GPIO_PIN(PORT_GPIO, 11))
+#define GPIO12      (GPIO_PIN(PORT_GPIO, 12))
+#define GPIO13      (GPIO_PIN(PORT_GPIO, 13))
+#define GPIO14      (GPIO_PIN(PORT_GPIO, 14))
+#define GPIO15      (GPIO_PIN(PORT_GPIO, 15))
+#define GPIO16      (GPIO_PIN(PORT_GPIO, 16))
+#define GPIO17      (GPIO_PIN(PORT_GPIO, 17))
+#define GPIO18      (GPIO_PIN(PORT_GPIO, 18))
+#define GPIO19      (GPIO_PIN(PORT_GPIO, 19))
+#define GPIO20      (GPIO_PIN(PORT_GPIO, 20))
+#define GPIO21      (GPIO_PIN(PORT_GPIO, 21))
+/** @} */
+
+/**
+ * @name   ADC configuration
+ *
+ * ESP32-C3 integrates two 12-bit ADCs (ADC1 and ADC2) with 6 channels in
+ * total:
+ *
+ * - **ADC1** supports 5 channels: GPIO0, GPIO1, GPIO2, GPIO3 and GPIO4
+ * - **ADC2** supports 1 channel: GPIO5 or internal signals such as vdd33
+ *
+ * The maximum number of ADC channels #ADC_NUMOF_MAX is 6.
+ *
+ * @note
+ * - ADC2 is also used by the WiFi module. The GPIOs connected to ADC2 are
+ *   therefore not available as ADC channels if the modules `esp_wifi` or
+ *   `esp_now` are used.
+ * - Vref can be read with function #adc_line_vref_to_gpio at GPIO5.
+ */
+
+/**
+ * @name   I2C configuration
+ *
+ * ESP32-C3 has one built-in I2C interfaces.
+ *
+ * The following table shows the default configuration of I2C interfaces
+ * used for ESP32-C3 boards. It can be overridden by
+ * [application-specific configurations](#esp32_application_specific_configurations).
+ *
+ * <center>
+ *
+ * Device     | Signal | Pin    | Symbol        | Remarks
+ * :----------|:-------|:-------|:--------------|:----------------
+ * I2C_DEV(0) |        |        | `#I2C0_SPEED` | default is `I2C_SPEED_FAST`
+ * I2C_DEV(0) | SCL    | GPIO4  | `#I2C0_SCL`   | -
+ * I2C_DEV(0) | SDA    | GPIO5  | `#I2C0_SDA`   | -
+ *
+ * </center><br>
+ */
+
+/**
+ * @name   PWM configuration
+ *
+ * The ESP32-C3 LEDC module has 1 channel group with 6 channels. Each of
+ * these channels can be clocked by one of the 4 timers.
+ */
+
+/**
+ * @name   SPI configuration
+ *
+ * ESP32-C3 has three SPI controllers where SPI0 and SPI1 share the same bus
+ * and can only operate in memory mode while SPI2 can be used as general
+ * purpose SPI:
+ *
+ * - controller SPI0 is reserved for external memories like flash and PSRAM
+ * - controller SPI1 is reserved for external memories like flash and PSRAM
+ * - controller SPI2 can be used for peripherals (also called FSPI)
+ *
+ * Thus, only SPI2 (FSPI) can be used as general purpose SPI in RIOT as
+ * SPI_DEV(0).
+ *
+ * The following table shows the pin configuration used by default, even
+ * though it **can vary** from board to board.
+ *
+ * <center>
+ *
+ * Device (Alias)          | Signal | Pin    | Symbol      | Remarks
+ * :-----------------------|:------:|:-------|:-----------:|:---------------------------
+ * `SPI_HOST0`/`SPI_HOST1` | SPICS0 | GPIO14 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPICLK | GPIO15 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPID   | GPIO16 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIQ   | GPIO17 | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIHD  | GPIO12 | - | reserved for Flash and PSRAM (only in `qio` or `qout` mode)
+ * `SPI_HOST0`/`SPI_HOST1` | SPIWP  | GPIO13 | - | reserved for Flash and PSRAM (only in `qio` or `qout` mode)
+ * `SPI_HOST2` (`FSPI`)    | SCK    | GPIO6  |`#SPI0_SCK`  | can be used
+ * `SPI_HOST2` (`FSPI`)    | MOSI   | GPIO7  |`#SPI0_MOSI` | can be used
+ * `SPI_HOST2` (`FSPI`)    | MISO   | GPIO2  |`#SPI0_MISO` | can be used
+ * `SPI_HOST2` (`FSPI`)    | CS0    | GPIO10 |`#SPI0_CS0`  | can be used
+ *
+ * </center><br>
+ */
+
+/**
+ * @name   Timer configuration depending on which implementation is used
+ *
+ * ESP32-C3 has two timer groups with one channel each.
+ */
+
+#ifdef MODULE_ESP_HW_COUNTER
+#error "Counter based timers are not supported by ESP32-C3"
+#endif
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-C3 integrates two UART interfaces. The following default pin
+ * configuration of UART interfaces as used by a most boards can be overridden
+ * by the application, see section [Application-Specific Configurations]
+ * (#esp32_application_specific_configurations).
+ *
+ * <center>
+ *
+ * Device      |Signal|Pin     |Symbol      |Remarks
+ * :-----------|:-----|:-------|:-----------|:----------------
+ * UART_DEV(0) | TxD  | GPIO21 |`#UART0_TXD`| cannot be changed
+ * UART_DEV(0) | RxD  | GPIO20 |`#UART0_RXD`| cannot be changed
+ * UART_DEV(1) | TxD  | -      |`#UART1_TXD`| optional, can be overridden (no direct I/O)
+ * UART_DEV(1) | RxD  | -      |`#UART1_RXD`| optional, can be overridden (no direct I/O)
+ *
+ * </center><br>
+ *
+ */
+
+#ifdef MODULE_PERIPH_CAN
+#include "can_esp.h"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CPU_ESP32C3_H */
+/** @} */

--- a/cpu/esp32/include/sdkconfig.h
+++ b/cpu/esp32/include/sdkconfig.h
@@ -46,6 +46,8 @@
  */
 #if defined(CPU_FAM_ESP32)
 #include "sdkconfig_esp32.h"
+#elif defined(CPU_FAM_ESP32C3)
+#include "sdkconfig_esp32c3.h"
 #else
 #error "ESP32x family implementation missing"
 #endif

--- a/cpu/esp32/include/sdkconfig_esp32c3.h
+++ b/cpu/esp32/include/sdkconfig_esp32c3.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       SDK configuration used by the ESP-IDF for ESP32C3
+ *
+ * The SDK configuration can be partially overridden by application-specific
+ * board configuration.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef SDKCONFIG_ESP32C3_H
+#define SDKCONFIG_ESP32C3_H
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+
+/* Mapping of Kconfig defines to the respective enumeration values */
+#if CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_2
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     2
+#elif CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_5
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     5
+#elif CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_10
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     10
+#elif CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_20
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     20
+#elif CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_40
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     40
+#elif CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_80
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     80
+#elif CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ_160
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ     160
+#endif
+
+/**
+ * @brief   Defines the CPU frequency [values = 2, 5, 10, 10, 40, 80, 160]
+ */
+#ifndef CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ
+#define CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ 80
+#endif
+/**
+ * @brief   Mapping configured ESP32 default clock to CLOCK_CORECLOCK define
+ */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ)
+/** @} */
+
+/**
+ * Default console configuration
+ *
+ * STDIO_UART_BAUDRATE is used as CONFIG_CONSOLE_UART_BAUDRATE and
+ * can be overridden by an application specific configuration.
+ */
+#define CONFIG_CONSOLE_UART_NUM 0
+#define CONFIG_ESP_CONSOLE_UART_NUM     CONFIG_CONSOLE_UART_NUM
+
+#ifndef CONFIG_CONSOLE_UART_BAUDRATE
+#define CONFIG_CONSOLE_UART_BAUDRATE    STDIO_UART_BAUDRATE
+#endif
+
+/**
+ * Log output configuration (DO NOT CHANGE)
+ */
+#ifndef CONFIG_LOG_DEFAULT_LEVEL
+#define CONFIG_LOG_DEFAULT_LEVEL    LOG_LEVEL
+#endif
+#define CONFIG_LOG_MAXIMUM_LEVEL    LOG_LEVEL
+
+/**
+ * RTC clock configuration
+ */
+#ifdef MODULE_ESP_RTC_TIMER_32K
+#define CONFIG_ESP32_RTC_CLK_SRC_EXT_CRYS       1
+#endif
+
+#define CONFIG_ESP32C3_RTC_CLK_CAL_CYCLES       (8 * 1024)
+
+/**
+ * System specific configuration (DO NOT CHANGE)
+ */
+#ifdef MODULE_NEWLIB_NANO
+#define CONFIG_NEWLIB_NANO_FORMAT               1
+#endif
+
+#define CONFIG_ESP_SYSTEM_CHECK_INT_LEVEL_4     1
+#define CONFIG_ESP_SYSTEM_EVENT_QUEUE_SIZE      32
+#define CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE 2560
+
+#define CONFIG_ESP_TIME_FUNCS_USE_ESP_TIMER     1
+#define CONFIG_ESP_TIMER_IMPL_SYSTIMER          1
+#define CONFIG_ESP_TIMER_INTERRUPT_LEVEL        1
+#define CONFIG_ESP_TIMER_TASK_STACK_SIZE        3584
+#define CONFIG_TIMER_TASK_STACK_SIZE            CONFIG_ESP_TIMER_TASK_STACK_SIZE
+
+#define CONFIG_APP_BUILD_USE_FLASH_SECTIONS     1
+#define CONFIG_APP_BUILD_BOOTLOADER 1
+#define CONFIG_APP_BUILD_GENERATE_BINARIES 1
+#define CONFIG_APP_BUILD_TYPE_APP_2NDBOOT 1
+#define CONFIG_APP_BUILD_USE_FLASH_SECTIONS 1
+
+#define CONFIG_EFUSE_MAX_BLK_LEN                256
+
+#define CONFIG_PARTITION_TABLE_OFFSET           0x8000
+#define CONFIG_PARTITION_TABLE_CUSTOM_FILENAME  "partitions.csv"
+#define CONFIG_PARTITION_TABLE_FILENAME         "partitions_singleapp.csv"
+#define CONFIG_PARTITION_TABLE_SINGLE_APP       1
+
+/**
+ * Bluetooth configuration (DO NOT CHANGE)
+ */
+#define CONFIG_BT_ENABLED                       0
+#define CONFIG_BT_RESERVE_DRAM                  0
+
+/**
+ * SPI Flash driver configuration (DO NOT CHANGE)
+ */
+#define CONFIG_SPI_FLASH_ROM_DRIVER_PATCH                   1
+#define CONFIG_SPI_FLASH_USE_LEGACY_IMPL                    1
+#define CONFIG_SPI_FLASH_DANGEROUS_WRITE_ABORTS             1
+#define CONFIG_SPI_FLASH_ENABLE_ENCRYPTED_READ_WRITE        1
+#define CONFIG_SPI_FLASH_ERASE_YIELD_DURATION_MS            20
+#define CONFIG_SPI_FLASH_ERASE_YIELD_TICKS                  1
+#define CONFIG_SPI_FLASH_ROM_DRIVER_PATCH                   1
+#define CONFIG_SPI_FLASH_SUPPORT_BOYA_CHIP                  1
+#define CONFIG_SPI_FLASH_SUPPORT_GD_CHIP                    1
+#define CONFIG_SPI_FLASH_SUPPORT_ISSI_CHIP                  1
+#define CONFIG_SPI_FLASH_SUPPORT_MXIC_CHIP                  1
+#define CONFIG_SPI_FLASH_SUPPORT_WINBOND_CHIP               1
+#define CONFIG_SPI_FLASH_WRITE_CHUNK_SIZE                   8192
+#define CONFIG_SPI_FLASH_WRITING_DANGEROUS_REGIONS_ABORTS   CONFIG_SPI_FLASH_DANGEROUS_WRITE_ABORTS
+#define CONFIG_SPI_FLASH_YIELD_DURING_ERASE                 1
+
+/**
+ * Serial flasher config (defined by CFLAGS, only sanity check here)
+ */
+#if !defined(CONFIG_FLASHMODE_DOUT) && \
+    !defined(CONFIG_FLASHMODE_DIO) && \
+    !defined(CONFIG_FLASHMODE_QOUT) && \
+    !defined(CONFIG_FLASHMODE_QIO)
+#error "Flash mode not configured"
+#endif
+
+/**
+ * Wi-Fi driver configuration (DO NOT CHANGE)
+ */
+#ifdef MODULE_ESP_WIFI_ANY
+#define CONFIG_ESP32_WIFI_ENABLED               1
+#endif
+#if defined(MODULE_ESP_WIFI_AP) || defined(MODULE_ESP_NOW)
+#define CONFIG_ESP_WIFI_SOFTAP_SUPPORT          1
+#endif
+
+#define CONFIG_ESP32_PHY_MAX_WIFI_TX_POWER      CONFIG_ESP_PHY_MAX_WIFI_TX_POWER
+#define CONFIG_ESP32_WIFI_AMPDU_RX_ENABLED      1
+#define CONFIG_ESP32_WIFI_AMPDU_TX_ENABLED      1
+#define CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM 32
+#define CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER     1
+#define CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM 32
+#define CONFIG_ESP32_WIFI_ENABLED               1
+#define CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE       1
+#define CONFIG_ESP32_WIFI_IRAM_OPT              1
+#define CONFIG_ESP32_WIFI_MGMT_SBUF_NUM         32
+#if MODULE_ESP_IDF_NVS_ENABLED
+#define CONFIG_ESP32_WIFI_NVS_ENABLED           1
+#endif
+#define CONFIG_ESP32_WIFI_RX_BA_WIN             6
+#define CONFIG_ESP32_WIFI_RX_IRAM_OPT           1
+#define CONFIG_ESP32_WIFI_SOFTAP_BEACON_MAX_LEN 752
+#define CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM  10
+#define CONFIG_ESP32_WIFI_TX_BA_WIN             6
+#define CONFIG_ESP32_WIFI_TX_BUFFER_TYPE        1
+
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_AP    1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_STA   1
+#define CONFIG_ESP_PHY_MAX_WIFI_TX_POWER        20
+
+/**
+ * PHY configuration
+ */
+#if MODULE_ESP_IDF_NVS_ENABLED
+#define CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE     1
+#endif
+
+#define CONFIG_ESP_PHY_MAX_TX_POWER                     20
+#define CONFIG_ESP_PHY_MAX_WIFI_TX_POWER                20
+
+#define CONFIG_ESP32_PHY_CALIBRATION_AND_DATA_STORAGE   CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE
+#define CONFIG_ESP32_PHY_MAX_WIFI_TX_POWER              CONFIG_ESP_PHY_MAX_WIFI_TX_POWER
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+#endif /* SDKCONFIG_ESP32C3_H */
+/** @} */

--- a/cpu/esp32/periph/adc_arch_esp32c3.c
+++ b/cpu/esp32/periph/adc_arch_esp32c3.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Architecture-specific ADC/DAC definitions for ESP32-C3 variant (family)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+#include "adc_arch_private.h"
+#include "esp_common.h"
+#include "soc/adc_channel.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   ADC hardware descriptor table (for internal use only)
+ *
+ * @note    The index of entries in the table MUST correspond to the
+ *          RTCIO GPIO number.
+ */
+const _adc_hw_desc_t _adc_hw[] = {
+    /* rtcio,         gpio,                    adc_ctrl,   adc_channel,   pad_name */
+    {  RTCIO_GPIO(0), ADC1_CHANNEL_0_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_0, "XTAL_32K_P" },
+    {  RTCIO_GPIO(1), ADC1_CHANNEL_1_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_1, "XTAL_32K_P" },
+    {  RTCIO_GPIO(2), ADC1_CHANNEL_2_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_2, "GPIO2" },
+    {  RTCIO_GPIO(3), ADC1_CHANNEL_3_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_3, "GPIO3" },
+    {  RTCIO_GPIO(4), ADC1_CHANNEL_4_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_4, "MTMS" },
+    {  RTCIO_GPIO(5), ADC2_CHANNEL_0_GPIO_NUM, ADC_UNIT_2, ADC_CHANNEL_0, "MTDI" },
+};
+
+/**
+ * @brief   GPIO to RTC IO map (for internal use only)
+ */
+const gpio_t _gpio_rtcio_map[] = {
+    RTCIO_GPIO(0),   /* GPIO0 */
+    RTCIO_GPIO(1),   /* GPIO1 */
+    RTCIO_GPIO(2),   /* GPIO2 */
+    RTCIO_GPIO(3),   /* GPIO3 */
+    RTCIO_GPIO(4),   /* GPIO4 */
+    RTCIO_GPIO(5),   /* GPIO5 */
+    RTCIO_NA,        /* GPIO6 */
+    RTCIO_NA,        /* GPIO7 */
+    RTCIO_NA,        /* GPIO8 */
+    RTCIO_NA,        /* GPIO9 */
+    RTCIO_NA,        /* GPIO10 */
+    RTCIO_NA,        /* GPIO11 */
+    RTCIO_NA,        /* GPIO12 */
+    RTCIO_NA,        /* GPIO13 */
+    RTCIO_NA,        /* GPIO14 */
+    RTCIO_NA,        /* GPIO15 */
+    RTCIO_NA,        /* GPIO16 */
+    RTCIO_NA,        /* GPIO17 */
+    RTCIO_NA,        /* GPIO18 */
+    RTCIO_NA,        /* GPIO19 */
+    RTCIO_NA,        /* GPIO20 */
+    RTCIO_NA,        /* GPIO21 */
+};
+
+_Static_assert(ARRAY_SIZE(_gpio_rtcio_map) == SOC_GPIO_PIN_COUNT,
+               "size of _gpio_rtcio_map does not match SOC_GPIO_PIN_COUNT");

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -96,6 +96,14 @@ static bool _gpio_pin_pd[GPIO_PIN_NUMOF] = { };
 #define GPIO_OUT_XOR(b) if (b < 32) { GPIO.out ^=  BIT(b); } else { GPIO.out1.val ^=  BIT(b-32); }
 #define GPIO_OUT_GET(b) (b < 32) ? (GPIO.out >> b) & 1 : (GPIO.out1.val >> (b-32)) & 1
 
+#elif defined(CPU_FAM_ESP32C3)
+
+#define GPIO_IN_GET(b)  GPIO.in.val & BIT(b)
+#define GPIO_OUT_SET(b) GPIO.out_w1ts.val = BIT(b)
+#define GPIO_OUT_CLR(b) GPIO.out_w1tc.val = BIT(b)
+#define GPIO_OUT_XOR(b) GPIO.out.val ^=  BIT(b)
+#define GPIO_OUT_GET(b) (GPIO.out.val >> b) & 1
+
 #else
 #error "Platform implementation is missing"
 #endif

--- a/cpu/esp32/periph/gpio_arch_esp32c3.c
+++ b/cpu/esp32/periph/gpio_arch_esp32c3.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     drivers_periph_gpio
+ * @{
+ *
+ * @file
+ * @brief       Architecture-specific GPIO definitions for ESP32-C3 variant (family)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "gpio_arch.h"
+#include "soc/io_mux_reg.h"
+
+#if !IS_USED(MODULE_ESP_IDF_GPIO_HAL)
+
+/* GPIO to IOMUX register mapping (see Technical Reference, Section 5.13.2 Register Summary)
+   https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf */
+
+const uint32_t _gpio_to_iomux_reg[GPIO_PIN_NUMOF] =
+{
+    PERIPHS_IO_MUX_XTAL_32K_P_U,    /* GPIO0 used for XTAL_32K_P */
+    PERIPHS_IO_MUX_XTAL_32K_N_U,    /* GPIO1 used for XTAL_32K_N*/
+    PERIPHS_IO_MUX_GPIO2_U,         /* GPIO2 */
+    PERIPHS_IO_MUX_GPIO3_U,         /* GPIO3 */
+    PERIPHS_IO_MUX_MTMS_U,          /* GPIO4 */
+    PERIPHS_IO_MUX_MTDI_U,          /* GPIO5 */
+    PERIPHS_IO_MUX_MTCK_U,          /* GPIO6 */
+    PERIPHS_IO_MUX_MTDO_U,          /* GPIO7 */
+    PERIPHS_IO_MUX_GPIO8_U,         /* GPIO8 */
+    PERIPHS_IO_MUX_GPIO9_U,         /* GPIO9 */
+    PERIPHS_IO_MUX_GPIO10_U,        /* GPIO10 */
+    PERIPHS_IO_MUX_VDD_SPI_U,       /* GPIO11 */
+    PERIPHS_IO_MUX_SPIHD_U,         /* GPIO12 */
+    PERIPHS_IO_MUX_SPIWP_U,         /* GPIO13 */
+    PERIPHS_IO_MUX_SPICS0_U,        /* GPIO14 */
+    PERIPHS_IO_MUX_SPICLK_U,        /* GPIO15 */
+    PERIPHS_IO_MUX_SPID_U,          /* GPIO16 */
+    PERIPHS_IO_MUX_SPIQ_U,          /* GPIO17 */
+    PERIPHS_IO_MUX_GPIO18_U,        /* GPIO18 */
+    PERIPHS_IO_MUX_GPIO19_U,        /* GPIO19 */
+    PERIPHS_IO_MUX_U0RXD_U,         /* GPIO20 */
+    PERIPHS_IO_MUX_U0TXD_U,         /* GPIO21 */
+};
+
+#endif /* !IS_USED(MODULE_ESP_IDF_GPIO_HAL) */
+
+/* Table of the usage type of each GPIO pin */
+gpio_pin_usage_t _gpio_pin_usage[GPIO_PIN_NUMOF] = {
+#if MODULE_ESP_RTC_TIMER_32K
+    _NOT_EXIST,   /* GPIO0 is used for external 32K crystal */
+    _NOT_EXIST,   /* GPIO1 is used for external 32K crystal */
+#else
+    _GPIO,        /* GPIO0 */
+    _GPIO,        /* GPIO1 */
+#endif
+    _GPIO,        /* GPIO2 */
+    _GPIO,        /* GPIO3 */
+    _GPIO,        /* GPIO4 */
+    _GPIO,        /* GPIO5 */
+    _GPIO,        /* GPIO6 */
+    _GPIO,        /* GPIO7 */
+    _GPIO,        /* GPIO8 */
+    _GPIO,        /* GPIO9 */
+    _GPIO,        /* GPIO10 */
+    _NOT_EXIST,   /* GPIO11 is used as SPI VDD */
+#if defined(CONFIG_FLASHMODE_QIO) || defined(CONFIG_FLASHMODE_QOUT)
+    /* in qio and qout mode these pins are used for Flash */
+    _SPIF,        /* GPIO12 is used as direct I/O SPI HD for Flash */
+    _SPIF,        /* GPIO13 is used as direct I/O SPI WP for Flash */
+#else
+    /* otherwise these pins can be used as GPIO */
+    _GPIO,        /* GPIO12 */
+    _GPIO,        /* GPIO13 */
+#endif
+    _SPIF,        /* GPIO14 is used as direct I/O SPI CS0 for Flash */
+    _SPIF,        /* GPIO15 is used as direct I/O SPI CLK for Flash */
+    _SPIF,        /* GPIO16 is used as direct I/O SPI MISO for Flash */
+    _SPIF,        /* GPIO17 is used as direct I/O SPI MOSI for Flash */
+    _GPIO,        /* GPIO18 could be used for builtin USB2JTAG bridge */
+    _GPIO,        /* GPIO19 could be used for builtin USB2JTAG bridge */
+    _UART,        /* GPIO20 is used as direct I/O UART0 RxD */
+    _UART,        /* GPIO21 is used as direct I/O UART0 TxD */
+};

--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -253,7 +253,7 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
 
         if (apb_clk / 5 < clk) {
             LOG_TAG_ERROR("spi", "APB clock rate (%"PRIu32" Hz) has to be at "
-                          "least 5 times SPI clock rate (%"PRIu32" Hz)\n",
+                          "least 5 times SPI clock rate (%d Hz)\n",
                           apb_clk, clk);
             assert(false);
         }
@@ -267,7 +267,7 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
         _spi[bus].timing.timing_miso_delay = 0;
         _spi[bus].timing.timing_dummy = 0;
 
-        DEBUG("%s bus %d: SPI clock frequency: clk=%"PRIu32" eff=%d "
+        DEBUG("%s bus %d: SPI clock frequency: clk=%d eff=%d "
               "reg=%08"PRIx32"\n",
               __func__, bus, clk, _clk, clk_reg);
     }

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -72,6 +72,16 @@
  * TMG1 is left disabled. TMG1 is only enabled when more than one
  * timer device is needed.
  *
+ * ---
+ * ESP32-C3 hast only two 54 bit hardware timers:
+ * two timer groups TMG0 and TMG1 with 1 timer each
+ *
+ * TMG0, timer 0 is used for system time in us and is therefore not
+ * available as low level timer. Timers have only one channel. Timer devices
+ * are mapped to hardware timer as following:
+ *
+ *     0 -> TMG1 timer 0
+ *
  * PLEASE NOTE: Don't use ETS timer functions ets_timer_* in and this hardware
  * timer implementation together!
  */
@@ -79,6 +89,11 @@
 #if defined(CPU_FAM_ESP32)
 
 #define HW_TIMER_CORRECTION   (RTC_PLL_320M / CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ)
+#define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION << 1, 5))
+
+#elif defined(CPU_FAM_ESP32C3)
+
+#define HW_TIMER_CORRECTION   10
 #define HW_TIMER_DELTA_MIN    (MAX(HW_TIMER_CORRECTION << 1, 5))
 
 #else
@@ -128,6 +143,14 @@ static const struct _hw_timer_desc_t _timers_desc[] =
         .int_mask = BIT(TIMER_1),
         .int_src  = ETS_TG1_T1_LEVEL_INTR_SOURCE,
     }
+#elif defined(CPU_FAM_ESP32C3)
+    {
+        .module = PERIPH_TIMG1_MODULE,
+        .group = TIMER_GROUP_1,
+        .index = TIMER_0,
+        .int_mask = BIT(TIMER_0),
+        .int_src  = ETS_TG1_T0_LEVEL_INTR_SOURCE
+    },
 #else
 #error "MCU implementation needed"
 #endif

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -219,7 +219,7 @@ static NORETURN void IRAM system_startup_cpu0(void)
 static NORETURN void IRAM system_init (void)
 {
     static_assert(MAXTHREADS >= 3,
-            "ESP32 requires at least 3 threads, esp_timer, idle, and main");
+            "ESP32x SoCs require at least 3 threads, esp_timer, idle, and main");
 #if defined(CPU_FAM_ESP32)
     /* enable cached read from flash */
     Cache_Read_Enable(PRO_CPU_NUM);

--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -59,8 +59,15 @@
 #define I2C_CLOCK_STRETCH 200
 
 /* gpio access macros */
+#if defined(CPU_FAM_ESP32)
 #define GPIO_SET(lo, hi, b) if (b < 32) { GPIO.lo =  BIT(b); } else { GPIO.hi.val =  BIT(b-32); }
 #define GPIO_GET(lo, hi, b) ((b < 32) ? GPIO.lo & BIT(b) : GPIO.hi.val & BIT(b-32))
+#elif defined(CPU_FAM_ESP32C3)
+#define GPIO_SET(lo, hi, b) GPIO.lo.val = BIT(b)
+#define GPIO_GET(lo, hi, b) GPIO.lo.val & BIT(b)
+#else
+#error "Platform implementation is missing"
+#endif
 
 #else /* MCU_ESP8266 */
 
@@ -110,6 +117,8 @@ static _i2c_bus_t _i2c_bus[I2C_NUMOF] = {};
 
 #if defined(CPU_FAM_ESP32)
 #define I2C_CLK_CAL     62      /* clock calibration offset */
+#elif defined(CPU_FAM_ESP32C3)
+#define I2C_CLK_CAL     32      /* clock calibration offset */
 #elif defined(MCU_ESP8266)
 #define I2C_CLK_CAL     47      /* clock calibration offset */
 #else

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14969,6 +14969,8 @@ pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMB
 pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_PARAMS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
 cpu/esp32/include/periph_cpu_esp32\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32\.h is not documented.
 cpu/esp32/include/periph_cpu_esp32c3\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32c3\.h is not documented.
+boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member LED[0-9]_[A-Z]+ \(macro definition\) of file board_common\.h is not documented.
+boards/common/esp32c3/include/board_common.h:[0-9]+: warning: Member SPIFFS_[_A-Z]+ \(macro definition\) of file board_common\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented.

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14968,6 +14968,7 @@ pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMB
 pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_FILTER_POLICY \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
 pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_PARAMS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
 cpu/esp32/include/periph_cpu_esp32\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32\.h is not documented.
+cpu/esp32/include/periph_cpu_esp32c3\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32c3\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
 boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented.


### PR DESCRIPTION
### Contribution description

This PR is a split-off from PR #17844, which provides
- the support for ESP32-C3 SoC
- a common ESP32-C3 board definition
- the board definition for the ESP32C3-DevKit board.

~This PR requires PRs #18335, #18336. #18338, #18339, #18340 and #18341 to be compilable in CI.~

### Testing procedure

Beside of Green CI some basic tests should work (Of course, I have already tested all of them and many more):
- `tests/shell`
- `tests/periph_cpuid`
- `tests/periph_gpio`
- `tests/periph_hwrng`
- `tests/periph_i2c`
- `tests/periph_spi`
- `tests/periph_rtt`
- `tests/periph_timer`
- `examples/gnrc_networking` using `esp_wifi` as optional module.

### Issues/PRs references

~Requires #18335
Requires #18336 
Requires #18338 
Requires #18339 
Requires #18340 
Requires #18341~
