### PR TITLE
unittest/main: do not intialize xtimer if ztimer_xtimer_compat

### DIFF
--- a/tests/unittests/main.c
+++ b/tests/unittests/main.c
@@ -31,7 +31,7 @@ int main(void)
     ztimer_init();
 #endif
 
-#ifdef MODULE_XTIMER
+#if IS_USED(MODULE_XTIMER) && !IS_USED(MODULE_ZTIMER_XTIMER_COMPAT)
     /* auto_init is disabled, but some modules depends on this module being initialized */
     xtimer_init();
 #endif


### PR DESCRIPTION
@miri64 found an issue with unittest and ztimer_sleep in

https://github.com/RIOT-OS/RIOT/pull/17680#issuecomment-1184312760

PR #18312 identified a potential double initialization of ztimer.

### Contribution description

this removes the xtimer initialzation call if  xtimer is used via ztimer_xtimer_compat. (this is the same behavior found in `auto_init`)

### Testing procedure

see #18312

### Issues/PRs references

