### PR TITLE
core/mutex: don't wake up stopped or sleeping thread on mutex_unlock()

### DIFF
--- a/tests/thread_sleep/Makefile
+++ b/tests/thread_sleep/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += ztimer_msec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_sleep/Makefile.ci
+++ b/tests/thread_sleep/Makefile.ci
@@ -1,0 +1,5 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-f031k6 \
+    nucleo-l011k4 \
+    stm32f030f4-demo \
+    #

--- a/tests/thread_sleep/main.c
+++ b/tests/thread_sleep/main.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Thread sleep test application
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "thread.h"
+#include "ztimer.h"
+
+static char t1_stack[THREAD_STACKSIZE_SMALL];
+static char t2_stack[THREAD_STACKSIZE_SMALL];
+
+static void *first_thread(void *arg)
+{
+    (void) arg;
+
+    while (1) {
+        puts("first thread");
+        ztimer_sleep(ZTIMER_MSEC, 10);
+    }
+
+    return NULL;
+}
+
+static void *second_thread(void *arg)
+{
+    (void) arg;
+
+    while (1) {
+        puts("second thread");
+        ztimer_sleep(ZTIMER_MSEC, 10);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    kernel_pid_t pid1 = thread_create(
+            t1_stack, sizeof(t1_stack),
+            THREAD_PRIORITY_MAIN - 1,
+            THREAD_CREATE_STACKTEST,
+            first_thread, NULL, "nr1");
+    kernel_pid_t pid2 = thread_create(
+            t2_stack, sizeof(t2_stack),
+            THREAD_PRIORITY_MAIN - 1,
+            THREAD_CREATE_STACKTEST,
+            second_thread, NULL, "nr2");
+
+    sched_set_status(thread_get(pid1), STATUS_SLEEPING);
+    sched_set_status(thread_get(pid2), STATUS_SLEEPING);
+
+    ztimer_sleep(ZTIMER_MSEC, 100);
+    puts("> wake sleeping threads");
+
+    sched_set_status(thread_get(pid1), STATUS_PENDING);
+    sched_set_status(thread_get(pid2), STATUS_PENDING);
+
+    thread_yield();
+    puts("> put threads to sleep again");
+
+    sched_set_status(thread_get(pid1), STATUS_SLEEPING);
+    sched_set_status(thread_get(pid2), STATUS_SLEEPING);
+
+    return 0;
+}

--- a/tests/thread_sleep/tests/01-run.py
+++ b/tests/thread_sleep/tests/01-run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 Benjamin Valentin <benjamin.valentin@ml-pa.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect('first thread')
+    child.expect('second thread')
+    child.expect('> wake sleeping threads')
+    child.expect('first thread')
+    child.expect('second thread')
+    child.expect('> put threads to sleep again')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

A `mutex_unlock()` should only wake up a thread that is in `STATUS_MUTEX_BLOCKED` state.



### Testing procedure

A test application is added that puts threads to sleep. The `mutex_unlock()` from the timer will not wake them up.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
