### PR TITLE
rust: Bring lock files in sync with toml files

### DIFF
--- a/examples/rust-gcoap/Cargo.lock
+++ b/examples/rust-gcoap/Cargo.lock
@@ -660,7 +660,12 @@ dependencies = [
  "coap-message-demos",
  "riot-coap-handler-demos",
  "riot-wrappers",
+ "rust_riotmodules",
 ]
+
+[[package]]
+name = "rust_riotmodules"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-hash"

--- a/examples/rust-hello-world/Cargo.lock
+++ b/examples/rust-hello-world/Cargo.lock
@@ -536,7 +536,12 @@ name = "rust-hello-world"
 version = "0.1.0"
 dependencies = [
  "riot-wrappers",
+ "rust_riotmodules",
 ]
+
+[[package]]
+name = "rust_riotmodules"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-hash"

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -493,7 +493,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.7.22"
+version = "0.7.23"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#db9d163e3eddcb7154edcf25db7207e4123964ee"
 dependencies = [
  "bare-metal 1.0.0",
  "cstr_core",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -536,7 +536,12 @@ name = "rust-minimal"
 version = "0.1.0"
 dependencies = [
  "riot-wrappers",
+ "rust_riotmodules",
 ]
+
+[[package]]
+name = "rust_riotmodules"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-hash"


### PR DESCRIPTION
The riotmodules dependency was missed in bc8ec6d5, and while generally
it does not severly harm builds, it does harm builds riotdocker CI where
branches are switched, which is blocked by dirty files in the checkout.

The riot-wrappers version was missed when what is now 5e75f4bd was
rebased onto fdc4e11a.

### Testing procedure

* Green CI
* Building anything (eg `riot-hello-world) locally does not result in a dirty checkout after building. (CI doesn't check for that, but riotdocker CI does).

### Issues/PRs references

Unblocks: https://github.com/RIOT-OS/riotdocker/pull/200 (or any other CI update, really)