### PR TITLE
sys/net: fix typo in docs

### DIFF
--- a/sys/net/ieee802154.txt
+++ b/sys/net/ieee802154.txt
@@ -33,7 +33,7 @@
  * their radios powered down. Some operation modes support channel hopping to avoid
  * frequencies used by others. Common variations are:
  *
- * * nonbeacon-eanbled: devices send whenever they want; beacons are only sent
+ * * nonbeacon-enabled: devices send whenever they want; beacons are only sent
  *   when devices ask for them in order to join the network. Optionally,
  *   packets can be held until the device asks for them ("indirect
  *   transmission").


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fixed a typo in the IEEE 802.15.4 docs.
```eanbled -> enabled```

(am I being helpful yet ?)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
