### PR TITLE
sock_dtls: make sock_dtls-header includeable without `sock_dtls` module

### DIFF
--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -998,7 +998,9 @@ static inline ssize_t sock_dtls_send(sock_dtls_t *sock,
  */
 void sock_dtls_close(sock_dtls_t *sock);
 
+#ifdef MODULE_SOCK_DTLS
 #include "sock_dtls_types.h"
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Currently, using optional DTLS code, requires a lot of preprocessor-foobar. With this change, it should be possible to use more C-conditionals instead.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
E.g. `make -C examples/gcoap -j` compiles with the following patch

```patch
diff --git a/sys/include/net/gcoap.h b/sys/include/net/gcoap.h
index 92006c045a..c54b225c3a 100644
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -403,5 +403,3 @@
 #include "net/sock/udp.h"
-#if IS_USED(MODULE_GCOAP_DTLS)
 #include "net/sock/dtls.h"
-#endif
 #include "net/nanocoap.h"
```

On the flip-side, apps that use `sock_dtls` should also still compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/18378#issuecomment-1197995428
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
