### PR TITLE
tests/ieee802154_*: fix tx_done handler on ACK_TIMEOUT and improve tests

### DIFF
--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -14,6 +14,7 @@
  * @brief       Test application for IEEE 802.15.4 Radio HAL
  *
  * @author      José I. Alamos <jose.alamos@haw-hamburg.de>
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  *
  * @}
  */
@@ -329,7 +330,7 @@ static int _init(void)
 uint8_t payload[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ornare lacinia mi elementum interdum ligula.";
 
 static int send(uint8_t *dst, size_t dst_len,
-                size_t len)
+                size_t len, bool ack_req)
 {
     uint8_t flags;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
@@ -342,7 +343,7 @@ static int send(uint8_t *dst, size_t dst_len,
         .iol_next = NULL,
     };
 
-    flags = IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_ACK_REQ;
+    flags = IEEE802154_FCF_TYPE_DATA | (ack_req ? IEEE802154_FCF_ACK_REQ : 0);
 
     src_pan = byteorder_btols(byteorder_htons(CONFIG_IEEE802154_DEFAULT_PANID));
     dst_pan = byteorder_btols(byteorder_htons(CONFIG_IEEE802154_DEFAULT_PANID));
@@ -429,9 +430,10 @@ int txtsnd(int argc, char **argv)
     uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
     size_t len;
     size_t res;
+    bool ack_req = false;
 
-    if (argc != 3) {
-        puts("Usage: txtsnd <ext_addr> <len>");
+    if (argc != 3 && !(argc == 4 && strcmp(argv[3], "ackreq") == 0)) {
+        puts("Usage: txtsnd <long_addr> <len> [ackreq]");
         return 1;
     }
 
@@ -441,7 +443,11 @@ int txtsnd(int argc, char **argv)
         return 1;
     }
     len = atoi(argv[2]);
-    return send(addr, res, len);
+
+    if (argc == 4) {
+        ack_req = true;
+    }
+    return send(addr, res, len, ack_req);
 }
 
 static int promisc(int argc, char **argv)

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -181,9 +181,9 @@ static void _tx_finish_handler(event_t *event)
     /* The TX_DONE event indicates it's safe to call the confirm counterpart */
     expect(ieee802154_radio_confirm_transmit(&_radio[0], &tx_info) >= 0);
 
+    ieee802154_radio_set_rx(&_radio[0]);
     if (!ieee802154_radio_has_irq_ack_timeout(&_radio[0]) && !ieee802154_radio_has_frame_retrans(&_radio[0])) {
         /* This is just to show how the MAC layer would handle ACKs... */
-        ieee802154_radio_set_rx(&_radio[0]);
         xtimer_set(&timer_ack, ACK_TIMEOUT_TIME);
     }
 

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -338,7 +338,7 @@ static void submac_rx_done(ieee802154_submac_t *submac)
     printf("%u, ", (unsigned)((buffer[1] & IEEE802154_FCF_VERS_MASK) >> 4));
     printf("Seq.: %u\n", (unsigned)ieee802154_get_seq(buffer));
     od_hex_dump(buffer + mhr_len, data_len - mhr_len, 0);
-    printf("txt: ");
+    printf("txt (%u chars): ", data_len - mhr_len);
     for (int i = mhr_len; i < data_len; i++) {
         if ((buffer[i] > 0x1F) && (buffer[i] < 0x80)) {
             putchar((char)buffer[i]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR takes over original work by @MichelRottleuthner and does essentially 3 things:
1. It fixes a missing call to `ieee802154_set_rx` on TX_DONE if the radio supports ACK_TIMEOUT or FRAME_RETRANS.
2. It adds support for ACK_REQ flag in `tests/ieee802154_hal`
3. It indicates the received packet length in `tests/ieee802154_submac`
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
1. Make sure `tests/ieee802154_hal` works as expected and try sending messages with and without ACK_REQ:
```
txtsnd <ext_addr> <len> ack_req
txtsnd <ext_addr> <len>
```
3. Make sure `tests/ieee802154_submac` works as expected and displays the received packet length.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far, but it will be required for the KW2xRF Radio HAL port
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
