### PR TITLE
cpu/esp: fix netdev register

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -458,6 +458,8 @@ void esp_eth_setup(esp_eth_netdev_t* dev)
     _esp_eth_dev.link_up = false;
     _esp_eth_dev.rx_len = 0;
     _esp_eth_dev.tx_len = 0;
+
+    netdev_register(&dev->netdev, NETDEV_ESP_ETH, 0);
 }
 
 #endif /* MODULE_ESP_ETH */

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -983,6 +983,8 @@ void esp_wifi_setup (esp_wifi_netdev_t* dev)
     dev->event_disc = 0;
     dev->connected = false;
 #endif /* MODULE_ESP_WIFI_AP */
+
+    netdev_register(&dev->netdev, NETDEV_ESP_WIFI, 0);
 }
 
 #endif /* MODULE_ESP_WIFI */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -329,6 +329,7 @@ typedef enum {
     NETDEV_ENCX24J600,
     NETDEV_ATWINC15X0,
     NETDEV_KW2XRF,
+    NETDEV_ESP_ETH,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -330,6 +330,7 @@ typedef enum {
     NETDEV_ATWINC15X0,
     NETDEV_KW2XRF,
     NETDEV_ESP_ETH,
+    NETDEV_ESP_WIFI,
     /* add more if needed */
 } netdev_type_t;
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR fixes missing netdev types and registration for `esp_wifi` and `esp_eth` and `tests/driver_esp_eth`.

In investigating why the nightlies have been failing since merging PR #17739, I found that `tests/driver_esp_eth` in `event_post` crashes when called here https://github.com/RIOT-OS/RIOT/blob/24ff493d048d4f511fd198ec022b32157d054ef6/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c#L71-L77 because `dev->context` is not set. The reason is that `NETDEV_ESP_ETH` was not defined and `netdev_register` is not called during setup in `esp_eth` driver.

This PR
- adds `NETDEV_ESP_ETH` and `NETDEV_ESP_WIFI`
- calls `netdev_register` in setup of `esp_eth` and `esp_wifi`

This PR **might need a backport** to 2022.07.

BTW, a fix for the compilation problem in nightlies will be provided once this PR is merged.

### Testing procedure

Use any ESP32 Ethernet capable board, for example:
```
BOARD=esp32-olimex-evb make -j8 -C tests/driver_esp_eth flash test
```
Without this PR, the test crashes with an assertion in `event_post`. With this PR, the test works.

### Issues/PRs references

