### PR TITLE
dist/tools/esptools: add macOS support to install/export scripts

### DIFF
--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -5,17 +5,6 @@ ESP32_GCC_VERSION_DIR="8.4.0"
 
 ESP32_OPENOCD_VERSION="v0.11.0-esp32-20211220"
 
-# qemu version depends on the version of ncurses lib
-if [ "$(ldconfig -p | grep libncursesw.so.6)" != "" ]; then
-    ESP32_QEMU_VERSION="esp-develop-20220203"
-else
-    ESP32_QEMU_VERSION="esp-develop-20210220"
-fi
-
-if [ -z ${IDF_TOOLS_PATH} ]; then
-    IDF_TOOLS_PATH=${HOME}/.espressif
-fi
-
 TOOLS_PATH=${IDF_TOOLS_PATH}/tools
 
 export_arch()
@@ -61,6 +50,17 @@ export_openocd()
 
 export_qemu()
 {
+    # qemu version depends on the version of ncurses lib
+    if [ "$(ldconfig -p | grep libncursesw.so.6)" != "" ]; then
+        ESP32_QEMU_VERSION="esp-develop-20220203"
+    else
+        ESP32_QEMU_VERSION="esp-develop-20210220"
+    fi
+
+    if [ -z ${IDF_TOOLS_PATH} ]; then
+        IDF_TOOLS_PATH=${HOME}/.espressif
+    fi
+
     TOOLS_DIR=${TOOLS_PATH}/qemu-esp32/${ESP32_QEMU_VERSION}/qemu
     TOOLS_DIR_IN_PATH=`echo $PATH | grep ${TOOLS_DIR}`
 

--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -50,6 +50,22 @@ export_openocd()
 
 export_qemu()
 {
+    # determine the platform using python
+    PLATFORM_SYSTEM=$(python3 -c "import platform; print(platform.system())")
+    PLATFORM_MACHINE=$(python3 -c "import platform; print(platform.machine())")
+    PLATFORM=${PLATFORM_SYSTEM}-${PLATFORM_MACHINE}
+
+    # map different platform names to a unique OS name
+    case ${PLATFORM} in
+        linux-amd64|linux64|Linux-x86_64|FreeBSD-amd64)
+            OS=linux-amd64
+            ;;
+        *)
+            echo "error: OS architecture ${PLATFORM} not supported"
+            exit 1
+            ;;
+    esac
+
     # qemu version depends on the version of ncurses lib
     if [ "$(ldconfig -p | grep libncursesw.so.6)" != "" ]; then
         ESP32_QEMU_VERSION="esp-develop-20220203"

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -7,13 +7,6 @@ ESP32_GCC_VERSION_DOWNLOAD="gcc8_4_0"
 ESP32_OPENOCD_VERSION="v0.11.0-esp32-20211220"
 ESP32_OPENOCD_VERSION_TGZ="0.11.0-esp32-20211220"
 
-# qemu version depends on the version of ncurses lib
-if [ "$(ldconfig -p | grep libncursesw.so.6)" != "" ]; then
-    ESP32_QEMU_VERSION="esp-develop-20220203"
-else
-    ESP32_QEMU_VERSION="esp-develop-20210220"
-fi
-
 # set the tool path to the default if not already set
 if [ -z ${IDF_TOOLS_PATH} ]; then
     IDF_TOOLS_PATH=${HOME}/.espressif
@@ -133,6 +126,13 @@ install_qemu()
     if [ ${OS} != "linux-amd64" ]; then
         echo "error: QEMU for ESP32 does not support OS ${OS}"
         exit 1
+    fi
+
+    # qemu version depends on the version of ncurses lib
+    if [ "$(ldconfig -p | grep libncursesw.so.6)" != "" ]; then
+        ESP32_QEMU_VERSION="esp-develop-20220203"
+    else
+        ESP32_QEMU_VERSION="esp-develop-20210220"
     fi
 
     TOOLS_DIR=${TOOLS_PATH}/qemu-esp32/${ESP32_QEMU_VERSION}

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -52,6 +52,9 @@ case ${PLATFORM} in
     linux-i686|linux32|Linux-i686|FreeBSD-i386)
         OS=linux-i686
         ;;
+    Darwin-x86_64)
+        OS=macos
+        ;;
     *)
         echo "error: OS architecture ${PLATFORM} not supported"
         exit 1


### PR DESCRIPTION
### Contribution description

This PR provides the folling changes in `dist/tools/esptools/{install,export}.sh` to support macOS:
- Since macOS doesn't have `ldconfig` command, the test for `libncursesw.so` version using the `ldconfig` command is moved to function `install_qemu`.
- Since the only platform support by `qemu-esp32` is `linux-amd64`, a platform test is added to the `export_qemu` function.
- Platform `Darwin-x86_64` added to the installation script.

The problem was found in https://forum.riot-os.org/t/esp32-undefined-reference-to-esp-mesh-is-scan-allowed/3680

Please note: I don't know whether the changes really work on macOS because of missing hardware.

### Testing procedure

- `dist/tools/esptools/{install,export}.sh all` should work as before on Linux.
- `dist/tools/esptools/{install,export}.sh all` should now work on macOS as well.

### Issues/PRs references

