### PR TITLE
drivers/mtd: fix module name for mtd_sdcard in Kconfig

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -25,9 +25,9 @@ config HAVE_MTD_NATIVE
     help
         Indicates that a native MTD is present.
 
-config HAVE_MTD_SD_SCARD
+config HAVE_MTD_SDCARD
     bool
-    imply MODULE_MTD_SD_CARD if MODULE_MTD
+    imply MODULE_MTD_SDCARD if MODULE_MTD
     help
         Indicates that a sdcard MTD is present
 


### PR DESCRIPTION
### Contribution description

This PR fixes the module name in `drivers/mtd/Kconfig` for module `mtd_sdcard`.

The used module is called `mtd_sdcard`. Dependencies in Kconfig has to use same name for the module and should use the name for the feature. Therefore,
- `HAVE_MTD_SD_CARD` is changed to `HAVE_MTD_SDCARD` and
-  `MODULE_MTD_SD_CARD` is changed to `MODULE_MTD_SDCARD`.

### Testing procedure

Green CI

### Issues/PRs references
