### PR TITLE
pkg/nimble: Replace double quotes with single quotes for two CFLAGS

### DIFF
--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -133,7 +133,7 @@ ifneq (,$(filter nimble_netif,$(USEMODULE)))
 
   # in order to fit a 251 byte COC data segment into a single mbuf buffer, the
   # used block size must be at least 297 byte (251 data + 48 overhead)
-  CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE="(MYNEWT_VAL_BLE_L2CAP_COC_MPS + 48)"
+  CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE='(MYNEWT_VAL_BLE_L2CAP_COC_MPS + 48)'
 
   # in the worst case, NimBLEs internal buffer needs to hold two full IPv6 MTUs
   # per connection (1 TX and 1 RX). But in practice this would be highly over-
@@ -156,7 +156,7 @@ else
 
     # in order to fit a 251 byte COC data segment into a single mbuf buffer, the
     # used block size must be at least 297 byte (251 data + 48 overhead)
-    CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE="(MYNEWT_VAL_BLE_L2CAP_COC_MPS + 48)"
+    CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE='(MYNEWT_VAL_BLE_L2CAP_COC_MPS + 48)'
   endif
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Using double quotes can cause issues when the final cmake command is called, and you end up with un-escaped nested double quotes.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
