### PR TITLE
cpu/esp32: add linker scripts for ESP32-S3

### DIFF
--- a/cpu/esp32/ld/esp32c3/sections.ld
+++ b/cpu/esp32/ld/esp32c3/sections.ld
@@ -223,7 +223,7 @@ SECTIONS
     *components/spi_flash/spi_flash_chip_winbond.*(.literal .literal.* .text .text.*)
     *components/spi_flash/*/spi_flash_rom_patch.*(.literal .literal.* .text .text.*)
     *components/spi_flash/spi_flash_timing_tuning.*(.literal .literal.* .text .text.*)
-    *components/spi_flash/spi_timing_config.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/*/spi_timing_config.*(.literal .literal.* .text .text.*)
 
     *components/riscv/interrupt.*(.literal .literal.* .text .text.*)
     *components/riscv/vectors.*(.literal .literal.* .text .text.*)
@@ -323,7 +323,7 @@ SECTIONS
     *components/spi_flash/spi_flash_chip_winbond.*(.rodata .rodata.*)
     *components/spi_flash/*/spi_flash_rom_patch.*(.rodata .rodata.*)
     *components/spi_flash/spi_flash_timing_tuning.*(.rodata .rodata.*)
-    *components/spi_flash/spi_timing_config.*(.rodata .rodata.*)
+    *components/spi_flash/*/spi_timing_config.*(.rodata .rodata.*)
 
     _data_end = ABSOLUTE(.);
     . = ALIGN(4);

--- a/cpu/esp32/ld/esp32s3/memory.ld
+++ b/cpu/esp32/ld/esp32s3/memory.ld
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ *                    ESP32-S3 Linker Script Memory Layout
+ * This file describes the memory layout (memory blocks) by virtual memory addresses.
+ * This linker script is passed through the C preprocessor to include configuration options.
+ * Please use preprocessor features sparingly!
+ * Restrict to simple macros with numeric values, and/or #if/#endif blocks.
+ */
+/*
+ * Automatically generated file. DO NOT EDIT.
+ * Espressif IoT Development Framework (ESP-IDF) Configuration Header
+ */
+
+/* List of deprecated options */
+/*
+ * SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* CPU instruction prefetch padding size for flash mmap scenario */
+_esp_flash_mmap_prefetch_pad_size = 16;
+/* CPU instruction prefetch padding size for memory protection scenario */
+_esp_memprot_prefetch_pad_size = 0;
+/* Memory alignment size for PMS */
+_esp_memprot_align_size = 0;
+/*
+ * 40370000 <- IRAM/Icache -> 40378000 <- D/IRAM (I) -> 403E0000
+ *                            3FC88000 <- D/IRAM (D) -> 3FCF0000 <- DRAM/DCache -> 3FD00000
+ *
+ * Startup code uses the IRAM from 0x403BA000 to 0x403E0000, which is not available for static
+ * memory, but can only be used after app starts.
+ *
+ * D cache use the memory from high address, so when it's configured to 16K/32K, the region
+ * 0x3FCF000 ~ (3FD00000 - DATA_CACHE_SIZE) should be available. This region is not used as
+ * static memory, leaving to the heap.
+ */
+MEMORY
+{
+  /**
+   *  All these values assume the flash cache is on, and have the blocks this uses subtracted from the length
+   *  of the various regions. The 'data access port' dram/drom regions map to the same iram/irom regions but
+   *  are connected to the data port of the CPU and eg allow byte-wise access.
+   */
+  /* IRAM for PRO CPU. */
+  iram0_0_seg (RX) : org = (0x40370000 + 0x4000), len = (((0x403BA000 - (0x40378000 - 0x3FC88000)) - 0x3FC88000) + 0x8000 - 0x4000)
+  /* Flash mapped instruction data */
+  iram0_2_seg (RX) : org = 0x42000020, len = 0x800000-0x20
+  /**
+   * (0x20 offset above is a convenience for the app binary image generation.
+   * Flash cache has 64KB pages. The .bin file which is flashed to the chip
+   * has a 0x18 byte file header, and each segment has a 0x08 byte segment
+   * header. Setting this offset makes it simple to meet the flash cache MMU's
+   * constraint that (paddr % 64KB == vaddr % 64KB).)
+   */
+  /**
+   * Shared data RAM, excluding memory reserved for ROM bss/data/stack.
+   * Enabling Bluetooth & Trace Memory features in menuconfig will decrease the amount of RAM available.
+   */
+  dram0_0_seg (RW) : org = (0x3FC88000), len = ((0x403BA000 - (0x40378000 - 0x3FC88000)) - 0x3FC88000)
+  /* Flash mapped constant data */
+  drom0_0_seg (R) : org = 0x3C000020, len = 0x800000-0x20
+  /* (See iram0_2_seg for meaning of 0x20 offset in the above.) */
+  /**
+   * RTC fast memory (executable). Persists over deep sleep.
+   */
+  rtc_iram_seg(RWX) : org = 0x600fe000, len = 0x2000 - 0
+  /**
+   * RTC fast memory (same block as above), viewed from data bus
+   */
+  rtc_data_seg(RW) : org = 0x600fe000, len = 0x2000 - 0
+  /**
+   * RTC slow memory (data accessible). Persists over deep sleep.
+   * Start of RTC slow memory is reserved for ULP co-processor code + data, if enabled.
+   */
+  rtc_slow_seg(RW) : org = 0x50000000 + 0,
+                                     len = 0x2000 - 0
+}
+_static_data_end = _bss_end;
+
+/**
+ * _heap_end = 0x40000000;
+ *
+ * NOTE:
+ * In RIOT, we suppose that
+ * - SRAM0 (0x4037_0000 ~ 0x4037_7FFF, 32 kByte) is completely used as ICache,
+ * - SRAM2 (0x3FCF_0000 ~ 0x3FCF_FFFF, 64 kByte) is completely used as DCache, and
+ * - SRAM1 (0x3FC8_0000 ~ 0x3FCE_FFFF and 0x4037_0000 ~ 0x4037_7FFF, 416 kByte)
+ *   addresses the same memory and is used as IRAM and DRAM.
+ * Therefore, we suppose _heap_end is at 0x3FCF_0000.
+ */
+_heap_end = 0x3FCF0000;
+/*_eheap = 0x3FCF0000; */
+
+_data_seg_org = ORIGIN(rtc_data_seg);
+REGION_ALIAS("rtc_data_location", rtc_slow_seg );
+REGION_ALIAS("default_code_seg", iram0_2_seg);
+REGION_ALIAS("default_rodata_seg", drom0_0_seg);
+/**
+ *  If rodata default segment is placed in `drom0_0_seg`, then flash's first rodata section must
+ *  also be first in the segment.
+ */
+/* TODO
+  ASSERT(_flash_rodata_dummy_start == ORIGIN(default_rodata_seg),
+         ".flash_rodata_dummy section must be placed at the beginning of the rodata segment.")
+*/

--- a/cpu/esp32/ld/esp32s3/sections.ld
+++ b/cpu/esp32/ld/esp32s3/sections.ld
@@ -1,23 +1,29 @@
 /* Automatically generated file; DO NOT EDIT */
 /* Espressif IoT Development Framework Linker Script */
-/* Generated from: esp-idf/components/esp_system/ld/esp32/sections.ld.in */
+/* Generated from: esp-idf/components/esp_system/ld/esp32s3/sections.ld.in */
 
 /*
  * SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/*  Default entry point:  */
+
+/* Default entry point */
 ENTRY(call_start_cpu0);
+
+_diram_i_start = 0x40378000;
 
 SECTIONS
 {
-  /* RTC fast memory holds RTC wake stub code,
-     including from any source file named rtc_wake_stub*.c
-  */
+  /**
+   * RTC fast memory holds RTC wake stub code,
+   * including from any source file named rtc_wake_stub*.c
+   */
   .rtc.text :
   {
     . = ALIGN(4);
+    _rtc_text_start = ABSOLUTE(.);
+    *(.rtc.entry.text)
 
     *(.rtc.literal .rtc.text .rtc.text.*)
 
@@ -25,10 +31,10 @@ SECTIONS
     _rtc_text_end = ABSOLUTE(.);
   } > rtc_iram_seg
 
-  /*
-    This section is required to skip rtc.text area because rtc_iram_seg and
-    rtc_data_seg are reflect the same address space on different buses.
-  */
+  /**
+   * This section is required to skip rtc.text area because rtc_iram_seg and
+   * rtc_data_seg are reflect the same address space on different buses.
+   */
   .rtc.dummy :
   {
     _rtc_dummy_start = ABSOLUTE(.);
@@ -37,10 +43,11 @@ SECTIONS
     _rtc_dummy_end = ABSOLUTE(.);
   } > rtc_data_seg
 
-  /* This section located in RTC FAST Memory area.
-     It holds data marked with RTC_FAST_ATTR attribute.
-     See the file "esp_attr.h" for more information.
-  */
+  /**
+   * This section located in RTC FAST Memory area.
+   * It holds data marked with RTC_FAST_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
   .rtc.force_fast :
   {
     . = ALIGN(4);
@@ -52,17 +59,17 @@ SECTIONS
 
     *(.rtc.force_fast .rtc.force_fast.*)
     . = ALIGN(4) ;
-
     _rtc_force_fast_end = ABSOLUTE(.);
   } > rtc_data_seg
 
-  /* RTC data section holds RTC wake stub
-     data/rodata, including from any source file
-     named rtc_wake_stub*.c and the data marked with
-     RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
-     The memory location of the data is dependent on
-     CONFIG_ESP32_RTCDATA_IN_FAST_MEM option.
-  */
+  /**
+   * RTC data section holds RTC wake stub
+   * data/rodata, including from any source file
+   * named rtc_wake_stub*.c and the data marked with
+   * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
+   * The memory location of the data is dependent on
+   * CONFIG_ESP32S3_RTCDATA_IN_FAST_MEM option.
+   */
   .rtc.data :
   {
     _rtc_data_start = ABSOLUTE(.);
@@ -75,7 +82,6 @@ SECTIONS
 
     *rtc_wake_stub*.*(.data .rodata .data.* .rodata.* .bss .bss.*)
     _rtc_data_end = ABSOLUTE(.);
-
   } > rtc_data_location
 
   /* RTC bss, from any source file named rtc_wake_stub*.c */
@@ -93,13 +99,13 @@ SECTIONS
     _rtc_bss_rtc_end = ABSOLUTE(.);
   } > rtc_data_location
 
-  /* This section holds data that should not be initialized at power up
-     and will be retained during deep sleep.
-     User data marked with RTC_NOINIT_ATTR will be placed
-     into this section. See the file "esp_attr.h" for more information.
-	 The memory location of the data is dependent on
-     CONFIG_ESP32_RTCDATA_IN_FAST_MEM option.
-  */
+  /**
+   * This section holds data that should not be initialized at power up
+   * and will be retained during deep sleep.
+   * User data marked with RTC_NOINIT_ATTR will be placed
+   * into this section. See the file "esp_attr.h" for more information.
+	 * The memory location of the data is dependent on CONFIG_ESP32S3_RTCDATA_IN_FAST_MEM option.
+   */
   .rtc_noinit (NOLOAD):
   {
     . = ALIGN(4);
@@ -109,10 +115,11 @@ SECTIONS
     _rtc_noinit_end = ABSOLUTE(.);
   } > rtc_data_location
 
-  /* This section located in RTC SLOW Memory area.
-     It holds data marked with RTC_SLOW_ATTR attribute.
-     See the file "esp_attr.h" for more information.
-  */
+  /**
+   * This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
   .rtc.force_slow :
   {
     . = ALIGN(4);
@@ -143,7 +150,6 @@ SECTIONS
     _iram_start = ABSOLUTE(.);
     /* Vectors go to IRAM */
     _vector_table = ABSOLUTE(.);
-    /* Vectors according to builds/RF-2015.2-win32/esp108_v1_2_s5_512int_2/config.html */
     . = 0x0;
     KEEP(*(.WindowVectors.text));
     . = 0x180;
@@ -174,16 +180,8 @@ SECTIONS
     *(.entry.text)
     *(.init.literal)
     *(.init)
-
     _init_end = ABSOLUTE(.);
   } > iram0_0_seg
-
-  /* If Bluetooth is not used, this DRAM section can be used as heap */
-  . = _data_start_btdm; /* 0x3ffae6e0 */
-  . = ALIGN (4);
-  _sheap1 = ABSOLUTE(.);
-  . = 0x3ffb0000;
-  _eheap1 = ABSOLUTE(.);
 
   .iram0.text :
   {
@@ -194,10 +192,9 @@ SECTIONS
 
     /* Xtensa basic functionality written in assembler should be placed in IRAM */
     *xtensa/*(.literal .text .literal.* .text.*)
-
     /* parts of RIOT that should run in IRAM */
+
     *core/*(.literal .text .literal.* .text.*)
-    *syscalls.*(.literal .text .literal.* .text.*)
     *esp_common_periph/flash.*(.literal .text .literal.* .text.*)
     *esp_common/thread_arch.*(.literal .text .literal.* .text.*)
     *esp_freertos_common/*(.literal .text .literal.* .text.*)
@@ -280,6 +277,15 @@ SECTIONS
 
   } > iram0_0_seg
 
+  /**
+   * This section is required to skip .iram0.text area because iram0_0_seg and
+   * dram0_0_seg reflect the same address space on different buses.
+   */
+  .dram0.dummy (NOLOAD):
+  {
+    . = ORIGIN(dram0_0_seg) + MAX(_iram_end - _diram_i_start, 0);
+  } > dram0_0_seg
+
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
@@ -303,8 +309,8 @@ SECTIONS
     _coredump_dram_start = ABSOLUTE(.);
     *(.dram1.coredump .dram1.coredump.*)
     _coredump_dram_end = ABSOLUTE(.);
-    *components/app_trace/app_trace.*(.rodata .rodata.*)
-    *components/app_trace/app_trace_util.*(.rodata .rodata.*)
+    *libapp_trace.a:app_trace.*(.rodata .rodata.*)
+    *libapp_trace.a:app_trace_util.*(.rodata .rodata.*)
     _bt_data_start = ABSOLUTE(.);
     *libbt.a:(.data .data.*)
     . = ALIGN(4);
@@ -370,22 +376,11 @@ SECTIONS
   } > dram0_0_seg
 
   /**
-   * This section holds data that won't be initialised when startup.
-   * This section locates in External RAM region.
+   * This section holds data that should not be initialized at power up.
+   * The section located in Internal SRAM memory region. The macro _NOINIT
+   * can be used as attribute to place data into this section.
+   * See the "esp_attr.h" file for more information.
    */
-  .ext_ram_noinit (NOLOAD) :
-  {
-    _ext_ram_noinit_start = ABSOLUTE(.);
-    *(.ext_ram_noinit*)
-    . = ALIGN(4);
-    _ext_ram_noinit_end = ABSOLUTE(.);
-  } > extern_ram_seg
-
-  /*This section holds data that should not be initialized at power up.
-    The section located in Internal SRAM memory region. The macro _NOINIT
-    can be used as attribute to place data into this section.
-    See the esp_attr.h file for more information.
-  */
   .noinit (NOLOAD):
   {
     . = ALIGN(4);
@@ -395,21 +390,12 @@ SECTIONS
     _noinit_end = ABSOLUTE(.);
   } > dram0_0_seg
 
-   /* external memory bss, from any global variable with EXT_RAM_ATTR attribute*/
-  .ext_ram.bss (NOLOAD) :
-  {
-    _ext_ram_bss_start = ABSOLUTE(.);
-
-
-    . = ALIGN(4);
-    _ext_ram_bss_end = ABSOLUTE(.);
-  } > extern_ram_seg
-
   /* Shared RAM */
   .dram0.bss (NOLOAD) :
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
+    *(.ext_ram.bss*)
 
     *(.bss .bss.*)
     *(.ext_ram.bss .ext_ram.bss.*)
@@ -428,109 +414,28 @@ SECTIONS
     . = ALIGN(4);
     _nimble_bss_end = ABSOLUTE(.);
 
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.share.mem)
+    *(.gnu.linkonce.b.*)
+
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
   } > dram0_0_seg
 
-  ASSERT(((_bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
-          "DRAM segment data does not fit.")
-
-  /* Reserved ROM/ETS data start at 0x3ffe000. */
-  . = 0x3ffe0000;
-  _heap_top = ABSOLUTE(.);
-  _eheap = ABSOLUTE(.);
-
-  /* Reserved ROM/ETS data region for PRO CPU: 0x3ffe0000 ... 0x3ffe440 */
-  . = 0x3ffe0440;
-  _sheap2 = ABSOLUTE(.);
-  . = 0x3ffe4000;
-  _eheap2 = ABSOLUTE(.);
-
-  /* Reserved ROM/ETS data region for APP CPU: 0x3ffe4000 ... 0x3ffe4350 */
-  . = 0x3ffe4350;
-  _sheap3 = ABSOLUTE(.);
-  . = 0x40000000;
-  _eheap3 = ABSOLUTE(.);
-
-  _rodata_start = ABSOLUTE(.);
-  .flash.rodata : ALIGN(0x10)
-  {
-    _flash_rodata_start = ABSOLUTE(.);
-
-    *(.rodata .rodata.*)
-
-    *(.rodata_wlog_error .rodata_wlog_error.*)
-    *(.rodata_wlog_info .rodata_wlog_info.*)
-    *(.rodata_wlog_warning .rodata_wlog_warning.*)
-
-    KEEP (*(SORT(.roxfa.*)))
-
-    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
-    *(.gnu.linkonce.r.*)
-    *(.rodata1)
-    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
-    *(.xt_except_table)
-    *(.gcc_except_table .gcc_except_table.*)
-    *(.gnu.linkonce.e.*)
-    *(.gnu.version_r)
-    . = (. + 3) & ~ 3;
-    __eh_frame = ABSOLUTE(.);
-    KEEP(*(.eh_frame))
-    . = (. + 7) & ~ 3;
-    /*  C++ constructor and destructor tables
-
-        Make a point of not including anything from crtbegin.o or crtend.o, as IDF doesn't use toolchain crt
-      */
-    __init_array_start = ABSOLUTE(.);
-    KEEP (*(EXCLUDE_FILE (*crtend.* *crtbegin.*) .ctors SORT(.ctors.*)))
-    __init_array_end = ABSOLUTE(.);
-
-    KEEP (*crtbegin.*(.dtors))
-    KEEP (*(EXCLUDE_FILE (*crtend.*) .dtors))
-    KEEP (*(SORT(.dtors.*)))
-    KEEP (*(.dtors))
-    /*  C++ exception handlers table:  */
-    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
-    *(.xt_except_desc)
-    *(.gnu.linkonce.h.*)
-    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
-    *(.xt_except_desc_end)
-    *(.dynamic)
-    *(.gnu.version_d)
-    /* Addresses of memory regions reserved via
-       SOC_RESERVE_MEMORY_REGION() */
-    soc_reserved_memory_region_start = ABSOLUTE(.);
-    KEEP (*(.reserved_memory_address))
-    soc_reserved_memory_region_end = ABSOLUTE(.);
-    _rodata_end = ABSOLUTE(.);
-    /* Literals are also RO data. */
-    _lit4_start = ABSOLUTE(.);
-    *(*.lit4)
-    *(.lit4.*)
-    *(.gnu.linkonce.lit4.*)
-    _lit4_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _thread_local_start = ABSOLUTE(.);
-    *(.tdata)
-    *(.tdata.*)
-    *(.tbss)
-    *(.tbss.*)
-    _thread_local_end = ABSOLUTE(.);
-    . = ALIGN(4);
-  } >default_rodata_seg
-
-  _flash_rodata_align = ALIGNOF(.flash.rodata);
-
-  .flash.rodata_noload (NOLOAD) :
-  {
-    . = ALIGN (4);
-    *(.rodata_wlog_debug .rodata_wlog_debug.*)
-    *(.rodata_wlog_verbose .rodata_wlog_verbose.*)
-  } > default_rodata_seg
+  ASSERT(((_bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)), "DRAM segment data does not fit.")
 
   .flash.text :
   {
     _stext = .;
+    _instruction_reserved_start = ABSOLUTE(.);
     _text_start = ABSOLUTE(.);
 
     *(.literal .literal.* .text .text.*)
@@ -555,19 +460,127 @@ SECTIONS
     . += _esp_flash_mmap_prefetch_pad_size;
 
     _text_end = ABSOLUTE(.);
+    _instruction_reserved_end = ABSOLUTE(.);
     _etext = .;
 
-    /* Similar to _iram_start, this symbol goes here so it is
-       resolved by addr2line in preference to the first symbol in
-       the flash.text segment.
-    */
+    /**
+     * Similar to _iram_start, this symbol goes here so it is
+     * resolved by addr2line in preference to the first symbol in
+     * the flash.text segment.
+     */
     _flash_cache_start = ABSOLUTE(0);
-  } >default_code_seg
+  } > default_code_seg
+
+  /**
+   * This dummy section represents the .flash.text section but in default_rodata_seg.
+   * Thus, it must have its alignement and (at least) its size.
+   */
+  .flash_rodata_dummy (NOLOAD):
+  {
+    _flash_rodata_dummy_start = .;
+    /* Start at the same alignement constraint than .flash.text */
+    . = ALIGN(ALIGNOF(.flash.text));
+    /* Create an empty gap as big as .flash.text section */
+    . = . + SIZEOF(.flash.text);
+    /* Prepare the alignement of the section above. Few bytes (0x20) must be
+     * added for the mapping header. */
+    . = ALIGN(0x10000) + 0x20;
+    _rodata_reserved_start = .;
+  } > default_rodata_seg
+
+  .flash.appdesc : ALIGN(0x10)
+  {
+    _rodata_start = ABSOLUTE(.);
+
+    *(.rodata_desc .rodata_desc.*)               /* Should be the first.  App version info.        DO NOT PUT ANYTHING BEFORE IT! */
+    *(.rodata_custom_desc .rodata_custom_desc.*) /* Should be the second. Custom app version info. DO NOT PUT ANYTHING BEFORE IT! */
+
+    /* Create an empty gap within this section. Thanks to this, the end of this
+     * section will match .flah.rodata's begin address. Thus, both sections
+     * will be merged when creating the final bin image. */
+    . = ALIGN(ALIGNOF(.flash.rodata));
+  } >default_rodata_seg
+
+  .flash.rodata : ALIGN(0x10)
+  {
+    _flash_rodata_start = ABSOLUTE(.);
+
+    *(.rodata .rodata.*)
+
+    *(.rodata_wlog_error .rodata_wlog_error.*)
+    *(.rodata_wlog_info .rodata_wlog_info.*)
+    *(.rodata_wlog_warning .rodata_wlog_warning.*)
+
+    KEEP (*(SORT(.roxfa.*)))
+
+    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
+    *(.xt_except_table)
+    *(.gcc_except_table .gcc_except_table.*)
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    . = (. + 3) & ~ 3;
+    __eh_frame = ABSOLUTE(.);
+    KEEP(*(.eh_frame))
+    . = (. + 7) & ~ 3;
+    /* C++ constructor and destructor tables */
+    /* Don't include anything from crtbegin.o or crtend.o, as IDF doesn't use toolchain crt */
+    __init_array_start = ABSOLUTE(.);
+    KEEP (*(EXCLUDE_FILE (*crtend.* *crtbegin.*) .ctors SORT(.ctors.*)))
+    __init_array_end = ABSOLUTE(.);
+    KEEP (*crtbegin.*(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.*) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    /* C++ exception handlers table: */
+    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    /* Addresses of memory regions reserved via SOC_RESERVE_MEMORY_REGION() */
+    soc_reserved_memory_region_start = ABSOLUTE(.);
+    KEEP (*(.reserved_memory_address))
+    soc_reserved_memory_region_end = ABSOLUTE(.);
+    _rodata_end = ABSOLUTE(.);
+    /* Literals are also RO data. */
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _thread_local_start = ABSOLUTE(.);
+    *(.tdata)
+    *(.tdata.*)
+    *(.tbss)
+    *(.tbss.*)
+    _thread_local_end = ABSOLUTE(.);
+    _rodata_reserved_end = ABSOLUTE(.);
+    . = ALIGN(4);
+  } > default_rodata_seg
+
+  _flash_rodata_align = ALIGNOF(.flash.rodata);
+
+  .flash.rodata_noload (NOLOAD) :
+  {
+    . = ALIGN (4);
+    *(.rodata_wlog_debug .rodata_wlog_debug.*)
+    *(.rodata_wlog_verbose .rodata_wlog_verbose.*)
+  } > default_rodata_seg
 
   /* Marks the end of IRAM code segment */
   .iram0.text_end (NOLOAD) :
   {
-    . = ALIGN (4);
+    /* ESP32-S3 memprot requires 16B padding for possible CPU prefetch and 256B alignment for PMS split lines */
+    . += _esp_memprot_prefetch_pad_size;
+    . = ALIGN(_esp_memprot_align_size);
+    /* iram_end_test section exists for use by memprot unit tests only */
+    *(.iram_end_test)
     _iram_text_end = ABSOLUTE(.);
   } > iram0_0_seg
 
@@ -603,6 +616,9 @@ SECTIONS
     _heap_start = ABSOLUTE(.);
     _sheap = ABSOLUTE(.);
   } > dram0_0_seg
+
+  . = _heap_end;
+  _eheap = ABSOLUTE(.);
 }
 
 ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),


### PR DESCRIPTION
### Contribution description

This PR is a split-off from #18185. It adds the linker script for ESP32-S3 and modify the ESP32-C3 linker scripts to be compatible with them. The goal is to use a section list of objects that is common for all ESP32x SoCs in future.

### Testing procedure

Green CI.

### Issues/PRs references

Split-off from #18185