### PR TITLE
dist/tools/edbg: bump version (and update SAML11 documentation)

### DIFF
--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -94,6 +94,8 @@ static const uart_conf_t uart_config[] = {
         .gclk_src = SAM0_GCLK_MAIN,
     },
     {    /* EXT1 */
+        /* For SAML11, see boards/saml11/doc.txt
+         * to properly enable this SERCOM */
         .dev      = &SERCOM1->USART,
         .rx_pin   = GPIO_PIN(PA, 9),
         .tx_pin   = GPIO_PIN(PA, 8),

--- a/boards/saml11-xpro/doc.txt
+++ b/boards/saml11-xpro/doc.txt
@@ -68,6 +68,17 @@ Connect the device to your Micro-USB cable.
 
 The standard method for flashing RIOT to the saml11-xpro is using EDBG.
 
+## Special case
+
+SERCOM1 (available on EXT1 connector) needs an extra step to be usable.
+By default, this SERCOM is only available in the secure world. As RIOT
+doesn't support it for now, the only option, to use it, is to enable
+SERCOM non-secure mode. To do so, a fuse bit must be set in User ROW
+flash memory. Such action can be done with the following EDBG command:
+'edbg -t saml11 -F w0,194,1'
+or pass it as argument when calling make:
+EDBG_ARGS="-F w0,194,1" BOARD=saml11-xpro make flash term -C tests/periph_uart
+
 ## Supported Toolchains
 
 For using the saml11-xpro board we strongly recommend the usage of the

--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=e2cd361327253808f130359e2f23fa50ef44dc63
+PKG_VERSION=42f1ed86c7094a405650dc8bd04ba2a79c399623
 PKG_LICENSE=BSD-3-Clause
 
 # manually set some RIOT env vars, so this Makefile can be called stand-alone


### PR DESCRIPTION
### Contribution description

This PR updates EDBG version to its lastest master. It contains a fix needed by SAML11 so we can properly set fuses in User ROW memory.
Also update SAML11 board documentation: In order to use SERCOM1 on EXT1 connector. A special fuse bit must be set to enable non-secure operation on this SERCOM (As RIOT doesn't support the secure world of the SAML11 yet).


### Testing procedure
Enable SERCOM1 non-secure mode using EDBG and try to use SERCOM1 with `tests/periph_uart`
`EDBG_ARGS="-F w0,194,1" BOARD=saml11-xpro make flash term -C tests/periph_uart`



### Issues/PRs references
Fixes #17206 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
