### PR TITLE
cpu/esp32: add ESP32-S3 support to makefiles

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -93,10 +93,15 @@ endif
 
 ifneq (,$(filter esp_spi_ram,$(USEMODULE)))
   FEATURES_REQUIRED += esp_spi_ram
+  FEATURES_OPTIONAL += esp_spi_oct
   USEMODULE += esp_idf_gpio
   USEMODULE += esp_idf_heap
   USEMODULE += esp_idf_spi_flash
   USEMODULE += esp_idf_spi_ram
+endif
+
+ifneq (,$(filter esp_spi_oct,$(FEATURES_USED)))
+  USEMODULE += esp_spi_oct
 endif
 
 ifneq (,$(filter esp_idf_heap,$(USEMODULE)))

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -1,9 +1,12 @@
-ifneq (,$(filter esp32,$(CPU_FAM)))
+ifeq (esp32,$(CPU_FAM))
   CPU_ARCH = xtensa
   CPU_CORE = xtensa-lx6
 else ifneq (,$(filter esp32c3,$(CPU_FAM)))
   CPU_ARCH = rv32
   CPU_CORE = rv32imc
+else ifneq (,$(filter esp32s3,$(CPU_FAM)))
+  CPU_ARCH = xtensa
+  CPU_CORE = xtensa-lx7
 else
   $(error Unkwnown ESP32x SoC variant (family))
 endif
@@ -20,8 +23,11 @@ ifeq (xtensa,$(CPU_ARCH))
   FEATURES_PROVIDED += esp_hw_counter
 endif
 
-ifneq (,$(filter esp32-wrover%,$(CPU_MODEL)))
+ifneq (,$(filter esp32-wrover% esp32s3%r2 esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))
   FEATURES_PROVIDED += esp_spi_ram
+  ifneq (,$(filter esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))
+    FEATURES_PROVIDED += esp_spi_oct
+  endif
 endif
 
 # This configuration enables modules that are only available when using Kconfig

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -8,7 +8,7 @@ ifeq (esp32,$(CPU_FAM))
   export FLASH_FREQ ?= 40m
   export FLASH_SIZE ?= 2
   BOOTLOADER_POS = 0x1000
-else ifeq (esp32c3,$(CPU_FAM))
+else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
   export FLASH_MODE ?= dio
   export FLASH_FREQ ?= 80m
   export FLASH_SIZE ?= 2
@@ -39,6 +39,7 @@ PSEUDOMODULES += esp_i2c_hw
 PSEUDOMODULES += esp_jtag
 PSEUDOMODULES += esp_rtc_timer_32k
 PSEUDOMODULES += esp_spi_ram
+PSEUDOMODULES += esp_spi_oct
 PSEUDOMODULES += esp_wifi_enterprise
 
 INCLUDES += -I$(RIOTCPU)/$(CPU)/esp-idf/include
@@ -150,18 +151,22 @@ LINKFLAGS += -T$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/ld/$(CPU_FAM).peripher
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.api.ld
 LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.ld
 
-ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
+ifeq (esp32,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-data.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-funcs.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib-time.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.spiflash.ld
-endif
-
-ifneq (,$(filter riscv%,$(TARGET_ARCH)))
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.libgcc.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.version.ld
-  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/esp32c3/ld/esp32c3.rom.eco3.ld
+else ifeq (esp32c3,$(CPU_FAM))
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.version.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3.ld
+else ifeq (esp32s3,$(CPU_FAM))
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.libgcc.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.version.ld
+else
+  $(error Unkwnown ESP32x SoC variant (family))
 endif
 
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections

--- a/cpu/esp32/esp-idf/adc/Makefile
+++ b/cpu/esp32/esp-idf/adc/Makefile
@@ -8,7 +8,7 @@ ESP32_SDK_SRC = \
   components/soc/$(CPU_FAM)/adc_periph.c \
   #
 
-ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
+ifneq (,$(filter esp32c3,$(CPU_FAM)))
   ESP32_SDK_SRC += components/driver/$(CPU_FAM)/adc2_init_cal.c
   INCLUDES += -I$(ESP32_SDK_DIR)/components/driver/include/driver
 endif

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -91,16 +91,26 @@ ifneq (,$(filter riscv%,$(TARGET_ARCH)))
   ESP32_SDK_ASMSRC += components/riscv/vectors.S
 endif
 
-ifneq (,$(filter esp32,$(CPU_FAM)))
+ifeq (esp32,$(CPU_FAM))
   ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_frc_legacy.c
 endif
 
-ifneq (,$(filter esp32c3,$(CPU_FAM)))
+ifeq (esp32c3,$(CPU_FAM))
   ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/cpu_util_$(CPU_FAM).c
   ESP32_SDK_SRC += components/esp_hw_support/sleep_retention.c
   ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c
   ESP32_SDK_SRC += components/hal/$(CPU_FAM)/rtc_cntl_hal.c
   ESP32_SDK_SRC += components/hal/systimer_hal.c
+endif
+
+ifeq (esp32s3,$(CPU_FAM))
+  ESP32_SDK_SRC += components/esp_hw_support/sleep_retention.c
+  ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c
+  ESP32_SDK_SRC += components/hal/$(CPU_FAM)/rtc_cntl_hal.c
+  ESP32_SDK_SRC += components/hal/$(CPU_FAM)/touch_sensor_hal.c
+  ESP32_SDK_SRC += components/hal/systimer_hal.c
+  ESP32_SDK_SRC += components/spi_flash/spi_flash_timing_tuning.c
+  ESP32_SDK_SRC += components/spi_flash/$(CPU_FAM)/spi_timing_config.c
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-idf/spi_flash/Makefile
+++ b/cpu/esp32/esp-idf/spi_flash/Makefile
@@ -6,7 +6,6 @@ ESP32_SDK_SRC = \
   components/driver/spi_common.c \
   components/spi_flash/$(CPU_FAM)/flash_ops_$(CPU_FAM).c \
   components/spi_flash/$(CPU_FAM)/spi_flash_rom_patch.c \
-  components/spi_flash/esp_flash_api.c \
   components/spi_flash/partition.c \
   #
 
@@ -16,6 +15,10 @@ ifeq (,$(filter periph_spi,$(USEMODULE)))
 endif
 
 ifneq (,$(filter esp32,$(CPU_FAM)))
+  ESP32_SDK_SRC += components/spi_flash/esp_flash_spi_init.c
+endif
+
+ifneq (,$(filter esp32 esp32s3,$(CPU_FAM)))
   ESP32_SDK_SRC += components/spi_flash/flash_mmap.c
 endif
 

--- a/cpu/esp32/esp-idf/spi_ram/Makefile
+++ b/cpu/esp32/esp-idf/spi_ram/Makefile
@@ -4,8 +4,15 @@ MODULE = esp_idf_spi_ram
 ESP32_SDK_SRC = \
   components/esp_hw_support/port/$(CPU_FAM)/spiram.c \
   components/esp_hw_support/port/$(CPU_FAM)/spiram_psram.c \
-  components/esp_hw_support/port/$(CPU_FAM)/cache_sram_mmu.c \
   #
+
+ifeq (esp32,$(CPU_FAM))
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/cache_sram_mmu.c
+endif
+
+ifneq (,$(filter esp_spi_oct,$(USEMODULE)))
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/opiram_psram.c
+endif
 
 # additional include pathes required by this module
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/$(CPU_FAM)/include


### PR DESCRIPTION
### Contribution description

This PR is a split-off from #18185 and adds the support of ESP32-S3 to the makefiles.

### Testing procedure

Green CI

### Issues/PRs references

Split-off from #18185