### PR TITLE
pkg/lwip: use sys/event for handling ISR and bhp

### DIFF
--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -3,6 +3,7 @@
 FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit
 
 DEFAULT_MODULE += auto_init_lwip
+USEMODULE += event
 
 ifneq (,$(filter sock_async,$(USEMODULE)))
   USEMODULE += lwip_sock_async
@@ -90,7 +91,7 @@ ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   USEMODULE += sema
   USEMODULE += ztimer_msec
   ifneq (,$(filter bhp,$(USEMODULE)))
-    USEMODULE += bhp_msg
+    USEMODULE += bhp_event
   endif
 endif
 

--- a/pkg/lwip/include/lwip.h
+++ b/pkg/lwip/include/lwip.h
@@ -19,9 +19,16 @@
 #ifndef LWIP_H
 #define LWIP_H
 
+#include "event.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief event queue for netdev events
+ */
+extern event_queue_t lwip_event_queue;
 
 /**
  * @brief   Initializes lwIP stack.

--- a/pkg/lwip/init_devs/auto_init_kw2xrf.c
+++ b/pkg/lwip/init_devs/auto_init_kw2xrf.c
@@ -1,11 +1,11 @@
 /*
-￼* Copyright (C) 2022 HAW Hamburg
-￼*
-￼* This file is subject to the terms and conditions of the GNU Lesser
-￼* General Public License v2.1. See the file LICENSE in the top level
-￼* directory for more details.
-￼*
-￼*/
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
 
 /**
  * @ingroup sys_auto_init_lwip_netif
@@ -20,9 +20,10 @@
 #include "kw2xrf.h"
 #include "kw2xrf_params.h"
 
+#include "lwip.h"
 #include "lwip_init_devs.h"
 
-#include "bhp/msg.h"
+#include "bhp/event.h"
 #include "net/netdev/ieee802154_submac.h"
 
 #define ENABLE_DEBUG    0
@@ -37,9 +38,10 @@ static netdev_ieee802154_submac_t kw2xrf_netdev[NETIF_KW2XRF_NUMOF];
 static void auto_init_kw2xrf(void)
 {
     for (unsigned i = 0; i < NETIF_KW2XRF_NUMOF; i++) {
-        bhp_msg_init(&netif[i].bhp, &kw2xrf_radio_hal_irq_handler, &kw2xrf_netdev[i].submac.dev);
+        bhp_event_init(&netif[i].bhp, &lwip_event_queue,
+                       &kw2xrf_radio_hal_irq_handler, &kw2xrf_netdev[i].submac.dev);
         kw2xrf_init(&kw2xrf_devs[i], &kw2xrf_params[i], &kw2xrf_netdev[i].submac.dev,
-                    bhp_msg_isr_cb, &netif[i].bhp);
+                    bhp_event_isr_cb, &netif[i].bhp);
 
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
         netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);

--- a/pkg/lwip/init_devs/auto_init_mrf24j40.c
+++ b/pkg/lwip/init_devs/auto_init_mrf24j40.c
@@ -1,11 +1,11 @@
 /*
-￼* Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
-￼*
-￼* This file is subject to the terms and conditions of the GNU Lesser
-￼* General Public License v2.1. See the file LICENSE in the top level
-￼* directory for more details.
-￼*
-￼*/
+ * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
 
 /**
  * @ingroup sys_auto_init_lwip_netif
@@ -21,8 +21,9 @@
 #include "mrf24j40.h"
 #include "mrf24j40_params.h"
 
+#include "bhp/event.h"
+#include "lwip.h"
 #include "lwip_init_devs.h"
-#include "bhp/msg.h"
 #include "net/netdev/ieee802154_submac.h"
 
 #define ENABLE_DEBUG    0
@@ -37,9 +38,10 @@ static netdev_ieee802154_submac_t mrf24j40_netdev[NETIF_MRF24J40_NUMOF];
 static void auto_init_mrf24j40(void)
 {
     for (unsigned i = 0; i < NETIF_MRF24J40_NUMOF; i++) {
-        bhp_msg_init(&netif[i].bhp, &mrf24j40_radio_irq_handler, &mrf24j40_netdev[i].submac.dev);
+        bhp_event_init(&netif[i].bhp, &lwip_event_queue, &mrf24j40_radio_irq_handler,
+                       &mrf24j40_netdev[i].submac.dev);
         mrf24j40_init(&mrf24j40_devs[i], &mrf24j40_params[i], &mrf24j40_netdev[i].submac.dev,
-                        bhp_msg_isr_cb, &netif[i].bhp);
+                      bhp_event_isr_cb, &netif[i].bhp);
 
 
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, i);


### PR DESCRIPTION
### Contribution description

This is many providing infrastructure for later use, specifically for making use of the `netdev_driver_t::confirm_send()`. However, as a positive side-effect, this should prevent lost IRQs. (E.g. consider one netdev saturating the message queue. If now a second netdev would
also need its ISR being run, it cannot enqueue its message and the IRQ is lost.)

### Testing procedure

The expected failure mode is that no network operation is possible when the ISRs are not being run correctly. I ran `make LWIP=1 BOARD=nucleo-f767zi -C examples/gcoap` and could still successfully ping the board.

### Issues/PRs references

Contains https://github.com/RIOT-OS/RIOT/pull/18357