### PR TITLE
sys/shell: improve 'ncget' command

### DIFF
--- a/sys/shell/commands/sc_nanocoap_vfs.c
+++ b/sys/shell/commands/sc_nanocoap_vfs.c
@@ -121,7 +121,16 @@ static int _nanocoap_get_handler(int argc, char **argv)
         }
         dst = buffer;
     } else {
+        char *filename = strrchr(url, '/');
         dst = argv[2];
+        if (_is_dir(dst) && filename) {
+            if (snprintf(buffer, sizeof(buffer), "%s%s",
+                         dst, filename + 1) >= (int)sizeof(buffer)) {
+                printf("Output file path too long\n");
+                return -ENOBUFS;
+            }
+            dst = buffer;
+        }
     }
 
     /* alternatively write the file to stdout */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently the `ncget` command always requires to specify the full destination path (including destination filename).
Allow to specify only the destination directory and concatenate the filename automatically from the source URL.



### Testing procedure

```
2022-08-01 17:05:27,664 - INFO # > ncget coap://[2001:1438:400c:7710:ab73:e659:68de:da87]/ict_concentrator-v3-12_fw1.bin /sd0/fw/

2022-08-01 17:05:42,296 - INFO # Saved as /sd0/fw/ict_concentrator-v3-12_fw1.bin
``` 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
