### PR TITLE
sys/shell/commands/ping: fix dependency [backport 2022.07]

### DIFF
--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -41,6 +41,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/examples/gcoap/Makefile.ci
+++ b/examples/gcoap/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -315,7 +315,7 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   endif
 
   ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
-    USEMODULE += netutils
+    USEMODULE += netutils xtimer
   endif
 
   ifneq (,$(gnrc_udp_cmd,$(USEMODULE)))

--- a/tests/gnrc_rpl/Makefile.ci
+++ b/tests/gnrc_rpl/Makefile.ci
@@ -4,9 +4,9 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-mega2560 \
     arduino-nano \
     arduino-uno \
+    atmega1284p \
     atmega328p \
     atmega328p-xplained-mini \
-    atmega1284p \
     atxmega-a3bu-xplained \
     bluepill-stm32f030c8 \
     derfmega128 \
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \
+    stm32f7508-dk \
     stm32g0316-disco \
     stm32l0538-disco \
     telosb \


### PR DESCRIPTION
# Backport of #18349

### Contribution description

Add missing dependency to xtimer so that the shell command `ping` is
again provided when requested.

### Testing procedure


Run `make BOARD=nucleo-f767zi -C examples/gnrc_networking flash term` and then `help`. If the `ping` command is listed again, the bug is fixed. (Did so, worked for me.)

### Issues/PRs references

None