### PR TITLE
boards/nucleo-f767zi: add PWM config

### DIFF
--- a/boards/nucleo-f767zi/Kconfig
+++ b/boards/nucleo-f767zi/Kconfig
@@ -16,20 +16,21 @@ config BOARD_NUCLEO_F767ZI
 
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_CAN
     select HAS_PERIPH_DMA
+    select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_PTP
+    select HAS_PERIPH_PTP_SPEED_ADJUSTMENT
+    select HAS_PERIPH_PTP_TIMER
+    select HAS_PERIPH_PTP_TXRX_TIMESTAMPS
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
-    select HAS_PERIPH_ETH
-    select HAS_PERIPH_PTP
-    select HAS_PERIPH_PTP_SPEED_ADJUSTMENT
-    select HAS_PERIPH_PTP_TIMER
-    select HAS_PERIPH_PTP_TXRX_TIMESTAMPS
-    select HAS_PERIPH_CAN
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f767zi
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c
@@ -10,13 +11,13 @@ FEATURES_PROVIDED += periph_ptp
 FEATURES_PROVIDED += periph_ptp_speed_adjustment
 FEATURES_PROVIDED += periph_ptp_timer
 FEATURES_PROVIDED += periph_ptp_txrx_timestamps
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
-FEATURES_PROVIDED += periph_can
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -211,6 +211,42 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
+/**
+ * @name    PWM configuration
+ * @{
+ */
+/**
+ * @brief   Actual PWM configuration
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6  CN10-4  */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5  CN10-6  */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3  CN10-10 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_E, 14) /* D38 CN10-28 */, .cc_chan = 3} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 12) /* D29 CN10-21 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_D, 13) /* D28 CN10-19 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_D, 14) /* D10  CN7-16 */, .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_D, 15) /* D9   CN7-18 */, .cc_chan = 3} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+};
+
+/**
+ * @brief   Number of PWM devices
+ */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

This is a verbatim copy of the PWM config of `boards/nucleo-f746zg`. However, those boards are almost identical. I successfully tested the configuration via https://github.com/RIOT-OS/RIOT/pull/18392

### Testing procedure

E.g. using `tests/periph_pwm` or any driver than uses PWM, such as https://github.com/RIOT-OS/RIOT/pull/18392

But to be honest, the F746ZG is a "subset" of the F767ZI MCU. So everything working on the F746ZG should just work on the F767ZI.

### Issues/PRs references

None