### PR TITLE
sys/shell/commands/ping: fix dependency & convert to ztimer

### DIFF
--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -41,6 +41,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -315,7 +315,7 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   endif
 
   ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
-    USEMODULE += netutils xtimer
+    USEMODULE += netutils ztimer_usec
   endif
 
   ifneq (,$(gnrc_udp_cmd,$(USEMODULE)))

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -315,7 +315,7 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   endif
 
   ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
-    USEMODULE += netutils
+    USEMODULE += netutils xtimer
   endif
 
   ifneq (,$(gnrc_udp_cmd,$(USEMODULE)))

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -63,9 +63,7 @@ ifneq (,$(filter gnrc_ipv6_blacklist,$(USEMODULE)))
   SRC += sc_blacklist.c
 endif
 ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
-ifneq (,$(filter xtimer,$(USEMODULE)))
   SRC += sc_gnrc_icmpv6_echo.c
-endif
 endif
 ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
     SRC += sc_gnrc_pktbuf.c

--- a/sys/shell/commands/sc_gnrc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_gnrc_icmpv6_echo.c
@@ -38,7 +38,7 @@
 #include "timex.h"
 #include "unaligned.h"
 #include "utlist.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef MODULE_LUID
 #include "luid.h"
@@ -60,7 +60,7 @@
 
 typedef struct {
     gnrc_netreg_entry_t netreg;
-    xtimer_t sched_timer;
+    ztimer_t sched_timer;
     msg_t sched_msg;
     ipv6_addr_t host;
     char *hostname;
@@ -110,7 +110,7 @@ static int _gnrc_icmpv6_ping(int argc, char **argv)
         msg_receive(&msg);
         switch (msg.type) {
             case GNRC_NETAPI_MSG_TYPE_RCV: {
-                _handle_reply(&data, msg.content.ptr, xtimer_now_usec());
+                _handle_reply(&data, msg.content.ptr, ztimer_now(ZTIMER_USEC));
                 gnrc_pktbuf_release(msg.content.ptr);
                 break;
             }
@@ -126,7 +126,7 @@ static int _gnrc_icmpv6_ping(int argc, char **argv)
         }
     } while (data.num_recv < data.count);
 finish:
-    xtimer_remove(&data.sched_timer);
+    ztimer_remove(ZTIMER_USEC, &data.sched_timer);
     res = _finish(&data);
     gnrc_netreg_unregister(GNRC_NETTYPE_ICMPV6, &data.netreg);
     while (msg_avail() > 0) {
@@ -232,7 +232,7 @@ static int _configure(int argc, char **argv, _ping_data_t *data)
     if (res != 0) {
         _usage(cmdname);
     }
-    data->id ^= (xtimer_now_usec() & UINT16_MAX);
+    data->id ^= (ztimer_now(ZTIMER_USEC) & UINT16_MAX);
 #ifdef MODULE_LUID
     luid_custom(&data->id, sizeof(data->id), data->id);
 #endif
@@ -244,7 +244,7 @@ static void _fill_payload(uint8_t *buf, size_t len)
     uint8_t i = 0;
 
     if (len >= sizeof(uint32_t)) {
-        uint32_t now = xtimer_now_usec();
+        uint32_t now = ztimer_now(ZTIMER_USEC);
         memcpy(buf, &now, sizeof(now));
         len -= sizeof(now);
         buf += sizeof(now);
@@ -305,7 +305,7 @@ static void _pinger(_ping_data_t *data)
             }
         }
     }
-    xtimer_set_msg(&data->sched_timer, timer, &data->sched_msg,
+    ztimer_set_msg(ZTIMER_USEC, &data->sched_timer, timer, &data->sched_msg,
                    thread_getpid());
     bf_unset(data->cktab, (size_t)data->num_sent % CKTAB_SIZE);
     pkt = gnrc_icmpv6_echo_build(ICMPV6_ECHO_REQ, data->id,

--- a/tests/gnrc_rpl/Makefile.ci
+++ b/tests/gnrc_rpl/Makefile.ci
@@ -4,9 +4,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     atmega328p-xplained-mini \
-    atmega1284p \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \


### PR DESCRIPTION
### Contribution description

Add missing dependency to xtimer so that the shell command `ping` is
again provided when requested.

### Testing procedure


Run `make BOARD=nucleo-f767zi -C examples/gnrc_networking flash term` and then `help`. If the `ping` command is listed again, the bug is fixed. (Did so, worked for me.)

### Issues/PRs references

None