### PR TITLE
gcoap_dns: various fixes [backport 2022.07]

### DIFF
--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -668,7 +668,7 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
         memcpy(&dns_buf[block.offset], pdu->payload, pdu->payload_len);
         if (block.blknum == 0) {
             context->dns_buf_len = pdu->payload_len;
-            if (block.more && strlen(_uri) > 0) {
+            if (block.more && strlen(_uri) == 0) {
                 DEBUG("gcoap_dns: Cannot complete block-wise\n");
                 context->res = -EINVAL;
                 goto unlock;
@@ -682,6 +682,8 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
             unsigned msg_type = coap_get_type(pdu);
             int len;
 
+            pdu->payload = (uint8_t *)pdu->hdr;
+            pdu->payload_len = CONFIG_GCOAP_DNS_PDU_BUF_SIZE;
             tl_type = _req_init(pdu, &_uri_comp, msg_type == COAP_TYPE_ACK);
             block.blknum++;
             if (coap_opt_add_block2_control(pdu, &block) < 0) {

--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -543,7 +543,7 @@ static int _do_block(coap_pkt_t *pdu, const sock_udp_ep_t *remote,
     coap_block1_finish(&slicer);
 
     if ((len = _send(pdu->hdr, len, remote, slicer.start == 0, context, tl_type)) <= 0) {
-        printf("gcoap_dns: msg send failed: %d\n", (int)len);
+        DEBUG("gcoap_dns: msg send failed: %d\n", (int)len);
         return len;
     }
     return len;
@@ -621,12 +621,12 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
     int family = context->family;
 
     if (memo->state == GCOAP_MEMO_TIMEOUT) {
-        printf("gcoap_dns: CoAP request timed out\n");
+        DEBUG("gcoap_dns: CoAP request timed out\n");
         context->res = -ETIMEDOUT;
         goto unlock;
     }
     else if (memo->state != GCOAP_MEMO_RESP) {
-        printf("gcoap_dns: error in response\n");
+        DEBUG("gcoap_dns: error in response\n");
         context->res = -EBADMSG;
         goto unlock;
     }


### PR DESCRIPTION
# Backport of #18367

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
While doing some more experiments with the current version of `gcoap_dns`, I noticed some bugs, specifically, when using block-wise transfer. This PR fixes those and also replaces some left-over `printf`s with `DEBUG`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Similar to the testing procedures in #16705:

```console
$ sudo dist/tools/tapsetup/tapsetup
$ sudo ip addr add 2001:db8::1 dev tapbr0
$ sudo ip route add 2001:db8::/64 via "<native link-local>" dev tapbr0
$ pip install --upgrade git+https://github.com/miri64/aiodnsprox.git@exp  # blockwise does not work with upstream aiodnsprox yet
$ cat << EOF > config.yaml
dtls_credentials:
  client_identity: Client_identity
  psk: secretPSK
mock_dns_upstream:
  IN:
    A: 192.0.2.7
    AAAA: 2001:db8::7
$ aiodns-proxy -C config.yaml -c 2001:db8::1
```

```shell
RIOT_CONFIG_KCONFIG_USEMODULE_GCOAP_DNS=y \
   RIOT_CONFIG_KCONFIG_USEMODULE_GCOAP=y \
   RIOT_CONFIG_GCOAP_DNS_PDU_BUF_SIZE=100 \
   RIOT_CONFIG_GCOAP_DNS_BLOCK_SIZE=16 \
   RIOT_CONFIG_GCOAP_RESEND_BUFS_MAX=2 \
   make -C tests/gcoap_dns/ flash -j term
 ```

```console
> ifconfig 7 add 2001:db8::2
ifconfig 7 add 2001:db8::2
success: added 2001:db8::2/64 to interface 7
> nib route add 7 default fe80::dc1a:a8ff:fe09:45b3
nib route add 7 default fe80::dc1a:a8ff:fe09:45b3
> uri coap://[2001:db8::1]/dns
uri coap://[2001:db8::1]/dns
Successfully added URI coap://[2001:db8::1]/dns
> query example.org inet6
query example.org inet6
Hostname example.org resolves to 2001:db8::7 (IPv6)
```

Wiershark also shows blockwise transfer for both request and response:

![grafik](https://user-images.githubusercontent.com/675644/180845905-0431f41a-8e55-4e5e-8789-ab5f5a7e4d79.png)

Without this fix `query example.org inet6` will just fail with `Unable to resolve query: Invalid argument` (stemming from the wrongly reported `-EINVAL`).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #16705 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
