### PR TITLE
tests/change: change CPU_FAM to MCU for ESP32x SoCs

### DIFF
--- a/tests/periph_gpio_ll/Makefile
+++ b/tests/periph_gpio_ll/Makefile
@@ -46,11 +46,11 @@ CFLAGS += -DPIN_OUT_0=$(PIN_OUT_0)
 CFLAGS += -DPIN_OUT_1=$(PIN_OUT_1)
 CFLAGS += -DLOW_ROM=$(LOW_ROM)
 
-ifneq ($(CPU_FAM),esp32)
+ifneq ($(MCU),esp32)
   # We only need 1 thread (+ the Idle thread on some platforms) and we really
   # want this app working on all boards.
   CFLAGS += -DMAXTHREADS=2
 else
-  # ESP32 uses an extra thread for esp_timer
+  # ESP32x SoCs uses an extra thread for esp_timer
   CFLAGS += -DMAXTHREADS=3
 endif

--- a/tests/pkg_fff/Makefile
+++ b/tests/pkg_fff/Makefile
@@ -5,10 +5,10 @@ FEATURES_BLACKLIST += periph_i2c
 
 include $(RIOTBASE)/Makefile.include
 
-ifneq ($(CPU_FAM),esp32)
+ifneq ($(MCU),esp32)
   # only two threads used
   CFLAGS += -DMAXTHREADS=2
 else
-  # ESP32 uses an extra thread for esp_timer
+  # ESP32x SoCs uses an extra thread for esp_timer
   CFLAGS += -DMAXTHREADS=3
 endif


### PR DESCRIPTION
### Contribution description

This PR provides a change so that MCU is used instead of CPU_FAM to be able to compile the tests for different ESP32x variants without having to define each ESP32x variant.

This PR is required for PR #18345.

### Testing procedure

Green CI

### Issues/PRs references

Required for PR #18345.

