### PR TITLE
cpu/esp32: fix provided features and Kconfig for esp_eth

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -34,6 +34,7 @@ derfmega128
 dwm1001
 esp32-ci
 esp32-heltec-lora32-v2
+esp32-olimex-evb
 esp8266-ci
 esp8266-esp-12x
 hamilton

--- a/boards/esp32-ethernet-kit-v1_0/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_0/Kconfig
@@ -13,13 +13,11 @@ config BOARD_ESP32_ETHERNET_KIT_V1_0
     default y
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROVER_B
+    select HAS_ESP_ETH
     select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
-    select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI if !MODULE_ESP_JTAG
-
-    select HAVE_ESP_ETH
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.features
@@ -4,8 +4,8 @@ CPU_MODEL = esp32-wrover
 include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board
+FEATURES_PROVIDED += esp_eth
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 

--- a/boards/esp32-ethernet-kit-v1_1/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_1/Kconfig
@@ -13,9 +13,9 @@ config BOARD_ESP32_ETHERNET_KIT_V1_1
     default y
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROVER_B
+    select HAS_ESP_ETH
     select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
-    select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI if !MODULE_ESP_JTAG

--- a/boards/esp32-ethernet-kit-v1_2/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_2/Kconfig
@@ -13,9 +13,9 @@ config BOARD_ESP32_ETHERNET_KIT_V1_2
     default y
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROVER_E
+    select HAS_ESP_ETH
     select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
-    select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI if !MODULE_ESP_JTAG

--- a/boards/esp32-olimex-evb/Kconfig
+++ b/boards/esp32-olimex-evb/Kconfig
@@ -13,14 +13,12 @@ config BOARD_ESP32_OLIMEX_EVB
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROOM_32
     select HAS_ARDUINO
+    select HAS_ESP_ETH
     select HAS_PERIPH_ADC if USEMODULE_OLIMEX_ESP32_GATEWAY
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI
-    select HAS_PERIPH_ETH
     select HAS_PERIPH_CAN
     select HAS_PERIPH_IR
-
-    select HAVE_ESP_ETH
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -12,7 +12,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 
 # unique features of the board
-FEATURES_PROVIDED += periph_eth     # Ethernet MAC (EMAC)
+FEATURES_PROVIDED += esp_eth        # Ethernet MAC (EMAC)
 FEATURES_PROVIDED += periph_can     # CAN peripheral interface
 FEATURES_PROVIDED += periph_ir      # IR peripheral interface
 

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -18,13 +18,13 @@ ifneq (,$(filter cpp,$(USEMODULE)))
 endif
 
 ifneq (,$(filter esp_eth,$(USEMODULE)))
+  FEATURES_REQUIRED += esp_eth
   USEMODULE += esp_idf_eth
   USEMODULE += esp_idf_event
   USEMODULE += esp_idf_gpio
   USEMODULE += esp_idf_spi_flash
   USEMODULE += netdev_eth
   USEMODULE += netopt
-  FEATURES_REQUIRED += periph_eth
   USEMODULE += ztimer_msec
 endif
 

--- a/cpu/esp32/esp-eth/Kconfig
+++ b/cpu/esp32/esp-eth/Kconfig
@@ -11,7 +11,8 @@ config MODULE_ESP_ETH
     depends on CPU_FAM_ESP32
     depends on HAS_ESP_ETH
     select MODULE_ESP_IDF_ETH
-    select MODULE_ESP_IDF_ETH_PHY
+    select MODULE_ESP_IDF_EVENT
+    select MODULE_ESP_IDF_SPI_FLASH
     select MODULE_NETDEV_ETH
     select MODULE_NETOPT
     select MODULE_ZTIMER

--- a/cpu/esp32/esp-eth/Kconfig
+++ b/cpu/esp32/esp-eth/Kconfig
@@ -9,8 +9,7 @@ config MODULE_ESP_ETH
     bool "ESP32 Ethernet device"
     depends on TEST_KCONFIG
     depends on CPU_FAM_ESP32
-    depends on HAS_PERIPH_ETH
-    select MODULE_ESP_FREERTOS
+    depends on HAS_ESP_ETH
     select MODULE_ESP_IDF_ETH
     select MODULE_ESP_IDF_ETH_PHY
     select MODULE_NETDEV_ETH
@@ -18,7 +17,7 @@ config MODULE_ESP_ETH
     select MODULE_ZTIMER
     select MODULE_ZTIMER_MSEC
 
-config HAVE_ESP_ETH
+config HAS_ESP_ETH
     bool
     select MODULE_ESP_ETH if MODULE_NETDEV_DEFAULT
     help

--- a/tests/driver_esp_eth/Kconfig
+++ b/tests/driver_esp_eth/Kconfig
@@ -9,4 +9,4 @@ config APPLICATION
     bool
     default y
     depends on HAS_ARCH_ESP32
-    depends on HAS_PERIPH_ETH
+    depends on HAS_ESP_ETH

--- a/tests/driver_esp_eth/Makefile
+++ b/tests/driver_esp_eth/Makefile
@@ -7,7 +7,6 @@ USEMODULE += test_utils_netdev_eth_minimal
 # the driver to test
 USEMODULE += esp_eth
 FEATURES_REQUIRED += arch_esp32
-FEATURES_REQUIRED += periph_eth
 
 INCLUDES += -I$(APPDIR)
 


### PR DESCRIPTION
### Contribution description

This PR fixes Kconfig problems for `esp_eth` introduced with PR #17739.

In `Makefiles.features`, `periph_eth` was defined as provided feature without having a peripheral driver implementation for the ETH interface  in `cpu/esp32/periph`. Instead, the `esp_eth` netdev driver directly uses the ESP-IDF Ethernet API. This caused compilation problems with Kconfig. Therefore the required feature `periph_eth` is replaced by the feature `esp_eth` and `HAS_PERIPH_ETH` is replaced by `HAS_ESP_ETH` in Kconfig.

Furthermore, the selection of modules in Kconfig was not correct if the module `esp_eth` was used. The reason for this is that the dependencies of modules have changed with the migration to ESP-IDF 4.4.

Since no board with the feature `esp_eth` was compiled with `TEST_KCONFIG=1`, the problems were not detected by the CI compilation and was only found when investigating the reasons for the failure of the nightly builds. Therefore, `esp32-olimex-evb` in `.murdock` is set to `TEST_KCONFIG_BOARDS_AVAILABLE`.

### Testing procedure

Use command
```
TEST_KCONFIG=1 BOARD=esp32-olimex-evb make -j8 -C tests/driver_esp_eth
``` 
to compile. Wihtout this PR, the compilation fails.

### Issues/PRs references
