### PR TITLE
gnrc_netif_conf: fix auto-6ctx switch [backport 2022.07]

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -200,8 +200,10 @@ extern "C" {
  * When set, 6LoWPAN compression context 0 will be automatically set for the prefix configured by
  * prefix deligation at the border router.
  */
+#if !IS_ACTIVE(CONFIG_KCONFIG_USEMODULE_GNRC_NETIF)
 #ifndef CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX
 #define CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX   1
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
# Backport of #18370

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
When configuring a boolean via Kconfig and setting it to `n`, the result is that the symbol will not be defined as a preprocessor macro. As a result, setting `CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX` to `n` has no effect, as

```
#ifndef CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX
#define CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX   1
#endif
```

(as was pointed out in https://github.com/RIOT-OS/RIOT/pull/17678#discussion_r810259709). Without changing the name to a negative, the only other valid option is to check if `gnrc_netif` was configured via Kconfig in addition to the normal `#ifndef`. This PR applies that change.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Once a global address is configured with
```
BOARD=native RIOT_CONFIG_GNRC_NETIF_IPV6_BR_AUTO_6CTX=n RIOT_CONFIG_KCONFIG_USEMODULE_GNRC_NETIF=y make -C examples/gnrc_border_router flash -j term
```
the table returned by `6ctx` should remain empty.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #17678
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
