### PR TITLE
cpu/esp32: extend GPIO wake-up from deep sleep

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1235,14 +1235,24 @@ ESP_PM_WUP_UART1 | disabled                 | Light | Positive UART1 RxD signal 
 - If `ESP_PM_GPIO_HOLD` is defined, GPIOs hold their last output level
   when entering _Deep-sleep_ mode. Please note that only RTC GPIOs
   can hold their output value in _Deep-sleep_ mode.
+  When restarting after a deep sleep, the GPIOs are reset to their default
+  configuration, which is usually the input-only mode. This means that the
+  output level of the GPIOs in output mode may change for up to 150 ms until
+  the GPIOs are reconfigured by the application in output mode. If a continuous
+  output level for such GPIOs is important, external pullups/pulldowns should
+  be used for these GPIOs to pull them to a specific level during deep sleep
+  and restart instead of defining `ESP_PM_GPIO_HOLD`.
 - `ESP_PM_WUP_PINS` specifies either a single RTC GPIO or a comma separated
   list of RTC GPIOs that are used as wake-up source in _Deep-sleep_ mode.
 - `ESP_PM_WUP_LEVEL` specifies the level for the wake-up pins in _Deep-sleep_
   mode:
   - `ESP_PM_WUP_PINS_ANY_HIGH` (default) - The system is woken up when any of
      the GPIOs specified in `ESP_PM_WUP_PINS` becomes HIGH.
+  - `ESP_PM_WUP_PINS_ANY_LOW` - The system is woken up when any of
+     the GPIOs specified in `ESP_PM_WUP_PINS` becomes LOW
+     (only available with the ESP32-C3 variant).
   - `ESP_PM_WUP_PINS_ALL_LOW` - The system is woken up when all GPIOs specified
-    in `ESP_PM_WUP_PINS` become LOW.
+    in `ESP_PM_WUP_PINS` become LOW (not available with the ESP32-C3 variant).
 - `ESP_PM_WUP_UART0` and `ESP_PM_WUP_UART1` define the number of positive
   edges of the RxD signal of the respective UART that are necessary to wake
   up the system in the _Light-sleep_ mode. The value must be greater than 2,

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -54,11 +54,24 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#if SOC_PM_SUPPORT_EXT_WAKEUP
 #define ESP_PM_WUP_PINS_ANY_HIGH    ESP_EXT1_WAKEUP_ANY_HIGH
 #define ESP_PM_WUP_PINS_ALL_LOW     ESP_EXT1_WAKEUP_ALL_LOW
+#define ESP_PM_WUP_PINS_ANY_LOW     -1
+#endif
+
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+#define ESP_PM_WUP_PINS_ANY_HIGH    ESP_GPIO_WAKEUP_GPIO_HIGH
+#define ESP_PM_WUP_PINS_ANY_LOW     ESP_GPIO_WAKEUP_GPIO_LOW
+#define ESP_PM_WUP_PINS_ALL_LOW     -1
+#endif
 
 #ifndef ESP_PM_WUP_LEVEL
 #define ESP_PM_WUP_LEVEL            ESP_PM_WUP_PINS_ANY_HIGH
+#endif
+
+#if ESP_PM_WUP_LEVEL == -1
+#error "ESP32x SoC does not support this ESP_PM_WUP_LEVEL"
 #endif
 
 #define GPIO_PRO_CPU_INTR_ENA       (BIT(2))
@@ -452,7 +465,15 @@ void gpio_pm_sleep_enter(unsigned mode)
             }
 #endif /* SOC_RTCIO_INPUT_OUTPUT_SUPPORTED */
         }
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+        /* ESP_PM_WUP_PINS_ANY_LOW or ESP_PM_WUP_PINS_ANY_HIGH */
+        esp_deep_sleep_enable_gpio_wakeup(wup_pin_mask, ESP_PM_WUP_LEVEL);
+#elif SOC_PM_SUPPORT_EXT_WAKEUP
+        /* ESP_PM_WUP_PINS_ALL_LOW or ESP_PM_WUP_PINS_ANY_HIGH */
         esp_sleep_enable_ext1_wakeup(wup_pin_mask, ESP_PM_WUP_LEVEL);
+#else
+        #error "ESP32x SoC variant doesn't allow to define GPIOs for wake-up from deep sleep"
+#endif
 #endif /* ESP_PM_WUP_PINS */
     }
     else {


### PR DESCRIPTION
### Contribution description

This PR extends the GPIO wake-up logic from deep sleep.

Depending on SoC capabilities, ESP32x SoC variants support different logical combinations of GPIO levels to wake-up from deep sleep. This change is necessary for example necessary to use GPIOs for waking up ESP32-C3 from deep sleep.

### Testing procedure

Without this PR, the compilation for all `ESP_PM_WUP_LEVEL` values:
```
CFLAGS='-DESP_PM_WUP_PINS=GPIO8 -DESP_PM_WUP_LEVEL=ESP_PM_WUP_PINS_ANY_HIGH \
        -DESP_PM_WUP_UART0=6 -DESP_PM_GPIO_HOLD' make BOARD=esp32c3-devkit -C tests/periph_pm
```
fail with `implicit declaration of function 'esp_sleep_enable_ext1_wakeup'`

With this PR
```
CFLAGS='-DESP_PM_WUP_PINS=GPIO8 -DESP_PM_WUP_LEVEL=ESP_PM_WUP_PINS_ANY_HIGH \
        -DESP_PM_WUP_UART0=6 -DESP_PM_GPIO_HOLD' make BOARD=esp32c3-devkit -C tests/periph_pm
```
and
```
CFLAGS='-DESP_PM_WUP_PINS=GPIO8 -DESP_PM_WUP_LEVEL=ESP_PM_WUP_PINS_ANY_LOW \
        -DESP_PM_WUP_UART0=6 -DESP_PM_GPIO_HOLD' make BOARD=esp32c3-devkit -C tests/periph_pm
```
compile successful.
```
CFLAGS='-DESP_PM_WUP_PINS=GPIO8 -DESP_PM_WUP_LEVEL=ESP_PM_WUP_PINS_ALL_LOW \
        -DESP_PM_WUP_UART0=6 -DESP_PM_GPIO_HOLD' make BOARD=esp32c3-devkit -C tests/periph_pm
```
give the error message `ESP32x SoC does not support this ESP_PM_WUP_LEVEL`.

### Issues/PRs references
