### PR TITLE
pkg/lwip: fix code style

### DIFF
--- a/pkg/lwip/contrib/_netif.c
+++ b/pkg/lwip/contrib/_netif.c
@@ -43,29 +43,29 @@ int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
     int res = -ENOTSUP;
     switch (opt) {
 #ifdef MODULE_LWIP_IPV6
-        case NETOPT_IPV6_ADDR: {
-                assert(max_len >= sizeof(ipv6_addr_t));
-                ipv6_addr_t *tgt = value;
+    case NETOPT_IPV6_ADDR: {
+            assert(max_len >= sizeof(ipv6_addr_t));
+            ipv6_addr_t *tgt = value;
 
-                res = 0;
-                for (unsigned i = 0;
-                     ((res + sizeof(ipv6_addr_t)) <= max_len) &&
-                     (i < LWIP_IPV6_NUM_ADDRESSES);
-                     i++) {
-                    if (netif_ip6_addr_state(netif, i) != IP6_ADDR_INVALID) {
-                        memcpy(tgt, &(netif_ip6_addr(netif, i)->addr), sizeof(ipv6_addr_t));
-                        res += sizeof(ipv6_addr_t);
-                        tgt++;
-                    }
+            res = 0;
+            for (unsigned i = 0;
+                 ((res + sizeof(ipv6_addr_t)) <= max_len) &&
+                 (i < LWIP_IPV6_NUM_ADDRESSES);
+                 i++) {
+                if (netif_ip6_addr_state(netif, i) != IP6_ADDR_INVALID) {
+                    memcpy(tgt, &(netif_ip6_addr(netif, i)->addr), sizeof(ipv6_addr_t));
+                    res += sizeof(ipv6_addr_t);
+                    tgt++;
                 }
             }
-            break;
+        }
+        break;
 #endif
-        default:
-            break;
+    default:
+        break;
     }
     if (res == -ENOTSUP) {
-        // Ask underlying netdev
+        /* Ask underlying netdev */
         res = dev->driver->get(dev, opt, value, max_len);
     }
     return res;

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -123,50 +123,50 @@ static int _parse_iphdr(struct netbuf *buf, void **data, void **ctx,
 
     switch (data_ptr[0] >> 4) {
 #if LWIP_IPV4
-        case 4:
-            if (remote != NULL) {
-                struct ip_hdr *iphdr = (struct ip_hdr *)data_ptr;
+    case 4:
+        if (remote != NULL) {
+            struct ip_hdr *iphdr = (struct ip_hdr *)data_ptr;
 
-                assert(buf->p->len > sizeof(struct ip_hdr));
-                remote->family = AF_INET;
-                memcpy(&remote->addr, &iphdr->src, sizeof(ip4_addr_t));
-                remote->netif = _ip4_addr_to_netif(&iphdr->dest);
-            }
-            if (local != NULL) {
-                struct ip_hdr *iphdr = (struct ip_hdr *)data_ptr;
+            assert(buf->p->len > sizeof(struct ip_hdr));
+            remote->family = AF_INET;
+            memcpy(&remote->addr, &iphdr->src, sizeof(ip4_addr_t));
+            remote->netif = _ip4_addr_to_netif(&iphdr->dest);
+        }
+        if (local != NULL) {
+            struct ip_hdr *iphdr = (struct ip_hdr *)data_ptr;
 
-                assert(buf->p->len > sizeof(struct ip_hdr));
-                local->family = AF_INET;
-                memcpy(&local->addr, &iphdr->dest, sizeof(ip4_addr_t));
-            }
-            data_ptr += sizeof(struct ip_hdr);
-            data_len -= sizeof(struct ip_hdr);
-            break;
+            assert(buf->p->len > sizeof(struct ip_hdr));
+            local->family = AF_INET;
+            memcpy(&local->addr, &iphdr->dest, sizeof(ip4_addr_t));
+        }
+        data_ptr += sizeof(struct ip_hdr);
+        data_len -= sizeof(struct ip_hdr);
+        break;
 #endif
 #if LWIP_IPV6
-        case 6:
-            if (remote != NULL) {
-                struct ip6_hdr *iphdr = (struct ip6_hdr *)data_ptr;
+    case 6:
+        if (remote != NULL) {
+            struct ip6_hdr *iphdr = (struct ip6_hdr *)data_ptr;
 
-                assert(buf->p->len > sizeof(struct ip6_hdr));
-                remote->family = AF_INET6;
-                memcpy(&remote->addr, &iphdr->src, sizeof(ip6_addr_t));
-                remote->netif = _ip6_addr_to_netif(&iphdr->dest);
-            }
-            if (local != NULL) {
-                struct ip6_hdr *iphdr = (struct ip6_hdr *)data_ptr;
+            assert(buf->p->len > sizeof(struct ip6_hdr));
+            remote->family = AF_INET6;
+            memcpy(&remote->addr, &iphdr->src, sizeof(ip6_addr_t));
+            remote->netif = _ip6_addr_to_netif(&iphdr->dest);
+        }
+        if (local != NULL) {
+            struct ip6_hdr *iphdr = (struct ip6_hdr *)data_ptr;
 
-                assert(buf->p->len > sizeof(struct ip6_hdr));
-                local->family = AF_INET6;
-                memcpy(&local->addr, &iphdr->dest, sizeof(ip6_addr_t));
-            }
-            data_ptr += sizeof(struct ip6_hdr);
-            data_len -= sizeof(struct ip6_hdr);
-            break;
+            assert(buf->p->len > sizeof(struct ip6_hdr));
+            local->family = AF_INET6;
+            memcpy(&local->addr, &iphdr->dest, sizeof(ip6_addr_t));
+        }
+        data_ptr += sizeof(struct ip6_hdr);
+        data_len -= sizeof(struct ip6_hdr);
+        break;
 #endif
-        default:
-            netbuf_delete(buf);
-            return -EPROTO;
+    default:
+        netbuf_delete(buf);
+        return -EPROTO;
     }
     *data = data_ptr;
     *ctx = buf;

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -50,15 +50,15 @@ static inline bool _af_not_supported(int af)
 {
     switch (af) {
 #if LWIP_IPV4
-        case AF_INET:
-            return false;
+    case AF_INET:
+        return false;
 #endif
 #if LWIP_IPV6
-        case AF_INET6:
-            return false;
+    case AF_INET6:
+        return false;
 #endif
-        default:
-            return true;
+    default:
+        return true;
     }
 }
 
@@ -66,13 +66,13 @@ static inline bool _af_not_supported(int af)
 static inline u8_t lwip_af_to_ip_addr_type(int af)
 {
     switch (af) {
-        case AF_INET:
-            return IPADDR_TYPE_V4;
-        case AF_INET6:
-        case AF_UNSPEC: /* in case of any address */
-            return IPADDR_TYPE_V6;
-        default:
-            return 0xff;
+    case AF_INET:
+        return IPADDR_TYPE_V4;
+    case AF_INET6:
+    case AF_UNSPEC: /* in case of any address */
+        return IPADDR_TYPE_V6;
+    default:
+        return 0xff;
     }
 }
 #endif
@@ -110,16 +110,16 @@ static const ip_addr_t *_netif_to_bind_addr(int family, uint16_t netif_num)
         if (netif->num == (netif_num - 1)) {
             switch (family) {
 #if LWIP_IPV4
-                case AF_INET:
-                    return &netif->ip_addr;
+            case AF_INET:
+                return &netif->ip_addr;
 #endif
 #if LWIP_IPV6
-                case AF_INET6:
-                    /* link-local address is always the 0th */
-                    return &netif->ip6_addr[0];
+            case AF_INET6:
+                /* link-local address is always the 0th */
+                return &netif->ip6_addr[0];
 #endif
-                default:
-                    return NULL;
+            default:
+                return NULL;
             }
         }
     }
@@ -136,20 +136,20 @@ static bool _addr_on_netif(int family, int netif_num, const ip_addr_t *addr)
         if (netif->num == (netif_num - 1)) {
             switch (family) {
 #if LWIP_IPV4
-                case AF_INET:
-                    return ip_2_ip4(&netif->ip_addr)->addr == ip_2_ip4(addr)->addr;
+            case AF_INET:
+                return ip_2_ip4(&netif->ip_addr)->addr == ip_2_ip4(addr)->addr;
 #endif
 #if LWIP_IPV6
-                case AF_INET6: {
-                    LOCK_TCPIP_CORE();
-                    /* link-local address is always the 0th */
-                    s8_t match = netif_get_ip6_addr_match(netif, ip_2_ip6(addr));
-                    UNLOCK_TCPIP_CORE();
-                    return match >= 0;
-                }
+            case AF_INET6: {
+                LOCK_TCPIP_CORE();
+                /* link-local address is always the 0th */
+                s8_t match = netif_get_ip6_addr_match(netif, ip_2_ip6(addr));
+                UNLOCK_TCPIP_CORE();
+                return match >= 0;
+            }
 #endif
-                default:
-                    return false;
+            default:
+                return false;
             }
         }
     }
@@ -283,45 +283,45 @@ static void _netconn_cb(struct netconn *conn, enum netconn_evt evt,
 
         (void)len;
         switch (evt) {
-            case NETCONN_EVT_RCVPLUS:
-                if (LWIP_TCP && (conn->type & NETCONN_TCP)) {
+        case NETCONN_EVT_RCVPLUS:
+            if (LWIP_TCP && (conn->type & NETCONN_TCP)) {
 #if LWIP_TCP    /* additional guard needed due to dependent member access */
-                    switch (conn->pcb.tcp->state) {
-                        case CLOSED:
-                        case CLOSE_WAIT:
-                        case CLOSING:
-                            flags |= SOCK_ASYNC_CONN_FIN;
-                            break;
-                        default:
-                            break;
-                    }
-                    if (mbox_avail(&conn->acceptmbox.mbox)) {
-                        flags |= SOCK_ASYNC_CONN_RECV;
-                    }
-                    if (mbox_avail(&conn->recvmbox.mbox)) {
-                        flags |= SOCK_ASYNC_MSG_RECV;
-                    }
-#endif
+                switch (conn->pcb.tcp->state) {
+                case CLOSED:
+                case CLOSE_WAIT:
+                case CLOSING:
+                    flags |= SOCK_ASYNC_CONN_FIN;
+                    break;
+                default:
+                    break;
                 }
-                else {
+                if (mbox_avail(&conn->acceptmbox.mbox)) {
+                    flags |= SOCK_ASYNC_CONN_RECV;
+                }
+                if (mbox_avail(&conn->recvmbox.mbox)) {
                     flags |= SOCK_ASYNC_MSG_RECV;
                 }
-                break;
-            case NETCONN_EVT_SENDPLUS:
-                flags |= SOCK_ASYNC_MSG_SENT;
-                break;
-            case NETCONN_EVT_ERROR:
-                if (LWIP_TCP && (conn->type & NETCONN_TCP)) {
-                    /* try to report this */
-                    flags |= SOCK_ASYNC_CONN_FIN;
-                }
-                break;
-            case NETCONN_EVT_RCVMINUS:
-            case NETCONN_EVT_SENDMINUS:
-                break;
-            default:
-                LWIP_ASSERT("unknown event", 0);
-                break;
+#endif
+            }
+            else {
+                flags |= SOCK_ASYNC_MSG_RECV;
+            }
+            break;
+        case NETCONN_EVT_SENDPLUS:
+            flags |= SOCK_ASYNC_MSG_SENT;
+            break;
+        case NETCONN_EVT_ERROR:
+            if (LWIP_TCP && (conn->type & NETCONN_TCP)) {
+                /* try to report this */
+                flags |= SOCK_ASYNC_CONN_FIN;
+            }
+            break;
+        case NETCONN_EVT_RCVMINUS:
+        case NETCONN_EVT_SENDMINUS:
+            break;
+        default:
+            LWIP_ASSERT("unknown event", 0);
+            break;
         }
         if (flags && sock->async_cb.gen) {
             sock->async_cb.gen(sock, flags, sock->async_cb_arg);
@@ -387,18 +387,18 @@ int lwip_sock_create(struct netconn **conn, const struct _sock_tl_ep *local,
         if (bind) {
             switch (netconn_bind(*conn, &local_addr, local_port)) {
 #if LWIP_TCP
-                case ERR_BUF:
-                    res = -ENOMEM;
-                    break;
+            case ERR_BUF:
+                res = -ENOMEM;
+                break;
 #endif
-                case ERR_USE:
-                    res = -EADDRINUSE;
-                    break;
-                case ERR_VAL:
-                    res = -EINVAL;
-                    break;
-                default:
-                    break;
+            case ERR_USE:
+                res = -EADDRINUSE;
+                break;
+            case ERR_VAL:
+                res = -EINVAL;
+                break;
+            default:
+                break;
             }
             if (res < 0) {
                 netconn_delete(*conn);
@@ -408,31 +408,31 @@ int lwip_sock_create(struct netconn **conn, const struct _sock_tl_ep *local,
         if (remote != NULL) {
             switch (netconn_connect(*conn, &remote_addr, remote_port)) {
 #if LWIP_TCP
-                case ERR_BUF:
-                    res = -ENOMEM;
-                    break;
-                case ERR_INPROGRESS:
-                    res = -EINPROGRESS;
-                    break;
-                case ERR_ISCONN:
-                    res = -EISCONN;
-                    break;
-                case ERR_IF:
-                case ERR_RTE:
-                    res = -ENETUNREACH;
-                    break;
-                case ERR_ABRT:
-                    res = -ETIMEDOUT;
-                    break;
+            case ERR_BUF:
+                res = -ENOMEM;
+                break;
+            case ERR_INPROGRESS:
+                res = -EINPROGRESS;
+                break;
+            case ERR_ISCONN:
+                res = -EISCONN;
+                break;
+            case ERR_IF:
+            case ERR_RTE:
+                res = -ENETUNREACH;
+                break;
+            case ERR_ABRT:
+                res = -ETIMEDOUT;
+                break;
 #endif
-                case ERR_USE:
-                    res = -EADDRINUSE;
-                    break;
-                case ERR_VAL:
-                    res = -EINVAL;
-                    break;
-                default:
-                    break;
+            case ERR_USE:
+                res = -EADDRINUSE;
+                break;
+            case ERR_VAL:
+                res = -EINVAL;
+                break;
+            default:
+                break;
             }
             if (res < 0) {
                 netconn_delete(*conn);
@@ -543,20 +543,20 @@ int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf)
         return -EAGAIN;
     }
     switch (netconn_recv(conn, buf)) {
-        case ERR_OK:
-            res = 0;
-            break;
+    case ERR_OK:
+        res = 0;
+        break;
 #if LWIP_SO_RCVTIMEO
-        case ERR_TIMEOUT:
-            res = -ETIMEDOUT;
-            break;
+    case ERR_TIMEOUT:
+        res = -ETIMEDOUT;
+        break;
 #endif
-        case ERR_MEM:
-            res = -ENOMEM;
-            break;
-        default:
-            res = -EPROTO;
-            break;
+    case ERR_MEM:
+        res = -ENOMEM;
+        break;
+    default:
+        res = -EPROTO;
+        break;
     }
     /* unset flags */
 #if LWIP_SO_RCVTIMEO
@@ -647,20 +647,20 @@ ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
         err = netconn_send(tmp, buf);
     }
     switch (err) {
-        case ERR_OK:
-            break;
-        case ERR_BUF:
-        case ERR_MEM:
-            res = -ENOMEM;
-            break;
-        case ERR_RTE:
-        case ERR_IF:
-            res = -EHOSTUNREACH;
-            break;
-        case ERR_VAL:
-        default:
-            res = -EINVAL;
-            break;
+    case ERR_OK:
+        break;
+    case ERR_BUF:
+    case ERR_MEM:
+        res = -ENOMEM;
+        break;
+    case ERR_RTE:
+    case ERR_IF:
+        res = -EHOSTUNREACH;
+        break;
+    case ERR_VAL:
+    default:
+        res = -EINVAL;
+        break;
     }
     netbuf_delete(buf);
     if (conn == NULL) {

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -85,18 +85,18 @@ int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
     memset(queue->array, 0, sizeof(sock_tcp_t) * queue_len);
     mutex_unlock(&queue->mutex);
     switch (netconn_listen_with_backlog(queue->base.conn, queue->len)) {
-        case ERR_OK:
-            break;
-        case ERR_MEM:
-            return -ENOMEM;
-        case ERR_USE:
-            return -EADDRINUSE;
-        case ERR_VAL:
-            return -EINVAL;
-        default:
-            assert(false); /* should not happen since queue->base.conn is not
-                            * closed and we have a TCP conn */
-            break;
+    case ERR_OK:
+        break;
+    case ERR_MEM:
+        return -ENOMEM;
+    case ERR_USE:
+        return -EADDRINUSE;
+    case ERR_VAL:
+        return -EINVAL;
+    default:
+        assert(false); /* should not happen since queue->base.conn is not
+                        * closed and we have a TCP conn */
+        break;
     }
     return 0;
 }
@@ -215,33 +215,33 @@ int sock_tcp_accept(sock_tcp_queue_t *queue, sock_tcp_t **sock,
             return -EAGAIN;
         }
         switch (netconn_accept(queue->base.conn, &tmp)) {
-            case ERR_OK:
-                for (unsigned short i = 0; i < queue->len; i++) {
-                    sock_tcp_t *s = &queue->array[i];
-                    if (s->base.conn == NULL) {
-                        _tcp_sock_init(s, tmp, queue);
-                        queue->used++;
-                        assert(queue->used > 0);
-                        *sock = s;
-                        break;
-                    }
+        case ERR_OK:
+            for (unsigned short i = 0; i < queue->len; i++) {
+                sock_tcp_t *s = &queue->array[i];
+                if (s->base.conn == NULL) {
+                    _tcp_sock_init(s, tmp, queue);
+                    queue->used++;
+                    assert(queue->used > 0);
+                    *sock = s;
+                    break;
                 }
-                break;
-            case ERR_ABRT:
-                res = -ECONNABORTED;
-                break;
-            case ERR_MEM:
-                res = -ENOMEM;
-                break;
+            }
+            break;
+        case ERR_ABRT:
+            res = -ECONNABORTED;
+            break;
+        case ERR_MEM:
+            res = -ENOMEM;
+            break;
 #if LWIP_SO_RCVTIMEO
-            case ERR_TIMEOUT:
-                res = -ETIMEDOUT;
-                break;
+        case ERR_TIMEOUT:
+            res = -ETIMEDOUT;
+            break;
 #endif
-            default:
-                assert(false);
-                res = -1;
-                break;
+        default:
+            assert(false);
+            res = -1;
+            break;
         }
     }
     else {
@@ -307,28 +307,28 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
             err_t err;
             if ((err = netconn_recv_tcp_pbuf(sock->base.conn, &buf)) < 0) {
                 switch (err) {
-                    case ERR_ABRT:
-                        res = -ECONNABORTED;
-                        break;
-                    case ERR_CONN:
-                        res = -EADDRNOTAVAIL;
-                        break;
-                    case ERR_RST:
-                    case ERR_CLSD:
-                        res = -ECONNRESET;
-                        break;
-                    case ERR_MEM:
-                        res = -ENOMEM;
-                        break;
+                case ERR_ABRT:
+                    res = -ECONNABORTED;
+                    break;
+                case ERR_CONN:
+                    res = -EADDRNOTAVAIL;
+                    break;
+                case ERR_RST:
+                case ERR_CLSD:
+                    res = -ECONNRESET;
+                    break;
+                case ERR_MEM:
+                    res = -ENOMEM;
+                    break;
 #if LWIP_SO_RCVTIMEO
-                    case ERR_TIMEOUT:
-                        res = -ETIMEDOUT;
-                        break;
+                case ERR_TIMEOUT:
+                    res = -ETIMEDOUT;
+                    break;
 #endif
-                    default:
-                        /* no applicable error */
-                        res = -1;
-                        break;
+                default:
+                    /* no applicable error */
+                    res = -1;
+                    break;
                 }
                 break;
             }

--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -153,14 +153,14 @@ u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout)
     stop = ztimer_now(ZTIMER_MSEC);
     ztimer_remove(ZTIMER_MSEC, &timer);  /* in case timer did not time out */
     switch (m.type) {
-        case _MSG_SUCCESS:
-            *msg = m.content.ptr;
-            return stop - start;
-        case _MSG_TIMEOUT:
-            break;
-        default:    /* should not happen */
-            LWIP_ASSERT("invalid message received", false);
-            break;
+    case _MSG_SUCCESS:
+        *msg = m.content.ptr;
+        return stop - start;
+    case _MSG_TIMEOUT:
+        break;
+    default:    /* should not happen */
+        LWIP_ASSERT("invalid message received", false);
+        break;
     }
     return SYS_ARCH_TIMEOUT;
 }


### PR DESCRIPTION
### Contribution description

This mostly converts switch statements from double indent style to Linux kernel style, as required per the coding convention.

From the C compiler perspective, this is a whitespace only change.

### Testing procedure

Double checking that changes are indeed white-space only is sufficient. Sadly, the github diff view doesn't really work well here...

### Issues/PRs references

I split this out of a yet to be opened PR, so that the PR with actual changes only contains actual changes.