### PR TITLE
pkg/lvgl: bump version to 8.3.1

### DIFF
--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=lvgl
 PKG_URL=https://github.com/littlevgl/lvgl
-PKG_VERSION=49c59f4615857759cc8caf88424324ab6386c888  # v8.3.0
+PKG_VERSION=9024b72b4853e1e7ac29a42e54b7a10d3c4f3b20  # v8.3.1
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

As the title says. This version of lvgl only contains bug fixes.

Firmware size of `tests/pkg_lvgl `is the same between master and this PR. For `tests/pkg_lvgl_touch`, it's smaller with this PR.
I tested `tests/pkg_lvgl` and `tests/pkg_lvgl_touch` on native and both still works.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Green Murdock
- `tests/pkg_lvgl` and `tests/pkg_lvgl_touch` are still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
