### PR TITLE
sys/net/gnrc/pktbuf_static: make use of alignas()

### DIFF
--- a/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
+++ b/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
@@ -28,6 +28,10 @@
 
 #include "mutex.h"
 
+#if IS_USED(MODULE_GNRC_PKTBUF_STATIC)
+#include "pktbuf_static.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -40,15 +44,6 @@ extern "C" {
  *          not be touched by external code
  */
 extern mutex_t gnrc_pktbuf_mutex;
-
-#if IS_USED(MODULE_GNRC_PKTBUF_STATIC) || DOXYGEN
-/**
- * @brief   The actual static buffer used when module gnrc_pktbuf_static is used
- *
- * @warning This is an internal buffer and should not be touched by external code
- */
-extern uint8_t *gnrc_pktbuf_static_buf;
-#endif
 
 /**
  * @brief   Check if the given pointer is indeed part of the packet buffer

--- a/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
+++ b/sys/net/gnrc/pktbuf/include/pktbuf_internal.h
@@ -28,10 +28,6 @@
 
 #include "mutex.h"
 
-#if IS_USED(MODULE_GNRC_PKTBUF_STATIC)
-#include "pktbuf_static.h"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,16 +52,7 @@ extern mutex_t gnrc_pktbuf_mutex;
  *                  the packet buffer
  * @retval  false   @p ptr does not point to data in the packet buffer
  */
-static inline bool gnrc_pktbuf_contains(void *ptr)
-{
-#if IS_USED(MODULE_GNRC_PKTBUF_STATIC)
-    return ((uintptr_t)ptr >= (uintptr_t)gnrc_pktbuf_static_buf) &&
-           ((uintptr_t)ptr < (uintptr_t)gnrc_pktbuf_static_buf + CONFIG_GNRC_PKTBUF_SIZE);
-#else
-    (void)ptr;
-    return true;
-#endif
-}
+bool gnrc_pktbuf_contains(void *ptr);
 
 /**
  * @brief   Release an internal buffer

--- a/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
+++ b/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
@@ -288,4 +288,12 @@ void gnrc_pktbuf_free_internal(void *data, size_t size)
     _free(data);
 }
 
+bool gnrc_pktbuf_contains(void *ptr)
+{
+    (void)ptr;
+    /* tracking the memory areas malloced is to expensive, so this function
+     * only is useful with gnrc_pktbuf_static */
+    return true;
+}
+
 /** @} */

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -18,9 +18,10 @@
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <stdalign.h>
 #include <stdbool.h>
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 
 #include "mutex.h"
@@ -44,7 +45,8 @@
 #endif
 
 #define CANARY 0x55
-alignas(sizeof(_unused_t)) uint8_t gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE];
+
+static alignas(sizeof(_unused_t)) uint8_t _static_buf[CONFIG_GNRC_PKTBUF_SIZE];
 static_assert((CONFIG_GNRC_PKTBUF_SIZE % sizeof(_unused_t)) == 0,
               "CONFIG_GNRC_PKTBUF_SIZE has to be a multiple of 8");
 static _unused_t *_first_unused;
@@ -88,13 +90,13 @@ void gnrc_pktbuf_init(void)
 {
     mutex_lock(&gnrc_pktbuf_mutex);
     if (CONFIG_GNRC_PKTBUF_CHECK_USE_AFTER_FREE) {
-        memset(gnrc_pktbuf_static_buf, CANARY, sizeof(gnrc_pktbuf_static_buf));
+        memset(_static_buf, CANARY, sizeof(_static_buf));
     }
-    /* Silence false -Wcast-align: gnrc_pktbuf_static_buf has qualifier
+    /* Silence false -Wcast-align: _static_buf has qualifier
      * `alignas(_unused_t)`, so it is guaranteed to be safe */
-    _first_unused = (_unused_t *)(uintptr_t)gnrc_pktbuf_static_buf;
+    _first_unused = (_unused_t *)(uintptr_t)_static_buf;
     _first_unused->next = NULL;
-    _first_unused->size = sizeof(gnrc_pktbuf_static_buf);
+    _first_unused->size = sizeof(_static_buf);
     mutex_unlock(&gnrc_pktbuf_mutex);
 }
 
@@ -281,12 +283,12 @@ void gnrc_pktbuf_stats(void)
 {
 #ifdef MODULE_OD
     _unused_t *ptr = _first_unused;
-    uint8_t *chunk = &gnrc_pktbuf_static_buf[0];
+    uint8_t *chunk = &_static_buf[0];
     int count = 0;
 
     printf("packet buffer: first byte: %p, last byte: %p (size: %u)\n",
-           (void *)&gnrc_pktbuf_static_buf[0],
-           (void *)&gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE],
+           (void *)&_static_buf[0],
+           (void *)&_static_buf[CONFIG_GNRC_PKTBUF_SIZE],
            CONFIG_GNRC_PKTBUF_SIZE);
     printf("  position of last byte used: %" PRIu16 "\n", max_byte_count);
     if (ptr == NULL) {  /* packet buffer is completely full */
@@ -312,8 +314,8 @@ void gnrc_pktbuf_stats(void)
         ptr = ptr->next;
     }
 
-    if (chunk <= &gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE - 1]) {
-        _print_chunk(chunk, &gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE] - chunk, count);
+    if (chunk <= &_static_buf[CONFIG_GNRC_PKTBUF_SIZE - 1]) {
+        _print_chunk(chunk, &_static_buf[CONFIG_GNRC_PKTBUF_SIZE] - chunk, count);
     }
 #else
     DEBUG("pktbuf: needs od module\n");
@@ -324,8 +326,8 @@ void gnrc_pktbuf_stats(void)
 #ifdef TEST_SUITES
 bool gnrc_pktbuf_is_empty(void)
 {
-    return ((uintptr_t)_first_unused == (uintptr_t)gnrc_pktbuf_static_buf) &&
-           (_first_unused->size == sizeof(gnrc_pktbuf_static_buf));
+    return ((uintptr_t)_first_unused == (uintptr_t)_static_buf) &&
+           (_first_unused->size == sizeof(_static_buf));
 }
 
 bool gnrc_pktbuf_is_sane(void)
@@ -335,8 +337,8 @@ bool gnrc_pktbuf_is_sane(void)
     /* Invariants of this implementation:
      *  - the head of _unused_t list is _first_unused
      *  - if _unused_t list is empty the packet buffer is full and _first_unused is NULL
-     *  - forall ptr_in _unused_t list: &gnrc_pktbuf_static_buf[0] < ptr
-     *                                  && ptr < &gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE]
+     *  - forall ptr_in _unused_t list: &_static_buf[0] < ptr
+     *                                  && ptr < &_static_buf[CONFIG_GNRC_PKTBUF_SIZE]
      *  - forall ptr in _unused_t list: ptr->next == NULL || ptr < ptr->next
      *  - forall ptr in _unused_t list: (ptr->next != NULL && ptr->size <= (ptr->next - ptr)) ||
      *                                  (ptr->next == NULL
@@ -344,14 +346,14 @@ bool gnrc_pktbuf_is_sane(void)
      */
 
     while (ptr) {
-        if ((&gnrc_pktbuf_static_buf[0] >= (uint8_t *)ptr)
-            && ((uint8_t *)ptr >= &gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE])) {
+        if ((&_static_buf[0] >= (uint8_t *)ptr)
+            && ((uint8_t *)ptr >= &_static_buf[CONFIG_GNRC_PKTBUF_SIZE])) {
             return false;
         }
         if ((ptr->next != NULL) && (ptr >= ptr->next)) {
             return false;
         }
-        size_t pos_in_buf = (uint8_t *)ptr - &gnrc_pktbuf_static_buf[0];
+        size_t pos_in_buf = (uint8_t *)ptr - &_static_buf[0];
         if (((ptr->next == NULL) || (ptr->size > (size_t)((uint8_t *)(ptr->next) - (uint8_t *)ptr)))
             && ((ptr->next != NULL) || (ptr->size != CONFIG_GNRC_PKTBUF_SIZE - pos_in_buf))) {
             return false;
@@ -415,7 +417,7 @@ static void *_pktbuf_alloc(size_t size)
          * We cast to uintptr_t as intermediate step to silence -Wcast-align */
         _unused_t *new = (_unused_t *)((uintptr_t)ptr + size);
 
-        if (((((uint8_t *)new) - &(gnrc_pktbuf_static_buf[0])) + sizeof(_unused_t))
+        if (((((uint8_t *)new) - &(_static_buf[0])) + sizeof(_unused_t))
             > CONFIG_GNRC_PKTBUF_SIZE) {
             /* content of new would exceed packet buffer size so set to NULL */
             _first_unused = NULL;
@@ -430,7 +432,7 @@ static void *_pktbuf_alloc(size_t size)
         new->size = ptr->size - size;
     }
 #ifdef DEVELHELP
-    uint16_t last_byte = (uint16_t)((((uint8_t *)ptr) + size) - &(gnrc_pktbuf_static_buf[0]));
+    uint16_t last_byte = (uint16_t)((((uint8_t *)ptr) + size) - &(_static_buf[0]));
     if (last_byte > max_byte_count) {
         max_byte_count = last_byte;
     }
@@ -488,7 +490,7 @@ void gnrc_pktbuf_free_internal(void *data, size_t size)
     new->size = _align(size);
     /* calculate number of bytes between new _unused_t chunk and end of packet
      * buffer */
-    bytes_at_end = ((&gnrc_pktbuf_static_buf[0] + CONFIG_GNRC_PKTBUF_SIZE)
+    bytes_at_end = ((&_static_buf[0] + CONFIG_GNRC_PKTBUF_SIZE)
                    - (((uint8_t *)new) + new->size));
     if (bytes_at_end < sizeof(_unused_t)) {
         /* new is very last segment and there is a little bit of memory left
@@ -507,6 +509,14 @@ void gnrc_pktbuf_free_internal(void *data, size_t size)
     if ((new->next != NULL) && (_too_small_hole(new, new->next))) {
         _merge(new, new->next);
     }
+}
+
+bool gnrc_pktbuf_contains(void *ptr)
+{
+    const uintptr_t start = (uintptr_t)_static_buf;
+    const uintptr_t end = start + sizeof(_static_buf);
+    uintptr_t pos = (uintptr_t)ptr;
+    return ((pos >= start) && (pos < end));
 }
 
 /** @} */

--- a/sys/net/gnrc/pktbuf_static/include/pktbuf_static.h
+++ b/sys/net/gnrc/pktbuf_static/include/pktbuf_static.h
@@ -22,6 +22,7 @@
 #define PKTBUF_STATIC_H
 
 #include <sys/types.h>
+#include <stdalign.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +40,17 @@ typedef struct _unused {
     struct _unused *next;   /**< the next unused section */
     unsigned int size;      /**< the size of the unused section */
 } _unused_t;
+
+
+/**
+ * @brief   The actual static buffer used when module gnrc_pktbuf_static is used
+ *
+ * @warning This is an internal buffer and should not be touched by external
+ *          code
+ *
+ * @details This buffer is aligned to boundaries of `sizeof(_unused_t)`
+ */
+extern alignas(sizeof(_unused_t)) uint8_t gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE];
 
 /**
  * @brief   Calculates the required space of a number of bytes including

--- a/sys/net/gnrc/pktbuf_static/include/pktbuf_static.h
+++ b/sys/net/gnrc/pktbuf_static/include/pktbuf_static.h
@@ -22,7 +22,6 @@
 #define PKTBUF_STATIC_H
 
 #include <sys/types.h>
-#include <stdalign.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,17 +39,6 @@ typedef struct _unused {
     struct _unused *next;   /**< the next unused section */
     unsigned int size;      /**< the size of the unused section */
 } _unused_t;
-
-
-/**
- * @brief   The actual static buffer used when module gnrc_pktbuf_static is used
- *
- * @warning This is an internal buffer and should not be touched by external
- *          code
- *
- * @details This buffer is aligned to boundaries of `sizeof(_unused_t)`
- */
-extern alignas(sizeof(_unused_t)) uint8_t gnrc_pktbuf_static_buf[CONFIG_GNRC_PKTBUF_SIZE];
 
 /**
  * @brief   Calculates the required space of a number of bytes including


### PR DESCRIPTION
### Contribution description

Since we are now using C11, we can make use of `alignas()` provided by `<stdalign.h>` to make the alignment code easier to read.

### Testing procedure

I didn't expect this to change binaries, but is safes 4 bytes. `elf_diff` shows that the compiler (at least GCC 11.3.0) was not able to detect that `gnrc_pktbuf_static_buf` was just an alias for `_pktbuf_buf`. That makes sense since it would be hard without LTO to rule out external writes to `gnrc_pktbuf_static_buf`, unless one would have added a `const` (to the pointer, not to the data the pointer points to).

The [output of `elf_diff`](https://mari-bu.de/pr_18348_gnrc_pktbuf_static_elf_diff.html) looks otherwise quite unscary.

Also:

```
$ make BOARD=nucleo-f767zi -C tests/unittests/ tests-pktbuf flash test
make: Entering directory '/home/maribu/Repos/software/RIOT/tests/unittests'
Building application "tests_unittests" for "nucleo-f767zi" with MCU "stm32".
[...]
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
.............................................
OK (45 tests)

make: Leaving directory '/home/maribu/Repos/software/RIOT/tests/unittests'
```

### Issues/PRs references

None