### PR TITLE
examples/dtls-echo: set address family for sessions [backport 2022.07]

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -121,6 +121,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
 
     dtls_session_init(&session);
     session.addr.port = remote.port;
+    session.addr.family = AF_INET6;
     if (remote.netif == SOCK_ADDR_ANY_NETIF) {
         session.ifindex = SOCK_ADDR_ANY_NETIF;
     }
@@ -359,6 +360,7 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
     }
 
     /* Second: We prepare the DTLS Session by means of ctx->app */
+    dst->addr.family = AF_INET6;
     dst->addr.port = remote->port;
 
     /* NOTE: remote.addr.ipv6 and dst->addr.ipv6 are different structures. */

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -116,6 +116,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
     /* (DTLS) session requires the remote peer address (IPv6:Port) and netif */
     dtls_session_init(&session);
     session.addr.port = remote_peer->remote->port;
+    session.addr.family = AF_INET6;
     if (remote_peer->remote->netif ==  SOCK_ADDR_ANY_NETIF) {
         session.ifindex = SOCK_ADDR_ANY_NETIF;
     }


### PR DESCRIPTION
# Backport of #18369


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
d424aaedacf5e77a8310edaf1a87543d22f6e6ab introduced address families to the RIOT interpretation of tinydtls-`session_t`s. However, while fixing the naming for the `addr` field, it did not set the `family` member for the sessions in the `dtls-echo` example, having that example run into [an assertion][1]. This patch fixes that.

[1]: https://github.com/eclipse/tinydtls/blob/bda40789a7c280f248eeca6d09ddd624cdaf5dc8/session.c#L146
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I used the same script to [find the issue](https://github.com/RIOT-OS/RIOT/pull/18368#issuecomment-1195474091) to test its fix (assuming you are in `RIOTBASE`:

```sh
sudo dist/tools/tapsetup/tapsetup
cat << EOF > test_dtls.py
#! /usr/bin/env python3
import sys

from riotctrl.ctrl import RIOTCtrl

sys.path.append("dist/pythonlibs")
from riotctrl_shell.netif import IfconfigListParser, Ifconfig

if __name__ == "__main__":
    RIOTCtrl.MAKE_ARGS = ("-j",)
    ctrl0 = RIOTCtrl(application_directory="examples/dtls-echo", env={"WERROR": "0"})
    ctrl1 = RIOTCtrl(
        application_directory="examples/dtls-echo", env={"PORT": "tap1", "WERROR": "0"}
    )
    ctrl0.make_run(["flash"])
    with ctrl0.run_term(reset=False), ctrl1.run_term(reset=False):
        ctrl0.term.logfile = sys.stdout
        ctrl1.term.logfile = sys.stdout
        shell0 = Ifconfig(ctrl0)
        shell1 = Ifconfig(ctrl1)
        netifs = IfconfigListParser().parse(shell1.ifconfig_list())
        server_addr = list(netifs.values())[0]["ipv6_addrs"][0]["addr"]
        res = shell1.cmd("dtlss start")
        assert res.strip() == "dtlss start"
        res = shell0.cmd(f"dtlsc {server_addr} hello")
        res1 = shell1.cmd("help")
        assert "Client: got DTLS Data App -- hello --" in res
EOF
chmod +x test_dtls.py
./test_dtls.py
```

It should succeed and its output should contain the following crucial lines:

```
> dtlsc fe80::d827:1dff:fea8:6424 hello
dtlsc fe80::d827:1dff:fea8:6424 hello
Client: got DTLS Data App -- hello --
> help

Server: got DTLS Data App: --- hello ---	(echo!)
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/17765
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
